### PR TITLE
[Pub/Sub to Elasticsearch] Fix error handling

### DIFF
--- a/v2/elasticsearch-common/pom.xml
+++ b/v2/elasticsearch-common/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <artifactId>elasticsearch-common</artifactId>
+    <version>1.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
@@ -24,7 +24,6 @@ import com.google.cloud.teleport.v2.elasticsearch.utils.ElasticsearchIO;
 import java.util.Optional;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PDone;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.Duration;
 
@@ -49,94 +48,94 @@ import org.joda.time.Duration;
  * function returns null then the index or type provided as {@link ConnectionInformation}.
  */
 @AutoValue
-public abstract class WriteToElasticsearch extends PTransform<PCollection<String>, PDone> {
+public abstract class WriteToElasticsearch extends PTransform<PCollection<String>, PCollection<String>> {
 
-  /** Convert provided long to {@link Duration}. */
-  private static Duration getDuration(Long milliseconds) {
-    return new Duration(milliseconds);
-  }
-
-  public static Builder newBuilder() {
-    return new AutoValue_WriteToElasticsearch.Builder();
-  }
-
-  public abstract ElasticsearchWriteOptions options();
-
-  /**
-   * Types have been removed in ES 7.0. Default will be _doc. See
-   * https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html"
-   */
-  private static final String DOCUMENT_TYPE = "_doc";
-
-  @Override
-  public PDone expand(PCollection<String> jsonStrings) {
-    ConnectionInformation connectionInformation =
-        new ConnectionInformation(options().getConnectionUrl());
-
-    ElasticsearchIO.ConnectionConfiguration config =
-        ElasticsearchIO.ConnectionConfiguration.create(
-            new String[] {connectionInformation.getElasticsearchURL().toString()},
-            options().getIndex(),
-            DOCUMENT_TYPE);
-
-    // If username and password are not blank, use them instead of ApiKey
-    if (StringUtils.isNotBlank(options().getElasticsearchUsername())
-        && StringUtils.isNotBlank(options().getElasticsearchPassword())) {
-      config =
-          config
-              .withUsername(options().getElasticsearchUsername())
-              .withPassword(options().getElasticsearchPassword());
-    } else {
-      config = config.withApiKey(options().getApiKey());
+    /** Convert provided long to {@link Duration}. */
+    private static Duration getDuration(Long milliseconds) {
+        return new Duration(milliseconds);
     }
 
-    ElasticsearchIO.Write elasticsearchWriter =
-        ElasticsearchIO.write()
-            .withConnectionConfiguration(config)
-            .withMaxBatchSize(options().getBatchSize())
-            .withMaxBatchSizeBytes(options().getBatchSizeBytes());
-
-    if (Optional.ofNullable(options().getMaxRetryAttempts()).isPresent()) {
-      elasticsearchWriter.withRetryConfiguration(
-          ElasticsearchIO.RetryConfiguration.create(
-              options().getMaxRetryAttempts(), getDuration(options().getMaxRetryDuration())));
+    public static Builder newBuilder() {
+        return new AutoValue_WriteToElasticsearch.Builder();
     }
 
-    return jsonStrings.apply("WriteDocuments", elasticsearchWriter);
-  }
+    public abstract ElasticsearchWriteOptions options();
 
-  /** Builder for {@link WriteToElasticsearch}. */
-  @AutoValue.Builder
-  public abstract static class Builder {
-    public abstract Builder setOptions(ElasticsearchWriteOptions options);
+    /**
+     * Types have been removed in ES 7.0. Default will be _doc.
+     * See https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html"
+     */
+    private static final String DOCUMENT_TYPE="_doc";
 
-    abstract ElasticsearchWriteOptions options();
+    @Override
+    public PCollection<String> expand(PCollection<String> jsonStrings) {
+        ConnectionInformation connectionInformation = new ConnectionInformation(options().getConnectionUrl());
 
-    abstract WriteToElasticsearch autoBuild();
+        ElasticsearchIO.ConnectionConfiguration config =
+                ElasticsearchIO.ConnectionConfiguration.create(
+                        new String[]{connectionInformation.getElasticsearchURL().toString()},
+                        options().getIndex(),
+                        DOCUMENT_TYPE);
 
-    public WriteToElasticsearch build() {
+        //If username and password are not blank, use them instead of ApiKey
+        if (StringUtils.isNotBlank(options().getElasticsearchUsername())
+                && StringUtils.isNotBlank(options().getElasticsearchPassword())) {
+            config = config
+                    .withUsername(options().getElasticsearchUsername())
+                    .withPassword(options().getElasticsearchPassword());
+        } else {
+            config = config.withApiKey(options().getApiKey());
+        }
 
-      checkArgument(options().getConnectionUrl() != null, "ConnectionUrl is required.");
+        ElasticsearchIO.Write elasticsearchWriter =
+                ElasticsearchIO.write()
+                        .withConnectionConfiguration(config)
+                        .withMaxBatchSize(options().getBatchSize())
+                        .withMaxBatchSizeBytes(options().getBatchSizeBytes());
 
-      checkArgument(options().getApiKey() != null, "ApiKey is required.");
+        if (Optional.ofNullable(options().getMaxRetryAttempts()).isPresent()) {
+            elasticsearchWriter.withRetryConfiguration(
+                    ElasticsearchIO.RetryConfiguration.create(
+                            options().getMaxRetryAttempts(), getDuration(options().getMaxRetryDuration())));
+        }
 
-      checkArgument(options().getIndex() != null, "Elasticsearch index should not be null.");
+        return jsonStrings.apply("WriteDocuments", elasticsearchWriter);
+    }
+
+    /** Builder for {@link WriteToElasticsearch}. */
+    @AutoValue.Builder
+    public abstract static class Builder {
+        public abstract Builder setOptions(ElasticsearchWriteOptions options);
+
+        abstract ElasticsearchWriteOptions options();
+
+        abstract WriteToElasticsearch autoBuild();
+
+        public WriteToElasticsearch build() {
+
+            checkArgument(
+                    options().getConnectionUrl() != null, "ConnectionUrl is required.");
+
+            checkArgument(
+                    options().getApiKey() != null, "ApiKey is required.");
+
+            checkArgument(options().getIndex() != null, "Elasticsearch index should not be null.");
 
       checkArgument(
           options().getBatchSize() > 0, "Batch size must be > 0. Got: " + options().getBatchSize());
 
-      checkArgument(
-          options().getBatchSizeBytes() > 0,
-          "Batch size bytes must be > 0. Got: " + options().getBatchSizeBytes());
+            checkArgument(
+                    options().getBatchSizeBytes() > 0,
+                    "Batch size bytes must be > 0. Got: " + options().getBatchSizeBytes());
 
-      /* Check that both {@link RetryConfiguration} parameters are supplied. */
-      if (options().getMaxRetryAttempts() != null || options().getMaxRetryDuration() != null) {
-        checkArgument(
-            options().getMaxRetryDuration() != null && options().getMaxRetryAttempts() != null,
-            "Both max retry duration and max attempts must be supplied.");
-      }
+            /* Check that both {@link RetryConfiguration} parameters are supplied. */
+            if (options().getMaxRetryAttempts() != null || options().getMaxRetryDuration() != null) {
+                checkArgument(
+                        options().getMaxRetryDuration() != null && options().getMaxRetryAttempts() != null,
+                        "Both max retry duration and max attempts must be supplied.");
+            }
 
-      return autoBuild();
+            return autoBuild();
+        }
     }
-  }
 }

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
@@ -48,94 +48,95 @@ import org.joda.time.Duration;
  * function returns null then the index or type provided as {@link ConnectionInformation}.
  */
 @AutoValue
-public abstract class WriteToElasticsearch extends PTransform<PCollection<String>, PCollection<String>> {
+public abstract class WriteToElasticsearch
+    extends PTransform<PCollection<String>, PCollection<String>> {
 
-    /** Convert provided long to {@link Duration}. */
-    private static Duration getDuration(Long milliseconds) {
-        return new Duration(milliseconds);
+  /** Convert provided long to {@link Duration}. */
+  private static Duration getDuration(Long milliseconds) {
+    return new Duration(milliseconds);
+  }
+
+  public static Builder newBuilder() {
+    return new AutoValue_WriteToElasticsearch.Builder();
+  }
+
+  public abstract ElasticsearchWriteOptions options();
+
+  /**
+   * Types have been removed in ES 7.0. Default will be _doc. See
+   * https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html"
+   */
+  private static final String DOCUMENT_TYPE = "_doc";
+
+  @Override
+  public PCollection<String> expand(PCollection<String> jsonStrings) {
+    ConnectionInformation connectionInformation =
+        new ConnectionInformation(options().getConnectionUrl());
+
+    ElasticsearchIO.ConnectionConfiguration config =
+        ElasticsearchIO.ConnectionConfiguration.create(
+            new String[] {connectionInformation.getElasticsearchURL().toString()},
+            options().getIndex(),
+            DOCUMENT_TYPE);
+
+    // If username and password are not blank, use them instead of ApiKey
+    if (StringUtils.isNotBlank(options().getElasticsearchUsername())
+        && StringUtils.isNotBlank(options().getElasticsearchPassword())) {
+      config =
+          config
+              .withUsername(options().getElasticsearchUsername())
+              .withPassword(options().getElasticsearchPassword());
+    } else {
+      config = config.withApiKey(options().getApiKey());
     }
 
-    public static Builder newBuilder() {
-        return new AutoValue_WriteToElasticsearch.Builder();
+    ElasticsearchIO.Write elasticsearchWriter =
+        ElasticsearchIO.write()
+            .withConnectionConfiguration(config)
+            .withMaxBatchSize(options().getBatchSize())
+            .withMaxBatchSizeBytes(options().getBatchSizeBytes());
+
+    if (Optional.ofNullable(options().getMaxRetryAttempts()).isPresent()) {
+      elasticsearchWriter.withRetryConfiguration(
+          ElasticsearchIO.RetryConfiguration.create(
+              options().getMaxRetryAttempts(), getDuration(options().getMaxRetryDuration())));
     }
 
-    public abstract ElasticsearchWriteOptions options();
+    return jsonStrings.apply("WriteDocuments", elasticsearchWriter);
+  }
 
-    /**
-     * Types have been removed in ES 7.0. Default will be _doc.
-     * See https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html"
-     */
-    private static final String DOCUMENT_TYPE="_doc";
+  /** Builder for {@link WriteToElasticsearch}. */
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setOptions(ElasticsearchWriteOptions options);
 
-    @Override
-    public PCollection<String> expand(PCollection<String> jsonStrings) {
-        ConnectionInformation connectionInformation = new ConnectionInformation(options().getConnectionUrl());
+    abstract ElasticsearchWriteOptions options();
 
-        ElasticsearchIO.ConnectionConfiguration config =
-                ElasticsearchIO.ConnectionConfiguration.create(
-                        new String[]{connectionInformation.getElasticsearchURL().toString()},
-                        options().getIndex(),
-                        DOCUMENT_TYPE);
+    abstract WriteToElasticsearch autoBuild();
 
-        //If username and password are not blank, use them instead of ApiKey
-        if (StringUtils.isNotBlank(options().getElasticsearchUsername())
-                && StringUtils.isNotBlank(options().getElasticsearchPassword())) {
-            config = config
-                    .withUsername(options().getElasticsearchUsername())
-                    .withPassword(options().getElasticsearchPassword());
-        } else {
-            config = config.withApiKey(options().getApiKey());
-        }
+    public WriteToElasticsearch build() {
 
-        ElasticsearchIO.Write elasticsearchWriter =
-                ElasticsearchIO.write()
-                        .withConnectionConfiguration(config)
-                        .withMaxBatchSize(options().getBatchSize())
-                        .withMaxBatchSizeBytes(options().getBatchSizeBytes());
+      checkArgument(options().getConnectionUrl() != null, "ConnectionUrl is required.");
 
-        if (Optional.ofNullable(options().getMaxRetryAttempts()).isPresent()) {
-            elasticsearchWriter.withRetryConfiguration(
-                    ElasticsearchIO.RetryConfiguration.create(
-                            options().getMaxRetryAttempts(), getDuration(options().getMaxRetryDuration())));
-        }
+      checkArgument(options().getApiKey() != null, "ApiKey is required.");
 
-        return jsonStrings.apply("WriteDocuments", elasticsearchWriter);
-    }
-
-    /** Builder for {@link WriteToElasticsearch}. */
-    @AutoValue.Builder
-    public abstract static class Builder {
-        public abstract Builder setOptions(ElasticsearchWriteOptions options);
-
-        abstract ElasticsearchWriteOptions options();
-
-        abstract WriteToElasticsearch autoBuild();
-
-        public WriteToElasticsearch build() {
-
-            checkArgument(
-                    options().getConnectionUrl() != null, "ConnectionUrl is required.");
-
-            checkArgument(
-                    options().getApiKey() != null, "ApiKey is required.");
-
-            checkArgument(options().getIndex() != null, "Elasticsearch index should not be null.");
+      checkArgument(options().getIndex() != null, "Elasticsearch index should not be null.");
 
       checkArgument(
           options().getBatchSize() > 0, "Batch size must be > 0. Got: " + options().getBatchSize());
 
-            checkArgument(
-                    options().getBatchSizeBytes() > 0,
-                    "Batch size bytes must be > 0. Got: " + options().getBatchSizeBytes());
+      checkArgument(
+          options().getBatchSizeBytes() > 0,
+          "Batch size bytes must be > 0. Got: " + options().getBatchSizeBytes());
 
-            /* Check that both {@link RetryConfiguration} parameters are supplied. */
-            if (options().getMaxRetryAttempts() != null || options().getMaxRetryDuration() != null) {
-                checkArgument(
-                        options().getMaxRetryDuration() != null && options().getMaxRetryAttempts() != null,
-                        "Both max retry duration and max attempts must be supplied.");
-            }
+      /* Check that both {@link RetryConfiguration} parameters are supplied. */
+      if (options().getMaxRetryAttempts() != null || options().getMaxRetryDuration() != null) {
+        checkArgument(
+            options().getMaxRetryDuration() != null && options().getMaxRetryAttempts() != null,
+            "Both max retry duration and max attempts must be supplied.");
+      }
 
-            return autoBuild();
-        }
+      return autoBuild();
     }
+  }
 }

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
@@ -1,17 +1,19 @@
 /*
- * Copyright (C) 1260 Google LLC
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.google.cloud.teleport.v2.elasticsearch.utils;
 
@@ -30,6 +32,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
@@ -37,14 +41,19 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.net.ssl.SSLContext;
+
+import com.google.gson.JsonArray;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
@@ -53,19 +62,23 @@ import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.GroupIntoBatches;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Reshuffle;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.util.BackOff;
 import org.apache.beam.sdk.util.BackOffUtils;
 import org.apache.beam.sdk.util.FluentBackoff;
 import org.apache.beam.sdk.util.Sleeper;
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Strings;
+import org.apache.http.ConnectionClosedException;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
@@ -73,6 +86,7 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.conn.ssl.TrustStrategy;
 import org.apache.http.entity.BufferedHttpEntity;
@@ -115,11 +129,47 @@ import org.slf4j.LoggerFactory;
  *
  * <p>You can also specify a query on the {@code read()} using {@code withQuery()}.
  *
+ * <p>There are many more configuration options which can be found by looking at the with* methods
+ * of {@link ElasticsearchIO.Read}
+ *
  * <h3>Writing to Elasticsearch</h3>
  *
  * <p>To write documents to Elasticsearch, use {@link ElasticsearchIO#write
  * ElasticsearchIO.write()}, which writes JSON documents from a {@link PCollection
  * PCollection&lt;String&gt;} (which can be bounded or unbounded).
+ *
+ * <p>{@link ElasticsearchIO.Write} involves 2 discrete steps:
+ *
+ * <ul>
+ *   <li>Converting the input PCollection of valid ES documents into Bulk API directives i.e. Should
+ *       the input document result in: update, insert, delete, with version, with routing, etc (See
+ *       {@link ElasticsearchIO.DocToBulk})
+ *   <li>Batching Bulk API directives together and interfacing with an Elasticsearch cluster. (See
+ *       {@link ElasticsearchIO.BulkIO})
+ * </ul>
+ *
+ * <p>In most cases, using {@link ElasticsearchIO#write} will be desirable. In some cases, one may
+ * want to use {@link ElasticsearchIO.DocToBulk} and {@link ElasticsearchIO.BulkIO} directly. Such
+ * cases might include:
+ *
+ * <ul>
+ *   <li>Unit testing. Ensure that output Bulk API entities for a given set of inputs will produce
+ *       an expected result, without the need for an available Elasticsearch cluster. See {@link
+ *       ElasticsearchIO.Write#docToBulk}
+ *   <li>Flexible options for data backup. Serialized Bulk API entities can be forked and sent to
+ *       both Elasticsearch and a data lake.
+ *   <li>Mirroring data to multiple clusters. Presently, mirroring data to multiple clusters would
+ *       require duplicate computation.
+ *   <li>Better batching with input streams in one job. A job may produce multiple "shapes" of Bulk
+ *       API directives based on multiple input types, and then "fan-in" all serialized Bulk
+ *       directives into a single BulkIO transform to improve batching semantics.
+ *   <li>Decoupled jobs. Job(s) could be made to produce Bulk directives and then publish them to a
+ *       message bus. A distinct job could consume from that message bus and solely be responsible
+ *       for IO with the target cluster(s).
+ * </ul>
+ *
+ * <p>Note that configurations options for {@link ElasticsearchIO.Write} are a union of
+ * configutation options for {@link ElasticsearchIO.DocToBulk} and {@link ElasticsearchIO.BulkIO}.
  *
  * <p>To configure {@link ElasticsearchIO#write ElasticsearchIO.write()}, similar to the read, you
  * have to provide a connection configuration. For instance:
@@ -133,53 +183,53 @@ import org.slf4j.LoggerFactory;
  *
  * }</pre>
  *
- * <p>Optionally, you can provide {@code withBatchSize()} and {@code withBatchSizeBytes()} to
- * specify the size of the write batch in number of documents or in bytes.
- *
- * <p>Optionally, you can provide an {@link ElasticsearchIO.Write.FieldValueExtractFn} using {@code
- * withIdFn()} that will be run to extract the id value out of the provided document rather than
- * using the document id auto-generated by Elasticsearch.
- *
- * <p>Optionally, you can provide {@link ElasticsearchIO.Write.FieldValueExtractFn} using {@code
- * withIndexFn()} or {@code withTypeFn()} to enable per-document routing to the target Elasticsearch
- * index (all versions) and type (version &gt; 6). Support for type routing was removed in
- * Elasticsearch 6 (see
- * https://www.elastic.co/blog/index-type-parent-child-join-now-future-in-elasticsearch)
- *
- * <p>When {withUsePartialUpdate()} is enabled, the input document must contain an id field and
- * {@code withIdFn()} must be used to allow its extraction by the ElasticsearchIO.
- *
- * <p>Optionally, {@code withSocketTimeout()} can be used to override the default retry timeout and
- * socket timeout of 30000ms. {@code withConnectTimeout()} can be used to override the default
- * connect timeout of 1000ms.
+ * <p>There are many more configuration options which can be found by looking at the with* methods
+ * of {@link ElasticsearchIO.Write}
  */
 @Experimental(Kind.SOURCE_SINK)
 @SuppressWarnings({
-  "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
+        "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
 })
 public class ElasticsearchIO {
+
+  private static final List<Integer> VALID_CLUSTER_VERSIONS = Arrays.asList(2, 5, 6, 7);
+  private static final List<String> VERSION_TYPES =
+          Arrays.asList("internal", "external", "external_gt", "external_gte");
+  private static final String VERSION_CONFLICT_ERROR = "version_conflict_engine_exception";
 
   private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchIO.class);
 
   public static Read read() {
-    // default scrollKeepalive = 5m as a majorant for un-predictable time between 2 start/read calls
+    // default scrollKeepalive = 5m as a majorant for un-predictable time between 2 start/read
+    // calls
     // default batchSize to 100 as recommended by ES dev team as a safe value when dealing
     // with big documents and still a good compromise for performances
     return new AutoValue_ElasticsearchIO_Read.Builder()
-        .setWithMetadata(false)
-        .setScrollKeepalive("5m")
-        .setBatchSize(100L)
-        .build();
+            .setWithMetadata(false)
+            .setScrollKeepalive("5m")
+            .setBatchSize(100L)
+            .build();
+  }
+
+  public static DocToBulk docToBulk() {
+    return new AutoValue_ElasticsearchIO_DocToBulk.Builder()
+            .setUsePartialUpdate(false) // default is document upsert
+            .build();
+  }
+
+  public static BulkIO bulkIO() {
+    return new AutoValue_ElasticsearchIO_BulkIO.Builder()
+            // advised default starting batch size in ES docs
+            .setMaxBatchSize(1000L)
+            // advised default starting batch size in ES docs
+            .setMaxBatchSizeBytes(5L * 1024L * 1024L)
+            .setUseStatefulBatches(false)
+            .setMaxParallelRequestsPerWindow(1)
+            .build();
   }
 
   public static Write write() {
-    return new AutoValue_ElasticsearchIO_Write.Builder()
-        // advised default starting batch size in ES docs
-        .setMaxBatchSize(1000L)
-        // advised default starting batch size in ES docs
-        .setMaxBatchSizeBytes(5L * 1024L * 1024L)
-        .setUsePartialUpdate(false) // default is document upsert
-        .build();
+    return new Write();
   }
 
   private ElasticsearchIO() {}
@@ -191,45 +241,53 @@ public class ElasticsearchIO {
     return mapper.readValue(responseEntity.getContent(), JsonNode.class);
   }
 
-  static void checkForErrors(HttpEntity responseEntity, int backendVersion, boolean partialUpdate)
-      throws IOException {
+  static String checkForErrors(StringBuilder bulkRequest, HttpEntity responseEntity, @Nullable Set<String> allowedErrorTypes)
+          throws IOException {
+
     JsonNode searchResult = parseResponse(responseEntity);
     boolean errors = searchResult.path("errors").asBoolean();
     if (errors) {
+      int numErrors = 0;
+
       StringBuilder errorMessages =
-          new StringBuilder("Error writing to Elasticsearch, some elements could not be inserted:");
+              new StringBuilder("Error writing to Elasticsearch, some elements could not be inserted:");
       JsonNode items = searchResult.path("items");
+      if (items.isMissingNode() || items.size() == 0) {
+        errorMessages.append(searchResult.toString());
+      }
       // some items present in bulk might have errors, concatenate error messages
       for (JsonNode item : items) {
-
-        String errorRootName = "";
-        // when use partial update, the response items includes all the update.
-        if (partialUpdate) {
-          errorRootName = "update";
-        } else {
-          if (backendVersion == 2) {
-            errorRootName = "create";
-          } else if (backendVersion >= 5) {
-            errorRootName = "index";
-          }
-        }
-        JsonNode errorRoot = item.path(errorRootName);
-        JsonNode error = errorRoot.get("error");
+        JsonNode error = item.findValue("error");
         if (error != null) {
+          // N.B. An empty-string within the allowedErrorTypes Set implies all errors are allowed.
           String type = error.path("type").asText();
           String reason = error.path("reason").asText();
-          String docId = errorRoot.path("_id").asText();
-          errorMessages.append(String.format("%nDocument id %s: %s (%s)", docId, reason, type));
-          JsonNode causedBy = error.get("caused_by");
-          if (causedBy != null) {
-            String cbReason = causedBy.path("reason").asText();
-            String cbType = causedBy.path("type").asText();
-            errorMessages.append(String.format("%nCaused by: %s (%s)", cbReason, cbType));
+          String docId = item.findValue("_id").asText();
+          JsonNode causedBy = error.path("caused_by"); // May not be present
+          String cbReason = causedBy.path("reason").asText();
+          String cbType = causedBy.path("type").asText();
+
+          if (allowedErrorTypes == null
+                  || (!allowedErrorTypes.contains(type) && !allowedErrorTypes.contains(cbType))) {
+            // 'error' and 'causedBy` fields are not null, and the error is not being ignored.
+            numErrors++;
+
+            errorMessages.append(String.format("%nDocument id %s: %s (%s)", docId, reason, type));
+
+            if (!causedBy.isMissingNode()) {
+              errorMessages.append(String.format("%nCaused by: %s (%s)", cbReason, cbType));
+            }
           }
         }
       }
-      throw new IOException(errorMessages.toString());
+      if (numErrors > 0) {
+        //JsonNode bulkEntities = mapper.readTree(bulkRequest.toString());
+        return searchResult.toString();
+        //throw new IOException(errorMessages.toString());
+      }
     }
+
+    return null;
   }
 
   /** A POJO describing a connection configuration to Elasticsearch. */
@@ -305,11 +363,78 @@ public class ElasticsearchIO {
       checkArgument(index != null, "index can not be null");
       checkArgument(type != null, "type can not be null");
       return new AutoValue_ElasticsearchIO_ConnectionConfiguration.Builder()
-          .setAddresses(Arrays.asList(addresses))
-          .setIndex(index)
-          .setType(type)
-          .setTrustSelfSignedCerts(false)
-          .build();
+              .setAddresses(Arrays.asList(addresses))
+              .setIndex(index)
+              .setType(type)
+              .setTrustSelfSignedCerts(false)
+              .build();
+    }
+
+    /**
+     * Creates a new Elasticsearch connection configuration with no default type.
+     *
+     * @param addresses list of addresses of Elasticsearch nodes
+     * @param index the index toward which the requests will be issued
+     * @return the connection configuration object
+     */
+    public static ConnectionConfiguration create(String[] addresses, String index) {
+      checkArgument(addresses != null, "addresses can not be null");
+      checkArgument(addresses.length > 0, "addresses can not be empty");
+      checkArgument(index != null, "index can not be null");
+      return new AutoValue_ElasticsearchIO_ConnectionConfiguration.Builder()
+              .setAddresses(Arrays.asList(addresses))
+              .setIndex(index)
+              .setType("")
+              .setTrustSelfSignedCerts(false)
+              .build();
+    }
+
+    /**
+     * Creates a new Elasticsearch connection configuration with no default index nor type.
+     *
+     * @param addresses list of addresses of Elasticsearch nodes
+     * @return the connection configuration object
+     */
+    public static ConnectionConfiguration create(String[] addresses) {
+      checkArgument(addresses != null, "addresses can not be null");
+      checkArgument(addresses.length > 0, "addresses can not be empty");
+      return new AutoValue_ElasticsearchIO_ConnectionConfiguration.Builder()
+              .setAddresses(Arrays.asList(addresses))
+              .setIndex("")
+              .setType("")
+              .setTrustSelfSignedCerts(false)
+              .build();
+    }
+
+    /**
+     * Generates the bulk API endpoint based on the set values.
+     *
+     * <p>Based on ConnectionConfiguration constructors, we know that one of the following is true:
+     *
+     * <ul>
+     *   <li>index and type are non-empty strings
+     *   <li>index is non-empty string, type is empty string
+     *   <li>index and type are empty string
+     * </ul>
+     *
+     * <p>Valid endpoints therefore include:
+     *
+     * <ul>
+     *   <li>/_bulk
+     *   <li>/index_name/_bulk
+     *   <li>/index_name/type_name/_bulk
+     * </ul>
+     */
+    public String getBulkEndPoint() {
+      StringBuilder sb = new StringBuilder();
+      if (!Strings.isNullOrEmpty(getIndex())) {
+        sb.append("/").append(getIndex());
+      }
+      if (!Strings.isNullOrEmpty(getType())) {
+        sb.append("/").append(getType());
+      }
+      sb.append("/").append("_bulk");
+      return sb.toString();
     }
 
     /**
@@ -452,18 +577,18 @@ public class ElasticsearchIO {
       if (getUsername() != null) {
         final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(
-            AuthScope.ANY, new UsernamePasswordCredentials(getUsername(), getPassword()));
+                AuthScope.ANY, new UsernamePasswordCredentials(getUsername(), getPassword()));
         restClientBuilder.setHttpClientConfigCallback(
-            httpAsyncClientBuilder ->
-                httpAsyncClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
+                httpAsyncClientBuilder ->
+                        httpAsyncClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
       }
       if (getApiKey() != null) {
         restClientBuilder.setDefaultHeaders(
-            new Header[] {new BasicHeader("Authorization", "ApiKey " + getApiKey())});
+                new Header[] {new BasicHeader("Authorization", "ApiKey " + getApiKey())});
       }
       if (getBearerToken() != null) {
         restClientBuilder.setDefaultHeaders(
-            new Header[] {new BasicHeader("Authorization", "Bearer " + getBearerToken())});
+                new Header[] {new BasicHeader("Authorization", "Bearer " + getBearerToken())});
       }
       if (getKeystorePath() != null && !getKeystorePath().isEmpty()) {
         try {
@@ -473,31 +598,31 @@ public class ElasticsearchIO {
             keyStore.load(is, (keystorePassword == null) ? null : keystorePassword.toCharArray());
           }
           final TrustStrategy trustStrategy =
-              isTrustSelfSignedCerts() ? new TrustSelfSignedStrategy() : null;
+                  isTrustSelfSignedCerts() ? new TrustSelfSignedStrategy() : null;
           final SSLContext sslContext =
-              SSLContexts.custom().loadTrustMaterial(keyStore, trustStrategy).build();
+                  SSLContexts.custom().loadTrustMaterial(keyStore, trustStrategy).build();
           final SSLIOSessionStrategy sessionStrategy = new SSLIOSessionStrategy(sslContext);
           restClientBuilder.setHttpClientConfigCallback(
-              httpClientBuilder ->
-                  httpClientBuilder.setSSLContext(sslContext).setSSLStrategy(sessionStrategy));
+                  httpClientBuilder ->
+                          httpClientBuilder.setSSLContext(sslContext).setSSLStrategy(sessionStrategy));
         } catch (Exception e) {
           throw new IOException("Can't load the client certificate from the keystore", e);
         }
       }
       restClientBuilder.setRequestConfigCallback(
-          new RestClientBuilder.RequestConfigCallback() {
-            @Override
-            public RequestConfig.Builder customizeRequestConfig(
-                RequestConfig.Builder requestConfigBuilder) {
-              if (getConnectTimeout() != null) {
-                requestConfigBuilder.setConnectTimeout(getConnectTimeout());
-              }
-              if (getSocketTimeout() != null) {
-                requestConfigBuilder.setSocketTimeout(getSocketTimeout());
-              }
-              return requestConfigBuilder;
-            }
-          });
+              new RestClientBuilder.RequestConfigCallback() {
+                @Override
+                public RequestConfig.Builder customizeRequestConfig(
+                        RequestConfig.Builder requestConfigBuilder) {
+                  if (getConnectTimeout() != null) {
+                    requestConfigBuilder.setConnectTimeout(getConnectTimeout());
+                  }
+                  if (getSocketTimeout() != null) {
+                    requestConfigBuilder.setSocketTimeout(getSocketTimeout());
+                  }
+                  return requestConfigBuilder;
+                }
+              });
       return restClientBuilder.build();
     }
   }
@@ -610,10 +735,10 @@ public class ElasticsearchIO {
      */
     public Read withBatchSize(long batchSize) {
       checkArgument(
-          batchSize > 0 && batchSize <= MAX_BATCH_SIZE,
-          "batchSize must be > 0 and <= %s, but was: %s",
-          MAX_BATCH_SIZE,
-          batchSize);
+              batchSize > 0 && batchSize <= MAX_BATCH_SIZE,
+              "batchSize must be > 0 and <= %s, but was: %s",
+              MAX_BATCH_SIZE,
+              batchSize);
       return builder().setBatchSize(batchSize).build();
     }
 
@@ -622,7 +747,7 @@ public class ElasticsearchIO {
       ConnectionConfiguration connectionConfiguration = getConnectionConfiguration();
       checkState(connectionConfiguration != null, "withConnectionConfiguration() is required");
       return input.apply(
-          org.apache.beam.sdk.io.Read.from(new BoundedElasticsearchSource(this, null, null, null)));
+              org.apache.beam.sdk.io.Read.from(new BoundedElasticsearchSource(this, null, null, null)));
     }
 
     @Override
@@ -651,12 +776,12 @@ public class ElasticsearchIO {
 
     // constructor used in split() when we know the backend version
     private BoundedElasticsearchSource(
-        Read spec,
-        @Nullable String shardPreference,
-        @Nullable Integer numSlices,
-        @Nullable Integer sliceId,
-        @Nullable Long estimatedByteSize,
-        int backendVersion) {
+            Read spec,
+            @Nullable String shardPreference,
+            @Nullable Integer numSlices,
+            @Nullable Integer sliceId,
+            @Nullable Long estimatedByteSize,
+            int backendVersion) {
       this.backendVersion = backendVersion;
       this.spec = spec;
       this.shardPreference = shardPreference;
@@ -667,10 +792,10 @@ public class ElasticsearchIO {
 
     @VisibleForTesting
     BoundedElasticsearchSource(
-        Read spec,
-        @Nullable String shardPreference,
-        @Nullable Integer numSlices,
-        @Nullable Integer sliceId) {
+            Read spec,
+            @Nullable String shardPreference,
+            @Nullable Integer numSlices,
+            @Nullable Integer sliceId) {
       this.spec = spec;
       this.shardPreference = shardPreference;
       this.numSlices = numSlices;
@@ -679,7 +804,7 @@ public class ElasticsearchIO {
 
     @Override
     public List<? extends BoundedSource<String>> split(
-        long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
+            long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
       ConnectionConfiguration connectionConfiguration = spec.getConnectionConfiguration();
       this.backendVersion = getBackendVersion(connectionConfiguration);
       List<BoundedElasticsearchSource> sources = new ArrayList<>();
@@ -694,14 +819,14 @@ public class ElasticsearchIO {
 
         JsonNode statsJson = BoundedElasticsearchSource.getStats(connectionConfiguration, true);
         JsonNode shardsJson =
-            statsJson.path("indices").path(connectionConfiguration.getIndex()).path("shards");
+                statsJson.path("indices").path(connectionConfiguration.getIndex()).path("shards");
 
         Iterator<Map.Entry<String, JsonNode>> shards = shardsJson.fields();
         while (shards.hasNext()) {
           Map.Entry<String, JsonNode> shardJson = shards.next();
           String shardId = shardJson.getKey();
           sources.add(
-              new BoundedElasticsearchSource(spec, shardId, null, null, null, backendVersion));
+                  new BoundedElasticsearchSource(spec, shardId, null, null, null, backendVersion));
         }
         checkArgument(!sources.isEmpty(), "No shard found");
       } else if (backendVersion >= 5) {
@@ -720,8 +845,8 @@ public class ElasticsearchIO {
         for (int i = 0; i < nbBundles; i++) {
           long estimatedByteSizeForBundle = getEstimatedSizeBytes(options) / nbBundles;
           sources.add(
-              new BoundedElasticsearchSource(
-                  spec, null, nbBundles, i, estimatedByteSizeForBundle, backendVersion));
+                  new BoundedElasticsearchSource(
+                          spec, null, nbBundles, i, estimatedByteSizeForBundle, backendVersion));
         }
       }
       return sources;
@@ -735,7 +860,7 @@ public class ElasticsearchIO {
       final ConnectionConfiguration connectionConfiguration = spec.getConnectionConfiguration();
       JsonNode statsJson = getStats(connectionConfiguration, false);
       JsonNode indexStats =
-          statsJson.path("indices").path(connectionConfiguration.getIndex()).path("primaries");
+              statsJson.path("indices").path(connectionConfiguration.getIndex()).path("primaries");
       long indexSize = indexStats.path("store").path("size_in_bytes").asLong();
       LOG.debug("estimate source byte size: total index size " + indexSize);
 
@@ -753,9 +878,9 @@ public class ElasticsearchIO {
       }
 
       String endPoint =
-          String.format(
-              "/%s/%s/_count",
-              connectionConfiguration.getIndex(), connectionConfiguration.getType());
+              String.format(
+                      "/%s/%s/_count",
+                      connectionConfiguration.getIndex(), connectionConfiguration.getType());
       try (RestClient restClient = connectionConfiguration.createClient()) {
         long count = queryCount(restClient, endPoint, query);
         LOG.debug("estimate source byte size: query document count " + count);
@@ -771,8 +896,8 @@ public class ElasticsearchIO {
     }
 
     private long queryCount(
-        @Nonnull RestClient restClient, @Nonnull String endPoint, @Nonnull String query)
-        throws IOException {
+            @Nonnull RestClient restClient, @Nonnull String endPoint, @Nonnull String query)
+            throws IOException {
       Request request = new Request("GET", endPoint);
       request.setEntity(new NStringEntity(query, ContentType.APPLICATION_JSON));
       JsonNode searchResult = parseResponse(restClient.performRequest(request).getEntity());
@@ -781,7 +906,7 @@ public class ElasticsearchIO {
 
     @VisibleForTesting
     static long estimateIndexSize(ConnectionConfiguration connectionConfiguration)
-        throws IOException {
+            throws IOException {
       // we use indices stats API to estimate size and list the shards
       // (https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-stats.html)
       // as Elasticsearch 2.x doesn't not support any way to do parallel read inside a shard
@@ -792,7 +917,7 @@ public class ElasticsearchIO {
       // #sliced-scroll)
       JsonNode statsJson = getStats(connectionConfiguration, false);
       JsonNode indexStats =
-          statsJson.path("indices").path(connectionConfiguration.getIndex()).path("primaries");
+              statsJson.path("indices").path(connectionConfiguration.getIndex()).path("primaries");
       JsonNode store = indexStats.path("store");
       return store.path("size_in_bytes").asLong();
     }
@@ -821,7 +946,7 @@ public class ElasticsearchIO {
     }
 
     private static JsonNode getStats(
-        ConnectionConfiguration connectionConfiguration, boolean shardLevel) throws IOException {
+            ConnectionConfiguration connectionConfiguration, boolean shardLevel) throws IOException {
       HashMap<String, String> params = new HashMap<>();
       if (shardLevel) {
         params.put("level", "shards");
@@ -859,14 +984,14 @@ public class ElasticsearchIO {
       if ((source.backendVersion >= 5) && source.numSlices != null && source.numSlices > 1) {
         // if there is more than one slice, add the slice to the user query
         String sliceQuery =
-            String.format("\"slice\": {\"id\": %s,\"max\": %s}", source.sliceId, source.numSlices);
+                String.format("\"slice\": {\"id\": %s,\"max\": %s}", source.sliceId, source.numSlices);
         query = query.replaceFirst("\\{", "{" + sliceQuery + ",");
       }
       String endPoint =
-          String.format(
-              "/%s/%s/_search",
-              source.spec.getConnectionConfiguration().getIndex(),
-              source.spec.getConnectionConfiguration().getType());
+              String.format(
+                      "/%s/%s/_search",
+                      source.spec.getConnectionConfiguration().getIndex(),
+                      source.spec.getConnectionConfiguration().getType());
       Map<String, String> params = new HashMap<>();
       params.put("scroll", source.spec.getScrollKeepalive());
       if (source.backendVersion == 2) {
@@ -896,9 +1021,9 @@ public class ElasticsearchIO {
         return true;
       } else {
         String requestBody =
-            String.format(
-                "{\"scroll\" : \"%s\",\"scroll_id\" : \"%s\"}",
-                source.spec.getScrollKeepalive(), scrollId);
+                String.format(
+                        "{\"scroll\" : \"%s\",\"scroll_id\" : \"%s\"}",
+                        source.spec.getScrollKeepalive(), scrollId);
         HttpEntity scrollEntity = new NStringEntity(requestBody, ContentType.APPLICATION_JSON);
         Request request = new Request("GET", "/_search/scroll");
         request.addParameters(Collections.emptyMap());
@@ -989,7 +1114,7 @@ public class ElasticsearchIO {
       abstract ElasticsearchIO.RetryConfiguration.Builder setMaxDuration(Duration maxDuration);
 
       abstract ElasticsearchIO.RetryConfiguration.Builder setRetryPredicate(
-          RetryPredicate retryPredicate);
+              RetryPredicate retryPredicate);
 
       abstract ElasticsearchIO.RetryConfiguration build();
     }
@@ -1005,13 +1130,13 @@ public class ElasticsearchIO {
     public static RetryConfiguration create(int maxAttempts, Duration maxDuration) {
       checkArgument(maxAttempts > 0, "maxAttempts must be greater than 0");
       checkArgument(
-          maxDuration != null && maxDuration.isLongerThan(Duration.ZERO),
-          "maxDuration must be greater than 0");
+              maxDuration != null && maxDuration.isLongerThan(Duration.ZERO),
+              "maxDuration must be greater than 0");
       return new AutoValue_ElasticsearchIO_RetryConfiguration.Builder()
-          .setMaxAttempts(maxAttempts)
-          .setMaxDuration(maxDuration)
-          .setRetryPredicate(DEFAULT_RETRY_PREDICATE)
-          .build();
+              .setMaxAttempts(maxAttempts)
+              .setMaxDuration(maxDuration)
+              .setRetryPredicate(DEFAULT_RETRY_PREDICATE)
+              .build();
     }
 
     // Exposed only to allow tests to easily simulate server errors
@@ -1071,38 +1196,41 @@ public class ElasticsearchIO {
     }
   }
 
-  /** A {@link PTransform} writing data to Elasticsearch. */
+  /** A {@link PTransform} converting docs to their Bulk API counterparts. */
   @AutoValue
-  public abstract static class Write extends PTransform<PCollection<String>, PDone> {
+  public abstract static class DocToBulk
+          extends PTransform<PCollection<String>, PCollection<String>> {
 
-    /**
-     * Interface allowing a specific field value to be returned from a parsed JSON document. This is
-     * used for using explicit document ids, and for dynamic routing (index/Type) on a document
-     * basis. A null response will result in default behaviour and an exception will be propagated
-     * as a failure.
-     */
-    public interface FieldValueExtractFn extends SerializableFunction<JsonNode, String> {}
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final int DEFAULT_RETRY_ON_CONFLICT = 5; // race conditions on updates
 
-    /** BooleanFieldValueExtractFn class. */
-    public interface BooleanFieldValueExtractFn extends SerializableFunction<JsonNode, Boolean> {}
+    static {
+      SimpleModule module = new SimpleModule();
+      module.addSerializer(DocumentMetadata.class, new DocumentMetadataSerializer());
+      OBJECT_MAPPER.registerModule(module);
+    }
 
     abstract @Nullable ConnectionConfiguration getConnectionConfiguration();
 
-    abstract long getMaxBatchSize();
+    abstract Write.@Nullable FieldValueExtractFn getIdFn();
 
-    abstract long getMaxBatchSizeBytes();
+    abstract Write.@Nullable FieldValueExtractFn getIndexFn();
 
-    abstract @Nullable FieldValueExtractFn getIdFn();
+    abstract Write.@Nullable FieldValueExtractFn getRoutingFn();
 
-    abstract @Nullable FieldValueExtractFn getIndexFn();
+    abstract Write.@Nullable FieldValueExtractFn getTypeFn();
 
-    abstract @Nullable FieldValueExtractFn getTypeFn();
+    abstract Write.@Nullable FieldValueExtractFn getDocVersionFn();
 
-    abstract @Nullable RetryConfiguration getRetryConfiguration();
+    abstract @Nullable String getDocVersionType();
 
-    abstract boolean getUsePartialUpdate();
+    abstract @Nullable String getUpsertScript();
 
-    abstract @Nullable BooleanFieldValueExtractFn getIsDeleteFn();
+    abstract @Nullable Boolean getUsePartialUpdate();
+
+    abstract Write.@Nullable BooleanFieldValueExtractFn getIsDeleteFn();
+
+    abstract @Nullable Integer getBackendVersion();
 
     abstract Builder builder();
 
@@ -1110,66 +1238,39 @@ public class ElasticsearchIO {
     abstract static class Builder {
       abstract Builder setConnectionConfiguration(ConnectionConfiguration connectionConfiguration);
 
-      abstract Builder setMaxBatchSize(long maxBatchSize);
+      abstract Builder setIdFn(Write.FieldValueExtractFn idFunction);
 
-      abstract Builder setMaxBatchSizeBytes(long maxBatchSizeBytes);
+      abstract Builder setIndexFn(Write.FieldValueExtractFn indexFn);
 
-      abstract Builder setIdFn(FieldValueExtractFn idFunction);
+      abstract Builder setRoutingFn(Write.FieldValueExtractFn routingFunction);
 
-      abstract Builder setIndexFn(FieldValueExtractFn indexFn);
+      abstract Builder setTypeFn(Write.FieldValueExtractFn typeFn);
 
-      abstract Builder setTypeFn(FieldValueExtractFn typeFn);
+      abstract Builder setDocVersionFn(Write.FieldValueExtractFn docVersionFn);
 
-      abstract Builder setUsePartialUpdate(boolean usePartialUpdate);
+      abstract Builder setDocVersionType(String docVersionType);
 
-      abstract Builder setRetryConfiguration(RetryConfiguration retryConfiguration);
+      abstract Builder setIsDeleteFn(Write.BooleanFieldValueExtractFn isDeleteFn);
 
-      abstract Builder setIsDeleteFn(BooleanFieldValueExtractFn isDeleteFn);
+      abstract Builder setUsePartialUpdate(Boolean usePartialUpdate);
 
-      abstract Write build();
+      abstract Builder setUpsertScript(String source);
+
+      abstract Builder setBackendVersion(Integer assumedBackendVersion);
+
+      abstract DocToBulk build();
     }
 
     /**
-     * Provide the Elasticsearch connection configuration object.
+     * Provide the Elasticsearch connection configuration object. Only required if
+     * withBackendVersion was not used i.e. getBackendVersion() returns null.
      *
      * @param connectionConfiguration the Elasticsearch {@link ConnectionConfiguration} object
-     * @return the {@link Write} with connection configuration set
+     * @return the {@link DocToBulk} with connection configuration set
      */
-    public Write withConnectionConfiguration(ConnectionConfiguration connectionConfiguration) {
+    public DocToBulk withConnectionConfiguration(ConnectionConfiguration connectionConfiguration) {
       checkArgument(connectionConfiguration != null, "connectionConfiguration can not be null");
       return builder().setConnectionConfiguration(connectionConfiguration).build();
-    }
-
-    /**
-     * Provide a maximum size in number of documents for the batch see bulk API
-     * (https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-bulk.html). Default is 1000
-     * docs (like Elasticsearch bulk size advice). See
-     * https://www.elastic.co/guide/en/elasticsearch/guide/current/bulk.html Depending on the
-     * execution engine, size of bundles may vary, this sets the maximum size. Change this if you
-     * need to have smaller Elasticsearch bulks.
-     *
-     * @param batchSize maximum batch size in number of documents
-     * @return the {@link Write} with connection batch size set
-     */
-    public Write withMaxBatchSize(long batchSize) {
-      checkArgument(batchSize > 0, "batchSize must be > 0, but was %s", batchSize);
-      return builder().setMaxBatchSize(batchSize).build();
-    }
-
-    /**
-     * Provide a maximum size in bytes for the batch see bulk API
-     * (https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-bulk.html). Default is 5MB
-     * (like Elasticsearch bulk size advice). See
-     * https://www.elastic.co/guide/en/elasticsearch/guide/current/bulk.html Depending on the
-     * execution engine, size of bundles may vary, this sets the maximum size. Change this if you
-     * need to have smaller Elasticsearch bulks.
-     *
-     * @param batchSizeBytes maximum batch size in bytes
-     * @return the {@link Write} with connection batch size in bytes set
-     */
-    public Write withMaxBatchSizeBytes(long batchSizeBytes) {
-      checkArgument(batchSizeBytes > 0, "batchSizeBytes must be > 0, but was %s", batchSizeBytes);
-      return builder().setMaxBatchSizeBytes(batchSizeBytes).build();
     }
 
     /**
@@ -1178,9 +1279,9 @@ public class ElasticsearchIO {
      * exception propagated.
      *
      * @param idFn to extract the document ID
-     * @return the {@link Write} with the function set
+     * @return the {@link DocToBulk} with the function set
      */
-    public Write withIdFn(FieldValueExtractFn idFn) {
+    public DocToBulk withIdFn(Write.FieldValueExtractFn idFn) {
       checkArgument(idFn != null, "idFn must not be null");
       return builder().setIdFn(idFn).build();
     }
@@ -1191,11 +1292,24 @@ public class ElasticsearchIO {
      * exception propagated.
      *
      * @param indexFn to extract the destination index from
-     * @return the {@link Write} with the function set
+     * @return the {@link DocToBulk} with the function set
      */
-    public Write withIndexFn(FieldValueExtractFn indexFn) {
+    public DocToBulk withIndexFn(Write.FieldValueExtractFn indexFn) {
       checkArgument(indexFn != null, "indexFn must not be null");
       return builder().setIndexFn(indexFn).build();
+    }
+
+    /**
+     * Provide a function to extract the target routing from the document allowing for dynamic
+     * document routing. Should the function throw an Exception then the batch will fail and the
+     * exception propagated.
+     *
+     * @param routingFn to extract the destination index from
+     * @return the {@link DocToBulk} with the function set
+     */
+    public DocToBulk withRoutingFn(Write.FieldValueExtractFn routingFn) {
+      checkArgument(routingFn != null, "routingFn must not be null");
+      return builder().setRoutingFn(routingFn).build();
     }
 
     /**
@@ -1207,9 +1321,9 @@ public class ElasticsearchIO {
      * discussed in this blog</a>.
      *
      * @param typeFn to extract the destination index from
-     * @return the {@link Write} with the function set
+     * @return the {@link DocToBulk} with the function set
      */
-    public Write withTypeFn(FieldValueExtractFn typeFn) {
+    public DocToBulk withTypeFn(Write.FieldValueExtractFn typeFn) {
       checkArgument(typeFn != null, "typeFn must not be null");
       return builder().setTypeFn(typeFn).build();
     }
@@ -1219,10 +1333,535 @@ public class ElasticsearchIO {
      * Elasticsearch.
      *
      * @param usePartialUpdate set to true to issue partial updates
-     * @return the {@link Write} with the partial update control set
+     * @return the {@link DocToBulk} with the partial update control set
      */
-    public Write withUsePartialUpdate(boolean usePartialUpdate) {
+    public DocToBulk withUsePartialUpdate(boolean usePartialUpdate) {
       return builder().setUsePartialUpdate(usePartialUpdate).build();
+    }
+
+    /**
+     * Whether to use scripted updates and what script to use.
+     *
+     * @param source set to the value of the script source, painless lang
+     * @return the {@link DocToBulk} with the scripted updates set
+     */
+    public DocToBulk withUpsertScript(String source) {
+      if (getBackendVersion() == null || getBackendVersion() == 2) {
+        LOG.warn("Painless scripts are not supported on Elasticsearch clusters before version 5.0");
+      }
+      return builder().setUsePartialUpdate(false).setUpsertScript(source).build();
+    }
+
+    /**
+     * Provide a function to extract the doc version from the document. This version number will be
+     * used as the document version in Elasticsearch. Should the function throw an Exception then
+     * the batch will fail and the exception propagated. Incompatible with update operations and
+     * should only be used with withUsePartialUpdate(false)
+     *
+     * @param docVersionFn to extract the document version
+     * @return the {@link DocToBulk} with the function set
+     */
+    public DocToBulk withDocVersionFn(Write.FieldValueExtractFn docVersionFn) {
+      checkArgument(docVersionFn != null, "docVersionFn must not be null");
+      return builder().setDocVersionFn(docVersionFn).build();
+    }
+
+    /**
+     * Provide a function to extract the target operation either upsert or delete from the document
+     * fields allowing dynamic bulk operation decision. While using withIsDeleteFn, it should be
+     * taken care that the document's id extraction is defined using the withIdFn function or else
+     * IllegalArgumentException is thrown. Should the function throw an Exception then the batch
+     * will fail and the exception propagated.
+     *
+     * @param isDeleteFn set to true for deleting the specific document
+     * @return the {@link Write} with the function set
+     */
+    public DocToBulk withIsDeleteFn(Write.BooleanFieldValueExtractFn isDeleteFn) {
+      checkArgument(isDeleteFn != null, "deleteFn is required");
+      return builder().setIsDeleteFn(isDeleteFn).build();
+    }
+
+    /**
+     * Provide a function to extract the doc version from the document. This version number will be
+     * used as the document version in Elasticsearch. Should the function throw an Exception then
+     * the batch will fail and the exception propagated. Incompatible with update operations and
+     * should only be used with withUsePartialUpdate(false)
+     *
+     * @param docVersionType the version type to use, one of {@value VERSION_TYPES}
+     * @return the {@link DocToBulk} with the doc version type set
+     */
+    public DocToBulk withDocVersionType(String docVersionType) {
+      checkArgument(
+              VERSION_TYPES.contains(docVersionType),
+              "docVersionType must be one of " + "%s",
+              String.join(", ", VERSION_TYPES));
+      return builder().setDocVersionType(docVersionType).build();
+    }
+
+    /**
+     * Use to set explicitly which version of Elasticsearch the destination cluster is running.
+     * Providing this hint means there is no need for setting {@link
+     * DocToBulk#withConnectionConfiguration}. This can also be very useful for testing purposes.
+     *
+     * <p>Note: if the value of @param backendVersion differs from the version the destination
+     * cluster is running, behavior is undefined and likely to yield errors.
+     *
+     * @param backendVersion the major version number of the version of Elasticsearch being run in
+     *     the cluster where documents will be indexed.
+     * @return the {@link DocToBulk} with the Elasticsearch major version number set
+     */
+    public DocToBulk withBackendVersion(int backendVersion) {
+      checkArgument(
+              VALID_CLUSTER_VERSIONS.contains(backendVersion),
+              "Backend version may only be one of " + "%s",
+              String.join(", ", VERSION_TYPES));
+      return builder().setBackendVersion(backendVersion).build();
+    }
+
+    @Override
+    public PCollection<String> expand(PCollection<String> docs) {
+      ConnectionConfiguration connectionConfiguration = getConnectionConfiguration();
+      Integer backendVersion = getBackendVersion();
+      Write.FieldValueExtractFn idFn = getIdFn();
+      Write.BooleanFieldValueExtractFn isDeleteFn = getIsDeleteFn();
+      checkState(
+              (backendVersion != null || connectionConfiguration != null),
+              "withBackendVersion() or withConnectionConfiguration() is required");
+      checkArgument(
+              isDeleteFn == null || idFn != null,
+              "Id needs to be specified by withIdFn for delete operation");
+
+      return docs.apply(ParDo.of(new DocToBulkFn(this)));
+    }
+
+    // Encapsulates the elements which form the metadata for an Elasticsearch bulk operation
+    private static class DocumentMetadata implements Serializable {
+      final String index;
+      final String type;
+      final String id;
+      final Integer retryOnConflict;
+      final String routing;
+      final Integer backendVersion;
+      final String version;
+      final String versionType;
+
+      DocumentMetadata(
+              String index,
+              String type,
+              String id,
+              Integer retryOnConflict,
+              String routing,
+              Integer backendVersion,
+              String version,
+              String versionType) {
+        this.index = index;
+        this.id = id;
+        this.type = type;
+        this.retryOnConflict = retryOnConflict;
+        this.routing = routing;
+        this.backendVersion = backendVersion;
+        this.version = version;
+        this.versionType = versionType;
+      }
+    }
+
+    private static class DocumentMetadataSerializer extends StdSerializer<DocumentMetadata> {
+      private DocumentMetadataSerializer() {
+        super(DocumentMetadata.class);
+      }
+
+      @Override
+      public void serialize(DocumentMetadata value, JsonGenerator gen, SerializerProvider provider)
+              throws IOException {
+        gen.writeStartObject();
+        if (value.index != null) {
+          gen.writeStringField("_index", value.index);
+        }
+        if (value.type != null) {
+          gen.writeStringField("_type", value.type);
+        }
+        if (value.id != null) {
+          gen.writeStringField("_id", value.id);
+        }
+        if (value.routing != null) {
+          gen.writeStringField("routing", value.routing);
+        }
+        if (value.retryOnConflict != null && value.backendVersion <= 6) {
+          gen.writeNumberField("_retry_on_conflict", value.retryOnConflict);
+        }
+        if (value.retryOnConflict != null && value.backendVersion >= 7) {
+          gen.writeNumberField("retry_on_conflict", value.retryOnConflict);
+        }
+        if (value.version != null) {
+          gen.writeStringField("version", value.version);
+        }
+        if (value.versionType != null) {
+          gen.writeStringField("version_type", value.versionType);
+        }
+        gen.writeEndObject();
+      }
+    }
+
+    @VisibleForTesting
+    static String createBulkApiEntity(DocToBulk spec, String document, int backendVersion)
+            throws IOException {
+      String documentMetadata = "{}";
+      boolean isDelete = false;
+      if (spec.getIndexFn() != null
+              || spec.getTypeFn() != null
+              || spec.getIdFn() != null
+              || spec.getRoutingFn() != null) {
+        // parse once and reused for efficiency
+        JsonNode parsedDocument = OBJECT_MAPPER.readTree(document);
+        documentMetadata = getDocumentMetadata(spec, parsedDocument, backendVersion);
+        if (spec.getIsDeleteFn() != null) {
+          isDelete = spec.getIsDeleteFn().apply(parsedDocument);
+        }
+      }
+
+      if (isDelete) {
+        // delete request used for deleting a document
+        return String.format("{ \"delete\" : %s }%n", documentMetadata);
+      } else {
+        // index is an insert/upsert and update is a partial update (or insert if not
+        // existing)
+        if (spec.getUsePartialUpdate()) {
+          return String.format(
+                  "{ \"update\" : %s }%n{ \"doc\" : %s, " + "\"doc_as_upsert\" : true }%n",
+                  documentMetadata, document);
+        } else if (spec.getUpsertScript() != null) {
+          return String.format(
+                  "{ \"update\" : %s }%n{ \"script\" : {\"source\": \"%s\", "
+                          + "\"params\": %s}, \"upsert\" : %s, \"scripted_upsert\": true}%n",
+                  documentMetadata, spec.getUpsertScript(), document, document);
+        } else {
+          return String.format("{ \"create\" : %s }%n%s%n", documentMetadata, document);
+        }
+      }
+    }
+
+    private static String lowerCaseOrNull(String input) {
+      return input == null ? null : input.toLowerCase();
+    }
+
+    /**
+     * Extracts the components that comprise the document address from the document using the {@link
+     * Write.FieldValueExtractFn} configured. This allows any or all of the index, type and document
+     * id to be controlled on a per document basis. If none are provided then an empty default of
+     * {@code {}} is returned. Sanitization of the index is performed, automatically lower-casing
+     * the value as required by Elasticsearch.
+     *
+     * @param parsedDocument the json from which the index, type and id may be extracted
+     * @return the document address as JSON or the default
+     * @throws IOException if the document cannot be parsed as JSON
+     */
+    private static String getDocumentMetadata(
+            DocToBulk spec, JsonNode parsedDocument, int backendVersion) throws IOException {
+      DocumentMetadata metadata =
+              new DocumentMetadata(
+                      spec.getIndexFn() != null
+                              ? lowerCaseOrNull(spec.getIndexFn().apply(parsedDocument))
+                              : null,
+                      spec.getTypeFn() != null ? spec.getTypeFn().apply(parsedDocument) : null,
+                      spec.getIdFn() != null ? spec.getIdFn().apply(parsedDocument) : null,
+                      (spec.getUsePartialUpdate()
+                              || (spec.getUpsertScript() != null && !spec.getUpsertScript().isEmpty()))
+                              ? DEFAULT_RETRY_ON_CONFLICT
+                              : null,
+                      spec.getRoutingFn() != null ? spec.getRoutingFn().apply(parsedDocument) : null,
+                      backendVersion,
+                      spec.getDocVersionFn() != null ? spec.getDocVersionFn().apply(parsedDocument) : null,
+                      spec.getDocVersionType());
+      return OBJECT_MAPPER.writeValueAsString(metadata);
+    }
+
+    /** {@link DoFn} to for the {@link DocToBulk} transform. */
+    @VisibleForTesting
+    static class DocToBulkFn extends DoFn<String, String> {
+      private final DocToBulk spec;
+      private int backendVersion;
+
+      public DocToBulkFn(DocToBulk spec) {
+        this.spec = spec;
+      }
+
+      @Setup
+      public void setup() throws IOException {
+        if (spec.getBackendVersion() != null) {
+          backendVersion = spec.getBackendVersion();
+        } else {
+          backendVersion = ElasticsearchIO.getBackendVersion(spec.getConnectionConfiguration());
+        }
+      }
+
+      @ProcessElement
+      public void processElement(ProcessContext c) throws IOException {
+        c.output(createBulkApiEntity(spec, c.element(), backendVersion));
+      }
+    }
+  }
+
+  /**
+   * A {@link PTransform} writing data to Elasticsearch.
+   *
+   * <p>This {@link PTransform} acts as a convenience wrapper for doing both document to bulk API
+   * serialization as well as batching those Bulk API entities and writing them to an Elasticsearch
+   * cluster. This class is effectively a thin proxy for DocToBulk->BulkIO all-in-one for
+   * convenience and backward compatibility.
+   */
+  public static class Write extends PTransform<PCollection<String>, PCollection<String>> {
+    public interface FieldValueExtractFn extends SerializableFunction<JsonNode, String> {}
+
+    public interface BooleanFieldValueExtractFn extends SerializableFunction<JsonNode, Boolean> {}
+
+    private DocToBulk docToBulk =
+            new AutoValue_ElasticsearchIO_DocToBulk.Builder()
+                    .setUsePartialUpdate(false) // default is document upsert
+                    .build();
+
+    private BulkIO bulkIO =
+            new AutoValue_ElasticsearchIO_BulkIO.Builder()
+                    // advised default starting batch size in ES docs
+                    .setMaxBatchSize(1000L)
+                    // advised default starting batch size in ES docs
+                    .setMaxBatchSizeBytes(5L * 1024L * 1024L)
+                    .setUseStatefulBatches(false)
+                    .setMaxParallelRequestsPerWindow(1)
+                    .build();
+
+    public DocToBulk getDocToBulk() {
+      return docToBulk;
+    }
+
+    public BulkIO getBulkIO() {
+      return bulkIO;
+    }
+
+    // For building Doc2Bulk
+    /** Refer to {@link DocToBulk#withIdFn}. */
+    public Write withIdFn(FieldValueExtractFn idFn) {
+      docToBulk = docToBulk.withIdFn(idFn);
+      return this;
+    }
+
+    /** Refer to {@link DocToBulk#withIndexFn}. */
+    public Write withIndexFn(FieldValueExtractFn indexFn) {
+      docToBulk = docToBulk.withIndexFn(indexFn);
+      return this;
+    }
+
+    /** Refer to {@link DocToBulk#withRoutingFn}. */
+    public Write withRoutingFn(FieldValueExtractFn routingFn) {
+      docToBulk = docToBulk.withRoutingFn(routingFn);
+      return this;
+    }
+
+    /** Refer to {@link DocToBulk#withTypeFn}. */
+    public Write withTypeFn(FieldValueExtractFn typeFn) {
+      docToBulk = docToBulk.withTypeFn(typeFn);
+      return this;
+    }
+
+    /** Refer to {@link DocToBulk#withDocVersionFn}. */
+    public Write withDocVersionFn(FieldValueExtractFn docVersionFn) {
+      docToBulk = docToBulk.withDocVersionFn(docVersionFn);
+      return this;
+    }
+
+    /** Refer to {@link DocToBulk#withDocVersionType}. */
+    public Write withDocVersionType(String docVersionType) {
+      docToBulk = docToBulk.withDocVersionType(docVersionType);
+      return this;
+    }
+
+    /** Refer to {@link DocToBulk#withUsePartialUpdate}. */
+    public Write withUsePartialUpdate(boolean usePartialUpdate) {
+      docToBulk = docToBulk.withUsePartialUpdate(usePartialUpdate);
+      return this;
+    }
+
+    /** Refer to {@link DocToBulk#withUpsertScript}. */
+    public Write withUpsertScript(String source) {
+      docToBulk = docToBulk.withUpsertScript(source);
+      return this;
+    }
+
+    /** Refer to {@link DocToBulk#withBackendVersion}. */
+    public Write withBackendVersion(int backendVersion) {
+      docToBulk = docToBulk.withBackendVersion(backendVersion);
+      return this;
+    }
+
+    /** Refer to {@link DocToBulk#withIsDeleteFn}. */
+    public Write withIsDeleteFn(Write.BooleanFieldValueExtractFn isDeleteFn) {
+      docToBulk = docToBulk.withIsDeleteFn(isDeleteFn);
+      return this;
+    }
+    // End building Doc2Bulk
+
+    /** Refer to {@link BulkIO#withConnectionConfiguration}. */
+    public Write withConnectionConfiguration(ConnectionConfiguration connectionConfiguration) {
+      checkArgument(connectionConfiguration != null, "connectionConfiguration can not be null");
+      docToBulk = docToBulk.withConnectionConfiguration(connectionConfiguration);
+      bulkIO = bulkIO.withConnectionConfiguration(connectionConfiguration);
+      return this;
+    }
+
+    /** Refer to {@link BulkIO#withMaxBatchSize}. */
+    public Write withMaxBatchSize(long batchSize) {
+      bulkIO = bulkIO.withMaxBatchSize(batchSize);
+      return this;
+    }
+
+    /** Refer to {@link BulkIO#withMaxBatchSizeBytes}. */
+    public Write withMaxBatchSizeBytes(long batchSizeBytes) {
+      bulkIO = bulkIO.withMaxBatchSizeBytes(batchSizeBytes);
+      return this;
+    }
+
+    /** Refer to {@link BulkIO#withRetryConfiguration}. */
+    public Write withRetryConfiguration(RetryConfiguration retryConfiguration) {
+      bulkIO = bulkIO.withRetryConfiguration(retryConfiguration);
+      return this;
+    }
+
+    /** Refer to {@link BulkIO#withIgnoreVersionConflicts}. */
+    public Write withIgnoreVersionConflicts(boolean ignoreVersionConflicts) {
+      bulkIO = bulkIO.withIgnoreVersionConflicts(ignoreVersionConflicts);
+      return this;
+    }
+
+    /** Refer to {@link BulkIO#withUseStatefulBatches}. */
+    public Write withUseStatefulBatches(boolean useStatefulBatches) {
+      bulkIO = bulkIO.withUseStatefulBatches(useStatefulBatches);
+      return this;
+    }
+
+    /** Refer to {@link BulkIO#withMaxBufferingDuration}. */
+    public Write withMaxBufferingDuration(Duration maxBufferingDuration) {
+      bulkIO = bulkIO.withMaxBufferingDuration(maxBufferingDuration);
+      return this;
+    }
+
+    /** Refer to {@link BulkIO#withMaxParallelRequestsPerWindow}. */
+    public Write withMaxParallelRequestsPerWindow(int maxParallelRequestsPerWindow) {
+      bulkIO = bulkIO.withMaxParallelRequestsPerWindow(maxParallelRequestsPerWindow);
+      return this;
+    }
+
+    /** Refer to {@link BulkIO#withAllowableResponseErrors}. */
+    public Write withAllowableResponseErrors(@Nullable Set<String> allowableResponseErrors) {
+      if (allowableResponseErrors == null) {
+        allowableResponseErrors = new HashSet<>();
+      }
+
+      bulkIO = bulkIO.withAllowableResponseErrors(allowableResponseErrors);
+      return this;
+    }
+
+    @Override
+    public PCollection<String> expand(PCollection<String> input) {
+      return input.apply(docToBulk).apply(bulkIO);
+    }
+  }
+
+  /**
+   * A {@link PTransform} writing Bulk API entities created by {@link ElasticsearchIO.DocToBulk} to
+   * an Elasticsearch cluster. Typically, using {@link ElasticsearchIO.Write} is preferred, whereas
+   * using {@link ElasticsearchIO.DocToBulk} and BulkIO separately is for advanced use cases such as
+   * mirroring data to multiple clusters or data lakes without recomputation.
+   */
+  @AutoValue
+  public abstract static class BulkIO extends PTransform<PCollection<String>, PCollection<String>> {
+    @VisibleForTesting
+    static final String RETRY_ATTEMPT_LOG = "Error writing to Elasticsearch. Retry attempt[%d]";
+
+    @VisibleForTesting
+    static final String RETRY_FAILED_LOG =
+            "Error writing to ES after %d attempt(s). No more attempts allowed";
+    
+    abstract @Nullable ConnectionConfiguration getConnectionConfiguration();
+
+    abstract long getMaxBatchSize();
+
+    abstract long getMaxBatchSizeBytes();
+
+    abstract @Nullable Duration getMaxBufferingDuration();
+
+    abstract boolean getUseStatefulBatches();
+
+    abstract int getMaxParallelRequestsPerWindow();
+
+    abstract @Nullable RetryConfiguration getRetryConfiguration();
+
+    abstract @Nullable Set<String> getAllowedResponseErrors();
+
+    abstract Builder builder();
+
+    @AutoValue.Builder
+    abstract static class Builder {
+
+      abstract Builder setConnectionConfiguration(ConnectionConfiguration connectionConfiguration);
+
+      abstract Builder setMaxBatchSize(long maxBatchSize);
+
+      abstract Builder setMaxBatchSizeBytes(long maxBatchSizeBytes);
+
+      abstract Builder setRetryConfiguration(RetryConfiguration retryConfiguration);
+
+      abstract Builder setAllowedResponseErrors(Set<String> allowedResponseErrors);
+
+      abstract Builder setMaxBufferingDuration(Duration maxBufferingDuration);
+
+      abstract Builder setUseStatefulBatches(boolean useStatefulBatches);
+
+      abstract Builder setMaxParallelRequestsPerWindow(int maxParallelRequestsPerWindow);
+
+      abstract BulkIO build();
+    }
+
+    /**
+     * Provide the Elasticsearch connection configuration object.
+     *
+     * @param connectionConfiguration the Elasticsearch {@link ConnectionConfiguration} object
+     * @return the {@link BulkIO} with connection configuration set
+     */
+    public BulkIO withConnectionConfiguration(ConnectionConfiguration connectionConfiguration) {
+      checkArgument(connectionConfiguration != null, "connectionConfiguration can not be null");
+
+      return builder().setConnectionConfiguration(connectionConfiguration).build();
+    }
+
+    /**
+     * Provide a maximum size in number of documents for the batch see bulk API
+     * (https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-bulk.html). Default is 1000
+     * docs (like Elasticsearch bulk size advice). See
+     * https://www.elastic.co/guide/en/elasticsearch/guide/current/bulk.html Depending on the
+     * execution engine, size of bundles may vary, this sets the maximum size. Change this if you
+     * need to have smaller ElasticSearch bulks.
+     *
+     * @param batchSize maximum batch size in number of documents
+     * @return the {@link BulkIO} with connection batch size set
+     */
+    public BulkIO withMaxBatchSize(long batchSize) {
+      checkArgument(batchSize > 0, "batchSize must be > 0, but was %s", batchSize);
+      return builder().setMaxBatchSize(batchSize).build();
+    }
+
+    /**
+     * Provide a maximum size in bytes for the batch see bulk API
+     * (https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-bulk.html). Default is 5MB
+     * (like Elasticsearch bulk size advice). See
+     * https://www.elastic.co/guide/en/elasticsearch/guide/current/bulk.html Depending on the
+     * execution engine, size of bundles may vary, this sets the maximum size. Change this if you
+     * need to have smaller ElasticSearch bulks.
+     *
+     * @param batchSizeBytes maximum batch size in bytes
+     * @return the {@link BulkIO} with connection batch size in bytes set
+     */
+    public BulkIO withMaxBatchSizeBytes(long batchSizeBytes) {
+      checkArgument(batchSizeBytes > 0, "batchSizeBytes must be > 0, but was %s", batchSizeBytes);
+      return builder().setMaxBatchSizeBytes(batchSizeBytes).build();
     }
 
     /**
@@ -1245,105 +1884,233 @@ public class ElasticsearchIO {
      * }</pre>
      *
      * @param retryConfiguration the rules which govern the retry behavior
-     * @return the {@link Write} with retrying configured
+     * @return the {@link BulkIO} with retrying configured
      */
-    public Write withRetryConfiguration(RetryConfiguration retryConfiguration) {
+    public BulkIO withRetryConfiguration(RetryConfiguration retryConfiguration) {
       checkArgument(retryConfiguration != null, "retryConfiguration is required");
       return builder().setRetryConfiguration(retryConfiguration).build();
     }
 
     /**
-     * Provide a function to extract the target operation either upsert or delete from the document
-     * fields allowing dynamic bulk operation decision. While using withIsDeleteFn, it should be
-     * taken care that the document's id extraction is defined using the withIdFn function or else
-     * IllegalArgumentException is thrown. Should the function throw an Exception then the batch
-     * will fail and the exception propagated.
+     * Whether or not to suppress version conflict errors in a Bulk API response. This can be useful
+     * if your use case involves using external version types.
      *
-     * @param isDeleteFn set to true for deleting the specific document
-     * @return the {@link Write} with the function set
+     * @param ignoreVersionConflicts true to suppress version conflicts, false to surface version
+     *     conflict errors.
+     * @return the {@link BulkIO} with version conflict handling configured
      */
-    public Write withIsDeleteFn(BooleanFieldValueExtractFn isDeleteFn) {
-      checkArgument(isDeleteFn != null, "deleteFn is required");
-      return builder().setIsDeleteFn(isDeleteFn).build();
+    public BulkIO withIgnoreVersionConflicts(boolean ignoreVersionConflicts) {
+      Set<String> allowedResponseErrors = getAllowedResponseErrors();
+      if (allowedResponseErrors == null) {
+        allowedResponseErrors = new HashSet<>();
+      }
+      if (ignoreVersionConflicts) {
+        allowedResponseErrors.add(VERSION_CONFLICT_ERROR);
+      }
+
+      return builder().setAllowedResponseErrors(allowedResponseErrors).build();
+    }
+
+    /**
+     * Provide a set of textual error types which can be contained in Bulk API response
+     * items[].error.type field. Any element in @param allowableResponseErrorTypes will suppress
+     * errors of the same type in Bulk responses.
+     *
+     * <p>See also
+     * https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#bulk-failures-ex
+     *
+     * @param allowableResponseErrorTypes
+     * @return the {@link BulkIO} with allowable response errors set
+     */
+    public BulkIO withAllowableResponseErrors(@Nullable Set<String> allowableResponseErrorTypes) {
+      if (allowableResponseErrorTypes == null) {
+        allowableResponseErrorTypes = new HashSet<>();
+      }
+
+      return builder().setAllowedResponseErrors(allowableResponseErrorTypes).build();
+    }
+
+    /**
+     * If using {@link BulkIO#withUseStatefulBatches}, this can be used to set a maximum elapsed
+     * time before buffered elements are emitted to Elasticsearch as a Bulk API request. If this
+     * config is not set, Bulk requests will not be issued until {@link BulkIO#getMaxBatchSize}
+     * number of documents have been buffered. This may result in higher latency in particular if
+     * your max batch size is set to a large value and your pipeline input is low volume.
+     *
+     * @param maxBufferingDuration the maximum duration to wait before sending any buffered
+     *     documents to Elasticsearch, regardless of maxBatchSize.
+     * @return the {@link BulkIO} with maximum buffering duration set
+     */
+    public BulkIO withMaxBufferingDuration(Duration maxBufferingDuration) {
+      LOG.warn(
+              "Use of withMaxBufferingDuration requires withUseStatefulBatches(true). "
+                      + "Setting that automatically.");
+      return builder()
+              .setUseStatefulBatches(true)
+              .setMaxBufferingDuration(maxBufferingDuration)
+              .build();
+    }
+
+    /**
+     * Whether or not to use Stateful Processing to ensure bulk requests have the desired number of
+     * entities i.e. as close to the maxBatchSize as possible. By default without this feature
+     * enabled, Bulk requests will not contain more than maxBatchSize entities, but the lower bound
+     * of batch size is determined by Beam Runner bundle sizes, which may be as few as 1.
+     *
+     * @param useStatefulBatches true enables the use of Stateful Processing to ensure that batches
+     *     are as close to the maxBatchSize as possible.
+     * @return the {@link BulkIO} with Stateful Processing enabled or disabled
+     */
+    public BulkIO withUseStatefulBatches(boolean useStatefulBatches) {
+      return builder().setUseStatefulBatches(useStatefulBatches).build();
+    }
+
+    /**
+     * When using {@link BulkIO#withUseStatefulBatches} Stateful Processing, states and therefore
+     * batches are maintained per-key-per-window. BE AWARE that low values for @param
+     * maxParallelRequestsPerWindow, in particular if the input data has a finite number of windows,
+     * can reduce parallelism greatly. If data is globally windowed and @param
+     * maxParallelRequestsPerWindow is set to 1,there will only ever be 1 request in flight. Having
+     * only a single request in flight can be beneficial for ensuring an Elasticsearch cluster is
+     * not overwhelmed by parallel requests,but may not work for all use cases. If this number is
+     * less than the number of maximum workers in your pipeline, the IO work will result in a
+     * sub-distribution of the last write step with most of the runners.
+     *
+     * @param maxParallelRequestsPerWindow the maximum number of parallel bulk requests for a window
+     *     of data
+     * @return the {@link BulkIO} with maximum parallel bulk requests per window set
+     */
+    public BulkIO withMaxParallelRequestsPerWindow(int maxParallelRequestsPerWindow) {
+      checkArgument(
+              maxParallelRequestsPerWindow > 0, "parameter value must be positive " + "a integer");
+      return builder().setMaxParallelRequestsPerWindow(maxParallelRequestsPerWindow).build();
+    }
+
+    /**
+     * Creates batches of documents using Stateful Processing based on user configurable settings of
+     * withMaxBufferingDuration and withMaxParallelRequestsPerWindow.
+     *
+     * <p>Mostly exists for testability of withMaxParallelRequestsPerWindow.
+     */
+    @VisibleForTesting
+    static class StatefulBatching
+            extends PTransform<PCollection<String>, PCollection<KV<Integer, Iterable<String>>>> {
+      final BulkIO spec;
+
+      private StatefulBatching(BulkIO bulkSpec) {
+        spec = bulkSpec;
+      }
+
+      public static StatefulBatching fromSpec(BulkIO spec) {
+        return new StatefulBatching(spec);
+      }
+
+      @Override
+      public PCollection<KV<Integer, Iterable<String>>> expand(PCollection<String> input) {
+        GroupIntoBatches<Integer, String> groupIntoBatches =
+                GroupIntoBatches.ofSize(spec.getMaxBatchSize());
+
+        if (spec.getMaxBufferingDuration() != null) {
+          groupIntoBatches =
+                  groupIntoBatches.withMaxBufferingDuration(spec.getMaxBufferingDuration());
+        }
+
+        return input
+                .apply(ParDo.of(new Reshuffle.AssignShardFn<>(spec.getMaxParallelRequestsPerWindow())))
+                .apply(groupIntoBatches);
+      }
     }
 
     @Override
-    public PDone expand(PCollection<String> input) {
+    public PCollection<String> expand(PCollection<String> input) {
       ConnectionConfiguration connectionConfiguration = getConnectionConfiguration();
-      FieldValueExtractFn idFn = getIdFn();
-      BooleanFieldValueExtractFn isDeleteFn = getIsDeleteFn();
+
       checkState(connectionConfiguration != null, "withConnectionConfiguration() is required");
-      checkArgument(
-          isDeleteFn == null || idFn != null,
-          "Id needs to be specified by withIdFn for delete operation");
-      input.apply(ParDo.of(new WriteFn(this)));
-      return PDone.in(input.getPipeline());
+
+      if (getUseStatefulBatches()) {
+        return input.apply(StatefulBatching.fromSpec(this))
+                .apply(ParDo.of(new BulkIOStatefulFn(this)));
+      } else {
+        return input.apply(ParDo.of(new BulkIOBundleFn(this)));
+      }
+
+      //return PDone.in(input.getPipeline());
     }
 
-    /** {@link DoFn} to for the {@link Write} transform. */
+    static class BulkIOBundleFn extends BulkIOBaseFn<String> {
+      @VisibleForTesting
+      BulkIOBundleFn(BulkIO bulkSpec) {
+        super(bulkSpec);
+      }
+
+      @ProcessElement
+      public void processElement(ProcessContext context) throws Exception {
+        String bulkApiEntity = context.element();
+
+        String result = addAndMaybeFlush(bulkApiEntity);
+        if (result != null) {
+          context.output(result);
+        }
+
+        //addAndMaybeFlush(bulkApiEntity);
+      }
+    }
+
+    /*
+    Intended for use in conjunction with {@link GroupIntoBatches}
+     */
+    static class BulkIOStatefulFn extends BulkIOBaseFn<KV<Integer, Iterable<String>>> {
+      @VisibleForTesting
+      BulkIOStatefulFn(BulkIO bulkSpec) {
+        super(bulkSpec);
+      }
+
+      @ProcessElement
+      public void processElement(ProcessContext context) throws Exception {
+        Iterable<String> bulkApiEntities = context.element().getValue();
+        for (String bulkApiEntity : bulkApiEntities) {
+          String errors = addAndMaybeFlush(bulkApiEntity);
+          if (errors != null) {
+            context.output(errors);
+          }
+          //context.output(addAndMaybeFlush(bulkApiEntity));
+          //addAndMaybeFlush(bulkApiEntity);
+        }
+      }
+    }
+
+    /** {@link DoFn} to for the {@link BulkIO} transform. */
     @VisibleForTesting
-    static class WriteFn extends DoFn<String, Void> {
-      private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-      private static final int DEFAULT_RETRY_ON_CONFLICT = 5; // race conditions on updates
-
+    private abstract static class BulkIOBaseFn<T> extends DoFn<T, String> {
       private static final Duration RETRY_INITIAL_BACKOFF = Duration.standardSeconds(5);
-
-      @VisibleForTesting
-      static final String RETRY_ATTEMPT_LOG = "Error writing to Elasticsearch. Retry attempt[%d]";
-
-      @VisibleForTesting
-      static final String RETRY_FAILED_LOG =
-          "Error writing to ES after %d attempt(s). No more attempts allowed";
 
       private transient FluentBackoff retryBackoff;
 
-      private int backendVersion;
-      private final Write spec;
+      private BulkIO spec;
       private transient RestClient restClient;
       private ArrayList<String> batch;
-      private long currentBatchSizeBytes;
+      long currentBatchSizeBytes;
 
-      // Encapsulates the elements which form the metadata for an Elasticsearch bulk operation
-      private static class DocumentMetadata implements Serializable {
-        final String index;
-        final String type;
-        final String id;
-        final Integer retryOnConflict;
-
-        DocumentMetadata(String index, String type, String id, Integer retryOnConflict) {
-          this.index = index;
-          this.type = type;
-          this.id = id;
-          this.retryOnConflict = retryOnConflict;
-        }
-      }
-
-      @VisibleForTesting
-      WriteFn(Write spec) {
-        this.spec = spec;
+      protected BulkIOBaseFn(BulkIO bulkSpec) {
+        this.spec = bulkSpec;
       }
 
       @Setup
       public void setup() throws IOException {
         ConnectionConfiguration connectionConfiguration = spec.getConnectionConfiguration();
-        backendVersion = getBackendVersion(connectionConfiguration);
+
         restClient = connectionConfiguration.createClient();
 
         retryBackoff =
-            FluentBackoff.DEFAULT.withMaxRetries(0).withInitialBackoff(RETRY_INITIAL_BACKOFF);
+                FluentBackoff.DEFAULT.withMaxRetries(0).withInitialBackoff(RETRY_INITIAL_BACKOFF);
 
         if (spec.getRetryConfiguration() != null) {
           retryBackoff =
-              FluentBackoff.DEFAULT
-                  .withInitialBackoff(RETRY_INITIAL_BACKOFF)
-                  .withMaxRetries(spec.getRetryConfiguration().getMaxAttempts() - 1)
-                  .withMaxCumulativeBackoff(spec.getRetryConfiguration().getMaxDuration());
+                  FluentBackoff.DEFAULT
+                          .withInitialBackoff(RETRY_INITIAL_BACKOFF)
+                          .withMaxRetries(spec.getRetryConfiguration().getMaxAttempts() - 1)
+                          .withMaxCumulativeBackoff(spec.getRetryConfiguration().getMaxDuration());
         }
-        // configure a custom serializer for metadata to be able to change serialization based
-        // on ES version
-        SimpleModule module = new SimpleModule();
-        module.addSerializer(DocumentMetadata.class, new DocumentMetadataSerializer());
-        OBJECT_MAPPER.registerModule(module);
       }
 
       @StartBundle
@@ -1352,157 +2119,123 @@ public class ElasticsearchIO {
         currentBatchSizeBytes = 0;
       }
 
-      private class DocumentMetadataSerializer extends StdSerializer<DocumentMetadata> {
-
-        private DocumentMetadataSerializer() {
-          super(DocumentMetadata.class);
-        }
-
-        @Override
-        public void serialize(
-            DocumentMetadata value, JsonGenerator gen, SerializerProvider provider)
-            throws IOException {
-          gen.writeStartObject();
-          if (value.index != null) {
-            gen.writeStringField("_index", value.index);
-          }
-          if (value.type != null) {
-            gen.writeStringField("_type", value.type);
-          }
-          if (value.id != null) {
-            gen.writeStringField("_id", value.id);
-          }
-          if (value.retryOnConflict != null && (backendVersion <= 6)) {
-            gen.writeNumberField("_retry_on_conflict", value.retryOnConflict);
-          }
-          if (value.retryOnConflict != null && backendVersion >= 7) {
-            gen.writeNumberField("retry_on_conflict", value.retryOnConflict);
-          }
-          gen.writeEndObject();
-        }
-      }
-      /**
-       * Extracts the components that comprise the document address from the document using the
-       * {@link FieldValueExtractFn} configured. This allows any or all of the index, type and
-       * document id to be controlled on a per document basis. Sanitization of the index is
-       * performed, automatically lower-casing the value as required by Elasticsearch.
-       *
-       * @param parsedDocument the json from which the index, type and id may be extracted
-       * @return the document address as JSON or the default
-       * @throws IOException if the document cannot be parsed as JSON
-       */
-      private String getDocumentMetadata(JsonNode parsedDocument) throws IOException {
-        DocumentMetadata metadata =
-            new DocumentMetadata(
-                spec.getIndexFn() != null
-                    ? lowerCaseOrNull(spec.getIndexFn().apply(parsedDocument))
-                    : null,
-                spec.getTypeFn() != null ? spec.getTypeFn().apply(parsedDocument) : null,
-                spec.getIdFn() != null ? spec.getIdFn().apply(parsedDocument) : null,
-                spec.getUsePartialUpdate() ? DEFAULT_RETRY_ON_CONFLICT : null);
-        return OBJECT_MAPPER.writeValueAsString(metadata);
-      }
-
-      private static String lowerCaseOrNull(String input) {
-        return input == null ? null : input.toLowerCase();
-      }
-
-      @ProcessElement
-      public void processElement(ProcessContext context) throws Exception {
-        String document = context.element(); // use configuration and auto-generated document IDs
-        String documentMetadata = "{}";
-        boolean isDelete = false;
-        if (spec.getIndexFn() != null || spec.getTypeFn() != null || spec.getIdFn() != null) {
-          // parse once and reused for efficiency
-          JsonNode parsedDocument = OBJECT_MAPPER.readTree(document);
-          documentMetadata = getDocumentMetadata(parsedDocument);
-          if (spec.getIsDeleteFn() != null) {
-            isDelete = spec.getIsDeleteFn().apply(parsedDocument);
-          }
-        }
-
-        if (isDelete) {
-          // delete request used for deleting a document.
-          batch.add(String.format("{ \"delete\" : %s }%n", documentMetadata));
-        } else {
-          // index is an insert/upsert and update is a partial update (or insert if not existing)
-          if (spec.getUsePartialUpdate()) {
-            batch.add(
-                String.format(
-                    "{ \"update\" : %s }%n{ \"doc\" : %s, \"doc_as_upsert\" : true }%n",
-                    documentMetadata, document));
-          } else {
-            batch.add(String.format("{ \"create\" : %s }%n%s%n", documentMetadata, document));
-          }
-        }
-
-        currentBatchSizeBytes += document.getBytes(StandardCharsets.UTF_8).length;
-        if (batch.size() >= spec.getMaxBatchSize()
-            || currentBatchSizeBytes >= spec.getMaxBatchSizeBytes()) {
-          flushBatch();
-        }
-      }
-
       @FinishBundle
       public void finishBundle(FinishBundleContext context)
-          throws IOException, InterruptedException {
+              throws IOException, InterruptedException {
         flushBatch();
+        //throw new RuntimeException();
       }
 
-      private void flushBatch() throws IOException, InterruptedException {
-        if (batch.isEmpty()) {
-          return;
+      protected String addAndMaybeFlush(String bulkApiEntity)
+              throws IOException, InterruptedException {
+        batch.add(bulkApiEntity);
+        currentBatchSizeBytes += bulkApiEntity.getBytes(StandardCharsets.UTF_8).length;
+
+        if (batch.size() >= spec.getMaxBatchSize()
+                || currentBatchSizeBytes >= spec.getMaxBatchSizeBytes()) {
+          return flushBatch();
         }
+
+        return null;
+      }
+
+      private boolean isRetryableClientException(Throwable t) {
+        // RestClient#performRequest only throws wrapped IOException so we must inspect the
+        // exception cause to determine if the exception is likely transient i.e. retryable or
+        // not.
+        return t.getCause() instanceof ConnectTimeoutException
+                || t.getCause() instanceof SocketTimeoutException
+                || t.getCause() instanceof ConnectionClosedException
+                || t.getCause() instanceof ConnectException;
+      }
+
+      private String flushBatch() throws IOException, InterruptedException {
+        if (batch.isEmpty()) {
+          return null;
+        }
+
+        LOG.info(
+                "ElasticsearchIO batch size: {}, batch size bytes: {}",
+                batch.size(),
+                currentBatchSizeBytes);
+
         StringBuilder bulkRequest = new StringBuilder();
         for (String json : batch) {
           bulkRequest.append(json);
         }
+
         batch.clear();
-        currentBatchSizeBytes = 0;
-        Response response;
-        HttpEntity responseEntity;
-        // Elasticsearch will default to the index/type provided here if none are set in the
-        // document meta (i.e. using ElasticsearchIO$Write#withIndexFn and
-        // ElasticsearchIO$Write#withTypeFn options)
-        String endPoint =
-            String.format(
-                "/%s/%s/_bulk",
-                spec.getConnectionConfiguration().getIndex(),
-                spec.getConnectionConfiguration().getType());
+        currentBatchSizeBytes = 0L;
+
+        Response response = null;
+        HttpEntity responseEntity = null;
+
+        // Elasticsearch will default to the index/type provided the {@link
+        // ConnectionConfiguration} if none are set in the document meta (i.e.
+        // using ElasticsearchIO$DocToBulk#withIndexFn and
+        // ElasticsearchIO$DocToBulk#withTypeFn options)
+        String endPoint = spec.getConnectionConfiguration().getBulkEndPoint();
+
         HttpEntity requestBody =
-            new NStringEntity(bulkRequest.toString(), ContentType.APPLICATION_JSON);
-        Request request = new Request("POST", endPoint);
-        request.addParameters(Collections.emptyMap());
-        request.setEntity(requestBody);
-        response = restClient.performRequest(request);
-        responseEntity = new BufferedHttpEntity(response.getEntity());
+                new NStringEntity(bulkRequest.toString(), ContentType.APPLICATION_JSON);
+        try {
+          Request request = new Request("POST", endPoint);
+          request.addParameters(Collections.emptyMap());
+          request.setEntity(requestBody);
+          response = restClient.performRequest(request);
+          responseEntity = new BufferedHttpEntity(response.getEntity());
+        } catch (java.io.IOException ex) {
+          if (spec.getRetryConfiguration() == null || !isRetryableClientException(ex)) {
+            throw ex;
+          }
+          LOG.error("Caught ES timeout, retrying", ex);
+        }
+
         if (spec.getRetryConfiguration() != null
-            && spec.getRetryConfiguration().getRetryPredicate().test(responseEntity)) {
+                && (response == null
+                || responseEntity == null
+                || spec.getRetryConfiguration().getRetryPredicate().test(responseEntity))) {
+          if (responseEntity != null
+                  && spec.getRetryConfiguration().getRetryPredicate().test(responseEntity)) {
+            LOG.warn("ES Cluster is responding with HTP 429 - TOO_MANY_REQUESTS.");
+          }
           responseEntity = handleRetry("POST", endPoint, Collections.emptyMap(), requestBody);
         }
-        checkForErrors(responseEntity, backendVersion, spec.getUsePartialUpdate());
+
+        return checkForErrors(bulkRequest, responseEntity, spec.getAllowedResponseErrors());
       }
 
       /** retry request based on retry configuration policy. */
       private HttpEntity handleRetry(
-          String method, String endpoint, Map<String, String> params, HttpEntity requestBody)
-          throws IOException, InterruptedException {
+              String method, String endpoint, Map<String, String> params, HttpEntity requestBody)
+              throws IOException, InterruptedException {
         Response response;
-        HttpEntity responseEntity;
+        HttpEntity responseEntity = null;
         Sleeper sleeper = Sleeper.DEFAULT;
         BackOff backoff = retryBackoff.backoff();
         int attempt = 0;
         // while retry policy exists
         while (BackOffUtils.next(sleeper, backoff)) {
           LOG.warn(String.format(RETRY_ATTEMPT_LOG, ++attempt));
-          Request request = new Request(method, endpoint);
-          request.addParameters(params);
-          request.setEntity(requestBody);
-          response = restClient.performRequest(request);
-          responseEntity = new BufferedHttpEntity(response.getEntity());
+          try {
+            Request request = new Request(method, endpoint);
+            request.addParameters(params);
+            request.setEntity(requestBody);
+            response = restClient.performRequest(request);
+            responseEntity = new BufferedHttpEntity(response.getEntity());
+          } catch (java.io.IOException ex) {
+            if (isRetryableClientException(ex)) {
+              LOG.error("Caught ES timeout, retrying", ex);
+              continue;
+            }
+          }
           // if response has no 429 errors
-          if (!spec.getRetryConfiguration().getRetryPredicate().test(responseEntity)) {
+          if (!Objects.requireNonNull(spec.getRetryConfiguration())
+                  .getRetryPredicate()
+                  .test(responseEntity)) {
             return responseEntity;
+          } else {
+            LOG.warn("ES Cluster is responding with HTP 429 - TOO_MANY_REQUESTS.");
           }
         }
         throw new IOException(String.format(RETRY_FAILED_LOG, attempt));
@@ -1523,16 +2256,13 @@ public class ElasticsearchIO {
       Response response = restClient.performRequest(request);
       JsonNode jsonNode = parseResponse(response.getEntity());
       int backendVersion =
-          Integer.parseInt(jsonNode.path("version").path("number").asText().substring(0, 1));
+              Integer.parseInt(jsonNode.path("version").path("number").asText().substring(0, 1));
       checkArgument(
-          (backendVersion == 2
-              || backendVersion == 5
-              || backendVersion == 6
-              || backendVersion == 7),
-          "The Elasticsearch version to connect to is %s.x. "
-              + "This version of the ElasticsearchIO is only compatible with "
-              + "Elasticsearch v7.x, v6.x, v5.x and v2.x",
-          backendVersion);
+              (VALID_CLUSTER_VERSIONS.contains(backendVersion)),
+              "The Elasticsearch version to connect to is %s.x. "
+                      + "This version of the ElasticsearchIO is only compatible with "
+                      + "Elasticsearch v7.x, v6.x, v5.x and v2.x",
+              backendVersion);
       return backendVersion;
 
     } catch (IOException e) {

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
@@ -1,19 +1,17 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright (C) 2022 Google LLC
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.google.cloud.teleport.v2.elasticsearch.utils;
 
@@ -190,13 +188,13 @@ import org.slf4j.LoggerFactory;
  */
 @Experimental(Kind.SOURCE_SINK)
 @SuppressWarnings({
-        "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
+  "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
 })
 public class ElasticsearchIO {
 
   private static final List<Integer> VALID_CLUSTER_VERSIONS = Arrays.asList(2, 5, 6, 7);
   private static final List<String> VERSION_TYPES =
-          Arrays.asList("internal", "external", "external_gt", "external_gte");
+      Arrays.asList("internal", "external", "external_gt", "external_gte");
   private static final String VERSION_CONFLICT_ERROR = "version_conflict_engine_exception";
 
   private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchIO.class);
@@ -207,26 +205,25 @@ public class ElasticsearchIO {
     // default batchSize to 100 as recommended by ES dev team as a safe value when dealing
     // with big documents and still a good compromise for performances
     return new AutoValue_ElasticsearchIO_Read.Builder()
-            .setWithMetadata(false)
-            .setScrollKeepalive("5m")
-            .setBatchSize(100L)
-            .build();
+        .setWithMetadata(false)
+        .setScrollKeepalive("5m")
+        .setBatchSize(100L)
+        .build();
   }
 
   public static DocToBulk docToBulk() {
-    return new AutoValue_ElasticsearchIO_DocToBulk.Builder()
-            .build();
+    return new AutoValue_ElasticsearchIO_DocToBulk.Builder().build();
   }
 
   public static BulkIO bulkIO() {
     return new AutoValue_ElasticsearchIO_BulkIO.Builder()
-            // advised default starting batch size in ES docs
-            .setMaxBatchSize(1000L)
-            // advised default starting batch size in ES docs
-            .setMaxBatchSizeBytes(5L * 1024L * 1024L)
-            .setUseStatefulBatches(false)
-            .setMaxParallelRequestsPerWindow(1)
-            .build();
+        // advised default starting batch size in ES docs
+        .setMaxBatchSize(1000L)
+        // advised default starting batch size in ES docs
+        .setMaxBatchSizeBytes(5L * 1024L * 1024L)
+        .setUseStatefulBatches(false)
+        .setMaxParallelRequestsPerWindow(1)
+        .build();
   }
 
   public static Write write() {
@@ -242,8 +239,9 @@ public class ElasticsearchIO {
     return mapper.readValue(responseEntity.getContent(), JsonNode.class);
   }
 
-  static List<String> checkForErrors(StringBuilder bulkRequest, HttpEntity responseEntity, @Nullable Set<String> allowedErrorTypes)
-          throws IOException {
+  static List<String> checkForErrors(
+      StringBuilder bulkRequest, HttpEntity responseEntity, @Nullable Set<String> allowedErrorTypes)
+      throws IOException {
 
     JsonNode searchResult = parseResponse(responseEntity);
     boolean errors = searchResult.path("errors").asBoolean();
@@ -251,7 +249,7 @@ public class ElasticsearchIO {
       int numErrors = 0;
 
       StringBuilder errorMessages =
-              new StringBuilder("Error writing to Elasticsearch, some elements could not be inserted:");
+          new StringBuilder("Error writing to Elasticsearch, some elements could not be inserted:");
       JsonNode items = searchResult.path("items");
       if (items.isMissingNode() || items.size() == 0) {
         errorMessages.append(searchResult.toString());
@@ -269,7 +267,7 @@ public class ElasticsearchIO {
           String cbType = causedBy.path("type").asText();
 
           if (allowedErrorTypes == null
-                  || (!allowedErrorTypes.contains(type) && !allowedErrorTypes.contains(cbType))) {
+              || (!allowedErrorTypes.contains(type) && !allowedErrorTypes.contains(cbType))) {
             // 'error' and 'causedBy` fields are not null, and the error is not being ignored.
             numErrors++;
 
@@ -282,13 +280,19 @@ public class ElasticsearchIO {
         }
       }
       if (numErrors > 0) {
-        String bulk = "[" + bulkRequest.toString().
-                replaceAll("\\{\\s+\"create\"\\s+:\\s+\\{\\}\\s+\\}[\r\n]+", ",")
-                .replaceFirst(",", "") + "]";
+        String bulk =
+            "["
+                + bulkRequest
+                    .toString()
+                    .replaceAll("\\{\\s+\"create\"\\s+:\\s+\\{\\}\\s+\\}[\r\n]+", ",")
+                    .replaceFirst(",", "")
+                + "]";
         TypeFactory typeFactory = mapper.getTypeFactory();
-        List<JsonNode> bulkMessages = mapper.readValue(bulk,
-                typeFactory.constructCollectionType(List.class, JsonNode.class));
-        List<JsonNode> responseMessages = mapper.readValue(searchResult.get("items").toString(),
+        List<JsonNode> bulkMessages =
+            mapper.readValue(bulk, typeFactory.constructCollectionType(List.class, JsonNode.class));
+        List<JsonNode> responseMessages =
+            mapper.readValue(
+                searchResult.get("items").toString(),
                 typeFactory.constructCollectionType(List.class, JsonNode.class));
         List<String> output = new ArrayList<>();
 
@@ -381,11 +385,11 @@ public class ElasticsearchIO {
       checkArgument(index != null, "index can not be null");
       checkArgument(type != null, "type can not be null");
       return new AutoValue_ElasticsearchIO_ConnectionConfiguration.Builder()
-              .setAddresses(Arrays.asList(addresses))
-              .setIndex(index)
-              .setType(type)
-              .setTrustSelfSignedCerts(false)
-              .build();
+          .setAddresses(Arrays.asList(addresses))
+          .setIndex(index)
+          .setType(type)
+          .setTrustSelfSignedCerts(false)
+          .build();
     }
 
     /**
@@ -400,11 +404,11 @@ public class ElasticsearchIO {
       checkArgument(addresses.length > 0, "addresses can not be empty");
       checkArgument(index != null, "index can not be null");
       return new AutoValue_ElasticsearchIO_ConnectionConfiguration.Builder()
-              .setAddresses(Arrays.asList(addresses))
-              .setIndex(index)
-              .setType("")
-              .setTrustSelfSignedCerts(false)
-              .build();
+          .setAddresses(Arrays.asList(addresses))
+          .setIndex(index)
+          .setType("")
+          .setTrustSelfSignedCerts(false)
+          .build();
     }
 
     /**
@@ -417,11 +421,11 @@ public class ElasticsearchIO {
       checkArgument(addresses != null, "addresses can not be null");
       checkArgument(addresses.length > 0, "addresses can not be empty");
       return new AutoValue_ElasticsearchIO_ConnectionConfiguration.Builder()
-              .setAddresses(Arrays.asList(addresses))
-              .setIndex("")
-              .setType("")
-              .setTrustSelfSignedCerts(false)
-              .build();
+          .setAddresses(Arrays.asList(addresses))
+          .setIndex("")
+          .setType("")
+          .setTrustSelfSignedCerts(false)
+          .build();
     }
 
     /**
@@ -595,18 +599,18 @@ public class ElasticsearchIO {
       if (getUsername() != null) {
         final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(
-                AuthScope.ANY, new UsernamePasswordCredentials(getUsername(), getPassword()));
+            AuthScope.ANY, new UsernamePasswordCredentials(getUsername(), getPassword()));
         restClientBuilder.setHttpClientConfigCallback(
-                httpAsyncClientBuilder ->
-                        httpAsyncClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
+            httpAsyncClientBuilder ->
+                httpAsyncClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
       }
       if (getApiKey() != null) {
         restClientBuilder.setDefaultHeaders(
-                new Header[] {new BasicHeader("Authorization", "ApiKey " + getApiKey())});
+            new Header[] {new BasicHeader("Authorization", "ApiKey " + getApiKey())});
       }
       if (getBearerToken() != null) {
         restClientBuilder.setDefaultHeaders(
-                new Header[] {new BasicHeader("Authorization", "Bearer " + getBearerToken())});
+            new Header[] {new BasicHeader("Authorization", "Bearer " + getBearerToken())});
       }
       if (getKeystorePath() != null && !getKeystorePath().isEmpty()) {
         try {
@@ -616,31 +620,31 @@ public class ElasticsearchIO {
             keyStore.load(is, (keystorePassword == null) ? null : keystorePassword.toCharArray());
           }
           final TrustStrategy trustStrategy =
-                  isTrustSelfSignedCerts() ? new TrustSelfSignedStrategy() : null;
+              isTrustSelfSignedCerts() ? new TrustSelfSignedStrategy() : null;
           final SSLContext sslContext =
-                  SSLContexts.custom().loadTrustMaterial(keyStore, trustStrategy).build();
+              SSLContexts.custom().loadTrustMaterial(keyStore, trustStrategy).build();
           final SSLIOSessionStrategy sessionStrategy = new SSLIOSessionStrategy(sslContext);
           restClientBuilder.setHttpClientConfigCallback(
-                  httpClientBuilder ->
-                          httpClientBuilder.setSSLContext(sslContext).setSSLStrategy(sessionStrategy));
+              httpClientBuilder ->
+                  httpClientBuilder.setSSLContext(sslContext).setSSLStrategy(sessionStrategy));
         } catch (Exception e) {
           throw new IOException("Can't load the client certificate from the keystore", e);
         }
       }
       restClientBuilder.setRequestConfigCallback(
-              new RestClientBuilder.RequestConfigCallback() {
-                @Override
-                public RequestConfig.Builder customizeRequestConfig(
-                        RequestConfig.Builder requestConfigBuilder) {
-                  if (getConnectTimeout() != null) {
-                    requestConfigBuilder.setConnectTimeout(getConnectTimeout());
-                  }
-                  if (getSocketTimeout() != null) {
-                    requestConfigBuilder.setSocketTimeout(getSocketTimeout());
-                  }
-                  return requestConfigBuilder;
-                }
-              });
+          new RestClientBuilder.RequestConfigCallback() {
+            @Override
+            public RequestConfig.Builder customizeRequestConfig(
+                RequestConfig.Builder requestConfigBuilder) {
+              if (getConnectTimeout() != null) {
+                requestConfigBuilder.setConnectTimeout(getConnectTimeout());
+              }
+              if (getSocketTimeout() != null) {
+                requestConfigBuilder.setSocketTimeout(getSocketTimeout());
+              }
+              return requestConfigBuilder;
+            }
+          });
       return restClientBuilder.build();
     }
   }
@@ -753,10 +757,10 @@ public class ElasticsearchIO {
      */
     public Read withBatchSize(long batchSize) {
       checkArgument(
-              batchSize > 0 && batchSize <= MAX_BATCH_SIZE,
-              "batchSize must be > 0 and <= %s, but was: %s",
-              MAX_BATCH_SIZE,
-              batchSize);
+          batchSize > 0 && batchSize <= MAX_BATCH_SIZE,
+          "batchSize must be > 0 and <= %s, but was: %s",
+          MAX_BATCH_SIZE,
+          batchSize);
       return builder().setBatchSize(batchSize).build();
     }
 
@@ -765,7 +769,7 @@ public class ElasticsearchIO {
       ConnectionConfiguration connectionConfiguration = getConnectionConfiguration();
       checkState(connectionConfiguration != null, "withConnectionConfiguration() is required");
       return input.apply(
-              org.apache.beam.sdk.io.Read.from(new BoundedElasticsearchSource(this, null, null, null)));
+          org.apache.beam.sdk.io.Read.from(new BoundedElasticsearchSource(this, null, null, null)));
     }
 
     @Override
@@ -794,12 +798,12 @@ public class ElasticsearchIO {
 
     // constructor used in split() when we know the backend version
     private BoundedElasticsearchSource(
-            Read spec,
-            @Nullable String shardPreference,
-            @Nullable Integer numSlices,
-            @Nullable Integer sliceId,
-            @Nullable Long estimatedByteSize,
-            int backendVersion) {
+        Read spec,
+        @Nullable String shardPreference,
+        @Nullable Integer numSlices,
+        @Nullable Integer sliceId,
+        @Nullable Long estimatedByteSize,
+        int backendVersion) {
       this.backendVersion = backendVersion;
       this.spec = spec;
       this.shardPreference = shardPreference;
@@ -810,10 +814,10 @@ public class ElasticsearchIO {
 
     @VisibleForTesting
     BoundedElasticsearchSource(
-            Read spec,
-            @Nullable String shardPreference,
-            @Nullable Integer numSlices,
-            @Nullable Integer sliceId) {
+        Read spec,
+        @Nullable String shardPreference,
+        @Nullable Integer numSlices,
+        @Nullable Integer sliceId) {
       this.spec = spec;
       this.shardPreference = shardPreference;
       this.numSlices = numSlices;
@@ -822,7 +826,7 @@ public class ElasticsearchIO {
 
     @Override
     public List<? extends BoundedSource<String>> split(
-            long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
+        long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
       ConnectionConfiguration connectionConfiguration = spec.getConnectionConfiguration();
       this.backendVersion = getBackendVersion(connectionConfiguration);
       List<BoundedElasticsearchSource> sources = new ArrayList<>();
@@ -837,14 +841,14 @@ public class ElasticsearchIO {
 
         JsonNode statsJson = BoundedElasticsearchSource.getStats(connectionConfiguration, true);
         JsonNode shardsJson =
-                statsJson.path("indices").path(connectionConfiguration.getIndex()).path("shards");
+            statsJson.path("indices").path(connectionConfiguration.getIndex()).path("shards");
 
         Iterator<Map.Entry<String, JsonNode>> shards = shardsJson.fields();
         while (shards.hasNext()) {
           Map.Entry<String, JsonNode> shardJson = shards.next();
           String shardId = shardJson.getKey();
           sources.add(
-                  new BoundedElasticsearchSource(spec, shardId, null, null, null, backendVersion));
+              new BoundedElasticsearchSource(spec, shardId, null, null, null, backendVersion));
         }
         checkArgument(!sources.isEmpty(), "No shard found");
       } else if (backendVersion >= 5) {
@@ -863,8 +867,8 @@ public class ElasticsearchIO {
         for (int i = 0; i < nbBundles; i++) {
           long estimatedByteSizeForBundle = getEstimatedSizeBytes(options) / nbBundles;
           sources.add(
-                  new BoundedElasticsearchSource(
-                          spec, null, nbBundles, i, estimatedByteSizeForBundle, backendVersion));
+              new BoundedElasticsearchSource(
+                  spec, null, nbBundles, i, estimatedByteSizeForBundle, backendVersion));
         }
       }
       return sources;
@@ -878,7 +882,7 @@ public class ElasticsearchIO {
       final ConnectionConfiguration connectionConfiguration = spec.getConnectionConfiguration();
       JsonNode statsJson = getStats(connectionConfiguration, false);
       JsonNode indexStats =
-              statsJson.path("indices").path(connectionConfiguration.getIndex()).path("primaries");
+          statsJson.path("indices").path(connectionConfiguration.getIndex()).path("primaries");
       long indexSize = indexStats.path("store").path("size_in_bytes").asLong();
       LOG.debug("estimate source byte size: total index size " + indexSize);
 
@@ -896,9 +900,9 @@ public class ElasticsearchIO {
       }
 
       String endPoint =
-              String.format(
-                      "/%s/%s/_count",
-                      connectionConfiguration.getIndex(), connectionConfiguration.getType());
+          String.format(
+              "/%s/%s/_count",
+              connectionConfiguration.getIndex(), connectionConfiguration.getType());
       try (RestClient restClient = connectionConfiguration.createClient()) {
         long count = queryCount(restClient, endPoint, query);
         LOG.debug("estimate source byte size: query document count " + count);
@@ -914,8 +918,8 @@ public class ElasticsearchIO {
     }
 
     private long queryCount(
-            @Nonnull RestClient restClient, @Nonnull String endPoint, @Nonnull String query)
-            throws IOException {
+        @Nonnull RestClient restClient, @Nonnull String endPoint, @Nonnull String query)
+        throws IOException {
       Request request = new Request("GET", endPoint);
       request.setEntity(new NStringEntity(query, ContentType.APPLICATION_JSON));
       JsonNode searchResult = parseResponse(restClient.performRequest(request).getEntity());
@@ -924,7 +928,7 @@ public class ElasticsearchIO {
 
     @VisibleForTesting
     static long estimateIndexSize(ConnectionConfiguration connectionConfiguration)
-            throws IOException {
+        throws IOException {
       // we use indices stats API to estimate size and list the shards
       // (https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-stats.html)
       // as Elasticsearch 2.x doesn't not support any way to do parallel read inside a shard
@@ -935,7 +939,7 @@ public class ElasticsearchIO {
       // #sliced-scroll)
       JsonNode statsJson = getStats(connectionConfiguration, false);
       JsonNode indexStats =
-              statsJson.path("indices").path(connectionConfiguration.getIndex()).path("primaries");
+          statsJson.path("indices").path(connectionConfiguration.getIndex()).path("primaries");
       JsonNode store = indexStats.path("store");
       return store.path("size_in_bytes").asLong();
     }
@@ -964,7 +968,7 @@ public class ElasticsearchIO {
     }
 
     private static JsonNode getStats(
-            ConnectionConfiguration connectionConfiguration, boolean shardLevel) throws IOException {
+        ConnectionConfiguration connectionConfiguration, boolean shardLevel) throws IOException {
       HashMap<String, String> params = new HashMap<>();
       if (shardLevel) {
         params.put("level", "shards");
@@ -1002,14 +1006,14 @@ public class ElasticsearchIO {
       if ((source.backendVersion >= 5) && source.numSlices != null && source.numSlices > 1) {
         // if there is more than one slice, add the slice to the user query
         String sliceQuery =
-                String.format("\"slice\": {\"id\": %s,\"max\": %s}", source.sliceId, source.numSlices);
+            String.format("\"slice\": {\"id\": %s,\"max\": %s}", source.sliceId, source.numSlices);
         query = query.replaceFirst("\\{", "{" + sliceQuery + ",");
       }
       String endPoint =
-              String.format(
-                      "/%s/%s/_search",
-                      source.spec.getConnectionConfiguration().getIndex(),
-                      source.spec.getConnectionConfiguration().getType());
+          String.format(
+              "/%s/%s/_search",
+              source.spec.getConnectionConfiguration().getIndex(),
+              source.spec.getConnectionConfiguration().getType());
       Map<String, String> params = new HashMap<>();
       params.put("scroll", source.spec.getScrollKeepalive());
       if (source.backendVersion == 2) {
@@ -1039,9 +1043,9 @@ public class ElasticsearchIO {
         return true;
       } else {
         String requestBody =
-                String.format(
-                        "{\"scroll\" : \"%s\",\"scroll_id\" : \"%s\"}",
-                        source.spec.getScrollKeepalive(), scrollId);
+            String.format(
+                "{\"scroll\" : \"%s\",\"scroll_id\" : \"%s\"}",
+                source.spec.getScrollKeepalive(), scrollId);
         HttpEntity scrollEntity = new NStringEntity(requestBody, ContentType.APPLICATION_JSON);
         Request request = new Request("GET", "/_search/scroll");
         request.addParameters(Collections.emptyMap());
@@ -1132,7 +1136,7 @@ public class ElasticsearchIO {
       abstract ElasticsearchIO.RetryConfiguration.Builder setMaxDuration(Duration maxDuration);
 
       abstract ElasticsearchIO.RetryConfiguration.Builder setRetryPredicate(
-              RetryPredicate retryPredicate);
+          RetryPredicate retryPredicate);
 
       abstract ElasticsearchIO.RetryConfiguration build();
     }
@@ -1148,13 +1152,13 @@ public class ElasticsearchIO {
     public static RetryConfiguration create(int maxAttempts, Duration maxDuration) {
       checkArgument(maxAttempts > 0, "maxAttempts must be greater than 0");
       checkArgument(
-              maxDuration != null && maxDuration.isLongerThan(Duration.ZERO),
-              "maxDuration must be greater than 0");
+          maxDuration != null && maxDuration.isLongerThan(Duration.ZERO),
+          "maxDuration must be greater than 0");
       return new AutoValue_ElasticsearchIO_RetryConfiguration.Builder()
-              .setMaxAttempts(maxAttempts)
-              .setMaxDuration(maxDuration)
-              .setRetryPredicate(DEFAULT_RETRY_PREDICATE)
-              .build();
+          .setMaxAttempts(maxAttempts)
+          .setMaxDuration(maxDuration)
+          .setRetryPredicate(DEFAULT_RETRY_PREDICATE)
+          .build();
     }
 
     // Exposed only to allow tests to easily simulate server errors
@@ -1217,7 +1221,7 @@ public class ElasticsearchIO {
   /** A {@link PTransform} converting docs to their Bulk API counterparts. */
   @AutoValue
   public abstract static class DocToBulk
-          extends PTransform<PCollection<String>, PCollection<String>> {
+      extends PTransform<PCollection<String>, PCollection<String>> {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final int DEFAULT_RETRY_ON_CONFLICT = 5; // race conditions on updates
@@ -1269,9 +1273,9 @@ public class ElasticsearchIO {
      */
     public DocToBulk withBackendVersion(int backendVersion) {
       checkArgument(
-              VALID_CLUSTER_VERSIONS.contains(backendVersion),
-              "Backend version may only be one of " + "%s",
-              String.join(", ", VERSION_TYPES));
+          VALID_CLUSTER_VERSIONS.contains(backendVersion),
+          "Backend version may only be one of " + "%s",
+          String.join(", ", VERSION_TYPES));
       return builder().setBackendVersion(backendVersion).build();
     }
 
@@ -1280,8 +1284,8 @@ public class ElasticsearchIO {
       ConnectionConfiguration connectionConfiguration = getConnectionConfiguration();
       Integer backendVersion = getBackendVersion();
       checkState(
-              (backendVersion != null || connectionConfiguration != null),
-              "withBackendVersion() or withConnectionConfiguration() is required");
+          (backendVersion != null || connectionConfiguration != null),
+          "withBackendVersion() or withConnectionConfiguration() is required");
 
       return docs.apply(ParDo.of(new DocToBulkFn(this)));
     }
@@ -1298,14 +1302,14 @@ public class ElasticsearchIO {
       final String versionType;
 
       DocumentMetadata(
-              String index,
-              String type,
-              String id,
-              Integer retryOnConflict,
-              String routing,
-              Integer backendVersion,
-              String version,
-              String versionType) {
+          String index,
+          String type,
+          String id,
+          Integer retryOnConflict,
+          String routing,
+          Integer backendVersion,
+          String version,
+          String versionType) {
         this.index = index;
         this.id = id;
         this.type = type;
@@ -1324,7 +1328,7 @@ public class ElasticsearchIO {
 
       @Override
       public void serialize(DocumentMetadata value, JsonGenerator gen, SerializerProvider provider)
-              throws IOException {
+          throws IOException {
         gen.writeStartObject();
         if (value.index != null) {
           gen.writeStringField("_index", value.index);
@@ -1356,7 +1360,7 @@ public class ElasticsearchIO {
 
     @VisibleForTesting
     static String createBulkApiEntity(DocToBulk spec, String document, int backendVersion)
-            throws IOException {
+        throws IOException {
       String documentMetadata = "{}";
       boolean isDelete = false;
 
@@ -1406,19 +1410,17 @@ public class ElasticsearchIO {
 
     public interface BooleanFieldValueExtractFn extends SerializableFunction<JsonNode, Boolean> {}
 
-    private DocToBulk docToBulk =
-            new AutoValue_ElasticsearchIO_DocToBulk.Builder()
-                    .build();
+    private DocToBulk docToBulk = new AutoValue_ElasticsearchIO_DocToBulk.Builder().build();
 
     private BulkIO bulkIO =
-            new AutoValue_ElasticsearchIO_BulkIO.Builder()
-                    // advised default starting batch size in ES docs
-                    .setMaxBatchSize(1000L)
-                    // advised default starting batch size in ES docs
-                    .setMaxBatchSizeBytes(5L * 1024L * 1024L)
-                    .setUseStatefulBatches(false)
-                    .setMaxParallelRequestsPerWindow(1)
-                    .build();
+        new AutoValue_ElasticsearchIO_BulkIO.Builder()
+            // advised default starting batch size in ES docs
+            .setMaxBatchSize(1000L)
+            // advised default starting batch size in ES docs
+            .setMaxBatchSizeBytes(5L * 1024L * 1024L)
+            .setUseStatefulBatches(false)
+            .setMaxParallelRequestsPerWindow(1)
+            .build();
 
     public DocToBulk getDocToBulk() {
       return docToBulk;
@@ -1513,8 +1515,8 @@ public class ElasticsearchIO {
 
     @VisibleForTesting
     static final String RETRY_FAILED_LOG =
-            "Error writing to ES after %d attempt(s). No more attempts allowed";
-    
+        "Error writing to ES after %d attempt(s). No more attempts allowed";
+
     abstract @Nullable ConnectionConfiguration getConnectionConfiguration();
 
     abstract long getMaxBatchSize();
@@ -1678,12 +1680,12 @@ public class ElasticsearchIO {
      */
     public BulkIO withMaxBufferingDuration(Duration maxBufferingDuration) {
       LOG.warn(
-              "Use of withMaxBufferingDuration requires withUseStatefulBatches(true). "
-                      + "Setting that automatically.");
+          "Use of withMaxBufferingDuration requires withUseStatefulBatches(true). "
+              + "Setting that automatically.");
       return builder()
-              .setUseStatefulBatches(true)
-              .setMaxBufferingDuration(maxBufferingDuration)
-              .build();
+          .setUseStatefulBatches(true)
+          .setMaxBufferingDuration(maxBufferingDuration)
+          .build();
     }
 
     /**
@@ -1717,7 +1719,7 @@ public class ElasticsearchIO {
      */
     public BulkIO withMaxParallelRequestsPerWindow(int maxParallelRequestsPerWindow) {
       checkArgument(
-              maxParallelRequestsPerWindow > 0, "parameter value must be positive " + "a integer");
+          maxParallelRequestsPerWindow > 0, "parameter value must be positive " + "a integer");
       return builder().setMaxParallelRequestsPerWindow(maxParallelRequestsPerWindow).build();
     }
 
@@ -1729,7 +1731,7 @@ public class ElasticsearchIO {
      */
     @VisibleForTesting
     static class StatefulBatching
-            extends PTransform<PCollection<String>, PCollection<KV<Integer, Iterable<String>>>> {
+        extends PTransform<PCollection<String>, PCollection<KV<Integer, Iterable<String>>>> {
       final BulkIO spec;
 
       private StatefulBatching(BulkIO bulkSpec) {
@@ -1743,16 +1745,16 @@ public class ElasticsearchIO {
       @Override
       public PCollection<KV<Integer, Iterable<String>>> expand(PCollection<String> input) {
         GroupIntoBatches<Integer, String> groupIntoBatches =
-                GroupIntoBatches.ofSize(spec.getMaxBatchSize());
+            GroupIntoBatches.ofSize(spec.getMaxBatchSize());
 
         if (spec.getMaxBufferingDuration() != null) {
           groupIntoBatches =
-                  groupIntoBatches.withMaxBufferingDuration(spec.getMaxBufferingDuration());
+              groupIntoBatches.withMaxBufferingDuration(spec.getMaxBufferingDuration());
         }
 
         return input
-                .apply(ParDo.of(new Reshuffle.AssignShardFn<>(spec.getMaxParallelRequestsPerWindow())))
-                .apply(groupIntoBatches);
+            .apply(ParDo.of(new Reshuffle.AssignShardFn<>(spec.getMaxParallelRequestsPerWindow())))
+            .apply(groupIntoBatches);
       }
     }
 
@@ -1763,12 +1765,12 @@ public class ElasticsearchIO {
       checkState(connectionConfiguration != null, "withConnectionConfiguration() is required");
 
       if (getUseStatefulBatches()) {
-        return input.apply(StatefulBatching.fromSpec(this))
-                .apply(ParDo.of(new BulkIOStatefulFn(this)));
+        return input
+            .apply(StatefulBatching.fromSpec(this))
+            .apply(ParDo.of(new BulkIOStatefulFn(this)));
       } else {
         return input.apply(ParDo.of(new BulkIOBundleFn(this)));
       }
-
     }
 
     static class BulkIOBundleFn extends BulkIOBaseFn<String> {
@@ -1840,14 +1842,14 @@ public class ElasticsearchIO {
         restClient = connectionConfiguration.createClient();
 
         retryBackoff =
-                FluentBackoff.DEFAULT.withMaxRetries(0).withInitialBackoff(RETRY_INITIAL_BACKOFF);
+            FluentBackoff.DEFAULT.withMaxRetries(0).withInitialBackoff(RETRY_INITIAL_BACKOFF);
 
         if (spec.getRetryConfiguration() != null) {
           retryBackoff =
-                  FluentBackoff.DEFAULT
-                          .withInitialBackoff(RETRY_INITIAL_BACKOFF)
-                          .withMaxRetries(spec.getRetryConfiguration().getMaxAttempts() - 1)
-                          .withMaxCumulativeBackoff(spec.getRetryConfiguration().getMaxDuration());
+              FluentBackoff.DEFAULT
+                  .withInitialBackoff(RETRY_INITIAL_BACKOFF)
+                  .withMaxRetries(spec.getRetryConfiguration().getMaxAttempts() - 1)
+                  .withMaxCumulativeBackoff(spec.getRetryConfiguration().getMaxDuration());
         }
       }
 
@@ -1859,7 +1861,7 @@ public class ElasticsearchIO {
 
       @FinishBundle
       public void finishBundle(FinishBundleContext context)
-              throws IOException, InterruptedException {
+          throws IOException, InterruptedException {
 
         List<String> result = flushBatch();
         if (result != null) {
@@ -1872,12 +1874,12 @@ public class ElasticsearchIO {
       }
 
       protected List<String> addAndMaybeFlush(String bulkApiEntity)
-              throws IOException, InterruptedException {
+          throws IOException, InterruptedException {
         batch.add(bulkApiEntity);
         currentBatchSizeBytes += bulkApiEntity.getBytes(StandardCharsets.UTF_8).length;
 
         if (batch.size() >= spec.getMaxBatchSize()
-                || currentBatchSizeBytes >= spec.getMaxBatchSizeBytes()) {
+            || currentBatchSizeBytes >= spec.getMaxBatchSizeBytes()) {
           return flushBatch();
         }
 
@@ -1889,9 +1891,9 @@ public class ElasticsearchIO {
         // exception cause to determine if the exception is likely transient i.e. retryable or
         // not.
         return t.getCause() instanceof ConnectTimeoutException
-                || t.getCause() instanceof SocketTimeoutException
-                || t.getCause() instanceof ConnectionClosedException
-                || t.getCause() instanceof ConnectException;
+            || t.getCause() instanceof SocketTimeoutException
+            || t.getCause() instanceof ConnectionClosedException
+            || t.getCause() instanceof ConnectException;
       }
 
       private List<String> flushBatch() throws IOException, InterruptedException {
@@ -1900,9 +1902,9 @@ public class ElasticsearchIO {
         }
 
         LOG.info(
-                "ElasticsearchIO batch size: {}, batch size bytes: {}",
-                batch.size(),
-                currentBatchSizeBytes);
+            "ElasticsearchIO batch size: {}, batch size bytes: {}",
+            batch.size(),
+            currentBatchSizeBytes);
 
         StringBuilder bulkRequest = new StringBuilder();
         for (String json : batch) {
@@ -1922,7 +1924,7 @@ public class ElasticsearchIO {
         String endPoint = spec.getConnectionConfiguration().getBulkEndPoint();
 
         HttpEntity requestBody =
-                new NStringEntity(bulkRequest.toString(), ContentType.APPLICATION_JSON);
+            new NStringEntity(bulkRequest.toString(), ContentType.APPLICATION_JSON);
         try {
           Request request = new Request("POST", endPoint);
           request.addParameters(Collections.emptyMap());
@@ -1937,11 +1939,11 @@ public class ElasticsearchIO {
         }
 
         if (spec.getRetryConfiguration() != null
-                && (response == null
+            && (response == null
                 || responseEntity == null
                 || spec.getRetryConfiguration().getRetryPredicate().test(responseEntity))) {
           if (responseEntity != null
-                  && spec.getRetryConfiguration().getRetryPredicate().test(responseEntity)) {
+              && spec.getRetryConfiguration().getRetryPredicate().test(responseEntity)) {
             LOG.warn("ES Cluster is responding with HTP 429 - TOO_MANY_REQUESTS.");
           }
           responseEntity = handleRetry("POST", endPoint, Collections.emptyMap(), requestBody);
@@ -1952,8 +1954,8 @@ public class ElasticsearchIO {
 
       /** retry request based on retry configuration policy. */
       private HttpEntity handleRetry(
-              String method, String endpoint, Map<String, String> params, HttpEntity requestBody)
-              throws IOException, InterruptedException {
+          String method, String endpoint, Map<String, String> params, HttpEntity requestBody)
+          throws IOException, InterruptedException {
         Response response;
         HttpEntity responseEntity = null;
         Sleeper sleeper = Sleeper.DEFAULT;
@@ -1976,8 +1978,8 @@ public class ElasticsearchIO {
           }
           // if response has no 429 errors
           if (!Objects.requireNonNull(spec.getRetryConfiguration())
-                  .getRetryPredicate()
-                  .test(responseEntity)) {
+              .getRetryPredicate()
+              .test(responseEntity)) {
             return responseEntity;
           } else {
             LOG.warn("ES Cluster is responding with HTP 429 - TOO_MANY_REQUESTS.");
@@ -2001,13 +2003,13 @@ public class ElasticsearchIO {
       Response response = restClient.performRequest(request);
       JsonNode jsonNode = parseResponse(response.getEntity());
       int backendVersion =
-              Integer.parseInt(jsonNode.path("version").path("number").asText().substring(0, 1));
+          Integer.parseInt(jsonNode.path("version").path("number").asText().substring(0, 1));
       checkArgument(
-              (VALID_CLUSTER_VERSIONS.contains(backendVersion)),
-              "The Elasticsearch version to connect to is %s.x. "
-                      + "This version of the ElasticsearchIO is only compatible with "
-                      + "Elasticsearch v7.x, v6.x, v5.x and v2.x",
-              backendVersion);
+          (VALID_CLUSTER_VERSIONS.contains(backendVersion)),
+          "The Elasticsearch version to connect to is %s.x. "
+              + "This version of the ElasticsearchIO is only compatible with "
+              + "Elasticsearch v7.x, v6.x, v5.x and v2.x",
+          backendVersion);
       return backendVersion;
 
     } catch (IOException e) {

--- a/v2/googlecloud-to-elasticsearch/docs/PubSubToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/PubSubToElasticsearch/README.md
@@ -19,6 +19,10 @@ To enable the out of the box integration:
 1. Install the Google Cloud [Logs integration](https://www.elastic.co/integrations?solution=observability&category=google-cloud) from Kibana UI
 2. [Export logs](https://cloud.google.com/logging/docs/export) from above data source to a separate Pub/Sub subscription. You can then use the Dataflow template's `dataset` parameter to specify the data source name and their corresponding `inputSubscription`.
 
+## Data validation
+
+Invalid input fields in messages will be fixed in runtime to not slowdown the pipeline and to prevent throwing exceptions.
+
 ### Requirements for this pipeline
 * Java 8
 * Maven

--- a/v2/googlecloud-to-elasticsearch/pom.xml
+++ b/v2/googlecloud-to-elasticsearch/pom.xml
@@ -33,6 +33,12 @@
             <artifactId>elasticsearch-common</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>2.4.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/PubSubToElasticsearch.java
+++ b/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/PubSubToElasticsearch.java
@@ -167,7 +167,7 @@ public class PubSubToElasticsearch {
      * Step 3b: Write elements that failed processing to error output PubSub topic via {@link PubSubIO}.
      */
     failedMessages
-        .apply(ParDo.of(new FailedElasticsearchMessageToPubsubTopicFn()))
+        .apply("FailedElasticsearchMessagesToPubSubTopic", ParDo.of(new FailedElasticsearchMessageToPubsubTopicFn()))
         .apply(
               "writeFailureMessages",
               PubsubIO.writeMessages().to(options.getErrorOutputTopic()));

--- a/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/FailedElasticsearchMessageToPubsubTopicFn.java
+++ b/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/FailedElasticsearchMessageToPubsubTopicFn.java
@@ -18,42 +18,40 @@ package com.google.cloud.teleport.v2.elasticsearch.transforms;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.cloud.teleport.v2.elasticsearch.utils.ElasticsearchUtils;
 import java.nio.charset.StandardCharsets;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.transforms.DoFn;
 
-
 /**
- * The {@link FailedElasticsearchMessageToPubsubTopicFn} converts PubSub message which have failed processing into
- * {@link com.google.api.services.pubsub.model.PubsubMessage} objects which can be output to a PubSub topic.
+ * The {@link FailedElasticsearchMessageToPubsubTopicFn} converts PubSub message which have failed
+ * processing into {@link com.google.api.services.pubsub.model.PubsubMessage} objects which can be
+ * output to a PubSub topic.
  */
-public class FailedElasticsearchMessageToPubsubTopicFn
-        extends DoFn<String, PubsubMessage> {
+public class FailedElasticsearchMessageToPubsubTopicFn extends DoFn<String, PubsubMessage> {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    /** Counter to track total failed messages. */
-    private static final Counter ERROR_MESSAGES_COUNTER =
-            Metrics.counter(FailedElasticsearchMessageToPubsubTopicFn.class, "total-failed-messages");
+  /** Counter to track total failed messages. */
+  private static final Counter ERROR_MESSAGES_COUNTER =
+      Metrics.counter(FailedElasticsearchMessageToPubsubTopicFn.class, "total-failed-messages");
 
-    @ProcessElement
-    public void processElement(ProcessContext context) {
-        String input = context.element();
+  @ProcessElement
+  public void processElement(ProcessContext context) {
+    String input = context.element();
 
-        // Build the output PubSub message
-        JsonNode outputMessage = null;
-        try {
-            outputMessage = OBJECT_MAPPER.readTree(input);
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-        }
-
-        ERROR_MESSAGES_COUNTER.inc();
-
-        context.output(new PubsubMessage(outputMessage.toString().getBytes(StandardCharsets.UTF_8), null));
+    // Build the output PubSub message
+    JsonNode outputMessage = null;
+    try {
+      outputMessage = OBJECT_MAPPER.readTree(input);
+    } catch (JsonProcessingException e) {
+      e.printStackTrace();
     }
 
+    ERROR_MESSAGES_COUNTER.inc();
+
+    context.output(
+        new PubsubMessage(outputMessage.toString().getBytes(StandardCharsets.UTF_8), null));
+  }
 }

--- a/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/FailedElasticsearchMessageToPubsubTopicFn.java
+++ b/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/FailedElasticsearchMessageToPubsubTopicFn.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.elasticsearch.transforms;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.teleport.v2.elasticsearch.utils.ElasticsearchUtils;
+import java.nio.charset.StandardCharsets;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.transforms.DoFn;
+
+
+/**
+ * The {@link FailedElasticsearchMessageToPubsubTopicFn} converts PubSub message which have failed processing into
+ * {@link com.google.api.services.pubsub.model.PubsubMessage} objects which can be output to a PubSub topic.
+ */
+public class FailedElasticsearchMessageToPubsubTopicFn
+        extends DoFn<String, PubsubMessage> {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    /** Counter to track total failed messages. */
+    private static final Counter ERROR_MESSAGES_COUNTER =
+            Metrics.counter(FailedElasticsearchMessageToPubsubTopicFn.class, "total-failed-messages");
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+        String input = context.element();
+
+        // Build the output PubSub message
+        JsonNode outputMessage = null;
+        try {
+            outputMessage = OBJECT_MAPPER.readTree(input);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+        ERROR_MESSAGES_COUNTER.inc();
+
+        context.output(new PubsubMessage(outputMessage.toString().getBytes(StandardCharsets.UTF_8), null));
+    }
+
+}

--- a/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/ProcessValidateJsonFields.java
+++ b/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/ProcessValidateJsonFields.java
@@ -52,6 +52,15 @@ public class ProcessValidateJsonFields extends PTransform<PCollection<String>, P
             .mappingProvider(new JacksonMappingProvider())
             .build();
 
+    /**
+     * "Having a field name with just dot will cause Elasticsearch to throw
+     * exception Index -1 out of bounds for length 0. This is because field like ".": {} is not valid.
+     * The error is thrown on this line because subfields has a length of 0 and hence it is trying to access index -1,
+     * which is not allowed. The method that splits the field names into paths called splitAndValidatePath
+     * and what it does is to split field names when it encounters . (i.e. a dot).
+     * This field is easily found in k8s logs"
+     * @param context
+     */
     @ProcessElement
     public void processElement(ProcessContext context) {
       String input = context.element();

--- a/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/ProcessValidateJsonFields.java
+++ b/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/ProcessValidateJsonFields.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.elasticsearch.transforms;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** ProcessValidateJsonFields is used to fix fields which contains only dot in name. */
+public class ProcessValidateJsonFields extends PTransform<PCollection<String>, PCollection<String>> {
+
+  @Override
+  public PCollection<String> expand(PCollection<String> input) {
+    return input.apply(ParDo.of(new ValidateJsonFieldsFn()));
+  }
+
+  static class ValidateJsonFieldsFn extends DoFn<String, String> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ValidateJsonFieldsFn.class);
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final Configuration configuration = Configuration.builder()
+            .jsonProvider(new JacksonJsonNodeJsonProvider())
+            .mappingProvider(new JacksonMappingProvider())
+            .build();
+
+    public boolean checkPort(Object port, String input){
+      return Objects.nonNull(port) && input.contains("healthcheck");
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      String input = context.element();
+      ObjectNode node = null;
+      JsonNode port = null;
+      try {
+        port = JsonPath.using(configuration).parse(input).read("$.protoPayload.response.spec.template.spec.containers.livenessProbe.httpGet.port");
+      } catch (Exception e) {}
+
+      JsonNode requestApp = null;
+      try {
+        requestApp = JsonPath.using(configuration).parse(input).read("$.protoPayload.request.metadata.labels.app");
+        if (requestApp != null) {
+          input = JsonPath.using(configuration).parse(input).put("$.protoPayload.request.metadata.labels", "app.kubernetes.io/name",
+                  JsonPath.using(configuration).parse(input).read("$.protoPayload.request.metadata.labels.app")).jsonString();
+          input = JsonPath.using(configuration).parse(input).delete("$.protoPayload.request.metadata.labels.app").jsonString();
+        }
+      } catch (Exception e) {}
+
+      JsonNode responseApp = null;
+      try {
+        responseApp = JsonPath.using(configuration).parse(input).read("$.protoPayload.response.metadata.labels.app");
+
+        if (responseApp != null) {
+          input = JsonPath.using(configuration).parse(input).put("$.protoPayload.response.metadata.labels", "app.kubernetes.io/name",
+                  JsonPath.using(configuration).parse(input).read("$.protoPayload.response.metadata.labels.app")).jsonString();
+          input = JsonPath.using(configuration).parse(input).delete("$.protoPayload.response.metadata.labels.app").jsonString();
+        }
+      } catch (Exception ex) {}
+
+      try {
+        try {
+          JsonNode response = node.get("protoPayload")
+                  .get("response");
+          input = JsonPath.using(configuration).parse(input).put("$.protoPayload.response", "status", objectMapper.createObjectNode()).jsonString();
+        } catch (NullPointerException ex) {}
+
+        node = removeEmptyFields((ObjectNode) objectMapper.readTree(input));
+      } catch (JsonProcessingException e) {
+        LOG.warn("Unable to parse Json payload. " + e);
+      }
+
+      String status = null;
+      try {
+        status = JsonPath.using(configuration).parse(input).read("$.protoPayload.response.status");
+      } catch (Exception e) {
+        node = JsonPath.using(configuration).parse(node.toString()).put("$.protoPayload.response", "status", objectMapper.createObjectNode()).json();
+      }
+
+      /*try {
+        System.out.println("protoPayload.request.spec.template.metadata.labels:\n"
+                + ((JsonNode)JsonPath.using(configuration).parse(input).read("$.protoPayload.request.spec.template.metadata.labels")).toPrettyString());
+      }catch (Exception e) {}
+
+      try {
+        System.out.println("protoPayload.response.spec.template.metadata.labels:\n"
+                + ((JsonNode)JsonPath.using(configuration).parse(input).read("$.protoPayload.response.spec.template.metadata.labels")).toPrettyString());
+      }catch (Exception e) {}
+
+      context.output(node.toString());
+
+      try {
+        System.out.println("protoPayload.response.spec.template.spec.containers.livenessProbe.httpGet:\n"
+                + ((JsonNode)JsonPath.using(configuration).parse(input).read("$.protoPayload.response.spec.template.spec.containers.livenessProbe.httpGet")).toPrettyString());
+      }catch (Exception e) {}*/
+
+      context.output(node.toString());
+    }
+
+    public static ObjectNode removeEmptyFields(final ObjectNode jsonNode) {
+      ObjectNode ret = new ObjectMapper().createObjectNode();
+      Iterator<Map.Entry<String, JsonNode>> iter = jsonNode.fields();
+
+      while (iter.hasNext()) {
+        Map.Entry<String, JsonNode> entry = iter.next();
+        String key = entry.getKey();
+        JsonNode value = entry.getValue();
+
+        if (key.equals(".")) {
+          ret.set("_", value);
+          continue;
+        }
+
+        if (value instanceof ObjectNode) {
+          Map<String, ObjectNode> map = new HashMap<>();
+          map.put(key, removeEmptyFields((ObjectNode)value));
+          ret.setAll(map);
+        }
+        else if (value instanceof ArrayNode) {
+          ret.set(key, removeEmptyFields((ArrayNode)value));
+        }
+        else if (value.asText() != null) {
+          ret.set(key, value);
+        }
+      }
+
+      return ret;
+    }
+
+    public static ArrayNode removeEmptyFields(ArrayNode array) {
+      ArrayNode ret = new ObjectMapper().createArrayNode();
+      Iterator<JsonNode> iter = array.elements();
+
+      while (iter.hasNext()) {
+        JsonNode value = iter.next();
+
+        if (value instanceof ArrayNode) {
+          ret.add(removeEmptyFields((ArrayNode)(value)));
+        }
+        else if (value instanceof ObjectNode) {
+          ret.add(removeEmptyFields((ObjectNode)(value)));
+        }
+        else if (value != null){
+          ret.add(value);
+        }
+      }
+
+      return ret;
+    }
+  }
+}

--- a/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/ProcessValidateJsonFields.java
+++ b/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/ProcessValidateJsonFields.java
@@ -27,7 +27,6 @@ import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Objects;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
@@ -35,7 +34,7 @@ import org.apache.beam.sdk.values.PCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** ProcessValidateJsonFields is used to fix fields which contains only dot in name. */
+/** ProcessValidateJsonFields is used to fix malformed fields, (ex. de-dot). */
 public class ProcessValidateJsonFields extends PTransform<PCollection<String>, PCollection<String>> {
 
   @Override
@@ -53,18 +52,13 @@ public class ProcessValidateJsonFields extends PTransform<PCollection<String>, P
             .mappingProvider(new JacksonMappingProvider())
             .build();
 
-    public boolean checkPort(Object port, String input){
-      return Objects.nonNull(port) && input.contains("healthcheck");
-    }
-
     @ProcessElement
     public void processElement(ProcessContext context) {
       String input = context.element();
       ObjectNode node = null;
-      JsonNode port = null;
       try {
-        port = JsonPath.using(configuration).parse(input).read("$.protoPayload.response.spec.template.spec.containers.livenessProbe.httpGet.port");
-      } catch (Exception e) {}
+        JsonPath.using(configuration).parse(input).read("$.protoPayload.response.spec.template.spec.containers.livenessProbe.httpGet.port");
+      } catch (Exception ignored) {}
 
       JsonNode requestApp = null;
       try {
@@ -74,7 +68,7 @@ public class ProcessValidateJsonFields extends PTransform<PCollection<String>, P
                   JsonPath.using(configuration).parse(input).read("$.protoPayload.request.metadata.labels.app")).jsonString();
           input = JsonPath.using(configuration).parse(input).delete("$.protoPayload.request.metadata.labels.app").jsonString();
         }
-      } catch (Exception e) {}
+      } catch (Exception ignored) {}
 
       JsonNode responseApp = null;
       try {
@@ -85,7 +79,7 @@ public class ProcessValidateJsonFields extends PTransform<PCollection<String>, P
                   JsonPath.using(configuration).parse(input).read("$.protoPayload.response.metadata.labels.app")).jsonString();
           input = JsonPath.using(configuration).parse(input).delete("$.protoPayload.response.metadata.labels.app").jsonString();
         }
-      } catch (Exception ex) {}
+      } catch (Exception ignored) {}
 
       try {
         try {
@@ -99,29 +93,11 @@ public class ProcessValidateJsonFields extends PTransform<PCollection<String>, P
         LOG.warn("Unable to parse Json payload. " + e);
       }
 
-      String status = null;
       try {
-        status = JsonPath.using(configuration).parse(input).read("$.protoPayload.response.status");
+        JsonPath.using(configuration).parse(input).read("$.protoPayload.response.status");
       } catch (Exception e) {
         node = JsonPath.using(configuration).parse(node.toString()).put("$.protoPayload.response", "status", objectMapper.createObjectNode()).json();
       }
-
-      /*try {
-        System.out.println("protoPayload.request.spec.template.metadata.labels:\n"
-                + ((JsonNode)JsonPath.using(configuration).parse(input).read("$.protoPayload.request.spec.template.metadata.labels")).toPrettyString());
-      }catch (Exception e) {}
-
-      try {
-        System.out.println("protoPayload.response.spec.template.metadata.labels:\n"
-                + ((JsonNode)JsonPath.using(configuration).parse(input).read("$.protoPayload.response.spec.template.metadata.labels")).toPrettyString());
-      }catch (Exception e) {}
-
-      context.output(node.toString());
-
-      try {
-        System.out.println("protoPayload.response.spec.template.spec.containers.livenessProbe.httpGet:\n"
-                + ((JsonNode)JsonPath.using(configuration).parse(input).read("$.protoPayload.response.spec.template.spec.containers.livenessProbe.httpGet")).toPrettyString());
-      }catch (Exception e) {}*/
 
       context.output(node.toString());
     }

--- a/v2/googlecloud-to-elasticsearch/src/test/java/com/google/cloud/teleport/v2/elasticsearch/transforms/ProcessValidateJsonFieldsTest.java
+++ b/v2/googlecloud-to-elasticsearch/src/test/java/com/google/cloud/teleport/v2/elasticsearch/transforms/ProcessValidateJsonFieldsTest.java
@@ -1,6 +1,22 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.teleport.v2.elasticsearch.transforms;
 
 import static org.junit.Assert.assertFalse;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -23,64 +39,66 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Test cases for {@link ProcessValidateJsonFields}.
- * Verifies the correct behavior of the template with invalid input messages.
+ * Test cases for {@link ProcessValidateJsonFields}. Verifies the correct behavior of the template
+ * with invalid input messages.
  */
 public class ProcessValidateJsonFieldsTest {
 
-    private static final String RESOURCES_DIR = "ProcessValidateJsonFields/";
-    private static final String INVALID_MESSAGE_FILE_PATH =
-            Resources.getResource(RESOURCES_DIR + "invalidMessage.json").getPath();
-    private static final boolean IS_WINDOWS = System.getProperty("os.name").contains("Windows");
-    @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+  private static final String RESOURCES_DIR = "ProcessValidateJsonFields/";
+  private static final String INVALID_MESSAGE_FILE_PATH =
+      Resources.getResource(RESOURCES_DIR + "invalidMessage.json").getPath();
+  private static final boolean IS_WINDOWS = System.getProperty("os.name").contains("Windows");
+  @Rule public final transient TestPipeline pipeline = TestPipeline.create();
 
-    /** Elasticsearch doesn't accept messages with only dot in field's name.
-     * Invalid message in runtime will be refused by Elasticsearch and sent to Pub/Sub errorOutputTopic.
-     */
-    @Test
-    public void testProcessValidateJsonFieldsWithInvalidInputMessage() throws IOException {
-        String inputMessage = readInputMessage(INVALID_MESSAGE_FILE_PATH);
-        CoderRegistry coderRegistry = pipeline.getCoderRegistry();
-        PubSubToElasticsearchOptions options =
-                TestPipeline.testingPipelineOptions().as(PubSubToElasticsearchOptions.class);
-        PCollection<String> pc = pipeline
-                .apply(Create.of(ImmutableList.of(inputMessage)))
-                .apply("Validate JSON fields", new ProcessValidateJsonFields());
+  /**
+   * Elasticsearch doesn't accept messages with only dot in field's name. Invalid message in runtime
+   * will be refused by Elasticsearch and sent to Pub/Sub errorOutputTopic.
+   */
+  @Test
+  public void testProcessValidateJsonFieldsWithInvalidInputMessage() throws IOException {
+    String inputMessage = readInputMessage(INVALID_MESSAGE_FILE_PATH);
+    CoderRegistry coderRegistry = pipeline.getCoderRegistry();
+    PubSubToElasticsearchOptions options =
+        TestPipeline.testingPipelineOptions().as(PubSubToElasticsearchOptions.class);
+    PCollection<String> pc =
+        pipeline
+            .apply(Create.of(ImmutableList.of(inputMessage)))
+            .apply("Validate JSON fields", new ProcessValidateJsonFields());
 
-        PAssert.that(pc)
-                .satisfies(
-                        x -> {
-                            String element = x.iterator().next();
+    PAssert.that(pc)
+        .satisfies(
+            x -> {
+              String element = x.iterator().next();
 
-                            JsonNode jsonNode = null;
-                            try {
-                                jsonNode = new ObjectMapper().readTree(element);
-                            } catch (JsonProcessingException e) {
-                                e.printStackTrace();
-                            }
-                            Iterator<Map.Entry<String, JsonNode>> iter = jsonNode.fields();
+              JsonNode jsonNode = null;
+              try {
+                jsonNode = new ObjectMapper().readTree(element);
+              } catch (JsonProcessingException e) {
+                e.printStackTrace();
+              }
+              Iterator<Map.Entry<String, JsonNode>> iter = jsonNode.fields();
 
-                            boolean hasInvalidFields = false;
-                            while (iter.hasNext()) {
-                                Map.Entry<String, JsonNode> entry = iter.next();
-                                String key = entry.getKey();
+              boolean hasInvalidFields = false;
+              while (iter.hasNext()) {
+                Map.Entry<String, JsonNode> entry = iter.next();
+                String key = entry.getKey();
 
-                                if (key.equals(".")) {
-                                    hasInvalidFields = true;
-                                    break;
-                                }
-                            }
+                if (key.equals(".")) {
+                  hasInvalidFields = true;
+                  break;
+                }
+              }
 
-                            assertFalse("Invalid message found", hasInvalidFields);
-                            return null;
-                        });
+              assertFalse("Invalid message found", hasInvalidFields);
+              return null;
+            });
 
-        pipeline.run(options);
-    }
+    pipeline.run(options);
+  }
 
-    private String readInputMessage(String filePath) throws IOException {
-        return Files.lines(Paths.get(IS_WINDOWS ? filePath.substring(1) : filePath), StandardCharsets.UTF_8)
-                .collect(Collectors.joining());
-    }
-
+  private String readInputMessage(String filePath) throws IOException {
+    return Files.lines(
+            Paths.get(IS_WINDOWS ? filePath.substring(1) : filePath), StandardCharsets.UTF_8)
+        .collect(Collectors.joining());
+  }
 }

--- a/v2/googlecloud-to-elasticsearch/src/test/java/com/google/cloud/teleport/v2/elasticsearch/transforms/ProcessValidateJsonFieldsTest.java
+++ b/v2/googlecloud-to-elasticsearch/src/test/java/com/google/cloud/teleport/v2/elasticsearch/transforms/ProcessValidateJsonFieldsTest.java
@@ -1,0 +1,86 @@
+package com.google.cloud.teleport.v2.elasticsearch.transforms;
+
+import static org.junit.Assert.assertFalse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.teleport.v2.elasticsearch.options.PubSubToElasticsearchOptions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.beam.sdk.coders.CoderRegistry;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test cases for {@link ProcessValidateJsonFields}.
+ * Verifies the correct behavior of the template with invalid input messages.
+ */
+public class ProcessValidateJsonFieldsTest {
+
+    private static final String RESOURCES_DIR = "ProcessValidateJsonFields/";
+    private static final String INVALID_MESSAGE_FILE_PATH =
+            Resources.getResource(RESOURCES_DIR + "invalidMessage.json").getPath();
+    private static final boolean IS_WINDOWS = System.getProperty("os.name").contains("Windows");
+    @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+
+    /** Elasticsearch doesn't accept messages with only dot in field's name.
+     * Invalid message in runtime will be refused by Elasticsearch and sent to Pub/Sub errorOutputTopic.
+     */
+    @Test
+    public void testProcessValidateJsonFieldsWithInvalidInputMessage() throws IOException {
+        String inputMessage = readInputMessage(INVALID_MESSAGE_FILE_PATH);
+        CoderRegistry coderRegistry = pipeline.getCoderRegistry();
+        PubSubToElasticsearchOptions options =
+                TestPipeline.testingPipelineOptions().as(PubSubToElasticsearchOptions.class);
+        PCollection<String> pc = pipeline
+                .apply(Create.of(ImmutableList.of(inputMessage)))
+                .apply("Validate JSON fields", new ProcessValidateJsonFields());
+
+        PAssert.that(pc)
+                .satisfies(
+                        x -> {
+                            String element = x.iterator().next();
+
+                            JsonNode jsonNode = null;
+                            try {
+                                jsonNode = new ObjectMapper().readTree(element);
+                            } catch (JsonProcessingException e) {
+                                e.printStackTrace();
+                            }
+                            Iterator<Map.Entry<String, JsonNode>> iter = jsonNode.fields();
+
+                            boolean hasInvalidFields = false;
+                            while (iter.hasNext()) {
+                                Map.Entry<String, JsonNode> entry = iter.next();
+                                String key = entry.getKey();
+
+                                if (key.equals(".")) {
+                                    hasInvalidFields = true;
+                                    break;
+                                }
+                            }
+
+                            assertFalse("Invalid message found", hasInvalidFields);
+                            return null;
+                        });
+
+        pipeline.run(options);
+    }
+
+    private String readInputMessage(String filePath) throws IOException {
+        return Files.lines(Paths.get(IS_WINDOWS ? filePath.substring(1) : filePath), StandardCharsets.UTF_8)
+                .collect(Collectors.joining());
+    }
+
+}

--- a/v2/googlecloud-to-elasticsearch/src/test/resources/ProcessValidateJsonFields/invalidMessage.json
+++ b/v2/googlecloud-to-elasticsearch/src/test/resources/ProcessValidateJsonFields/invalidMessage.json
@@ -1,0 +1,132 @@
+{
+  "insertId": "09489d66-5017-4726-9920-8403db18c499",
+  "labels": {
+    "authorization.k8s.io/decision": "allow",
+    "authorization.k8s.io/reason": "RBAC: allowed by ClusterRoleBinding \"system:managed-certificate-controller\" of ClusterRole \"system:managed-certificate-controller\" to User \"system:managed-certificate-controller\""
+  },
+  "logName": "projects/elastic-sa/logs/cloudaudit.googleapis.com%2Factivity",
+  "operation": {
+    "first": true,
+    "id": "09489d66-5017-4726-9920-8403db18c499",
+    "last": true,
+    "producer": "k8s.io"
+  },
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "authenticationInfo": {
+      "principalEmail": "system:managed-certificate-controller"
+    },
+    "authorizationInfo": [
+      {
+        "granted": true,
+        "permission": "io.k8s.core.v1.endpoints.update",
+        "resource": "core/v1/namespaces/kube-system/endpoints/managed-certificate-controller"
+      }
+    ],
+    "methodName": "io.k8s.core.v1.endpoints.update",
+    "request": {
+      "@type": "core.k8s.io/v1.Endpoints",
+      "apiVersion": "v1",
+      "kind": "Endpoints",
+      "metadata": {
+        "annotations": {
+          "control-plane.alpha.kubernetes.io/leader": "{\"holderIdentity\":\"gke-7812297a2547498a8e1d-1d63-aa58-vm\",\"leaseDurationSeconds\":15,\"acquireTime\":\"2021-11-10T04:32:40Z\",\"renewTime\":\"2021-11-11T18:48:32Z\",\"leaderTransitions\":12}"
+        },
+        "creationTimestamp": "2021-06-15T14:05:31Z",
+        "managedFields": [
+          {
+            "apiVersion": "v1",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:annotations": {
+                  ".": {},
+                  "f:control-plane.alpha.kubernetes.io/leader": {}
+                }
+              }
+            },
+            "manager": "managed-certificate-controller",
+            "operation": "Update",
+            "time": "2021-06-15T14:05:31Z"
+          }
+        ],
+        "name": "managed-certificate-controller",
+        "namespace": "kube-system",
+        "resourceVersion": "74733013",
+        "uid": "952ffd12-9104-46c9-b2c0-fdc4a74e0929"
+      }
+    },
+    "requestMetadata": {
+      "callerIp": "::1",
+      "callerSuppliedUserAgent": "managed-certificate-controller/v0.0.0 (linux/amd64) kubernetes/$Format"
+    },
+    "resourceName": "core/v1/namespaces/kube-system/endpoints/managed-certificate-controller",
+    "response": {
+      "@type": "core.k8s.io/v1.Endpoints",
+      "apiVersion": "v1",
+      "kind": "Endpoints",
+      "metadata": {
+        "annotations": {
+          "control-plane.alpha.kubernetes.io/leader": "{\"holderIdentity\":\"gke-7812297a2547498a8e1d-1d63-aa58-vm\",\"leaseDurationSeconds\":15,\"acquireTime\":\"2021-11-10T04:32:40Z\",\"renewTime\":\"2021-11-11T18:48:32Z\",\"leaderTransitions\":12}"
+        },
+        "creationTimestamp": "2021-06-15T14:05:31Z",
+        "managedFields": [
+          {
+            "apiVersion": "v1",
+            "fieldsType": "FieldsV1",
+            "fieldsV1": {
+              "f:metadata": {
+                "f:annotations": {
+                  ".": {},
+                  "f:control-plane.alpha.kubernetes.io/leader": {}
+                }
+              }
+            },
+            "manager": "managed-certificate-controller",
+            "operation": "Update",
+            "time": "2021-06-15T14:05:31Z"
+          }
+        ],
+        "name": "managed-certificate-controller",
+        "namespace": "kube-system",
+        "resourceVersion": "74733023",
+        "uid": "952ffd12-9104-46c9-b2c0-fdc4a74e0929"
+      }
+    },
+    "serviceName": "k8s.io",
+    "status": {}
+  },
+  "receiveTimestamp": "2021-11-11T18:48:35.305404026Z",
+  "resource": {
+    "labels": {
+      "cluster_name": "cluster-1-demoamy",
+      "location": "us-central1-c",
+      "project_id": "elastic-sa"
+    },
+    "type": "k8s_cluster"
+  },
+  "logging.googleapis.com/timestamp": "2021-11-11T18:48:32.827087Z",
+  "@timestamp": "2021-11-11T18:48:32.827087Z",
+  "agent": {
+    "type": "dataflow",
+    "name": "",
+    "version": "1.0.0",
+    "id": ""
+  },
+  "data_stream": {
+    "type": "logs",
+    "dataset": "gcp.audit",
+    "namespace": "default"
+  },
+  "ecs": {
+    "version": "1.10.0"
+  },
+  "message": "{\"insertId\":\"09489d66-5017-4726-9920-8403db18c499\",\"labels\":{\"authorization.k8s.io/decision\":\"allow\",\"authorization.k8s.io/reason\":\"RBAC: allowed by ClusterRoleBinding \\\"system:managed-certificate-controller\\\" of ClusterRole \\\"system:managed-certificate-controller\\\" to User \\\"system:managed-certificate-controller\\\"\"},\"logName\":\"projects/elastic-sa/logs/cloudaudit.googleapis.com%2Factivity\",\"operation\":{\"first\":true,\"id\":\"09489d66-5017-4726-9920-8403db18c499\",\"last\":true,\"producer\":\"k8s.io\"},\"protoPayload\":{\"@type\":\"type.googleapis.com/google.cloud.audit.AuditLog\",\"authenticationInfo\":{\"principalEmail\":\"system:managed-certificate-controller\"},\"authorizationInfo\":[{\"granted\":true,\"permission\":\"io.k8s.core.v1.endpoints.update\",\"resource\":\"core/v1/namespaces/kube-system/endpoints/managed-certificate-controller\"}],\"methodName\":\"io.k8s.core.v1.endpoints.update\",\"request\":{\"@type\":\"core.k8s.io/v1.Endpoints\",\"apiVersion\":\"v1\",\"kind\":\"Endpoints\",\"metadata\":{\"annotations\":{\"control-plane.alpha.kubernetes.io/leader\":\"{\\\"holderIdentity\\\":\\\"gke-7812297a2547498a8e1d-1d63-aa58-vm\\\",\\\"leaseDurationSeconds\\\":15,\\\"acquireTime\\\":\\\"2021-11-10T04:32:40Z\\\",\\\"renewTime\\\":\\\"2021-11-11T18:48:32Z\\\",\\\"leaderTransitions\\\":12}\"},\"creationTimestamp\":\"2021-06-15T14:05:31Z\",\"managedFields\":[{\"apiVersion\":\"v1\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:metadata\":{\"f:annotations\":{\".\":{},\"f:control-plane.alpha.kubernetes.io/leader\":{}}}},\"manager\":\"managed-certificate-controller\",\"operation\":\"Update\",\"time\":\"2021-06-15T14:05:31Z\"}],\"name\":\"managed-certificate-controller\",\"namespace\":\"kube-system\",\"resourceVersion\":\"74733013\",\"uid\":\"952ffd12-9104-46c9-b2c0-fdc4a74e0929\"}},\"requestMetadata\":{\"callerIp\":\"::1\",\"callerSuppliedUserAgent\":\"managed-certificate-controller/v0.0.0 (linux/amd64) kubernetes/$Format\"},\"resourceName\":\"core/v1/namespaces/kube-system/endpoints/managed-certificate-controller\",\"response\":{\"@type\":\"core.k8s.io/v1.Endpoints\",\"apiVersion\":\"v1\",\"kind\":\"Endpoints\",\"metadata\":{\"annotations\":{\"control-plane.alpha.kubernetes.io/leader\":\"{\\\"holderIdentity\\\":\\\"gke-7812297a2547498a8e1d-1d63-aa58-vm\\\",\\\"leaseDurationSeconds\\\":15,\\\"acquireTime\\\":\\\"2021-11-10T04:32:40Z\\\",\\\"renewTime\\\":\\\"2021-11-11T18:48:32Z\\\",\\\"leaderTransitions\\\":12}\"},\"creationTimestamp\":\"2021-06-15T14:05:31Z\",\"managedFields\":[{\"apiVersion\":\"v1\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:metadata\":{\"f:annotations\":{\".\":{},\"f:control-plane.alpha.kubernetes.io/leader\":{}}}},\"manager\":\"managed-certificate-controller\",\"operation\":\"Update\",\"time\":\"2021-06-15T14:05:31Z\"}],\"name\":\"managed-certificate-controller\",\"namespace\":\"kube-system\",\"resourceVersion\":\"74733023\",\"uid\":\"952ffd12-9104-46c9-b2c0-fdc4a74e0929\"}},\"serviceName\":\"k8s.io\",\"status\":{}},\"receiveTimestamp\":\"2021-11-11T18:48:35.305404026Z\",\"resource\":{\"labels\":{\"cluster_name\":\"cluster-1-demoamy\",\"location\":\"us-central1-c\",\"project_id\":\"elastic-sa\"},\"type\":\"k8s_cluster\"},\"timestamp\":\"2021-11-11T18:48:32.827087Z\",\"logging.googleapis.com/timestamp\":\"2021-11-11T18:48:32.827087Z\"}",
+  "service": {
+    "type": "gcp.audit"
+  },
+  "event": {
+    "module": "gcp",
+    "dataset": "gcp.audit"
+  }
+}


### PR DESCRIPTION
This pull request contains many changes in custom ElasticsearchIO to be able to handle failed inserts. Now ElasticsearchIO.Write is not a terminal step but returns JSON with error message to be sent to error-output-topic.

Now failed inserts don't slow down the pipeline and the throughput remain stable.

It's a draft PR and additional refactoring can be required.