### PR TITLE
Pub/Sub Resource Manager + Sample Integration test PubsubToTextIT

### DIFF
--- a/it/src/main/java/com/google/cloud/teleport/it/dataflow/DataflowUtils.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/dataflow/DataflowUtils.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.it.dataflow;
 
+import com.google.common.base.CaseFormat;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -37,22 +38,12 @@ public final class DataflowUtils {
    *     prefix
    */
   public static String createJobName(String prefix) {
-    StringBuilder properlyFormatted = new StringBuilder();
-    for (int i = 0; i < prefix.length(); ++i) {
-      char c = prefix.charAt(i);
-      if (Character.isUpperCase(c)) {
-        properlyFormatted.append("-");
-        properlyFormatted.append(Character.toLowerCase(c));
-      } else {
-        properlyFormatted.append(c);
-      }
-    }
-
-    return String.format(
-        "%s-%s",
-        properlyFormatted,
+    String convertedPrefix =
+        CaseFormat.UPPER_CAMEL.converterTo(CaseFormat.LOWER_HYPHEN).convert(prefix);
+    String formattedTimestamp =
         DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
             .withZone(ZoneId.of("UTC"))
-            .format(Instant.now()));
+            .format(Instant.now());
+    return String.format("%s-%s", convertedPrefix, formattedTimestamp);
   }
 }

--- a/it/src/main/java/com/google/cloud/teleport/it/pubsub/DefaultPubsubPublisherFactory.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/pubsub/DefaultPubsubPublisherFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.pubsub;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.pubsub.v1.TopicName;
+import java.io.IOException;
+
+/**
+ * Default class for implementation of {@link PubsubPublisherFactory} interface.
+ *
+ * <p>The class provides an interaction with the real Pub/Sub client, with operations related to
+ * creating a Pub/Sub Publisher.
+ */
+class DefaultPubsubPublisherFactory implements PubsubPublisherFactory {
+
+  private final CredentialsProvider credentialsProvider;
+
+  DefaultPubsubPublisherFactory(CredentialsProvider credentialsProvider) {
+    this.credentialsProvider = credentialsProvider;
+  }
+
+  @Override
+  public Publisher createPublisher(TopicName topic) {
+    try {
+      return Publisher.newBuilder(topic).setCredentialsProvider(credentialsProvider).build();
+    } catch (IOException e) {
+      throw new PubsubResourceManagerException("Error creating publisher for topic", e);
+    }
+  }
+}

