### PR TITLE
Add debug info to Googlecloud-to-elasticsearch

### DIFF
--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.teleport.v2.elasticsearch.options;
 
-import com.google.cloud.teleport.v2.elasticsearch.utils.ElasticsearchIO;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.v2.elasticsearch.options;
 
+import com.google.cloud.teleport.v2.elasticsearch.utils.ElasticsearchIO;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -73,4 +74,10 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
   Long getMaxRetryDuration();
 
   void setMaxRetryDuration(Long maxRetryDuration);
+
+  @Description("Enable additional debug output")
+  @Default.Boolean(false)
+  Boolean getVerboseDebugMessages();
+
+  void setVerboseDebugMessages(Boolean verboseDebugMessages);
 }

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
@@ -92,7 +92,8 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
                 ElasticsearchIO.write()
                         .withConnectionConfiguration(config)
                         .withMaxBatchSize(options().getBatchSize())
-                        .withMaxBatchSizeBytes(options().getBatchSizeBytes());
+                        .withMaxBatchSizeBytes(options().getBatchSizeBytes())
+                        .withVerboseDebugMessages(options().getVerboseDebugMessages());
 
         if (Optional.ofNullable(options().getMaxRetryAttempts()).isPresent()) {
             elasticsearchWriter.withRetryConfiguration(

--- a/v2/googlecloud-to-elasticsearch/docs/PubSubToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/PubSubToElasticsearch/README.md
@@ -37,6 +37,7 @@ The template requires the following parameters:
 The template has the following optional parameters:
 * elasticsearchUsername: Elasticsearch username used to connect to Elasticsearch endpoint. Overrides ApiKey option if specified.
 * elasticsearchPassword: Elasticsearch password used to connect to Elasticsearch endpoint. Overrides ApiKey option if specified.
+* verboseDebugMessages: Log entire input message for debugging purposes
 * dataset: The type of logs sent via Pub/Sub for which we have out of the box dashboard. Known log types values are `audit`, `vpcflow`, and `firewall`. If no known log type is detected, we default to `pubsub` type.
 * namespace: An arbitrary grouping, such as an environment (dev, prod, or qa), a team, or a strategic business unit. Default is `default`
 * batchSize: Batch size in number of documents. Default: 1000
@@ -147,6 +148,13 @@ echo '{
               "name":"elasticsearchPassword",
               "label":"Password for Elasticsearch endpoint. Overrides ApiKey option if specified.",
               "helpText":"Password for Elasticsearch endpoint. Overrides ApiKey option if specified.",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"verboseDebugMessages",
+              "label":"Log entire input message for debugging purposes.",
+              "helpText":"Log entire input message for debugging purposes.",
               "paramType":"TEXT",
               "isOptional":true
           },

--- a/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/ProcessEventMetadata.java
+++ b/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/ProcessEventMetadata.java
@@ -20,9 +20,13 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** ProcessEventMetadata is used to enrich input message from Pub/Sub with metadata. */
 public class ProcessEventMetadata extends PTransform<PCollection<String>, PCollection<String>> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ProcessEventMetadata.class);
 
   @Override
   public PCollection<String> expand(PCollection<String> input) {
@@ -36,6 +40,11 @@ public class ProcessEventMetadata extends PTransform<PCollection<String>, PColle
       String input = context.element();
       PubSubToElasticsearchOptions options =
           context.getPipelineOptions().as(PubSubToElasticsearchOptions.class);
+
+      //Log input message
+      if (options.getVerboseDebugMessages()) {
+        LOG.info("Input message: " + input);
+      }
 
       context.output(EventMetadataBuilder.build(input, options).getEnrichedMessageAsString());
     }


### PR DESCRIPTION
Added optional parameter **verboseDebugMessages** that enables additional output when error occurs. It shows full response when there's an issue writing to Elasticsearch. Changes made by this PR will be discarded after migration to Apache Beam 2.33.