### PR TITLE
Add stale bot configuration to auto-close stale PRs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,28 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: pulls
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+pulls:
+  # Number of days of inactivity before an Issue or Pull Request becomes stale
+  daysUntilStale: 45
+  # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+  # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+  daysUntilClose: 7
+  # Comment to post when marking as stale. Set to `false` to disable
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+  # Label to use when marking as stale
+  staleLabel: stale
+
+  # Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+  exemptLabels:
+    - pinned
+    - security
+    - "[Status] Maybe Later"


### PR DESCRIPTION
This configuration will:
* Close PRs open with no activity for longer than 45 days
* Give a 7 day warning before closing
* Allow for the assignment of labels to disable this behavior for a particular PR

Fixes #124 