### PR TITLE
Excluded DataStreamBigQueryMerger from build

### DIFF
--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -393,6 +393,11 @@
                     <!-- <compilerArgument>-parameters</compilerArgument> -->
                     <parameters>true</parameters>
                     <testCompilerArgument>-parameters</testCompilerArgument>
+                    <excludes>
+                        <exclude>
+                            com/google/cloud/teleport/v2/cdc/merge/DataStreamBigQueryMerger.java
+                        </exclude>
+                    </excludes>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
DataStreamBigQueryMerger.java has following dependencies that has been excluded from Github causing build failure.
com.google.cloud.teleport.v2.cdc.mappers.MergeInfoMapper
com.google.cloud.teleport.v2.utils.DataStreamClient

While we are in the process of excluding DataStreamBigQueryMerger.java, in the interim this file has been excluded from build process to avoid build failures 