### PR TITLE
Added support for debezium decimal.handling.mode=precise

### DIFF
--- a/v2/cdc-parent/README.md
+++ b/v2/cdc-parent/README.md
@@ -387,7 +387,7 @@ The solution ends up resolving types like this:
 | Float types  | `FLOAT`, `DOUBLE`  | `DOUBLE`  |   |
 | Byte types  |  `BINARY`, `VARBINARY`, `BLOB` | `BYTES` |  |
 | String types  |  `CHAR`, `VARCHAR`, `TEXT`, `ENUM` | `STRING` |  |
-| NUMERIC types  | `NUMERIC`, `DECIMAL`  | `STRING`  | Support for better conversion TBD. |
+| NUMERIC types  | `NUMERIC`, `DECIMAL`  | `STRING`, `DECIMAL` (if the property `debezium.decimal.handling.mode=precise` is set)  |  |
 | Time-related times  |  |  | Time-related types have specific type conversions. See detailed table below. |
 
 ### Type handling for time-related types

--- a/v2/cdc-parent/cdc-common/src/main/java/com/google/cloud/dataflow/cdc/common/SchemaUtils.java
+++ b/v2/cdc-parent/cdc-common/src/main/java/com/google/cloud/dataflow/cdc/common/SchemaUtils.java
@@ -39,6 +39,7 @@ public class SchemaUtils {
           .put("BOOL", org.apache.beam.sdk.schemas.Schema.TypeName.BOOLEAN)
           .put("BYTES", org.apache.beam.sdk.schemas.Schema.TypeName.BYTES)
           .put("DOUBLE", org.apache.beam.sdk.schemas.Schema.TypeName.DOUBLE)
+          .put("NUMERIC", org.apache.beam.sdk.schemas.Schema.TypeName.DECIMAL)
           .put("INT16", org.apache.beam.sdk.schemas.Schema.TypeName.INT16)
           .put("INT32", org.apache.beam.sdk.schemas.Schema.TypeName.INT32)
           .put("INT64", org.apache.beam.sdk.schemas.Schema.TypeName.INT64)

--- a/v2/cdc-parent/cdc-common/src/test/java/com/google/cloud/dataflow/cdc/common/SchemaUtilsTest.java
+++ b/v2/cdc-parent/cdc-common/src/test/java/com/google/cloud/dataflow/cdc/common/SchemaUtilsTest.java
@@ -40,6 +40,7 @@ public class SchemaUtilsTest {
             .addStringField("country")
             .addInt32Field("year_founded")
             .addInt16Field("tiny_int")
+            .addDecimalField("decimal")
             .build())
         .addInt64Field("timestampMs")
         .build();

--- a/v2/cdc-parent/cdc-embedded-connector/src/test/java/com/google/cloud/dataflow/cdc/connector/DebeziumSourceRecordToDataflowCdcFormatTranslatorTest.java
+++ b/v2/cdc-parent/cdc-embedded-connector/src/test/java/com/google/cloud/dataflow/cdc/connector/DebeziumSourceRecordToDataflowCdcFormatTranslatorTest.java
@@ -22,8 +22,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.google.cloud.dataflow.cdc.common.DataflowCdcRowFormat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+
+import java.math.BigDecimal;
 import java.util.List;
 import org.apache.beam.sdk.values.Row;
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -52,6 +55,7 @@ public class DebeziumSourceRecordToDataflowCdcFormatTranslatorTest {
         .field("some_timestamp", Schema.INT64_SCHEMA)
         .field("float_field", Schema.FLOAT32_SCHEMA)
         .field("double_field", Schema.FLOAT64_SCHEMA)
+        .field("decimal_field", Decimal.schema(8))
         .field("struct_field", internalStructSchema)
         .build();
 
@@ -70,6 +74,7 @@ public class DebeziumSourceRecordToDataflowCdcFormatTranslatorTest {
             .put("some_timestamp", 123456579L)
             .put("float_field", new Float(123.456))
             .put("double_field", 123456579.98654321)
+            .put("decimal_field", new BigDecimal("123456579.98654321"))
             .put("struct_field",
                 new Struct(internalStructSchema).put("astring", "mastring")));
 
@@ -105,6 +110,8 @@ public class DebeziumSourceRecordToDataflowCdcFormatTranslatorTest {
         is(value.getStruct("after").getFloat32("float_field")));
     assertThat(fullRecord.getDouble("double_field"),
         is(value.getStruct("after").getFloat64("double_field")));
+    assertThat(fullRecord.getValue("decimal_field"),
+        is(value.getStruct("after").get("decimal_field")));
     assertThat(fullRecord.getRow("struct_field").getString("astring"),
         is(value.getStruct("after").getStruct("struct_field").getString("astring")));
   }
@@ -125,6 +132,7 @@ public class DebeziumSourceRecordToDataflowCdcFormatTranslatorTest {
         .field("some_timestamp", Schema.INT64_SCHEMA)
         .field("float_field", Schema.FLOAT32_SCHEMA)
         .field("double_field", Schema.FLOAT64_SCHEMA)
+        .field("decimal_field", Decimal.schema(8))
         .field("struct_field", internalStructSchema)
         .build();
 
@@ -143,6 +151,7 @@ public class DebeziumSourceRecordToDataflowCdcFormatTranslatorTest {
             .put("some_timestamp", 123456579L)
             .put("float_field", new Float(123.456))
             .put("double_field", 123456579.98654321)
+            .put("decimal_field", new BigDecimal("123456579.98654321"))
             .put("struct_field",
                 new Struct(internalStructSchema).put("astring", "mastring")));
 
@@ -177,6 +186,8 @@ public class DebeziumSourceRecordToDataflowCdcFormatTranslatorTest {
         is(value.getStruct("after").getFloat32("float_field")));
     assertThat(fullRecord.getDouble("double_field"),
         is(value.getStruct("after").getFloat64("double_field")));
+    assertThat(fullRecord.getValue("decimal_field"),
+        is(value.getStruct("after").get("decimal_field")));
     assertThat(fullRecord.getRow("struct_field").getString("astring"),
         is(value.getStruct("after").getStruct("struct_field").getString("astring")));
   }


### PR DESCRIPTION
This pull request adds support for kafka Decimal fields, which means decimals will be stored as NUMERIC data type in BigQuery.

This partially resolves https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/108