### PR TITLE
Multiple kafka topics to BigQuery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 target/
 bin/
 dependency-reduced-pom.xml
-
+libs/
+.idea/
+.classpath
+.factorypath

--- a/pom.xml
+++ b/pom.xml
@@ -55,13 +55,13 @@
     <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
     <mockito-core.version>2.25.0</mockito-core.version>
     <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.version>1.7.28</slf4j.version>
     <joda.version>2.4</joda.version>
     <generated-grpc-beta.version>0.19.0</generated-grpc-beta.version>
     <spanner.version>1.6.0</spanner.version>
     <gax.version>1.38.0</gax.version>
     <bigtable.version>1.5.0</bigtable.version>
-    <bigquery.version>v2-rev374-1.22.0</bigquery.version>
+    <bigquery.version>v2-rev438-1.25.0</bigquery.version>
     <protobuf-util.version>3.6.1</protobuf-util.version>
     <protobuf.version>3.6.0</protobuf.version>
     <findbugs.version>3.0.1</findbugs.version>
@@ -142,6 +142,7 @@
       <artifactId>beam-vendor-guava-20_0</artifactId>
       <version>${beam-vendor-guava.version}</version>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.apache.beam/beam-sdks-java-io-kafka -->
 
     <!-- Test -->
     <dependency>
@@ -694,6 +695,11 @@
         <repository>
           <id>apache.snapshots</id>
           <url>https://repository.apache.org/content/repositories/snapshots</url>
+        </repository>
+        <repository>
+            <id>com.google.cloud.teleport.templates</id>
+            <name>DataflowTemplates</name>
+            <url>file://${project.basedir}/libs</url>
         </repository>
       </repositories>
     </profile>

--- a/src/main/java/com/google/cloud/teleport/kafka/connector/ConsumerSpEL.java
+++ b/src/main/java/com/google/cloud/teleport/kafka/connector/ConsumerSpEL.java
@@ -23,6 +23,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import java.util.Collection;
 import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
@@ -50,6 +53,8 @@ class ConsumerSpEL {
   private Expression seek2endExpression = parser.parseExpression("#consumer.seekToEnd(#tp)");
 
   private Expression assignExpression = parser.parseExpression("#consumer.assign(#tp)");
+
+  private Expression subscribeExpression = parser.parseExpression("#consumer.subscribe(#topicRegex)");
 
   private boolean hasRecordTimestamp = false;
   private boolean hasOffsetsForTimes = false;
@@ -103,6 +108,13 @@ class ConsumerSpEL {
     mapContext.setVariable("consumer", consumer);
     mapContext.setVariable("tp", topicPartitions);
     assignExpression.getValue(mapContext);
+  }
+
+  public void evaluateSubscribe(Consumer consumer, Pattern topicRegex){
+    StandardEvaluationContext mapContext = new StandardEvaluationContext();
+    mapContext.setVariable("consumer", consumer);
+    mapContext.setVariable("topicRegex", topicRegex);
+    subscribeExpression.getValue(mapContext);
   }
 
   public long getRecordTimestamp(ConsumerRecord<byte[], byte[]> rawRecord) {

--- a/src/main/java/com/google/cloud/teleport/kafka/connector/KafkaIO.java
+++ b/src/main/java/com/google/cloud/teleport/kafka/connector/KafkaIO.java
@@ -862,11 +862,8 @@ public class KafkaIO {
               // default to latest offset when we are not resuming.
               ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
               "latest",
-              /*
-              // enable auto commit of offsets. this is required for consume subscribed topic from regex formula.
-              ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,
-              true,
-              */
+
+              // group id config
               ConsumerConfig.GROUP_ID_CONFIG,
               "multikafka-bq-" + System.currentTimeMillis()
       );

--- a/src/main/java/com/google/cloud/teleport/kafka/connector/KafkaIO.java
+++ b/src/main/java/com/google/cloud/teleport/kafka/connector/KafkaIO.java
@@ -481,11 +481,11 @@ public class KafkaIO {
     }
 
     public Read<K, V> withCustomizedKeyRegex(String customizedKeyRegex) {
-      return withCustomizedKeyRegex(StaticValueProvider.of(customizedKeyRegex));
+      return toBuilder().setCustomizedKeyRegex(customizedKeyRegex).build();
     }
 
     public Read<K, V> withCustomizedKeyReplacement(String customizedKeyReplacement) {
-      return withCustomizedKeyReplacement(StaticValueProvider.of(customizedKeyReplacement));
+      return toBuilder().setCustomizedKeyReplacement(customizedKeyReplacement).build();
     }
 
     /**
@@ -868,7 +868,7 @@ public class KafkaIO {
               true,
               */
               ConsumerConfig.GROUP_ID_CONFIG,
-              "multi-kafka-bq-consumer"
+              "multikafka-bq-" + System.currentTimeMillis()
       );
     }
 

