### PR TITLE
Fix batched messages sent to deadletter topic for PubSubToSplunk template

### DIFF
--- a/src/main/java/com/google/cloud/teleport/splunk/HttpEventPublisher.java
+++ b/src/main/java/com/google/cloud/teleport/splunk/HttpEventPublisher.java
@@ -177,7 +177,8 @@ public abstract class HttpEventPublisher {
   }
 
   /** Utility method to get payload string from a list of {@link SplunkEvent}s. */
-  protected String getStringPayload(List<SplunkEvent> events) {
+  @VisibleForTesting
+  String getStringPayload(List<SplunkEvent> events) {
     StringBuilder sb = new StringBuilder();
     events.forEach(event -> sb.append(GSON.toJson(event)));
     return sb.toString();


### PR DESCRIPTION
Fixes concatenated messages sent to the deadletter topic if the `batchCount` is set to higher than 1. 