### PR TITLE
Support useSubscription for pubsub-to-text/avro templates

### DIFF
--- a/src/main/java/com/google/cloud/teleport/templates/PubsubToAvro.java
+++ b/src/main/java/com/google/cloud/teleport/templates/PubsubToAvro.java
@@ -116,7 +116,7 @@ import org.apache.beam.sdk.values.PCollection;
  * userTempLocation=gs://${OUTPUT_BUCKET}/tmp/,\
  * outputDirectory=gs://${OUTPUT_BUCKET}/output/,\
  * outputFilenamePrefix=windowed-file,\
- * outputFilenameSuffix=.txt"
+ * outputFilenameSuffix=.avro"
  * </pre>
  *
  * </p>
@@ -225,8 +225,6 @@ public class PubsubToAvro {
     // Create the pipeline
     Pipeline pipeline = Pipeline.create(options);
 
-    ValueProvider<String> inputSubscription = options.getInputSubscription();
-    ValueProvider<String> inputTopic = options.getInputTopic();
     PCollection<PubsubMessage> messages = null;
 
     /*

--- a/src/main/java/com/google/cloud/teleport/templates/PubsubToAvro.java
+++ b/src/main/java/com/google/cloud/teleport/templates/PubsubToAvro.java
@@ -40,6 +40,7 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.PCollection;
 
 /**
  * This pipeline ingests incoming data from a Cloud Pub/Sub topic and outputs the raw data into
@@ -59,26 +60,66 @@ import org.apache.beam.sdk.transforms.windowing.Window;
  *      ]
  *   }
  * </pre>
+ * </p>
  *
  * <p>Example Usage:
  *
  * <pre>
+ * # Set the pipeline vars
+ * PIPELINE_NAME=PubsubToAvro
+ * PROJECT_ID=PROJECT ID HERE
+ * PIPELINE_BUCKET=TEMPLATE STORAGE BUCKET NAME HERE
+ * OUTPUT_BUCKET=JOB OUTPUT BUCKET NAME HERE
+ * USE_SUBSCRIPTION=true or false depending on whether the pipeline should read
+ *                  from a Pub/Sub Subscription or a Pub/Sub Topic.
+ * PIPELINE_FOLDER=gs://${PIPELINE_BUCKET}/dataflow/pipelines/pubsub-to-gcs-avro
+ *
+ * # Set the runner
+ * RUNNER=DataflowRunner
+ *
+ * # Build the template
  * mvn compile exec:java \
- *   -Dexec.mainClass=com.google.cloud.teleport.templates.${PIPELINE_NAME} \
- *   -Dexec.cleanupDaemonThreads=false \
- *   -Dexec.args=" \
- *   --project=${PROJECT_ID} \
- *   --stagingLocation=gs://${PROJECT_ID}/dataflow/pipelines/${PIPELINE_FOLDER}/staging \
- *   --tempLocation=gs://${PROJECT_ID}/dataflow/pipelines/${PIPELINE_FOLDER}/temp \
- *   --runner=DataflowRunner \
- *   --windowDuration=2m \
- *   --numShards=1 \
- *   --topic=projects/${PROJECT_ID}/topics/windowed-files \
- *   --outputDirectory=gs://${PROJECT_ID}/temp/ \
- *   --outputFilenamePrefix=windowed-file \
- *   --outputFilenameSuffix=.avro
- *   --avroTempDirectory=gs://${PROJECT_ID}/avro-temp-dir/"
+ -Dexec.mainClass=com.google.cloud.teleport.templates.${PIPELINE_NAME} \
+ -Dexec.cleanupDaemonThreads=false \
+ -Dexec.args=" \
+ --project=${PROJECT_ID} \
+ --stagingLocation=${PIPELINE_FOLDER}/staging \
+ --tempLocation=${PIPELINE_FOLDER}/temp \
+ --templateLocation=${PIPELINE_FOLDER}/template \
+ --runner=${RUNNER} \
+ --useSubscription=${USE_SUBSCRIPTION}"
+ *
+ * # Execute the template
+ * JOB_NAME=pubsub-to-bigquery-$USER-`date +"%Y%m%d-%H%M%S%z"`
+ *
+ * # Execute a pipeline to read from a Topic.
+ * gcloud dataflow jobs run ${JOB_NAME} \
+ * --gcs-location=${PIPELINE_FOLDER}/template \
+ * --zone=us-east1-d \
+ * --parameters \
+ * "inputTopic=projects/${PROJECT_ID}/topics/input-topic-name,\
+ * windowDuration=5m,\
+ * numShards=1,\
+ * userTempLocation=gs://${OUTPUT_BUCKET}/tmp/,\
+ * outputDirectory=gs://${OUTPUT_BUCKET}/output/,\
+ * outputFilenamePrefix=windowed-file,\
+ * outputFilenameSuffix=.txt"
+ *
+ * # Execute a pipeline to read from a Subscription.
+ * gcloud dataflow jobs run ${JOB_NAME} \
+ * --gcs-location=${PIPELINE_FOLDER}/template \
+ * --zone=us-east1-d \
+ * --parameters \
+ * "inputSubscription=projects/${PROJECT_ID}/subscriptions/input-subscription-name,\
+ * windowDuration=5m,\
+ * numShards=1,\
+ * userTempLocation=gs://${OUTPUT_BUCKET}/tmp/,\
+ * outputDirectory=gs://${OUTPUT_BUCKET}/output/,\
+ * outputFilenamePrefix=windowed-file,\
+ * outputFilenameSuffix=.txt"
  * </pre>
+ *
+ * </p>
  */
 public class PubsubToAvro {
 
@@ -88,11 +129,26 @@ public class PubsubToAvro {
    * <p>Inherits standard configuration options.
    */
   public interface Options extends PipelineOptions, StreamingOptions {
+    @Description(
+        "The Cloud Pub/Sub subscription to consume from. "
+            + "The name should be in the format of "
+            + "projects/<project-id>/subscriptions/<subscription-name>.")
+    ValueProvider<String> getInputSubscription();
+
+    void setInputSubscription(ValueProvider<String> value);
+
     @Description("The Cloud Pub/Sub topic to read from.")
-    @Required
     ValueProvider<String> getInputTopic();
 
     void setInputTopic(ValueProvider<String> value);
+
+    @Description(
+        "This determines whether the template reads from "
+            + "a pub/sub subscription or a topic")
+    @Default.Boolean(false)
+    Boolean getUseSubscription();
+
+    void setUseSubscription(Boolean value);
 
     @Description("The directory to output files to. Must end with a slash.")
     @Required
@@ -169,16 +225,25 @@ public class PubsubToAvro {
     // Create the pipeline
     Pipeline pipeline = Pipeline.create(options);
 
+    ValueProvider<String> inputSubscription = options.getInputSubscription();
+    ValueProvider<String> inputTopic = options.getInputTopic();
+    PCollection<PubsubMessage> messages = null;
+
     /*
      * Steps:
      *   1) Read messages from PubSub
      *   2) Window the messages into minute intervals specified by the executor.
      *   3) Output the windowed data into Avro files, one per window by default.
      */
-    pipeline
-        .apply(
-            "Read PubSub Events",
-            PubsubIO.readMessagesWithAttributes().fromTopic(options.getInputTopic()))
+
+    if (options.getUseSubscription()) {
+        messages = pipeline.apply("Read PubSub Events", PubsubIO.readMessagesWithAttributes()
+          .fromSubscription(options.getInputSubscription()));
+    } else {
+        messages = pipeline.apply("Read PubSub Events", PubsubIO.readMessagesWithAttributes()
+          .fromTopic(options.getInputTopic()));
+    }
+    messages
         .apply("Map to Archive", ParDo.of(new PubsubMessageToArchiveDoFn()))
         .apply(
             options.getWindowDuration() + " Window",

--- a/src/main/java/com/google/cloud/teleport/templates/PubsubToText.java
+++ b/src/main/java/com/google/cloud/teleport/templates/PubsubToText.java
@@ -199,8 +199,6 @@ public class PubsubToText {
     // Create the pipeline
     Pipeline pipeline = Pipeline.create(options);
 
-    ValueProvider<String> inputSubscription = options.getInputSubscription();
-    ValueProvider<String> inputTopic = options.getInputTopic();
     PCollection<String> messages = null;
 
     /*

--- a/src/main/java/com/google/cloud/teleport/templates/PubsubToText.java
+++ b/src/main/java/com/google/cloud/teleport/templates/PubsubToText.java
@@ -130,6 +130,7 @@ public class PubsubToText {
         + "a pub/sub subscription or a topic")
     @Default.Boolean(false)
     Boolean getUseSubscription();
+    void setUseSubscription(Boolean value);
 
     @Description("The directory to output files to. Must end with a slash.")
     @Required

--- a/src/main/java/com/google/cloud/teleport/templates/PubsubToText.java
+++ b/src/main/java/com/google/cloud/teleport/templates/PubsubToText.java
@@ -39,6 +39,7 @@ import org.apache.beam.sdk.options.ValueProvider.NestedValueProvider;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.PCollection;
 
 /**
  * This pipeline ingests incoming data from a Cloud Pub/Sub topic and
@@ -48,22 +49,60 @@ import org.apache.beam.sdk.transforms.windowing.Window;
  * <p> Example Usage:
  *
  * <pre>
+ * # Set the pipeline vars
+ * PIPELINE_NAME=PubsubToText
+ * PROJECT_ID=PROJECT ID HERE
+ * PIPELINE_BUCKET=TEMPLATE STORAGE BUCKET NAME HERE
+ * OUTPUT_BUCKET=JOB OUTPUT BUCKET NAME HERE
+ * PIPELINE_FOLDER=gs://${PIPELINE_BUCKET}/dataflow/pipelines/pubsub-to-gcs-text
+ * USE_SUBSCRIPTION=true or false depending on whether the pipeline should read
+ *                  from a Pub/Sub Subscription or a Pub/Sub Topic.
+ *
+ * # Set the runner
+ * RUNNER=DataflowRunner
+ *
+ * # Build the template
  * mvn compile exec:java \
  -Dexec.mainClass=com.google.cloud.teleport.templates.${PIPELINE_NAME} \
  -Dexec.cleanupDaemonThreads=false \
  -Dexec.args=" \
  --project=${PROJECT_ID} \
- --stagingLocation=gs://${PROJECT_ID}/dataflow/pipelines/${PIPELINE_FOLDER}/staging \
- --tempLocation=gs://${PROJECT_ID}/dataflow/pipelines/${PIPELINE_FOLDER}/temp \
- --runner=DataflowRunner \
- --windowDuration=2m \
- --numShards=1 \
- --inputTopic=projects/${PROJECT_ID}/topics/windowed-files \
- --userTempLocation=gs://${PROJECT_ID}/tmp/ \
- --outputDirectory=gs://${PROJECT_ID}/output/ \
- --outputFilenamePrefix=windowed-file \
- --outputFilenameSuffix=.txt"
+ --stagingLocation=${PIPELINE_FOLDER}/staging \
+ --tempLocation=${PIPELINE_FOLDER}/temp \
+ --templateLocation=${PIPELINE_FOLDER}/template \
+ --runner=${RUNNER} \
+ --useSubscription=${USE_SUBSCRIPTION}"
+ *
+ * # Execute the template
+ * JOB_NAME=pubsub-to-bigquery-$USER-`date +"%Y%m%d-%H%M%S%z"`
+ *
+ * # Execute a pipeline to read from a Topic.
+ * gcloud dataflow jobs run ${JOB_NAME} \
+ * --gcs-location=${PIPELINE_FOLDER}/template \
+ * --zone=us-east1-d \
+ * --parameters \
+ * "inputTopic=projects/${PROJECT_ID}/topics/input-topic-name,\
+ * userTempLocation=gs://${OUTPUT_BUCKET}/tmp/,\
+ * windowDuration=5m,\
+ * numShards=1,\
+ * outputDirectory=gs://${OUTPUT_BUCKET}/output/,\
+ * outputFilenamePrefix=windowed-file,\
+ * outputFilenameSuffix=.txt"
+ *
+ * # Execute a pipeline to read from a Subscription.
+ * gcloud dataflow jobs run ${JOB_NAME} \
+ * --gcs-location=${PIPELINE_FOLDER}/template \
+ * --zone=us-east1-d \
+ * --parameters \
+ * "inputSubscription=projects/${PROJECT_ID}/subscriptions/input-subscription-name,\
+ * windowDuration=5m,\
+ * numShards=1,\
+ * userTempLocation=gs://${OUTPUT_BUCKET}/tmp/,\
+ * outputDirectory=gs://${OUTPUT_BUCKET}/output/,\
+ * outputFilenamePrefix=windowed-file,\
+ * outputFilenameSuffix=.txt"
  * </pre>
+ *
  * </p>
  */
 public class PubsubToText {
@@ -74,10 +113,23 @@ public class PubsubToText {
    * <p>Inherits standard configuration options.</p>
    */
   public interface Options extends PipelineOptions, StreamingOptions {
+    @Description(
+        "The Cloud Pub/Sub subscription to consume from. "
+            + "The name should be in the format of "
+            + "projects/<project-id>/subscriptions/<subscription-name>.")
+    ValueProvider<String> getInputSubscription();
+
+    void setInputSubscription(ValueProvider<String> value);
+
     @Description("The Cloud Pub/Sub topic to read from.")
-    @Required
     ValueProvider<String> getInputTopic();
     void setInputTopic(ValueProvider<String> value);
+
+    @Description(
+        "This determines whether the template reads from "
+        + "a pub/sub subscription or a topic")
+    @Default.Boolean(false)
+    Boolean getUseSubscription();
 
     @Description("The directory to output files to. Must end with a slash.")
     @Required
@@ -147,14 +199,24 @@ public class PubsubToText {
     // Create the pipeline
     Pipeline pipeline = Pipeline.create(options);
 
+    ValueProvider<String> inputSubscription = options.getInputSubscription();
+    ValueProvider<String> inputTopic = options.getInputTopic();
+    PCollection<String> messages = null;
+
     /*
      * Steps:
      *   1) Read string messages from PubSub
      *   2) Window the messages into minute intervals specified by the executor.
      *   3) Output the windowed files to GCS
      */
-    pipeline
-        .apply("Read PubSub Events", PubsubIO.readStrings().fromTopic(options.getInputTopic()))
+    if (options.getUseSubscription()) {
+        messages = pipeline.apply("Read PubSub Events", PubsubIO.readStrings()
+          .fromSubscription(options.getInputSubscription()));
+    } else {
+        messages = pipeline.apply("Read PubSub Events", PubsubIO.readStrings()
+          .fromTopic(options.getInputTopic()));
+    }
+    messages
         .apply(
             options.getWindowDuration() + " Window",
             Window.into(FixedWindows.of(DurationUtils.parseDuration(options.getWindowDuration()))))


### PR DESCRIPTION
Following the pattern of the PubsubToBigquery template, allow building a
template that supports `inputSubscription` rather than `inputTopic` for
the PubsubToAvro and PubsubToText templates.

This addresses the feedback in https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/235

Signed-off-by: Nathan J. Mehl <n@oden.io>