### PR TITLE
Fix errors due to package-private PipelineOptions interfaces

### DIFF
--- a/src/main/java/com/google/cloud/teleport/templates/DatastoreSchemasCountToText.java
+++ b/src/main/java/com/google/cloud/teleport/templates/DatastoreSchemasCountToText.java
@@ -31,7 +31,7 @@ import org.apache.beam.sdk.options.PipelineOptionsFactory;
  */
 public class DatastoreSchemasCountToText {
 
-  interface DatastoreSchemaCountToTextOptions extends
+  public interface DatastoreSchemaCountToTextOptions extends
       PipelineOptions,
       DatastoreReadSchemaCountOptions,
       FilesystemWriteOptions {}

--- a/src/main/java/com/google/cloud/teleport/templates/DatastoreToBigQuery.java
+++ b/src/main/java/com/google/cloud/teleport/templates/DatastoreToBigQuery.java
@@ -35,7 +35,7 @@ import org.apache.beam.sdk.options.ValueProvider;
  * Dataflow template which copies Datastore Entities to a BigQuery table.
  */
 public class DatastoreToBigQuery {
-  interface DatastoreToBigQueryOptions
+  public interface DatastoreToBigQueryOptions
       extends PipelineOptions, DatastoreReadOptions, JavascriptTextTransformerOptions {
     @Description("The BigQuery table spec to write the output to")
     ValueProvider<String> getOutputTableSpec();

--- a/src/main/java/com/google/cloud/teleport/templates/DatastoreToPubsub.java
+++ b/src/main/java/com/google/cloud/teleport/templates/DatastoreToPubsub.java
@@ -32,7 +32,7 @@ import org.apache.beam.sdk.options.PipelineOptionsFactory;
  * https://cloud.google.com/datastore/docs/reference/rest/v1/Entity
  */
 public class DatastoreToPubsub {
-  interface DatastoreToPubsubOptions extends
+  public interface DatastoreToPubsubOptions extends
       PipelineOptions,
       DatastoreReadOptions,
       JavascriptTextTransformerOptions,

--- a/src/main/java/com/google/cloud/teleport/templates/PubsubToDatastore.java
+++ b/src/main/java/com/google/cloud/teleport/templates/PubsubToDatastore.java
@@ -33,7 +33,7 @@ import org.apache.beam.sdk.options.PipelineOptionsFactory;
  * https://cloud.google.com/datastore/docs/reference/rest/v1/Entity
  */
 public class PubsubToDatastore {
-  interface PubsubToDatastoreOptions
+  public interface PubsubToDatastoreOptions
       extends
       PipelineOptions,
       PubsubReadOptions,


### PR DESCRIPTION
Running e.g. the DatastoreToBigQuery template resulted in the following exception due to the DatastoreToBigQueryOptions interface being non-public:

java.lang.IllegalArgumentException: Please mark non-public interface com.google.cloud.teleport.templates.DatastoreToBigQuery$DatastoreToBigQueryOptions as public. The JVM requires that all non-public interfaces to be in the same package which will prevent the PipelineOptions proxy class to implement all of the interfaces.
    at org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument (Preconditions.java:216)
    at org.apache.beam.sdk.options.PipelineOptionsFactory.validateClass (PipelineOptionsFactory.java:952)
    at org.apache.beam.sdk.options.PipelineOptionsFactory.access$2200 (PipelineOptionsFactory.java:115)
    at org.apache.beam.sdk.options.PipelineOptionsFactory$Cache.validateWellFormed (PipelineOptionsFactory.java:1901)
    at org.apache.beam.sdk.options.PipelineOptionsFactory$Cache.validateWellFormed (PipelineOptionsFactory.java:1842)
    at org.apache.beam.sdk.options.PipelineOptionsFactory$Cache.access$800 (PipelineOptionsFactory.java:1786)
    at org.apache.beam.sdk.options.PipelineOptionsFactory.parseObjects (PipelineOptionsFactory.java:1603)
    at org.apache.beam.sdk.options.PipelineOptionsFactory.access$400 (PipelineOptionsFactory.java:115)
    at org.apache.beam.sdk.options.PipelineOptionsFactory$Builder.as (PipelineOptionsFactory.java:298)
    at com.google.cloud.teleport.templates.DatastoreToBigQuery.main (DatastoreToBigQuery.java:62)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:564)
    at org.codehaus.mojo.exec.ExecJavaMojo$1.run (ExecJavaMojo.java:282)
    at java.lang.Thread.run (Thread.java:832)