--- a/it/src/main/java/com/google/cloud/teleport/it/pubsub/DefaultPubsubResourceManager.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/pubsub/DefaultPubsubResourceManager.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.pubsub;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.cloud.pubsub.v1.TopicAdminSettings;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.PushConfig;
+import com.google.pubsub.v1.Subscription;
+import com.google.pubsub.v1.SubscriptionName;
+import com.google.pubsub.v1.Topic;
+import com.google.pubsub.v1.TopicName;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default class for implementation of {@link PubsubResourceManager} interface.
+ *
+ * <p>The class provides an interaction with the real Pub/Sub client, with operations related to
+ * management of topics and subscriptions.
+ */
+public final class DefaultPubsubResourceManager implements PubsubResourceManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultPubsubResourceManager.class);
+
+  private static final int DEFAULT_ACK_DEADLINE_SECONDS = 600;
+  private static final String RESOURCE_NAME_SEPARATOR = "-";
+
+  private final String testId;
+  private final String projectId;
+  private final PubsubPublisherFactory publisherFactory;
+  private final TopicAdminClient topicAdminClient;
+  private final SubscriptionAdminClient subscriptionAdminClient;
+
+  private final Set<TopicName> createdTopics;
+  private final Set<SubscriptionName> createdSubscriptions;
+
+  private DefaultPubsubResourceManager(Builder builder) throws IOException {
+    this(
+        builder.testName,
+        builder.projectId,
+        new DefaultPubsubPublisherFactory(builder.credentialsProvider),
+        TopicAdminClient.create(
+            TopicAdminSettings.newBuilder()
+                .setCredentialsProvider(builder.credentialsProvider)
+                .build()),
+        SubscriptionAdminClient.create(
+            SubscriptionAdminSettings.newBuilder()
+                .setCredentialsProvider(builder.credentialsProvider)
+                .build()));
+  }
+
+  @VisibleForTesting
+  DefaultPubsubResourceManager(
+      String testName,
+      String projectId,
+      PubsubPublisherFactory publisherFactory,
+      TopicAdminClient topicAdminClient,
+      SubscriptionAdminClient subscriptionAdminClient) {
+    this.projectId = projectId;
+    this.testId = PubsubUtils.createTestId(testName);
+    this.publisherFactory = publisherFactory;
+    this.topicAdminClient = topicAdminClient;
+    this.subscriptionAdminClient = subscriptionAdminClient;
+    this.createdTopics = Collections.synchronizedSet(new HashSet<>());
+    this.createdSubscriptions = Collections.synchronizedSet(new HashSet<>());
+  }
+
+  public static Builder builder(String testName, String projectId) {
+    checkArgument(!Strings.isNullOrEmpty(testName), "testName can not be null or empty");
+    checkArgument(!projectId.isEmpty(), "projectId can not be empty");
+    return new Builder(testName, projectId);
+  }
+
+  /**
+   * Create a topic based on the given topic name. However, it adds a prefix based on the test id
+   * and timestamp, to uniquely identify the current execution instance.
+   *
+   * @see PubsubResourceManager#createTopic(String)
+   */
+  @Override
+  public TopicName createTopic(String topicName) {
+    checkArgument(!topicName.isEmpty(), "topicName can not be empty");
+    checkIsUsable();
+
+    LOG.info("Creating topic '{}'...", topicName);
+
+    Topic topic = topicAdminClient.createTopic(getTopicName(topicName));
+    TopicName reference = PubsubUtils.toTopicName(topic);
+    createdTopics.add(reference);
+
+    LOG.info("Topic '{}' was created successfully!", topicName);
+
+    return reference;
+  }
+
+  /**
+   * Create a subscription based on the given name. However, it adds a prefix based on the test id
+   * and timestamp, to uniquely identify the current execution instance.
+   *
+   * @see PubsubResourceManager#createSubscription(TopicName, String)
+   */
+  @Override
+  public SubscriptionName createSubscription(TopicName topicName, String subscriptionName) {
+    checkArgument(!subscriptionName.isEmpty(), "subscriptionName can not be empty");
+    checkIsUsable();
+
+    if (!createdTopics.contains(topicName)) {
+      throw new IllegalArgumentException(
+          "Can not create a subscription for a topic not managed by this instance.");
+    }
+
+    LOG.info("Creating subscription '{}' for topic '{}'", subscriptionName, topicName);
+
+    Subscription subscription =
+        subscriptionAdminClient.createSubscription(
+            getSubscriptionName(subscriptionName),
+            topicName,
+            PushConfig.getDefaultInstance(),
+            DEFAULT_ACK_DEADLINE_SECONDS);
+    SubscriptionName reference = PubsubUtils.toSubscriptionName(subscription);
+    createdSubscriptions.add(reference);
+
+    LOG.info(
+        "Subscription '{}' for topic '{}' was created successfully!", topicName, subscriptionName);
+
+    return reference;
+  }
+
+  @Override
+  public String publish(TopicName topic, Map<String, String> attributes, ByteString data)
+      throws PubsubResourceManagerException {
+    checkIsUsable();
+
+    if (!createdTopics.contains(topic)) {
+      throw new IllegalArgumentException(
+          "Can not publish to a topic not managed by this instance.");
+    }
+
+    LOG.info("Publishing message with {} bytes to topic '{}'", data.size(), topic);
+
+    PubsubMessage pubsubMessage =
+        PubsubMessage.newBuilder().putAllAttributes(attributes).setData(data).build();
+
+    try {
+      String messageId = publisherFactory.createPublisher(topic).publish(pubsubMessage).get();
+      LOG.info("Message published with id '{}'", messageId);
+      return messageId;
+    } catch (Exception e) {
+      throw new PubsubResourceManagerException("Error publishing message to Pubsub", e);
+    }
+  }
+
+  @Override
+  public synchronized void cleanupAll() {
+    // Ignore call if it was cleaned up before
+    if (isNotUsable()) {
+      return;
+    }
+
+    LOG.info("Attempting to cleanup manager.");
+
+    try {
+      for (SubscriptionName subscription : createdSubscriptions) {
+        LOG.info("Deleting subscription '{}'", subscription);
+        subscriptionAdminClient.deleteSubscription(subscription);
+      }
+
+      for (TopicName topic : createdTopics) {
+        LOG.info("Deleting topic '{}'", topic);
+        topicAdminClient.deleteTopic(topic);
+      }
+    } finally {
+      subscriptionAdminClient.close();
+      topicAdminClient.close();
+    }
+
+    LOG.info("Manager successfully cleaned up.");
+  }
+
+  SubscriptionName getSubscriptionName(String subscriptionName) {
+    return SubscriptionName.of(projectId, testId + RESOURCE_NAME_SEPARATOR + subscriptionName);
+  }
+
+  TopicName getTopicName(String topicName) {
+    return TopicName.of(projectId, testId + RESOURCE_NAME_SEPARATOR + topicName);
+  }
+
+  /**
+   * Check if the clients started by this instance are still usable, and throwing {@link
+   * IllegalStateException} otherwise.
+   */
+  private void checkIsUsable() throws IllegalStateException {
+    if (isNotUsable()) {
+      throw new IllegalStateException("Manager has cleaned up resources and is unusable.");
+    }
+  }
+
+  private boolean isNotUsable() {
+    return topicAdminClient.isShutdown() || subscriptionAdminClient.isShutdown();
+  }
+
+  /** Builder for {@link DefaultPubsubResourceManager}. */
+  public static final class Builder {
+
+    private final String projectId;
+    private final String testName;
+    private CredentialsProvider credentialsProvider;
+
+    private Builder(String testName, String projectId) {
+      this.testName = testName;
+      this.projectId = projectId;
+    }
+
+    public Builder credentialsProvider(CredentialsProvider credentialsProvider) {
+      this.credentialsProvider = credentialsProvider;
+      return this;
+    }
+
+    public DefaultPubsubResourceManager build() throws IOException {
+      return new DefaultPubsubResourceManager(this);
+    }
+  }
+}

