### PR TITLE
ElasticsearchIO template improvements

### DIFF
--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
@@ -118,4 +118,9 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
   Boolean getUsePartialUpdate();
 
   void setUsePartialUpdate(Boolean usePartialUpdate);
+
+  @Description("Whether to use index (supports upsert) rather than create (errors on duplicate _id) in bulk requests")
+  Boolean getUseBulkIndexRatherThanCreate();
+
+  void setUseBulkIndexRatherThanCreate(Boolean useBulkIndexRatherThanCreate);
 }

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.v2.elasticsearch.options;
 
+import com.google.cloud.teleport.v2.elasticsearch.utils.BulkInsertMethod.BulkInsertMethodOptions;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -79,7 +80,7 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
 
   void setPropertyAsIndex(String propertyAsIndex);
 
-  @Description("GCS path to JavaScript udf source for index extraction function")
+  @Description("GCS path to JavaScript UDF source for index extraction function")
   String getJavaScriptIndexFnGCSPath();
 
   void setJavaScriptIndexFnGCSPath(String javaScriptTextTransformGCSPath);
@@ -94,7 +95,7 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
 
   void setPropertyAsId(String propertyAsId);
 
-  @Description("GCS path to JavaScript udf source for id extraction function")
+  @Description("GCS path to JavaScript UDF source for id extraction function")
   String getJavaScriptIdFnGCSPath();
 
   void setJavaScriptIdFnGCSPath(String javaScriptTextTransformGCSPath);
@@ -104,7 +105,7 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
 
   void setJavaScriptIdFnName(String javaScriptTextTransformFunctionName);
 
-  @Description("GCS path to JavaScript udf source for type extraction function")
+  @Description("GCS path to JavaScript UDF source for type extraction function")
   String getJavaScriptTypeFnGCSPath();
 
   void setJavaScriptTypeFnGCSPath(String javaScriptTextTransformGCSPath);
@@ -114,7 +115,7 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
 
   void setJavaScriptTypeFnName(String javaScriptTextTransformFunctionName);
 
-  @Description("GCS path to JavaScript udf source for deletion determination")
+  @Description("GCS path to JavaScript UDF source for deletion determination")
   String getJavaScriptIsDeleteFnGCSPath();
 
   void setJavaScriptIsDeleteFnGCSPath(String javaScriptTextTransformGCSPath);
@@ -129,8 +130,9 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
 
   void setUsePartialUpdate(Boolean usePartialUpdate);
 
-  @Description("Whether to use index (supports upsert) rather than create (errors on duplicate _id) in bulk requests")
-  Boolean getUseBulkIndexRatherThanCreate();
+  @Description("Whether to use INDEX (index, supports upsert) or CREATE (create, errors on duplicate _id) in bulk requests")
+  @Default.Enum("CREATE")
+  BulkInsertMethodOptions getBulkInsertMethod();
 
-  void setUseBulkIndexRatherThanCreate(Boolean useBulkIndexRatherThanCreate);
+  void setBulkInsertMethod(BulkInsertMethodOptions bulkInsertMethod);
 }

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
@@ -74,6 +74,11 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
 
   void setMaxRetryDuration(Long maxRetryDuration);
 
+  @Description("A property in the document being indexed whose value specifies which index to add the doc to (takes precendence over an index UDF)")
+  String getPropertyAsIndex();
+
+  void setPropertyAsIndex(String propertyAsIndex);
+
   @Description("Gcs path to javascript udf source for index extraction function")
   String getJavascriptIndexFnGcsPath();
 
@@ -83,6 +88,11 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
   String getJavascriptIndexFnName();
 
   void setJavascriptIndexFnName(String javascriptTextTransformFunctionName);
+
+  @Description("A property in the document being indexed whose value specifies which _id to use for the doc (takes precendence over an id UDF)")
+  String getPropertyAsId();
+
+  void setPropertyAsId(String propertyAsId);
 
   @Description("Gcs path to javascript udf source for id extraction function")
   String getJavascriptIdFnGcsPath();

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
@@ -75,52 +75,62 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
 
   void setMaxRetryDuration(Long maxRetryDuration);
 
-  @Description("A property in the document being indexed whose value will specify _index metadata to be included with document in bulk request (takes precendence over an index UDF)")
+  @Description(
+      "A property in the document being indexed whose value will specify _index metadata to be included with document in bulk request (takes precendence over an index UDF)")
   String getPropertyAsIndex();
 
   void setPropertyAsIndex(String propertyAsIndex);
 
-  @Description("GCS path to JavaScript UDF source for function that will specify _index metadata to be included with document in bulk request")
+  @Description(
+      "GCS path to JavaScript UDF source for function that will specify _index metadata to be included with document in bulk request")
   String getJavaScriptIndexFnGcsPath();
 
   void setJavaScriptIndexFnGcsPath(String javaScriptTextTransformGcsPath);
 
-  @Description("UDF JavaScript Function Name for function that will specify _index metadata to be included with document in bulk request")
+  @Description(
+      "UDF JavaScript Function Name for function that will specify _index metadata to be included with document in bulk request")
   String getJavaScriptIndexFnName();
 
   void setJavaScriptIndexFnName(String javaScriptTextTransformFunctionName);
 
-  @Description("A property in the document being indexed whose value will specify _id metadata to be included with document in bulk request (takes precendence over an id UDF)")
+  @Description(
+      "A property in the document being indexed whose value will specify _id metadata to be included with document in bulk request (takes precendence over an id UDF)")
   String getPropertyAsId();
 
   void setPropertyAsId(String propertyAsId);
 
-  @Description("GCS path to JavaScript UDF source for function that will specify _id metadata to be included with document in bulk request")
+  @Description(
+      "GCS path to JavaScript UDF source for function that will specify _id metadata to be included with document in bulk request")
   String getJavaScriptIdFnGcsPath();
 
   void setJavaScriptIdFnGcsPath(String javaScriptTextTransformGcsPath);
 
-  @Description("UDF JavaScript Function Name for function that will specify _id metadata to be included with document in bulk request")
+  @Description(
+      "UDF JavaScript Function Name for function that will specify _id metadata to be included with document in bulk request")
   String getJavaScriptIdFnName();
 
   void setJavaScriptIdFnName(String javaScriptTextTransformFunctionName);
 
-  @Description("GCS path to JavaScript UDF source for function that will specify _type metadata to be included with document in bulk request")
+  @Description(
+      "GCS path to JavaScript UDF source for function that will specify _type metadata to be included with document in bulk request")
   String getJavaScriptTypeFnGcsPath();
 
   void setJavaScriptTypeFnGcsPath(String javaScriptTextTransformGcsPath);
 
-  @Description("UDF JavaScript Function Name for function that will specify _type metadata to be included with document in bulk request")
+  @Description(
+      "UDF JavaScript Function Name for function that will specify _type metadata to be included with document in bulk request")
   String getJavaScriptTypeFnName();
 
   void setJavaScriptTypeFnName(String javaScriptTextTransformFunctionName);
 
-  @Description("GCS path to JavaScript UDF source for function that will determine if document should be deleted rather than inserted or updated, function should return string value \"true\" or \"false\"")
+  @Description(
+      "GCS path to JavaScript UDF source for function that will determine if document should be deleted rather than inserted or updated, function should return string value \"true\" or \"false\"")
   String getJavaScriptIsDeleteFnGcsPath();
 
   void setJavaScriptIsDeleteFnGcsPath(String javaScriptTextTransformGcsPath);
 
-  @Description("UDF JavaScript Function Name for function that will determine if document should be deleted rather than inserted or updated, function should return string value \"true\" or \"false\"")
+  @Description(
+      "UDF JavaScript Function Name for function that will determine if document should be deleted rather than inserted or updated, function should return string value \"true\" or \"false\"")
   String getJavaScriptIsDeleteFnName();
 
   void setJavaScriptIsDeleteFnName(String javaScriptTextTransformFunctionName);
@@ -130,7 +140,8 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
 
   void setUsePartialUpdate(Boolean usePartialUpdate);
 
-  @Description("Whether to use INDEX (index, supports upsert) or CREATE (create, errors on duplicate _id) in bulk requests")
+  @Description(
+      "Whether to use INDEX (index, supports upsert) or CREATE (create, errors on duplicate _id) in bulk requests")
   @Default.Enum("CREATE")
   BulkInsertMethodOptions getBulkInsertMethod();
 

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
@@ -113,4 +113,9 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
   String getJavascriptIsDeleteFnName();
 
   void setJavascriptIsDeleteFnName(String javascriptTextTransformFunctionName);
+
+  @Description("Whether to use partial updates (update type) with Elasticsearch requests")
+  Boolean getUsePartialUpdate();
+
+  void setUsePartialUpdate(Boolean usePartialUpdate);
 }

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
@@ -75,52 +75,52 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
 
   void setMaxRetryDuration(Long maxRetryDuration);
 
-  @Description("A property in the document being indexed whose value specifies which index to add the doc to (takes precendence over an index UDF)")
+  @Description("A property in the document being indexed whose value will specify _index metadata to be included with document in bulk request (takes precendence over an index UDF)")
   String getPropertyAsIndex();
 
   void setPropertyAsIndex(String propertyAsIndex);
 
-  @Description("GCS path to JavaScript UDF source for index extraction function")
-  String getJavaScriptIndexFnGCSPath();
+  @Description("GCS path to JavaScript UDF source for function that will specify _index metadata to be included with document in bulk request")
+  String getJavaScriptIndexFnGcsPath();
 
-  void setJavaScriptIndexFnGCSPath(String javaScriptTextTransformGCSPath);
+  void setJavaScriptIndexFnGcsPath(String javaScriptTextTransformGcsPath);
 
-  @Description("UDF JavaScript Function Name for index extraction")
+  @Description("UDF JavaScript Function Name for function that will specify _index metadata to be included with document in bulk request")
   String getJavaScriptIndexFnName();
 
   void setJavaScriptIndexFnName(String javaScriptTextTransformFunctionName);
 
-  @Description("A property in the document being indexed whose value specifies which _id to use for the doc (takes precendence over an id UDF)")
+  @Description("A property in the document being indexed whose value will specify _id metadata to be included with document in bulk request (takes precendence over an id UDF)")
   String getPropertyAsId();
 
   void setPropertyAsId(String propertyAsId);
 
-  @Description("GCS path to JavaScript UDF source for id extraction function")
-  String getJavaScriptIdFnGCSPath();
+  @Description("GCS path to JavaScript UDF source for function that will specify _id metadata to be included with document in bulk request")
+  String getJavaScriptIdFnGcsPath();
 
-  void setJavaScriptIdFnGCSPath(String javaScriptTextTransformGCSPath);
+  void setJavaScriptIdFnGcsPath(String javaScriptTextTransformGcsPath);
 
-  @Description("UDF JavaScript Function Name for id extraction")
+  @Description("UDF JavaScript Function Name for function that will specify _id metadata to be included with document in bulk request")
   String getJavaScriptIdFnName();
 
   void setJavaScriptIdFnName(String javaScriptTextTransformFunctionName);
 
-  @Description("GCS path to JavaScript UDF source for type extraction function")
-  String getJavaScriptTypeFnGCSPath();
+  @Description("GCS path to JavaScript UDF source for function that will specify _type metadata to be included with document in bulk request")
+  String getJavaScriptTypeFnGcsPath();
 
-  void setJavaScriptTypeFnGCSPath(String javaScriptTextTransformGCSPath);
+  void setJavaScriptTypeFnGcsPath(String javaScriptTextTransformGcsPath);
 
-  @Description("UDF JavaScript Function Name for type extraction")
+  @Description("UDF JavaScript Function Name for function that will specify _type metadata to be included with document in bulk request")
   String getJavaScriptTypeFnName();
 
   void setJavaScriptTypeFnName(String javaScriptTextTransformFunctionName);
 
-  @Description("GCS path to JavaScript UDF source for deletion determination")
-  String getJavaScriptIsDeleteFnGCSPath();
+  @Description("GCS path to JavaScript UDF source for function that will determine if document should be deleted rather than inserted or updated, function should return string value \"true\" or \"false\"")
+  String getJavaScriptIsDeleteFnGcsPath();
 
-  void setJavaScriptIsDeleteFnGCSPath(String javaScriptTextTransformGCSPath);
+  void setJavaScriptIsDeleteFnGcsPath(String javaScriptTextTransformGcsPath);
 
-  @Description("UDF JavaScript Function Name for deletion determination")
+  @Description("UDF JavaScript Function Name for function that will determine if document should be deleted rather than inserted or updated, function should return string value \"true\" or \"false\"")
   String getJavaScriptIsDeleteFnName();
 
   void setJavaScriptIsDeleteFnName(String javaScriptTextTransformFunctionName);

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
@@ -79,50 +79,50 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
 
   void setPropertyAsIndex(String propertyAsIndex);
 
-  @Description("Gcs path to javascript udf source for index extraction function")
-  String getJavascriptIndexFnGcsPath();
+  @Description("GCS path to JavaScript udf source for index extraction function")
+  String getJavaScriptIndexFnGCSPath();
 
-  void setJavascriptIndexFnGcsPath(String javascriptTextTransformGcsPath);
+  void setJavaScriptIndexFnGCSPath(String javaScriptTextTransformGCSPath);
 
-  @Description("UDF Javascript Function Name for index extraction")
-  String getJavascriptIndexFnName();
+  @Description("UDF JavaScript Function Name for index extraction")
+  String getJavaScriptIndexFnName();
 
-  void setJavascriptIndexFnName(String javascriptTextTransformFunctionName);
+  void setJavaScriptIndexFnName(String javaScriptTextTransformFunctionName);
 
   @Description("A property in the document being indexed whose value specifies which _id to use for the doc (takes precendence over an id UDF)")
   String getPropertyAsId();
 
   void setPropertyAsId(String propertyAsId);
 
-  @Description("Gcs path to javascript udf source for id extraction function")
-  String getJavascriptIdFnGcsPath();
+  @Description("GCS path to JavaScript udf source for id extraction function")
+  String getJavaScriptIdFnGCSPath();
 
-  void setJavascriptIdFnGcsPath(String javascriptTextTransformGcsPath);
+  void setJavaScriptIdFnGCSPath(String javaScriptTextTransformGCSPath);
 
-  @Description("UDF Javascript Function Name for id extraction")
-  String getJavascriptIdFnName();
+  @Description("UDF JavaScript Function Name for id extraction")
+  String getJavaScriptIdFnName();
 
-  void setJavascriptIdFnName(String javascriptTextTransformFunctionName);
+  void setJavaScriptIdFnName(String javaScriptTextTransformFunctionName);
 
-  @Description("Gcs path to javascript udf source for type extraction function")
-  String getJavascriptTypeFnGcsPath();
+  @Description("GCS path to JavaScript udf source for type extraction function")
+  String getJavaScriptTypeFnGCSPath();
 
-  void setJavascriptTypeFnGcsPath(String javascriptTextTransformGcsPath);
+  void setJavaScriptTypeFnGCSPath(String javaScriptTextTransformGCSPath);
 
-  @Description("UDF Javascript Function Name for type extraction")
-  String getJavascriptTypeFnName();
+  @Description("UDF JavaScript Function Name for type extraction")
+  String getJavaScriptTypeFnName();
 
-  void setJavascriptTypeFnName(String javascriptTextTransformFunctionName);
+  void setJavaScriptTypeFnName(String javaScriptTextTransformFunctionName);
 
-  @Description("Gcs path to javascript udf source for deletion determination")
-  String getJavascriptIsDeleteFnGcsPath();
+  @Description("GCS path to JavaScript udf source for deletion determination")
+  String getJavaScriptIsDeleteFnGCSPath();
 
-  void setJavascriptIsDeleteFnGcsPath(String javascriptTextTransformGcsPath);
+  void setJavaScriptIsDeleteFnGCSPath(String javaScriptTextTransformGCSPath);
 
