### PR TITLE
Minor improvements to GitHub Actions

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -65,5 +65,7 @@ runs:
       shell: bash
       run: |
         cd cicd/
-        go build ./cmd/...
+        for CMD in $(ls cmd); do
+          go build ./cmd/$CMD
+        done
         cd ..

--- a/cicd/internal/flags/common-flags.go
+++ b/cicd/internal/flags/common-flags.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package flags
+
+import (
+	"flag"
+	"log"
+	"strings"
+)
+
+// Avoid making these vars public.
+var (
+	changedFiles string
+)
+
+func RegisterCommonFlags() {
+	flag.StringVar(&changedFiles, "changed-files", "", "List of changed files as a comma-separated string")
+}
+
+func ChangedFiles() []string {
+	if len(changedFiles) == 0 {
+		log.Println("WARNING: No changed files were passed. This could indicate an error.")
+		return make([]string, 0)
+	}
+
+	return strings.Split(changedFiles, ",")
+}

--- a/cicd/internal/flags/common-flags_test.go
+++ b/cicd/internal/flags/common-flags_test.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package flags
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestChangedFiles(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{
+			input:    "file1,file2",
+			expected: []string{"file1", "file2"},
+		},
+		{
+			input:    "file1",
+			expected: []string{"file1"},
+		},
+	}
+
+	for _, test := range tests {
+		changedFiles = test.input
+		actual := ChangedFiles()
+		if !reflect.DeepEqual(actual, test.expected) {
+			t.Errorf("Returned files are not equal. Expected %v. Got %v.", test.expected, actual)
+		}
+	}
+}
+
+func TestChangedFilesEmpty(t *testing.T) {
+	changedFiles = ""
+	actual := ChangedFiles()
+	if len(actual) != 0 {
+		t.Errorf("Expected empty slice, but got %v of len %v", actual, len(actual))
+	}
+}

--- a/cicd/internal/repo/modules.go
+++ b/cicd/internal/repo/modules.go
@@ -171,9 +171,11 @@ func findUniqueFlexModules(paths []string) []string {
 
 		if possible != nil {
 			allModules = append(allModules, possible.value)
+		} else {
+			// Include the possibility of having no module. The receiver can decide what
+			// to do with it.
+			allModules = append(allModules, "")
 		}
-		// We don't error from not finding anything, since it could be a root-level file
-		// that isn't part of any module.
 	}
 
 	unique := make(map[string]interface{})

--- a/cicd/internal/repo/modules_test.go
+++ b/cicd/internal/repo/modules_test.go
@@ -51,10 +51,11 @@ func TestGetModulesForPaths(t *testing.T) {
 				"v2/pubsub-binary-to-bigquery/avro",
 				"src/something-else",
 				"v2/pubsub-binary-to-bigquery/proto",
+				"v2/something",
 			},
 			expected: map[string][]string{
 				ClassicRoot: []string{},
-				FlexRoot:    []string{"pubsub-binary-to-bigquery"},
+				FlexRoot:    []string{"pubsub-binary-to-bigquery", ""},
 			},
 		},
 		{
@@ -73,7 +74,7 @@ func TestGetModulesForPaths(t *testing.T) {
 			input: []string{"something", "it/something", "v2/something"},
 			expected: map[string][]string{
 				ClassicRoot: make([]string, 0),
-				FlexRoot:    make([]string, 0),
+				FlexRoot:    []string{""},
 			},
 		},
 		{


### PR DESCRIPTION
Changes:

1. Simplified `run-spotless`.
2. Accounted for the root module for Flex Templates. Individual commands can take better advantage of it.
3. Added a place for common flags, since practically all commands will have a `changed-files` flag.
4. Fixed a bug in the `setup-env` `go build` script that would have surfaced once we added a second thing to build.