### PR TITLE
Fixes to CDC template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 bin/
 dependency-reduced-pom.xml
 
+.idea

--- a/v2/cdc-parent/README.md
+++ b/v2/cdc-parent/README.md
@@ -62,7 +62,7 @@ It will need to be supplied of two/three
 basic configuration files:
 
 - A properties file containing:
-  - The name of the database: `databaseName=...`
+  - The instance name in GCP: `instanceName=...`
   - A username to access the database changelog: `databaseUsername=...`
   - An IP address or DNS to connect to the database: `databaseAddress=...`
   - **Optionally** a port to connect to the database: `databasePort=...` (default: 3306)
@@ -211,10 +211,10 @@ This prefix will be passed as an argument to the Debezium connector, along with
 a Google Cloud project. The PubSub topics that we'll create are:
 
 - Table: `my-mysql.cdc_demo.people`
-  - Topic: `export_demo_my-mysql_cdc_demo_people`
+  - Topic: `export_demo_my-mysql.cdc_demo.people`
   - Subscription: `cdc_demo_people_subscription`
 - Table: `my-mysql.cdc_demo.pets`
-  - Topic: `export_demo_my-mysql_cdc_demo_pets`
+  - Topic: `export_demo_my-mysql.cdc_demo.pets`
   - Subscription: `cdc_demo_pets_subscription`
 
 You can then pass this prefix to the Debezium connector via properties

--- a/v2/cdc-parent/cdc-change-applier/src/main/java/com/google/cloud/dataflow/cdc/applier/BigQueryChangeApplier.java
+++ b/v2/cdc-parent/cdc-change-applier/src/main/java/com/google/cloud/dataflow/cdc/applier/BigQueryChangeApplier.java
@@ -144,7 +144,7 @@ public class BigQueryChangeApplier extends PTransform<PCollection<Row>, PDone> {
             .withSideInputs(schemaMapView))
         .apply("BuildMergeStatements",
             ParDo.of(
-                new MergeStatementBuildingFn(replicaDataset, changeLogDataset, gcpProjectId)))
+                new MergeStatementBuildingFn(changeLogDataset, replicaDataset, gcpProjectId)))
         .setCoder(SerializableCoder.of(
             TypeDescriptors.kvs(
                 TypeDescriptors.strings(),

--- a/v2/cdc-parent/cdc-embedded-connector/src/main/java/com/google/cloud/dataflow/cdc/connector/App.java
+++ b/v2/cdc-parent/cdc-embedded-connector/src/main/java/com/google/cloud/dataflow/cdc/connector/App.java
@@ -33,7 +33,7 @@ import org.slf4j.impl.StaticLoggerBinder;
  * connector will look for a properties file in {@literal /etc/dataflow_cdc.properties}, and it
  * expects the following parameters:</p>
  *
- * * {@literal databaseName} - the string name of a MySQL database.
+ * * {@literal instanceName} - the instance name on GCP.
  * * {@literal databaseUsername} - a user with privileges to access the binary log for MySQL.
  * * {@literal databasePassword} - the password to use to log into the database. This parameter can
  *     be passed with the default properties file, or in a separate properties file
@@ -96,7 +96,7 @@ public class App {
             System.getenv("GOOGLE_APPLICATION_CREDENTIALS"));
 
         startSender(
-            config.getString("databaseName"),
+            config.getString("instanceName"),
             config.getString("databaseUsername"),
             config.getString("databasePassword"),
             config.getString("databaseAddress"),
@@ -147,7 +147,7 @@ public class App {
     }
 
     static void startSender(
-        String databaseName,
+        String instanceName,
         String databaseUserName,
         String databasePassword,
         String databaseAddress,
@@ -158,7 +158,7 @@ public class App {
         Boolean inMemoryOffsetStorage,
         String commaSeparatedWhiteListedTables) {
         DebeziumMysqlToPubSubDataSender dataSender = new DebeziumMysqlToPubSubDataSender(
-            databaseName,
+            instanceName,
             databaseUserName,
             databasePassword,
             databaseAddress,

--- a/v2/cdc-parent/cdc-embedded-connector/src/main/resources/dataflow_cdc.properties
+++ b/v2/cdc-parent/cdc-embedded-connector/src/main/resources/dataflow_cdc.properties
@@ -1,4 +1,4 @@
-databaseName=${DATABASE}
+instanceName=${DB_INSTANCE}
 databaseUsername=${DB_USERNAME}
 databaseAddress=${DB_ADDRESS}
 databasePort=${DB_PORT}


### PR DESCRIPTION
* Change databaseName property to instanceName that maps
  to Debezium's property database.server.name.
* Clarify in README that PubSub topic names are dot separated
  in the form ${PREFIX}${DB_INSTANCE}.${DATABASE}.${TABLE}
* Fix order in which changeLogDataset, replicaDataset names
  are passed to MergeStatementBuildingFn in BigQueryChangeApplier.
* Pass whitelistedTables property to Debezium.

Resolves #98.