### PR TITLE
Fix issue with null error messages in BulkDecompressor

### DIFF
--- a/src/main/java/com/google/cloud/teleport/spanner/AvroSchemaToDdlConverter.java
+++ b/src/main/java/com/google/cloud/teleport/spanner/AvroSchemaToDdlConverter.java
@@ -266,7 +266,8 @@ public class AvroSchemaToDdlConverter {
           return com.google.cloud.teleport.spanner.common.Type.numeric();
         }
         if (LogicalTypes.decimal(NumericUtils.PG_MAX_PRECISION, NumericUtils.PG_MAX_SCALE)
-            .equals(logicalType) && dialect == Dialect.POSTGRESQL) {
+                .equals(logicalType)
+            && dialect == Dialect.POSTGRESQL) {
           return com.google.cloud.teleport.spanner.common.Type.pgNumeric();
         }
         return (dialect == Dialect.GOOGLE_STANDARD_SQL)

--- a/src/main/java/com/google/cloud/teleport/spanner/ExportPipeline.java
+++ b/src/main/java/com/google/cloud/teleport/spanner/ExportPipeline.java
@@ -138,9 +138,11 @@ public class ExportPipeline {
             // a bug resulting in the label value being set to the original parameter value,
             // with no fallback to the default project.
             // TODO: remove NestedValueProvider when this is fixed in Beam.
-            .withProjectId(NestedValueProvider.of(options.getSpannerProjectId(),
-                (SerializableFunction<String, String>) input ->
-                    input != null ? input : SpannerOptions.getDefaultProjectId()))
+            .withProjectId(
+                NestedValueProvider.of(
+                    options.getSpannerProjectId(),
+                    (SerializableFunction<String, String>)
+                        input -> input != null ? input : SpannerOptions.getDefaultProjectId()))
             .withHost(options.getSpannerHost())
             .withInstanceId(options.getInstanceId())
             .withDatabaseId(options.getDatabaseId())

--- a/src/main/java/com/google/cloud/teleport/spanner/ImportPipeline.java
+++ b/src/main/java/com/google/cloud/teleport/spanner/ImportPipeline.java
@@ -130,9 +130,11 @@ public class ImportPipeline {
             // a bug resulting in the label value being set to the original parameter value,
             // with no fallback to the default project.
             // TODO: remove NestedValueProvider when this is fixed in Beam.
-            .withProjectId(NestedValueProvider.of(options.getSpannerProjectId(),
-                (SerializableFunction<String, String>) input ->
-                    input != null ? input : SpannerOptions.getDefaultProjectId()))
+            .withProjectId(
+                NestedValueProvider.of(
+                    options.getSpannerProjectId(),
+                    (SerializableFunction<String, String>)
+                        input -> input != null ? input : SpannerOptions.getDefaultProjectId()))
             .withHost(options.getSpannerHost())
             .withInstanceId(options.getInstanceId())
             .withDatabaseId(options.getDatabaseId())

--- a/src/main/java/com/google/cloud/teleport/spanner/TextImportPipeline.java
+++ b/src/main/java/com/google/cloud/teleport/spanner/TextImportPipeline.java
@@ -193,9 +193,11 @@ public class TextImportPipeline {
             // a bug resulting in the label value being set to the original parameter value,
             // with no fallback to the default project.
             // TODO: remove NestedValueProvider when this is fixed in Beam.
-            .withProjectId(NestedValueProvider.of(options.getSpannerProjectId(),
-                (SerializableFunction<String, String>) input ->
-                    input != null ? input : SpannerOptions.getDefaultProjectId()))
+            .withProjectId(
+                NestedValueProvider.of(
+                    options.getSpannerProjectId(),
+                    (SerializableFunction<String, String>)
+                        input -> input != null ? input : SpannerOptions.getDefaultProjectId()))
             .withHost(options.getSpannerHost())
             .withInstanceId(options.getInstanceId())
             .withDatabaseId(options.getDatabaseId())

--- a/src/main/java/com/google/cloud/teleport/spanner/ddl/Index.java
+++ b/src/main/java/com/google/cloud/teleport/spanner/ddl/Index.java
@@ -50,10 +50,7 @@ public abstract class Index implements Serializable {
   abstract String interleaveIn();
 
   public static Builder builder(Dialect dialect) {
-    return new AutoValue_Index.Builder()
-        .dialect(dialect)
-        .nullFiltered(false)
-        .unique(false);
+    return new AutoValue_Index.Builder().dialect(dialect).nullFiltered(false).unique(false);
   }
 
   public static Builder builder() {

--- a/src/main/java/com/google/cloud/teleport/spanner/ddl/IndexColumn.java
+++ b/src/main/java/com/google/cloud/teleport/spanner/ddl/IndexColumn.java
@@ -39,11 +39,7 @@ public abstract class IndexColumn implements Serializable {
   public abstract NullsOrder nullsOrder();
 
   public static IndexColumn create(String name, Order order, Dialect dialect) {
-    return new AutoValue_IndexColumn.Builder()
-        .dialect(dialect)
-        .name(name)
-        .order(order)
-        .autoBuild();
+    return new AutoValue_IndexColumn.Builder().dialect(dialect).name(name).order(order).autoBuild();
   }
 
   public static IndexColumn create(String name, Order order) {
@@ -87,8 +83,8 @@ public abstract class IndexColumn implements Serializable {
         .append(identifierQuote + " ")
         .append(order().title);
     if (nullsOrder() != null) {
-        appendable.append(" NULLS ").append(nullsOrder().title);
-      }
+      appendable.append(" NULLS ").append(nullsOrder().title);
+    }
   }
 
   public String prettyPrint() {

--- a/src/main/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScanner.java
+++ b/src/main/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScanner.java
@@ -136,15 +136,15 @@ public class InformationSchemaScanner {
     switch (dialect) {
       case GOOGLE_STANDARD_SQL:
         return Statement.of(
-                "SELECT t.option_name, t.option_type, t.option_value "
-                    + " FROM information_schema.database_options AS t "
-                    + " WHERE t.catalog_name = '' AND t.schema_name = ''");
+            "SELECT t.option_name, t.option_type, t.option_value "
+                + " FROM information_schema.database_options AS t "
+                + " WHERE t.catalog_name = '' AND t.schema_name = ''");
       case POSTGRESQL:
         return Statement.of(
-                "SELECT t.option_name, t.option_type, t.option_value "
-                    + " FROM information_schema.database_options AS t "
-                    + " WHERE t.schema_name NOT IN "
-                    + "('information_schema', 'spanner_sys', 'pg_catalog')");
+            "SELECT t.option_name, t.option_type, t.option_value "
+                + " FROM information_schema.database_options AS t "
+                + " WHERE t.schema_name NOT IN "
+                + "('information_schema', 'spanner_sys', 'pg_catalog')");
       default:
         throw new IllegalArgumentException("Unrecognized dialect: " + dialect);
     }
@@ -269,23 +269,23 @@ public class InformationSchemaScanner {
     switch (dialect) {
       case GOOGLE_STANDARD_SQL:
         return Statement.of(
-                "SELECT c.table_name, c.column_name,"
-                    + " c.ordinal_position, c.spanner_type, c.is_nullable,"
-                    + " c.is_generated, c.generation_expression, c.is_stored"
-                    + " FROM information_schema.columns as c"
-                    + " WHERE c.table_catalog = '' AND c.table_schema = '' "
-                    + " AND c.spanner_state = 'COMMITTED' "
-                    + " ORDER BY c.table_name, c.ordinal_position");
+            "SELECT c.table_name, c.column_name,"
+                + " c.ordinal_position, c.spanner_type, c.is_nullable,"
+                + " c.is_generated, c.generation_expression, c.is_stored"
+                + " FROM information_schema.columns as c"
+                + " WHERE c.table_catalog = '' AND c.table_schema = '' "
+                + " AND c.spanner_state = 'COMMITTED' "
+                + " ORDER BY c.table_name, c.ordinal_position");
       case POSTGRESQL:
         return Statement.of(
-                "SELECT c.table_name, c.column_name,"
-                    + " c.ordinal_position, c.spanner_type, c.is_nullable,"
-                    + " c.is_generated, c.generation_expression, c.is_stored, c.column_default"
-                    + " FROM information_schema.columns as c"
-                    + " WHERE c.table_schema NOT IN "
-                    + " ('information_schema', 'spanner_sys', 'pg_catalog') "
-                    + " AND c.spanner_state = 'COMMITTED' "
-                    + " ORDER BY c.table_name, c.ordinal_position");
+            "SELECT c.table_name, c.column_name,"
+                + " c.ordinal_position, c.spanner_type, c.is_nullable,"
+                + " c.is_generated, c.generation_expression, c.is_stored, c.column_default"
+                + " FROM information_schema.columns as c"
+                + " WHERE c.table_schema NOT IN "
+                + " ('information_schema', 'spanner_sys', 'pg_catalog') "
+                + " AND c.spanner_state = 'COMMITTED' "
+                + " ORDER BY c.table_name, c.ordinal_position");
       default:
         throw new IllegalArgumentException("Unrecognized dialect: " + dialect);
     }
@@ -336,20 +336,20 @@ public class InformationSchemaScanner {
     switch (dialect) {
       case GOOGLE_STANDARD_SQL:
         return Statement.of(
-                "SELECT t.table_name, t.index_name, t.parent_table_name, t.is_unique,"
-                    + " t.is_null_filtered"
-                    + " FROM information_schema.indexes AS t"
-                    + " WHERE t.table_catalog = '' AND t.table_schema = '' AND"
-                    + " t.index_type='INDEX' AND t.spanner_is_managed = FALSE"
-                    + " ORDER BY t.table_name, t.index_name");
+            "SELECT t.table_name, t.index_name, t.parent_table_name, t.is_unique,"
+                + " t.is_null_filtered"
+                + " FROM information_schema.indexes AS t"
+                + " WHERE t.table_catalog = '' AND t.table_schema = '' AND"
+                + " t.index_type='INDEX' AND t.spanner_is_managed = FALSE"
+                + " ORDER BY t.table_name, t.index_name");
       case POSTGRESQL:
         return Statement.of(
-                "SELECT t.table_name, t.index_name, t.parent_table_name, t.is_unique,"
-                    + " t.is_null_filtered, t.filter FROM information_schema.indexes AS t "
-                    + " WHERE t.table_schema NOT IN "
-                    + " ('information_schema', 'spanner_sys', 'pg_catalog')"
-                    + " AND t.index_type='INDEX' AND t.spanner_is_managed = 'NO' "
-                    + " ORDER BY t.table_name, t.index_name");
+            "SELECT t.table_name, t.index_name, t.parent_table_name, t.is_unique,"
+                + " t.is_null_filtered, t.filter FROM information_schema.indexes AS t "
+                + " WHERE t.table_schema NOT IN "
+                + " ('information_schema', 'spanner_sys', 'pg_catalog')"
+                + " AND t.index_type='INDEX' AND t.spanner_is_managed = 'NO' "
+                + " ORDER BY t.table_name, t.index_name");
       default:
         throw new IllegalArgumentException("Unrecognized dialect: " + dialect);
     }
@@ -413,17 +413,17 @@ public class InformationSchemaScanner {
     switch (dialect) {
       case GOOGLE_STANDARD_SQL:
         return Statement.of(
-                "SELECT t.table_name, t.column_name, t.column_ordering, t.index_name "
-                    + "FROM information_schema.index_columns AS t "
-                    + "WHERE t.table_catalog = '' AND t.table_schema = '' "
-                    + "ORDER BY t.table_name, t.index_name, t.ordinal_position");
+            "SELECT t.table_name, t.column_name, t.column_ordering, t.index_name "
+                + "FROM information_schema.index_columns AS t "
+                + "WHERE t.table_catalog = '' AND t.table_schema = '' "
+                + "ORDER BY t.table_name, t.index_name, t.ordinal_position");
       case POSTGRESQL:
         return Statement.of(
-                "SELECT t.table_name, t.column_name, t.column_ordering, t.index_name "
-                    + "FROM information_schema.index_columns AS t "
-                    + "WHERE t.table_schema NOT IN "
-                    + "('information_schema', 'spanner_sys', 'pg_catalog') "
-                    + "ORDER BY t.table_name, t.index_name, t.ordinal_position");
+            "SELECT t.table_name, t.column_name, t.column_ordering, t.index_name "
+                + "FROM information_schema.index_columns AS t "
+                + "WHERE t.table_schema NOT IN "
+                + "('information_schema', 'spanner_sys', 'pg_catalog') "
+                + "ORDER BY t.table_name, t.index_name, t.ordinal_position");
       default:
         throw new IllegalArgumentException("Unrecognized dialect: " + dialect);
     }
@@ -475,19 +475,19 @@ public class InformationSchemaScanner {
     switch (dialect) {
       case GOOGLE_STANDARD_SQL:
         return Statement.of(
-                "SELECT t.table_name, t.column_name, t.option_name, t.option_type,"
-                    + " t.option_value"
-                    + " FROM information_schema.column_options AS t"
-                    + " WHERE t.table_catalog = '' AND t.table_schema = ''"
-                    + " ORDER BY t.table_name, t.column_name");
+            "SELECT t.table_name, t.column_name, t.option_name, t.option_type,"
+                + " t.option_value"
+                + " FROM information_schema.column_options AS t"
+                + " WHERE t.table_catalog = '' AND t.table_schema = ''"
+                + " ORDER BY t.table_name, t.column_name");
       case POSTGRESQL:
         return Statement.of(
-                "SELECT t.table_name, t.column_name, t.option_name, t.option_type,"
-                    + " t.option_value"
-                    + " FROM information_schema.column_options AS t"
-                    + " WHERE t.table_schema NOT IN "
-                    + " ('information_schema', 'spanner_sys', 'pg_catalog')"
-                    + " ORDER BY t.table_name, t.column_name");
+            "SELECT t.table_name, t.column_name, t.option_name, t.option_type,"
+                + " t.option_value"
+                + " FROM information_schema.column_options AS t"
+                + " WHERE t.table_schema NOT IN "
+                + " ('information_schema', 'spanner_sys', 'pg_catalog')"
+                + " ORDER BY t.table_name, t.column_name");
       default:
         throw new IllegalArgumentException("Unrecognized dialect: " + dialect);
     }

--- a/src/main/java/com/google/cloud/teleport/spanner/ddl/Table.java
+++ b/src/main/java/com/google/cloud/teleport/spanner/ddl/Table.java
@@ -166,10 +166,10 @@ public abstract class Table implements Serializable {
           .append(",\nINTERLEAVE IN PARENT " + identifierQuote)
           .append(interleaveInParent())
           .append(identifierQuote);
-        if (onDeleteCascade()) {
-          appendable.append(" ON DELETE CASCADE");
-        }
+      if (onDeleteCascade()) {
+        appendable.append(" ON DELETE CASCADE");
       }
+    }
     if (includeIndexes) {
       appendable.append("\n");
       appendable.append(String.join("\n", indexes()));

--- a/src/main/java/com/google/cloud/teleport/templates/BulkDecompressor.java
+++ b/src/main/java/com/google/cloud/teleport/templates/BulkDecompressor.java
@@ -26,6 +26,7 @@ import java.nio.channels.WritableByteChannel;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.Compression;
@@ -345,17 +346,18 @@ public class BulkDecompressor {
      * @param inputFile The input file which failed decompression.
      * @param compression The compression mode used during decompression.
      * @return The sanitized error message. If the error was not from a malformed file, the same
-     *     error message passed will be returned.
+     *     error message passed will be returned (if not null) or an empty string will be returned
+     *     (if null).
      */
     private String sanitizeDecompressionErrorMsg(
-        String errorMsg, ResourceId inputFile, Compression compression) {
+        @Nullable String errorMsg, ResourceId inputFile, Compression compression) {
       if (errorMsg != null
           && (errorMsg.contains("not in the BZip2 format")
               || errorMsg.contains("incorrect header check"))) {
         errorMsg = String.format(MALFORMED_ERROR_MSG, inputFile.toString(), compression);
       }
 
-      return errorMsg;
+      return errorMsg == null ? "" : errorMsg;
     }
   }
 }

--- a/src/main/java/com/google/cloud/teleport/templates/SpannerToText.java
+++ b/src/main/java/com/google/cloud/teleport/templates/SpannerToText.java
@@ -78,7 +78,7 @@ public class SpannerToText {
   /** Custom PipelineOptions. */
   public interface SpannerToTextOptions
       extends PipelineOptions, SpannerReadOptions, FilesystemWriteOptions {
-    
+
     @Description("Temporary Directory to store Csv files.")
     ValueProvider<String> getCsvTempDirectory();
 

--- a/src/main/java/com/google/cloud/teleport/templates/common/SplunkTokenSource.java
+++ b/src/main/java/com/google/cloud/teleport/templates/common/SplunkTokenSource.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.google.cloud.teleport.templates.common;
 
 /** Supported sources for a Splunk Token. */

--- a/src/main/java/com/google/cloud/teleport/util/SecretManagerValueProvider.java
+++ b/src/main/java/com/google/cloud/teleport/util/SecretManagerValueProvider.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.google.cloud.teleport.util;
 
 import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;

--- a/src/main/java/com/google/cloud/teleport/util/TokenNestedValueProvider.java
+++ b/src/main/java/com/google/cloud/teleport/util/TokenNestedValueProvider.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.google.cloud.teleport.util;
 
 import static com.google.common.base.Preconditions.checkArgument;

--- a/src/test/java/com/google/cloud/teleport/spanner/CopyDbTest.java
+++ b/src/test/java/com/google/cloud/teleport/spanner/CopyDbTest.java
@@ -760,7 +760,7 @@ public class CopyDbTest {
     createAndPopulate(ddl, 100);
     runTest(Dialect.POSTGRESQL);
   }
-  
+
   @Test
   public void changeStreams() throws Exception {
     Ddl ddl =

--- a/src/test/java/com/google/cloud/teleport/spanner/DdlToAvroSchemaConverterTest.java
+++ b/src/test/java/com/google/cloud/teleport/spanner/DdlToAvroSchemaConverterTest.java
@@ -775,7 +775,7 @@ public class DdlToAvroSchemaConverterTest {
     assertThat(fields.get(1).schema(), equalTo(nullableTimestampUnion()));
     assertThat(fields.get(1).getProp("sqlType"), equalTo("timestamp with time zone"));
   }
-  
+
   @Test
   public void changeStreams() {
     DdlToAvroSchemaConverter converter =

--- a/src/test/java/com/google/cloud/teleport/spanner/ImportFromAvroTest.java
+++ b/src/test/java/com/google/cloud/teleport/spanner/ImportFromAvroTest.java
@@ -944,7 +944,7 @@ public class ImportFromAvroTest {
                 .build()),
         Dialect.POSTGRESQL);
   }
-  
+
   @Test
   public void changeStreams() throws Exception {
     Map<String, Schema> avroFiles = new HashMap<>();

--- a/src/test/java/com/google/cloud/teleport/spanner/SpannerServerResource.java
+++ b/src/test/java/com/google/cloud/teleport/spanner/SpannerServerResource.java
@@ -57,11 +57,7 @@ public class SpannerServerResource extends ExternalResource {
   protected void before() {
     SpannerOptions spannerOptions;
     if (EMULATOR_HOST == null) {
-      spannerOptions =
-          SpannerOptions.newBuilder()
-              .setProjectId(projectId)
-              .setHost(host)
-              .build();
+      spannerOptions = SpannerOptions.newBuilder().setProjectId(projectId).setHost(host).build();
     } else {
       spannerOptions =
           SpannerOptions.newBuilder()

--- a/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
+++ b/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
@@ -670,7 +670,7 @@ public class InformationSchemaScannerIT {
     statements.set(0, alterStatement.replace(dbId, "%db_name%"));
     assertThat(ddl.prettyPrint(), equalToCompressingWhiteSpace(String.join("", statements)));
   }
-  
+
   @Test
   public void changeStreams() throws Exception {
     List<String> statements =

--- a/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerTest.java
+++ b/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerTest.java
@@ -24,8 +24,10 @@ import org.junit.Test;
 /** Unit tests for InformationSchemaScanner class. */
 public class InformationSchemaScannerTest {
 
-  final InformationSchemaScanner googleSQLInfoScanner = new InformationSchemaScanner(null, Dialect.GOOGLE_STANDARD_SQL);
-  final InformationSchemaScanner postgresSQLInfoScanner = new InformationSchemaScanner(null, Dialect.POSTGRESQL);
+  final InformationSchemaScanner googleSQLInfoScanner =
+      new InformationSchemaScanner(null, Dialect.GOOGLE_STANDARD_SQL);
+  final InformationSchemaScanner postgresSQLInfoScanner =
+      new InformationSchemaScanner(null, Dialect.POSTGRESQL);
 
   @Test
   public void testDatabaseOptionsSQL() {

--- a/src/test/java/com/google/cloud/teleport/templates/SpannerServerResource.java
+++ b/src/test/java/com/google/cloud/teleport/templates/SpannerServerResource.java
@@ -58,10 +58,7 @@ public class SpannerServerResource extends ExternalResource {
     SpannerOptions spannerOptions;
     if (EMULATOR_HOST == null) {
       spannerOptions =
-          SpannerOptions.newBuilder()
-              .setProjectId(this.projectId)
-              .setHost(host)
-              .build();
+          SpannerOptions.newBuilder().setProjectId(this.projectId).setHost(host).build();
     } else {
       spannerOptions =
           SpannerOptions.newBuilder()

--- a/src/test/java/com/google/cloud/teleport/util/TokenNestedValueProviderTest.java
+++ b/src/test/java/com/google/cloud/teleport/util/TokenNestedValueProviderTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.google.cloud.teleport.util;
 
 import static junit.framework.Assert.assertEquals;


### PR DESCRIPTION
If the `IOException` returns null for `getMessage`, which may happen with `EOFException`, this will now return an empty string rather than letting the null get returned to a `KV` that isn't set up to handle nulls.

Also ran spotless, since there's been a lot of changes to Classic Templates that violate spotless.