### PR TITLE
Fix payloadString dosent serialized json

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
     <commons-text.version>1.6</commons-text.version>
     <google.cloud.core>1.61.0</google.cloud.core>
     <grpc.version>1.13.1</grpc.version>
+    <google-http-client.version>1.27.0</google-http-client.version>
     <google-storage-api.version>v1-rev20181013-1.27.0</google-storage-api.version>
     <mvn-target-dir>${basedir}/target</mvn-target-dir>
     <derby.version>10.12.1.1</derby.version>
@@ -334,6 +335,11 @@
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-storage</artifactId>
       <version>${google-storage-api.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+      <version>${google-http-client.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>

--- a/src/main/java/com/google/cloud/teleport/templates/TextToBigQueryStreaming.java
+++ b/src/main/java/com/google/cloud/teleport/templates/TextToBigQueryStreaming.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.teleport.templates;
 
+import com.google.api.client.json.JsonFactory;
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.cloud.teleport.coders.FailsafeElementCoder;
 import com.google.cloud.teleport.templates.common.BigQueryConverters.FailsafeJsonToTableRow;
@@ -36,6 +37,7 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.coders.CoderRegistry;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.extensions.gcp.util.Transport;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.io.fs.ResourceId;
@@ -262,17 +264,13 @@ public class TextToBigQueryStreaming {
    * @return FailsafeElement object.
    * @throws IOException
    */
-  protected static FailsafeElement<String, String> wrapBigQueryInsertError(
-      BigQueryInsertError insertError) {
-
+  protected static FailsafeElement<String, String> wrapBigQueryInsertError(BigQueryInsertError insertError) {
     FailsafeElement<String, String> failsafeElement;
+
     try {
-
-      failsafeElement =
-          FailsafeElement.of(
-              insertError.getRow().toPrettyString(), insertError.getRow().toPrettyString());
-      failsafeElement.setErrorMessage(insertError.getError().toPrettyString());
-
+      JsonFactory factory = Transport.getJsonFactory();
+      failsafeElement = FailsafeElement.of(factory.toPrettyString(insertError.getRow()), factory.toPrettyString(insertError.getRow()));
+      failsafeElement.setErrorMessage(factory.toPrettyString(insertError.getError()));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/com/google/cloud/teleport/templates/TextToBigQueryStreamingTest.java
+++ b/src/test/java/com/google/cloud/teleport/templates/TextToBigQueryStreamingTest.java
@@ -1,0 +1,60 @@
+package com.google.cloud.teleport.templates;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.api.client.json.JsonFactory;
+import com.google.api.services.bigquery.model.ErrorProto;
+import com.google.api.services.bigquery.model.TableDataInsertAllResponse;
+import com.google.api.services.bigquery.model.TableReference;
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.cloud.teleport.values.FailsafeElement;
+import java.io.IOException;
+import java.util.Collections;
+import org.apache.beam.sdk.extensions.gcp.util.Transport;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryInsertError;
+import org.junit.Test;
+
+/** Test cases for the {@link TextToBigQueryStreaming} class. */
+public class TextToBigQueryStreamingTest {
+    /**
+     * Tests the TextToBigQueryStreaming.wrapBigQueryInsertError() returns the FailsafeElement
+     * with jsonized table row and error message.
+     */
+    @Test
+    public void wrapBigQueryInsertErrorTest() {
+        TableRow row = new TableRow();
+        row.set("ticker", "GOOGL");
+        row.set("price", 1006.94);
+
+        BigQueryInsertError error = createBigQueryInsertError(row);
+        FailsafeElement failsafeElement = TextToBigQueryStreaming.wrapBigQueryInsertError(error);
+
+        try {
+            JsonFactory factory = Transport.getJsonFactory();
+            assertThat(failsafeElement.getOriginalPayload(), is(equalTo(factory.toPrettyString(error.getRow()))));
+            assertThat(failsafeElement.getErrorMessage(), is(equalTo(factory.toPrettyString(error.getError()))));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private BigQueryInsertError createBigQueryInsertError(TableRow row) {
+        return new BigQueryInsertError(
+            row,
+            new TableDataInsertAllResponse.InsertErrors()
+                .setIndex(0L)
+                .setErrors(Collections.singletonList(
+                    new ErrorProto()
+                        .setReason("a Reason")
+                        .setLocation("A location")
+                        .setMessage("A Message")
+                        .setDebugInfo("The debug info")
+                )),
+            new TableReference()
+                .setProjectId("dummy-project-id")
+                .setDatasetId("dummy-dataset-id")
+                .setTableId("dummy-table-id"));
+    }
+}


### PR DESCRIPTION
## Summary

similar to #25 

I encountered that the error can not be restore error records to bigquery because the payloadString from BigQueryInsertError is not JSON.

before:
```
java.lang.AssertionError: WrapInsertionErrors/Map/ParMultiDo(Anonymous).output:
Expected: is "{\"ticker\":\"GOOGL\",\"price\":1006.94}"
     got: "{ticker=GOOGL, price=1006.94}"

Expected :{\"ticker\":\"GOOGL\",\"price\":1006.94}
Actual   :{ticker=GOOGL, price=1006.94}
```

The cause of this format was jsonFactory not set to TableRow.

```java
  public String toPrettyString() throws IOException {
    if (jsonFactory != null) {
      return jsonFactory.toPrettyString(this);
    }
    return super.toString();
  }
```

https://github.com/googleapis/google-http-java-client/blob/0988ae4e0f26a80f579b6adb2b276dd8254928de/google-http-client/src/main/java/com/google/api/client/json/GenericJson.java#L77-L82

I do not know how to fix this, so please give a review :)