--- a/it/src/main/java/com/google/cloud/teleport/it/pubsub/PubsubPublisherFactory.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/pubsub/PubsubPublisherFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.pubsub;
+
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.pubsub.v1.TopicName;
+
+/** Interface for building Pub/Sub publishers in integration tests. */
+interface PubsubPublisherFactory {
+
+  /** Create a {@link Publisher} instance for the given topic reference. */
+  Publisher createPublisher(TopicName topic);
+}

--- a/it/src/main/java/com/google/cloud/teleport/it/pubsub/PubsubResourceManager.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/pubsub/PubsubResourceManager.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.pubsub;
+
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.SubscriptionName;
+import com.google.pubsub.v1.TopicName;
+import java.util.Map;
+
+/** Interface for managing Pub/Sub resources in integration tests. */
+public interface PubsubResourceManager {
+
+  /**
+   * Creates a topic with the given name on Pub/Sub.
+   *
+   * @param topicName Topic name to create. The underlying implementation may not use the topic name
+   *     directly, and can add a prefix or a suffix to identify specific executions.
+   * @return The instance of the TopicName that was just created.
+   */
+  TopicName createTopic(String topicName);
+
+  /**
+   * Creates a subscription at the specific topic, with a given name.
+   *
+   * @param topicName Topic Name reference to add the subscription.
+   * @param subscriptionName Name of the subscription to use. Note that the underlying
+   *     implementation may not use the subscription name literally, and can use a prefix or a
+   *     suffix to identify specific executions.
+   * @return The instance of the SubscriptionName that was just created.
+   */
+  SubscriptionName createSubscription(TopicName topicName, String subscriptionName);
+
+  /**
+   * Publishes a message with the given data to the publisher context's topic.
+   *
+   * @param topic Reference to the topic to send the message.
+   * @param attributes Attributes to send with the message.
+   * @param data Byte data to send.
+   * @return The message id that was generated.
+   */
+  String publish(TopicName topic, Map<String, String> attributes, ByteString data)
+      throws PubsubResourceManagerException;
+
+  /** Delete any topics or subscriptions created by this manager. */
+  void cleanupAll();
+}

--- a/it/src/main/java/com/google/cloud/teleport/it/pubsub/PubsubResourceManagerException.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/pubsub/PubsubResourceManagerException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.pubsub;
+
+/** Custom exception for {@link PubsubResourceManager} implementations. */
+class PubsubResourceManagerException extends RuntimeException {
+
+  PubsubResourceManagerException(String errorMessage, Throwable err) {
+    super(errorMessage, err);
+  }
+}

