### PR TITLE
Support for BigQueryConverters transformation from Row to TableRow

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java
@@ -668,17 +668,9 @@ public class BigQueryConverters {
   }
 
   /**
-   * The {@link RowToTableRowFn} class converts a row to tableRow using {@link
-   * BigQueryUtils#toTableRow()}.
+   * Converts a row to tableRow via {@link BigQueryUtils#toTableRow()}.
    */
-  public static class RowToTableRowFn extends DoFn<Row, TableRow> {
-
-    @ProcessElement
-    public void processElement(ProcessContext context) {
-      Row row = context.element();
-      context.output(BigQueryUtils.toTableRow(row));
-    }
-  }
+  public static SerializableFunction<Row, TableRow> RowToTableRowFn = BigQueryUtils::toTableRow;
 
   /**
    * The {@link FailsafeRowToTableRow} transform converts {@link Row} to {@link TableRow} objects.

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java
@@ -670,7 +670,7 @@ public class BigQueryConverters {
   /**
    * Converts a row to tableRow via {@link BigQueryUtils#toTableRow()}.
    */
-  public static SerializableFunction<Row, TableRow> RowToTableRowFn = BigQueryUtils::toTableRow;
+  public static SerializableFunction<Row, TableRow> rowToTableRowFn = BigQueryUtils::toTableRow;
 
   /**
    * The {@link FailsafeRowToTableRow} transform converts {@link Row} to {@link TableRow} objects.

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java
@@ -666,4 +666,72 @@ public class BigQueryConverters {
       }
     }
   }
+
+  /**
+   * The {@link RowToTableRowFn} class converts a row to tableRow using {@link
+   * BigQueryUtils#toTableRow()}.
+   */
+  public static class RowToTableRowFn extends DoFn<Row, TableRow> {
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      Row row = context.element();
+      context.output(BigQueryUtils.toTableRow(row));
+    }
+  }
+
+  /**
+   * The {@link FailsafeRowToTableRow} transform converts {@link Row} to {@link TableRow} objects.
+   * The transform accepts a {@link FailsafeElement} object so the original payload of the incoming
+   * record can be maintained across multiple series of transforms.
+   */
+  @AutoValue
+  public abstract static class FailsafeRowToTableRow<T>
+          extends PTransform<PCollection<FailsafeElement<T, Row>>, PCollectionTuple> {
+
+    public static <T> Builder<T> newBuilder() {
+      return new AutoValue_BigQueryConverters_FailsafeRowToTableRow.Builder<>();
+    }
+
+    public abstract TupleTag<TableRow> successTag();
+
+    public abstract TupleTag<FailsafeElement<T, Row>> failureTag();
+
+    @Override
+    public PCollectionTuple expand(PCollection<FailsafeElement<T, Row>> failsafeElements) {
+      return failsafeElements.apply(
+              "FailsafeRowToTableRow",
+              ParDo.of(
+                      new DoFn<FailsafeElement<T, Row>, TableRow>() {
+                        @ProcessElement
+                        public void processElement(ProcessContext context) {
+                          FailsafeElement<T, Row> element = context.element();
+                          Row row = element.getPayload();
+
+                          try {
+                            TableRow tableRow = BigQueryUtils.toTableRow(row);
+                            context.output(tableRow);
+                          } catch (Exception e) {
+                            context.output(
+                                    failureTag(),
+                                    FailsafeElement.of(element)
+                                            .setErrorMessage(e.getMessage())
+                                            .setStacktrace(Throwables.getStackTraceAsString(e)));
+                          }
+                        }
+                      })
+                      .withOutputTags(successTag(), TupleTagList.of(failureTag())));
+    }
+
+    /** Builder for {@link FailsafeRowToTableRow}. */
+    @AutoValue.Builder
+    public abstract static class Builder<T> {
+
+      public abstract Builder<T> setSuccessTag(TupleTag<TableRow> successTag);
+
+      public abstract Builder<T> setFailureTag(TupleTag<FailsafeElement<T, Row>> failureTag);
+
+      public abstract FailsafeRowToTableRow<T> build();
+    }
+  }
 }


### PR DESCRIPTION
To implement new templates that will use the native Beam `Row` class for data transformation we suggest extending the functionality of the `BigQueryConverters` class.

This PR adds transformation from `Row` to `TableRow` into `BigQueryConverters`.