### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ mvn compile exec:java \
 --stagingLocation=gs://<bucket-name>/staging \
 --tempLocation=gs://<bucket-name>/temp \
 --templateLocation=gs://<bucket-name>/templates/<template-name>.json \
---runner=DataflowRunner"
+--runner=DataflowRunner
+--region=<gcp-region>"
 ```
 
 


### PR DESCRIPTION
`--region` flag was made compulsory starting apache beam version 2.21.0 and gave warning since 2.15.0. Without the `--region` flag specified the template build fails [1]. This behaviour is documented in [#BEAM-9199](https://issues.apache.org/jira/browse/BEAM-9199)

[1] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.6.0:java (default-cli) on project google-cloud-teleport-java: An exception occured while executing the Java class. Failed to construct instance from factory method DataflowRunner#fromOptions(interface org.apache.beam.sdk.options.PipelineOptions): InvocationTargetException: Missing required pipeline options: region -> [Help 1]