### PR TITLE
Take more control of Java dependency cache

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -49,7 +49,6 @@ runs:
       with:
         distribution: 'zulu'
         java-version: ${{ inputs.java-version }}
-        cache: 'maven'
     - name: Setup Go
       uses: actions/setup-go@44e221478fc6847752e5c574fc7a7b3247b00fbf
       with:
@@ -69,3 +68,5 @@ runs:
           go build ./cmd/$CMD
         done
         cd ..
+    - name: Setup Java Cache
+      uses: ./.github/actions/setup-java-cache

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -44,11 +44,6 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Setup Java
-      uses: actions/setup-java@a12e082d834968c1847f782019214fadd20719f6
-      with:
-        distribution: 'zulu'
-        java-version: ${{ inputs.java-version }}
     - name: Setup Go
       uses: actions/setup-go@44e221478fc6847752e5c574fc7a7b3247b00fbf
       with:
@@ -68,5 +63,7 @@ runs:
           go build ./cmd/$CMD
         done
         cd ..
-    - name: Setup Java Cache
-      uses: ./.github/actions/setup-java-cache
+    - name: Setup Java
+      uses: ./.github/actions/setup-java-env
+      with:
+        java-version: ${{ inputs.java-version }}

--- a/.github/actions/setup-java-cache/action.yml
+++ b/.github/actions/setup-java-cache/action.yml
@@ -1,0 +1,53 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sets up the cache for Java dependencies. If a specific key is given, then the
+# key is used to resolve or else resolving the first entry that matches the prefix
+# without the key. Otherwise, today's date and yetserday's date (both in UTC) will be
+# tried before going to the first match without any date.
+
+name: 'Setup Java Cache'
+description: 'Sets up the Java dependency cache.'
+
+inputs:
+  key:
+    type: string
+    description: 'Key to use for the cache entry'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Prepare Key
+      shell: bash
+      env:
+        KEY: ${{ inputs.key }}
+      run: |
+        if [[ "$KEY" == "" ]]; then
+          echo "TODAY=$(date -u +%Y%m%d)" >> $GITHUB_ENV
+          echo "YESTERDAY=$(date -u --date='1 day ago' +%Y%m%d)" >> $GITHUB_ENV
+        else
+          echo "TODAY=${{ inputs.key }}" >> $GITHUB_ENV
+          echo "YESTERDAY=${{ inputs.key }}" >> $GITHUB_ENV
+        fi
+    - name: Setup Cache
+      uses: actions/cache@72d1e4fdff0ff7b1b6e86b415f2d4f5941e5c006
+      with:
+        path: |
+          ~/.m2
+        key: java-maven-cache-${{ env.TODAY }}
+        restore-keys: |
+          java-maven-cache-${{ env.YESTERDAY }}
+          java-maven-cache

--- a/.github/actions/setup-java-env/action.yml
+++ b/.github/actions/setup-java-env/action.yml
@@ -17,33 +17,48 @@
 # without the key. Otherwise, today's date and yetserday's date (both in UTC) will be
 # tried before going to the first match without any date.
 
-name: 'Setup Java Cache'
-description: 'Sets up the Java dependency cache.'
+name: 'Setup Java Environment'
+description: 'Sets up the full Java environment.'
 
 inputs:
-  key:
+  cache-key:
     type: string
     description: 'Key to use for the cache entry'
     required: false
     default: ''
+  java-version:
+    type: string
+    description: 'The version of Java to install'
+    required: false
+    default: '8'
+outputs:
+  cache-hit:
+    description: 'Whether or not there was a cache hit'
+    value: ${{ steps.setup-cache.outputs.cache-hit }}
 
 runs:
   using: 'composite'
   steps:
+    - name: Setup Java
+      uses: actions/setup-java@a12e082d834968c1847f782019214fadd20719f6
+      with:
+        distribution: 'zulu'
+        java-version: ${{ inputs.java-version }}
     - name: Prepare Key
       shell: bash
       env:
