### PR TITLE
Fix #153 - v2 flex-template image compilation failure

### DIFF
--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -572,7 +572,6 @@
     <modules>
         <module>bigquery-to-elasticsearch</module>
         <module>bigquery-to-parquet</module>
-        <module>datastream-to-bigquery</module>
         <module>common</module>
         <module>cdc-parent</module>
         <module>csv-to-elasticsearch</module>


### PR DESCRIPTION
The datastream-to-bigquery module entry in the v2 pom.xml file points
to a non-existent module which results in compiliation errors when
building flex-template images.
This fix removes the module entry to enable successful compliations.