### PR TITLE
add support for field mode in TextIOToBigQuery.java

### DIFF
--- a/src/main/java/com/google/cloud/teleport/templates/TextIOToBigQuery.java
+++ b/src/main/java/com/google/cloud/teleport/templates/TextIOToBigQuery.java
@@ -87,6 +87,7 @@ public class TextIOToBigQuery {
   private static final String BIGQUERY_SCHEMA = "BigQuery Schema";
   private static final String NAME = "name";
   private static final String TYPE = "type";
+  private static final String MODE = "mode";
 
   public static void main(String[] args) {
     Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
@@ -124,11 +125,17 @@ public class TextIOToBigQuery {
                                   jsonSchema.getJSONArray(BIGQUERY_SCHEMA);
 
                               for (int i = 0; i < bqSchemaJsonArray.length(); i++) {
-                                fields.add(
+                                JSONObject inputField = bqSchemaJsonArray.getJSONObject(i);
+                                TableFieldSchema field =
                                     new TableFieldSchema()
-                                        .setName(bqSchemaJsonArray.getJSONObject(i).getString(NAME))
-                                        .setType(
-                                            bqSchemaJsonArray.getJSONObject(i).getString(TYPE)));
+                                        .setName(inputField.getString(NAME))
+                                        .setType(inputField.getString(TYPE));
+
+                                if (inputField.has(MODE)) {
+                                  field.setMode(inputField.getString(MODE));
+                                }
+
+                                fields.add(field)
                               }
                               tableSchema.setFields(fields);
 

--- a/src/main/java/com/google/cloud/teleport/templates/TextIOToBigQuery.java
+++ b/src/main/java/com/google/cloud/teleport/templates/TextIOToBigQuery.java
@@ -135,7 +135,7 @@ public class TextIOToBigQuery {
                                   field.setMode(inputField.getString(MODE));
                                 }
 
-                                fields.add(field)
+                                fields.add(field);
                               }
                               tableSchema.setFields(fields);
 


### PR DESCRIPTION
This commit adds support for the `mode` field in bigquery schemas, so that the GCS text to bigquery template can use repeated and/or required fields.  Existing behavior is unchanged, because the mode is only set on the Bigquery schema if it is present in the input schema.