--- a/it/src/main/java/com/google/cloud/teleport/it/pubsub/PubsubUtils.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/pubsub/PubsubUtils.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.pubsub;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.base.CaseFormat;
+import com.google.pubsub.v1.Subscription;
+import com.google.pubsub.v1.SubscriptionName;
+import com.google.pubsub.v1.Topic;
+import com.google.pubsub.v1.TopicName;
+import com.google.re2j.Matcher;
+import com.google.re2j.Pattern;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/** Utilities to make working with Pubsub easier. */
+final class PubsubUtils {
+  private PubsubUtils() {}
+
+  /**
+   * Regular expression to validate/extract a topic name string, following
+   * projects/{project_id}/subscription/{topic_name}.
+   */
+  private static final Pattern TOPICS_PATTERN =
+      Pattern.compile("^projects/(?P<project_id>[^/]+)/topics/(?P<topic_name>[^/]+)$");
+
+  /**
+   * Regular expression to validate/extract a subscription name string, following
+   * projects/{project_id}/subscription/{subscription_name}.
+   */
+  private static final Pattern SUBSCRIPTIONS_PATTERN =
+      Pattern.compile(
+          "^projects/(?P<project_id>[^/]+)/subscriptions/(?P<subscription_name>[^/]+)$");
+
+  /**
+   * Convert the instance of {@link Topic} to a {@link TopicName}.
+   *
+   * <p>The idea of this project is to abstract the conversion/parse of the format
+   * <strong>projects/{project_id}/topics/{topic_name}</strong>
+   *
+   * @param topic Base topic.
+   * @return The reference to the topic.
+   */
+  static TopicName toTopicName(Topic topic) {
+    Matcher matcher = TOPICS_PATTERN.matcher(topic.getName());
+    checkArgument(
+        matcher.find(),
+        "Topic name must be in the format 'projects/{project_id}/topics/{topic_name}.");
+
+    return TopicName.of(matcher.group("project_id"), matcher.group("topic_name"));
+  }
+
+  /**
+   * Convert the instance of {@link Subscription} to a {@link SubscriptionName}.
+   *
+   * <p>The idea of this project is to abstract the conversion/parse of the format
+   * <strong>projects/{project_id}/subscription/{subscription_name}</strong>
+   *
+   * @param subscription Base subscription.
+   * @return The reference to the subscription.
+   */
+  static SubscriptionName toSubscriptionName(Subscription subscription) {
+    Matcher matcher = SUBSCRIPTIONS_PATTERN.matcher(subscription.getName());
+    checkArgument(
+        matcher.find(),
+        "Subscription name must be in the format 'projects/{project_id}/subscriptions/{subscription_name}.");
+
+    return SubscriptionName.of(matcher.group("project_id"), matcher.group("subscription_name"));
+  }
+
+  /**
+   * Creates a topic name. Based on {@link
+   * com.google.cloud.teleport.it.dataflow.DataflowUtils#createJobName(String)}
+   *
+   * <p>If there are uppercase characters in {@code prefix}, then this will convert them into a dash
+   * followed by the lowercase equivalent of that letter.
+   *
+   * <p>The topic name will normally be unique, but this is not guaranteed if multiple topics with
+   * the same prefix are created in a short period of time.
+   *
+   * @param prefix a prefix for the topic
+   * @return the prefix plus some way of identifying it separate from other topics with the same
+   *     prefix
+   */
+  static String createTestId(String prefix) {
+    String convertedPrefix =
+        CaseFormat.UPPER_CAMEL.converterTo(CaseFormat.LOWER_HYPHEN).convert(prefix);
+    String formattedTimestamp =
+        DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS")
+            .withZone(ZoneId.of("UTC"))
+            .format(Instant.now());
+    return String.format("%s-%s", convertedPrefix, formattedTimestamp);
+  }
+}

--- a/it/src/main/java/com/google/cloud/teleport/it/pubsub/package-info.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/pubsub/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/** Package for managing Pub/Sub resources within integration tests. */
+package com.google.cloud.teleport.it.pubsub;

