### PR TITLE
Limit precondition permissions

### DIFF
--- a/.github/workflows/preconditions.yml
+++ b/.github/workflows/preconditions.yml
@@ -20,6 +20,8 @@ on:
   pull_request:
     branches: ['main']
 
+permissions: read-all
+
 jobs:
   spotless_check:
     name: Spotless


### PR DESCRIPTION
These checks should only require read permissions. In fact, in almost all cases, they should be coming from forks, where that's all they'd get anyways.