### PR TITLE
JdbcToBigQuery template: Fix java.lang.ClassCastException: class java.sql.Timestamp

### DIFF
--- a/src/main/java/com/google/cloud/teleport/templates/common/JdbcConverters.java
+++ b/src/main/java/com/google/cloud/teleport/templates/common/JdbcConverters.java
@@ -143,6 +143,7 @@ public class JdbcConverters {
             outputTableRow.set(
                 metaData.getColumnName(i), dateFormatter.format(resultSet.getObject(i)));
             break;
+          case "datetime2":
           case "datetime":
             Object item = resultSet.getObject(i);
             String datetime;

--- a/src/main/java/com/google/cloud/teleport/templates/common/JdbcConverters.java
+++ b/src/main/java/com/google/cloud/teleport/templates/common/JdbcConverters.java
@@ -18,6 +18,7 @@ package com.google.cloud.teleport.templates.common;
 import com.google.api.services.bigquery.model.TableRow;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
+import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
@@ -143,9 +144,15 @@ public class JdbcConverters {
                 metaData.getColumnName(i), dateFormatter.format(resultSet.getObject(i)));
             break;
           case "datetime":
+            Object item = resultSet.getObject(i);
+            String datetime;
+            if(item instanceof Timestamp){
+              datetime = timestampFormatter.format(item);
+            }else {
+              datetime = datetimeFormatter.format((TemporalAccessor) item);
+            }
             outputTableRow.set(
-                metaData.getColumnName(i),
-                datetimeFormatter.format((TemporalAccessor) resultSet.getObject(i)));
+                metaData.getColumnName(i),datetime);
             break;
           case "timestamp":
             outputTableRow.set(

--- a/src/test/java/com/google/cloud/teleport/templates/common/JdbcConvertersTest.java
+++ b/src/test/java/com/google/cloud/teleport/templates/common/JdbcConvertersTest.java
@@ -86,13 +86,15 @@ public class JdbcConvertersTest {
     LocalDateTime datetimeObj = LocalDateTime.parse(TIMESTAMP.split("Z")[0]);
     Date dateObj = Date.valueOf(TIMESTAMP.split("T")[0]);
     Timestamp timestampObj = Timestamp.from(Instant.parse(TIMESTAMP));
+    Timestamp timestampObjAsDatetime = Timestamp.valueOf(TIMESTAMP.split("Z")[0].replace("T", " "));
 
     Mockito.when(resultSet.getObject(1)).thenReturn(datetimeObj);
     Mockito.when(resultSet.getObject(2)).thenReturn(dateObj);
     Mockito.when(resultSet.getObject(3)).thenReturn(timestampObj);
+    Mockito.when(resultSet.getObject(4)).thenReturn(timestampObjAsDatetime);
     Mockito.when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
 
-    Mockito.when(resultSetMetaData.getColumnCount()).thenReturn(3);
+    Mockito.when(resultSetMetaData.getColumnCount()).thenReturn(4);
 
     Mockito.when(resultSetMetaData.getColumnName(1)).thenReturn("datetime_column");
     Mockito.when(resultSetMetaData.getColumnTypeName(1)).thenReturn("datetime");
@@ -103,10 +105,14 @@ public class JdbcConvertersTest {
     Mockito.when(resultSetMetaData.getColumnName(3)).thenReturn("timestamp_column");
     Mockito.when(resultSetMetaData.getColumnTypeName(3)).thenReturn("timestamp");
 
+    Mockito.when(resultSetMetaData.getColumnName(4)).thenReturn("timestamp_datetime_column");
+    Mockito.when(resultSetMetaData.getColumnTypeName(4)).thenReturn("datetime");
+
     expectedTableRow = new TableRow();
     expectedTableRow.set("datetime_column", datetimeFormatter.format(datetimeObj));
     expectedTableRow.set("date_column", dateFormatter.format(dateObj));
     expectedTableRow.set("timestamp_column", timestampFormatter.format(timestampObj));
+    expectedTableRow.set("timestamp_datetime_column", timestampFormatter.format(timestampObjAsDatetime));
 
     JdbcIO.RowMapper<TableRow> resultSetConverters = JdbcConverters.getResultSetToTableRow();
     TableRow actualTableRow = resultSetConverters.mapRow(resultSet);


### PR DESCRIPTION
### Context
This PR is an extension to this https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/253.
It turned out that MySQL is not returning a `java.time.LocalDateTime` even if the column-type received with `java.sql.ResultSet.getMetaData().getColumnTypeName()` is "datetime", but instead it returns `java.sql.Timestamp`.
That leads to `java.lang.ClassCastException: class java.sql.Timestamp cannot be cast to class java.time.temporal.TemporalAccessor` as it tries to cast the result to TemporalAccessor (see [here](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/src/main/java/com/google/cloud/teleport/templates/common/JdbcConverters.java#L148)) 

I've tried multiple JDBC drivers to verify this issue, all with the same result:
* net.sourceforge.jtds.jdbc.Driver
* com.mysql.jdbc.Driver
* com.mysql.cj.jdbc.Driver
* com.microsoft.sqlserver.jdbc.SQLServerDriver

All the drivers return a java.sql.Timestamp instance when `resultSet.getObject()` is called.

I've added a simple check to avoid a ClassCastException for this particular case.

### Tests
I extended the existing tests with a related test case. Sadly i wasn't able to execute all the tests as i got connection exception from Cassandra which seems not to be able to connect to localhost somehow (i guess). So i executed test classes individually, i hope thats enough 🤞 