--- a/it/src/test/java/com/google/cloud/teleport/it/pubsub/DefaultPubsubResourceManagerTest.java
+++ b/it/src/test/java/com/google/cloud/teleport/it/pubsub/DefaultPubsubResourceManagerTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.pubsub;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.ApiFutures;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.Subscription;
+import com.google.pubsub.v1.SubscriptionName;
+import com.google.pubsub.v1.Topic;
+import com.google.pubsub.v1.TopicName;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/** Unit tests for {@link DefaultPubsubResourceManager}. */
+@RunWith(JUnit4.class)
+public final class DefaultPubsubResourceManagerTest {
+  @Rule public final MockitoRule mockito = MockitoJUnit.rule();
+
+  private static final String TEST_ID = "test-id";
+  private static final String PROJECT_ID = "test-project";
+  private static final String TOPIC_NAME = "test-topic-name";
+  private static final String SUBSCRIPTION_NAME = "test-topic-name-sub0";
+  private static final TopicName TOPIC_REFERENCE = TopicName.of("test-project", "test-topic");
+  private static final String VALID_MESSAGE_ID = "abcdef";
+
+  @Mock private TopicAdminClient topicAdminClient;
+  @Mock private SubscriptionAdminClient subscriptionAdminClient;
+  @Mock private Topic topic;
+  @Mock private Subscription subscription;
+  @Mock private Publisher publisher;
+  @Mock private PubsubPublisherFactory publisherFactory;
+
+  private DefaultPubsubResourceManager testManager;
+
+  @Captor private ArgumentCaptor<TopicName> topicNameCaptor;
+  @Captor private ArgumentCaptor<SubscriptionName> subscriptionNameCaptor;
+  @Captor private ArgumentCaptor<PubsubMessage> pubsubMessageCaptor;
+
+  @Before
+  public void setUp() throws IOException {
+    // Using spy to inject our mocked publisher at getPublisher(topic)
+    testManager =
+        new DefaultPubsubResourceManager(
+            TEST_ID, PROJECT_ID, publisherFactory, topicAdminClient, subscriptionAdminClient);
+
+    when(topic.getName()).thenReturn("projects/" + PROJECT_ID + "/topics/" + TOPIC_NAME);
+    when(subscription.getName())
+        .thenReturn("projects/" + PROJECT_ID + "/subscriptions/" + SUBSCRIPTION_NAME);
+    when(publisherFactory.createPublisher(any())).thenReturn(publisher);
+  }
+
+  @Test
+  public void testBuilderWithInvalidProjectShouldFail() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> DefaultPubsubResourceManager.builder("test-a", ""));
+    assertThat(exception).hasMessageThat().contains("projectId can not be empty");
+  }
+
+  @Test
+  public void testCreateTopicWithInvalidNameShouldFail() {
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> testManager.createTopic(""));
+    assertThat(exception).hasMessageThat().contains("topicName can not be empty");
+  }
+
+  @Test
+  public void testCreateSubscriptionWithInvalidNameShouldFail() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> testManager.createSubscription(TopicName.of(PROJECT_ID, "topic-a"), ""));
+    assertThat(exception).hasMessageThat().contains("subscriptionName can not be empty");
+  }
+
+  @Test
+  public void testCreateTopicShouldCreate() {
+    when(topicAdminClient.createTopic(any(TopicName.class))).thenReturn(topic);
+
+    TopicName createTopic = testManager.createTopic("topic-name");
+
+    assertThat(createTopic).isNotNull();
+    verify(topicAdminClient).createTopic(topicNameCaptor.capture());
+    TopicName actualTopicName = topicNameCaptor.getValue();
+    assertThat(actualTopicName.getProject()).isEqualTo(PROJECT_ID);
+    assertThat(actualTopicName.getTopic()).matches(TEST_ID + "-\\d{17}-topic-name");
+  }
+
+  @Test
+  public void testCreateSubscriptionShouldCreate() {
+    when(topicAdminClient.createTopic(any(TopicName.class))).thenReturn(topic);
+    when(subscriptionAdminClient.createSubscription(
+            any(SubscriptionName.class), any(TopicName.class), any(), anyInt()))
+        .thenReturn(subscription);
+
+    TopicName createTopic = testManager.createTopic("topic-name");
+    SubscriptionName createSub = testManager.createSubscription(createTopic, "subscription-name");
+
+    assertThat(createSub).isNotNull();
+    verify(subscriptionAdminClient)
+        .createSubscription(
+            subscriptionNameCaptor.capture(), topicNameCaptor.capture(), any(), anyInt());
+    SubscriptionName subscriptionName = subscriptionNameCaptor.getValue();
+    TopicName actualTopicName = topicNameCaptor.getValue();
+    assertThat(subscriptionName.getProject()).isEqualTo(PROJECT_ID);
+    assertThat(subscriptionName.getSubscription()).matches(TEST_ID + "-\\d{17}-subscription-name");
+    assertThat(actualTopicName.getProject()).isEqualTo(PROJECT_ID);
+    assertThat(actualTopicName.getTopic()).matches(createTopic.getTopic());
+  }
+
+  @Test
+  public void testCreateSubscriptionUnmanagedTopicShouldFail() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                testManager.createSubscription(
+                    TopicName.of(PROJECT_ID, "topic-name"), "subscription-name"));
+    assertThat(exception).hasMessageThat().contains("topic not managed");
+  }
+
+  @Test
+  public void testPublishMessageShouldPublish() {
+    when(topicAdminClient.createTopic(any(TopicName.class))).thenReturn(topic);
+    when(publisher.publish(any())).thenReturn(ApiFutures.immediateFuture(VALID_MESSAGE_ID));
+    Map<String, String> attributes = ImmutableMap.of("key1", "value1");
+    ByteString data = ByteString.copyFromUtf8("valid message");
+
+    TopicName topic = testManager.createTopic(TOPIC_NAME);
+    String publishMessage = testManager.publish(topic, attributes, data);
+
+    assertThat(publishMessage).isEqualTo(VALID_MESSAGE_ID);
+    verify(publisher).publish(pubsubMessageCaptor.capture());
+    PubsubMessage actualMessage = pubsubMessageCaptor.getValue();
+    assertThat(actualMessage.getAttributesMap()).isEqualTo(attributes);
+    assertThat(actualMessage.getData()).isEqualTo(data);
+  }
+
+  @Test
+  public void testPublishMessageUnmanagedTopicShouldFail() {
+    Map<String, String> attributes = ImmutableMap.of("key1", "value1");
+    ByteString data = ByteString.copyFromUtf8("valid message");
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> testManager.publish(TOPIC_REFERENCE, attributes, data));
+    assertThat(exception).hasMessageThat().contains("topic not managed");
+  }
+
+  @Test
+  public void testCleanupTopicsShouldDeleteTopics() {
+    TopicName topicName1 = testManager.getTopicName("topic1");
+    TopicName topicName2 = testManager.getTopicName("topic2");
+    when(topic.getName()).thenReturn(topicName1.toString(), topicName2.toString());
+    when(topicAdminClient.createTopic(any(TopicName.class))).thenReturn(topic);
+
+    testManager.createTopic("topic1");
+    testManager.createTopic("topic2");
+    testManager.cleanupAll();
+
+    verify(topicAdminClient, times(2)).deleteTopic(topicNameCaptor.capture());
+    assertThat(topicNameCaptor.getAllValues()).hasSize(2);
+    assertThat(topicNameCaptor.getAllValues()).containsExactly(topicName1, topicName2);
+  }
+
+  @Test
+  public void testCleanupSubscriptionsShouldDeleteResources() {
+    SubscriptionName subscriptionName1 = testManager.getSubscriptionName("topic1-sub0");
+    SubscriptionName subscriptionName2 = testManager.getSubscriptionName("topic1-sub1");
+    SubscriptionName subscriptionName3 = testManager.getSubscriptionName("topic2-sub0");
+    when(topicAdminClient.createTopic(any(TopicName.class))).thenReturn(topic);
+    when(subscription.getName())
+        .thenReturn(
+            subscriptionName1.toString(),
+            subscriptionName2.toString(),
+            subscriptionName3.toString());
+    when(subscriptionAdminClient.createSubscription(
+            any(SubscriptionName.class), any(TopicName.class), any(), anyInt()))
+        .thenReturn(subscription);
+
+    TopicName topic1 = testManager.createTopic("topic1");
+    TopicName topic2 = testManager.createTopic("topic2");
+    testManager.createSubscription(topic1, "topic1-sub0");
+    testManager.createSubscription(topic1, "topic1-sub1");
+    testManager.createSubscription(topic2, "topic2-sub0");
+    testManager.cleanupAll();
+
+    verify(subscriptionAdminClient, times(3)).deleteSubscription(subscriptionNameCaptor.capture());
+    assertThat(subscriptionNameCaptor.getAllValues()).hasSize(3);
+    assertThat(subscriptionNameCaptor.getAllValues())
+        .containsExactly(subscriptionName1, subscriptionName2, subscriptionName3);
+  }
+}

