### PR TITLE
Run Spotless on PRs

### DIFF
--- a/.github/workflows/preconditions.yml
+++ b/.github/workflows/preconditions.yml
@@ -1,0 +1,51 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Checks that don't run any template code and only on PRs.
+
+name: Precondition Checks
+
+on:
+  pull_request:
+    branches: ['main']
+
+jobs:
+  spotless_check:
+    name: Spotless
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@230611dbd0eb52da1e1f4f7bc8bb0c3a339fc8b7
+      - name: Setup Java
+        uses: actions/setup-java@a12e082d834968c1847f782019214fadd20719f6
+        with:
+          distribution: 'zulu'
+          version: '11' # Spotless won't work on version 8
+          cache: 'maven'
+      - name: Run Spotless
+        run: |
+          function get_change_count {
+            echo $(git status | grep -e $1 | wc -l)
+          }
+          if [[ $(get_change_count '[^/]src/') -gt 0 ]]; then
+            mvn spotless:check
+          else
+            echo 'No changes to Classic Templates. Skipping spotless check'
+          fi
+          if [[ $(get_change_count '[^/]v2/') -gt 0 ]]; then
+            mvn spotless:check -f v2/pom.xml
+          else
+            echo 'No changes to Flex Templates. Skipping spotless check.'
+          fi


### PR DESCRIPTION
Spotless violations frequently slip through. This should prevent that.

The check will only run on the relevant template "family" (i.e. Classic or Flex) to hopefully speed things up. We can make it more granular later if Flex Templates start taking too long, but the check normally completes in a matter of seconds at the current time.