### PR TITLE
datastream to mongodb - dataflow template implementation

### DIFF
--- a/v2/datastream-to-mongodb/pom.xml
+++ b/v2/datastream-to-mongodb/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (C) 2020 Google Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.google.cloud.teleport.v2</groupId>
+        <artifactId>dynamic-templates</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>datastream-to-mongodb</artifactId>
+
+    <description>
+        Stream CDC Data from DataStream to MongoDB via GCS
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.cloud.teleport.v2</groupId>
+            <artifactId>common</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.beam</groupId>
+            <artifactId>beam-sdks-java-io-mongodb</artifactId>
+            <version>2.29.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <directory>${mvn-target-dir}</directory>
+        <plugins>
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>
+

--- a/v2/datastream-to-mongodb/readme.md
+++ b/v2/datastream-to-mongodb/readme.md
@@ -1,0 +1,165 @@
+# DataStream to MongoDB Dataflow Template
+
+The [DataStreamToMongoDB](src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToMongoDB.java) pipeline 
+ingests data supplied by DataStream, optionally applies a Javascript or Python UDF if supplied 
+and writes the data to MongoDB collections.  
+
+## Getting Started
+
+### Requirements
+* Java 8
+* Maven
+* DataStream stream is created and sending data to storage
+* PubSub Subscription exists or GCS Bucket contains data
+
+### Building Template
+This is a Flex Template meaning that the pipeline code will be containerized and the container will be
+used to launch the Dataflow pipeline.
+
+#### Building Container Image
+* Set environment variables.
+
+```sh
+export PROJECT=<my-project>
+export IMAGE_NAME=datastream-to-mongodb
+export BUCKET_NAME=gs://<bucket-name>
+export TARGET_GCR_IMAGE=gcr.io/${PROJECT}/${IMAGE_NAME}
+export BASE_CONTAINER_IMAGE=gcr.io/dataflow-templates-base/java8-template-launcher-base
+export BASE_CONTAINER_IMAGE_VERSION=latest
+export APP_ROOT=/template/${IMAGE_NAME}
+export DATAFLOW_JAVA_COMMAND_SPEC=${APP_ROOT}/resources/${IMAGE_NAME}-command-spec.json
+export TEMPLATE_IMAGE_SPEC=${BUCKET_NAME}/images/${IMAGE_NAME}-image-spec.json
+
+export TOPIC=projects/${PROJECT}/topics/<topic-name>
+export SUBSCRIPTION=projects/${PROJECT}/subscriptions/<subscription-name>
+export DEADLETTER_TABLE=${PROJECT}:${DATASET_TEMPLATE}.dead_letter
+
+gcloud config set project ${PROJECT}
+```
+
+* Build and push image to Google Container Repository
+
+```sh
+mvn clean package \
+-Dimage=${TARGET_GCR_IMAGE} \
+-Dbase-container-image=${BASE_CONTAINER_IMAGE} \
+-Dbase-container-image.version=${BASE_CONTAINER_IMAGE_VERSION} \
+-Dapp-root=${APP_ROOT} \
+-Dcommand-spec=${DATAFLOW_JAVA_COMMAND_SPEC} \
+-am -pl ${IMAGE_NAME}
+```
+
+#### Creating Image Spec
+
+* Create file in Cloud Storage with path to container image in Google Container Repository.
+```sh
+echo '{
+    "image":"'${TARGET_GCR_IMAGE}'",
+    "metadata":{"name":"PubSub CDC to MongoDB",
+    "description":"Replicate Pub/Sub Data into MongoDB Collections",
+    "parameters":[
+        {
+            "name":"inputFilePattern",
+            "label":"GCS Stream location",
+            "helpText":"GCS Stream location",
+            "paramType":"TEXT"
+        },
+        {
+            "name":"inputFileFormat",
+            "label":"GCS Stream format",
+            "helpText":"GCS Stream format",
+            "paramType":"TEXT"
+        },
+        {
+            "name":"streamName",
+            "label":"Datastream Name",
+            "helpText":"Datastream Name",
+            "paramType":"TEXT"
+        },
+        {
+            "name":"inputSubscription",
+            "label":"PubSub Subscription Name",
+            "helpText":"Full subscription reference",
+            "paramType":"TEXT"
+        },
+        {
+            "name":"mongoDBUri",
+            "label":"MongoDB Connection String",
+            "helpText":"MongoDB Connection String",
+            "paramType":"TEXT"
+        },
+        {
+            "name":"database",
+            "label":"MongoDB Database Name",
+            "helpText":"MongoDB Database Name",
+            "paramType":"TEXT"
+        },
+        {
+            "name":"collection",
+            "label":"MongoDB Collection Name",
+            "helpText":"MongoDB Collection Name",
+            "paramType":"TEXT"
+        },
+
+        {
+            "name":"autoscalingAlgorithm","label":"Autoscaling algorithm to use",
+            "helpText":"Autoscaling algorithm to use: THROUGHPUT_BASED",
+            "paramType":"TEXT",
+            "isOptional":true
+        },
+        {
+            "name":"numWorkers","label":"Number of workers Dataflow will start with",
+            "helpText":"Number of workers Dataflow will start with",
+            "paramType":"TEXT",
+            "isOptional":true
+        },
+
+        {
+            "name":"maxNumWorkers","label":"Maximum number of workers Dataflow job will use",
+            "helpText":"Maximum number of workers Dataflow job will use",
+            "paramType":"TEXT",
+            "isOptional":true
+        },
+        {
+            "name":"workerMachineType","label":"Worker Machine Type to use in Dataflow Job",
+            "helpText":"Machine Type to Use: n1-standard-4",
+            "paramType":"TEXT",
+            "isOptional":true
+        }
+    ]},
+    "sdk_info":{"language":"JAVA"}
+}' > image_spec.json
+gsutil cp image_spec.json ${TEMPLATE_IMAGE_SPEC}
+rm image_spec.json
+```
+
+### Testing Template
+
+The template unit tests can be run using:
+```sh
+mvn test
+```
+
+### Executing Template
+
+The template requires the following parameters:
+* inputSubscription: PubSub subscription to read from (ie. projects/<project-id>/subscriptions/<subscription-name>)
+* outputDatasetTemplate: The name of the dataset or templated logic to extract it (ie. 'prefix_{schema_name}')
+* outputTableNameTemplate: The name of the table or templated logic to extract it (ie. 'prefix_{table_name}')
+* outputDeadletterTable: Deadletter table for failed inserts in form: project-id:dataset.table
+
+The template has the following optional parameters:
+* javascriptTextTransformGcsPath: Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null
+* javascriptTextTransformFunctionName: UDF Javascript Function Name. Default: null
+
+* maxRetryAttempts: Max retry attempts, must be > 0. Default: no retries
+* maxRetryDuration: Max retry duration in milliseconds, must be > 0. Default: no retries
+
+Template can be executed using the following API call:
+```sh
+export JOB_NAME="${IMAGE_NAME}-`date +%Y%m%d-%H%M%S-%N`"
+gcloud beta dataflow flex-template run ${JOB_NAME} \
+        --project=${PROJECT} --region=us-central1 \
+        --template-file-gcs-location=${TEMPLATE_IMAGE_SPEC} \
+        --parameters inputSubscription=${SUBSCRIPTION},outputDeadletterTable=${DEADLETTER_TABLE}
+```

