### PR TITLE
Update beam version from 2.29.0 to 2.31.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <apache-http-client-v2>1.39.2</apache-http-client-v2>
     <avro.version>1.8.2</avro.version>
     <checkstyle.version>8.7</checkstyle.version>
-    <beam.version>2.29.0</beam.version>
+    <beam.version>2.31.0</beam.version>
     <beam-vendor-guava.version>0.1</beam-vendor-guava.version>
     <extra.enforcer.rules.version>1.3</extra.enforcer.rules.version>
     <hamcrest.version>2.1</hamcrest.version>

--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -29,7 +29,7 @@
         <autovalue.annotations.version>1.7.4</autovalue.annotations.version>
         <autovalue.service.version>1.0-rc6</autovalue.service.version>
         <checkstyle.version>8.7</checkstyle.version>
-        <beam.version>2.29.0</beam.version>
+        <beam.version>2.31.0</beam.version>
         <beam-vendor-guava.version>0.1</beam-vendor-guava.version>
         <hamcrest.version>2.1</hamcrest.version>
         <hadoop.version>2.10.1</hadoop.version>


### PR DESCRIPTION
Hello everyone, many people have been having a lot of exceptions with Beam version 2.29.0:

#281 
[StackOverflow](https://stackoverflow.com/questions/67606930/i-am-getting-this-error-getting-severe-channel-managedchannelimpllogid-1-targe)
https://github.com/googleapis/google-cloud-java/issues/3693

This PR has a goal to update Beam version 2.29.0 to 2.31.0 to solve these issues.