### PR TITLE
fix special characters in dataset name

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/cdc/mappers/DataStreamMapper.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/cdc/mappers/DataStreamMapper.java
@@ -64,7 +64,7 @@ public class DataStreamMapper extends BigQueryMapper<TableRow, KV<TableId, Table
   public TableId getTableId(TableRow input) {
     DatastreamRow row = DatastreamRow.of(input);
 
-    String datasetName = row.formatStringTemplateForBigQuery(datasetNameTemplate);
+    String datasetName = row.formatStringTemplateForBigQueryDataset(datasetNameTemplate);
     String tableName = row.formatStringTemplateForBigQuery(tableNameTemplate);
 
     return TableId.of(getProjectId(), datasetName, tableName);

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/cdc/mappers/MergeInfoMapper.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/cdc/mappers/MergeInfoMapper.java
@@ -105,11 +105,11 @@ public class MergeInfoMapper
                             METADATA_DELETED,
                             TableId.of(
                                 projectId,
-                                row.formatStringTemplateForBigQuery(stagingDataset),
+                                row.formatStringTemplateForBigQueryDataset(stagingDataset),
                                 row.formatStringTemplateForBigQuery(stagingTable)),
                             TableId.of(
                                 projectId,
-                                row.formatStringTemplateForBigQuery(replicaDataset),
+                                row.formatStringTemplateForBigQueryDataset(replicaDataset),
                                 row.formatStringTemplateForBigQuery(replicaTable)));
 
                     return Lists.newArrayList(mergeInfo);

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java
@@ -584,6 +584,7 @@ public class BigQueryConverters {
   /**
    * Returns a sanitized string by replacing invalid BigQuery Dataset characters
    * (non- Letters, numbers or underscores) with the replacement argument supplied.
+   * https://cloud.google.com/bigquery/docs/datasets#dataset-naming
    */
   public static String sanitizeBigQueryDatasetChars(String name, String replacement) {
     return BQ_SANITIZE_DATASET_PATTERN.matcher(name).replaceAll(replacement);

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java
@@ -90,6 +90,7 @@ import org.slf4j.LoggerFactory;
 public class BigQueryConverters {
 
   private static final Pattern BQ_SANITIZE_PATTERN = Pattern.compile("\\$|\\.");
+  private static final Pattern BQ_SANITIZE_DATASET_PATTERN = Pattern.compile("[^0-9a-zA-Z_]");
 
   /* Logger for class. */
   private static final Logger LOG = LoggerFactory.getLogger(BigQueryConverters.class);
@@ -578,6 +579,14 @@ public class BigQueryConverters {
    */
   public static String sanitizeBigQueryChars(String name, String replacement) {
     return BQ_SANITIZE_PATTERN.matcher(name).replaceAll(replacement);
+  }
+
+  /**
+   * Returns a sanitized string by replacing invalid BigQuery Dataset characters
+   * (non- Letters, numbers or underscores) with the replacement argument supplied.
+   */
+  public static String sanitizeBigQueryDatasetChars(String name, String replacement) {
+    return BQ_SANITIZE_DATASET_PATTERN.matcher(name).replaceAll(replacement);
   }
 
   /** A {@link SerializableFunction} to convert a {@link TableRow} to a {@link GenericRecord}. */

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/values/DatastreamRow.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/values/DatastreamRow.java
@@ -145,6 +145,14 @@ public class DatastreamRow {
     return BigQueryConverters.sanitizeBigQueryChars(this.formatStringTemplate(template), "_");
   }
 
+  /**
+  * Returns the formatted string after applying the data inside the row and stripped invalid BigQuery Dataset
+  * characters.
+  */
+  public String formatStringTemplateForBigQueryDataset(String template) {
+    return BigQueryConverters.sanitizeBigQueryDatasetChars(this.formatStringTemplate(template), "_");
+  }
+
   /* Returns the list of field/column names for the given row. */
   public Iterable<String> getFieldNames() {
     if (this.jsonRow != null) {

--- a/v2/common/src/test/java/com/google/cloud/teleport/v2/transforms/BigQueryConvertersTest.java
+++ b/v2/common/src/test/java/com/google/cloud/teleport/v2/transforms/BigQueryConvertersTest.java
@@ -579,4 +579,13 @@ public class BigQueryConvertersTest {
 
     assertThat(name).isEqualTo("my_table_name");
   }
+
+  @Test
+  public void testSanitizeBigQueryDatasetChars() {
+    String sourceName = "my$data-set.name";
+
+    String name = BigQueryConverters.sanitizeBigQueryDatasetChars(sourceName, "_");
+
+    assertThat(name).isEqualTo("my_data_set_name");
+  }
 }


### PR DESCRIPTION
google have a [much more restrictive set of characters that are allowed for dataset names](https://cloud.google.com/bigquery/docs/datasets#:~:text=Letters%20(uppercase%20or%20lowercase)%2C%20numbers%2C%20and%20underscores) than tables. in our case, the source mysql database had a `-` in its name. this is not allowed in a bq dataset. 

this pr replaces invalid characters with an `_`