### PR TITLE
Add composite action for setting up environment

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -46,6 +46,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set Shell Options
+      shell: bash
       run: |
         set +o history
     - name: Setup Java
@@ -66,6 +67,7 @@ runs:
     # It shouldn't take too long to build all of this, and it will at least
     # make running the target program easier
     - name: Build CI/CD
+      shell: bash
       run: |
         cd cicd/
         go build ./cmd/...

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -21,7 +21,6 @@
 #   2. Set up Go, which our CI/CD programs are written in
 #   3. Build everything under cicd/cmd
 #   4. Gets all the changed files
-#   5. Configure options (e.g. through the `set` built-in command)
 
 name: 'Setup Environment'
 description: 'Sets up common environment for Dataflow Templates workflows'
@@ -45,10 +44,6 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Set Shell Options
-      shell: bash
-      run: |
-        set +o history
     - name: Setup Java
       uses: actions/setup-java@a12e082d834968c1847f782019214fadd20719f6
       with:

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,0 +1,64 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Action used to set up the environment. This assumes that we are using
+# a Linux-based VM.
+#
+# General steps are:
+#   1. Set up Java, which templates and tests are written in
+#   2. Set up Go, which our CI/CD programs are written in
+#   3. Gets all the changed files
+#   4. Configure options (e.g. through the `set` built-in command)
+
+name: 'Setup Environment'
+description: 'Sets up common environment for Dataflow Templates workflows'
+
+inputs:
+  java-version:
+    type: string
+    description: 'The version of Java to install'
+    required: false
+    default: '8'
+  go-version:
+    type: string
+    description: 'The version of Go to install'
+    required: false
+    default: '1.17'
+outputs:
+  changed-files:
+    description: 'Comma-separated list of files that were changed'
+    value: ${{ steps.changed-files.outputs.all_changed_files }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set Shell Options
+      run: |
+        set +o history
+    - name: Setup Java
+      uses: actions/setup-java@a12e082d834968c1847f782019214fadd20719f6
+      with:
+        distribution: 'zulu'
+        java-version: ${{ inputs.java-version }}
+        cache: 'maven'
+    - name: Setup Go
+      uses: actions/setup-go@44e221478fc6847752e5c574fc7a7b3247b00fbf
+      with:
+        go-version: ${{ inputs.go-version }}
+    - name: Get Changed Files
+      id: changed-files
+      uses: tj-actions/changed-files@61ee456a9d0f512e7ecfdf28863634c97dae2d16
+      with:
+        separator: ','

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -19,8 +19,9 @@
 # General steps are:
 #   1. Set up Java, which templates and tests are written in
 #   2. Set up Go, which our CI/CD programs are written in
-#   3. Gets all the changed files
-#   4. Configure options (e.g. through the `set` built-in command)
+#   3. Build everything under cicd/cmd
+#   4. Gets all the changed files
+#   5. Configure options (e.g. through the `set` built-in command)
 
 name: 'Setup Environment'
 description: 'Sets up common environment for Dataflow Templates workflows'
@@ -62,3 +63,10 @@ runs:
       uses: tj-actions/changed-files@61ee456a9d0f512e7ecfdf28863634c97dae2d16
       with:
         separator: ','
+    # It shouldn't take too long to build all of this, and it will at least
+    # make running the target program easier
+    - name: Build CI/CD
+      run: |
+        cd cicd/
+        go build ./cmd/...
+        cd ..

--- a/.github/workflows/preconditions.yml
+++ b/.github/workflows/preconditions.yml
@@ -28,22 +28,12 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@230611dbd0eb52da1e1f4f7bc8bb0c3a339fc8b7
-      - name: Setup Java
-        uses: actions/setup-java@a12e082d834968c1847f782019214fadd20719f6
+      - name: Setup Environment
+        id: setup-env
+        uses: ./.github/actions/setup-env
         with:
-          distribution: 'zulu'
           java-version: '11' # Spotless won't work on version 8
-          cache: 'maven'
-      - name: Setup Go
-        uses: actions/setup-go@44e221478fc6847752e5c574fc7a7b3247b00fbf
-        with:
-          go-version: '1.17'
-      - name: Get Changed Files
-        id: changed-files
-        uses: tj-actions/changed-files@61ee456a9d0f512e7ecfdf28863634c97dae2d16
-        with:
-          separator: ','
       - name: Run Spotless
         run: |
           cd cicd/ && go build ./cmd/run-spotless && cd ..
-          ./cicd/run-spotless --changed-files="${{ steps.changed-files.outputs.all_changed_files }}"
+          ./cicd/run-spotless --changed-files="${{ steps.setup-env.outputs.changed-files }}"

--- a/.github/workflows/preconditions.yml
+++ b/.github/workflows/preconditions.yml
@@ -34,6 +34,4 @@ jobs:
         with:
           java-version: '11' # Spotless won't work on version 8
       - name: Run Spotless
-        run: |
-          cd cicd/ && go build ./cmd/run-spotless && cd ..
-          ./cicd/run-spotless --changed-files="${{ steps.setup-env.outputs.changed-files }}"
+        run: ./cicd/run-spotless --changed-files="${{ steps.setup-env.outputs.changed-files }}"


### PR DESCRIPTION
Moves the environment setup to a composite action. A composite action was used over a reusable workflow, since it easier to test when added or modified (kind of like in this PR).

Once the action exists, we should have the following:

1. Both Java and Go are ready for use. This includes our Java build system (for now Maven).
2. All the CI/CD commands are ready for use. This _might_ get too expensive in time, but we can worry about that if it ever becomes a practical concern.
3. A comma-separated list of all the changed files available for reference.

Of course, we still need to checkout the code for each job, but this will make writing jobs considerably easier than before.