### PR TITLE
Change Write Disposition from WRITE_TRUNCATE to WRITE_APPEND

### DIFF
--- a/src/main/java/com/google/cloud/teleport/templates/TextIOToBigQuery.java
+++ b/src/main/java/com/google/cloud/teleport/templates/TextIOToBigQuery.java
@@ -147,7 +147,7 @@ public class TextIOToBigQuery {
                         }))
                 .to(options.getOutputTable())
                 .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
-                .withWriteDisposition(WriteDisposition.WRITE_TRUNCATE)
+                .withWriteDisposition(WriteDisposition.WRITE_APPEND)
                 .withCustomGcsTempLocation(options.getBigQueryLoadingTemporaryDirectory()));
 
     pipeline.run();


### PR DESCRIPTION
Setting a default template to delete all existing data in a BQ table not only limits its use, but is also a bit dangerous (as I just found out, all my existing data was gone when I started using Dataflow). Setting it to Append instead makes the template more useful. Most people who end up using this template probably want to schedule Dataflow to incrementally new data as it arrives. The trucation at the moment is a dangerous side effect, as someone running this template would have no clue they are going to lose all existing data by using this template.