### PR TITLE
Replacing Nashorn JS Engine with GraalVM js implementation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/
 dependency-reduced-pom.xml
 
 .idea
+*nb-configuration.xml

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <cassandra.driver.version>3.6.0</cassandra.driver.version>
     <kms.version>1.40.0</kms.version>
     <proto-kms.version>0.87.0</proto-kms.version>
-     <graalvm.version>20.2.0</graalvm.version>
+    <graalvm.version>20.2.0</graalvm.version>
   </properties>
 
   <dependencies>
@@ -604,7 +604,6 @@
       <groupId>org.graalvm.sdk</groupId>
       <artifactId>graal-sdk</artifactId>
       <version>${graalvm.version}</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.graalvm.js</groupId>
@@ -613,6 +612,10 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <!-- 
+        When migrating to jdk11 this will be necessary in order to maintain compatibility with the ScriptEngine API, in JDK8 is included. 
+        Another alternative is to use GraalVM Context API to launch the js scripts.  
+      -->
       <groupId>org.graalvm.js</groupId>
       <artifactId>js-scriptengine</artifactId>
       <version>${graalvm.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  ~ Copyright (C) 2017 Google Inc.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
-  ~ use this file except in compliance with the License. You may obtain a copy of
-  ~ the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-  ~ License for the specific language governing permissions and limitations under
-  ~ the License.
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+~ Copyright (C) 2017 Google Inc.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+~ use this file except in compliance with the License. You may obtain a copy of
+~ the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+~ License for the specific language governing permissions and limitations under
+~ the License.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -104,6 +104,7 @@
     <cassandra.driver.version>3.6.0</cassandra.driver.version>
     <kms.version>1.40.0</kms.version>
     <proto-kms.version>0.87.0</proto-kms.version>
+     <graalvm.version>20.2.0</graalvm.version>
   </properties>
 
   <dependencies>
@@ -190,7 +191,10 @@
       <artifactId>hadoop-mapreduce-client-core</artifactId>
       <version>${hadoop.version}</version>
       <exclusions>
-        <exclusion><groupId>org.codehaus.jackson</groupId><artifactId>*</artifactId></exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -198,8 +202,11 @@
       <artifactId>hadoop-common</artifactId>
       <version>${hadoop.version}</version>
       <exclusions>
-      <exclusion><groupId>org.codehaus.jackson</groupId><artifactId>*</artifactId></exclusion>
-    </exclusions>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
@@ -387,8 +394,8 @@
       <scope>runtime</scope>
       <exclusions>
         <!-- slf4j-log4j12 and log4j-over-slf4j cannot coexist
-             https://www.slf4j.org/codes.html
-             -->
+        https://www.slf4j.org/codes.html
+        -->
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
@@ -593,6 +600,36 @@
       <artifactId>proto</artifactId>
       <version>${tensorflow.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.graalvm.sdk</groupId>
+      <artifactId>graal-sdk</artifactId>
+      <version>${graalvm.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.graalvm.js</groupId>
+      <artifactId>js</artifactId>
+      <version>${graalvm.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.graalvm.js</groupId>
+      <artifactId>js-scriptengine</artifactId>
+      <version>${graalvm.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.graalvm.tools</groupId>
+      <artifactId>profiler</artifactId>
+      <version>${graalvm.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.graalvm.tools</groupId>
+      <artifactId>chromeinspector</artifactId>
+      <version>${graalvm.version}</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -640,7 +677,7 @@
                 </filters>
                 <transformers>
                   <transformer
-                      implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                    implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 </transformers>
               </configuration>
             </execution>
@@ -708,17 +745,17 @@
                 <ignoredUsedUndeclaredDependency>
                   org.hamcrest:hamcrest
                 </ignoredUsedUndeclaredDependency>
-             </ignoredUsedUndeclaredDependencies>
-             <ignoredUnusedDeclaredDependencies>
+              </ignoredUsedUndeclaredDependencies>
+              <ignoredUnusedDeclaredDependencies>
                 <ignoredUnusedDeclaredDependency>org.threeten:threetenbp</ignoredUnusedDeclaredDependency>
                 <ignoredUnusedDeclaredDependency>org.json:json</ignoredUnusedDeclaredDependency>
-               <ignoredUnusedDeclaredDependency>org.apache.hadoop:hadoop-mapreduce-client-core</ignoredUnusedDeclaredDependency>
+                <ignoredUnusedDeclaredDependency>org.apache.hadoop:hadoop-mapreduce-client-core</ignoredUnusedDeclaredDependency>
                 <ignoredUnusedDeclaredDependency>org.apache.hadoop:hadoop-common</ignoredUnusedDeclaredDependency>
                 <ignoredUnusedDeclaredDependency>org.codehaus.jackson:jackson-core-asl</ignoredUnusedDeclaredDependency>
-               <ignoredUnusedDeclaredDependency>org.codehaus.jackson:jackson-mapper-asl</ignoredUnusedDeclaredDependency>
-               <ignoredUnusedDeclaredDependency>io.opencensus:opencensus-api</ignoredUnusedDeclaredDependency>
-             </ignoredUnusedDeclaredDependencies>
-           </configuration>
+                <ignoredUnusedDeclaredDependency>org.codehaus.jackson:jackson-mapper-asl</ignoredUnusedDeclaredDependency>
+                <ignoredUnusedDeclaredDependency>io.opencensus:opencensus-api</ignoredUnusedDeclaredDependency>
+              </ignoredUnusedDeclaredDependencies>
+            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -750,11 +787,11 @@
 
       <plugin>
         <!-- Set up Javadoc configuration for javadoc run via in the Maven
-             build. Teleport only uses the plugin to create the individual javadoc
-             attached artifacts used for IDEs. The combined javadoc for the
-             website is built in the sdks/java/javadoc directory. Rather than
-             duplicate a raft of configuration between the ant.xml there and
-             here, we leave things simple here. -->
+        build. Teleport only uses the plugin to create the individual javadoc
+        attached artifacts used for IDEs. The combined javadoc for the
+        website is built in the sdks/java/javadoc directory. Rather than
+        duplicate a raft of configuration between the ant.xml there and
+        here, we leave things simple here. -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${maven-javadoc-plugin.version}</version>
@@ -924,10 +961,10 @@
 
   <profiles>
     <!-- The following snapshot profile allows us to test teleport with
-         unreleased apache sw. E.g. to test with a snapshot version of beam we
-         could do
-              mvn test -Psnapshot -Dbeam.version=A.B.C-SNAPSHOT
-      -->
+       unreleased apache sw. E.g. to test with a snapshot version of beam we
+       could do
+            mvn test -Psnapshot -Dbeam.version=A.B.C-SNAPSHOT
+    -->
     <profile>
       <id>snapshot</id>
       <repositories>

--- a/src/main/java/com/google/cloud/teleport/templates/common/JavascriptTextTransformer.java
+++ b/src/main/java/com/google/cloud/teleport/templates/common/JavascriptTextTransformer.java
@@ -137,22 +137,13 @@ public abstract class JavascriptTextTransformer {
     }
 
     /**
-     * Returns the instance of a script engine.
-     *
-     * @return an instance of an invocable script engine.
-     */
-    protected static ScriptEngine scriptEngineInstance() {
-      return new ScriptEngineManager().getEngineByName("JavaScript");
-    }
-
-    /**
      * Factory method for making a new Invocable.
      *
      * @param scripts a collection of javascript scripts encoded with UTF8 to load in
      */
     @Nullable
     private static Invocable newInvocable(Collection<String> scripts) throws ScriptException {
-      ScriptEngine engine = scriptEngineInstance();
+      ScriptEngine engine = new ScriptEngineManager().getEngineByName("JavaScript");
 
       for (String script : scripts) {
         engine.eval(script);
@@ -219,21 +210,6 @@ public abstract class JavascriptTextTransformer {
                       .collect(Collectors.toList());
 
       return scripts;
-    }
-  }
-
-  /**
-   * Delivers a Javascript runtime based on the GraalVM implementation of the script engine APIs.
-   */
-  public abstract static class GraalVMJavascriptRuntime extends JavascriptTextTransformer.JavascriptRuntime {
-
-    /**
-     * Returns a GraalVM instance of a script engine.
-     *
-     * @return an instance of an invocable script engine.
-     */
-    protected static ScriptEngine scriptEngineInstance() {
-      return new ScriptEngineManager().getEngineByName("graal.js");
     }
   }
 

--- a/src/test/java/com/google/cloud/teleport/templates/common/JavascriptTextTransformerTest.java
+++ b/src/test/java/com/google/cloud/teleport/templates/common/JavascriptTextTransformerTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.cloud.teleport.coders.FailsafeElementCoder;
 import com.google.cloud.teleport.templates.common.JavascriptTextTransformer.FailsafeJavascriptUdf;
-import com.google.cloud.teleport.templates.common.JavascriptTextTransformer.GraalVMJavascriptRuntime;
 import com.google.cloud.teleport.templates.common.JavascriptTextTransformer.JavascriptRuntime;
 import com.google.cloud.teleport.templates.common.JavascriptTextTransformer.TransformTextViaJavascript;
 import com.google.cloud.teleport.values.FailsafeElement;
@@ -93,8 +92,8 @@ public class JavascriptTextTransformerTest {
    */
   @Test
   public void testInvokeThrowsException() throws Exception {
-    JavascriptTextTransformer.JavascriptRuntime javascriptRuntime
-            = JavascriptTextTransformer.JavascriptRuntime.newBuilder()
+    JavascriptRuntime javascriptRuntime
+            = JavascriptRuntime.newBuilder()
                     .setFunctionName("transform")
                     .setFileSystemPath("gs://some/bad/random/path")
                     .build();
@@ -124,21 +123,6 @@ public class JavascriptTextTransformerTest {
   public void testInvokeGood() throws Exception {
     JavascriptRuntime javascriptRuntime
             = JavascriptRuntime.newBuilder()
-                    .setFileSystemPath(TRANSFORM_FILE_PATH)
-                    .setFunctionName("transform")
-                    .build();
-    String data = javascriptRuntime.invoke("{\"answerToLife\": 42}");
-    Assert.assertEquals("{\"answerToLife\":42,\"someProp\":\"someValue\"}", data);
-  }
-
-  /**
-   * Test {@link JavascriptRuntime#invoke(String)} returns transformed data when a good javascript transform function given, in this case
-   * utilizing GraalVM as the runtime for the scripts.
-   */
-  @Test
-  public void testInvokeGoodGraalVM() throws Exception {
-    JavascriptRuntime javascriptRuntime
-            = GraalVMJavascriptRuntime.newBuilder()
                     .setFileSystemPath(TRANSFORM_FILE_PATH)
                     .setFunctionName("transform")
                     .build();

--- a/src/test/java/com/google/cloud/teleport/templates/common/JavascriptTextTransformerTest.java
+++ b/src/test/java/com/google/cloud/teleport/templates/common/JavascriptTextTransformerTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.google.cloud.teleport.templates.common;
 
 import static org.hamcrest.CoreMatchers.anyOf;
@@ -26,6 +25,7 @@ import static org.junit.Assert.assertThat;
 
 import com.google.cloud.teleport.coders.FailsafeElementCoder;
 import com.google.cloud.teleport.templates.common.JavascriptTextTransformer.FailsafeJavascriptUdf;
+import com.google.cloud.teleport.templates.common.JavascriptTextTransformer.GraalVMJavascriptRuntime;
 import com.google.cloud.teleport.templates.common.JavascriptTextTransformer.JavascriptRuntime;
 import com.google.cloud.teleport.templates.common.JavascriptTextTransformer.TransformTextViaJavascript;
 import com.google.cloud.teleport.values.FailsafeElement;
@@ -57,28 +57,34 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link JavascriptTextTransformer}. */
+/**
+ * Unit tests for {@link JavascriptTextTransformer}.
+ */
 @RunWith(JUnit4.class)
 public class JavascriptTextTransformerTest {
 
-  @Rule public ExpectedException thrown = ExpectedException.none();
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
-  @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+  @Rule
+  public final transient TestPipeline pipeline = TestPipeline.create();
 
   // Define the TupleTag's here otherwise the anonymous class will force the test method to
   // be serialized.
-  private static final TupleTag<FailsafeElement<PubsubMessage, String>> SUCCESS_TAG =
-      new TupleTag<FailsafeElement<PubsubMessage, String>>() {};
+  private static final TupleTag<FailsafeElement<PubsubMessage, String>> SUCCESS_TAG
+          = new TupleTag<FailsafeElement<PubsubMessage, String>>() {
+  };
 
-  private static final TupleTag<FailsafeElement<PubsubMessage, String>> FAILURE_TAG =
-      new TupleTag<FailsafeElement<PubsubMessage, String>>() {};
+  private static final TupleTag<FailsafeElement<PubsubMessage, String>> FAILURE_TAG
+          = new TupleTag<FailsafeElement<PubsubMessage, String>>() {
+  };
 
   private static final String RESOURCES_DIR = "JavascriptTextTransformerTest/";
 
-  private static final String TRANSFORM_FILE_PATH =
-      Resources.getResource(RESOURCES_DIR + "transform.js").getPath();
-  private static final String SCRIPT_PARSE_EXCEPTION_FILE_PATH =
-      Resources.getResource(RESOURCES_DIR + "scriptParseException.js").getPath();
+  private static final String TRANSFORM_FILE_PATH
+          = Resources.getResource(RESOURCES_DIR + "transform.js").getPath();
+  private static final String SCRIPT_PARSE_EXCEPTION_FILE_PATH
+          = Resources.getResource(RESOURCES_DIR + "scriptParseException.js").getPath();
 
   /**
    * Test {@link JavascriptRuntime#getInvocable} throws IllegalArgumentException if bad filepath.
@@ -87,61 +93,75 @@ public class JavascriptTextTransformerTest {
    */
   @Test
   public void testInvokeThrowsException() throws Exception {
-    JavascriptRuntime javascriptRuntime =
-        JavascriptRuntime.newBuilder()
-            .setFunctionName("transform")
-            .setFileSystemPath("gs://some/bad/random/path")
-            .build();
+    JavascriptTextTransformer.JavascriptRuntime javascriptRuntime
+            = JavascriptTextTransformer.JavascriptRuntime.newBuilder()
+                    .setFunctionName("transform")
+                    .setFileSystemPath("gs://some/bad/random/path")
+                    .build();
 
     thrown.expect(anyOf(instanceOf(IOException.class), instanceOf(IllegalArgumentException.class)));
     javascriptRuntime.getInvocable();
   }
 
-  /** Test @{link JavscriptRuntime#getInvocable} throws ScriptException if error in script. */
+  /**
+   * Test @{link JavscriptRuntime#getInvocable} throws ScriptException if error in script.
+   */
   @Test
   public void testInvokeScriptException() throws Exception {
-    JavascriptRuntime javascriptRuntime =
-        JavascriptRuntime.newBuilder()
-            .setFileSystemPath(SCRIPT_PARSE_EXCEPTION_FILE_PATH)
-            .setFunctionName("transform")
-            .build();
+    JavascriptRuntime javascriptRuntime
+            = JavascriptRuntime.newBuilder()
+                    .setFileSystemPath(SCRIPT_PARSE_EXCEPTION_FILE_PATH)
+                    .setFunctionName("transform")
+                    .build();
     thrown.expect(ScriptException.class);
     String data = javascriptRuntime.invoke("{\"answerToLife\": 42}");
   }
 
   /**
-   * Test {@link JavascriptRuntime#invoke(String)} returns transformed data when a good javascript
-   * transform function given.
+   * Test {@link JavascriptRuntime#invoke(String)} returns transformed data when a good javascript transform function given.
    */
   @Test
   public void testInvokeGood() throws Exception {
-    JavascriptRuntime javascriptRuntime =
-        JavascriptRuntime.newBuilder()
-            .setFileSystemPath(TRANSFORM_FILE_PATH)
-            .setFunctionName("transform")
-            .build();
+    JavascriptRuntime javascriptRuntime
+            = JavascriptRuntime.newBuilder()
+                    .setFileSystemPath(TRANSFORM_FILE_PATH)
+                    .setFunctionName("transform")
+                    .build();
     String data = javascriptRuntime.invoke("{\"answerToLife\": 42}");
     Assert.assertEquals("{\"answerToLife\":42,\"someProp\":\"someValue\"}", data);
   }
 
   /**
-   * Test {@link JavascriptRuntime#invoke(String)} errors when undefined data returned from
-   * javascript function.
+   * Test {@link JavascriptRuntime#invoke(String)} returns transformed data when a good javascript transform function given, in this case
+   * utilizing GraalVM as the runtime for the scripts.
+   */
+  @Test
+  public void testInvokeGoodGraalVM() throws Exception {
+    JavascriptRuntime javascriptRuntime
+            = GraalVMJavascriptRuntime.newBuilder()
+                    .setFileSystemPath(TRANSFORM_FILE_PATH)
+                    .setFunctionName("transform")
+                    .build();
+    String data = javascriptRuntime.invoke("{\"answerToLife\": 42}");
+    Assert.assertEquals("{\"answerToLife\":42,\"someProp\":\"someValue\"}", data);
+  }
+
+  /**
+   * Test {@link JavascriptRuntime#invoke(String)} errors when undefined data returned from javascript function.
    */
   @Test
   public void testInvokeUndefined() throws Exception {
-    JavascriptRuntime javascriptRuntime =
-        JavascriptRuntime.newBuilder()
-            .setFileSystemPath(TRANSFORM_FILE_PATH)
-            .setFunctionName("transformWithFilter")
-            .build();
+    JavascriptRuntime javascriptRuntime
+            = JavascriptRuntime.newBuilder()
+                    .setFileSystemPath(TRANSFORM_FILE_PATH)
+                    .setFunctionName("transformWithFilter")
+                    .build();
     String data = javascriptRuntime.invoke("{\"answerToLife\": 43}");
     Assert.assertNull(data);
   }
 
   /**
-   * Test {@link TransformTextViaJavascript} returns transformed data when a good javascript
-   * transform given.
+   * Test {@link TransformTextViaJavascript} returns transformed data when a good javascript transform given.
    */
   @Test
   @Category(NeedsRunner.class)
@@ -149,34 +169,36 @@ public class JavascriptTextTransformerTest {
     List<String> inJson = Arrays.asList("{\"answerToLife\": 42}");
     List<String> expectedJson = Arrays.asList("{\"answerToLife\":42,\"someProp\":\"someValue\"}");
 
-    PCollection<String> transformedJson =
-        pipeline
-            .apply("Create", Create.of(inJson))
-            .apply(
-                TransformTextViaJavascript.newBuilder()
-                    .setFileSystemPath(StaticValueProvider.of(TRANSFORM_FILE_PATH))
-                    .setFunctionName(StaticValueProvider.of("transform"))
-                    .build());
+    PCollection<String> transformedJson
+            = pipeline
+                    .apply("Create", Create.of(inJson))
+                    .apply(
+                            TransformTextViaJavascript.newBuilder()
+                                    .setFileSystemPath(StaticValueProvider.of(TRANSFORM_FILE_PATH))
+                                    .setFunctionName(StaticValueProvider.of("transform"))
+                                    .build());
 
     PAssert.that(transformedJson).containsInAnyOrder(expectedJson);
 
     pipeline.run();
   }
 
-  /** Test {@link TransformTextViaJavascript} passes through data when empty strings as args. */
+  /**
+   * Test {@link TransformTextViaJavascript} passes through data when empty strings as args.
+   */
   @Test
   @Category(NeedsRunner.class)
   public void testDoFnPassthroughEmptyStrings() {
     List<String> inJson = Arrays.asList("{\"answerToLife\":    42}");
 
-    PCollection<String> transformedJson =
-        pipeline
-            .apply("Create", Create.of(inJson))
-            .apply(
-                TransformTextViaJavascript.newBuilder()
-                    .setFunctionName(StaticValueProvider.of(""))
-                    .setFileSystemPath(StaticValueProvider.of(""))
-                    .build());
+    PCollection<String> transformedJson
+            = pipeline
+                    .apply("Create", Create.of(inJson))
+                    .apply(
+                            TransformTextViaJavascript.newBuilder()
+                                    .setFunctionName(StaticValueProvider.of(""))
+                                    .setFileSystemPath(StaticValueProvider.of(""))
+                                    .build());
 
     PAssert.that(transformedJson).containsInAnyOrder(inJson);
 
@@ -184,22 +206,21 @@ public class JavascriptTextTransformerTest {
   }
 
   /**
-   * Test {@link TransformTextViaJavascript} passes through data when null strings as args. when
-   * hasInvocable returns false.
+   * Test {@link TransformTextViaJavascript} passes through data when null strings as args. when hasInvocable returns false.
    */
   @Test
   @Category(NeedsRunner.class)
   public void testDoFnPassthroughNullStrings() {
     List<String> inJson = Arrays.asList("{\"answerToLife\":    42}");
 
-    PCollection<String> transformedJson =
-        pipeline
-            .apply("Create", Create.of(inJson))
-            .apply(
-                TransformTextViaJavascript.newBuilder()
-                    .setFunctionName(StaticValueProvider.of(null))
-                    .setFileSystemPath(StaticValueProvider.of(null))
-                    .build());
+    PCollection<String> transformedJson
+            = pipeline
+                    .apply("Create", Create.of(inJson))
+                    .apply(
+                            TransformTextViaJavascript.newBuilder()
+                                    .setFunctionName(StaticValueProvider.of(null))
+                                    .setFileSystemPath(StaticValueProvider.of(null))
+                                    .build());
 
     PAssert.that(transformedJson).containsInAnyOrder(inJson);
 
@@ -207,22 +228,21 @@ public class JavascriptTextTransformerTest {
   }
 
   /**
-   * Test {@link TransformTextViaJavascript} passes through data when null ValueProvider as args.
-   * when hasInvocable returns false.
+   * Test {@link TransformTextViaJavascript} passes through data when null ValueProvider as args. when hasInvocable returns false.
    */
   @Test
   @Category(NeedsRunner.class)
   public void testDoFnPassthroughNullValueProvider() {
     List<String> inJson = Arrays.asList("{\"answerToLife\":    42}");
 
-    PCollection<String> transformedJson =
-        pipeline
-            .apply("Create", Create.of(inJson))
-            .apply(
-                TransformTextViaJavascript.newBuilder()
-                    .setFunctionName(null)
-                    .setFileSystemPath(null)
-                    .build());
+    PCollection<String> transformedJson
+            = pipeline
+                    .apply("Create", Create.of(inJson))
+                    .apply(
+                            TransformTextViaJavascript.newBuilder()
+                                    .setFunctionName(null)
+                                    .setFileSystemPath(null)
+                                    .build());
 
     PAssert.that(transformedJson).containsInAnyOrder(inJson);
 
@@ -230,8 +250,7 @@ public class JavascriptTextTransformerTest {
   }
 
   /**
-   * Test {@link TransformTextViaJavascript} allows for script to disregard some data by returning
-   * null / undefined.
+   * Test {@link TransformTextViaJavascript} allows for script to disregard some data by returning null / undefined.
    */
   @Test
   @Category(NeedsRunner.class)
@@ -239,21 +258,23 @@ public class JavascriptTextTransformerTest {
     List<String> inJson = Arrays.asList("{\"answerToLife\":42}", "{\"answerToLife\":43}");
     List<String> expectedJson = Arrays.asList("{\"answerToLife\":42}");
 
-    PCollection<String> transformedJson =
-        pipeline
-            .apply("Create", Create.of(inJson))
-            .apply(
-                TransformTextViaJavascript.newBuilder()
-                    .setFileSystemPath(StaticValueProvider.of(TRANSFORM_FILE_PATH))
-                    .setFunctionName(StaticValueProvider.of("transformWithFilter"))
-                    .build());
+    PCollection<String> transformedJson
+            = pipeline
+                    .apply("Create", Create.of(inJson))
+                    .apply(
+                            TransformTextViaJavascript.newBuilder()
+                                    .setFileSystemPath(StaticValueProvider.of(TRANSFORM_FILE_PATH))
+                                    .setFunctionName(StaticValueProvider.of("transformWithFilter"))
+                                    .build());
 
     PAssert.that(transformedJson).containsInAnyOrder(expectedJson);
 
     pipeline.run();
   }
 
-  /** Tests the {@link FailsafeJavascriptUdf} when the input is valid. */
+  /**
+   * Tests the {@link FailsafeJavascriptUdf} when the input is valid.
+   */
   @Test
   @Category(NeedsRunner.class)
   public void testFailsafeJavaScriptUdfValidInput() {
@@ -269,41 +290,41 @@ public class JavascriptTextTransformerTest {
 
     // Register the coder for the pipeline. This prevents having to invoke .setCoder() on
     // many transforms.
-    FailsafeElementCoder<PubsubMessage, String> coder =
-        FailsafeElementCoder.of(PubsubMessageWithAttributesCoder.of(), StringUtf8Coder.of());
+    FailsafeElementCoder<PubsubMessage, String> coder
+            = FailsafeElementCoder.of(PubsubMessageWithAttributesCoder.of(), StringUtf8Coder.of());
 
     CoderRegistry coderRegistry = pipeline.getCoderRegistry();
     coderRegistry.registerCoderForType(coder.getEncodedTypeDescriptor(), coder);
 
     // Build the pipeline
-    PCollectionTuple output =
-        pipeline
-            .apply("CreateInput", Create.of(input).withCoder(coder))
-            .apply(
-                "InvokeUdf",
-                FailsafeJavascriptUdf.<PubsubMessage>newBuilder()
-                    .setFileSystemPath(fileSystemPath)
-                    .setFunctionName(functionName)
-                    .setSuccessTag(SUCCESS_TAG)
-                    .setFailureTag(FAILURE_TAG)
-                    .build());
+    PCollectionTuple output
+            = pipeline
+                    .apply("CreateInput", Create.of(input).withCoder(coder))
+                    .apply(
+                            "InvokeUdf",
+                            FailsafeJavascriptUdf.<PubsubMessage>newBuilder()
+                                    .setFileSystemPath(fileSystemPath)
+                                    .setFunctionName(functionName)
+                                    .setSuccessTag(SUCCESS_TAG)
+                                    .setFailureTag(FAILURE_TAG)
+                                    .build());
 
     // Assert
     PAssert.that(output.get(SUCCESS_TAG))
-        .satisfies(
-            collection -> {
-              FailsafeElement<PubsubMessage, String> result = collection.iterator().next();
-              PubsubMessage resultMessage = result.getOriginalPayload();
-              String expectedPayload =
-                  "{\"ticker\":\"GOOGL\",\"price\":1006.94,\"someProp\":\"someValue\"}";
+            .satisfies(
+                    collection -> {
+                      FailsafeElement<PubsubMessage, String> result = collection.iterator().next();
+                      PubsubMessage resultMessage = result.getOriginalPayload();
+                      String expectedPayload
+                      = "{\"ticker\":\"GOOGL\",\"price\":1006.94,\"someProp\":\"someValue\"}";
 
-              assertThat(new String(resultMessage.getPayload()), is(equalTo(payload)));
-              assertThat(resultMessage.getAttributeMap(), is(equalTo(attributes)));
-              assertThat(result.getPayload(), is(equalTo(expectedPayload)));
-              assertThat(result.getErrorMessage(), is(nullValue()));
-              assertThat(result.getStacktrace(), is(nullValue()));
-              return null;
-            });
+                      assertThat(new String(resultMessage.getPayload()), is(equalTo(payload)));
+                      assertThat(resultMessage.getAttributeMap(), is(equalTo(attributes)));
+                      assertThat(result.getPayload(), is(equalTo(expectedPayload)));
+                      assertThat(result.getErrorMessage(), is(nullValue()));
+                      assertThat(result.getStacktrace(), is(nullValue()));
+                      return null;
+                    });
 
     PAssert.that(output.get(FAILURE_TAG)).empty();
 
@@ -312,9 +333,8 @@ public class JavascriptTextTransformerTest {
   }
 
   /**
-   * Tests the {@link FailsafeJavascriptUdf} when it's passed invalid JSON. In this case the UDF
-   * should output the input {@link FailsafeElement} to the dead-letter enriched with error
-   * information.
+   * Tests the {@link FailsafeJavascriptUdf} when it's passed invalid JSON. In this case the UDF should output the input
+   * {@link FailsafeElement} to the dead-letter enriched with error information.
    */
   @Test
   @Category(NeedsRunner.class)
@@ -331,40 +351,40 @@ public class JavascriptTextTransformerTest {
 
     // Register the coder for the pipeline. This prevents having to invoke .setCoder() on
     // many transforms.
-    FailsafeElementCoder<PubsubMessage, String> coder =
-        FailsafeElementCoder.of(PubsubMessageWithAttributesCoder.of(), StringUtf8Coder.of());
+    FailsafeElementCoder<PubsubMessage, String> coder
+            = FailsafeElementCoder.of(PubsubMessageWithAttributesCoder.of(), StringUtf8Coder.of());
 
     CoderRegistry coderRegistry = pipeline.getCoderRegistry();
     coderRegistry.registerCoderForType(coder.getEncodedTypeDescriptor(), coder);
 
     // Build the pipeline
-    PCollectionTuple output =
-        pipeline
-            .apply("CreateInput", Create.of(input).withCoder(coder))
-            .apply(
-                "InvokeUdf",
-                FailsafeJavascriptUdf.<PubsubMessage>newBuilder()
-                    .setFileSystemPath(fileSystemPath)
-                    .setFunctionName(functionName)
-                    .setSuccessTag(SUCCESS_TAG)
-                    .setFailureTag(FAILURE_TAG)
-                    .build());
+    PCollectionTuple output
+            = pipeline
+                    .apply("CreateInput", Create.of(input).withCoder(coder))
+                    .apply(
+                            "InvokeUdf",
+                            FailsafeJavascriptUdf.<PubsubMessage>newBuilder()
+                                    .setFileSystemPath(fileSystemPath)
+                                    .setFunctionName(functionName)
+                                    .setSuccessTag(SUCCESS_TAG)
+                                    .setFailureTag(FAILURE_TAG)
+                                    .build());
 
     // Assert
     PAssert.that(output.get(SUCCESS_TAG)).empty();
     PAssert.that(output.get(FAILURE_TAG))
-        .satisfies(
-            collection -> {
-              FailsafeElement<PubsubMessage, String> result = collection.iterator().next();
-              PubsubMessage resultMessage = result.getOriginalPayload();
+            .satisfies(
+                    collection -> {
+                      FailsafeElement<PubsubMessage, String> result = collection.iterator().next();
+                      PubsubMessage resultMessage = result.getOriginalPayload();
 
-              assertThat(new String(resultMessage.getPayload()), is(equalTo(payload)));
-              assertThat(resultMessage.getAttributeMap(), is(equalTo(attributes)));
-              assertThat(result.getPayload(), is(equalTo(payload)));
-              assertThat(result.getErrorMessage(), is(notNullValue()));
-              assertThat(result.getStacktrace(), is(notNullValue()));
-              return null;
-            });
+                      assertThat(new String(resultMessage.getPayload()), is(equalTo(payload)));
+                      assertThat(resultMessage.getAttributeMap(), is(equalTo(attributes)));
+                      assertThat(result.getPayload(), is(equalTo(payload)));
+                      assertThat(result.getErrorMessage(), is(notNullValue()));
+                      assertThat(result.getStacktrace(), is(notNullValue()));
+                      return null;
+                    });
 
     // Execute the test
     pipeline.run();


### PR DESCRIPTION
Given the deprecation of Nashorn as the JS Engine for Java, and the future potential changes on the JDK requirements (from JDK8 to JDK11+) for this project, this PR adds the needed maven dependencies to automatically switch the JS Engine in use from the default one to the GraalVM implementation (truffle API). 

In the future, if this change sticks, we could completely remove the dependencies to the ScriptEngine API and replace them with GraalVM Polyglot Context's ones. 