### PR TITLE
Fixed DataflowRunner Option

### DIFF
--- a/v2/cdc-parent/README.md
+++ b/v2/cdc-parent/README.md
@@ -350,6 +350,7 @@ mvn exec:java -pl cdc-change-applier -Dexec.args="--runner=DataflowRunner \
               --changeLogDataset=${CHANGELOG_BQ_DATASET} \
               --replicaDataset=${REPLICA_BQ_DATASET} \
               --project=${GCP_PROJECT} \
+              --region=${DEPLOY_REGION} \
               --useSingleTopic=true"
 ```
 


### PR DESCRIPTION
As stated in the [documentation](https://cloud.google.com/dataflow/docs/guides/specifying-exec-params#configuring-pipelineoptions-for-execution-on-the-cloud-dataflow-service), in Apache Beam SDK for Java 2.15.0 and later, an error occurs if you do not select "_**region**_" in PipelineOptions.

The error message is "Caused by: java.lang.IllegalArgumentException: Missing required pipeline options: region"

This is an option that can be set in versions prior to 2.15.0, so it would be nice to have it listed in the README from the beginning.