### PR TITLE
MongoDB batch template - Removed bucketing to avoid aggregation at read time

### DIFF
--- a/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQuery.java
+++ b/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQuery.java
@@ -68,7 +68,6 @@ public class MongoDbToBigQuery {
         .apply(
             "Read Documents",
             MongoDbIO.read()
-                .withBucketAuto(true)
                 .withUri(options.getMongoDbUri())
                 .withDatabase(options.getDatabase())
                 .withCollection(options.getCollection()))


### PR DESCRIPTION
I have removed the .withBucketAuto(true) from MongoDb to BigQuery batch pipeline. This will enhance the MongoDb read capability. If this line is present the read will perform aggregation on mongodb database - This will fail if we consider huge number of documents being read. 