### PR TITLE
Support for CsvConverters to directly provide JSON schema

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/CsvConverters.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/CsvConverters.java
@@ -260,6 +260,9 @@ public class CsvConverters {
     @Nullable
     public abstract String jsonSchemaPath();
 
+    @Nullable
+    public abstract String jsonSchema();
+
     public abstract TupleTag<String> headerTag();
 
     public abstract TupleTag<String> lineTag();
@@ -293,9 +296,14 @@ public class CsvConverters {
       }
 
       // If no udf then use json schema
-      if (jsonSchemaPath() != null) {
+      if (jsonSchemaPath() != null || jsonSchema() != null) {
 
-        String schema = SchemaUtils.getGcsFileAsString(jsonSchemaPath());
+        String schema;
+        if (jsonSchemaPath() != null) {
+          schema = SchemaUtils.getGcsFileAsString(jsonSchemaPath());
+        } else {
+          schema = jsonSchema();
+        }
 
         return lineFailsafeElements.apply(
             "LineToDocumentUsingSchema",
@@ -346,6 +354,8 @@ public class CsvConverters {
       public abstract Builder setUdfFunctionName(String udfFunctionName);
 
       public abstract Builder setJsonSchemaPath(String jsonSchemaPath);
+
+      public abstract Builder setJsonSchema(String jsonSchema);
 
       public abstract Builder setHeaderTag(TupleTag<String> headerTag);
 

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/CsvConverters.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/CsvConverters.java
@@ -297,13 +297,9 @@ public class CsvConverters {
 
       // If no udf then use json schema
       if (jsonSchemaPath() != null || jsonSchema() != null) {
-
-        String schema;
-        if (jsonSchemaPath() != null) {
-          schema = SchemaUtils.getGcsFileAsString(jsonSchemaPath());
-        } else {
-          schema = jsonSchema();
-        }
+        String schema =
+            jsonSchemaPath() != null ? SchemaUtils.getGcsFileAsString(jsonSchemaPath()) :
+                jsonSchema();
 
         return lineFailsafeElements.apply(
             "LineToDocumentUsingSchema",


### PR DESCRIPTION
To implement new templates that will use CSV as an input source, we suggest extending the functionality of the `CsvConverters` class.

This PR makes it possible to provide JSON schema of the input CSV lines via String.