--- a/v2/datastream-to-mongodb/readme.md
+++ b/v2/datastream-to-mongodb/readme.md
@@ -11,6 +11,8 @@ and writes the data to MongoDB collections.
 * Maven
 * DataStream stream is created and sending data to storage
 * PubSub Subscription exists or GCS Bucket contains data
+* MongoDB On premise or Atlas cluster is created and you should have the URI.
+
 
 ### Building Template
 This is a Flex Template meaning that the pipeline code will be containerized and the container will be
@@ -32,7 +34,6 @@ export TEMPLATE_IMAGE_SPEC=${BUCKET_NAME}/images/${IMAGE_NAME}-image-spec.json
 
 export TOPIC=projects/${PROJECT}/topics/<topic-name>
 export SUBSCRIPTION=projects/${PROJECT}/subscriptions/<subscription-name>
-export DEADLETTER_TABLE=${PROJECT}:${DATASET_TEMPLATE}.dead_letter
 
 gcloud config set project ${PROJECT}
 ```

--- a/v2/datastream-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToMongoDB.java
+++ b/v2/datastream-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToMongoDB.java
@@ -95,7 +95,7 @@ public class DataStreamToMongoDB {
     void setRfcStartDateTime(String value);
 
     @Description("The number of concurrent DataStream files to read.")
-    @Default.Integer(30)
+    @Default.Integer(10)
     Integer getFileReadConcurrency();
     void setFileReadConcurrency(Integer value);
 

--- a/v2/datastream-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToMongoDB.java
+++ b/v2/datastream-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToMongoDB.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.teleport.v2.templates;
+import com.google.cloud.teleport.v2.cdc.sources.DataStreamIO;
+import com.google.cloud.teleport.v2.values.FailsafeElement;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.io.mongodb.MongoDbIO;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.StreamingOptions;
+import org.apache.beam.sdk.transforms.*;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.beam.sdk.values.TupleTag;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This pipeline ingests DataStream data from GCS. The data is then transformed to BSON documents
+ * they are automatically added to MongoDB.
+ *
+ * <p>Example Usage: TODO: FIX EXMAPLE USAGE
+ *
+ */
+public class DataStreamToMongoDB {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DataStreamToMongoDB.class);
+  private static final String AVRO_SUFFIX = "avro";
+  private static final String JSON_SUFFIX = "json";
+  public static final Set<String> MAPPER_IGNORE_FIELDS = new HashSet<String>(
+          Arrays.asList(
+                  "_metadata_stream", "_metadata_schema", "_metadata_table", "_metadata_source",
+                  "_metadata_ssn", "_metadata_rs_id", "_metadata_tx_id",
+                  "_metadata_dlq_reconsumed", "_metadata_error", "_metadata_retry_count",
+                  "_metadata_timestamp", "_metadata_read_timestamp", "_metadata_read_method",
+                  "_metadata_source_type", "_metadata_deleted", "_metadata_change_type",
+                  "_metadata_log_file", "_metadata_log_position"));
+
+  /** The tag for the main output of the json transformation. */
+  public static final TupleTag<FailsafeElement<String, String>> TRANSFORM_OUT =
+          new TupleTag<FailsafeElement<String, String>>() {};
+
+
+  /**
+   * Options supported by the pipeline.
+   *
+   * <p>Inherits standard configuration options.</p>
+   */
+  public interface Options extends PipelineOptions, StreamingOptions {
+    @Description("The GCS location of the avro files you'd like to process")
+    String getInputFilePattern();
+    void setInputFilePattern(String value);
+
+    @Description("The GCS output format avro/json")
+    @Default.String("json")
+    String getInputFileFormat();
+    void setInputFileFormat(String value);
+
+    @Description(
+        "The Pub/Sub subscription with DataStream file notifications."
+            + "The name should be in the format of "
+            + "projects/<project-id>/subscriptions/<subscription-name>.")
+    String getInputSubscription();
+    void setInputSubscription(String value);
+
+    @Description("The DataStream Stream to Reference.")
+    String getStreamName();
+    void setStreamName(String value);
+
+    @Description("The starting DateTime used to fetch from GCS (https://tools.ietf.org/html/rfc3339).")
+    @Default.String("1970-01-01T00:00:00.00Z")
+    String getRfcStartDateTime();
+    void setRfcStartDateTime(String value);
+
+    @Description("The number of concurrent DataStream files to read.")
+    @Default.Integer(30)
+    Integer getFileReadConcurrency();
+    void setFileReadConcurrency(Integer value);
+
+    // Destination MongoDB Connection String
+    @Description("The MongoDB Atlas connection string")
+    @Default.String("{_metadata_dataset}")
+    String getMongoDBUri();
+    void setMongoDBUri(String value);
+
+    @Description("The MongoDB Database name")
+    @Default.String("{_metadata_dataset}")
+    String getDatabase();
+    void setDatabase(String value);
+
+    @Description("The MongoDB Collection")
+    @Default.String("{_metadata_dataset}")
+    String getCollection();
+    void setCollection(String value);
+
+
+    @Description("The number of minutes between merges for a given table")
+    @Default.Integer(5)
+    Integer getMergeFrequencyMinutes();
+    void setMergeFrequencyMinutes(Integer value);
+
+  }
+
+  /**
+   * Main entry point for executing the pipeline.
+   * @param args  The command-line arguments to the pipeline.
+   */
+  public static void main(String[] args) {
+    LOG.info("Starting Input Files to BigQuery");
+
+    Options options = PipelineOptionsFactory
+        .fromArgs(args)
+        .withValidation()
+        .as(Options.class);
+
+    options.setStreaming(true);
+
+    validateOptions(options);
+    run(options);
+  }
+
+  private static void validateOptions(Options options) {
+
+    String inputFileFormat = options.getInputFileFormat();
+    if (!(inputFileFormat.equals(AVRO_SUFFIX)
+           || inputFileFormat.equals(JSON_SUFFIX))){
+      throw new IllegalArgumentException(
+          "Input file format must be one of: avro, json or left empty - found " + inputFileFormat);
+    }
+  }
+
+  /**
+   * Runs the pipeline with the supplied options.
+   *
+   * @param options The execution parameters to the pipeline.
+   * @return  The result of the pipeline execution.
+   */
+  public static PipelineResult run(Options options) {
+    /*
+     * Stages:
+     *   1) Ingest and Normalize Data to FailsafeElement with JSON Strings
+     *   2) Push the data to MongoDB
+     */
+
+    Pipeline pipeline = Pipeline.create(options);
+
+    /*
+     * Stage 1: Ingest and Normalize Data to FailsafeElement with JSON Strings
+     *   a) Read DataStream data from GCS into JSON String FailsafeElements (datastreamJsonRecords)
+     */
+     PCollection<FailsafeElement<String, String>> datastreamJsonRecords = pipeline
+         .apply(
+             new DataStreamIO(
+                    options.getStreamName(),
+                    options.getInputFilePattern(),
+                    options.getInputFileFormat(),
+                    options.getInputSubscription(),
+                    options.getRfcStartDateTime())
+             .withFileReadConcurrency(options.getFileReadConcurrency()));
+
+
+    PCollection<FailsafeElement<String, String>> jsonRecords =
+        PCollectionList.of(datastreamJsonRecords)
+            .apply(Flatten.pCollections());
+
+    /*
+     * Stage 4: Write Failures to GCS Dead Letter Queue
+     */
+    // TODO: Cover tableRowRecords.get(TRANSFORM_DEADLETTER_OUT) error values
+    jsonRecords
+            .apply("transform", MapElements.via(
+                    new SimpleFunction<FailsafeElement<String, String>, Document>() {
+                      @Override
+                      public Document apply(FailsafeElement<String, String> jsonString) {
+                        String s = jsonString.getOriginalPayload();
+                        Document doc = Document.parse(s);
+                        return removeTableRowFields(doc, MAPPER_IGNORE_FIELDS);
+                      }
+                    }))
+        .apply(
+            "Write To MongoDB",
+                MongoDbIO.write().withUri(options.getMongoDBUri())
+                        .withDatabase(options.getDatabase())
+                        .withCollection(options.getCollection())
+                        //To update to an existing collection. Beam connector change is in
+                        //progress after which this can be used.
+                        //.withIsUpdate(true)
+                        //.withUpdateKey("accId").withUpdateField("transactions")
+                        //.withUpdateOperator("$push")
+        );
+
+    // Execute the pipeline and return the result.
+    return pipeline.run();
+  }
+
+  /** DoFn that will parse the given string elements as Bson Documents. */
+  private static class ParseAsDocumentsFn extends DoFn<String, Document> {
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      context.output(new Document("value", context.element()));
+    }
+  }
+
+  private static Document removeTableRowFields(Document doc, Set<String> ignoreFields) {
+
+    for (String ignoreField : ignoreFields) {
+      if (doc.containsKey(ignoreField)) {
+        doc.remove(ignoreField);
+      }
+    }
+
+    return doc;
+  }
+}

--- a/v2/datastream-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/package-info.java
+++ b/v2/datastream-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package info for DataStream to BigQuery module.
+ */
+package com.google.cloud.teleport.v2.templates;

--- a/v2/datastream-to-mongodb/src/main/resources/datastream-to-mongodb-command-spec.json
+++ b/v2/datastream-to-mongodb/src/main/resources/datastream-to-mongodb-command-spec.json
@@ -1,0 +1,7 @@
+{
+  "mainClass": "com.google.cloud.teleport.v2.templates.DataStreamToMongoDB",
+  "classPath": "/template/datastream-to-mongodb/*:/template/datastream-to-mongodb/libs/*:/template/datastream-to-mongodb/classes",
+  "defaultParameterValues": {
+    "labels": "{\"goog-dataflow-provided-template-type\":\"flex\",\"goog-dataflow-provided-template-name\":\"datastream_to_mongodb\"}"
+  }
+}


### PR DESCRIPTION
A template to replicate Datastream CDC changes to MongoDB

The current design uses an append only strategy as the MongodbIO does not support the full suite of desired upsert collection utilities.  The improvements to allow these are being pushed upstream to Beam