--- a/it/src/test/java/com/google/cloud/teleport/it/pubsub/PubsubUtilsTest.java
+++ b/it/src/test/java/com/google/cloud/teleport/it/pubsub/PubsubUtilsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.pubsub;
+
+import static com.google.cloud.teleport.it.pubsub.PubsubUtils.createTestId;
+import static com.google.cloud.teleport.it.pubsub.PubsubUtils.toSubscriptionName;
+import static com.google.cloud.teleport.it.pubsub.PubsubUtils.toTopicName;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.pubsub.v1.Subscription;
+import com.google.pubsub.v1.SubscriptionName;
+import com.google.pubsub.v1.Topic;
+import com.google.pubsub.v1.TopicName;
+import org.junit.Test;
+
+/** Unit tests for {@link PubsubUtils}. */
+public class PubsubUtilsTest {
+
+  @Test
+  public void testToTopicNameValid() {
+    TopicName topicName =
+        toTopicName(Topic.newBuilder().setName("projects/project-a/topics/topic-x").build());
+    assertThat(topicName.getProject()).isEqualTo("project-a");
+    assertThat(topicName.getTopic()).isEqualTo("topic-x");
+  }
+
+  @Test
+  public void testToTopicNameInvalidShouldFail() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> toTopicName(Topic.newBuilder().setName("project-a.topic-x").build()));
+  }
+
+  @Test
+  public void testToSubscriptionNameValid() {
+    SubscriptionName subscriptionName =
+        toSubscriptionName(
+            Subscription.newBuilder()
+                .setName("projects/project-a/subscriptions/topic-x-sub0")
+                .build());
+    assertThat(subscriptionName.getProject()).isEqualTo("project-a");
+    assertThat(subscriptionName.getSubscription()).isEqualTo("topic-x-sub0");
+  }
+
+  @Test
+  public void testToSubscriptionNameInvalidShouldFail() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            toSubscriptionName(
+                Subscription.newBuilder().setName("project-a.topic-x-sub0").build()));
+  }
+
+  @Test
+  public void testCreateTopicName() {
+    String name = "create-topic-name";
+    assertThat(createTestId(name)).matches(name + "-\\d{17}");
+  }
+
+  @Test
+  public void testCreateTopicNameWithUppercase() {
+    assertThat(createTestId("testWithUpperCase")).matches("test-with-upper-case-\\d{17}");
+  }
+}

