### PR TITLE
Fix parsing timestamp nested under Pub/Sub message 'data' field

### DIFF
--- a/src/main/java/com/google/cloud/teleport/templates/common/SplunkConverters.java
+++ b/src/main/java/com/google/cloud/teleport/templates/common/SplunkConverters.java
@@ -60,6 +60,8 @@ public class SplunkConverters {
   private static final String HEC_SOURCE_TYPE_KEY = "sourcetype";
 
   private static final String TIMESTAMP_KEY = "timestamp";
+  
+  private static final String DATA = "data";
 
   /**
    * Returns a {@link FailsafeStringToSplunkEvent} {@link PTransform} that consumes {@link
@@ -183,6 +185,9 @@ public class SplunkConverters {
                           String parsedTimestamp;
                           if (metadataAvailable) {
                             parsedTimestamp = metadata.optString(HEC_TIME_KEY);
+                          } else if (json.optJSONObject(DATA) != null
+                              && json.getJSONObject(DATA).has(TIMESTAMP_KEY)) {
+                            parsedTimestamp = json.getJSONObject(DATA).getString(TIMESTAMP_KEY);
                           } else {
                             parsedTimestamp = json.optString(TIMESTAMP_KEY);
                           }


### PR DESCRIPTION
This PR modifies the Pub/Sub to Splunk template to add support for parsing `timestamp` field nested under the `data` field for Pub/Sub messages, when `includePubsubMessage=true`.