### PR TITLE
CDC Template: add support for INT16 data type (MySQL TINYINT).

### DIFF
--- a/v2/cdc-parent/cdc-common/src/main/java/com/google/cloud/dataflow/cdc/common/SchemaUtils.java
+++ b/v2/cdc-parent/cdc-common/src/main/java/com/google/cloud/dataflow/cdc/common/SchemaUtils.java
@@ -40,6 +40,7 @@ public class SchemaUtils {
           .put("BOOL", org.apache.beam.sdk.schemas.Schema.TypeName.BOOLEAN)
           .put("BYTES", org.apache.beam.sdk.schemas.Schema.TypeName.BYTES)
           .put("DOUBLE", org.apache.beam.sdk.schemas.Schema.TypeName.DOUBLE)
+          .put("INT16", org.apache.beam.sdk.schemas.Schema.TypeName.INT16)
           .put("INT32", org.apache.beam.sdk.schemas.Schema.TypeName.INT32)
           .put("INT64", org.apache.beam.sdk.schemas.Schema.TypeName.INT64)
           .put("STRING", org.apache.beam.sdk.schemas.Schema.TypeName.STRING)

--- a/v2/cdc-parent/cdc-common/src/test/java/com/google/cloud/dataflow/cdc/common/SchemaUtilsTest.java
+++ b/v2/cdc-parent/cdc-common/src/test/java/com/google/cloud/dataflow/cdc/common/SchemaUtilsTest.java
@@ -39,6 +39,7 @@ public class SchemaUtilsTest {
             .addField(Field.of("city", FieldType.STRING))
             .addStringField("country")
             .addInt32Field("year_founded")
+            .addInt16Field("tiny_int")
             .build())
         .addInt64Field("timestampMs")
         .build();


### PR DESCRIPTION
This adds support for INT16 Beam schema type to allow streaming MySQL tables with TINYINT columns.

Resolves #101
Attn: @pabloem