-        KEY: ${{ inputs.key }}
+        KEY: ${{ inputs.cache-key }}
       run: |
-        if [[ "$KEY" == "" ]]; then
+        if [[ "$KEY" == "" || "$KEY" == "''" ]]; then
           echo "TODAY=$(date -u +%Y%m%d)" >> $GITHUB_ENV
           echo "YESTERDAY=$(date -u --date='1 day ago' +%Y%m%d)" >> $GITHUB_ENV
         else
-          echo "TODAY=${{ inputs.key }}" >> $GITHUB_ENV
-          echo "YESTERDAY=${{ inputs.key }}" >> $GITHUB_ENV
+          echo "TODAY=$KEY" >> $GITHUB_ENV
+          echo "YESTERDAY=$KEY" >> $GITHUB_ENV
         fi
     - name: Setup Cache
       uses: actions/cache@72d1e4fdff0ff7b1b6e86b415f2d4f5941e5c006
+      id: setup-cache
       with:
         path: |
           ~/.m2

--- a/.github/workflows/prepare-java-cache.yml
+++ b/.github/workflows/prepare-java-cache.yml
@@ -1,0 +1,74 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Prepares the Java cache either daily on demand. Since GitHub's cache action doesn't
+# allow overwriting an existing entry, this is necessary to try to keep the cached dependencies
+# as up-to-date as possible, hopefully minimizing the time it takes for PR checks to
+# complete.
+
+name: Prepare Java Cache
+
+on:
+  # At the start of each day, refresh the cache.
+  schedule:
+    - cron: '0 0 * * *'
+  # A way to try to force the cache forward should something cause it to get stuck.
+  workflow_dispatch:
+    inputs:
+      days:
+        type: choice
+        description: 'The cache entry N days ahead to claim.'
+        required: true
+        default: '1'
+        options: ['1', '2', '3', '4', '5', '6']
+  # Run on PRs that change this workflow or our local actions just to make sure nothing breaks.
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - '.github/workflows/prepare-java-chace.yml'
+      - '.github/actions/setup-java-env/*'
+
+permissions: read-all
+
+jobs:
+  cache_dependencies:
+    name: Cache Java Dependencies
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Manual Key
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "$(date -u --date='${{ inputs.days }} days' +%Y%m%d)" >> $GITHUB_ENV
+      - name: Set Empty Key
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        run: |
+          echo "CACHE_KEY=''" >> $GITHUB_ENV
+      - name: Checkout Code
+        uses: actions/checkout@230611dbd0eb52da1e1f4f7bc8bb0c3a339fc8b7
+      - name: Setup Java
+        id: setup-java
+        uses: ./.github/actions/setup-java-env
+        with:
+          cache-key: ${{ env.CACHE_KEY }}
+      - name: Resolve Dependencies
+        if: ${{ steps.setup-java.outputs.cache-hit != 'true' || github.event_name == 'pull_request' }}
+        run: |
+          for DIR in $(find . -maxdepth 1 -type d); do
+            POMF="$DIR/pom.xml"
+            if [[ -f "$POMF" ]]; then
+              mvn -B clean install -f "$POMF" -am -amd -Dmaven.test.skip -Dcheckstyle.skip -Djib.skip -Dmdep.analyze.skip
+            fi
+          done


### PR DESCRIPTION
A drawback of the `actions/setup-java` is that its caching uses `actions/cache`, which doesn't allow forcing an overwrite of the cached data. For us, this means that a short-running workflow, like checking formatting, can easily claim the cache entry. This effectively makes the cache useless for longer-running workflows. The only real workaround is to change the key, which is what is done here.

Since `actions/setup-java` is intended for simple uses of the cache, this switches to using `actions/cache` directly. It'll attempt to refresh the cache daily, but we can manually claim a future date in case something goes wrong. Worst case scenario is one of those short workflows runs and keeps the cache constant, but since it would pull from the previous cache, it's better than what we have now.