### PR TITLE
Set maxElapsedMillis on HttpEventPublisher to speedup Splunk tests

### DIFF
--- a/src/test/java/com/google/cloud/teleport/splunk/HttpEventPublisherTest.java
+++ b/src/test/java/com/google/cloud/teleport/splunk/HttpEventPublisherTest.java
@@ -248,12 +248,15 @@ public class HttpEventPublisherTest {
     byte[] rootCa =
         Resources.toString(Resources.getResource(INCORRECT_ROOT_CA_PATH), StandardCharsets.UTF_8)
             .getBytes();
+
+    int timeoutInMillis = 5000; // 5 seconds
     HttpEventPublisher publisher =
         HttpEventPublisher.newBuilder()
             .withUrl("https://localhost:" + String.valueOf(mockServer.getPort()))
             .withToken("test-token")
             .withDisableCertificateValidation(false)
             .withRootCaCertificate(rootCa)
+            .withMaxElapsedMillis(timeoutInMillis)
             .withEnableGzipHttpCompression(true)
             .build();
     publisher.execute(SPLUNK_EVENTS);


### PR DESCRIPTION
### Context

I noticed that a fair chunk of the unit test time is spent on a single Splunk test case (`HttpEventPublisherTest - unrecognizedSelfSignedCertificateTest`).

It expects an `SSLHandshakeException` for an invalid/self-signed certificate, which is correct, but the default configurations for `HttpEventPublisher`/`HttpRequest` is to use an exponential backoff strategy for any subclass of `IOException` (note that `SSLHandshakeException -> SSLException -> IOException`).

So my idea is to define `maxElapsedMillis` on that test to limit the amount of time it stays on the backoff loop.
The publisher defaults to `ExponentialBackOff.DEFAULT_MAX_ELAPSED_TIME_MILLIS` (900s). Which is a lot, but `numRetries` defaults to 10 on `HttpRequest`, so it takes about ~55s to fail ([sum from i=0 to 9 of 0.5 * 1.5^i](https://www.wolframalpha.com/input?i=sum+from+i%3D0+to+9+of+0.5+*+1.5%5Ei)).

Reducing `maxElapsedMillis` to 5 seconds, it will still allow the retry to happen about 4 times ([sum from i=0 to 4 of 0.5 * 1.5^i](https://www.wolframalpha.com/input?i=sum+from+i%3D0+to+4+of+0.5+*+1.5%5Ei)) and produce the same results.

With or without `maxElapsedMillis`, the same exception is thrown by `publisher.execute`:

> javax.net.ssl.SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target


### Results

#### Before
```
-------------------------------------------------------------------------------
Test set: com.google.cloud.teleport.splunk.HttpEventPublisherTest
-------------------------------------------------------------------------------
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 72.357 s
```


#### After
```
-------------------------------------------------------------------------------
Test set: com.google.cloud.teleport.splunk.HttpEventPublisherTest
-------------------------------------------------------------------------------
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.521 s
```
