### PR TITLE
Fix incompatible PubsubMessage for Pub/Sub to Splunk template

### DIFF
--- a/src/main/java/com/google/cloud/teleport/templates/PubSubToSplunk.java
+++ b/src/main/java/com/google/cloud/teleport/templates/PubSubToSplunk.java
@@ -31,10 +31,10 @@ import com.google.cloud.teleport.templates.common.SplunkConverters.SplunkOptions
 import com.google.cloud.teleport.util.KMSEncryptedNestedValueProvider;
 import com.google.cloud.teleport.values.FailsafeElement;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializer;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.coders.CoderRegistry;
@@ -146,19 +146,16 @@ public class PubSubToSplunk {
       new TupleTag<FailsafeElement<String, String>>() {};
 
   /** GSON to process a {@link PubsubMessage}. */
-  private static final Gson GSON =
-      new GsonBuilder()
-          .registerTypeAdapter(
-              byte[].class,
-              (JsonSerializer<byte[]>)
-                  (bytes, type, jsonSerializationContext) ->
-                      new JsonPrimitive(new String(bytes, StandardCharsets.UTF_8)))
-          .create();
+  private static final Gson GSON = new Gson();
 
   /** Logger for class. */
   private static final Logger LOG = LoggerFactory.getLogger(PubSubToSplunk.class);
   
   private static final Boolean DEFAULT_INCLUDE_PUBSUBMESSAGE = false;
+  
+  private static final String ATTRIBUTES = "attributes";
+  private static final String MESSAGE_ID = "messageId";
+  private static final String DATA = "data";
   
   /**
    * The main entry-point for pipeline execution. This method will start the pipeline but will not
@@ -345,7 +342,7 @@ public class PubSubToSplunk {
                     @ProcessElement
                     public void processElement(ProcessContext context) {
                       if (includePubsubMessage) {
-                        context.output(GSON.toJson(context.element()));
+                        context.output(formatPubsubMessage(context.element()));
                       } else {
                         context.output(
                             new String(context.element().getPayload(), StandardCharsets.UTF_8));
@@ -375,5 +372,49 @@ public class PubSubToSplunk {
   private static ValueProvider<String> maybeDecrypt(
       ValueProvider<String> unencryptedToken, ValueProvider<String> kmsKey) {
     return new KMSEncryptedNestedValueProvider(unencryptedToken, kmsKey);
+  }
+
+  /**
+   * Utility method that formats {@link org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage} according
+   * to the model defined in {@link com.google.pubsub.v1.PubsubMessage}.
+   *
+   * @param pubsubMessage {@link org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage}
+   * @return JSON String that adheres to the model defined in {@link
+   *     com.google.pubsub.v1.PubsubMessage}
+   */
+  private static String formatPubsubMessage(PubsubMessage pubsubMessage) {
+    JsonObject messageJson = new JsonObject();
+    
+    String payload = new String(pubsubMessage.getPayload(), StandardCharsets.UTF_8);
+    try {
+      JsonObject data = GSON.fromJson(payload, JsonObject.class);
+      messageJson.add(DATA, data);
+    } catch (JsonSyntaxException e) {
+      messageJson.addProperty(DATA, payload);
+    }
+    
+    JsonObject attributes = getAttributesJson(pubsubMessage.getAttributeMap());
+    messageJson.add(ATTRIBUTES, attributes);
+
+    if (pubsubMessage.getMessageId() != null) {
+      messageJson.addProperty(MESSAGE_ID, pubsubMessage.getMessageId());
+    }
+    
+    return messageJson.toString();
+  }
+
+  /**
+   * Constructs a {@link JsonObject} from a {@link Map} of Pub/Sub attributes.
+   *
+   * @param attributesMap {@link Map} of Pub/Sub attributes
+   * @return {@link JsonObject} of Pub/Sub attributes
+   */
+  private static JsonObject getAttributesJson(Map<String, String> attributesMap) {
+    JsonObject attributesJson = new JsonObject();
+    for (String key : attributesMap.keySet()) {
+      attributesJson.addProperty(key, attributesMap.get(key));
+    }
+
+    return attributesJson;
   }
 }