-  @Description("UDF Javascript Function Name for deletion determination")
-  String getJavascriptIsDeleteFnName();
+  @Description("UDF JavaScript Function Name for deletion determination")
+  String getJavaScriptIsDeleteFnName();
 
-  void setJavascriptIsDeleteFnName(String javascriptTextTransformFunctionName);
+  void setJavaScriptIsDeleteFnName(String javaScriptTextTransformFunctionName);
 
   @Description("Whether to use partial updates (update type) with Elasticsearch requests")
   Boolean getUsePartialUpdate();

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
@@ -73,4 +73,44 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
   Long getMaxRetryDuration();
 
   void setMaxRetryDuration(Long maxRetryDuration);
+
+  @Description("Gcs path to javascript udf source for index extraction function")
+  String getJavascriptIndexFnGcsPath();
+
+  void setJavascriptIndexFnGcsPath(String javascriptTextTransformGcsPath);
+
+  @Description("UDF Javascript Function Name for index extraction")
+  String getJavascriptIndexFnName();
+
+  void setJavascriptIndexFnName(String javascriptTextTransformFunctionName);
+
+  @Description("Gcs path to javascript udf source for id extraction function")
+  String getJavascriptIdFnGcsPath();
+
+  void setJavascriptIdFnGcsPath(String javascriptTextTransformGcsPath);
+
+  @Description("UDF Javascript Function Name for id extraction")
+  String getJavascriptIdFnName();
+
+  void setJavascriptIdFnName(String javascriptTextTransformFunctionName);
+
+  @Description("Gcs path to javascript udf source for type extraction function")
+  String getJavascriptTypeFnGcsPath();
+
+  void setJavascriptTypeFnGcsPath(String javascriptTextTransformGcsPath);
+
+  @Description("UDF Javascript Function Name for type extraction")
+  String getJavascriptTypeFnName();
+
+  void setJavascriptTypeFnName(String javascriptTextTransformFunctionName);
+
+  @Description("Gcs path to javascript udf source for deletion determination")
+  String getJavascriptIsDeleteFnGcsPath();
+
+  void setJavascriptIsDeleteFnGcsPath(String javascriptTextTransformGcsPath);
+
+  @Description("UDF Javascript Function Name for deletion determination")
+  String getJavascriptIsDeleteFnName();
+
+  void setJavascriptIsDeleteFnName(String javascriptTextTransformFunctionName);
 }

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/ValueExtractorTransform.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/ValueExtractorTransform.java
@@ -37,9 +37,7 @@ import javax.script.ScriptException;
  */
 public class ValueExtractorTransform {
 
-  /**
-   * Base Class for routing functions that implements {@link FieldValueExtractFn}.
-   */
+  /** Base Class for routing functions that implements {@link FieldValueExtractFn}. */
   public abstract static class ValueExtractorFn {
     @Nullable
     abstract String functionName();

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
@@ -19,6 +19,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 
 import com.google.auto.value.AutoValue;
 import com.google.cloud.teleport.v2.elasticsearch.options.ElasticsearchWriteOptions;
+import com.google.cloud.teleport.v2.elasticsearch.transforms.ValueExtractorTransform.ValueExtractorFn;
 import com.google.cloud.teleport.v2.elasticsearch.utils.ConnectionInformation;
 import com.google.cloud.teleport.v2.elasticsearch.utils.ElasticsearchIO;
 import java.util.Optional;
@@ -95,6 +96,42 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
             .withConnectionConfiguration(config)
             .withMaxBatchSize(options().getBatchSize())
             .withMaxBatchSizeBytes(options().getBatchSizeBytes());
+    
+    if (options().getJavascriptIdFnGcsPath() != null && options().getJavascriptIdFnName() != null){
+      ValueExtractorFn idFn = ValueExtractorFn.newBuilder()
+      .setFileSystemPath(options().getJavascriptIdFnGcsPath())
+      .setFunctionName(options().getJavascriptIdFnName())
+      .build();
+
+      elasticsearchWriter.withIdFn(idFn);
+    }
+
+    if (options().getJavascriptIndexFnGcsPath() != null && options().getJavascriptIndexFnName() != null){
+      ValueExtractorFn indexFn = ValueExtractorFn.newBuilder()
+      .setFileSystemPath(options().getJavascriptIndexFnGcsPath())
+      .setFunctionName(options().getJavascriptIndexFnName())
+      .build();
+
+      elasticsearchWriter.withIndexFn(indexFn);
+    }
+
+    if (options().getJavascriptTypeFnGcsPath() != null && options().getJavascriptTypeFnName() != null){
+      ValueExtractorFn typeFn = ValueExtractorFn.newBuilder()
+      .setFileSystemPath(options().getJavascriptTypeFnGcsPath())
+      .setFunctionName(options().getJavascriptTypeFnName())
+      .build();
+
+      elasticsearchWriter.withTypeFn(typeFn);
+    }
+
+    if (options().getJavascriptIsDeleteFnGcsPath() != null && options().getJavascriptIsDeleteFnName() != null){
+      ValueExtractorFn isDeleteFn = ValueExtractorFn.newBuilder()
+        .setFileSystemPath(options().getJavascriptIsDeleteFnGcsPath())
+        .setFunctionName(options().getJavascriptIsDeleteFnName())
+        .build();
+
+      elasticsearchWriter.withIsDeleteFn(isDeleteFn);
+    }
 
     if (Optional.ofNullable(options().getMaxRetryAttempts()).isPresent()) {
       elasticsearchWriter.withRetryConfiguration(

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
@@ -57,8 +57,8 @@ import org.joda.time.Duration;
 public abstract class WriteToElasticsearch extends PTransform<PCollection<String>, PDone> {
 
   /**
-   * The {@link StringFieldValueExtractFn} class is a class implementation for {@link FieldValueExtractFn} 
-   * to extract a property by name.
+   * The {@link StringFieldValueExtractFn} class is a class implementation for {@link
+   * FieldValueExtractFn} to extract a property by name.
    */
   @AutoValue
   abstract static class StringFieldValueExtractFn implements FieldValueExtractFn {
@@ -136,9 +136,10 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
           StringFieldValueExtractFn.newBuilder()
               .setPropertyName(options().getPropertyAsId())
               .build();
-    
+
       elasticsearchWriter = elasticsearchWriter.withIdFn(idFn);
-    } else if (options().getJavaScriptIdFnGcsPath() != null && options().getJavaScriptIdFnName() != null) {
+    } else if (options().getJavaScriptIdFnGcsPath() != null
+        && options().getJavaScriptIdFnName() != null) {
       StringValueExtractorFn idFn =
           StringValueExtractorFn.newBuilder()
               .setFileSystemPath(options().getJavaScriptIdFnGcsPath())
@@ -196,8 +197,7 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
 
     if (options().getBulkInsertMethod() != null) {
       elasticsearchWriter =
-          elasticsearchWriter.withBulkInsertMethod(
-              options().getBulkInsertMethod());
+          elasticsearchWriter.withBulkInsertMethod(options().getBulkInsertMethod());
     }
 
     if (Optional.ofNullable(options().getMaxRetryAttempts()).isPresent()) {

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
@@ -20,7 +20,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import com.google.auto.value.AutoValue;
 import com.google.cloud.teleport.v2.elasticsearch.options.ElasticsearchWriteOptions;
 import com.google.cloud.teleport.v2.elasticsearch.transforms.ValueExtractorTransform.BooleanValueExtractorFn;
-import com.google.cloud.teleport.v2.elasticsearch.transforms.ValueExtractorTransform.ValueExtractorFn;
+import com.google.cloud.teleport.v2.elasticsearch.transforms.ValueExtractorTransform.StringValueExtractorFn;
 import com.google.cloud.teleport.v2.elasticsearch.utils.ConnectionInformation;
 import com.google.cloud.teleport.v2.elasticsearch.utils.ElasticsearchIO;
 import java.util.Optional;
@@ -99,8 +99,8 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
             .withMaxBatchSizeBytes(options().getBatchSizeBytes());
 
     if (options().getJavascriptIdFnGcsPath() != null && options().getJavascriptIdFnName() != null) {
-      ValueExtractorFn idFn =
-          ValueExtractorFn.newBuilder()
+      StringValueExtractorFn idFn =
+          StringValueExtractorFn.newBuilder()
               .setFileSystemPath(options().getJavascriptIdFnGcsPath())
               .setFunctionName(options().getJavascriptIdFnName())
               .build();
@@ -110,8 +110,8 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
 
     if (options().getJavascriptIndexFnGcsPath() != null
         && options().getJavascriptIndexFnName() != null) {
-      ValueExtractorFn indexFn =
-          ValueExtractorFn.newBuilder()
+      StringValueExtractorFn indexFn =
+          StringValueExtractorFn.newBuilder()
               .setFileSystemPath(options().getJavascriptIndexFnGcsPath())
               .setFunctionName(options().getJavascriptIndexFnName())
               .build();
@@ -121,8 +121,8 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
 
     if (options().getJavascriptTypeFnGcsPath() != null
         && options().getJavascriptTypeFnName() != null) {
-      ValueExtractorFn typeFn =
-          ValueExtractorFn.newBuilder()
+      StringValueExtractorFn typeFn =
+          StringValueExtractorFn.newBuilder()
               .setFileSystemPath(options().getJavascriptTypeFnGcsPath())
               .setFunctionName(options().getJavascriptTypeFnName())
               .build();
@@ -145,6 +145,12 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
       elasticsearchWriter =
           elasticsearchWriter.withUsePartialUpdate(
               Boolean.TRUE.equals(options().getUsePartialUpdate()));
+    }
+
+    if (options().getUseBulkIndexRatherThanCreate() != null) {
+      elasticsearchWriter =
+          elasticsearchWriter.withUseBulkIndexRatherThanCreate(
+              Boolean.TRUE.equals(options().getUseBulkIndexRatherThanCreate()));
     }
 
     if (Optional.ofNullable(options().getMaxRetryAttempts()).isPresent()) {

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
@@ -109,11 +109,11 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
         }
       };
       elasticsearchWriter = elasticsearchWriter.withIdFn(idFn);
-    } else if (options().getJavascriptIdFnGcsPath() != null && options().getJavascriptIdFnName() != null) {
+    } else if (options().getJavaScriptIdFnGcsPath() != null && options().getJavaScriptIdFnName() != null) {
       StringValueExtractorFn idFn =
           StringValueExtractorFn.newBuilder()
-              .setFileSystemPath(options().getJavascriptIdFnGcsPath())
-              .setFunctionName(options().getJavascriptIdFnName())
+              .setFileSystemPath(options().getJavaScriptIdFnGcsPath())
+              .setFunctionName(options().getJavaScriptIdFnName())
               .build();
 
       elasticsearchWriter = elasticsearchWriter.withIdFn(idFn);
@@ -128,34 +128,34 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
         }
       };
       elasticsearchWriter = elasticsearchWriter.withIdFn(indexFn);
-    } else if (options().getJavascriptIndexFnGcsPath() != null
-        && options().getJavascriptIndexFnName() != null) {
+    } else if (options().getJavaScriptIndexFnGcsPath() != null
+        && options().getJavaScriptIndexFnName() != null) {
       StringValueExtractorFn indexFn =
           StringValueExtractorFn.newBuilder()
-              .setFileSystemPath(options().getJavascriptIndexFnGcsPath())
-              .setFunctionName(options().getJavascriptIndexFnName())
+              .setFileSystemPath(options().getJavaScriptIndexFnGcsPath())
+              .setFunctionName(options().getJavaScriptIndexFnName())
               .build();
 
       elasticsearchWriter = elasticsearchWriter.withIndexFn(indexFn);
     }
 
-    if (options().getJavascriptTypeFnGcsPath() != null
-        && options().getJavascriptTypeFnName() != null) {
+    if (options().getJavaScriptTypeFnGcsPath() != null
+        && options().getJavaScriptTypeFnName() != null) {
       StringValueExtractorFn typeFn =
           StringValueExtractorFn.newBuilder()
-              .setFileSystemPath(options().getJavascriptTypeFnGcsPath())
-              .setFunctionName(options().getJavascriptTypeFnName())
+              .setFileSystemPath(options().getJavaScriptTypeFnGcsPath())
+              .setFunctionName(options().getJavaScriptTypeFnName())
               .build();
 
       elasticsearchWriter = elasticsearchWriter.withTypeFn(typeFn);
     }
 
-    if (options().getJavascriptIsDeleteFnGcsPath() != null
-        && options().getJavascriptIsDeleteFnName() != null) {
+    if (options().getJavaScriptIsDeleteFnGcsPath() != null
+        && options().getJavaScriptIsDeleteFnName() != null) {
       BooleanValueExtractorFn isDeleteFn =
           BooleanValueExtractorFn.newBuilder()
-              .setFileSystemPath(options().getJavascriptIsDeleteFnGcsPath())
-              .setFunctionName(options().getJavascriptIsDeleteFnName())
+              .setFileSystemPath(options().getJavaScriptIsDeleteFnGcsPath())
+              .setFunctionName(options().getJavaScriptIsDeleteFnName())
               .build();
 
       elasticsearchWriter = elasticsearchWriter.withIsDeleteFn(isDeleteFn);

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
@@ -138,10 +138,10 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
               .build();
     
       elasticsearchWriter = elasticsearchWriter.withIdFn(idFn);
-    } else if (options().getJavaScriptIdFnGCSPath() != null && options().getJavaScriptIdFnName() != null) {
+    } else if (options().getJavaScriptIdFnGcsPath() != null && options().getJavaScriptIdFnName() != null) {
       StringValueExtractorFn idFn =
           StringValueExtractorFn.newBuilder()
-              .setFileSystemPath(options().getJavaScriptIdFnGCSPath())
+              .setFileSystemPath(options().getJavaScriptIdFnGcsPath())
               .setFunctionName(options().getJavaScriptIdFnName())
               .build();
 
@@ -154,34 +154,34 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
               .setPropertyName(options().getPropertyAsIndex())
               .build();
 
-      elasticsearchWriter = elasticsearchWriter.withIdFn(indexFn);
-    } else if (options().getJavaScriptIdFnGCSPath() != null
+      elasticsearchWriter = elasticsearchWriter.withIndexFn(indexFn);
+    } else if (options().getJavaScriptIndexFnGcsPath() != null
         && options().getJavaScriptIndexFnName() != null) {
       StringValueExtractorFn indexFn =
           StringValueExtractorFn.newBuilder()
-              .setFileSystemPath(options().getJavaScriptIdFnGCSPath())
+              .setFileSystemPath(options().getJavaScriptIndexFnGcsPath())
               .setFunctionName(options().getJavaScriptIndexFnName())
               .build();
 
       elasticsearchWriter = elasticsearchWriter.withIndexFn(indexFn);
     }
 
-    if (options().getJavaScriptTypeFnGCSPath() != null
+    if (options().getJavaScriptTypeFnGcsPath() != null
         && options().getJavaScriptTypeFnName() != null) {
       StringValueExtractorFn typeFn =
           StringValueExtractorFn.newBuilder()
-              .setFileSystemPath(options().getJavaScriptTypeFnGCSPath())
+              .setFileSystemPath(options().getJavaScriptTypeFnGcsPath())
               .setFunctionName(options().getJavaScriptTypeFnName())
               .build();
 
       elasticsearchWriter = elasticsearchWriter.withTypeFn(typeFn);
     }
 
-    if (options().getJavaScriptIsDeleteFnGCSPath() != null
+    if (options().getJavaScriptIsDeleteFnGcsPath() != null
         && options().getJavaScriptIsDeleteFnName() != null) {
       BooleanValueExtractorFn isDeleteFn =
           BooleanValueExtractorFn.newBuilder()
-              .setFileSystemPath(options().getJavaScriptIsDeleteFnGCSPath())
+              .setFileSystemPath(options().getJavaScriptIsDeleteFnGcsPath())
               .setFunctionName(options().getJavaScriptIsDeleteFnName())
               .build();
 

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
@@ -166,22 +166,22 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
       elasticsearchWriter = elasticsearchWriter.withIndexFn(indexFn);
     }
 
-    if (options().getJavaScriptTypeFnGcsPath() != null
+    if (options().getJavaScriptTypeFnGCSPath() != null
         && options().getJavaScriptTypeFnName() != null) {
       StringValueExtractorFn typeFn =
           StringValueExtractorFn.newBuilder()
-              .setFileSystemPath(options().getJavaScriptTypeFnGcsPath())
+              .setFileSystemPath(options().getJavaScriptTypeFnGCSPath())
               .setFunctionName(options().getJavaScriptTypeFnName())
               .build();
 
       elasticsearchWriter = elasticsearchWriter.withTypeFn(typeFn);
     }
 
-    if (options().getJavaScriptIsDeleteFnGcsPath() != null
+    if (options().getJavaScriptIsDeleteFnGCSPath() != null
         && options().getJavaScriptIsDeleteFnName() != null) {
       BooleanValueExtractorFn isDeleteFn =
           BooleanValueExtractorFn.newBuilder()
-              .setFileSystemPath(options().getJavaScriptIsDeleteFnGcsPath())
+              .setFileSystemPath(options().getJavaScriptIsDeleteFnGCSPath())
               .setFunctionName(options().getJavaScriptIsDeleteFnName())
               .build();
 

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
@@ -25,8 +25,8 @@ import com.google.cloud.teleport.v2.elasticsearch.transforms.ValueExtractorTrans
 import com.google.cloud.teleport.v2.elasticsearch.utils.ConnectionInformation;
 import com.google.cloud.teleport.v2.elasticsearch.utils.ElasticsearchIO;
 import com.google.cloud.teleport.v2.elasticsearch.utils.ElasticsearchIO.Write.FieldValueExtractFn;
-import javax.annotation.Nullable;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
@@ -61,7 +61,7 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
    * to extract a property by name.
    */
   @AutoValue
-  static abstract class StringFieldValueExtractFn implements FieldValueExtractFn {
+  abstract static class StringFieldValueExtractFn implements FieldValueExtractFn {
 
     @Nullable
     abstract String propertyName();

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
@@ -138,10 +138,10 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
               .build();
     
       elasticsearchWriter = elasticsearchWriter.withIdFn(idFn);
-    } else if (options().getJavaScriptIdFnGcsPath() != null && options().getJavaScriptIdFnName() != null) {
+    } else if (options().getJavaScriptIdFnGCSPath() != null && options().getJavaScriptIdFnName() != null) {
       StringValueExtractorFn idFn =
           StringValueExtractorFn.newBuilder()
-              .setFileSystemPath(options().getJavaScriptIdFnGcsPath())
+              .setFileSystemPath(options().getJavaScriptIdFnGCSPath())
               .setFunctionName(options().getJavaScriptIdFnName())
               .build();
 
@@ -155,11 +155,11 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
               .build();
 
       elasticsearchWriter = elasticsearchWriter.withIdFn(indexFn);
-    } else if (options().getJavaScriptIndexFnGcsPath() != null
+    } else if (options().getJavaScriptIdFnGCSPath() != null
         && options().getJavaScriptIndexFnName() != null) {
       StringValueExtractorFn indexFn =
           StringValueExtractorFn.newBuilder()
-              .setFileSystemPath(options().getJavaScriptIndexFnGcsPath())
+              .setFileSystemPath(options().getJavaScriptIdFnGCSPath())
               .setFunctionName(options().getJavaScriptIndexFnName())
               .build();
 

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/BulkInsertMethod.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/BulkInsertMethod.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.elasticsearch.utils;
+
+/** Exposes BulkInsertMethodOptions. */
+public class BulkInsertMethod {
+  /** Possible bulk request document add options for Elasticsearch templates. */
+  public enum BulkInsertMethodOptions {
+    CREATE,
+    INDEX
+  }
+}

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
@@ -183,6 +183,7 @@ public class ElasticsearchIO {
         // advised default starting batch size in ES docs
         .setMaxBatchSizeBytes(5L * 1024L * 1024L)
         .setUsePartialUpdate(false) // default is document upsert
+        .setUseBulkIndexRatherThanCreate(false) // default to create (error on duplicate _id)
         .build();
   }
 
@@ -1252,7 +1253,7 @@ public class ElasticsearchIO {
 
     /**
      * Provide an instruction to control whether bulk requests use index (allows upserts) or 
-     * create (errors on duplicate _id)
+     * create (errors on duplicate _id).
      *
      * @param useBulkIndexRatherThanCreate set to true to use index rather than create
      * @return the {@link Write} with the index or create control set

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
@@ -1452,7 +1452,8 @@ public class ElasticsearchIO {
                     "{ \"update\" : %s }%n{ \"doc\" : %s, \"doc_as_upsert\" : true }%n",
                     documentMetadata, document));
           } else {
-            batch.add(String.format("{ \"create\" : %s }%n%s%n", documentMetadata, document));
+            // switch from create to index to allow upsert (beneficial in case of duplication due to timeout/retry)
+            batch.add(String.format("{ \"index\" : %s }%n%s%n", documentMetadata, document));
           }
         }
 

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
@@ -184,7 +184,8 @@ public class ElasticsearchIO {
         // advised default starting batch size in ES docs
         .setMaxBatchSizeBytes(5L * 1024L * 1024L)
         .setUsePartialUpdate(false) // default is document upsert
-        .setBulkInsertMethod(BulkInsertMethodOptions.CREATE) // default to create (error on duplicate _id)
+        .setBulkInsertMethod(
+            BulkInsertMethodOptions.CREATE) // default to create (error on duplicate _id)
         .build();
   }
 
@@ -1253,8 +1254,8 @@ public class ElasticsearchIO {
     }
 
     /**
-     * Provide an instruction to control whether bulk requests use index (allows upserts) or 
-     * create (errors on duplicate _id).
+     * Provide an instruction to control whether bulk requests use index (allows upserts) or create
+     * (errors on duplicate _id).
      *
      * @param bulkInsertMethod set to INDEX to use index or CREATE to use create
      * @return the {@link Write} with the index or create control set
@@ -1478,7 +1479,7 @@ public class ElasticsearchIO {
             } else {
               // create will error if document with same _id already exists
               batch.add(String.format("{ \"create\" : %s }%n%s%n", documentMetadata, document));
-            }            
+            }
           }
         }
 

--- a/v2/elasticsearch-common/src/test/java/com/google/cloud/teleport/v2/elasticsearch/transforms/ValueExtractorTransformTest.java
+++ b/v2/elasticsearch-common/src/test/java/com/google/cloud/teleport/v2/elasticsearch/transforms/ValueExtractorTransformTest.java
@@ -47,7 +47,7 @@ public class ValueExtractorTransformTest {
     JsonNode jsonNode = objectMapper.readTree(stringifiedJsonRecord);
 
     String result =
-        ValueExtractorTransform.ValueExtractorFn.newBuilder()
+        ValueExtractorTransform.StringValueExtractorFn.newBuilder()
             .setFileSystemPath(TRANSFORM_FILE_PATH)
             .setFunctionName("transform")
             .build()
@@ -73,7 +73,7 @@ public class ValueExtractorTransformTest {
     JsonNode jsonNode = objectMapper.readTree(stringifiedJsonRecord);
 
     String result =
-        ValueExtractorTransform.ValueExtractorFn.newBuilder()
+        ValueExtractorTransform.StringValueExtractorFn.newBuilder()
             .setFileSystemPath(null)
             .setFunctionName(null)
             .build()
@@ -99,7 +99,7 @@ public class ValueExtractorTransformTest {
     JsonNode jsonNode = objectMapper.readTree(stringifiedJsonRecord);
 
     String result =
-        ValueExtractorTransform.ValueExtractorFn.newBuilder()
+        ValueExtractorTransform.StringValueExtractorFn.newBuilder()
             .setFileSystemPath(null)
             .setFunctionName("transform")
             .build()
@@ -123,7 +123,7 @@ public class ValueExtractorTransformTest {
     JsonNode jsonNode = objectMapper.readTree(stringifiedJsonRecord);
 
     String result =
-        ValueExtractorTransform.ValueExtractorFn.newBuilder()
+        ValueExtractorTransform.StringValueExtractorFn.newBuilder()
             .setFileSystemPath(TRANSFORM_FILE_PATH)
             .setFunctionName(null)
             .build()

--- a/v2/googlecloud-to-elasticsearch/docs/BigQueryToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/BigQueryToElasticsearch/README.md
@@ -141,56 +141,70 @@ echo '{
               "isOptional":true
           },
           {
-              "name":"JavaScriptIndexFnGCSPath",
+              "name":"propertyAsIndex",
+              "label":"Document property used to specify index",
+              "helpText":"A property in the document being indexed whose value specifies which index to add the doc to (takes precendence over an index UDF)",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIndexFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract index name from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptIndexFnName",
+              "name":"javascriptIndexFnName",
               "label":"UDF JavaScript Function Name for function to extract index name from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptIdFnGCSPath",
+              "name":"propertyAsId",
+              "label":"Document property used to specify _id",
+              "helpText":"A property in the document being indexed whose value specifies which _id to use for the doc (takes precendence over an id UDF)",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIdFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract id value from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptIdFnName",
+              "name":"javascriptIdFnName",
               "label":"UDF JavaScript Function Name for function to extract id value from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptTypeFnGCSPath",
+              "name":"javascriptTypeFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract type value from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptTypeFnName",
+              "name":"javascriptTypeFnName",
               "label":"UDF JavaScript Function Name for function to extract type value from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptIsDeleteFnGCSPath",
+              "name":"javascriptIsDeleteFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract whether operation is delete or not from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptIsDeleteFnName",
+              "name":"javascriptIsDeleteFnName",
               "label":"UDF JavaScript Function Name for function to extract whether operation is delete or not from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
@@ -243,14 +257,16 @@ The template has the following optional parameters:
 * batchSizeBytes: Batch size in number of bytes. Default: 5242880 (5mb)
 * maxRetryAttempts: Max retry attempts, must be > 0. Default: no retries
 * maxRetryDuration: Max retry duration in milliseconds, must be > 0. Default: no retries
-* JavaScriptIndexFnGCSPath: GCS path of storage location for JavaScript UDF to extract _index from row data
-* JavaScriptIndexFnName: Function name for JavaScript UDF to extract _index from row data
-* JavaScriptIdFnGCSPath: GCS path of storage location for JavaScript UDF to extract _id from row data
-* JavaScriptIdFnName: Function name for JavaScript UDF to extract _id from row data
-* JavaScriptTypeFnGCSPath: GCS path of storage location for JavaScript UDF to extract _type from row data
-* JavaScriptTypeFnName: Function name for JavaScript UDF to extract _type from row data
-* JavaScriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
-* JavaScriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* propertyAsIndex: A property in the document being indexed whose value specifies which _index to add the doc to (takes precendence over an index UDF)
+* javascriptIndexFnGCSPath: GCS path of storage location for JavaScript UDF to extract _index from row data
+* javascriptIndexFnName: Function name for JavaScript UDF to extract _index from row data
+* propertyAsId: A property in the document being indexed whose value specifies which _id to use for the doc (takes precendence over an id UDF)
+* javascriptIdFnGCSPath: GCS path of storage location for JavaScript UDF to extract _id from row data
+* javascriptIdFnName: Function name for JavaScript UDF to extract _id from row data
+* javascriptTypeFnGCSPath: GCS path of storage location for JavaScript UDF to extract _type from row data
+* javascriptTypeFnName: Function name for JavaScript UDF to extract _type from row data
+* javascriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* javascriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
 * usePartialUpdate:  Whether to use partial document updates (update rather than create or index, allows partial document updates)
 * useBulkIndexRatherThanCreate: Whether to use index (allows upserts) rather than create (errors on duplicate _id) with Elasticsearch bulk requests
 

--- a/v2/googlecloud-to-elasticsearch/docs/BigQueryToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/BigQueryToElasticsearch/README.md
@@ -148,14 +148,14 @@ echo '{
               "isOptional":true
           },
           {
-              "name":"javascriptIndexFnGCSPath",
+              "name":"javaScriptIndexFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract index name from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIndexFnName",
+              "name":"javaScriptIndexFnName",
               "label":"UDF JavaScript Function Name for function to extract index name from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
@@ -169,42 +169,42 @@ echo '{
               "isOptional":true
           },
           {
-              "name":"javascriptIdFnGCSPath",
+              "name":"javaScriptIdFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract id value from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIdFnName",
+              "name":"javaScriptIdFnName",
               "label":"UDF JavaScript Function Name for function to extract id value from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptTypeFnGCSPath",
+              "name":"javaScriptTypeFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract type value from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptTypeFnName",
+              "name":"javaScriptTypeFnName",
               "label":"UDF JavaScript Function Name for function to extract type value from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIsDeleteFnGCSPath",
+              "name":"javaScriptIsDeleteFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract whether operation is delete or not from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIsDeleteFnName",
+              "name":"javaScriptIsDeleteFnName",
               "label":"UDF JavaScript Function Name for function to extract whether operation is delete or not from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
@@ -258,15 +258,15 @@ The template has the following optional parameters:
 * maxRetryAttempts: Max retry attempts, must be > 0. Default: no retries
 * maxRetryDuration: Max retry duration in milliseconds, must be > 0. Default: no retries
 * propertyAsIndex: A property in the document being indexed whose value specifies which _index to add the doc to (takes precendence over an index UDF)
-* javascriptIndexFnGCSPath: GCS path of storage location for JavaScript UDF to extract _index from row data
-* javascriptIndexFnName: Function name for JavaScript UDF to extract _index from row data
+* javaScriptIndexFnGCSPath: GCS path of storage location for JavaScript UDF to extract _index from row data
+* javaScriptIndexFnName: Function name for JavaScript UDF to extract _index from row data
 * propertyAsId: A property in the document being indexed whose value specifies which _id to use for the doc (takes precendence over an id UDF)
-* javascriptIdFnGCSPath: GCS path of storage location for JavaScript UDF to extract _id from row data
-* javascriptIdFnName: Function name for JavaScript UDF to extract _id from row data
-* javascriptTypeFnGCSPath: GCS path of storage location for JavaScript UDF to extract _type from row data
-* javascriptTypeFnName: Function name for JavaScript UDF to extract _type from row data
-* javascriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
-* javascriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* javaScriptIdFnGCSPath: GCS path of storage location for JavaScript UDF to extract _id from row data
+* javaScriptIdFnName: Function name for JavaScript UDF to extract _id from row data
+* javaScriptTypeFnGCSPath: GCS path of storage location for JavaScript UDF to extract _type from row data
+* javaScriptTypeFnName: Function name for JavaScript UDF to extract _type from row data
+* javaScriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* javaScriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
 * usePartialUpdate:  Whether to use partial document updates (update rather than create or index, allows partial document updates)
 * useBulkIndexRatherThanCreate: Whether to use index (allows upserts) rather than create (errors on duplicate _id) with Elasticsearch bulk requests
 

--- a/v2/googlecloud-to-elasticsearch/docs/BigQueryToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/BigQueryToElasticsearch/README.md
@@ -68,7 +68,7 @@ echo '{
               "label":"Table in BigQuery to read from",
               "helpText":"Table in BigQuery to read from in form of: my-project:my-dataset.my-table. Either this or query must be provided.",
               "paramType":"TEXT",
-              "isOptional":false
+              "isOptional":true
           },
           {
               "name":"connectionUrl",
@@ -90,6 +90,13 @@ echo '{
               "helpText":"Password for Elasticsearch endpoint",
               "paramType":"TEXT",
               "isOptional":false
+          },
+          {
+            "name":"apiKey",
+            "label":"Elasticsearch apiKey",
+            "helpText":"API key for access without requiring basic authentication.",
+            "paramType":"TEXT",
+            "isOptional":false
           },
           {
               "name":"index",
@@ -247,6 +254,7 @@ The template requires the following parameters:
 * index: The index toward which the requests will be issued, ex: my-index
 * elasticsearchUsername: Elasticsearch username used to connect to Elasticsearch endpoint
 * elasticsearchPassword: Elasticsearch password used to connect to Elasticsearch endpoint
+* apiKey: Base64 Encoded API Key for access without requiring basic authentication. Refer  https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html#security-api-create-api-key-request.
 
 The template has the following optional parameters:
 * useLegacySql: Set to true to use legacy SQL (only applicable if supplying query). Default: false

--- a/v2/googlecloud-to-elasticsearch/docs/BigQueryToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/BigQueryToElasticsearch/README.md
@@ -218,9 +218,9 @@ echo '{
               "isOptional":true
           },
           {
-              "name":"useBulkIndexRatherThanCreate",
-              "label":"Use index (allows upserts) rather than create (errors on duplicate _id) in bulk requests",
-              "helpText":"Whether to use index (allows upserts) rather than create (errors on duplicate _id) with Elasticsearch bulk requests",
+              "name":"bulkInsertMethod",
+              "label":"Use INDEX (index, allows upserts) or CREATE (create, errors on duplicate _id) in bulk requests",
+              "helpText":"Whether to use INDEX (index, allows upserts) or the default CREATE (create, errors on duplicate _id) with Elasticsearch bulk requests",
               "paramType":"TEXT",
               "isOptional":true
           }
@@ -268,7 +268,7 @@ The template has the following optional parameters:
 * javaScriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
 * javaScriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
 * usePartialUpdate:  Whether to use partial document updates (update rather than create or index, allows partial document updates)
-* useBulkIndexRatherThanCreate: Whether to use index (allows upserts) rather than create (errors on duplicate _id) with Elasticsearch bulk requests
+* bulkInsertMethod: Whether to use INDEX (index, allows upserts) or the default CREATE (create, errors on duplicate _id) with Elasticsearch bulk requests
 
 Template can be executed using the following gcloud command:
 ```sh

--- a/v2/googlecloud-to-elasticsearch/docs/BigQueryToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/BigQueryToElasticsearch/README.md
@@ -142,70 +142,70 @@ echo '{
           },
           {
               "name":"propertyAsIndex",
-              "label":"Document property used to specify index",
-              "helpText":"A property in the document being indexed whose value specifies which index to add the doc to (takes precendence over an index UDF)",
+              "label":"Document property used to specify _index metadata with document in bulk request",
+              "helpText":"A property in the document being indexed whose value will specify _index metadata to be included with document in bulk request (takes precendence over an index UDF)",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javaScriptIndexFnGCSPath",
-              "label":"GCS path to JavaScript UDF source for function to extract index name from row",
-              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
+              "name":"javaScriptIndexFnGcsPath",
+              "label":"GCS path to JavaScript UDF source for function that will specify _index metadata to be included with document in bulk request",
+              "helpText":"GCS path to JavaScript UDF source. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
               "name":"javaScriptIndexFnName",
-              "label":"UDF JavaScript Function Name for function to extract index name from row",
+              "label":"UDF JavaScript Function Name for function that will specify _index metadata to be included with document in bulk request",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
               "name":"propertyAsId",
-              "label":"Document property used to specify _id",
-              "helpText":"A property in the document being indexed whose value specifies which _id to use for the doc (takes precendence over an id UDF)",
+              "label":"Document property used to specify _id metadata with document in bulk request",
+              "helpText":"A property in the document being indexed whose value will specify _id metadata to be included with document in bulk request (takes precendence over an index UDF)",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javaScriptIdFnGCSPath",
-              "label":"GCS path to JavaScript UDF source for function to extract id value from row",
-              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
+              "name":"javaScriptIdFnGcsPath",
+              "label":"GCS path to JavaScript UDF source function that will specify _id metadata to be included with document in bulk request",
+              "helpText":"GCS path to JavaScript UDF source. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
               "name":"javaScriptIdFnName",
-              "label":"UDF JavaScript Function Name for function to extract id value from row",
+              "label":"UDF JavaScript Function Name for function that will specify _id metadata to be included with document in bulk request",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javaScriptTypeFnGCSPath",
-              "label":"GCS path to JavaScript UDF source for function to extract type value from row",
-              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
+              "name":"javaScriptTypeFnGcsPath",
+              "label":"GCS path to JavaScript UDF source for function that will specify _type metadata to be included with document in bulk request",
+              "helpText":"GCS path to JavaScript UDF source. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
               "name":"javaScriptTypeFnName",
-              "label":"UDF JavaScript Function Name for function to extract type value from row",
+              "label":"UDF JavaScript Function Name for function that will specify _type metadata to be included with document in bulk request",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javaScriptIsDeleteFnGCSPath",
-              "label":"GCS path to JavaScript UDF source for function to extract whether operation is delete or not from row",
-              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
+              "name":"javaScriptIsDeleteFnGcsPath",
+              "label":"GCS path to JavaScript UDF source for function that will determine if document should be deleted rather than inserted or updated, function should return string value \"true\" or \"false\"",
+              "helpText":"GCS path to JavaScript UDF source. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
               "name":"javaScriptIsDeleteFnName",
-              "label":"UDF JavaScript Function Name for function to extract whether operation is delete or not from row",
+              "label":"UDF JavaScript Function Name for function that will determine if document should be deleted rather than inserted or updated, function should return string value \"true\" or \"false\"",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
@@ -257,16 +257,16 @@ The template has the following optional parameters:
 * batchSizeBytes: Batch size in number of bytes. Default: 5242880 (5mb)
 * maxRetryAttempts: Max retry attempts, must be > 0. Default: no retries
 * maxRetryDuration: Max retry duration in milliseconds, must be > 0. Default: no retries
-* propertyAsIndex: A property in the document being indexed whose value specifies which _index to add the doc to (takes precendence over an index UDF)
-* javaScriptIndexFnGCSPath: GCS path of storage location for JavaScript UDF to extract _index from row data
-* javaScriptIndexFnName: Function name for JavaScript UDF to extract _index from row data
-* propertyAsId: A property in the document being indexed whose value specifies which _id to use for the doc (takes precendence over an id UDF)
-* javaScriptIdFnGCSPath: GCS path of storage location for JavaScript UDF to extract _id from row data
-* javaScriptIdFnName: Function name for JavaScript UDF to extract _id from row data
-* javaScriptTypeFnGCSPath: GCS path of storage location for JavaScript UDF to extract _type from row data
-* javaScriptTypeFnName: Function name for JavaScript UDF to extract _type from row data
-* javaScriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
-* javaScriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* propertyAsIndex: A property in the document being indexed whose value will specify _index metadata to be included with document in bulk request (takes precendence over an index UDF)
+* javaScriptIndexFnGcsPath: GCS path of storage location for JavaScript UDF that will specify _index metadata to be included with document in bulk request
+* javaScriptIndexFnName: Function name for JavaScript UDF that will specify _index metadata to be included with document in bulk request
+* propertyAsId: A property in the document being indexed whose value will specify _id metadata to be included with document in bulk request (takes precendence over an index UDF)
+* javaScriptIdFnGcsPath: GCS path of storage location for JavaScript UDF that will specify _id metadata to be included with document in bulk request
+* javaScriptIdFnName: Function name for JavaScript UDF that will specify _id metadata to be included with document in bulk request
+* javaScriptTypeFnGcsPath: GCS path of storage location for JavaScript UDF that will specify _type metadata to be included with document in bulk request
+* javaScriptTypeFnName: Function name for JavaScript UDF that will specify _type metadata to be included with document in bulk request
+* javaScriptIsDeleteFnGcsPath: GCS path of storage location for JavaScript UDF that will determine if document should be deleted rather than inserted or updated, function should return string value "true" or "false"
+* javaScriptIsDeleteFnName: Function name for JavaScript UDF that will determine if document should be deleted rather than inserted or updated, function should return string value "true" or "false"
 * usePartialUpdate:  Whether to use partial document updates (update rather than create or index, allows partial document updates)
 * bulkInsertMethod: Whether to use INDEX (index, allows upserts) or the default CREATE (create, errors on duplicate _id) with Elasticsearch bulk requests
 
@@ -275,6 +275,6 @@ Template can be executed using the following gcloud command:
 export JOB_NAME="${TEMPLATE_MODULE}-`date +%Y%m%d-%H%M%S-%N`"
 gcloud dataflow flex-template run ${JOB_NAME} \
         --project=${PROJECT} --region=us-central1 \
-        --template-file-GCS-location=${TEMPLATE_IMAGE_SPEC} \
+        --template-file-gcs-location=${TEMPLATE_IMAGE_SPEC} \
         --parameters inputTableSpec=${INPUT_TABLE_SPEC},connectionUrl=${CONNECTION_URL},index=${INDEX},elasticsearchUsername=${ELASTICSEARCH_USERNAME},elasticsearchPassword=${ELASTICSEARCH_PASSWORD},useLegacySql=${USE_LEGACY_SQL}
 ```

--- a/v2/googlecloud-to-elasticsearch/docs/BigQueryToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/BigQueryToElasticsearch/README.md
@@ -141,58 +141,58 @@ echo '{
               "isOptional":true
           },
           {
-              "name":"javascriptIndexFnGcsPath",
-              "label":"Gcs path to javascript udf source for function to extract index name from row",
-              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "name":"JavaScriptIndexFnGCSPath",
+              "label":"GCS path to JavaScript UDF source for function to extract index name from row",
+              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIndexFnName",
-              "label":"UDF Javascript Function Name for function to extract index name from row",
-              "helpText":"UDF Javascript Function Name. Default: null",
+              "name":"JavaScriptIndexFnName",
+              "label":"UDF JavaScript Function Name for function to extract index name from row",
+              "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIdFnGcsPath",
-              "label":"Gcs path to javascript udf source for function to extract id value from row",
-              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "name":"JavaScriptIdFnGCSPath",
+              "label":"GCS path to JavaScript UDF source for function to extract id value from row",
+              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIdFnName",
-              "label":"UDF Javascript Function Name for function to extract id value from row",
-              "helpText":"UDF Javascript Function Name. Default: null",
+              "name":"JavaScriptIdFnName",
+              "label":"UDF JavaScript Function Name for function to extract id value from row",
+              "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptTypeFnGcsPath",
-              "label":"Gcs path to javascript udf source for function to extract type value from row",
-              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "name":"JavaScriptTypeFnGCSPath",
+              "label":"GCS path to JavaScript UDF source for function to extract type value from row",
+              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptTypeFnName",
-              "label":"UDF Javascript Function Name for function to extract type value from row",
-              "helpText":"UDF Javascript Function Name. Default: null",
+              "name":"JavaScriptTypeFnName",
+              "label":"UDF JavaScript Function Name for function to extract type value from row",
+              "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIsDeleteFnGcsPath",
-              "label":"Gcs path to javascript udf source for function to extract whether operation is delete or not from row",
-              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "name":"JavaScriptIsDeleteFnGCSPath",
+              "label":"GCS path to JavaScript UDF source for function to extract whether operation is delete or not from row",
+              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIsDeleteFnName",
-              "label":"UDF Javascript Function Name for function to extract whether operation is delete or not from row",
-              "helpText":"UDF Javascript Function Name. Default: null",
+              "name":"JavaScriptIsDeleteFnName",
+              "label":"UDF JavaScript Function Name for function to extract whether operation is delete or not from row",
+              "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
@@ -200,6 +200,13 @@ echo '{
               "name":"usePartialUpdate",
               "label":"Use partial updates (update rather than create or index, allowing partial docs) with Elasticsearch requests",
               "helpText":"Whether to use partial updates (update rather than create or index, allowing partial docs) with Elasticsearch requests",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"useBulkIndexRatherThanCreate",
+              "label":"Use index (allows upserts) rather than create (errors on duplicate _id) in bulk requests",
+              "helpText":"Whether to use index (allows upserts) rather than create (errors on duplicate _id) with Elasticsearch bulk requests",
               "paramType":"TEXT",
               "isOptional":true
           }
@@ -236,21 +243,22 @@ The template has the following optional parameters:
 * batchSizeBytes: Batch size in number of bytes. Default: 5242880 (5mb)
 * maxRetryAttempts: Max retry attempts, must be > 0. Default: no retries
 * maxRetryDuration: Max retry duration in milliseconds, must be > 0. Default: no retries
-* javascriptIndexFnGcsPath: GCS path of storage location for Javascript UDF to extract _index from row data
-* javascriptIndexFnName: Function name for Javascript UDF to extract _index from row data
-* javascriptIdFnGcsPath: GCS path of storage location for Javascript UDF to extract _id from row data
-* javascriptIdFnName: Function name for Javascript UDF to extract _id from row data
-* javascriptTypeFnGcsPath: GCS path of storage location for Javascript UDF to extract _type from row data
-* javascriptTypeFnName: Function name for Javascript UDF to extract _type from row data
-* javascriptIsDeleteFnGcsPath: GCS path of storage location for Javascript UDF to determine if row should be a delete operation (rather than create, index, or update)
-* javascriptIsDeleteFnName: Function name for Javascript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* JavaScriptIndexFnGCSPath: GCS path of storage location for JavaScript UDF to extract _index from row data
+* JavaScriptIndexFnName: Function name for JavaScript UDF to extract _index from row data
+* JavaScriptIdFnGCSPath: GCS path of storage location for JavaScript UDF to extract _id from row data
+* JavaScriptIdFnName: Function name for JavaScript UDF to extract _id from row data
+* JavaScriptTypeFnGCSPath: GCS path of storage location for JavaScript UDF to extract _type from row data
+* JavaScriptTypeFnName: Function name for JavaScript UDF to extract _type from row data
+* JavaScriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* JavaScriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
 * usePartialUpdate:  Whether to use partial document updates (update rather than create or index, allows partial document updates)
+* useBulkIndexRatherThanCreate: Whether to use index (allows upserts) rather than create (errors on duplicate _id) with Elasticsearch bulk requests
 
 Template can be executed using the following gcloud command:
 ```sh
 export JOB_NAME="${TEMPLATE_MODULE}-`date +%Y%m%d-%H%M%S-%N`"
 gcloud dataflow flex-template run ${JOB_NAME} \
         --project=${PROJECT} --region=us-central1 \
-        --template-file-gcs-location=${TEMPLATE_IMAGE_SPEC} \
+        --template-file-GCS-location=${TEMPLATE_IMAGE_SPEC} \
         --parameters inputTableSpec=${INPUT_TABLE_SPEC},connectionUrl=${CONNECTION_URL},index=${INDEX},elasticsearchUsername=${ELASTICSEARCH_USERNAME},elasticsearchPassword=${ELASTICSEARCH_PASSWORD},useLegacySql=${USE_LEGACY_SQL}
 ```

--- a/v2/googlecloud-to-elasticsearch/docs/BigQueryToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/BigQueryToElasticsearch/README.md
@@ -29,7 +29,7 @@ export TARGET_GCR_IMAGE=gcr.io/${PROJECT}/${IMAGE_NAME}
 export BASE_CONTAINER_IMAGE=gcr.io/dataflow-templates-base/java8-template-launcher-base
 export BASE_CONTAINER_IMAGE_VERSION=latest
 export TEMPLATE_MODULE=bigquery-to-elasticsearch
-export APP_ROOT=/template/googlecloud-to-elasticsearch
+export APP_ROOT=/template/${TEMPLATE_MODULE}
 export COMMAND_SPEC=${APP_ROOT}/resources/${TEMPLATE_MODULE}-command-spec.json
 export TEMPLATE_IMAGE_SPEC=${BUCKET_NAME}/images/${TEMPLATE_MODULE}-image-spec.json
 
@@ -50,7 +50,7 @@ mvn clean package \
     -Dbase-container-image.version=${BASE_CONTAINER_IMAGE_VERSION} \
     -Dapp-root=${APP_ROOT} \
     -Dcommand-spec=${COMMAND_SPEC} \
-    -am -pl ${TEMPLATE_MODULE}
+    -am -pl googlecloud-to-elasticsearch
 ```
 
 #### Creating Image Spec
@@ -139,6 +139,69 @@ echo '{
               "helpText":"Max retry duration in milliseconds, must be > 0. Default: no retries",
               "paramType":"TEXT",
               "isOptional":true
+          },
+          {
+              "name":"javascriptIndexFnGcsPath",
+              "label":"Gcs path to javascript udf source for function to extract index name from row",
+              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIndexFnName",
+              "label":"UDF Javascript Function Name for function to extract index name from row",
+              "helpText":"UDF Javascript Function Name. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIdFnGcsPath",
+              "label":"Gcs path to javascript udf source for function to extract id value from row",
+              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIdFnName",
+              "label":"UDF Javascript Function Name for function to extract id value from row",
+              "helpText":"UDF Javascript Function Name. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptTypeFnGcsPath",
+              "label":"Gcs path to javascript udf source for function to extract type value from row",
+              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptTypeFnName",
+              "label":"UDF Javascript Function Name for function to extract type value from row",
+              "helpText":"UDF Javascript Function Name. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIsDeleteFnGcsPath",
+              "label":"Gcs path to javascript udf source for function to extract whether operation is delete or not from row",
+              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIsDeleteFnName",
+              "label":"UDF Javascript Function Name for function to extract whether operation is delete or not from row",
+              "helpText":"UDF Javascript Function Name. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"usePartialUpdate",
+              "label":"Use partial updates (update rather than create or index, allowing partial docs) with Elasticsearch requests",
+              "helpText":"Whether to use partial updates (update rather than create or index, allowing partial docs) with Elasticsearch requests",
+              "paramType":"TEXT",
+              "isOptional":true
           }
       ]
     },
@@ -173,11 +236,20 @@ The template has the following optional parameters:
 * batchSizeBytes: Batch size in number of bytes. Default: 5242880 (5mb)
 * maxRetryAttempts: Max retry attempts, must be > 0. Default: no retries
 * maxRetryDuration: Max retry duration in milliseconds, must be > 0. Default: no retries
+* javascriptIndexFnGcsPath: GCS path of storage location for Javascript UDF to extract _index from row data
+* javascriptIndexFnName: Function name for Javascript UDF to extract _index from row data
+* javascriptIdFnGcsPath: GCS path of storage location for Javascript UDF to extract _id from row data
+* javascriptIdFnName: Function name for Javascript UDF to extract _id from row data
+* javascriptTypeFnGcsPath: GCS path of storage location for Javascript UDF to extract _type from row data
+* javascriptTypeFnName: Function name for Javascript UDF to extract _type from row data
+* javascriptIsDeleteFnGcsPath: GCS path of storage location for Javascript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* javascriptIsDeleteFnName: Function name for Javascript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* usePartialUpdate:  Whether to use partial document updates (update rather than create or index, allows partial document updates)
 
 Template can be executed using the following gcloud command:
 ```sh
 export JOB_NAME="${TEMPLATE_MODULE}-`date +%Y%m%d-%H%M%S-%N`"
-gcloud beta dataflow flex-template run ${JOB_NAME} \
+gcloud dataflow flex-template run ${JOB_NAME} \
         --project=${PROJECT} --region=us-central1 \
         --template-file-gcs-location=${TEMPLATE_IMAGE_SPEC} \
         --parameters inputTableSpec=${INPUT_TABLE_SPEC},connectionUrl=${CONNECTION_URL},index=${INDEX},elasticsearchUsername=${ELASTICSEARCH_USERNAME},elasticsearchPassword=${ELASTICSEARCH_PASSWORD},useLegacySql=${USE_LEGACY_SQL}

--- a/v2/googlecloud-to-elasticsearch/docs/GCSToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/GCSToElasticsearch/README.md
@@ -103,6 +103,13 @@ echo '{
               "isOptional":false
           },
           {
+            "name":"apiKey",
+            "label":"Elasticsearch apiKey",
+            "helpText":"API key for access without requiring basic authentication.",
+            "paramType":"TEXT",
+            "isOptional":false
+          },
+          {
               "name":"index",
               "label":"Elasticsearch index",
               "helpText":"The index toward which the requests will be issued, ex: my-index",
@@ -310,6 +317,7 @@ The template requires the following parameters:
 * delimiter: Delimiting character in CSV file(s). Default: use delimiter found in csvFormat
 * elasticsearchUsername: Elasticsearch username used to connect to Elasticsearch endpoint
 * elasticsearchPassword: Elasticsearch password used to connect to Elasticsearch endpoint
+* apiKey: Base64 Encoded API Key for access without requiring basic authentication. Refer  https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html#security-api-create-api-key-request.
 
 The template has the following optional parameters:
 * inputFormat: The format of the input files, default is CSV.

--- a/v2/googlecloud-to-elasticsearch/docs/GCSToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/GCSToElasticsearch/README.md
@@ -173,14 +173,14 @@ echo '{
               "isOptional":true
           },
           {
-              "name":"javascriptTextTransformGCSPath",
+              "name":"javaScriptTextTransformGCSPath",
               "label":"GCS path to JavaScript UDF source",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptTextTransformFunctionName",
+              "name":"javaScriptTextTransformFunctionName",
               "label":"UDF JavaScript Function Name",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
@@ -208,14 +208,14 @@ echo '{
               "isOptional":true
           },
           {
-              "name":"javascriptIndexFnGCSPath",
+              "name":"javaScriptIndexFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract index name from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIndexFnName",
+              "name":"javaScriptIndexFnName",
               "label":"UDF JavaScript Function Name for function to extract index name from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
@@ -229,42 +229,42 @@ echo '{
               "isOptional":true
           },
           {
-              "name":"javascriptIdFnGCSPath",
+              "name":"javaScriptIdFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract id value from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIdFnName",
+              "name":"javaScriptIdFnName",
               "label":"UDF JavaScript Function Name for function to extract id value from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptTypeFnGCSPath",
+              "name":"javaScriptTypeFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract type value from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptTypeFnName",
+              "name":"javaScriptTypeFnName",
               "label":"UDF JavaScript Function Name for function to extract type value from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIsDeleteFnGCSPath",
+              "name":"javaScriptIsDeleteFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract whether operation is delete or not from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIsDeleteFnName",
+              "name":"javaScriptIsDeleteFnName",
               "label":"UDF JavaScript Function Name for function to extract whether operation is delete or not from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
@@ -319,20 +319,20 @@ The template has the following optional parameters:
 * largeNumFiles: Set to true if number of files is in the tens of thousands. Default: false
 * batchSize: Batch size in number of documents. Default: 1000
 * batchSizeBytes: Batch size in number of bytes. Default: 5242880 (5mb)
-* javascriptTextTransformGCSPath: GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null
-* javascriptTextTransformFunctionName: UDF JavaScript Function Name. Default: null
+* javaScriptTextTransformGCSPath: GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null
+* javaScriptTextTransformFunctionName: UDF JavaScript Function Name. Default: null
 * maxRetryAttempts: Max retry attempts, must be > 0. Default: no retries
 * maxRetryDuration: Max retry duration in milliseconds, must be > 0. Default: no retries
 * propertyAsIndex: A property in the document being indexed whose value specifies which _index to add the doc to (takes precendence over an index UDF)
-* javascriptIndexFnGCSPath: GCS path of storage location for JavaScript UDF to extract _index from row data
-* javascriptIndexFnName: Function name for JavaScript UDF to extract _index from row data
+* javaScriptIndexFnGCSPath: GCS path of storage location for JavaScript UDF to extract _index from row data
+* javaScriptIndexFnName: Function name for JavaScript UDF to extract _index from row data
 * propertyAsId: A property in the document being indexed whose value specifies which _id to use for the doc (takes precendence over an id UDF)
-* javascriptIdFnGCSPath: GCS path of storage location for JavaScript UDF to extract _id from row data
-* javascriptIdFnName: Function name for JavaScript UDF to extract _id from row data
-* javascriptTypeFnGCSPath: GCS path of storage location for JavaScript UDF to extract _type from row data
-* javascriptTypeFnName: Function name for JavaScript UDF to extract _type from row data
-* javascriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
-* javascriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* javaScriptIdFnGCSPath: GCS path of storage location for JavaScript UDF to extract _id from row data
+* javaScriptIdFnName: Function name for JavaScript UDF to extract _id from row data
+* javaScriptTypeFnGCSPath: GCS path of storage location for JavaScript UDF to extract _type from row data
+* javaScriptTypeFnName: Function name for JavaScript UDF to extract _type from row data
+* javaScriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* javaScriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
 * usePartialUpdate:  Whether to use partial document updates (update rather than create or index, allows partial document updates)
 * useBulkIndexRatherThanCreate: Whether to use index (allows upserts) rather than create (errors on duplicate _id) with Elasticsearch bulk requests
 

--- a/v2/googlecloud-to-elasticsearch/docs/GCSToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/GCSToElasticsearch/README.md
@@ -38,7 +38,7 @@ export TARGET_GCR_IMAGE=gcr.io/${PROJECT}/${IMAGE_NAME}
 export BASE_CONTAINER_IMAGE=gcr.io/dataflow-templates-base/java8-template-launcher-base
 export BASE_CONTAINER_IMAGE_VERSION=latest
 export TEMPLATE_MODULE=gcs-to-elasticsearch
-export APP_ROOT=/template/googlecloud-to-elasticsearch
+export APP_ROOT=/template/${TEMPLATE_MODULE}
 export COMMAND_SPEC=${APP_ROOT}/resources/${TEMPLATE_MODULE}-command-spec.json
 export TEMPLATE_IMAGE_SPEC=${BUCKET_NAME}/images/${TEMPLATE_MODULE}-image-spec.json
 
@@ -61,7 +61,7 @@ mvn clean package \
     -Dbase-container-image.version=${BASE_CONTAINER_IMAGE_VERSION} \
     -Dapp-root=${APP_ROOT} \
     -Dcommand-spec=${COMMAND_SPEC} \
-    -am -pl ${TEMPLATE_MODULE}
+    -am -pl googlecloud-to-elasticsearch
 ```
 
 #### Creating Image Spec
@@ -199,6 +199,69 @@ echo '{
               "helpText":"Max retry duration in milliseconds, must be > 0. Default: no retries",
               "paramType":"TEXT",
               "isOptional":true
+          },
+          {
+              "name":"javascriptIndexFnGcsPath",
+              "label":"Gcs path to javascript udf source for function to extract index name from row",
+              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIndexFnName",
+              "label":"UDF Javascript Function Name for function to extract index name from row",
+              "helpText":"UDF Javascript Function Name. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIdFnGcsPath",
+              "label":"Gcs path to javascript udf source for function to extract id value from row",
+              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIdFnName",
+              "label":"UDF Javascript Function Name for function to extract id value from row",
+              "helpText":"UDF Javascript Function Name. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptTypeFnGcsPath",
+              "label":"Gcs path to javascript udf source for function to extract type value from row",
+              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptTypeFnName",
+              "label":"UDF Javascript Function Name for function to extract type value from row",
+              "helpText":"UDF Javascript Function Name. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIsDeleteFnGcsPath",
+              "label":"Gcs path to javascript udf source for function to extract whether operation is delete or not from row",
+              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIsDeleteFnName",
+              "label":"UDF Javascript Function Name for function to extract whether operation is delete or not from row",
+              "helpText":"UDF Javascript Function Name. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"usePartialUpdate",
+              "label":"Use partial updates (update rather than create or index, allowing partial docs) with Elasticsearch requests",
+              "helpText":"Whether to use partial updates (update rather than create or index, allowing partial docs) with Elasticsearch requests",
+              "paramType":"TEXT",
+              "isOptional":true
           }
       ]
     },
@@ -239,6 +302,15 @@ The template has the following optional parameters:
 * javascriptTextTransformFunctionName: UDF Javascript Function Name. Default: null
 * maxRetryAttempts: Max retry attempts, must be > 0. Default: no retries
 * maxRetryDuration: Max retry duration in milliseconds, must be > 0. Default: no retries
+* javascriptIndexFnGcsPath: GCS path of storage location for Javascript UDF to extract _index from row data
+* javascriptIndexFnName: Function name for Javascript UDF to extract _index from row data
+* javascriptIdFnGcsPath: GCS path of storage location for Javascript UDF to extract _id from row data
+* javascriptIdFnName: Function name for Javascript UDF to extract _id from row data
+* javascriptTypeFnGcsPath: GCS path of storage location for Javascript UDF to extract _type from row data
+* javascriptTypeFnName: Function name for Javascript UDF to extract _type from row data
+* javascriptIsDeleteFnGcsPath: GCS path of storage location for Javascript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* javascriptIsDeleteFnName: Function name for Javascript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* usePartialUpdate:  Whether to use partial document updates (update rather than create or index, allows partial document updates)
 
 Template can be executed using the following gcloud command:
 ```sh

--- a/v2/googlecloud-to-elasticsearch/docs/GCSToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/GCSToElasticsearch/README.md
@@ -173,14 +173,14 @@ echo '{
               "isOptional":true
           },
           {
-              "name":"JavaScriptTextTransformGCSPath",
+              "name":"javascriptTextTransformGCSPath",
               "label":"GCS path to JavaScript UDF source",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptTextTransformFunctionName",
+              "name":"javascriptTextTransformFunctionName",
               "label":"UDF JavaScript Function Name",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
@@ -201,56 +201,70 @@ echo '{
               "isOptional":true
           },
           {
-              "name":"JavaScriptIndexFnGCSPath",
+              "name":"propertyAsIndex",
+              "label":"Document property used to specify index",
+              "helpText":"A property in the document being indexed whose value specifies which index to add the doc to (takes precendence over an index UDF)",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIndexFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract index name from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptIndexFnName",
+              "name":"javascriptIndexFnName",
               "label":"UDF JavaScript Function Name for function to extract index name from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptIdFnGCSPath",
+              "name":"propertyAsId",
+              "label":"Document property used to specify _id",
+              "helpText":"A property in the document being indexed whose value specifies which _id to use for the doc (takes precendence over an id UDF)",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIdFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract id value from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptIdFnName",
+              "name":"javascriptIdFnName",
               "label":"UDF JavaScript Function Name for function to extract id value from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptTypeFnGCSPath",
+              "name":"javascriptTypeFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract type value from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptTypeFnName",
+              "name":"javascriptTypeFnName",
               "label":"UDF JavaScript Function Name for function to extract type value from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptIsDeleteFnGCSPath",
+              "name":"javascriptIsDeleteFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract whether operation is delete or not from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptIsDeleteFnName",
+              "name":"javascriptIsDeleteFnName",
               "label":"UDF JavaScript Function Name for function to extract whether operation is delete or not from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
@@ -305,18 +319,20 @@ The template has the following optional parameters:
 * largeNumFiles: Set to true if number of files is in the tens of thousands. Default: false
 * batchSize: Batch size in number of documents. Default: 1000
 * batchSizeBytes: Batch size in number of bytes. Default: 5242880 (5mb)
-* JavaScriptTextTransformGCSPath: GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null
-* JavaScriptTextTransformFunctionName: UDF JavaScript Function Name. Default: null
+* javascriptTextTransformGCSPath: GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null
+* javascriptTextTransformFunctionName: UDF JavaScript Function Name. Default: null
 * maxRetryAttempts: Max retry attempts, must be > 0. Default: no retries
 * maxRetryDuration: Max retry duration in milliseconds, must be > 0. Default: no retries
-* JavaScriptIndexFnGCSPath: GCS path of storage location for JavaScript UDF to extract _index from row data
-* JavaScriptIndexFnName: Function name for JavaScript UDF to extract _index from row data
-* JavaScriptIdFnGCSPath: GCS path of storage location for JavaScript UDF to extract _id from row data
-* JavaScriptIdFnName: Function name for JavaScript UDF to extract _id from row data
-* JavaScriptTypeFnGCSPath: GCS path of storage location for JavaScript UDF to extract _type from row data
-* JavaScriptTypeFnName: Function name for JavaScript UDF to extract _type from row data
-* JavaScriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
-* JavaScriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* propertyAsIndex: A property in the document being indexed whose value specifies which _index to add the doc to (takes precendence over an index UDF)
+* javascriptIndexFnGCSPath: GCS path of storage location for JavaScript UDF to extract _index from row data
+* javascriptIndexFnName: Function name for JavaScript UDF to extract _index from row data
+* propertyAsId: A property in the document being indexed whose value specifies which _id to use for the doc (takes precendence over an id UDF)
+* javascriptIdFnGCSPath: GCS path of storage location for JavaScript UDF to extract _id from row data
+* javascriptIdFnName: Function name for JavaScript UDF to extract _id from row data
+* javascriptTypeFnGCSPath: GCS path of storage location for JavaScript UDF to extract _type from row data
+* javascriptTypeFnName: Function name for JavaScript UDF to extract _type from row data
+* javascriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* javascriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
 * usePartialUpdate:  Whether to use partial document updates (update rather than create or index, allows partial document updates)
 * useBulkIndexRatherThanCreate: Whether to use index (allows upserts) rather than create (errors on duplicate _id) with Elasticsearch bulk requests
 

--- a/v2/googlecloud-to-elasticsearch/docs/GCSToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/GCSToElasticsearch/README.md
@@ -278,9 +278,9 @@ echo '{
               "isOptional":true
           },
           {
-              "name":"useBulkIndexRatherThanCreate",
-              "label":"Use index (allows upserts) rather than create (errors on duplicate _id) in bulk requests",
-              "helpText":"Whether to use index (allows upserts) rather than create (errors on duplicate _id) with Elasticsearch bulk requests",
+              "name":"bulkInsertMethod",
+              "label":"Use INDEX (index, allows upserts) or CREATE (create, errors on duplicate _id) in bulk requests",
+              "helpText":"Whether to use INDEX (index, allows upserts) or the default CREATE (create, errors on duplicate _id) with Elasticsearch bulk requests",
               "paramType":"TEXT",
               "isOptional":true
           }
@@ -334,7 +334,7 @@ The template has the following optional parameters:
 * javaScriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
 * javaScriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
 * usePartialUpdate:  Whether to use partial document updates (update rather than create or index, allows partial document updates)
-* useBulkIndexRatherThanCreate: Whether to use index (allows upserts) rather than create (errors on duplicate _id) with Elasticsearch bulk requests
+* bulkInsertMethod: Whether to use INDEX (index, allows upserts) or the default CREATE (create, errors on duplicate _id) with Elasticsearch bulk requests
 
 Template can be executed using the following gcloud command:
 ```sh

--- a/v2/googlecloud-to-elasticsearch/docs/GCSToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/GCSToElasticsearch/README.md
@@ -3,7 +3,7 @@
 The [GCSToElasticsearch](../../src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/GCSToElasticsearch.java) pipeline ingests
 data from one or more CSV files in Google Cloud Storage into Elasticsearch. The template creates the schema for the
 JSON document using one of the following:
-1. Javascript UDF (if provided)
+1. JavaScript UDF (if provided)
 2. JSON schema (if provided)
 3. CSV headers* (default)
 
@@ -13,7 +13,7 @@ If either a UDF or JSON schema is provided then it will be used instead of the C
 
 Pipeline flow is illustrated below:
 
-![alt text](../img/gcs-to-elasticsearch-dataflow.png "GCS to Elasticsearch pipeline flow")
+![alt text](../img/GCS-to-elasticsearch-dataflow.png "GCS to Elasticsearch pipeline flow")
 
 ## Getting Started
 
@@ -37,7 +37,7 @@ export BUCKET_NAME=gs://<bucket-name>
 export TARGET_GCR_IMAGE=gcr.io/${PROJECT}/${IMAGE_NAME}
 export BASE_CONTAINER_IMAGE=gcr.io/dataflow-templates-base/java8-template-launcher-base
 export BASE_CONTAINER_IMAGE_VERSION=latest
-export TEMPLATE_MODULE=gcs-to-elasticsearch
+export TEMPLATE_MODULE=GCS-to-elasticsearch
 export APP_ROOT=/template/${TEMPLATE_MODULE}
 export COMMAND_SPEC=${APP_ROOT}/resources/${TEMPLATE_MODULE}-command-spec.json
 export TEMPLATE_IMAGE_SPEC=${BUCKET_NAME}/images/${TEMPLATE_MODULE}-image-spec.json
@@ -173,16 +173,16 @@ echo '{
               "isOptional":true
           },
           {
-              "name":"javascriptTextTransformGcsPath",
-              "label":"Gcs path to javascript udf source",
-              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "name":"JavaScriptTextTransformGCSPath",
+              "label":"GCS path to JavaScript UDF source",
+              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptTextTransformFunctionName",
-              "label":"UDF Javascript Function Name",
-              "helpText":"UDF Javascript Function Name. Default: null",
+              "name":"JavaScriptTextTransformFunctionName",
+              "label":"UDF JavaScript Function Name",
+              "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
@@ -201,58 +201,58 @@ echo '{
               "isOptional":true
           },
           {
-              "name":"javascriptIndexFnGcsPath",
-              "label":"Gcs path to javascript udf source for function to extract index name from row",
-              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "name":"JavaScriptIndexFnGCSPath",
+              "label":"GCS path to JavaScript UDF source for function to extract index name from row",
+              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIndexFnName",
-              "label":"UDF Javascript Function Name for function to extract index name from row",
-              "helpText":"UDF Javascript Function Name. Default: null",
+              "name":"JavaScriptIndexFnName",
+              "label":"UDF JavaScript Function Name for function to extract index name from row",
+              "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIdFnGcsPath",
-              "label":"Gcs path to javascript udf source for function to extract id value from row",
-              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "name":"JavaScriptIdFnGCSPath",
+              "label":"GCS path to JavaScript UDF source for function to extract id value from row",
+              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIdFnName",
-              "label":"UDF Javascript Function Name for function to extract id value from row",
-              "helpText":"UDF Javascript Function Name. Default: null",
+              "name":"JavaScriptIdFnName",
+              "label":"UDF JavaScript Function Name for function to extract id value from row",
+              "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptTypeFnGcsPath",
-              "label":"Gcs path to javascript udf source for function to extract type value from row",
-              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "name":"JavaScriptTypeFnGCSPath",
+              "label":"GCS path to JavaScript UDF source for function to extract type value from row",
+              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptTypeFnName",
-              "label":"UDF Javascript Function Name for function to extract type value from row",
-              "helpText":"UDF Javascript Function Name. Default: null",
+              "name":"JavaScriptTypeFnName",
+              "label":"UDF JavaScript Function Name for function to extract type value from row",
+              "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIsDeleteFnGcsPath",
-              "label":"Gcs path to javascript udf source for function to extract whether operation is delete or not from row",
-              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "name":"JavaScriptIsDeleteFnGCSPath",
+              "label":"GCS path to JavaScript UDF source for function to extract whether operation is delete or not from row",
+              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIsDeleteFnName",
-              "label":"UDF Javascript Function Name for function to extract whether operation is delete or not from row",
-              "helpText":"UDF Javascript Function Name. Default: null",
+              "name":"JavaScriptIsDeleteFnName",
+              "label":"UDF JavaScript Function Name for function to extract whether operation is delete or not from row",
+              "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
@@ -260,6 +260,13 @@ echo '{
               "name":"usePartialUpdate",
               "label":"Use partial updates (update rather than create or index, allowing partial docs) with Elasticsearch requests",
               "helpText":"Whether to use partial updates (update rather than create or index, allowing partial docs) with Elasticsearch requests",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"useBulkIndexRatherThanCreate",
+              "label":"Use index (allows upserts) rather than create (errors on duplicate _id) in bulk requests",
+              "helpText":"Whether to use index (allows upserts) rather than create (errors on duplicate _id) with Elasticsearch bulk requests",
               "paramType":"TEXT",
               "isOptional":true
           }
@@ -298,25 +305,26 @@ The template has the following optional parameters:
 * largeNumFiles: Set to true if number of files is in the tens of thousands. Default: false
 * batchSize: Batch size in number of documents. Default: 1000
 * batchSizeBytes: Batch size in number of bytes. Default: 5242880 (5mb)
-* javascriptTextTransformGcsPath: Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null
-* javascriptTextTransformFunctionName: UDF Javascript Function Name. Default: null
+* JavaScriptTextTransformGCSPath: GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null
+* JavaScriptTextTransformFunctionName: UDF JavaScript Function Name. Default: null
 * maxRetryAttempts: Max retry attempts, must be > 0. Default: no retries
 * maxRetryDuration: Max retry duration in milliseconds, must be > 0. Default: no retries
-* javascriptIndexFnGcsPath: GCS path of storage location for Javascript UDF to extract _index from row data
-* javascriptIndexFnName: Function name for Javascript UDF to extract _index from row data
-* javascriptIdFnGcsPath: GCS path of storage location for Javascript UDF to extract _id from row data
-* javascriptIdFnName: Function name for Javascript UDF to extract _id from row data
-* javascriptTypeFnGcsPath: GCS path of storage location for Javascript UDF to extract _type from row data
-* javascriptTypeFnName: Function name for Javascript UDF to extract _type from row data
-* javascriptIsDeleteFnGcsPath: GCS path of storage location for Javascript UDF to determine if row should be a delete operation (rather than create, index, or update)
-* javascriptIsDeleteFnName: Function name for Javascript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* JavaScriptIndexFnGCSPath: GCS path of storage location for JavaScript UDF to extract _index from row data
+* JavaScriptIndexFnName: Function name for JavaScript UDF to extract _index from row data
+* JavaScriptIdFnGCSPath: GCS path of storage location for JavaScript UDF to extract _id from row data
+* JavaScriptIdFnName: Function name for JavaScript UDF to extract _id from row data
+* JavaScriptTypeFnGCSPath: GCS path of storage location for JavaScript UDF to extract _type from row data
+* JavaScriptTypeFnName: Function name for JavaScript UDF to extract _type from row data
+* JavaScriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* JavaScriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
 * usePartialUpdate:  Whether to use partial document updates (update rather than create or index, allows partial document updates)
+* useBulkIndexRatherThanCreate: Whether to use index (allows upserts) rather than create (errors on duplicate _id) with Elasticsearch bulk requests
 
 Template can be executed using the following gcloud command:
 ```sh
 export JOB_NAME="${TEMPLATE_MODULE}-`date +%Y%m%d-%H%M%S-%N`"
 gcloud beta dataflow flex-template run ${JOB_NAME} \
         --project=${PROJECT} --region=us-central1 \
-        --template-file-gcs-location=${TEMPLATE_IMAGE_SPEC} \
+        --template-file-GCS-location=${TEMPLATE_IMAGE_SPEC} \
         --parameters inputFileSpec=${INPUT_FILE_SPEC},connectionUrl=${CONNECTION_URL},index=${INDEX},elasticsearchUsername=${ELASTICSEARCH_USERNAME},elasticsearchPassword=${ELASTICSEARCH_PASSWORD},containsHeaders=${HEADERS},deadletterTable=${DEADLETTER_TABLE},delimiter=${DELIMITER}
 ```

--- a/v2/googlecloud-to-elasticsearch/docs/GCSToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/GCSToElasticsearch/README.md
@@ -202,70 +202,70 @@ echo '{
           },
           {
               "name":"propertyAsIndex",
-              "label":"Document property used to specify index",
-              "helpText":"A property in the document being indexed whose value specifies which index to add the doc to (takes precendence over an index UDF)",
+              "label":"Document property used to specify _index metadata with document in bulk request",
+              "helpText":"A property in the document being indexed whose value will specify _index metadata to be included with document in bulk request (takes precendence over an index UDF)",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javaScriptIndexFnGCSPath",
-              "label":"GCS path to JavaScript UDF source for function to extract index name from row",
-              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
+              "name":"javaScriptIndexFnGcsPath",
+              "label":"GCS path to JavaScript UDF source for function that will specify _index metadata to be included with document in bulk request",
+              "helpText":"GCS path to JavaScript UDF source. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
               "name":"javaScriptIndexFnName",
-              "label":"UDF JavaScript Function Name for function to extract index name from row",
+              "label":"UDF JavaScript Function Name for function that will specify _index metadata to be included with document in bulk request",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
               "name":"propertyAsId",
-              "label":"Document property used to specify _id",
-              "helpText":"A property in the document being indexed whose value specifies which _id to use for the doc (takes precendence over an id UDF)",
+              "label":"Document property used to specify _id metadata with document in bulk request",
+              "helpText":"A property in the document being indexed whose value will specify _id metadata to be included with document in bulk request (takes precendence over an index UDF)",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javaScriptIdFnGCSPath",
-              "label":"GCS path to JavaScript UDF source for function to extract id value from row",
-              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
+              "name":"javaScriptIdFnGcsPath",
+              "label":"GCS path to JavaScript UDF source function that will specify _id metadata to be included with document in bulk request",
+              "helpText":"GCS path to JavaScript UDF source. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
               "name":"javaScriptIdFnName",
-              "label":"UDF JavaScript Function Name for function to extract id value from row",
+              "label":"UDF JavaScript Function Name for function that will specify _id metadata to be included with document in bulk request",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javaScriptTypeFnGCSPath",
-              "label":"GCS path to JavaScript UDF source for function to extract type value from row",
-              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
+              "name":"javaScriptTypeFnGcsPath",
+              "label":"GCS path to JavaScript UDF source for function that will specify _type metadata to be included with document in bulk request",
+              "helpText":"GCS path to JavaScript UDF source. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
               "name":"javaScriptTypeFnName",
-              "label":"UDF JavaScript Function Name for function to extract type value from row",
+              "label":"UDF JavaScript Function Name for function that will specify _type metadata to be included with document in bulk request",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javaScriptIsDeleteFnGCSPath",
-              "label":"GCS path to JavaScript UDF source for function to extract whether operation is delete or not from row",
-              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
+              "name":"javaScriptIsDeleteFnGcsPath",
+              "label":"GCS path to JavaScript UDF source for function that will determine if document should be deleted rather than inserted or updated, function should return string value \"true\" or \"false\"",
+              "helpText":"GCS path to JavaScript UDF source. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
               "name":"javaScriptIsDeleteFnName",
-              "label":"UDF JavaScript Function Name for function to extract whether operation is delete or not from row",
+              "label":"UDF JavaScript Function Name for function that will determine if document should be deleted rather than inserted or updated, function should return string value \"true\" or \"false\"",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
@@ -323,16 +323,16 @@ The template has the following optional parameters:
 * javaScriptTextTransformFunctionName: UDF JavaScript Function Name. Default: null
 * maxRetryAttempts: Max retry attempts, must be > 0. Default: no retries
 * maxRetryDuration: Max retry duration in milliseconds, must be > 0. Default: no retries
-* propertyAsIndex: A property in the document being indexed whose value specifies which _index to add the doc to (takes precendence over an index UDF)
-* javaScriptIndexFnGCSPath: GCS path of storage location for JavaScript UDF to extract _index from row data
-* javaScriptIndexFnName: Function name for JavaScript UDF to extract _index from row data
-* propertyAsId: A property in the document being indexed whose value specifies which _id to use for the doc (takes precendence over an id UDF)
-* javaScriptIdFnGCSPath: GCS path of storage location for JavaScript UDF to extract _id from row data
-* javaScriptIdFnName: Function name for JavaScript UDF to extract _id from row data
-* javaScriptTypeFnGCSPath: GCS path of storage location for JavaScript UDF to extract _type from row data
-* javaScriptTypeFnName: Function name for JavaScript UDF to extract _type from row data
-* javaScriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
-* javaScriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* propertyAsIndex: A property in the document being indexed whose value will specify _index metadata to be included with document in bulk request (takes precendence over an index UDF)
+* javaScriptIndexFnGcsPath: GCS path of storage location for JavaScript UDF that will specify _index metadata to be included with document in bulk request
+* javaScriptIndexFnName: Function name for JavaScript UDF that will specify _index metadata to be included with document in bulk request
+* propertyAsId: A property in the document being indexed whose value will specify _id metadata to be included with document in bulk request (takes precendence over an index UDF)
+* javaScriptIdFnGcsPath: GCS path of storage location for JavaScript UDF that will specify _id metadata to be included with document in bulk request
+* javaScriptIdFnName: Function name for JavaScript UDF that will specify _id metadata to be included with document in bulk request
+* javaScriptTypeFnGcsPath: GCS path of storage location for JavaScript UDF that will specify _type metadata to be included with document in bulk request
+* javaScriptTypeFnName: Function name for JavaScript UDF that will specify _type metadata to be included with document in bulk request
+* javaScriptIsDeleteFnGcsPath: GCS path of storage location for JavaScript UDF that will determine if document should be deleted rather than inserted or updated, function should return string value "true" or "false"
+* javaScriptIsDeleteFnName: Function name for JavaScript UDF that will determine if document should be deleted rather than inserted or updated, function should return string value "true" or "false"
 * usePartialUpdate:  Whether to use partial document updates (update rather than create or index, allows partial document updates)
 * bulkInsertMethod: Whether to use INDEX (index, allows upserts) or the default CREATE (create, errors on duplicate _id) with Elasticsearch bulk requests
 
@@ -341,6 +341,6 @@ Template can be executed using the following gcloud command:
 export JOB_NAME="${TEMPLATE_MODULE}-`date +%Y%m%d-%H%M%S-%N`"
 gcloud beta dataflow flex-template run ${JOB_NAME} \
         --project=${PROJECT} --region=us-central1 \
-        --template-file-GCS-location=${TEMPLATE_IMAGE_SPEC} \
+        --template-file-gcs-location=${TEMPLATE_IMAGE_SPEC} \
         --parameters inputFileSpec=${INPUT_FILE_SPEC},connectionUrl=${CONNECTION_URL},index=${INDEX},elasticsearchUsername=${ELASTICSEARCH_USERNAME},elasticsearchPassword=${ELASTICSEARCH_PASSWORD},containsHeaders=${HEADERS},deadletterTable=${DEADLETTER_TABLE},delimiter=${DELIMITER}
 ```

--- a/v2/googlecloud-to-elasticsearch/docs/PubSubToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/PubSubToElasticsearch/README.md
@@ -45,6 +45,15 @@ The template has the following optional parameters:
 * javascriptTextTransformFunctionName: UDF Javascript Function Name. Default: null
 * maxRetryAttempts: Max retry attempts, must be > 0. Default: no retries
 * maxRetryDuration: Max retry duration in milliseconds, must be > 0. Default: no retries
+* javascriptIndexFnGcsPath: GCS path of storage location for Javascript UDF to extract _index from row data
+* javascriptIndexFnName: Function name for Javascript UDF to extract _index from row data
+* javascriptIdFnGcsPath: GCS path of storage location for Javascript UDF to extract _id from row data
+* javascriptIdFnName: Function name for Javascript UDF to extract _id from row data
+* javascriptTypeFnGcsPath: GCS path of storage location for Javascript UDF to extract _type from row data
+* javascriptTypeFnName: Function name for Javascript UDF to extract _type from row data
+* javascriptIsDeleteFnGcsPath: GCS path of storage location for Javascript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* javascriptIsDeleteFnName: Function name for Javascript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* usePartialUpdate:  Whether to use partial document updates (update rather than create or index, allows partial document updates)
 
 ### Building Template
 This is a Flex Template meaning that the pipeline code will be containerized, and the container will be used to launch the Dataflow pipeline.
@@ -59,7 +68,7 @@ export TARGET_GCR_IMAGE=gcr.io/${PROJECT}/${IMAGE_NAME}
 export BASE_CONTAINER_IMAGE=gcr.io/dataflow-templates-base/java8-template-launcher-base
 export BASE_CONTAINER_IMAGE_VERSION=latest
 export TEMPLATE_MODULE=pubsub-to-elasticsearch
-export APP_ROOT=/template/googlecloud-to-elasticsearch
+export APP_ROOT=/template/${TEMPLATE_MODULE}
 export COMMAND_SPEC=${APP_ROOT}/resources/${TEMPLATE_MODULE}-command-spec.json
 export TEMPLATE_IMAGE_SPEC=${BUCKET_NAME}/images/${TEMPLATE_MODULE}-image-spec.json
 
@@ -81,7 +90,7 @@ mvn clean package -Dimage=${TARGET_GCR_IMAGE} \
                   -Dbase-container-image.version=${BASE_CONTAINER_IMAGE_VERSION} \
                   -Dapp-root=${APP_ROOT} \
                   -Dcommand-spec=${COMMAND_SPEC} \
-                  -am -pl ${TEMPLATE_MODULE}
+                  -am -pl googlecloud-to-elasticsearch
 ```
 
 #### Creating Image Spec
@@ -175,6 +184,69 @@ echo '{
               "name":"maxRetryDuration",
               "label":"Max retry duration in milliseconds",
               "helpText":"Max retry duration in milliseconds, must be > 0. Default: no retries",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIndexFnGcsPath",
+              "label":"Gcs path to javascript udf source for function to extract index name from row",
+              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIndexFnName",
+              "label":"UDF Javascript Function Name for function to extract index name from row",
+              "helpText":"UDF Javascript Function Name. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIdFnGcsPath",
+              "label":"Gcs path to javascript udf source for function to extract id value from row",
+              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIdFnName",
+              "label":"UDF Javascript Function Name for function to extract id value from row",
+              "helpText":"UDF Javascript Function Name. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptTypeFnGcsPath",
+              "label":"Gcs path to javascript udf source for function to extract type value from row",
+              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptTypeFnName",
+              "label":"UDF Javascript Function Name for function to extract type value from row",
+              "helpText":"UDF Javascript Function Name. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIsDeleteFnGcsPath",
+              "label":"Gcs path to javascript udf source for function to extract whether operation is delete or not from row",
+              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIsDeleteFnName",
+              "label":"UDF Javascript Function Name for function to extract whether operation is delete or not from row",
+              "helpText":"UDF Javascript Function Name. Default: null",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"usePartialUpdate",
+              "label":"Use partial updates (update rather than create or index, allowing partial docs) with Elasticsearch requests",
+              "helpText":"Whether to use partial updates (update rather than create or index, allowing partial docs) with Elasticsearch requests",
               "paramType":"TEXT",
               "isOptional":true
           }

--- a/v2/googlecloud-to-elasticsearch/docs/PubSubToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/PubSubToElasticsearch/README.md
@@ -41,20 +41,20 @@ The template has the following optional parameters:
 * namespace: An arbitrary grouping, such as an environment (dev, prod, or qa), a team, or a strategic business unit. Default is `default`
 * batchSize: Batch size in number of documents. Default: 1000
 * batchSizeBytes: Batch size in number of bytes. Default: 5242880 (5mb)
-* javascriptTextTransformGCSPath: GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null
-* javascriptTextTransformFunctionName: UDF JavaScript Function Name. Default: null
+* javaScriptTextTransformGCSPath: GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null
+* javaScriptTextTransformFunctionName: UDF JavaScript Function Name. Default: null
 * maxRetryAttempts: Max retry attempts, must be > 0. Default: no retries
 * maxRetryDuration: Max retry duration in milliseconds, must be > 0. Default: no retries
 * propertyAsIndex: A property in the document being indexed whose value specifies which _index to add the doc to (takes precendence over an index UDF)
-* javascriptIndexFnGCSPath: GCS path of storage location for JavaScript UDF to extract _index from row data
-* javascriptIndexFnName: Function name for JavaScript UDF to extract _index from row data
+* javaScriptIndexFnGCSPath: GCS path of storage location for JavaScript UDF to extract _index from row data
+* javaScriptIndexFnName: Function name for JavaScript UDF to extract _index from row data
 * propertyAsId: A property in the document being indexed whose value specifies which _id to use for the doc (takes precendence over an id UDF)
-* javascriptIdFnGCSPath: GCS path of storage location for JavaScript UDF to extract _id from row data
-* javascriptIdFnName: Function name for JavaScript UDF to extract _id from row data
-* javascriptTypeFnGCSPath: GCS path of storage location for JavaScript UDF to extract _type from row data
-* javascriptTypeFnName: Function name for JavaScript UDF to extract _type from row data
-* javascriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
-* javascriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* javaScriptIdFnGCSPath: GCS path of storage location for JavaScript UDF to extract _id from row data
+* javaScriptIdFnName: Function name for JavaScript UDF to extract _id from row data
+* javaScriptTypeFnGCSPath: GCS path of storage location for JavaScript UDF to extract _type from row data
+* javaScriptTypeFnName: Function name for JavaScript UDF to extract _type from row data
+* javaScriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* javaScriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
 * usePartialUpdate:  Whether to use partial document updates (update rather than create or index, allows partial document updates)
 * useBulkIndexRatherThanCreate: Whether to use index (allows upserts) rather than create (errors on duplicate _id) with Elasticsearch bulk requests
 
@@ -198,14 +198,14 @@ echo '{
               "isOptional":true
           },
           {
-              "name":"javascriptIndexFnGCSPath",
+              "name":"javaScriptIndexFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract index name from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIndexFnName",
+              "name":"javaScriptIndexFnName",
               "label":"UDF JavaScript Function Name for function to extract index name from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
@@ -219,42 +219,42 @@ echo '{
               "isOptional":true
           },
           {
-              "name":"javascriptIdFnGCSPath",
+              "name":"javaScriptIdFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract id value from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIdFnName",
+              "name":"javaScriptIdFnName",
               "label":"UDF JavaScript Function Name for function to extract id value from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptTypeFnGCSPath",
+              "name":"javaScriptTypeFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract type value from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptTypeFnName",
+              "name":"javaScriptTypeFnName",
               "label":"UDF JavaScript Function Name for function to extract type value from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIsDeleteFnGCSPath",
+              "name":"javaScriptIsDeleteFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract whether operation is delete or not from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIsDeleteFnName",
+              "name":"javaScriptIsDeleteFnName",
               "label":"UDF JavaScript Function Name for function to extract whether operation is delete or not from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",

--- a/v2/googlecloud-to-elasticsearch/docs/PubSubToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/PubSubToElasticsearch/README.md
@@ -56,7 +56,7 @@ The template has the following optional parameters:
 * javaScriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
 * javaScriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
 * usePartialUpdate:  Whether to use partial document updates (update rather than create or index, allows partial document updates)
-* useBulkIndexRatherThanCreate: Whether to use index (allows upserts) rather than create (errors on duplicate _id) with Elasticsearch bulk requests
+* bulkInsertMethod: Whether to use INDEX (index, allows upserts) or the default CREATE (create, errors on duplicate _id) with Elasticsearch bulk requests
 
 ### Building Template
 This is a Flex Template meaning that the pipeline code will be containerized, and the container will be used to launch the Dataflow pipeline.
@@ -268,9 +268,9 @@ echo '{
               "isOptional":true
           },
           {
-              "name":"useBulkIndexRatherThanCreate",
-              "label":"Use index (allows upserts) rather than create (errors on duplicate _id) in bulk requests",
-              "helpText":"Whether to use index (allows upserts) rather than create (errors on duplicate _id) with Elasticsearch bulk requests",
+              "name":"bulkInsertMethod",
+              "label":"Use INDEX (index, allows upserts) or CREATE (create, errors on duplicate _id) in bulk requests",
+              "helpText":"Whether to use INDEX (index, allows upserts) or the default CREATE (create, errors on duplicate _id) with Elasticsearch bulk requests",
               "paramType":"TEXT",
               "isOptional":true
           }

--- a/v2/googlecloud-to-elasticsearch/docs/PubSubToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/PubSubToElasticsearch/README.md
@@ -41,18 +41,20 @@ The template has the following optional parameters:
 * namespace: An arbitrary grouping, such as an environment (dev, prod, or qa), a team, or a strategic business unit. Default is `default`
 * batchSize: Batch size in number of documents. Default: 1000
 * batchSizeBytes: Batch size in number of bytes. Default: 5242880 (5mb)
-* JavaScriptTextTransformGCSPath: GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null
-* JavaScriptTextTransformFunctionName: UDF JavaScript Function Name. Default: null
+* javascriptTextTransformGCSPath: GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null
+* javascriptTextTransformFunctionName: UDF JavaScript Function Name. Default: null
 * maxRetryAttempts: Max retry attempts, must be > 0. Default: no retries
 * maxRetryDuration: Max retry duration in milliseconds, must be > 0. Default: no retries
-* JavaScriptIndexFnGCSPath: GCS path of storage location for JavaScript UDF to extract _index from row data
-* JavaScriptIndexFnName: Function name for JavaScript UDF to extract _index from row data
-* JavaScriptIdFnGCSPath: GCS path of storage location for JavaScript UDF to extract _id from row data
-* JavaScriptIdFnName: Function name for JavaScript UDF to extract _id from row data
-* JavaScriptTypeFnGCSPath: GCS path of storage location for JavaScript UDF to extract _type from row data
-* JavaScriptTypeFnName: Function name for JavaScript UDF to extract _type from row data
-* JavaScriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
-* JavaScriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* propertyAsIndex: A property in the document being indexed whose value specifies which _index to add the doc to (takes precendence over an index UDF)
+* javascriptIndexFnGCSPath: GCS path of storage location for JavaScript UDF to extract _index from row data
+* javascriptIndexFnName: Function name for JavaScript UDF to extract _index from row data
+* propertyAsId: A property in the document being indexed whose value specifies which _id to use for the doc (takes precendence over an id UDF)
+* javascriptIdFnGCSPath: GCS path of storage location for JavaScript UDF to extract _id from row data
+* javascriptIdFnName: Function name for JavaScript UDF to extract _id from row data
+* javascriptTypeFnGCSPath: GCS path of storage location for JavaScript UDF to extract _type from row data
+* javascriptTypeFnName: Function name for JavaScript UDF to extract _type from row data
+* javascriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* javascriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
 * usePartialUpdate:  Whether to use partial document updates (update rather than create or index, allows partial document updates)
 * useBulkIndexRatherThanCreate: Whether to use index (allows upserts) rather than create (errors on duplicate _id) with Elasticsearch bulk requests
 
@@ -189,56 +191,70 @@ echo '{
               "isOptional":true
           },
           {
-              "name":"JavaScriptIndexFnGCSPath",
+              "name":"propertyAsIndex",
+              "label":"Document property used to specify index",
+              "helpText":"A property in the document being indexed whose value specifies which index to add the doc to (takes precendence over an index UDF)",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIndexFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract index name from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptIndexFnName",
+              "name":"javascriptIndexFnName",
               "label":"UDF JavaScript Function Name for function to extract index name from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptIdFnGCSPath",
+              "name":"propertyAsId",
+              "label":"Document property used to specify _id",
+              "helpText":"A property in the document being indexed whose value specifies which _id to use for the doc (takes precendence over an id UDF)",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"javascriptIdFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract id value from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptIdFnName",
+              "name":"javascriptIdFnName",
               "label":"UDF JavaScript Function Name for function to extract id value from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptTypeFnGCSPath",
+              "name":"javascriptTypeFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract type value from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptTypeFnName",
+              "name":"javascriptTypeFnName",
               "label":"UDF JavaScript Function Name for function to extract type value from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptIsDeleteFnGCSPath",
+              "name":"javascriptIsDeleteFnGCSPath",
               "label":"GCS path to JavaScript UDF source for function to extract whether operation is delete or not from row",
               "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"JavaScriptIsDeleteFnName",
+              "name":"javascriptIsDeleteFnName",
               "label":"UDF JavaScript Function Name for function to extract whether operation is delete or not from row",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",

--- a/v2/googlecloud-to-elasticsearch/docs/PubSubToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/PubSubToElasticsearch/README.md
@@ -45,16 +45,16 @@ The template has the following optional parameters:
 * javaScriptTextTransformFunctionName: UDF JavaScript Function Name. Default: null
 * maxRetryAttempts: Max retry attempts, must be > 0. Default: no retries
 * maxRetryDuration: Max retry duration in milliseconds, must be > 0. Default: no retries
-* propertyAsIndex: A property in the document being indexed whose value specifies which _index to add the doc to (takes precendence over an index UDF)
-* javaScriptIndexFnGCSPath: GCS path of storage location for JavaScript UDF to extract _index from row data
-* javaScriptIndexFnName: Function name for JavaScript UDF to extract _index from row data
-* propertyAsId: A property in the document being indexed whose value specifies which _id to use for the doc (takes precendence over an id UDF)
-* javaScriptIdFnGCSPath: GCS path of storage location for JavaScript UDF to extract _id from row data
-* javaScriptIdFnName: Function name for JavaScript UDF to extract _id from row data
-* javaScriptTypeFnGCSPath: GCS path of storage location for JavaScript UDF to extract _type from row data
-* javaScriptTypeFnName: Function name for JavaScript UDF to extract _type from row data
-* javaScriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
-* javaScriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* propertyAsIndex: A property in the document being indexed whose value will specify _index metadata to be included with document in bulk request (takes precendence over an index UDF)
+* javaScriptIndexFnGcsPath: GCS path of storage location for JavaScript UDF that will specify _index metadata to be included with document in bulk request
+* javaScriptIndexFnName: Function name for JavaScript UDF that will specify _index metadata to be included with document in bulk request
+* propertyAsId: A property in the document being indexed whose value will specify _id metadata to be included with document in bulk request (takes precendence over an index UDF)
+* javaScriptIdFnGcsPath: GCS path of storage location for JavaScript UDF that will specify _id metadata to be included with document in bulk request
+* javaScriptIdFnName: Function name for JavaScript UDF that will specify _id metadata to be included with document in bulk request
+* javaScriptTypeFnGcsPath: GCS path of storage location for JavaScript UDF that will specify _type metadata to be included with document in bulk request
+* javaScriptTypeFnName: Function name for JavaScript UDF that will specify _type metadata to be included with document in bulk request
+* javaScriptIsDeleteFnGcsPath: GCS path of storage location for JavaScript UDF that will determine if document should be deleted rather than inserted or updated, function should return string value "true" or "false"
+* javaScriptIsDeleteFnName: Function name for JavaScript UDF that will determine if document should be deleted rather than inserted or updated, function should return string value "true" or "false"
 * usePartialUpdate:  Whether to use partial document updates (update rather than create or index, allows partial document updates)
 * bulkInsertMethod: Whether to use INDEX (index, allows upserts) or the default CREATE (create, errors on duplicate _id) with Elasticsearch bulk requests
 
@@ -192,70 +192,70 @@ echo '{
           },
           {
               "name":"propertyAsIndex",
-              "label":"Document property used to specify index",
-              "helpText":"A property in the document being indexed whose value specifies which index to add the doc to (takes precendence over an index UDF)",
+              "label":"Document property used to specify _index metadata with document in bulk request",
+              "helpText":"A property in the document being indexed whose value will specify _index metadata to be included with document in bulk request (takes precendence over an index UDF)",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javaScriptIndexFnGCSPath",
-              "label":"GCS path to JavaScript UDF source for function to extract index name from row",
-              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
+              "name":"javaScriptIndexFnGcsPath",
+              "label":"GCS path to JavaScript UDF source for function that will specify _index metadata to be included with document in bulk request",
+              "helpText":"GCS path to JavaScript UDF source. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
               "name":"javaScriptIndexFnName",
-              "label":"UDF JavaScript Function Name for function to extract index name from row",
+              "label":"UDF JavaScript Function Name for function that will specify _index metadata to be included with document in bulk request",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
               "name":"propertyAsId",
-              "label":"Document property used to specify _id",
-              "helpText":"A property in the document being indexed whose value specifies which _id to use for the doc (takes precendence over an id UDF)",
+              "label":"Document property used to specify _id metadata with document in bulk request",
+              "helpText":"A property in the document being indexed whose value will specify _id metadata to be included with document in bulk request (takes precendence over an index UDF)",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javaScriptIdFnGCSPath",
-              "label":"GCS path to JavaScript UDF source for function to extract id value from row",
-              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
+              "name":"javaScriptIdFnGcsPath",
+              "label":"GCS path to JavaScript UDF source function that will specify _id metadata to be included with document in bulk request",
+              "helpText":"GCS path to JavaScript UDF source. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
               "name":"javaScriptIdFnName",
-              "label":"UDF JavaScript Function Name for function to extract id value from row",
+              "label":"UDF JavaScript Function Name for function that will specify _id metadata to be included with document in bulk request",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javaScriptTypeFnGCSPath",
-              "label":"GCS path to JavaScript UDF source for function to extract type value from row",
-              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
+              "name":"javaScriptTypeFnGcsPath",
+              "label":"GCS path to JavaScript UDF source for function that will specify _type metadata to be included with document in bulk request",
+              "helpText":"GCS path to JavaScript UDF source. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
               "name":"javaScriptTypeFnName",
-              "label":"UDF JavaScript Function Name for function to extract type value from row",
+              "label":"UDF JavaScript Function Name for function that will specify _type metadata to be included with document in bulk request",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javaScriptIsDeleteFnGCSPath",
-              "label":"GCS path to JavaScript UDF source for function to extract whether operation is delete or not from row",
-              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
+              "name":"javaScriptIsDeleteFnGcsPath",
+              "label":"GCS path to JavaScript UDF source for function that will determine if document should be deleted rather than inserted or updated, function should return string value \"true\" or \"false\"",
+              "helpText":"GCS path to JavaScript UDF source. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
               "name":"javaScriptIsDeleteFnName",
-              "label":"UDF JavaScript Function Name for function to extract whether operation is delete or not from row",
+              "label":"UDF JavaScript Function Name for function that will determine if document should be deleted rather than inserted or updated, function should return string value \"true\" or \"false\"",
               "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
@@ -297,6 +297,6 @@ Template can be executed using the following gcloud command.
 export JOB_NAME="${TEMPLATE_MODULE}-`date +%Y%m%d-%H%M%S-%N`"
 gcloud beta dataflow flex-template run ${JOB_NAME} \
         --project=${PROJECT} --region=us-central1 \
-        --template-file-GCS-location=${TEMPLATE_IMAGE_SPEC} \
+        --template-file-gcs-location=${TEMPLATE_IMAGE_SPEC} \
         --parameters inputSubscription=${SUBSCRIPTION},connectionUrl=${CONNECTION_URL},dataset=${DATASET},namespace=${NAMESPACE},apiKey=${API_KEY},errorOutputTopic=${ERROR_OUTPUT_TOPIC}
 ```

--- a/v2/googlecloud-to-elasticsearch/docs/PubSubToElasticsearch/README.md
+++ b/v2/googlecloud-to-elasticsearch/docs/PubSubToElasticsearch/README.md
@@ -41,19 +41,20 @@ The template has the following optional parameters:
 * namespace: An arbitrary grouping, such as an environment (dev, prod, or qa), a team, or a strategic business unit. Default is `default`
 * batchSize: Batch size in number of documents. Default: 1000
 * batchSizeBytes: Batch size in number of bytes. Default: 5242880 (5mb)
-* javascriptTextTransformGcsPath: Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null
-* javascriptTextTransformFunctionName: UDF Javascript Function Name. Default: null
+* JavaScriptTextTransformGCSPath: GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null
+* JavaScriptTextTransformFunctionName: UDF JavaScript Function Name. Default: null
 * maxRetryAttempts: Max retry attempts, must be > 0. Default: no retries
 * maxRetryDuration: Max retry duration in milliseconds, must be > 0. Default: no retries
-* javascriptIndexFnGcsPath: GCS path of storage location for Javascript UDF to extract _index from row data
-* javascriptIndexFnName: Function name for Javascript UDF to extract _index from row data
-* javascriptIdFnGcsPath: GCS path of storage location for Javascript UDF to extract _id from row data
-* javascriptIdFnName: Function name for Javascript UDF to extract _id from row data
-* javascriptTypeFnGcsPath: GCS path of storage location for Javascript UDF to extract _type from row data
-* javascriptTypeFnName: Function name for Javascript UDF to extract _type from row data
-* javascriptIsDeleteFnGcsPath: GCS path of storage location for Javascript UDF to determine if row should be a delete operation (rather than create, index, or update)
-* javascriptIsDeleteFnName: Function name for Javascript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* JavaScriptIndexFnGCSPath: GCS path of storage location for JavaScript UDF to extract _index from row data
+* JavaScriptIndexFnName: Function name for JavaScript UDF to extract _index from row data
+* JavaScriptIdFnGCSPath: GCS path of storage location for JavaScript UDF to extract _id from row data
+* JavaScriptIdFnName: Function name for JavaScript UDF to extract _id from row data
+* JavaScriptTypeFnGCSPath: GCS path of storage location for JavaScript UDF to extract _type from row data
+* JavaScriptTypeFnName: Function name for JavaScript UDF to extract _type from row data
+* JavaScriptIsDeleteFnGCSPath: GCS path of storage location for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
+* JavaScriptIsDeleteFnName: Function name for JavaScript UDF to determine if row should be a delete operation (rather than create, index, or update)
 * usePartialUpdate:  Whether to use partial document updates (update rather than create or index, allows partial document updates)
+* useBulkIndexRatherThanCreate: Whether to use index (allows upserts) rather than create (errors on duplicate _id) with Elasticsearch bulk requests
 
 ### Building Template
 This is a Flex Template meaning that the pipeline code will be containerized, and the container will be used to launch the Dataflow pipeline.
@@ -188,58 +189,58 @@ echo '{
               "isOptional":true
           },
           {
-              "name":"javascriptIndexFnGcsPath",
-              "label":"Gcs path to javascript udf source for function to extract index name from row",
-              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "name":"JavaScriptIndexFnGCSPath",
+              "label":"GCS path to JavaScript UDF source for function to extract index name from row",
+              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIndexFnName",
-              "label":"UDF Javascript Function Name for function to extract index name from row",
-              "helpText":"UDF Javascript Function Name. Default: null",
+              "name":"JavaScriptIndexFnName",
+              "label":"UDF JavaScript Function Name for function to extract index name from row",
+              "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIdFnGcsPath",
-              "label":"Gcs path to javascript udf source for function to extract id value from row",
-              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "name":"JavaScriptIdFnGCSPath",
+              "label":"GCS path to JavaScript UDF source for function to extract id value from row",
+              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIdFnName",
-              "label":"UDF Javascript Function Name for function to extract id value from row",
-              "helpText":"UDF Javascript Function Name. Default: null",
+              "name":"JavaScriptIdFnName",
+              "label":"UDF JavaScript Function Name for function to extract id value from row",
+              "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptTypeFnGcsPath",
-              "label":"Gcs path to javascript udf source for function to extract type value from row",
-              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "name":"JavaScriptTypeFnGCSPath",
+              "label":"GCS path to JavaScript UDF source for function to extract type value from row",
+              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptTypeFnName",
-              "label":"UDF Javascript Function Name for function to extract type value from row",
-              "helpText":"UDF Javascript Function Name. Default: null",
+              "name":"JavaScriptTypeFnName",
+              "label":"UDF JavaScript Function Name for function to extract type value from row",
+              "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIsDeleteFnGcsPath",
-              "label":"Gcs path to javascript udf source for function to extract whether operation is delete or not from row",
-              "helpText":"Gcs path to javascript udf source. Udf will be preferred option for transformation if supplied. Default: null",
+              "name":"JavaScriptIsDeleteFnGCSPath",
+              "label":"GCS path to JavaScript UDF source for function to extract whether operation is delete or not from row",
+              "helpText":"GCS path to JavaScript UDF source. UDF will be preferred option for transformation if supplied. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
           {
-              "name":"javascriptIsDeleteFnName",
-              "label":"UDF Javascript Function Name for function to extract whether operation is delete or not from row",
-              "helpText":"UDF Javascript Function Name. Default: null",
+              "name":"JavaScriptIsDeleteFnName",
+              "label":"UDF JavaScript Function Name for function to extract whether operation is delete or not from row",
+              "helpText":"UDF JavaScript Function Name. Default: null",
               "paramType":"TEXT",
               "isOptional":true
           },
@@ -247,6 +248,13 @@ echo '{
               "name":"usePartialUpdate",
               "label":"Use partial updates (update rather than create or index, allowing partial docs) with Elasticsearch requests",
               "helpText":"Whether to use partial updates (update rather than create or index, allowing partial docs) with Elasticsearch requests",
+              "paramType":"TEXT",
+              "isOptional":true
+          },
+          {
+              "name":"useBulkIndexRatherThanCreate",
+              "label":"Use index (allows upserts) rather than create (errors on duplicate _id) in bulk requests",
+              "helpText":"Whether to use index (allows upserts) rather than create (errors on duplicate _id) with Elasticsearch bulk requests",
               "paramType":"TEXT",
               "isOptional":true
           }
@@ -273,6 +281,6 @@ Template can be executed using the following gcloud command.
 export JOB_NAME="${TEMPLATE_MODULE}-`date +%Y%m%d-%H%M%S-%N`"
 gcloud beta dataflow flex-template run ${JOB_NAME} \
         --project=${PROJECT} --region=us-central1 \
-        --template-file-gcs-location=${TEMPLATE_IMAGE_SPEC} \
+        --template-file-GCS-location=${TEMPLATE_IMAGE_SPEC} \
         --parameters inputSubscription=${SUBSCRIPTION},connectionUrl=${CONNECTION_URL},dataset=${DATASET},namespace=${NAMESPACE},apiKey=${API_KEY},errorOutputTopic=${ERROR_OUTPUT_TOPIC}
 ```

--- a/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/BigQueryToElasticsearch.java
+++ b/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/BigQueryToElasticsearch.java
@@ -32,7 +32,6 @@ import org.apache.beam.sdk.transforms.ParDo;
  * README.md</a></b> for further information.
  */
 public class BigQueryToElasticsearch {
-
   /**
    * Main entry point for pipeline execution.
    *
@@ -57,7 +56,6 @@ public class BigQueryToElasticsearch {
 
     // Create the pipeline.
     Pipeline pipeline = Pipeline.create(options);
-
     /*
      * Steps: 1) Read records from BigQuery via BigQueryIO.
      *        2) Create json string from Table Row.

--- a/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/GCSToElasticsearch.java
+++ b/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/GCSToElasticsearch.java
@@ -55,7 +55,7 @@ public class GCSToElasticsearch {
   /** The tag for the lines of the CSV. */
   static final TupleTag<String> CSV_LINES = new TupleTag<String>() {};
 
-  /** The tag for the dead-letter output of the udf. */
+  /** The tag for the dead-letter output of the UDF. */
   static final TupleTag<FailsafeElement<String, String>> PROCESSING_DEADLETTER_OUT =
       new TupleTag<FailsafeElement<String, String>>() {};
 


### PR DESCRIPTION
switch create to index to allow duplicates (due to timeout/retry) to not cause errors + add javascript functions for extraction of id, index, type, and whether or not to delete (already supported by ElasticsearchIO)

Resolves #388 
Resolves #408 