### PR TITLE
Add support for custom DateTime patterns for WindowedFilenamePolicy class

### DIFF
--- a/src/main/java/com/google/cloud/teleport/io/WindowedFilenamePolicy.java
+++ b/src/main/java/com/google/cloud/teleport/io/WindowedFilenamePolicy.java
@@ -16,6 +16,10 @@
 
 package com.google.cloud.teleport.io;
 
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+
+import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.io.DefaultFilenamePolicy;
 import org.apache.beam.sdk.io.FileBasedSink.FilenamePolicy;
 import org.apache.beam.sdk.io.FileBasedSink.OutputFileHints;
@@ -27,6 +31,7 @@ import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -38,60 +43,264 @@ import org.slf4j.LoggerFactory;
  * writes.
  */
 @SuppressWarnings("serial")
-public class WindowedFilenamePolicy extends FilenamePolicy {
+@AutoValue
+public abstract class WindowedFilenamePolicy extends FilenamePolicy {
   /** The logger to output status messages to. */
   private static final Logger LOG = LoggerFactory.getLogger(WindowedFilenamePolicy.class);
-
-  private static final DateTimeFormatter YEAR = DateTimeFormat.forPattern("YYYY");
-  private static final DateTimeFormatter MONTH = DateTimeFormat.forPattern("MM");
-  private static final DateTimeFormatter DAY = DateTimeFormat.forPattern("dd");
-  private static final DateTimeFormatter HOUR = DateTimeFormat.forPattern("HH");
-  private static final DateTimeFormatter MINUTE = DateTimeFormat.forPattern("mm");
-  /** The filename baseFile. */
-  private final ValueProvider<String> outputDirectory;
-  /** The prefix of the file to output. */
-  private final ValueProvider<String> outputFilenamePrefix;
-  /** The filename suffix. */
-  private final ValueProvider<String> suffix;
-  /** The shard template used during file formatting. */
-  private final ValueProvider<String> shardTemplate;
-
-  /**
-   * Constructs a new {@link WindowedFilenamePolicy} with the supplied baseFile used for output
-   * files.
-   *
-   * @param outputDirectory The output directory for all files.
-   * @param outputFilenamePrefix The common prefix for output files.
-   * @param shardTemplate The template used to create uniquely named sharded files.
-   * @param suffix The suffix to append to all files output by the policy.
-   */
-  public WindowedFilenamePolicy(
-      String outputDirectory, String outputFilenamePrefix, String shardTemplate, String suffix) {
-    this(
-        StaticValueProvider.of(outputDirectory),
-        StaticValueProvider.of(outputFilenamePrefix),
-        StaticValueProvider.of(shardTemplate),
-        StaticValueProvider.of(suffix));
+  
+  public static WindowedFilenamePolicy writeWindowedFiles() {
+    return new AutoValue_WindowedFilenamePolicy.Builder().build();
   }
-
+  
+  @Nullable
+  abstract ValueProvider<String> outputDirectory();
+  
+  @Nullable
+  abstract ValueProvider<String> outputFilenamePrefix();
+  
+  @Nullable
+  abstract ValueProvider<String> shardTemplate();
+  
+  @Nullable
+  abstract ValueProvider<String> suffix();
+  
+  @Nullable
+  abstract ValueProvider<String> yearPattern();
+  
+  @Nullable
+  abstract ValueProvider<String> monthPattern();
+  
+  @Nullable
+  abstract ValueProvider<String> dayPattern();
+  
+  @Nullable
+  abstract ValueProvider<String> hourPattern();
+  
+  @Nullable
+  abstract ValueProvider<String> minutePattern();
+  
+  abstract Builder toBuilder();
+  
+  @AutoValue.Builder
+  abstract static class Builder {
+    
+    abstract Builder setOutputDirectory(ValueProvider<String> outputDirectory);
+    
+    abstract Builder setOutputFilenamePrefix(ValueProvider<String> outputFilenamePrefix);
+    
+    abstract Builder setShardTemplate(ValueProvider<String> shardTemplate);
+    
+    abstract Builder setSuffix(ValueProvider<String> suffix);
+    
+    abstract Builder setYearPattern(ValueProvider<String> year);
+    
+    abstract Builder setMonthPattern(ValueProvider<String> month);
+    
+    abstract Builder setDayPattern(ValueProvider<String> day);
+    
+    abstract Builder setHourPattern(ValueProvider<String> hour);
+    
+    abstract Builder setMinutePattern(ValueProvider<String> minute);
+    
+    abstract WindowedFilenamePolicy build();
+  }
+  
   /**
-   * Constructs a new {@link WindowedFilenamePolicy} with the supplied baseFile used for output
-   * files.
+   * Sets the directory to output files to.
    *
-   * @param outputDirectory The output directory for all files.
-   * @param outputFilenamePrefix The common prefix for output files.
-   * @param shardTemplate The template used to create uniquely named sharded files.
-   * @param suffix The suffix to append to all files output by the policy.
+   * @param outputDirectory The filename baseFile.
+   * @return {@link WindowedFilenamePolicy}
    */
-  public WindowedFilenamePolicy(
-      ValueProvider<String> outputDirectory,
-      ValueProvider<String> outputFilenamePrefix,
-      ValueProvider<String> shardTemplate,
-      ValueProvider<String> suffix) {
-    this.outputDirectory = outputDirectory;
-    this.outputFilenamePrefix = outputFilenamePrefix;
-    this.shardTemplate = shardTemplate;
-    this.suffix = suffix;
+  public WindowedFilenamePolicy withOutputDirectory(ValueProvider<String> outputDirectory) {
+    checkArgument(outputDirectory != null, "withOutputDirectory(outputDirectory) called with null input.");
+    return toBuilder().setOutputDirectory(outputDirectory).build();
+  }
+  
+  /**
+   * Sets the filename prefix of the files to write to.
+   *
+   * @param outputFilenamePrefix The prefix of the file to output.
+   * @return {@link WindowedFilenamePolicy}
+   */
+  public WindowedFilenamePolicy withOutputFilenamePrefix(ValueProvider<String> outputFilenamePrefix) {
+    checkArgument(outputFilenamePrefix != null, "withOutputFilenamePrefix(outputFilenamePrefix) called with null input.");
+    return toBuilder().setOutputFilenamePrefix(outputFilenamePrefix).build();
+  }
+  
+  /**
+   * Sets the shard template of the output file.
+   *
+   * @param shardTemplate The shard template used during file formatting.
+   * @return {@link WindowedFilenamePolicy}
+   */
+  public WindowedFilenamePolicy withShardTemplate(ValueProvider<String> shardTemplate) {
+    checkArgument(shardTemplate != null, "withShardTemplate(shardTemplate) called with null input.");
+    return toBuilder().setShardTemplate(shardTemplate).build();
+  }
+  
+  /**
+   * Sets the suffix of the files to write.
+   *
+   * @param suffix The filename suffix.
+   * @return {@link WindowedFilenamePolicy}
+   */
+  public WindowedFilenamePolicy withSuffix(ValueProvider<String> suffix) {
+    checkArgument(suffix != null, "withSuffix(suffix) called with null input.");
+    return toBuilder().setSuffix(suffix).build();
+  }
+  
+  /**
+   * Sets the custom year pattern to use for the output directory.
+   *
+   * @param year The custom year pattern.
+   * @return {@link WindowedFilenamePolicy}
+   */
+  public WindowedFilenamePolicy withYearPattern(ValueProvider<String> year) {
+    checkArgument(year != null, "withYear(year) called with null input.");
+    return toBuilder().setYearPattern(year).build();
+  }
+  
+  /**
+   * Sets the custom month pattern to use for the output directory.
+   *
+   * @param month The custom month pattern.
+   * @return {@link WindowedFilenamePolicy}
+   */
+  public WindowedFilenamePolicy withMonthPattern(ValueProvider<String> month) {
+    checkArgument(month != null, "withMonth(month) called with null input.");
+    return toBuilder().setMonthPattern(month).build();
+  }
+  
+  /**
+   * Sets the custom day pattern to use for the output directory.
+   *
+   * @param day The custom day pattern.
+   * @return {@link WindowedFilenamePolicy}
+   */
+  public WindowedFilenamePolicy withDayPattern(ValueProvider<String> day) {
+    checkArgument(day != null, "withDay(day) called with null input.");
+    return toBuilder().setDayPattern(day).build();
+  }
+  
+  /**
+   * Sets the custom hour pattern to use for the output directory.
+   *
+   * @param hour The custom hour pattern.
+   * @return {@link WindowedFilenamePolicy}
+   */
+  public WindowedFilenamePolicy withHourPattern(ValueProvider<String> hour) {
+    checkArgument(hour != null, "withHour(hour) called with null input.");
+    return toBuilder().setHourPattern(hour).build();
+  }
+  
+  /**
+   * Sets the custom minute pattern to use for the output directory.
+   *
+   * @param minute The custom minute pattern.
+   * @return {@link WindowedFilenamePolicy}
+   */
+  public WindowedFilenamePolicy withMinutePattern(ValueProvider<String> minute) {
+    checkArgument(minute != null, "withMinute(minute) called with null input.");
+    return toBuilder().setMinutePattern(minute).build();
+  }
+  
+  /**
+   * Same as {@link WindowedFilenamePolicy#withOutputDirectory(ValueProvider)} but without {@link ValueProvider}.
+   *
+   * @param outputDirectory The filename baseFile.
+   * @return {@link WindowedFilenamePolicy}
+   */
+  public WindowedFilenamePolicy withOutputDirectory(String outputDirectory) {
+    checkArgument(outputDirectory != null, "withOutputDirectory(outputDirectory) called with null input.");
+    return toBuilder().setOutputDirectory(StaticValueProvider.of(outputDirectory)).build();
+  }
+  
+  /**
+   * Same as {@link WindowedFilenamePolicy#withOutputFilenamePrefix(ValueProvider)} but without {@link ValueProvider}.
+   *
+   * @param outputFilenamePrefix The prefix of the file to output.
+   * @return {@link WindowedFilenamePolicy}
+   */
+  public WindowedFilenamePolicy withOutputFilenamePrefix(String outputFilenamePrefix) {
+    checkArgument(outputFilenamePrefix != null, "withOutputFilenamePrefix(outputFilenamePrefix) called with null input.");
+    return toBuilder().setOutputFilenamePrefix(StaticValueProvider.of(outputFilenamePrefix)).build();
+  }
+  
+  /**
+   * Same as {@link WindowedFilenamePolicy#withShardTemplate(ValueProvider)} but without {@link ValueProvider}.
+   *
+   * @param shardTemplate The shard template used during file formatting.
+   * @return {@link WindowedFilenamePolicy}
+   */
+  public WindowedFilenamePolicy withShardTemplate(String shardTemplate) {
+    checkArgument(shardTemplate != null, "withShardTemplate(shardTemplate) called with null input.");
+    return toBuilder().setShardTemplate(StaticValueProvider.of(shardTemplate)).build();
+  }
+  
+  /**
+   * Same as {@link WindowedFilenamePolicy#withSuffix(ValueProvider)} but without {@link ValueProvider}.
+   *
+   * @param suffix The filename suffix.
+   * @return {@link WindowedFilenamePolicy}
+   */
+  public WindowedFilenamePolicy withSuffix(String suffix) {
+    checkArgument(suffix != null, "withSuffix(suffix) called with null input.");
+    return toBuilder().setSuffix(StaticValueProvider.of(suffix)).build();
+  }
+  
+  /**
+   * Same as {@link WindowedFilenamePolicy#withYearPattern(ValueProvider)} but without {@link ValueProvider}.
+   *
+   * @param year The custom year pattern.
+   * @return {@link WindowedFilenamePolicy}
+   */
+  public WindowedFilenamePolicy withYearPattern(String year) {
+    checkArgument(year != null, "withYear(year) called with null input.");
+    return toBuilder().setYearPattern(StaticValueProvider.of(year)).build();
+  }
+  
+  /**
+   * Same as {@link WindowedFilenamePolicy#withMonthPattern(ValueProvider)} but without {@link ValueProvider}.
+   *
+   * @param month The custom month pattern.
+   * @return {@link WindowedFilenamePolicy}
+   */
+  public WindowedFilenamePolicy withMonthPattern(String month) {
+    checkArgument(month != null, "withMonth(month) called with null input.");
+    return toBuilder().setMonthPattern(StaticValueProvider.of(month)).build();
+  }
+  
+  /**
+   * Same as {@link WindowedFilenamePolicy#withDayPattern(ValueProvider)} but without {@link ValueProvider}.
+   *
+   * @param day The custom day pattern.
+   * @return {@link WindowedFilenamePolicy}
+   */
+  public WindowedFilenamePolicy withDayPattern(String day) {
+    checkArgument(day != null, "withDay(day) called with null input.");
+    return toBuilder().setDayPattern(StaticValueProvider.of(day)).build();
+  }
+  
+  /**
+   * Same as {@link WindowedFilenamePolicy#withHourPattern(ValueProvider)} but without {@link ValueProvider}.
+   *
+   * @param hour The custom hour pattern.
+   * @return {@link WindowedFilenamePolicy}
+   */
+  public WindowedFilenamePolicy withHourPattern(String hour) {
+    checkArgument(hour != null, "withHour(hour) called with null input.");
+    return toBuilder().setHourPattern(StaticValueProvider.of(hour)).build();
+  }
+  
+  /**
+   * Same as {@link WindowedFilenamePolicy#withMinutePattern(ValueProvider)} but without {@link ValueProvider}.
+   *
+   * @param minute The custom minute pattern.
+   * @return {@link WindowedFilenamePolicy}
+   */
+  public WindowedFilenamePolicy withMinutePattern(String minute) {
+    checkArgument(minute != null, "withMinute(minute) called with null input.");
+    return toBuilder().setMinutePattern(StaticValueProvider.of(minute)).build();
   }
 
   /**
@@ -108,13 +317,37 @@ public class WindowedFilenamePolicy extends FilenamePolicy {
       PaneInfo paneInfo,
       OutputFileHints outputFileHints) {
 
+    checkArgument(
+        outputDirectory() != null && outputDirectory().get() != null,
+        "Output directory is required for writing files.");
+
+    String shardTemplate = "";
+    String suffix = "";
+    String outputFilenamePrefix = "";
+
+    if (shardTemplate() != null) {
+      if (shardTemplate().get() != null) {
+        shardTemplate = shardTemplate().get();
+      }
+    }
+    if (suffix() != null) {
+      if (suffix().get() != null) {
+        suffix = suffix().get();
+      }
+    }
+    if (outputFilenamePrefix() != null) {
+      if (outputFilenamePrefix().get() != null) {
+        outputFilenamePrefix = outputFilenamePrefix().get();
+      }
+    }
+
     ResourceId outputFile =
-        resolveWithDateTemplates(outputDirectory, window)
-            .resolve(outputFilenamePrefix.get(), StandardResolveOptions.RESOLVE_FILE);
+        resolveWithDateTemplates(outputDirectory(), window)
+            .resolve(outputFilenamePrefix, StandardResolveOptions.RESOLVE_FILE);
 
     DefaultFilenamePolicy policy =
         DefaultFilenamePolicy.fromStandardParameters(
-            StaticValueProvider.of(outputFile), shardTemplate.get(), suffix.get(), true);
+            StaticValueProvider.of(outputFile), shardTemplate, suffix, true);
     ResourceId result =
         policy.windowedFilename(shardNumber, numShards, window, paneInfo, outputFileHints);
     LOG.debug("Windowed file name policy created: {}", result.toString());
@@ -137,22 +370,68 @@ public class WindowedFilenamePolicy extends FilenamePolicy {
   /**
    * Resolves any date variables which exist in the output directory path. This allows for the
    * dynamically changing of the output location based on the window end time.
+   * A custom pattern can be used, if provided.
    *
    * @return The new output directory with all variables resolved.
    */
-  private ResourceId resolveWithDateTemplates(
+  public ResourceId resolveWithDateTemplates(
       ValueProvider<String> outputDirectoryStr, BoundedWindow window) {
     ResourceId outputDirectory = FileSystems.matchNewResource(outputDirectoryStr.get(), true);
-
+  
     if (window instanceof IntervalWindow) {
       IntervalWindow intervalWindow = (IntervalWindow) window;
       DateTime time = intervalWindow.end().toDateTime();
       String outputPath = outputDirectory.toString();
-      outputPath = outputPath.replace("YYYY", YEAR.print(time));
-      outputPath = outputPath.replace("MM", MONTH.print(time));
-      outputPath = outputPath.replace("DD", DAY.print(time));
-      outputPath = outputPath.replace("HH", HOUR.print(time));
-      outputPath = outputPath.replace("mm", MINUTE.print(time));
+
+      // Default Date patterns.
+      String yearPattern = "YYYY";
+      String monthPattern = "MM";
+      String dayPattern = "DD";
+      String hourPattern = "HH";
+      String minutePattern = "mm";
+
+      // Use a custom pattern, if provided.
+      if (yearPattern() != null) {
+        yearPattern = MoreObjects.firstNonNull(yearPattern().get(), yearPattern);
+      }
+      LOG.debug("Year pattern set to: {}", yearPattern);
+
+      if (monthPattern() != null) {
+        monthPattern = MoreObjects.firstNonNull(monthPattern().get(), monthPattern);
+      }
+      LOG.debug("Month pattern set to: {}", monthPattern);
+
+      if (dayPattern() != null) {
+        dayPattern = MoreObjects.firstNonNull(dayPattern().get(), dayPattern);
+      }
+      LOG.debug("Day pattern set to: {}", dayPattern);
+
+      if (hourPattern() != null) {
+        hourPattern = MoreObjects.firstNonNull(hourPattern().get(), hourPattern);
+      }
+      LOG.debug("Hour pattern set to: {}", hourPattern);
+
+      if (minutePattern() != null) {
+        minutePattern = MoreObjects.firstNonNull(minutePattern().get(), minutePattern);
+      }
+      LOG.debug("Minute pattern set to: {}", minutePattern);
+
+      try {
+        final DateTimeFormatter yearFormatter = DateTimeFormat.forPattern(yearPattern);
+        final DateTimeFormatter monthFormatter = DateTimeFormat.forPattern(monthPattern);
+        final DateTimeFormatter dayFormatter = DateTimeFormat.forPattern(dayPattern);
+        final DateTimeFormatter hourFormatter = DateTimeFormat.forPattern(hourPattern);
+        final DateTimeFormatter minuteFormatter = DateTimeFormat.forPattern(minutePattern);
+    
+        outputPath = outputPath.replace(yearPattern, yearFormatter.print(time));
+        outputPath = outputPath.replace(monthPattern, monthFormatter.print(time));
+        outputPath = outputPath.replace(dayPattern, dayFormatter.print(time));
+        outputPath = outputPath.replace(hourPattern, hourFormatter.print(time));
+        outputPath = outputPath.replace(minutePattern, minuteFormatter.print(time));
+      } catch (IllegalArgumentException e) {
+        throw new RuntimeException("Could not resolve custom DateTime pattern. " + e.getMessage(), e);
+      }
+  
       outputDirectory = FileSystems.matchNewResource(outputPath, true);
     }
     return outputDirectory;

--- a/src/main/java/com/google/cloud/teleport/options/WindowedFilenamePolicyOptions.java
+++ b/src/main/java/com/google/cloud/teleport/options/WindowedFilenamePolicyOptions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.google.cloud.teleport.options;
 
 import org.apache.beam.sdk.options.Default;

--- a/src/main/java/com/google/cloud/teleport/options/WindowedFilenamePolicyOptions.java
+++ b/src/main/java/com/google/cloud/teleport/options/WindowedFilenamePolicyOptions.java
@@ -1,0 +1,64 @@
+package com.google.cloud.teleport.options;
+
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.ValueProvider;
+import org.joda.time.format.DateTimeFormat;
+
+/**
+ * Provides options for shards and overriding {@link DateTimeFormat} patterns for windowed files.
+ */
+public interface WindowedFilenamePolicyOptions extends PipelineOptions {
+
+  @Description(
+      "The shard template of the output file. Specified as repeating sequences "
+          + "of the letters 'S' or 'N' (example: SSS-NNN). These are replaced with the "
+          + "shard number, or number of shards respectively")
+  @Default.String("W-P-SS-of-NN")
+  ValueProvider<String> getOutputShardTemplate();
+  
+  void setOutputShardTemplate(ValueProvider<String> value);
+  
+  @Description("The maximum number of output shards produced when writing.")
+  @Default.Integer(1)
+  Integer getNumShards();
+  
+  void setNumShards(Integer value);
+  
+  @Description(
+      "The window duration in which data will be written. Defaults to 5m. "
+          + "Allowed formats are: "
+          + "Ns (for seconds, example: 5s), "
+          + "Nm (for minutes, example: 12m), "
+          + "Nh (for hours, example: 2h).")
+  @Default.String("5m")
+  String getWindowDuration();
+  
+  void setWindowDuration(String value);
+  
+  @Description("The custom year pattern to use for the output directory.")
+  ValueProvider<String> getYearPattern();
+  
+  void setYearPattern(ValueProvider<String> yearPattern);
+  
+  @Description("The custom month pattern to use for the output directory.")
+  ValueProvider<String> getMonthPattern();
+  
+  void setMonthPattern(ValueProvider<String> monthPattern);
+  
+  @Description("The custom day pattern to use for the output directory.")
+  ValueProvider<String> getDayPattern();
+  
+  void setDayPattern(ValueProvider<String> dayPattern);
+  
+  @Description("The custom hour pattern to use for the output directory.")
+  ValueProvider<String> getHourPattern();
+  
+  void setHourPattern(ValueProvider<String> hourPattern);
+  
+  @Description("The custom minute pattern to use for the output directory.")
+  ValueProvider<String> getMinutePattern();
+  
+  void setMinutePattern(ValueProvider<String> minutePattern);
+}

--- a/src/main/java/com/google/cloud/teleport/options/package-info.java
+++ b/src/main/java/com/google/cloud/teleport/options/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Pipeline Options for templates.
+ */
+package com.google.cloud.teleport.options;

--- a/src/main/java/com/google/cloud/teleport/templates/PubsubToText.java
+++ b/src/main/java/com/google/cloud/teleport/templates/PubsubToText.java
@@ -19,6 +19,7 @@
 package com.google.cloud.teleport.templates;
 
 import com.google.cloud.teleport.io.WindowedFilenamePolicy;
+import com.google.cloud.teleport.options.WindowedFilenamePolicyOptions;
 import com.google.cloud.teleport.util.DualInputNestedValueProvider;
 import com.google.cloud.teleport.util.DualInputNestedValueProvider.TranslatorInput;
 import com.google.cloud.teleport.util.DurationUtils;
@@ -112,7 +113,7 @@ public class PubsubToText {
    *
    * <p>Inherits standard configuration options.</p>
    */
-  public interface Options extends PipelineOptions, StreamingOptions {
+  public interface Options extends PipelineOptions, StreamingOptions, WindowedFilenamePolicyOptions {
     @Description(
         "The Cloud Pub/Sub subscription to consume from. "
             + "The name should be in the format of "
@@ -151,27 +152,6 @@ public class PubsubToText {
     @Default.String("")
     ValueProvider<String> getOutputFilenameSuffix();
     void setOutputFilenameSuffix(ValueProvider<String> value);
-
-    @Description("The shard template of the output file. Specified as repeating sequences "
-        + "of the letters 'S' or 'N' (example: SSS-NNN). These are replaced with the "
-        + "shard number, or number of shards respectively")
-    @Default.String("W-P-SS-of-NN")
-    ValueProvider<String> getOutputShardTemplate();
-    void setOutputShardTemplate(ValueProvider<String> value);
-
-    @Description("The maximum number of output shards produced when writing.")
-    @Default.Integer(1)
-    Integer getNumShards();
-    void setNumShards(Integer value);
-
-    @Description("The window duration in which data will be written. Defaults to 5m. "
-        + "Allowed formats are: "
-        + "Ns (for seconds, example: 5s), "
-        + "Nm (for minutes, example: 12m), "
-        + "Nh (for hours, example: 2h).")
-    @Default.String("5m")
-    String getWindowDuration();
-    void setWindowDuration(String value);
   }
 
   /**
@@ -228,17 +208,22 @@ public class PubsubToText {
                 .withWindowedWrites()
                 .withNumShards(options.getNumShards())
                 .to(
-                    new WindowedFilenamePolicy(
-                        options.getOutputDirectory(),
-                        options.getOutputFilenamePrefix(),
-                        options.getOutputShardTemplate(),
-                        options.getOutputFilenameSuffix()))
-                .withTempDirectory(NestedValueProvider.of(
-                    maybeUseUserTempLocation(
-                        options.getUserTempLocation(),
-                        options.getOutputDirectory()),
-                    (SerializableFunction<String, ResourceId>) input ->
-                        FileBasedSink.convertToFileResourceIfPossible(input))));
+                    WindowedFilenamePolicy.writeWindowedFiles()
+                        .withOutputDirectory(options.getOutputDirectory())
+                        .withOutputFilenamePrefix(options.getOutputFilenamePrefix())
+                        .withShardTemplate(options.getOutputShardTemplate())
+                        .withSuffix(options.getOutputFilenameSuffix())
+                        .withYearPattern(options.getYearPattern())
+                        .withMonthPattern(options.getMonthPattern())
+                        .withDayPattern(options.getDayPattern())
+                        .withHourPattern(options.getHourPattern())
+                        .withMinutePattern(options.getMinutePattern()))
+                .withTempDirectory(
+                    NestedValueProvider.of(
+                        maybeUseUserTempLocation(
+                            options.getUserTempLocation(), options.getOutputDirectory()),
+                        (SerializableFunction<String, ResourceId>)
+                            input -> FileBasedSink.convertToFileResourceIfPossible(input))));
 
     // Execute the pipeline and return the result.
     return pipeline.run();


### PR DESCRIPTION
Allows WindowedFilenamePolicy class to use a custom DateTime pattern for the output directory.

Resolves #155 