--- a/src/main/java/com/google/cloud/teleport/templates/PubSubToSplunk.java
+++ b/src/main/java/com/google/cloud/teleport/templates/PubSubToSplunk.java
@@ -152,13 +152,13 @@ public class PubSubToSplunk {
   /** Logger for class. */
   private static final Logger LOG = LoggerFactory.getLogger(PubSubToSplunk.class);
   
-  private static final Boolean DEFAULT_INCLUDE_PUBSUBMESSAGE = false;
+  private static final Boolean DEFAULT_INCLUDE_PUBSUB_MESSAGE = false;
   
   @VisibleForTesting
-  protected static final String ATTRIBUTES = "attributes";
+  protected static final String PUBSUB_MESSAGE_ATTRIBUTE_FIELD = "attributes";
   @VisibleForTesting
-  protected static final String DATA = "data";
-  private static final String MESSAGE_ID = "messageId";
+  protected static final String PUBSUB_MESSAGE_DATA_FIELD = "data";
+  private static final String PUBSUB_MESSAGE_ID_FIELD = "messageId";
   
   /**
    * The main entry-point for pipeline execution. This method will start the pipeline but will not
@@ -338,7 +338,7 @@ public class PubSubToSplunk {
                       }
                       includePubsubMessage =
                           MoreObjects.firstNonNull(
-                              includePubsubMessage, DEFAULT_INCLUDE_PUBSUBMESSAGE);
+                              includePubsubMessage, DEFAULT_INCLUDE_PUBSUB_MESSAGE);
                       LOG.info("includePubsubMessage set to: {}", includePubsubMessage);
                     }
 
@@ -388,22 +388,22 @@ public class PubSubToSplunk {
   @VisibleForTesting
   protected static String formatPubsubMessage(PubsubMessage pubsubMessage) {
     JsonObject messageJson = new JsonObject();
-    
+
     String payload = new String(pubsubMessage.getPayload(), StandardCharsets.UTF_8);
     try {
       JsonObject data = GSON.fromJson(payload, JsonObject.class);
-      messageJson.add(DATA, data);
+      messageJson.add(PUBSUB_MESSAGE_DATA_FIELD, data);
     } catch (JsonSyntaxException e) {
-      messageJson.addProperty(DATA, payload);
+      messageJson.addProperty(PUBSUB_MESSAGE_DATA_FIELD, payload);
     }
-    
+
     JsonObject attributes = getAttributesJson(pubsubMessage.getAttributeMap());
-    messageJson.add(ATTRIBUTES, attributes);
+    messageJson.add(PUBSUB_MESSAGE_ATTRIBUTE_FIELD, attributes);
 
     if (pubsubMessage.getMessageId() != null) {
-      messageJson.addProperty(MESSAGE_ID, pubsubMessage.getMessageId());
+      messageJson.addProperty(PUBSUB_MESSAGE_ID_FIELD, pubsubMessage.getMessageId());
     }
-    
+
     return messageJson.toString();
   }
 

--- a/src/main/java/com/google/cloud/teleport/templates/PubSubToSplunk.java
+++ b/src/main/java/com/google/cloud/teleport/templates/PubSubToSplunk.java
@@ -30,6 +30,7 @@ import com.google.cloud.teleport.templates.common.SplunkConverters;
 import com.google.cloud.teleport.templates.common.SplunkConverters.SplunkOptions;
 import com.google.cloud.teleport.util.KMSEncryptedNestedValueProvider;
 import com.google.cloud.teleport.values.FailsafeElement;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
@@ -153,9 +154,11 @@ public class PubSubToSplunk {
   
   private static final Boolean DEFAULT_INCLUDE_PUBSUBMESSAGE = false;
   
-  private static final String ATTRIBUTES = "attributes";
+  @VisibleForTesting
+  protected static final String ATTRIBUTES = "attributes";
+  @VisibleForTesting
+  protected static final String DATA = "data";
   private static final String MESSAGE_ID = "messageId";
-  private static final String DATA = "data";
   
   /**
    * The main entry-point for pipeline execution. This method will start the pipeline but will not
@@ -382,7 +385,8 @@ public class PubSubToSplunk {
    * @return JSON String that adheres to the model defined in {@link
    *     com.google.pubsub.v1.PubsubMessage}
    */
-  private static String formatPubsubMessage(PubsubMessage pubsubMessage) {
+  @VisibleForTesting
+  protected static String formatPubsubMessage(PubsubMessage pubsubMessage) {
     JsonObject messageJson = new JsonObject();
     
     String payload = new String(pubsubMessage.getPayload(), StandardCharsets.UTF_8);

--- a/src/test/java/com/google/cloud/teleport/templates/PubsubToSplunkTest.java
+++ b/src/test/java/com/google/cloud/teleport/templates/PubsubToSplunkTest.java
@@ -40,29 +40,31 @@ public class PubsubToSplunkTest {
 
     String formattedPubsubMessage = PubSubToSplunk.formatPubsubMessage(pubsubMessage);
 
-    assertThat(formattedPubsubMessage).contains(PubSubToSplunk.DATA);
-    assertThat(formattedPubsubMessage).contains(PubSubToSplunk.ATTRIBUTES);
+    assertThat(formattedPubsubMessage).contains(PubSubToSplunk.PUBSUB_MESSAGE_DATA_FIELD);
+    assertThat(formattedPubsubMessage).contains(PubSubToSplunk.PUBSUB_MESSAGE_ATTRIBUTE_FIELD);
 
     JsonObject messageJson = GSON.fromJson(formattedPubsubMessage, JsonObject.class);
-    assertThat(messageJson.get(PubSubToSplunk.DATA).getAsString()).isEqualTo(payload);
+    assertThat(messageJson.get(PubSubToSplunk.PUBSUB_MESSAGE_DATA_FIELD).getAsString())
+        .isEqualTo(payload);
   }
 
   /** Tests whether a Pub/Sub message with JSON payload is parsed correctly. */
   @Test
   public void testJsonPubsubMessage() {
     String payload =
-        "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"ipsum\":\"id\"}}}";
+        "{\"type\":\"object\",\"properties\":{\"id\":{\"@type\":\"string\",\"ipsum\":\"id\"}}}";
     Map<String, String> attributes = ImmutableMap.of("key", "value");
 
     PubsubMessage pubsubMessage = new PubsubMessage(payload.getBytes(), attributes);
 
     String formattedPubsubMessage = PubSubToSplunk.formatPubsubMessage(pubsubMessage);
 
-    assertThat(formattedPubsubMessage).contains(PubSubToSplunk.DATA);
-    assertThat(formattedPubsubMessage).contains(PubSubToSplunk.ATTRIBUTES);
+    assertThat(formattedPubsubMessage).contains(PubSubToSplunk.PUBSUB_MESSAGE_DATA_FIELD);
+    assertThat(formattedPubsubMessage).contains(PubSubToSplunk.PUBSUB_MESSAGE_ATTRIBUTE_FIELD);
 
     JsonObject messageJson = GSON.fromJson(formattedPubsubMessage, JsonObject.class);
-    assertThat(messageJson.getAsJsonObject(PubSubToSplunk.DATA).toString()).isEqualTo(payload);
+    assertThat(messageJson.getAsJsonObject(PubSubToSplunk.PUBSUB_MESSAGE_DATA_FIELD).toString())
+        .isEqualTo(payload);
   }
 
   /** Tests whether a Pub/Sub message with complex attributes is parsed correctly. */
@@ -76,11 +78,12 @@ public class PubsubToSplunkTest {
 
     String formattedPubsubMessage = PubSubToSplunk.formatPubsubMessage(pubsubMessage);
 
-    assertThat(formattedPubsubMessage).contains(PubSubToSplunk.DATA);
-    assertThat(formattedPubsubMessage).contains(PubSubToSplunk.ATTRIBUTES);
+    assertThat(formattedPubsubMessage).contains(PubSubToSplunk.PUBSUB_MESSAGE_DATA_FIELD);
+    assertThat(formattedPubsubMessage).contains(PubSubToSplunk.PUBSUB_MESSAGE_ATTRIBUTE_FIELD);
 
     JsonObject messageJson = GSON.fromJson(formattedPubsubMessage, JsonObject.class);
-    JsonObject attributesJson = messageJson.getAsJsonObject(PubSubToSplunk.ATTRIBUTES);
+    JsonObject attributesJson =
+        messageJson.getAsJsonObject(PubSubToSplunk.PUBSUB_MESSAGE_ATTRIBUTE_FIELD);
 
     for (String key : attributes.keySet()) {
       assertThat(attributesJson.get(key).getAsString()).isEqualTo(attributes.get(key));

--- a/src/test/java/com/google/cloud/teleport/templates/PubsubToSplunkTest.java
+++ b/src/test/java/com/google/cloud/teleport/templates/PubsubToSplunkTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.teleport.templates;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import java.util.Map;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+/** Unit tests for {@link PubSubToSplunk}. */
+public class PubsubToSplunkTest {
+
+  private static final Gson GSON = new Gson();
+
+  /** Tests whether a Pub/Sub message with a {@link String} payload is parsed correctly. */
+  @Test
+  public void testStringPubsubMessage() {
+    String payload = "payload";
+    Map<String, String> attributes = ImmutableMap.of("key", "value");
+
+    PubsubMessage pubsubMessage = new PubsubMessage(payload.getBytes(), attributes);
+
+    String formattedPubsubMessage = PubSubToSplunk.formatPubsubMessage(pubsubMessage);
+
+    assertThat(formattedPubsubMessage).contains(PubSubToSplunk.DATA);
+    assertThat(formattedPubsubMessage).contains(PubSubToSplunk.ATTRIBUTES);
+
+    JsonObject messageJson = GSON.fromJson(formattedPubsubMessage, JsonObject.class);
+    assertThat(messageJson.get(PubSubToSplunk.DATA).getAsString()).isEqualTo(payload);
+  }
+
+  /** Tests whether a Pub/Sub message with JSON payload is parsed correctly. */
+  @Test
+  public void testJsonPubsubMessage() {
+    String payload =
+        "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"ipsum\":\"id\"}}}";
+    Map<String, String> attributes = ImmutableMap.of("key", "value");
+
+    PubsubMessage pubsubMessage = new PubsubMessage(payload.getBytes(), attributes);
+
+    String formattedPubsubMessage = PubSubToSplunk.formatPubsubMessage(pubsubMessage);
+
+    assertThat(formattedPubsubMessage).contains(PubSubToSplunk.DATA);
+    assertThat(formattedPubsubMessage).contains(PubSubToSplunk.ATTRIBUTES);
+
+    JsonObject messageJson = GSON.fromJson(formattedPubsubMessage, JsonObject.class);
+    assertThat(messageJson.getAsJsonObject(PubSubToSplunk.DATA).toString()).isEqualTo(payload);
+  }
+
+  /** Tests whether a Pub/Sub message with complex attributes is parsed correctly. */
+  @Test
+  public void testPubsubMessageWithComplexAttributes() {
+    String payload = "payload";
+    Map<String, String> attributes =
+        ImmutableMap.of("logging.googleapis.com/timestamp", "2021-03-17T17:14:23.270642Z");
+
+    PubsubMessage pubsubMessage = new PubsubMessage(payload.getBytes(), attributes);
+
+    String formattedPubsubMessage = PubSubToSplunk.formatPubsubMessage(pubsubMessage);
+
+    assertThat(formattedPubsubMessage).contains(PubSubToSplunk.DATA);
+    assertThat(formattedPubsubMessage).contains(PubSubToSplunk.ATTRIBUTES);
+
+    JsonObject messageJson = GSON.fromJson(formattedPubsubMessage, JsonObject.class);
+    JsonObject attributesJson = messageJson.getAsJsonObject(PubSubToSplunk.ATTRIBUTES);
+
+    for (String key : attributes.keySet()) {
+      assertThat(attributesJson.get(key).getAsString()).isEqualTo(attributes.get(key));
+    }
+  }
+}


### PR DESCRIPTION
- Publish Pub/Sub message body as a JSON object instead of a stringified JSON
- Nest Pub/Sub message body under `data` field instead of `message` field