### PR TITLE
Relax the schema attribute pattern to match other white spaces

### DIFF
--- a/v2/streaming-data-generator/src/main/java/com/google/cloud/teleport/v2/transforms/StreamingDataGeneratorWriteToPubSub.java
+++ b/v2/streaming-data-generator/src/main/java/com/google/cloud/teleport/v2/transforms/StreamingDataGeneratorWriteToPubSub.java
@@ -87,7 +87,7 @@ public final class StreamingDataGeneratorWriteToPubSub {
     private ObjectMapper mapper;
     private TypeReference<HashMap<String, String>> hashMapRef;
     private static final Pattern ATTRIBUTE_PATTERN =
-        Pattern.compile("^\\{\"?payload\"?:.+\"?attributes\"?:.+");
+        Pattern.compile("^\\{\\s*\"?payload\"?:.+\"?attributes\"?:.+");
     private static final int PUBSUB_ATTRIBUTE_VALUE_MAX_LENGTH = 1024;
     private boolean hasAttributes;
 

--- a/v2/streaming-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/StreamingDataGeneratorTest.java
+++ b/v2/streaming-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/StreamingDataGeneratorTest.java
@@ -161,12 +161,12 @@ public class StreamingDataGeneratorTest {
 
   /** Tests generation of fake Json data message with attributes. */
   @Test
-  public void testJsonMessageGenerator_WithAttributes_returnsFakeMessageContaingAttributes()
+  public void testJsonMessageGenerator_WithAttributes_returnsFakeMessageContainingAttributes()
       throws IOException {
     // Arrange
     String schema =
         "{\n"
-            + "\t\"payload\": {\n"
+            + "  \t\"payload\": {\n"
             + "\t\t\"eventId\": \"{{put(\"eventId\",uuid())}}\",\n"
             + "\t\t\"eventTime\": {{put(\"eventTime\", timestamp())}},\n"
             + "\t\t\"username\": \"{{put(\"username \", username())}}\",\n"
@@ -176,7 +176,7 @@ public class StreamingDataGeneratorTest {
             + "\t\t\"teamavg\": {{put(\"teamavg\",float(100000, 10000000,\"%.7f\"))}},\n"
             + "\t\t\"completed\": {{bool()}}\n"
             + "\t},\n"
-            + "\t\"attributes\": {\n"
+            + "  \t\"attributes\": {\n"
             + "\t\t\"eventId\": \"{{get(\"eventId\")}}\",\n"
             + "\t\t\"eventTime\": {{get(\"eventTime\")}},\n"
             + "\t\t\"appId\": {{ integer(1, 10) }},\n"


### PR DESCRIPTION
Current pattern doesn't allow any other white spaces like space before
the payload, for example the sample pattern in the README also doesn't
match.