--- a/it/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/it/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,2 @@
+# Required to mock final methods:
+mock-maker-inline

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/pubsubtotext/PubsubToTextIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/pubsubtotext/PubsubToTextIT.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.pubsubtotext;
+
+import static com.google.cloud.teleport.it.artifacts.ArtifactUtils.createGcsClient;
+import static com.google.cloud.teleport.it.artifacts.ArtifactUtils.getFullGcsPath;
+import static com.google.cloud.teleport.it.dataflow.DataflowUtils.createJobName;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.auth.Credentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.teleport.it.TestProperties;
+import com.google.cloud.teleport.it.artifacts.Artifact;
+import com.google.cloud.teleport.it.artifacts.ArtifactClient;
+import com.google.cloud.teleport.it.artifacts.GcsArtifactClient;
+import com.google.cloud.teleport.it.dataflow.DataflowOperator;
+import com.google.cloud.teleport.it.dataflow.DataflowOperator.Result;
+import com.google.cloud.teleport.it.dataflow.DataflowTemplateClient;
+import com.google.cloud.teleport.it.dataflow.DataflowTemplateClient.JobInfo;
+import com.google.cloud.teleport.it.dataflow.DataflowTemplateClient.JobState;
+import com.google.cloud.teleport.it.dataflow.DataflowTemplateClient.LaunchConfig;
+import com.google.cloud.teleport.it.dataflow.FlexTemplateClient;
+import com.google.cloud.teleport.it.pubsub.DefaultPubsubResourceManager;
+import com.google.cloud.teleport.it.pubsub.PubsubResourceManager;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.SubscriptionName;
+import com.google.pubsub.v1.TopicName;
+import com.google.re2j.Pattern;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Integration test for {@link PubsubToText} (Cloud_PubSub_to_GCS_Text_Flex). */
+@RunWith(JUnit4.class)
+public final class PubsubToTextIT {
+
+  @Rule public final TestName testName = new TestName();
+
+  private static final String ARTIFACT_BUCKET = TestProperties.artifactBucket();
+  private static final Credentials CREDENTIALS = TestProperties.googleCredentials();
+  private static final CredentialsProvider CREDENTIALS_PROVIDER =
+      FixedCredentialsProvider.create(CREDENTIALS);
+  private static final String PROJECT = TestProperties.project();
+  private static final String REGION = TestProperties.region();
+  private static final String SPEC_PATH = TestProperties.specPath();
+
+  private static final String TEST_ROOT_DIR = PubsubToTextIT.class.getSimpleName();
+
+  private static final String INPUT_TOPIC = "inputTopic";
+  private static final String INPUT_SUBSCRIPTION = "inputSubscription";
+  private static final String NUM_SHARDS_KEY = "numShards";
+  private static final String OUTPUT_DIRECTORY_KEY = "outputDirectory";
+  private static final String WINDOW_DURATION_KEY = "windowDuration";
+  private static final String OUTPUT_FILENAME_PREFIX = "outputFilenamePrefix";
+
+  private static final String DEFAULT_WINDOW_DURATION = "10s";
+
+  private static PubsubResourceManager pubsubResourceManager;
+  private static ArtifactClient artifactClient;
+
+  @Before
+  public void setup() throws IOException {
+    Storage gcsClient = createGcsClient(CREDENTIALS);
+
+    pubsubResourceManager =
+        DefaultPubsubResourceManager.builder(testName.getMethodName(), PROJECT)
+            .credentialsProvider(CREDENTIALS_PROVIDER)
+            .build();
+
+    artifactClient = GcsArtifactClient.builder(gcsClient, ARTIFACT_BUCKET, TEST_ROOT_DIR).build();
+  }
+
+  @After
+  public void tearDownClass() {
+    artifactClient.cleanupRun();
+    pubsubResourceManager.cleanupAll();
+  }
+
+  @Test
+  public void testTopicToGcs() throws IOException {
+    // Arrange
+    String name = testName.getMethodName();
+    String jobName = createJobName(name);
+    String messageString = String.format("msg-%s", jobName);
+    Pattern expectedFilePattern = Pattern.compile(".*topic-output-.*");
+
+    TopicName topic = pubsubResourceManager.createTopic("input");
+    LaunchConfig options =
+        LaunchConfig.builder(jobName, SPEC_PATH)
+            .addParameter(INPUT_TOPIC, topic.toString())
+            .addParameter(WINDOW_DURATION_KEY, DEFAULT_WINDOW_DURATION)
+            .addParameter(OUTPUT_DIRECTORY_KEY, getTestMethodDirPath(name))
+            .addParameter(NUM_SHARDS_KEY, "1")
+            .addParameter(OUTPUT_FILENAME_PREFIX, "topic-output-")
+            .build();
+    DataflowTemplateClient dataflow =
+        FlexTemplateClient.builder().setCredentials(CREDENTIALS).build();
+
+    // Act
+    JobInfo info = dataflow.launchTemplate(PROJECT, REGION, options);
+    assertThat(info.state()).isIn(JobState.ACTIVE_STATES);
+
+    AtomicReference<List<Artifact>> artifacts = new AtomicReference<>();
+
+    Result result =
+        new DataflowOperator(dataflow)
+            .waitForConditionAndFinish(
+                createConfig(info),
+                () -> {
+                  ByteString messageData = ByteString.copyFromUtf8(messageString);
+                  pubsubResourceManager.publish(topic, ImmutableMap.of(), messageData);
+
+                  artifacts.set(artifactClient.listArtifacts(name, expectedFilePattern));
+                  return !artifacts.get().isEmpty();
+                });
+
+    // Assert
+    assertThat(result).isEqualTo(Result.CONDITION_MET);
+
+    // Make sure that files contain only the messages produced by this test
+    String allMessages =
+        artifacts.get().stream()
+            .map(artifact -> new String(artifact.contents()))
+            .collect(Collectors.joining());
+    assertThat(allMessages.replace(messageString, "").trim()).isEmpty();
+  }
+
+  @Test
+  public void testSubscriptionToGcs() throws IOException {
+    // Arrange
+    String name = testName.getMethodName();
+    String jobName = createJobName(name);
+    String messageString = String.format("msg-%s", jobName);
+    Pattern expectedFilePattern = Pattern.compile(".*subscription-output-.*");
+
+    TopicName topic = pubsubResourceManager.createTopic("input");
+
+    SubscriptionName subscription = pubsubResourceManager.createSubscription(topic, jobName + "-1");
+
+    LaunchConfig options =
+        LaunchConfig.builder(jobName, SPEC_PATH)
+            .addParameter(INPUT_SUBSCRIPTION, subscription.toString())
+            .addParameter(WINDOW_DURATION_KEY, DEFAULT_WINDOW_DURATION)
+            .addParameter(OUTPUT_DIRECTORY_KEY, getTestMethodDirPath(name))
+            .addParameter(NUM_SHARDS_KEY, "1")
+            .addParameter(OUTPUT_FILENAME_PREFIX, "subscription-output-")
+            .build();
+    DataflowTemplateClient dataflow =
+        FlexTemplateClient.builder().setCredentials(CREDENTIALS).build();
+
+    // Act
+    JobInfo info = dataflow.launchTemplate(PROJECT, REGION, options);
+    assertThat(info.state()).isIn(JobState.ACTIVE_STATES);
+
+    AtomicReference<List<Artifact>> artifacts = new AtomicReference<>();
+
+    Result result =
+        new DataflowOperator(dataflow)
+            .waitForConditionAndFinish(
+                createConfig(info),
+                () -> {
+                  ByteString messageData = ByteString.copyFromUtf8(messageString);
+                  pubsubResourceManager.publish(topic, ImmutableMap.of(), messageData);
+
+                  artifacts.set(artifactClient.listArtifacts(name, expectedFilePattern));
+                  return !artifacts.get().isEmpty();
+                });
+
+    // Assert
+    assertThat(result).isEqualTo(Result.CONDITION_MET);
+
+    // Make sure that files contain only the messages produced by this test
+    String allMessages =
+        artifacts.get().stream()
+            .map(artifact -> new String(artifact.contents()))
+            .collect(Collectors.joining());
+    assertThat(allMessages.replace(messageString, "").trim()).isEmpty();
+  }
+
+  private static String getTestMethodDirPath(String testMethod) {
+    return getFullGcsPath(ARTIFACT_BUCKET, TEST_ROOT_DIR, artifactClient.runId(), testMethod);
+  }
+
+  private static DataflowOperator.Config createConfig(JobInfo info) {
+    return DataflowOperator.Config.builder()
+        .setJobId(info.jobId())
+        .setProject(PROJECT)
+        .setRegion(REGION)
+        .build();
+  }
+}


### PR DESCRIPTION
I have created a structure for integration tests using Pub/Sub. Currently, the following operations are available:

- PubsubResourceManager
  - createTopic
  - createSubscription
  - publish


In order to test it, I have created an integration test `PubsubToTextIT`, based on the available integration tests for templates (`StreamingDataGeneratorIT`).

Since Pub/Sub topics are created directly below the project, and there's no concepts of groups, the manager will keep track of all the topics/subscriptions that were created by that instance -- which are then used on the `cleanupAll`.  
If `cleanupAll` is not called, resources will stay in the project, and require external cleanups (in which having the timestamp on the topic/subscription name will be handy).

