### PR TITLE
Stop caching the Templates with their dependencies

### DIFF
--- a/.github/actions/cleanup-java-env/action.yml
+++ b/.github/actions/cleanup-java-env/action.yml
@@ -1,0 +1,35 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Cleans up the Java environment. This is mostly intended to help keep the
+# Java cache a bit smaller by removing unnecessary dependencies or stuff that
+# we will always rebuild anyways.
+
+name: 'Cleanup Java Environment'
+description: 'Do some cleanup of the Java environment'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Remove Teleport Artifacts
+      shell: bash
+      run: |
+        TELEPORT_DIR=~/.m2/repository/com/google/cloud/teleport
+        if [[ -d "$TELEPORT_DIR" ]]; then
+          echo "Cleaning up $TELEPORT_DIR"
+          rm -r "$TELEPORT_DIR"
+          echo "$TELEPORT_DIR successfully cleaned up"
+        else
+          echo "$TELEPORT_DIR not found"
+        fi

--- a/.github/workflows/prepare-java-cache.yml
+++ b/.github/workflows/prepare-java-cache.yml
@@ -39,6 +39,7 @@ on:
     paths:
       - '.github/workflows/prepare-java-chace.yml'
       - '.github/actions/setup-java-env/*'
+      - '.github/actions/cleanup-java-env/*'
 
 permissions: read-all
 
@@ -72,3 +73,5 @@ jobs:
               mvn -B clean install -f "$POMF" -am -amd -Dmaven.test.skip -Dcheckstyle.skip -Djib.skip -Dmdep.analyze.skip
             fi
           done
+      - name: Cleanup Java Environment
+        uses: ./.github/actions/cleanup-java-env


### PR DESCRIPTION
Tries to optimize cache use by removing the artifacts under `com/google/cloud/teleport/`. Since we rebuild these artifacts every time, it makes no sense to cache them. It also takes up a lot of space, so this will help a lot with keeping the cache size under control.