--- a/src/main/java/com/google/cloud/teleport/kafka/connector/KafkaRecord.java
+++ b/src/main/java/com/google/cloud/teleport/kafka/connector/KafkaRecord.java
@@ -40,6 +40,7 @@ public class KafkaRecord<K, V> implements Serializable {
   private final KV<K, V> kv;
   private final long timestamp;
   private final KafkaTimestampType timestampType;
+  private final String customizedKey;
 
   public KafkaRecord(
       String topic,
@@ -50,10 +51,24 @@ public class KafkaRecord<K, V> implements Serializable {
       @Nullable Headers headers,
       K key,
       V value) {
-    this(topic, partition, offset, timestamp, timestampType, headers, KV.of(key, value));
+    this("", topic, partition, offset, timestamp, timestampType, headers, KV.of(key, value));
   }
 
   public KafkaRecord(
+          String customizedKey,
+          String topic,
+          int partition,
+          long offset,
+          long timestamp,
+          KafkaTimestampType timestampType,
+          @Nullable Headers headers,
+          K key,
+          V value) {
+    this(customizedKey, topic, partition, offset, timestamp, timestampType, headers, KV.of(key, value));
+  }
+
+  public KafkaRecord(
+      String customizedKey,
       String topic,
       int partition,
       long offset,
@@ -61,6 +76,7 @@ public class KafkaRecord<K, V> implements Serializable {
       KafkaTimestampType timestampType,
       @Nullable Headers headers,
       KV<K, V> kv) {
+    this.customizedKey = customizedKey;
     this.topic = topic;
     this.partition = partition;
     this.offset = offset;
@@ -69,6 +85,8 @@ public class KafkaRecord<K, V> implements Serializable {
     this.headers = headers;
     this.kv = kv;
   }
+
+  public String getCustomizedKey() { return customizedKey; }
 
   public String getTopic() {
     return topic;
@@ -114,6 +132,7 @@ public class KafkaRecord<K, V> implements Serializable {
       @SuppressWarnings("unchecked")
       KafkaRecord<Object, Object> other = (KafkaRecord<Object, Object>) obj;
       return topic.equals(other.topic)
+          && customizedKey == other.customizedKey
           && partition == other.partition
           && offset == other.offset
           && timestamp == other.timestamp

--- a/src/main/java/com/google/cloud/teleport/kafka/connector/KafkaRecordCoder.java
+++ b/src/main/java/com/google/cloud/teleport/kafka/connector/KafkaRecordCoder.java
@@ -70,6 +70,7 @@ public class KafkaRecordCoder<K, V> extends StructuredCoder<KafkaRecord<K, V>> {
   public KafkaRecord<K, V> decode(InputStream inStream) throws IOException {
     return new KafkaRecord<>(
         stringCoder.decode(inStream),
+        stringCoder.decode(inStream),
         intCoder.decode(inStream),
         longCoder.decode(inStream),
         longCoder.decode(inStream),
@@ -124,6 +125,7 @@ public class KafkaRecordCoder<K, V> extends StructuredCoder<KafkaRecord<K, V>> {
       return value;
     } else {
       return new KafkaRecord<>(
+          value.getCustomizedKey(),
           value.getTopic(),
           value.getPartition(),
           value.getOffset(),

--- a/src/main/java/com/google/cloud/teleport/kafka/connector/KafkaUnboundedReader.java
+++ b/src/main/java/com/google/cloud/teleport/kafka/connector/KafkaUnboundedReader.java
@@ -335,6 +335,7 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
           bytesRead.inc(recordSize);
           bytesReadBySplit.inc(recordSize);
 
+          curTimestamp = new Instant(System.currentTimeMillis());
           curRecord = record;
           return true;
 

--- a/src/main/java/com/google/cloud/teleport/kafka/connector/KafkaUnboundedSource.java
+++ b/src/main/java/com/google/cloud/teleport/kafka/connector/KafkaUnboundedSource.java
@@ -76,12 +76,12 @@ class KafkaUnboundedSource<K, V> extends UnboundedSource<KafkaRecord<K, V>, Kafk
 
     Read.Builder updatedSpecBuilder = updatedSpec.toBuilder().setTopics(null);
 
-    if (spec.getCustomizedKeyRegex() != null) {
+    if (spec.getCustomizedKeyRegexProvider() != null) {
       updatedSpecBuilder.setCustomizedKeyRegexProvider(spec.getCustomizedKeyRegexProvider());
       updatedSpecBuilder.setCustomizedKeyRegex(spec.getCustomizedKeyRegexProvider().get());
     }
 
-    if (spec.getCustomizedKeyReplacement() != null) {
+    if (spec.getCustomizedKeyReplacementProvider() != null) {
       updatedSpecBuilder.setCustomizedKeyReplacementProvider(spec.getCustomizedKeyReplacementProvider());
       updatedSpecBuilder.setCustomizedKeyReplacement(spec.getCustomizedKeyReplacementProvider().get());
     }

--- a/src/main/java/com/google/cloud/teleport/templates/MultipleKafkaTopicsToBigQuery.java
+++ b/src/main/java/com/google/cloud/teleport/templates/MultipleKafkaTopicsToBigQuery.java
@@ -103,8 +103,10 @@ import java.nio.charset.StandardCharsets;
  * --parameters \
  * "bootstrapServers=my_host:9092,\
  * inputTopicRegex=(.*),\
- * outputTableFormat=(.*)=project-id:dataset.table_prefix_$1_suffix,\
- * outputDeadletterTableFormat=(.*)=project-id:dataset.deadletter_table_prefix_$1_suffix"
+ * outputTableRegexPattern=(.*),\
+ * outputTableReplacement=BigQueryProjectID:dataset.table_prefix_$1_suffix
+ * javascriptTextTransformGcsPath=gs://my_bucket/my_udf.js
+ * javascriptTextTransformFunctionName=myFunction
  * </pre>
  */
 public class MultipleKafkaTopicsToBigQuery {

--- a/src/main/java/com/google/cloud/teleport/templates/MultipleKafkaTopicsToBigQuery.java
+++ b/src/main/java/com/google/cloud/teleport/templates/MultipleKafkaTopicsToBigQuery.java
@@ -1,0 +1,431 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.teleport.templates;
+
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.api.services.bigquery.model.TableSchema;
+import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.coders.FailsafeElementCoder;
+import com.google.cloud.teleport.kafka.connector.KafkaIO;
+import com.google.cloud.teleport.kafka.connector.KafkaRecord;
+import com.google.cloud.teleport.templates.common.BigQueryConverters.FailsafeJsonToTableRow;
+import com.google.cloud.teleport.templates.common.JavascriptTextTransformer.FailsafeJavascriptUdf;
+import com.google.cloud.teleport.templates.common.JavascriptTextTransformer.JavascriptTextTransformerOptions;
+import com.google.cloud.teleport.util.DualInputNestedValueProvider;
+import com.google.cloud.teleport.util.DualInputNestedValueProvider.TranslatorInput;
+import com.google.cloud.teleport.util.ResourceUtils;
+import com.google.cloud.teleport.util.ValueProviderUtils;
+import com.google.cloud.teleport.values.FailsafeElement;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderRegistry;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.io.gcp.bigquery.*;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.transforms.*;
+import org.apache.beam.sdk.transforms.DoFn.ProcessElement;
+import org.apache.beam.sdk.values.*;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * The {@link MultipleKafkaTopicsToBigQuery} pipeline is a streaming pipeline which ingests data in JSON format
+ * from Kafka, executes a UDF, and outputs the resulting records to BigQuery. Any errors which occur
+ * in the transformation of the data or execution of the UDF will be output to a separate errors
+ * table in BigQuery. The errors table will be created if it does not exist prior to execution. Both
+ * output and error tables are specified by the user as template parameters.
+ *
+ * <p><b>Pipeline Requirements</b>
+ *
+ * <ul>
+ *   <li>The Kafka topic exists and the message is encoded in a valid JSON format.
+ *   <li>The BigQuery output table exists.
+ * </ul>
+ *
+ * <p><b>Example Usage</b>
+ *
+ * <pre>
+ * # Set the pipeline vars
+ * PROJECT_ID=PROJECT ID HERE
+ * BUCKET_NAME=BUCKET NAME HERE
+ * PIPELINE_FOLDER=gs://${BUCKET_NAME}/dataflow/pipelines/multikafka-bq
+ *
+ * # Set the runner
+ * RUNNER=DataflowRunner
+ *
+ * # Build the template
+ * mvn compile exec:java \
+ * -Dexec.mainClass=com.google.cloud.teleport.templates.MultipleKafkaTopicsToBigQuery \
+ * -Dexec.cleanupDaemonThreads=false \
+ * -Dexec.args=" \
+ * --project=${PROJECT_ID} \
+ * --stagingLocation=${PIPELINE_FOLDER}/staging \
+ * --tempLocation=${PIPELINE_FOLDER}/temp \
+ * --templateLocation=${PIPELINE_FOLDER}/template \
+ * --runner=${RUNNER}"
+ *
+ * # Execute the template
+ * JOB_NAME=multiple-kafka-topics-to-bigquery-$USER-`date +"%Y%m%d-%H%M%S%z"`
+ *
+ * gcloud dataflow jobs run ${JOB_NAME} \
+ * --gcs-location=${PIPELINE_FOLDER}/template \
+ * --zone=us-east1-d \
+ * --parameters \
+ * "bootstrapServers=my_host:9092,\
+ * inputTopicRegex=(.*),\
+ * outputTableFormat=(.*)=project-id:dataset.table_prefix_$1_suffix,\
+ * outputDeadletterTableFormat=(.*)=project-id:dataset.deadletter_table_prefix_$1_suffix"
+ * </pre>
+ */
+public class MultipleKafkaTopicsToBigQuery {
+
+  /** The log to output status messages to. */
+  private static final Logger LOG = LoggerFactory.getLogger(MultipleKafkaTopicsToBigQuery.class);
+
+  /** The tag for the main output for the UDF. */
+  public static final TupleTag<FailsafeElement<KV<String, String>, String>> UDF_OUT =
+          new TupleTag<FailsafeElement<KV<String, String>, String>>() {};
+
+  /** The tag for the main output of the json transformation. */
+  public static final TupleTag<TableRow> TRANSFORM_OUT = new TupleTag<TableRow>() {};
+
+  /** The tag for the dead-letter output of the udf. */
+  public static final TupleTag<FailsafeElement<KV<String, String>, String>> UDF_DEADLETTER_OUT =
+          new TupleTag<FailsafeElement<KV<String, String>, String>>() {};
+
+  /** The tag for the dead-letter output of the json to table row transform. */
+  public static final TupleTag<FailsafeElement<KV<String, String>, String>>
+          TRANSFORM_DEADLETTER_OUT = new TupleTag<FailsafeElement<KV<String, String>, String>>() {};
+
+  /** The default suffix for error tables if dead letter table is not specified. */
+  public static final String DEFAULT_DEADLETTER_TABLE_SUFFIX = "_error_records";
+
+  /**
+   * The {@link Options} class provides the custom execution options passed by the executor at the
+   * command-line.
+   */
+  public interface Options extends PipelineOptions, JavascriptTextTransformerOptions {
+    @Description("Kafka topic regex to read the input from")
+    ValueProvider<String> getInputTopicRegex();
+
+    void setInputTopicRegex(ValueProvider<String> value);
+
+    @Description("BigQuery Project ID")
+    ValueProvider<String> getBigQueryProjectID();
+
+    void setBigQueryProjectID(ValueProvider<String> value);
+
+    @Description("Dataset")
+    ValueProvider<String> getDataset();
+
+    void setDataset(ValueProvider<String> value);
+
+    @Description("Table regex pattern")
+    ValueProvider<String> getOutputTableRegexPattern();
+
+    void setOutputTableRegexPattern(ValueProvider<String> value);
+
+    @Description("Table regex replacement")
+    ValueProvider<String> getOutputTableReplacement();
+
+    void setOutputTableReplacement(ValueProvider<String> value);
+
+    @Description("Kafka Bootstrap Servers")
+    ValueProvider<String> getBootstrapServers();
+
+    void setBootstrapServers(ValueProvider<String> value);
+
+    @Description("Deadletter Table Spec")
+    ValueProvider<String> getOutputDeadletterTable();
+
+    void setOutputDeadletterTable(ValueProvider<String> value);
+  }
+
+  /**
+   * The main entry-point for pipeline execution. This method will start the pipeline but will not
+   * wait for it's execution to finish. If blocking execution is required, use the {@link
+   * MultipleKafkaTopicsToBigQuery#run(Options)} method to start the pipeline and invoke {@code
+   * result.waitUntilFinish()} on the {@link PipelineResult}.
+   *
+   * @param args The command-line args passed by the executor.
+   */
+  public static void main(String[] args) {
+    Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+
+    run(options);
+  }
+
+  /**
+   * Runs the pipeline to completion with the specified options. This method does not wait until the
+   * pipeline is finished before returning. Invoke {@code result.waitUntilFinish()} on the result
+   * object to block until the pipeline is finished running if blocking programmatic execution is
+   * required.
+   *
+   * @param options The execution options.
+   * @return The pipeline result.
+   */
+  public static PipelineResult run(Options options) {
+
+    Pipeline pipeline = Pipeline.create(options);
+
+    // Register the coder for pipeline
+    FailsafeElementCoder<KV<String, String>, String> coder =
+            FailsafeElementCoder.of(
+                    KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()), StringUtf8Coder.of());
+
+    CoderRegistry coderRegistry = pipeline.getCoderRegistry();
+    coderRegistry.registerCoderForType(coder.getEncodedTypeDescriptor(), coder);
+
+    /*
+     * Steps:
+     *  1) Read messages in from Kafka
+     *  2) Transform the Kafka Messages into TableRows
+     *     - Transform message payload via UDF
+     *     - Convert UDF result to TableRow objects
+     *  3) Write successful records out to BigQuery
+     *  4) Write failed records out to BigQuery
+     */
+    PCollectionTuple transformOut =
+            (PCollectionTuple) pipeline
+                    /*
+                     * Step #1: Read messages in from Kafka
+                     */
+                    .apply(
+                            "ReadFromKafka",
+                            KafkaIO.<String, String>read()
+                                    .withBootstrapServers(options.getBootstrapServers())
+                                    .withTopicRegex(options.getInputTopicRegex())
+                                    .withKeyDeserializer(StringDeserializer.class)
+                                    .withValueDeserializer(StringDeserializer.class)
+                                    // NumSplits is hard-coded to 1 for single-partition use cases (e.g., Debezium
+                                    // Change Data Capture). Once Dataflow dynamic templates are available, this can
+                                    // be deprecated.
+                                    .withNumSplits(1))
+                    .apply(ParDo.of(new DoFn<KafkaRecord<String, String>, KV<String, String>>(){
+                      @ProcessElement
+                      public void processElement(ProcessContext c){
+                        KafkaRecord<String, String> element = c.element();
+                        c.output(KV.of(element.getTopic(), element.getKV().getValue()));
+                      }
+                    }))
+                    .apply("TransformMessagesUsingUDF", new TransformMessagesUsingUDF(options));
+
+
+    /*
+     * Step #3: Write the successful records out to BigQuery
+     */
+    transformOut
+            .get(UDF_OUT)
+            .apply("WritetoBigQuery",
+                    BigQueryIO
+                            .<FailsafeElement<KV<String, String>, String>>write()
+                            .to(new SerializableFunction<ValueInSingleWindow<FailsafeElement<KV<String, String>, String>>, TableDestination>() {
+                              public TableDestination apply(ValueInSingleWindow<FailsafeElement<KV<String, String>, String>> value) {
+                                // The cast below is safe because CalendarWindows.days(1) produces IntervalWindows.
+                                String tableName = value.getValue().getOriginalPayload().getKey()
+                                                        .replaceAll(options.getOutputTableRegexPattern().get(), options.getOutputTableReplacement().get());
+                                return new TableDestination(
+                                        options.getBigQueryProjectID().get() + ":" + options.getDataset().get() + "." + tableName,
+                                        "Record from Kafka"
+                                );
+                              }
+                            })
+                            .withFormatFunction(new SerializableFunction<FailsafeElement<KV<String, String>, String>, TableRow>() {
+                              @Override
+                              public TableRow apply(FailsafeElement<KV<String, String>, String> element) {
+                                String json = element.getPayload();
+                                TableRow row = null;
+                                // Parse the JSON into a {@link TableRow} object.
+                                try (InputStream inputStream =
+                                             new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))) {
+                                  row = TableRowJsonCoder.of().decode(inputStream, Coder.Context.OUTER);
+
+                                } catch (IOException e) {
+                                  throw new RuntimeException("Failed to serialize json to table row: " + json, e);
+                                }
+
+                                return row;
+                              }
+                            })
+            );
+
+    return pipeline.run();
+  }
+
+  /**
+   * The {@link TransformMessagesUsingUDF} class is a {@link PTransform} which transforms incoming Kafka
+   * Message objects by applying an optional UDF to the input. The executions of the UDF objects
+   * is done in a fail-safe way by wrapping the element with it's original payload inside
+   * the {@link FailsafeElement} class. The {@link TransformMessagesUsingUDF} will output
+   * a {@link PCollectionTuple} which contains all UDF output and dead-letter {@link PCollection}.
+   *
+   * <p>The {@link PCollectionTuple} output will contain the following {@link PCollection}:
+   *
+   * <ul>
+   *   <li>{@link TransformMessagesUsingUDF#UDF_OUT} - Contains all {@link FailsafeElement} records
+   *       successfully processed by the optional UDF.
+   *   <li>{@link TransformMessagesUsingUDF#UDF_DEADLETTER_OUT} - Contains all {@link FailsafeElement} records
+   *       which failed processing during the UDF execution.
+   * </ul>
+   */
+  static class TransformMessagesUsingUDF
+          extends PTransform<PCollection<KV<String, String>>, PCollectionTuple> {
+
+    private final Options options;
+
+    TransformMessagesUsingUDF(Options options) {
+      this.options = options;
+    }
+
+    @Override
+    public PCollectionTuple expand(PCollection<KV<String, String>> input) {
+
+      PCollectionTuple udfOut =
+              input
+                      // Map the incoming messages into FailsafeElements so we can recover from failures
+                      // across multiple transforms.
+                      .apply("MapToRecord", ParDo.of(new MessageToFailsafeElementFn()))
+                      .apply(
+                              "InvokeUDF",
+                              FailsafeJavascriptUdf.<KV<String, String>>newBuilder()
+                                      .setFileSystemPath(options.getJavascriptTextTransformGcsPath())
+                                      .setFunctionName(options.getJavascriptTextTransformFunctionName())
+                                      .setSuccessTag(UDF_OUT)
+                                      .setFailureTag(UDF_DEADLETTER_OUT)
+                                      .build());
+
+      // Re-wrap the PCollections so we can return a single PCollectionTuple
+      return PCollectionTuple.of(UDF_OUT, udfOut.get(UDF_OUT))
+              .and(UDF_DEADLETTER_OUT, udfOut.get(UDF_DEADLETTER_OUT));
+    }
+  }
+
+  /**
+   * The {@link MessageToFailsafeElementFn} wraps an Kafka Message with the {@link FailsafeElement}
+   * class so errors can be recovered from and the original message can be output to a error records
+   * table.
+   */
+  static class MessageToFailsafeElementFn
+          extends DoFn<KV<String, String>, FailsafeElement<KV<String, String>, String>> {
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      KV<String, String> message = context.element();
+      context.output(FailsafeElement.of(message, message.getValue()));
+    }
+  }
+
+  /**
+   * The {@link WriteKafkaMessageErrors} class is a transform which can be used to write messages
+   * which failed processing to an error records table. Each record is saved to the error table is
+   * enriched with the timestamp of that record and the details of the error including an error
+   * message and stacktrace for debugging.
+   */
+  @AutoValue
+  public abstract static class WriteKafkaMessageErrors
+          extends PTransform<PCollection<FailsafeElement<KV<String, String>, String>>, WriteResult> {
+
+    public abstract ValueProvider<String> getErrorRecordsTable();
+
+    public abstract String getErrorRecordsTableSchema();
+
+    public static Builder newBuilder() {
+      return new AutoValue_MultipleKafkaTopicsToBigQuery_WriteKafkaMessageErrors.Builder();
+    }
+
+    /** Builder for {@link WriteKafkaMessageErrors}. */
+    @AutoValue.Builder
+    public abstract static class Builder {
+      public abstract Builder setErrorRecordsTable(ValueProvider<String> errorRecordsTable);
+
+      public abstract Builder setErrorRecordsTableSchema(String errorRecordsTableSchema);
+
+      public abstract WriteKafkaMessageErrors build();
+    }
+
+    @Override
+    public WriteResult expand(
+            PCollection<FailsafeElement<KV<String, String>, String>> failedRecords) {
+
+      return failedRecords
+              .apply("FailedRecordToTableRow", ParDo.of(new FailedMessageToTableRowFn()))
+              .apply(
+                      "WriteFailedRecordsToBigQuery",
+                      BigQueryIO.writeTableRows()
+                              .to(getErrorRecordsTable())
+                              .withJsonSchema(getErrorRecordsTableSchema())
+                              .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
+                              .withWriteDisposition(WriteDisposition.WRITE_APPEND));
+    }
+  }
+
+  /**
+   * The {@link FailedMessageToTableRowFn} converts Kafka message which have failed processing into
+   * {@link TableRow} objects which can be output to a dead-letter table.
+   */
+  public static class FailedMessageToTableRowFn
+          extends DoFn<FailsafeElement<KV<String, String>, String>, TableRow> {
+
+    /**
+     * The formatter used to convert timestamps into a BigQuery compatible <a
+     * href="https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp-type">format</a>.
+     */
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER =
+            DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      FailsafeElement<KV<String, String>, String> failsafeElement = context.element();
+      final KV<String, String> message = failsafeElement.getOriginalPayload();
+
+      // Format the timestamp for insertion
+      String timestamp =
+              TIMESTAMP_FORMATTER.print(context.timestamp().toDateTime(DateTimeZone.UTC));
+
+      // Build the table row
+      final TableRow failedRow =
+              new TableRow()
+                      .set("timestamp", timestamp)
+                      .set("errorMessage", failsafeElement.getErrorMessage())
+                      .set("stacktrace", failsafeElement.getStacktrace());
+
+      // Only set the payload if it's populated on the message.
+      failedRow.set(
+              "payloadString",
+              "key: "
+                      + (message.getKey() == null ? "" : message.getKey())
+                      + "value: "
+                      + (message.getValue() == null ? "" : message.getValue()));
+      context.output(failedRow);
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/teleport/templates/MultipleKafkaTopicsToBigQuery.java
+++ b/src/main/java/com/google/cloud/teleport/templates/MultipleKafkaTopicsToBigQuery.java
@@ -154,11 +154,6 @@ public class MultipleKafkaTopicsToBigQuery {
     ValueProvider<String> getBootstrapServers();
 
     void setBootstrapServers(ValueProvider<String> value);
-
-    @Description("Deadletter Table Spec")
-    ValueProvider<String> getOutputDeadletterTable();
-
-    void setOutputDeadletterTable(ValueProvider<String> value);
   }
 
   /**
@@ -223,7 +218,7 @@ public class MultipleKafkaTopicsToBigQuery {
                                     // Change Data Capture). Once Dataflow dynamic templates are available, this can
                                     // be deprecated.
                                     .withNumSplits(1))
-                    .apply(ParDo.of(new DoFn<KafkaRecord<String, String>, KV<String, String>>(){
+                    .apply("SetRecordToProperTableName", ParDo.of(new DoFn<KafkaRecord<String, String>, KV<String, String>>(){
                       @ProcessElement
                       public void processElement(ProcessContext c){
                         KafkaRecord<String, String> element = c.element();

--- a/src/test/java/com/google/cloud/teleport/templates/MultipleKafkaTopicsToBigQueryTest.java
+++ b/src/test/java/com/google/cloud/teleport/templates/MultipleKafkaTopicsToBigQueryTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.teleport.templates;
+
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.cloud.teleport.coders.FailsafeElementCoder;
+import com.google.cloud.teleport.templates.KafkaToBigQuery.MessageToTableRow;
+import com.google.common.io.Resources;
+import org.apache.beam.sdk.coders.CoderRegistry;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/** Test cases for the {@link MultipleKafkaTopicsToBigQueryTest} class. */
+public class MultipleKafkaTopicsToBigQueryTest {
+
+  @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+
+  private static final String RESOURCES_DIR = "JavascriptTextTransformerTest/";
+
+  private static final String TRANSFORM_FILE_PATH =
+      Resources.getResource(RESOURCES_DIR + "transform.js").getPath();
+
+  /** Tests the {@link MultipleKafkaTopicsToBigQueryTest} pipeline end-to-end. */
+  @Test
+  public void testMultipleKafkaTopicsToBigQueryE2E() throws Exception {
+    // Test input
+    final String key = "{\"id\": \"1001\"}";
+    final String payload = "{\"ticker\": \"GOOGL\", \"price\": 1006.94}";
+    final KV<String, String> message = KV.of(key, payload);
+
+    final Instant timestamp =
+        new DateTime(2022, 2, 22, 22, 22, 22, 222, DateTimeZone.UTC).toInstant();
+
+    final FailsafeElementCoder<KV<String, String>, String> coder =
+        FailsafeElementCoder.of(
+            KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()), StringUtf8Coder.of());
+
+    CoderRegistry coderRegistry = pipeline.getCoderRegistry();
+    coderRegistry.registerCoderForType(coder.getEncodedTypeDescriptor(), coder);
+
+    // Parameters
+    ValueProvider<String> transformPath = pipeline.newProvider(TRANSFORM_FILE_PATH);
+    ValueProvider<String> transformFunction = pipeline.newProvider("transform");
+
+    MultipleKafkaTopicsToBigQuery.Options options =
+        PipelineOptionsFactory.create().as(MultipleKafkaTopicsToBigQuery.Options.class);
+
+    options.setJavascriptTextTransformGcsPath(transformPath);
+    options.setJavascriptTextTransformFunctionName(transformFunction);
+/*
+    // Build pipeline
+    PCollectionTuple transformOut =
+        pipeline
+            .apply(
+                "ReadFromKafka",
+                Create.of(message)
+                    .withCoder(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply("TransformMessagesUsingUDF", new TransformMessagesUsingUDF(options));
+
+    // Assert
+    PAssert.that(transformOut.get(MultipleKafkaTopicsToBigQuery.UDF_DEADLETTER_OUT)).empty();
+
+    PAssert.that(transformOut.get(KafkaToBigQuery.TRANSFORM_DEADLETTER_OUT)).empty();
+    PAssert.that(transformOut.get(KafkaToBigQuery.TRANSFORM_OUT))
+        .satisfies(
+            collection -> {
+              TableRow result = collection.iterator().next();
+              assertThat(result.get("ticker"), is(equalTo("GOOGL")));
+              assertThat(result.get("price"), is(equalTo(1006.94)));
+              return null;
+            });
+*/
+    // Execute pipeline
+    pipeline.run();
+  }
+}


### PR DESCRIPTION
Allow user to use 1 Dataflow for multiple Kafka topics and stream the messages to multiple BigQuery tables. Messages from a topic would be exported to one table. 

Usage:
```
bootstrapServers=myhost:9092
inputTopicRegex=topicPrefix(.*)
outputTableRegexPattern=topicPrefix(.*)
outputTableReplacement=BigQueryProjectID:dataset.tblPrefix$1Suffix
javascriptTextTransformGcsPath=gs://mybucket/my_udf_file.js
javascriptTextTransformFunctionName=my_transform_function
```

Example:
you have 3 topics in Kafka, named: topicPrefixFirst, topicPrefixSecond, and topicPrefixThird
Messages from all topics would be streamed to 3 tables.
- Messages in topicPrefixFirst would be streamed to BigQueryProjectID:dataset.tblPrefixFirstSuffix
- Messages in topicSecondFirst would be streamed to BigQueryProjectID:dataset.tblPrefixSecondSuffix
- Messages in topicThirdFirst would be streamed to BigQueryProjectID:dataset.tblPrefixThirdSuffix

I know this modification is still far from perfect. But, I am very glad to hear your suggestions and advice so we could make it perfect together. 

Thanks in advance