### PR TITLE
Log UDF errors

### DIFF
--- a/src/main/java/com/google/cloud/teleport/templates/PubSubToSplunk.java
+++ b/src/main/java/com/google/cloud/teleport/templates/PubSubToSplunk.java
@@ -227,6 +227,7 @@ public class PubSubToSplunk {
                 FailsafeJavascriptUdf.<String>newBuilder()
                     .setFileSystemPath(options.getJavascriptTextTransformGcsPath())
                     .setFunctionName(options.getJavascriptTextTransformFunctionName())
+                    .setLoggingEnabled(ValueProvider.StaticValueProvider.of(true))
                     .setSuccessTag(UDF_OUT)
                     .setFailureTag(UDF_DEADLETTER_OUT)
                     .build());


### PR DESCRIPTION
-  Add optional UDF error logging support for `FailsafeJavascriptUdf`
-  Enable UDF error logging for Pub/Sub to Splunk template