### PR TITLE
Fix node name

### DIFF
--- a/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/transforms/CreateDml.java
+++ b/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/transforms/CreateDml.java
@@ -85,7 +85,7 @@ public class CreateDml {
           .apply("Reshuffle Into Buckets",
             Reshuffle.<FailsafeElement<String, String>>viaRandomKey()
                 .withNumBuckets(NUM_THREADS))
-          .apply("Format to Postgres DML", ParDo.of(datastreamToDML));
+          .apply("Format to DML", ParDo.of(datastreamToDML));
     }
   }
 }


### PR DESCRIPTION
Not all use's of this will be Postgres, there are also cases where we are writing to mysql, so the node name should be more generic