### PR TITLE
fix jdbc to BigQuery datetime template

### DIFF
--- a/src/main/java/com/google/cloud/teleport/templates/common/JdbcConverters.java
+++ b/src/main/java/com/google/cloud/teleport/templates/common/JdbcConverters.java
@@ -113,9 +113,9 @@ public class JdbcConverters {
 
     static SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd");
     static DateTimeFormatter datetimeFormatter =
-        DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss.SSSSSS");
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
     static SimpleDateFormat timestampFormatter =
-        new SimpleDateFormat("yyyy-MM-dd hh:mm:ss.SSSSSSXXX");
+        new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSSSSXXX");
 
     @Override
     public TableRow mapRow(ResultSet resultSet) throws Exception {


### PR DESCRIPTION
dataflow timestamp format is wrong use HH instead of hh


please read this documents
```
   h       clock-hour-of-am-pm (1-12)  number            12
   H       hour-of-day (0-23)          number            0
```

 https://docs.oracle.com/javase/jp/8/docs/api/java/time/format/DateTimeFormatter.html



please look at after this pr because this template can not use for SQL Server
https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/371