### PR TITLE
Fix JdbcToBigQuery template to handle DATETIME, TIMESTAMP, DATE datatypes

### DIFF
--- a/src/main/java/com/google/cloud/teleport/templates/common/JdbcConverters.java
+++ b/src/main/java/com/google/cloud/teleport/templates/common/JdbcConverters.java
@@ -22,7 +22,6 @@ import java.sql.ResultSetMetaData;
 import java.text.SimpleDateFormat;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
-
 import org.apache.beam.sdk.io.jdbc.JdbcIO;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;

--- a/src/test/java/com/google/cloud/teleport/templates/common/JdbcConvertersTest.java
+++ b/src/test/java/com/google/cloud/teleport/templates/common/JdbcConvertersTest.java
@@ -20,10 +20,15 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.api.services.bigquery.model.TableRow;
+import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import org.apache.beam.sdk.io.jdbc.JdbcIO;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -38,15 +43,20 @@ public class JdbcConvertersTest {
     private static final String NAME_VALUE = "John";
     private static final String AGE_KEY = "age";
     private static final int AGE_VALUE = 24;
+    private static final String TIMESTAMP = "2020-10-15T00:37:23.000Z";
+
+    static SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd");
+    static DateTimeFormatter datetimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss.SSSSSS");
+    static SimpleDateFormat timestampFormatter = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss.SSSSSSXXX");
+
     private static TableRow expectedTableRow;
 
     @Mock private ResultSet resultSet;
 
     @Mock private ResultSetMetaData resultSetMetaData;
 
-    @Before
-    public void setUp() throws Exception {
-
+    @Test
+    public void testRowMapper() throws Exception {
         Mockito.when(resultSet.getObject(1)).thenReturn(NAME_VALUE);
         Mockito.when(resultSet.getObject(2)).thenReturn(AGE_VALUE);
         Mockito.when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
@@ -54,16 +64,73 @@ public class JdbcConvertersTest {
         Mockito.when(resultSetMetaData.getColumnCount()).thenReturn(2);
 
         Mockito.when(resultSetMetaData.getColumnName(1)).thenReturn(NAME_KEY);
+        Mockito.when(resultSetMetaData.getColumnTypeName(1)).thenReturn("string");
 
         Mockito.when(resultSetMetaData.getColumnName(2)).thenReturn(AGE_KEY);
+        Mockito.when(resultSetMetaData.getColumnTypeName(2)).thenReturn("integer");
 
         expectedTableRow = new TableRow();
         expectedTableRow.set(NAME_KEY, NAME_VALUE);
         expectedTableRow.set(AGE_KEY, AGE_VALUE);
+
+        JdbcIO.RowMapper<TableRow> resultSetConverters = JdbcConverters.getResultSetToTableRow();
+        TableRow actualTableRow = resultSetConverters.mapRow(resultSet);
+
+        assertThat(expectedTableRow.size(), equalTo(actualTableRow.size()));
+        assertThat(actualTableRow, equalTo(expectedTableRow));
     }
 
     @Test
-    public void testRowMapper() throws Exception {
+    public void testTemporalFields() throws Exception {
+        LocalDateTime datetimeObj = LocalDateTime.parse(TIMESTAMP.split("Z")[0]);
+        Date dateObj = Date.valueOf(TIMESTAMP.split("T")[0]);
+        Timestamp timestampObj = Timestamp.from(Instant.parse(TIMESTAMP));
+
+        Mockito.when(resultSet.getObject(1)).thenReturn(datetimeObj);
+        Mockito.when(resultSet.getObject(2)).thenReturn(dateObj);
+        Mockito.when(resultSet.getObject(3)).thenReturn(timestampObj);
+        Mockito.when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
+
+        Mockito.when(resultSetMetaData.getColumnCount()).thenReturn(3);
+
+        Mockito.when(resultSetMetaData.getColumnName(1)).thenReturn("datetime_column");
+        Mockito.when(resultSetMetaData.getColumnTypeName(1)).thenReturn("datetime");
+
+        Mockito.when(resultSetMetaData.getColumnName(2)).thenReturn("date_column");
+        Mockito.when(resultSetMetaData.getColumnTypeName(2)).thenReturn("date");
+
+        Mockito.when(resultSetMetaData.getColumnName(3)).thenReturn("timestamp_column");
+        Mockito.when(resultSetMetaData.getColumnTypeName(3)).thenReturn("timestamp");
+
+        expectedTableRow = new TableRow();
+        expectedTableRow.set("datetime_column", datetimeFormatter.format(datetimeObj));
+        expectedTableRow.set("date_column", dateFormatter.format(dateObj));
+        expectedTableRow.set("timestamp_column", timestampFormatter.format(timestampObj));
+
+        JdbcIO.RowMapper<TableRow> resultSetConverters = JdbcConverters.getResultSetToTableRow();
+        TableRow actualTableRow = resultSetConverters.mapRow(resultSet);
+
+        assertThat(expectedTableRow.size(), equalTo(actualTableRow.size()));
+        assertThat(actualTableRow, equalTo(expectedTableRow));
+    }
+
+    @Test
+    public void testNullFields() throws Exception {
+        Mockito.when(resultSet.getObject(1)).thenReturn(null);
+        Mockito.when(resultSet.getObject(2)).thenReturn(null);
+        Mockito.when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
+
+        Mockito.when(resultSetMetaData.getColumnCount()).thenReturn(2);
+
+        Mockito.when(resultSetMetaData.getColumnName(1)).thenReturn(NAME_KEY);
+        Mockito.when(resultSetMetaData.getColumnTypeName(1)).thenReturn("string");
+
+        Mockito.when(resultSetMetaData.getColumnName(2)).thenReturn("date_column");
+        Mockito.when(resultSetMetaData.getColumnTypeName(2)).thenReturn("date");
+
+        expectedTableRow = new TableRow();
+        expectedTableRow.set(NAME_KEY, null);
+        expectedTableRow.set("date_column", null);
 
         JdbcIO.RowMapper<TableRow> resultSetConverters = JdbcConverters.getResultSetToTableRow();
         TableRow actualTableRow = resultSetConverters.mapRow(resultSet);


### PR DESCRIPTION
Current JdbcToBigQuery template fails if any of the columns in SQL database is of type `DATETIME`, `TIMESTAMP`, `DATE`. 

The issue I believe is due to:
- BigQuery not supporting loads in milliseconds for `DATETIME` and `TIMESTAMP` but rather supports UNIX TIME which is in seconds for loads from GCS [2].
- `DATE` fails due to JDBC drivers give result in milliseconds but BigQuery uses canonical format for DATE [1]

Current workaround used is converting all these data types to their canonical format [1]:

- TIMESTAMP: `yyyy-MM-dd hh:mm:ss.SSSSSSXXX`
- DATETIME:    `yyyy-MM-dd hh:mm:ss.SSSSSS`
- TIME:             `yyyy-MM-dd`

[1] https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types
[2] https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-json#details_of_loading_json_data