### PR TITLE
Improve retry mechanism for Pub/Sub to Splunk network errors

### DIFF
--- a/src/main/java/com/google/cloud/teleport/splunk/HttpEventPublisher.java
+++ b/src/main/java/com/google/cloud/teleport/splunk/HttpEventPublisher.java
@@ -86,8 +86,6 @@ public abstract class HttpEventPublisher {
 
   private static final String HTTPS_PROTOCOL_PREFIX = "https";
   
-  private static final int READ_TIMEOUT = 60000;
-  
   public static Builder newBuilder() {
     return new AutoValue_HttpEventPublisher.Builder();
   }
@@ -125,9 +123,7 @@ public abstract class HttpEventPublisher {
     HttpIOExceptionHandler ioExceptionHandler =
         new HttpBackOffIOExceptionHandler(getConfiguredBackOff());
     request.setIOExceptionHandler(ioExceptionHandler);
-
-    request.setReadTimeout(READ_TIMEOUT);
-
+    
     setHeaders(request, token());
 
     return request.execute();

--- a/src/main/java/com/google/cloud/teleport/splunk/HttpEventPublisher.java
+++ b/src/main/java/com/google/cloud/teleport/splunk/HttpEventPublisher.java
@@ -20,9 +20,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.client.http.ByteArrayContent;
 import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpBackOffIOExceptionHandler;
 import com.google.api.client.http.HttpBackOffUnsuccessfulResponseHandler;
 import com.google.api.client.http.HttpBackOffUnsuccessfulResponseHandler.BackOffRequired;
 import com.google.api.client.http.HttpContent;
+import com.google.api.client.http.HttpIOExceptionHandler;
 import com.google.api.client.http.HttpMediaType;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestFactory;
@@ -83,7 +85,9 @@ public abstract class HttpEventPublisher {
   private static final String AUTHORIZATION_SCHEME = "Splunk %s";
 
   private static final String HTTPS_PROTOCOL_PREFIX = "https";
-
+  
+  private static final int READ_TIMEOUT = 60000;
+  
   public static Builder newBuilder() {
     return new AutoValue_HttpEventPublisher.Builder();
   }
@@ -115,10 +119,15 @@ public abstract class HttpEventPublisher {
 
     HttpBackOffUnsuccessfulResponseHandler responseHandler =
         new HttpBackOffUnsuccessfulResponseHandler(getConfiguredBackOff());
-
     responseHandler.setBackOffRequired(BackOffRequired.ON_SERVER_ERROR);
-
     request.setUnsuccessfulResponseHandler(responseHandler);
+
+    HttpIOExceptionHandler ioExceptionHandler =
+        new HttpBackOffIOExceptionHandler(getConfiguredBackOff());
+    request.setIOExceptionHandler(ioExceptionHandler);
+
+    request.setReadTimeout(READ_TIMEOUT);
+
     setHeaders(request, token());
 
     return request.execute();


### PR DESCRIPTION
- Add IOException handler with exponential backoff for Splunk requests
- Increase read timeout to 60s (previous default value - 20s)