### PR TITLE
Options to Exclude Big Query Replica

### DIFF
--- a/v2/cdc-parent/cdc-change-applier/src/main/java/com/google/cloud/dataflow/cdc/applier/BigQueryChangeApplier.java
+++ b/v2/cdc-parent/cdc-change-applier/src/main/java/com/google/cloud/dataflow/cdc/applier/BigQueryChangeApplier.java
@@ -140,7 +140,7 @@ public class BigQueryChangeApplier extends PTransform<PCollection<Row>, PDone> {
 
     // If the input collection does not have a primary key field, then we do not need to issue
     // periodic merge requests.
-    if (inputCollectionSchema.hasField(DataflowCdcRowFormat.PRIMARY_KEY)) {
+    if (inputCollectionSchema.hasField(DataflowCdcRowFormat.PRIMARY_KEY) && replicaDataset != null) {
       p.apply("MergeHeartbeat",
           GenerateSequence
               .from(0)


### PR DESCRIPTION
In this PR I allow the option to execute the dataflow with fewer options and bypassing the automatic replica dataset part.

Note: I myself then generate my own custom replica with a query that is better optimised with clustering to avoid high costs for large tables.

Example
mvn exec:java -pl cdc-change-applier -Dexec.args="--runner=DataflowRunner \
              --inputSubscriptions=${PUBSUB_SUBSCRIPTION} \
              --changeLogDataset=${CHANGELOG_BQ_DATASET} \
              --project=${GCP_PROJECT} \
              --useSingleTopic=true"