### PR TITLE
Remove duplicate com.google.truth dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,12 +252,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.truth</groupId>
-      <artifactId>truth</artifactId>
-      <version>${truth.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mock-server</groupId>
       <artifactId>mockserver-netty</artifactId>
       <version>${mock-server-netty.version}</version>


### PR DESCRIPTION
Fixes maven build warning
```bash
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: com.google.truth:truth:jar -> duplicate declaration of version ${truth.version}
```