### PR TITLE
Fix DLPTextToBigQueryStreaming for multibyte characters

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@
 *   Eric Anderson
 *   Jason Kuster
 *   Kevin Si
+*   Naruhito Nakaharai
 *   Nithin Sujir
 *   Pramod Rao
 *   Roderick Yao

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,7 +11,6 @@
 *   Eric Anderson
 *   Jason Kuster
 *   Kevin Si
-*   Naruhito Nakaharai
 *   Nithin Sujir
 *   Pramod Rao
 *   Roderick Yao

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ their functionality.
 * [Bigtable to GCS Avro](src/main/java/com/google/cloud/teleport/bigtable/BigtableToAvro.java)
 * [Bulk Compressor](src/main/java/com/google/cloud/teleport/templates/BulkCompressor.java)
 * [Bulk Decompressor](src/main/java/com/google/cloud/teleport/templates/BulkDecompressor.java)
+* [DLP Text to BigQuery (Streaming)](src/main/java/com/google/cloud/teleport/templates/DLPTextToBigQueryStreaming.java)
 * [Datastore Bulk Delete](src/main/java/com/google/cloud/teleport/templates/DatastoreToDatastoreDelete.java) *
 * [Datastore to BigQuery](src/main/java/com/google/cloud/teleport/templates/DatastoreToBigQuery.java)
 * [Datastore to GCS Text](src/main/java/com/google/cloud/teleport/templates/DatastoreToText.java) *

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ their functionality.
 * [Bigtable to GCS Avro](src/main/java/com/google/cloud/teleport/bigtable/BigtableToAvro.java)
 * [Bulk Compressor](src/main/java/com/google/cloud/teleport/templates/BulkCompressor.java)
 * [Bulk Decompressor](src/main/java/com/google/cloud/teleport/templates/BulkDecompressor.java)
-* [DLP Text to BigQuery (Streaming)](src/main/java/com/google/cloud/teleport/templates/DLPTextToBigQueryStreaming.java)
 * [Datastore Bulk Delete](src/main/java/com/google/cloud/teleport/templates/DatastoreToDatastoreDelete.java) *
 * [Datastore to BigQuery](src/main/java/com/google/cloud/teleport/templates/DatastoreToBigQuery.java)
 * [Datastore to GCS Text](src/main/java/com/google/cloud/teleport/templates/DatastoreToText.java) *
 * [Datastore to Pub/Sub](src/main/java/com/google/cloud/teleport/templates/DatastoreToPubsub.java) *
 * [Datastore Unique Schema Count](src/main/java/com/google/cloud/teleport/templates/DatastoreSchemasCountToText.java)
+* [DLP Text to BigQuery (Streaming)](src/main/java/com/google/cloud/teleport/templates/DLPTextToBigQueryStreaming.java)
 * [GCS Avro to Bigtable](src/main/java/com/google/cloud/teleport/bigtable/AvroToBigtable.java)
 * [GCS Avro to Spanner](src/main/java/com/google/cloud/teleport/spanner/ImportPipeline.java)
 * [GCS Text to Spanner](src/main/java/com/google/cloud/teleport/spanner/TextImportPipeline.java)

--- a/src/main/java/com/google/cloud/teleport/templates/DLPTextToBigQueryStreaming.java
+++ b/src/main/java/com/google/cloud/teleport/templates/DLPTextToBigQueryStreaming.java
@@ -131,6 +131,7 @@ import org.slf4j.LoggerFactory;
  * --zone=us-east1-d \
  * --parameters \
  * "inputFilePattern=gs://<bucketName>/<fileName>.csv, batchSize=15,datasetName=<BQDatasetId>,
+ *  dlpProjectId=<projectId>,
  *  deidentifyTemplateName=projects/{projectId}/deidentifyTemplates/{deIdTemplateId}
  * </pre>
  */
@@ -728,7 +729,7 @@ public class DLPTextToBigQueryStreaming {
 
     if (channel != null) {
 
-      br = new BufferedReader(Channels.newReader(channel, Charsets.ISO_8859_1.name()));
+      br = new BufferedReader(Channels.newReader(channel, Charsets.UTF_8.name()));
     }
 
     return br;

--- a/src/test/java/com/google/cloud/teleport/templates/DLPTextToBigQueryStreamingTest.java
+++ b/src/test/java/com/google/cloud/teleport/templates/DLPTextToBigQueryStreamingTest.java
@@ -69,10 +69,10 @@ public class DLPTextToBigQueryStreamingTest {
   private static StringBuilder fileContents = new StringBuilder();
   private static final String HEADER_ROW =
       "CardTypeCode,CardTypeFullName,IssuingBank,CardNumber,CardHoldersName,CVVCVV2,IssueDate,ExpiryDate,"
-          + "BillingDate,CardPIN,CreditLimit";
+          + "BillingDate,CardPIN,CreditLimit,MultibyteCharacters";
   private static final String CONTENTS_ROW =
       "MC,Master Card,Wells Fargo,E5ssxfuqnGfF36Kk,Jeremy O Wilson,"
-          + "NK3,12/2007,12/2008,3,vmFF,19800";
+          + "NK3,12/2007,12/2008,3,vmFF,19800,鈴木一郎";
   private static String tokenizedFilePath;
 
   @BeforeClass
@@ -116,7 +116,7 @@ public class DLPTextToBigQueryStreamingTest {
             collection -> {
               KV<String, Table> tableData = collection.iterator().next();
               assertThat(tableData.getKey(), is(equalTo("tokenization_data")));
-              assertThat(tableData.getValue().getHeadersCount(), is(equalTo(11)));
+              assertThat(tableData.getValue().getHeadersCount(), is(equalTo(12)));
               assertThat(tableData.getValue().getRowsCount(), is(equalTo(1)));
               return null;
             });
@@ -140,6 +140,7 @@ public class DLPTextToBigQueryStreamingTest {
               assertThat(result.getValue().get("BillingDate"), is(equalTo("3")));
               assertThat(result.getValue().get("CardPIN"), is(equalTo("vmFF")));
               assertThat(result.getValue().get("CreditLimit"), is(equalTo("19800")));
+              assertThat(result.getValue().get("MultibyteCharacters"), is(equalTo("鈴木一郎")));
               return null;
             });
     p.run();


### PR DESCRIPTION
Hello,

While following the steps written in this document https://cloud.google.com/dataflow/docs/guides/templates/provided-streaming#dlptexttobigquerystreaming , I found that `DLPTextToBigQueryStreaming.java` has a minor issue for multibyte characters like Japanese names.

Before the fix:

![before-the-fix](https://user-images.githubusercontent.com/263047/116791590-5cc4a500-aaf6-11eb-938b-2fecb8734072.png)

After the fix:

![after-the-fix](https://user-images.githubusercontent.com/263047/116791597-60f0c280-aaf6-11eb-8f53-80fc38b099e4.png)

I hope this could be merged soon and become usable from GCP Cloud Console (Web UI), as we cannot use the DataFlow template for Japanese documents with PII.

Best Regards,

Naruhito