### PR TITLE
Add support for Splunk 'fields' metadata

### DIFF
--- a/src/main/java/com/google/cloud/teleport/splunk/SplunkEvent.java
+++ b/src/main/java/com/google/cloud/teleport/splunk/SplunkEvent.java
@@ -19,6 +19,7 @@ package com.google.cloud.teleport.splunk;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auto.value.AutoValue;
+import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 import javax.annotation.Nullable;
 
@@ -44,10 +45,13 @@ public abstract class SplunkEvent {
   @Nullable
   @SerializedName("sourcetype")
   public abstract String sourceType();
-
+  
   @Nullable
   public abstract String index();
-
+  
+  @Nullable
+  public abstract JsonObject fields();
+  
   @Nullable
   public abstract String event();
 
@@ -68,7 +72,9 @@ public abstract class SplunkEvent {
     abstract Builder setIndex(String index);
 
     abstract Builder setEvent(String event);
-
+  
+    abstract Builder setFields(JsonObject fields);
+  
     abstract String event();
 
     abstract SplunkEvent autoBuild();
@@ -101,6 +107,12 @@ public abstract class SplunkEvent {
       checkNotNull(index, "withIndex(index) called with null input.");
 
       return setIndex(index);
+    }
+  
+    public Builder withFields(JsonObject fields) {
+      checkNotNull(fields, "withFields(fields) called with null input.");
+    
+      return setFields(fields);
     }
 
     public Builder withEvent(String event) {

--- a/src/main/java/com/google/cloud/teleport/templates/common/SplunkConverters.java
+++ b/src/main/java/com/google/cloud/teleport/templates/common/SplunkConverters.java
@@ -205,7 +205,7 @@ public class SplunkConverters {
                               builder.withTime(DateTime.parseRfc3339(parsedTimestamp).getValue());
                             } catch (NumberFormatException n) {
                               // We log this exception but don't want to fail the entire record.
-                              LOG.debug(
+                              LOG.warn(
                                   "Unable to parse non-rfc3339 formatted timestamp: {}",
                                   parsedTimestamp);
                             }
@@ -241,7 +241,11 @@ public class SplunkConverters {
                             
                             String fields = metadata.optString(HEC_FIELDS_KEY);
                             if (!fields.isEmpty()) {
-                              builder.withFields(GSON.fromJson(fields, JsonObject.class));
+                              try {
+                                builder.withFields(GSON.fromJson(fields, JsonObject.class));
+                              } catch (JsonParseException e) {
+                                LOG.warn("Unable to parse 'fields' metadata JSON");
+                              }
                             }
                             // We remove the _metadata entry from the payload
                             // to avoid duplicates in Splunk. The relevant entries
@@ -254,7 +258,7 @@ public class SplunkConverters {
                             }
                           }
 
-                        } catch (JSONException | JsonParseException je) {
+                        } catch (JSONException je) {
                           // input is either not a properly formatted JSONObject
                           // or has other exceptions. In this case, we will
                           // simply capture the entire input as an 'event' and

--- a/src/main/java/com/google/cloud/teleport/templates/common/SplunkConverters.java
+++ b/src/main/java/com/google/cloud/teleport/templates/common/SplunkConverters.java
@@ -238,13 +238,14 @@ public class SplunkConverters {
                             if (!event.isEmpty()) {
                               builder.withEvent(event);
                             }
-                            
+
                             String fields = metadata.optString(HEC_FIELDS_KEY);
                             if (!fields.isEmpty()) {
                               try {
                                 builder.withFields(GSON.fromJson(fields, JsonObject.class));
                               } catch (JsonParseException e) {
-                                LOG.warn("Unable to parse 'fields' metadata JSON");
+                                LOG.warn(
+                                    "Unable to convert 'fields' metadata value:{} into JSON object", fields);
                               }
                             }
                             // We remove the _metadata entry from the payload

--- a/src/test/java/com/google/cloud/teleport/splunk/SplunkEventCoderTest.java
+++ b/src/test/java/com/google/cloud/teleport/splunk/SplunkEventCoderTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import com.google.gson.JsonObject;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -53,6 +54,34 @@ public class SplunkEventCoderTest {
             .withTime(time)
             .build();
 
+    SplunkEventCoder coder = SplunkEventCoder.of();
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+      coder.encode(actualEvent, bos);
+      try (ByteArrayInputStream bin = new ByteArrayInputStream(bos.toByteArray())) {
+        SplunkEvent decodedEvent = coder.decode(bin);
+        assertThat(decodedEvent, is(equalTo(actualEvent)));
+      }
+    }
+  }
+  
+  /**
+   * Test whether {@link SplunkEventCoder} is able to encode/decode a {@link SplunkEvent}
+   * with metadata 'fields'.
+   * @throws IOException
+   */
+  @Test
+  public void testEncodeDecodeFields() throws IOException {
+    
+    String event = "test-event";
+    JsonObject fields = new JsonObject();
+    fields.addProperty("test-key", "test-value");
+    
+    SplunkEvent actualEvent =
+        SplunkEvent.newBuilder()
+            .withEvent(event)
+            .withFields(fields)
+            .build();
+    
     SplunkEventCoder coder = SplunkEventCoder.of();
     try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
       coder.encode(actualEvent, bos);

--- a/src/test/java/com/google/cloud/teleport/splunk/SplunkEventTest.java
+++ b/src/test/java/com/google/cloud/teleport/splunk/SplunkEventTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 
+import com.google.gson.JsonObject;
 import org.junit.Test;
 
 /** Unit tests for {@link SplunkEvent} class. */
@@ -38,6 +39,8 @@ public class SplunkEventTest {
     String source = "test-source";
     String sourceType = "test-source-type";
     Long time = 123456789L;
+    JsonObject fields = new JsonObject();
+    fields.addProperty("test-key", "test-value");
 
     SplunkEvent actualEvent =
         SplunkEvent.newBuilder()
@@ -47,6 +50,7 @@ public class SplunkEventTest {
             .withSource(source)
             .withSourceType(sourceType)
             .withTime(time)
+            .withFields(fields)
             .build();
 
     assertThat(
@@ -60,6 +64,7 @@ public class SplunkEventTest {
                     .withSource(source)
                     .withSourceType(sourceType)
                     .withTime(time)
+                    .withFields(fields)
                     .build())));
 
     assertThat(
@@ -74,6 +79,7 @@ public class SplunkEventTest {
                         .withSource(source)
                         .withSourceType(sourceType)
                         .withTime(time)
+                        .withFields(fields)
                         .build()))));
   }
 }

--- a/src/test/java/com/google/cloud/teleport/templates/common/SplunkConvertersTest.java
+++ b/src/test/java/com/google/cloud/teleport/templates/common/SplunkConvertersTest.java
@@ -41,7 +41,7 @@ public class SplunkConvertersTest {
   private static final TupleTag<FailsafeElement<String, String>> SPLUNK_EVENT_DEADLETTER_OUT =
       new TupleTag<FailsafeElement<String, String>>() {};
   @Rule public final transient TestPipeline pipeline = TestPipeline.create();
-  
+
   private static final Gson GSON = new Gson();
 
   /** Test successful conversion of simple String payloads. */
@@ -81,23 +81,10 @@ public class SplunkConvertersTest {
         FailsafeElement.of(
             "" + "\t\"name\": \"Jim\",\n" + "}", "{\n" + "\t\"name\": \"Jim\",\n" + "}");
 
-    pipeline.getCoderRegistry().registerCoderForClass(SplunkEvent.class, SplunkEventCoder.of());
+    SplunkEvent expectedSplunkEvent =
+        SplunkEvent.newBuilder().withEvent("{\n" + "\t\"name\": \"Jim\",\n" + "}").build();
 
-    PCollectionTuple tuple =
-        pipeline
-            .apply(
-                Create.of(input)
-                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-            .apply(
-                SplunkConverters.failsafeStringToSplunkEvent(
-                    SPLUNK_EVENT_OUT, SPLUNK_EVENT_DEADLETTER_OUT));
-
-    PAssert.that(tuple.get(SPLUNK_EVENT_DEADLETTER_OUT)).empty();
-    PAssert.that(tuple.get(SPLUNK_EVENT_OUT))
-        .containsInAnyOrder(
-            SplunkEvent.newBuilder().withEvent("{\n" + "\t\"name\": \"Jim\",\n" + "}").build());
-
-    pipeline.run();
+    matchesSplunkEvent(input, expectedSplunkEvent);
   }
 
   /** Test successful conversion of JSON messages. */
@@ -109,23 +96,10 @@ public class SplunkConvertersTest {
         FailsafeElement.of(
             "" + "\t\"name\": \"Jim\",\n" + "}", "{\n" + "\t\"name\": \"Jim\"\n" + "}");
 
-    pipeline.getCoderRegistry().registerCoderForClass(SplunkEvent.class, SplunkEventCoder.of());
+    SplunkEvent expectedSplunkEvent =
+        SplunkEvent.newBuilder().withEvent("{\n" + "\t\"name\": \"Jim\"\n" + "}").build();
 
-    PCollectionTuple tuple =
-        pipeline
-            .apply(
-                Create.of(input)
-                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-            .apply(
-                SplunkConverters.failsafeStringToSplunkEvent(
-                    SPLUNK_EVENT_OUT, SPLUNK_EVENT_DEADLETTER_OUT));
-
-    PAssert.that(tuple.get(SPLUNK_EVENT_DEADLETTER_OUT)).empty();
-    PAssert.that(tuple.get(SPLUNK_EVENT_OUT))
-        .containsInAnyOrder(
-            SplunkEvent.newBuilder().withEvent("{\n" + "\t\"name\": \"Jim\"\n" + "}").build());
-
-    pipeline.run();
+    matchesSplunkEvent(input, expectedSplunkEvent);
   }
 
   /** Test successful conversion of JSON messages with a valid timestamp. */
@@ -142,31 +116,18 @@ public class SplunkConvertersTest {
                 + "\t\"timestamp\": \"2019-10-15T11:32:26.553Z\"\n"
                 + "}");
 
-    pipeline.getCoderRegistry().registerCoderForClass(SplunkEvent.class, SplunkEventCoder.of());
+    SplunkEvent expectedSplunkEvent =
+        SplunkEvent.newBuilder()
+            .withEvent(
+                "{\n"
+                    + "\t\"name\": \"Jim\",\n"
+                    + "\t\"logName\": \"test-log-name\",\n"
+                    + "\t\"timestamp\": \"2019-10-15T11:32:26.553Z\"\n"
+                    + "}")
+            .withTime(DateTime.parseRfc3339("2019-10-15T11:32:26.553Z").getValue())
+            .build();
 
-    PCollectionTuple tuple =
-        pipeline
-            .apply(
-                Create.of(input)
-                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-            .apply(
-                SplunkConverters.failsafeStringToSplunkEvent(
-                    SPLUNK_EVENT_OUT, SPLUNK_EVENT_DEADLETTER_OUT));
-
-    PAssert.that(tuple.get(SPLUNK_EVENT_DEADLETTER_OUT)).empty();
-    PAssert.that(tuple.get(SPLUNK_EVENT_OUT))
-        .containsInAnyOrder(
-            SplunkEvent.newBuilder()
-                .withEvent(
-                    "{\n"
-                        + "\t\"name\": \"Jim\",\n"
-                        + "\t\"logName\": \"test-log-name\",\n"
-                        + "\t\"timestamp\": \"2019-10-15T11:32:26.553Z\"\n"
-                        + "}")
-                .withTime(DateTime.parseRfc3339("2019-10-15T11:32:26.553Z").getValue())
-                .build());
-
-    pipeline.run();
+    matchesSplunkEvent(input, expectedSplunkEvent);
   }
 
   /** Test successful conversion of JSON messages with an invalid timestamp. */
@@ -183,30 +144,17 @@ public class SplunkConvertersTest {
                 + "\t\"timestamp\": \"2019-1011:32:26.553Z\"\n"
                 + "}");
 
-    pipeline.getCoderRegistry().registerCoderForClass(SplunkEvent.class, SplunkEventCoder.of());
+    SplunkEvent expectedSplunkEvent =
+        SplunkEvent.newBuilder()
+            .withEvent(
+                "{\n"
+                    + "\t\"name\": \"Jim\",\n"
+                    + "\t\"logName\": \"test-log-name\",\n"
+                    + "\t\"timestamp\": \"2019-1011:32:26.553Z\"\n"
+                    + "}")
+            .build();
 
-    PCollectionTuple tuple =
-        pipeline
-            .apply(
-                Create.of(input)
-                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-            .apply(
-                SplunkConverters.failsafeStringToSplunkEvent(
-                    SPLUNK_EVENT_OUT, SPLUNK_EVENT_DEADLETTER_OUT));
-
-    PAssert.that(tuple.get(SPLUNK_EVENT_DEADLETTER_OUT)).empty();
-    PAssert.that(tuple.get(SPLUNK_EVENT_OUT))
-        .containsInAnyOrder(
-            SplunkEvent.newBuilder()
-                .withEvent(
-                    "{\n"
-                        + "\t\"name\": \"Jim\",\n"
-                        + "\t\"logName\": \"test-log-name\",\n"
-                        + "\t\"timestamp\": \"2019-1011:32:26.553Z\"\n"
-                        + "}")
-                .build());
-
-    pipeline.run();
+    matchesSplunkEvent(input, expectedSplunkEvent);
   }
 
   /** Test successful conversion of JSON messages with a user provided _metadata. */
@@ -222,26 +170,13 @@ public class SplunkConvertersTest {
                 + "\t\"_metadata\": {\"source\": \"test-log-name\"}\n"
                 + "}");
 
-    pipeline.getCoderRegistry().registerCoderForClass(SplunkEvent.class, SplunkEventCoder.of());
+    SplunkEvent expectedSplunkEvent =
+        SplunkEvent.newBuilder()
+            .withEvent("{\"name\":\"Jim\"}")
+            .withSource("test-log-name")
+            .build();
 
-    PCollectionTuple tuple =
-        pipeline
-            .apply(
-                Create.of(input)
-                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-            .apply(
-                SplunkConverters.failsafeStringToSplunkEvent(
-                    SPLUNK_EVENT_OUT, SPLUNK_EVENT_DEADLETTER_OUT));
-
-    PAssert.that(tuple.get(SPLUNK_EVENT_DEADLETTER_OUT)).empty();
-    PAssert.that(tuple.get(SPLUNK_EVENT_OUT))
-        .containsInAnyOrder(
-            SplunkEvent.newBuilder()
-                .withEvent("{\"name\":\"Jim\"}")
-                .withSource("test-log-name")
-                .build());
-
-    pipeline.run();
+    matchesSplunkEvent(input, expectedSplunkEvent);
   }
 
   /** Test successful conversion of JSON messages with a user provided host. */
@@ -257,23 +192,10 @@ public class SplunkConvertersTest {
                 + "\t\"_metadata\": {\"host\": \"test-host\"}\n"
                 + "}");
 
-    pipeline.getCoderRegistry().registerCoderForClass(SplunkEvent.class, SplunkEventCoder.of());
+    SplunkEvent expectedSplunkEvent =
+        SplunkEvent.newBuilder().withEvent("{\"name\":\"Jim\"}").withHost("test-host").build();
 
-    PCollectionTuple tuple =
-        pipeline
-            .apply(
-                Create.of(input)
-                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-            .apply(
-                SplunkConverters.failsafeStringToSplunkEvent(
-                    SPLUNK_EVENT_OUT, SPLUNK_EVENT_DEADLETTER_OUT));
-
-    PAssert.that(tuple.get(SPLUNK_EVENT_DEADLETTER_OUT)).empty();
-    PAssert.that(tuple.get(SPLUNK_EVENT_OUT))
-        .containsInAnyOrder(
-            SplunkEvent.newBuilder().withEvent("{\"name\":\"Jim\"}").withHost("test-host").build());
-
-    pipeline.run();
+    matchesSplunkEvent(input, expectedSplunkEvent);
   }
 
   /** Test successful conversion of JSON messages with a user provided index. */
@@ -290,33 +212,20 @@ public class SplunkConvertersTest {
                 + "\"index\":\"test-index\"}\n"
                 + "}");
 
-    pipeline.getCoderRegistry().registerCoderForClass(SplunkEvent.class, SplunkEventCoder.of());
+    SplunkEvent expectedSplunkEvent =
+        SplunkEvent.newBuilder()
+            .withEvent("{\"name\":\"Jim\"}")
+            .withHost("test-host")
+            .withIndex("test-index")
+            .build();
 
-    PCollectionTuple tuple =
-        pipeline
-            .apply(
-                Create.of(input)
-                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-            .apply(
-                SplunkConverters.failsafeStringToSplunkEvent(
-                    SPLUNK_EVENT_OUT, SPLUNK_EVENT_DEADLETTER_OUT));
-
-    PAssert.that(tuple.get(SPLUNK_EVENT_DEADLETTER_OUT)).empty();
-    PAssert.that(tuple.get(SPLUNK_EVENT_OUT))
-        .containsInAnyOrder(
-            SplunkEvent.newBuilder()
-                .withEvent("{\"name\":\"Jim\"}")
-                .withHost("test-host")
-                .withIndex("test-index")
-                .build());
-
-    pipeline.run();
+    matchesSplunkEvent(input, expectedSplunkEvent);
   }
 
   /** Test successful conversion of JSON messages with user provided index 'fields'. */
   @Test
   @Category(NeedsRunner.class)
-  public void testFailsafeStringToSplunkEventValidFields() {
+  public void testFailsafeStringToSplunkEvent_withValidFields() {
 
     FailsafeElement<String, String> input =
         FailsafeElement.of(
@@ -326,68 +235,38 @@ public class SplunkConvertersTest {
                 + "\t\"_metadata\": {\"fields\":{\"test-key\":\"test-value\"}}\n"
                 + "}");
 
-    pipeline.getCoderRegistry().registerCoderForClass(SplunkEvent.class, SplunkEventCoder.of());
+    SplunkEvent expectedSplunkEvent =
+        SplunkEvent.newBuilder()
+            .withEvent("{\"name\":\"Jim\"}")
+            .withFields(GSON.fromJson("{\"test-key\":\"test-value\"}", JsonObject.class))
+            .build();
 
-    PCollectionTuple tuple =
-        pipeline
-            .apply(
-                Create.of(input)
-                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-            .apply(
-                SplunkConverters.failsafeStringToSplunkEvent(
-                    SPLUNK_EVENT_OUT, SPLUNK_EVENT_DEADLETTER_OUT));
-
-    PAssert.that(tuple.get(SPLUNK_EVENT_DEADLETTER_OUT)).empty();
-    PAssert.that(tuple.get(SPLUNK_EVENT_OUT))
-        .containsInAnyOrder(
-            SplunkEvent.newBuilder()
-                .withEvent("{\"name\":\"Jim\"}")
-                .withFields(GSON.fromJson("{\"test-key\":\"test-value\"}", JsonObject.class))
-                .build());
-
-    pipeline.run();
+    matchesSplunkEvent(input, expectedSplunkEvent);
   }
-  
+
   /** Test successful conversion of JSON messages with user provided empty index 'fields'. */
   @Test
   @Category(NeedsRunner.class)
-  public void testFailsafeStringToSplunkEventEmptyFields() {
-    
+  public void testFailsafeStringToSplunkEvent_withEmptyFields() {
+
     FailsafeElement<String, String> input =
         FailsafeElement.of(
-            "",
-            "{\n"
-                + "\t\"name\": \"Jim\",\n"
-                + "\t\"_metadata\": {\"fields\":{}}\n"
-                + "}");
-    
-    pipeline.getCoderRegistry().registerCoderForClass(SplunkEvent.class, SplunkEventCoder.of());
-    
-    PCollectionTuple tuple =
-        pipeline
-            .apply(
-                Create.of(input)
-                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-            .apply(
-                SplunkConverters.failsafeStringToSplunkEvent(
-                    SPLUNK_EVENT_OUT, SPLUNK_EVENT_DEADLETTER_OUT));
-    
-    PAssert.that(tuple.get(SPLUNK_EVENT_DEADLETTER_OUT)).empty();
-    PAssert.that(tuple.get(SPLUNK_EVENT_OUT))
-        .containsInAnyOrder(
-            SplunkEvent.newBuilder()
-                .withEvent("{\"name\":\"Jim\"}")
-                .withFields(GSON.fromJson("{}", JsonObject.class))
-                .build());
-    
-    pipeline.run();
+            "", "{\n" + "\t\"name\": \"Jim\",\n" + "\t\"_metadata\": {\"fields\":{}}\n" + "}");
+
+    SplunkEvent expectedSplunkEvent =
+        SplunkEvent.newBuilder()
+            .withEvent("{\"name\":\"Jim\"}")
+            .withFields(GSON.fromJson("{}", JsonObject.class))
+            .build();
+
+    matchesSplunkEvent(input, expectedSplunkEvent);
   }
-  
+
   /** Test successful conversion of JSON messages with user provided invalid index 'fields'. */
   @Test
   @Category(NeedsRunner.class)
-  public void testFailsafeStringToSplunkEventInvalidFields() {
-    
+  public void testFailsafeStringToSplunkEvent_withInvalidFields() {
+
     FailsafeElement<String, String> input =
         FailsafeElement.of(
             "",
@@ -395,26 +274,11 @@ public class SplunkConvertersTest {
                 + "\t\"name\": \"Jim\",\n"
                 + "\t\"_metadata\": {\"fields\":\"invalid-json-fields\"}\n"
                 + "}");
-    
-    pipeline.getCoderRegistry().registerCoderForClass(SplunkEvent.class, SplunkEventCoder.of());
-    
-    PCollectionTuple tuple =
-        pipeline
-            .apply(
-                Create.of(input)
-                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-            .apply(
-                SplunkConverters.failsafeStringToSplunkEvent(
-                    SPLUNK_EVENT_OUT, SPLUNK_EVENT_DEADLETTER_OUT));
-    
-    PAssert.that(tuple.get(SPLUNK_EVENT_DEADLETTER_OUT)).empty();
-    PAssert.that(tuple.get(SPLUNK_EVENT_OUT))
-        .containsInAnyOrder(
-            SplunkEvent.newBuilder()
-                .withEvent("{\"name\":\"Jim\"}")
-                .build());
-    
-    pipeline.run();
+
+    SplunkEvent expectedSplunkEvent =
+        SplunkEvent.newBuilder().withEvent("{\"name\":\"Jim\"}").build();
+
+    matchesSplunkEvent(input, expectedSplunkEvent);
   }
 
   /** Test successful conversion of JSON messages with provided overrides for time and source. */
@@ -431,35 +295,21 @@ public class SplunkConvertersTest {
                 + "\"source\": \"test-source-name\"}\n"
                 + "}");
 
-    pipeline.getCoderRegistry().registerCoderForClass(SplunkEvent.class, SplunkEventCoder.of());
+    SplunkEvent expectedSplunkEvent =
+        SplunkEvent.newBuilder()
+            .withEvent("{" + "\"timestamp\":\"2019-10-15T11:32:26.553Z\"" + "}")
+            .withSource("test-source-name")
+            .withTime(DateTime.parseRfc3339("2019-11-22T11:32:26.553Z").getValue())
+            .build();
 
-    PCollectionTuple tuple =
-        pipeline
-            .apply(
-                Create.of(input)
-                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-            .apply(
-                SplunkConverters.failsafeStringToSplunkEvent(
-                    SPLUNK_EVENT_OUT, SPLUNK_EVENT_DEADLETTER_OUT));
-
-    PAssert.that(tuple.get(SPLUNK_EVENT_DEADLETTER_OUT)).empty();
-    PAssert.that(tuple.get(SPLUNK_EVENT_OUT))
-        .containsInAnyOrder(
-            SplunkEvent.newBuilder()
-                .withEvent(
-                    "{" + "\"timestamp\":\"2019-10-15T11:32:26.553Z\"" + "}")
-                .withSource("test-source-name")
-                .withTime(DateTime.parseRfc3339("2019-11-22T11:32:26.553Z").getValue())
-                .build());
-
-    pipeline.run();
+    matchesSplunkEvent(input, expectedSplunkEvent);
   }
-  
+
   /** Test successful conversion of Pub/Sub messages with provided override for time. */
   @Test
   @Category(NeedsRunner.class)
   public void testFailsafeStringToSplunkEventPubsubMessageTimeOverride() {
-  
+
     FailsafeElement<String, String> input =
         FailsafeElement.of(
             "",
@@ -472,8 +322,28 @@ public class SplunkConvertersTest {
                 + "  }\n"
                 + "}");
 
+    SplunkEvent expectedSplunkEvent =
+        SplunkEvent.newBuilder()
+            .withEvent(
+                "{\n"
+                    + "  \"data\": {\n"
+                    + "    \"timestamp\": \"2021-04-16T14:10:04.634492Z\"\n"
+                    + "  },\n"
+                    + "  \"attributes\": {\n"
+                    + "    \"test-key\": \"test-value\"\n"
+                    + "  }\n"
+                    + "}")
+            .withTime(DateTime.parseRfc3339("2021-04-16T14:10:04.634492Z").getValue())
+            .build();
+
+    matchesSplunkEvent(input, expectedSplunkEvent);
+  }
+
+  @Category(NeedsRunner.class)
+  private void matchesSplunkEvent(
+      FailsafeElement<String, String> input, SplunkEvent expectedSplunkEvent) {
     pipeline.getCoderRegistry().registerCoderForClass(SplunkEvent.class, SplunkEventCoder.of());
-    
+
     PCollectionTuple tuple =
         pipeline
             .apply(
@@ -482,21 +352,9 @@ public class SplunkConvertersTest {
             .apply(
                 SplunkConverters.failsafeStringToSplunkEvent(
                     SPLUNK_EVENT_OUT, SPLUNK_EVENT_DEADLETTER_OUT));
-    
+
     PAssert.that(tuple.get(SPLUNK_EVENT_DEADLETTER_OUT)).empty();
-    PAssert.that(tuple.get(SPLUNK_EVENT_OUT))
-        .containsInAnyOrder(
-            SplunkEvent.newBuilder()
-                .withEvent("{\n"
-                        + "  \"data\": {\n"
-                        + "    \"timestamp\": \"2021-04-16T14:10:04.634492Z\"\n"
-                        + "  },\n"
-                        + "  \"attributes\": {\n"
-                        + "    \"test-key\": \"test-value\"\n"
-                        + "  }\n"
-                        + "}")
-                .withTime(DateTime.parseRfc3339("2021-04-16T14:10:04.634492Z").getValue())
-                .build());
+    PAssert.that(tuple.get(SPLUNK_EVENT_OUT)).containsInAnyOrder(expectedSplunkEvent);
 
     pipeline.run();
   }


### PR DESCRIPTION
This PR adds support for Splunk HEC 'fields' [event metadata](https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector#Event_metadata).