### PR TITLE
Running all unit tests before throwing failure

### DIFF
--- a/cicd/cmd/run-unit-tests/main.go
+++ b/cicd/cmd/run-unit-tests/main.go
@@ -29,7 +29,8 @@ func main() {
 		mvnFlags.IncludeDependents(),
 		mvnFlags.SkipCheckstyle(),
 		mvnFlags.SkipDependencyAnalysis(),
-		mvnFlags.SkipJib())
+		mvnFlags.SkipJib(),
+		mvnFlags.FailAtTheEnd())
 	if err != nil {
 		log.Fatalf("%v\n", err)
 	}

--- a/cicd/internal/workflows/maven-workflows.go
+++ b/cicd/internal/workflows/maven-workflows.go
@@ -51,6 +51,7 @@ type MavenFlags interface {
 	SkipDependencyAnalysis() string
 	SkipJib() string
 	SkipTests() string
+	FailAtTheEnd() string
 }
 
 type mvnFlags struct{}
@@ -77,6 +78,10 @@ func (*mvnFlags) SkipJib() string {
 
 func (*mvnFlags) SkipTests() string {
 	return "-Dmaven.test.skip"
+}
+
+func (*mvnFlags) FailAtTheEnd() string {
+	return "-fae"
 }
 
 func NewMavenFlags() MavenFlags {


### PR DESCRIPTION
This allows Java unit tests to run to completion, and only then fail. This grants us full information about how many tests are passing / failing / skipped.