### PR TITLE
Add --tokenKMSEncryptionKey option for PubSubToSplunkTemplate.

### DIFF
--- a/src/main/java/com/google/cloud/teleport/templates/common/SplunkConverters.java
+++ b/src/main/java/com/google/cloud/teleport/templates/common/SplunkConverters.java
@@ -116,6 +116,13 @@ public class SplunkConverters {
     ValueProvider<Boolean> getIncludePubsubMessage();
   
     void setIncludePubsubMessage(ValueProvider<Boolean> includePubsubMessage);
+
+    @Description(
+        "KMS Encryption Key for the token. The Key should be in the format "
+            + "projects/{gcp_project}/locations/{key_region}/keyRings/{key_ring}/cryptoKeys/{kms_key_name}")
+    ValueProvider<String> getTokenKMSEncryptionKey();
+
+    void setTokenKMSEncryptionKey(ValueProvider<String> keyName);
   }
 
   private static class FailsafeStringToSplunkEvent


### PR DESCRIPTION
Adds an optional parameter to specify a Cloud KMS Encryption Key if an encrypted `token` parameter is passed to the template.

Fixes #122 