### PR TITLE
Updated merge statement to avoid duplicates

### DIFF
--- a/v2/cdc-parent/cdc-change-applier/src/main/java/com/google/cloud/dataflow/cdc/applier/MergeStatementBuildingFn.java
+++ b/v2/cdc-parent/cdc-change-applier/src/main/java/com/google/cloud/dataflow/cdc/applier/MergeStatementBuildingFn.java
@@ -143,8 +143,8 @@ public class MergeStatementBuildingFn
       "ON %s ",
       "WHEN MATCHED AND changelog.operation = \"DELETE\" ",
       "THEN DELETE ",
-      "WHEN MATCHED THEN %s ",
-      "WHEN NOT MATCHED BY TARGET AND changelog.operation != \"DELETE\" THEN %s");
+      "WHEN MATCHED AND changelog.operation = \"UPDATE\" THEN %s ",
+      "WHEN NOT MATCHED BY TARGET AND changelog.operation = \"INSERT\" THEN %s");
 
   public static String buildQueryMergeReplicaTableWithChangeLogTable(
       String replicaTableName, String changelogTableName,


### PR DESCRIPTION
Changed merges to avoid duplicate PK rows in the replica table caused by rapid inserts and updates on the same PK