### PR TITLE
handle auto-mapping of records and repeated fields along with auto-detection of basic data types

### DIFF
--- a/v2/pubsub-cdc-to-bigquery/README.md
+++ b/v2/pubsub-cdc-to-bigquery/README.md
@@ -22,6 +22,7 @@ used to launch the Dataflow pipeline.
 export PROJECT=<my-project>
 export IMAGE_NAME=pubsub-cdc-to-bigquery
 export BUCKET_NAME=gs://<bucket-name>
+export DATASET_TEMPLATE=<dataset-name>
 export TARGET_GCR_IMAGE=gcr.io/${PROJECT}/${IMAGE_NAME}
 export BASE_CONTAINER_IMAGE=gcr.io/dataflow-templates-base/java8-template-launcher-base
 export BASE_CONTAINER_IMAGE_VERSION=latest


### PR DESCRIPTION
This fixes #130 

In addition to mapping json arrays to REPEATED fields and json objects to recursive BQ RECORDS, it also creates BQ fields of INTEGER, BOOLEAN, FLOAT, with a default fallback to STRING. I prefer this behaviour as it will lead to a BQ schema with the "right" data types which in turn should optimize storage and query performance. The risk in this level of schema evolution is that we could detect false positives like this:

`{"id": 1, "message": true} <== would create a field message of type BOOLEAN `
`{"id": 2, "message": "hello world"} <== this would then fail on inserting`

To me the benefit of getting the BQ datatype right outweighs the risk of this false positive, but other may feel differently. So maybe the type auto-mapping can be turned on and off with a new config option? 
The new logic from 2b655c77cb915be79cb2485f67b1afb71ad2eb3e actually helps with the situation. Because if we played it safe and created the field as STRING, the boolean value would still get inserted. 