### PR TITLE
Removed Example Usage

### DIFF
--- a/src/main/java/com/google/cloud/teleport/templates/PubsubToText.java
+++ b/src/main/java/com/google/cloud/teleport/templates/PubsubToText.java
@@ -42,26 +42,6 @@ import org.apache.beam.sdk.transforms.windowing.Window;
  * This pipeline ingests incoming data from a Cloud Pub/Sub topic and
  * outputs the raw data into windowed files at the specified output
  * directory.
- *
- * <p> Example Usage:
- *
- * <pre>
- * mvn compile exec:java \
- -Dexec.mainClass=com.google.cloud.teleport.templates.${PIPELINE_NAME} \
- -Dexec.cleanupDaemonThreads=false \
- -Dexec.args=" \
- --project=${PROJECT_ID} \
- --stagingLocation=gs://${PROJECT_ID}/dataflow/pipelines/${PIPELINE_FOLDER}/staging \
- --tempLocation=gs://${PROJECT_ID}/dataflow/pipelines/${PIPELINE_FOLDER}/temp \
- --runner=DataflowRunner \
- --windowDuration=2m \
- --numShards=1 \
- --topic=projects/${PROJECT_ID}/topics/windowed-files \
- --outputDirectory=gs://${PROJECT_ID}/temp/ \
- --outputFilenamePrefix=windowed-file \
- --outputFilenameSuffix=.txt"
- * </pre>
- * </p>
  */
 public class PubsubToText {
 

--- a/src/main/java/com/google/cloud/teleport/templates/PubsubToText.java
+++ b/src/main/java/com/google/cloud/teleport/templates/PubsubToText.java
@@ -42,6 +42,23 @@ import org.apache.beam.sdk.transforms.windowing.Window;
  * This pipeline ingests incoming data from a Cloud Pub/Sub topic and
  * outputs the raw data into windowed files at the specified output
  * directory.
+ *
+ * <p> Example Usage:
+ *
+ * <pre>
+ * 
+ Compilation: 
+ mvn compile exec:java \
+ -Dexec.mainClass=com.google.cloud.teleport.templates.<template-class> \
+ -Dexec.cleanupDaemonThreads=false \
+ -Dexec.args=" \
+ --project=<project-id> \
+ --stagingLocation=gs://<bucket-name>/staging \
+ --tempLocation=gs://<bucket-name>/temp \
+ --templateLocation=gs://<bucket-name>/templates/<template-name>.json \
+ --runner=DataflowRunner"
+ * </pre>
+ * </p>
  */
 public class PubsubToText {
 


### PR DESCRIPTION
The provided example usage was misleading / incorrect because, when using the example usage to compile the file, it threw an error, 
`[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.6.0:java (default-cli) on project google-cloud-teleport-java: An exception occured while executing the Java class. Class interface com.google.cloud.teleport.templates.PubsubToText$Options missing a property named 'topic'. -> [Help 1]`
even if `--topic` or `--inputTopic` argument is passed. 
The correct steps has been properly documented here [Dataflow Documentation](https://cloud.google.com/dataflow/docs/templates/overview) in the creating and executing templates section. To reiterate, compile without passing arguments at compile time, and pass the arguments at run time instead when executing the dataflow job.