### PR TITLE
Avoid test error when pipeline.apply() is called without pipeline.run()

### DIFF
--- a/v2/common/src/test/java/com/google/cloud/teleport/v2/transforms/AvroConvertersTest.java
+++ b/v2/common/src/test/java/com/google/cloud/teleport/v2/transforms/AvroConvertersTest.java
@@ -75,13 +75,10 @@ public class AvroConvertersTest {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("withSchema(schema) called with null input.");
 
-    pipeline.apply(
-        AvroConverters.ReadAvroFile.newBuilder()
-            .withInputFileSpec(AVRO_FILE_PATH)
-            .withSchema(null)
-            .build());
-
-    pipeline.run();
+    AvroConverters.ReadAvroFile.newBuilder()
+        .withInputFileSpec(AVRO_FILE_PATH)
+        .withSchema(null)
+        .build();
   }
 
   /**
@@ -93,13 +90,10 @@ public class AvroConvertersTest {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("withInputFileSpec(inputFileSpec) called with null input.");
 
-    pipeline.apply(
-        AvroConverters.ReadAvroFile.newBuilder()
-            .withInputFileSpec(null)
-            .withSchema(SCHEMA_FILE_PATH)
-            .build());
-
-    pipeline.run();
+    AvroConverters.ReadAvroFile.newBuilder()
+        .withInputFileSpec(null)
+        .withSchema(SCHEMA_FILE_PATH)
+        .build();
   }
 
   /**
@@ -111,19 +105,7 @@ public class AvroConvertersTest {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("withSchema(schema) called with null input.");
 
-    pipeline
-        .apply(
-            AvroConverters.ReadAvroFile.newBuilder()
-                .withInputFileSpec(AVRO_FILE_PATH)
-                .withSchema(SCHEMA_FILE_PATH)
-                .build())
-        .apply(
-            AvroConverters.WriteAvroFile.newBuilder()
-                .withOutputFile(FAKE_DIR)
-                .withSchema(null)
-                .build());
-
-    pipeline.run();
+    AvroConverters.WriteAvroFile.newBuilder().withOutputFile(FAKE_DIR).withSchema(null).build();
   }
 
   /**
@@ -135,18 +117,9 @@ public class AvroConvertersTest {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("withOutputFile(outputFile) called with null input.");
 
-    pipeline
-        .apply(
-            AvroConverters.ReadAvroFile.newBuilder()
-                .withInputFileSpec(AVRO_FILE_PATH)
-                .withSchema(SCHEMA_FILE_PATH)
-                .build())
-        .apply(
-            AvroConverters.WriteAvroFile.newBuilder()
-                .withOutputFile(null)
-                .withSchema(AVRO_FILE_PATH)
-                .build());
-
-    pipeline.run();
+    AvroConverters.WriteAvroFile.newBuilder()
+        .withOutputFile(null)
+        .withSchema(AVRO_FILE_PATH)
+        .build();
   }
 }

--- a/v2/common/src/test/java/com/google/cloud/teleport/v2/transforms/ParquetConvertersTest.java
+++ b/v2/common/src/test/java/com/google/cloud/teleport/v2/transforms/ParquetConvertersTest.java
@@ -80,8 +80,6 @@ public class ParquetConvertersTest {
             .withInputFileSpec(PARQUET_FILE_PATH)
             .withSchema(null)
             .build());
-
-    pipeline.run();
   }
 
   /**
@@ -93,13 +91,10 @@ public class ParquetConvertersTest {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("withInputFileSpec(inputFileSpec) called with null input.");
 
-    pipeline.apply(
-        ParquetConverters.ReadParquetFile.newBuilder()
-            .withInputFileSpec(null)
-            .withSchema(SCHEMA_FILE_PATH)
-            .build());
-
-    pipeline.run();
+    ParquetConverters.ReadParquetFile.newBuilder()
+        .withInputFileSpec(null)
+        .withSchema(SCHEMA_FILE_PATH)
+        .build();
   }
 
   /**
@@ -111,19 +106,10 @@ public class ParquetConvertersTest {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("withSchema(schema) called with null input.");
 
-    pipeline
-        .apply(
-            ParquetConverters.ReadParquetFile.newBuilder()
-                .withInputFileSpec(PARQUET_FILE_PATH)
-                .withSchema(SCHEMA_FILE_PATH)
-                .build())
-        .apply(
-            ParquetConverters.WriteParquetFile.newBuilder()
-                .withOutputFile(FAKE_DIR)
-                .withSchema(null)
-                .build());
-
-    pipeline.run();
+    ParquetConverters.WriteParquetFile.newBuilder()
+        .withOutputFile(FAKE_DIR)
+        .withSchema(null)
+        .build();
   }
 
   /**
@@ -135,18 +121,9 @@ public class ParquetConvertersTest {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("withOutputFile(outputFile) called with null input.");
 
-    pipeline
-        .apply(
-            ParquetConverters.ReadParquetFile.newBuilder()
-                .withInputFileSpec(PARQUET_FILE_PATH)
-                .withSchema(SCHEMA_FILE_PATH)
-                .build())
-        .apply(
-            ParquetConverters.WriteParquetFile.newBuilder()
-                .withOutputFile(null)
-                .withSchema(SCHEMA_FILE_PATH)
-                .build());
-
-    pipeline.run();
+    ParquetConverters.WriteParquetFile.newBuilder()
+        .withOutputFile(null)
+        .withSchema(SCHEMA_FILE_PATH)
+        .build();
   }
 }

--- a/v2/common/src/test/java/com/google/cloud/teleport/v2/transforms/WriteToGCSAvroTest.java
+++ b/v2/common/src/test/java/com/google/cloud/teleport/v2/transforms/WriteToGCSAvroTest.java
@@ -15,10 +15,7 @@
  */
 package com.google.cloud.teleport.v2.transforms;
 
-import org.apache.beam.sdk.coders.KvCoder;
-import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.testing.TestPipeline;
-import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.KV;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,19 +52,12 @@ public class WriteToGCSAvroTest {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("withOutputDirectory(outputDirectory) called with null input.");
 
-    pipeline
-        .apply(
-            "CreateInput",
-            Create.of(message).withCoder(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-        .apply(
-            "WriteTextFile(s)",
-            WriteToGCSAvro.newBuilder()
-                .withOutputDirectory(null)
-                .withOutputFilenamePrefix(AVRO_FILENAME_PREFIX)
-                .setNumShards(NUM_SHARDS)
-                .withTempLocation(FAKE_TEMP_LOCATION)
-                .build());
-    pipeline.run();
+    WriteToGCSAvro.newBuilder()
+        .withOutputDirectory(null)
+        .withOutputFilenamePrefix(AVRO_FILENAME_PREFIX)
+        .setNumShards(NUM_SHARDS)
+        .withTempLocation(FAKE_TEMP_LOCATION)
+        .build();
   }
 
   /**
@@ -78,18 +68,11 @@ public class WriteToGCSAvroTest {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("withTempLocation(tempLocation) called with null input. ");
 
-    pipeline
-        .apply(
-            "CreateInput",
-            Create.of(message).withCoder(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-        .apply(
-            "WriteTextFile(s)",
-            WriteToGCSAvro.newBuilder()
-                .withOutputDirectory(FAKE_DIR)
-                .withOutputFilenamePrefix(AVRO_FILENAME_PREFIX)
-                .setNumShards(NUM_SHARDS)
-                .withTempLocation(null)
-                .build());
-    pipeline.run();
+    WriteToGCSAvro.newBuilder()
+        .withOutputDirectory(FAKE_DIR)
+        .withOutputFilenamePrefix(AVRO_FILENAME_PREFIX)
+        .setNumShards(NUM_SHARDS)
+        .withTempLocation(null)
+        .build();
   }
 }

--- a/v2/common/src/test/java/com/google/cloud/teleport/v2/transforms/WriteToGCSParquetTest.java
+++ b/v2/common/src/test/java/com/google/cloud/teleport/v2/transforms/WriteToGCSParquetTest.java
@@ -15,10 +15,7 @@
  */
 package com.google.cloud.teleport.v2.transforms;
 
-import org.apache.beam.sdk.coders.KvCoder;
-import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.testing.TestPipeline;
-import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.KV;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,17 +50,10 @@ public class WriteToGCSParquetTest {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("withOutputDirectory(outputDirectory) called with null input.");
 
-    pipeline
-        .apply(
-            "CreateInput",
-            Create.of(message).withCoder(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-        .apply(
-            "WriteTextFile(s)",
-            WriteToGCSParquet.newBuilder()
-                .withOutputDirectory(null)
-                .withOutputFilenamePrefix(PARQUET_FILENAME_PREFIX)
-                .setNumShards(NUM_SHARDS)
-                .build());
-    pipeline.run();
+    WriteToGCSParquet.newBuilder()
+        .withOutputDirectory(null)
+        .withOutputFilenamePrefix(PARQUET_FILENAME_PREFIX)
+        .setNumShards(NUM_SHARDS)
+        .build();
   }
 }

--- a/v2/common/src/test/java/com/google/cloud/teleport/v2/transforms/WriteToGCSTextTest.java
+++ b/v2/common/src/test/java/com/google/cloud/teleport/v2/transforms/WriteToGCSTextTest.java
@@ -15,10 +15,7 @@
  */
 package com.google.cloud.teleport.v2.transforms;
 
-import org.apache.beam.sdk.coders.KvCoder;
-import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.testing.TestPipeline;
-import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.KV;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,19 +52,12 @@ public class WriteToGCSTextTest {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("withOutputDirectory(outputDirectory) called with null input.");
 
-    pipeline
-        .apply(
-            "CreateInput",
-            Create.of(message).withCoder(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-        .apply(
-            "WriteTextFile(s)",
-            WriteToGCSText.newBuilder()
-                .withOutputDirectory(null)
-                .withOutputFilenamePrefix(TEXT_FILENAME_PREFIX)
-                .setNumShards(NUM_SHARDS)
-                .withTempLocation(FAKE_TEMP_LOCATION)
-                .build());
-    pipeline.run();
+    WriteToGCSText.newBuilder()
+        .withOutputDirectory(null)
+        .withOutputFilenamePrefix(TEXT_FILENAME_PREFIX)
+        .setNumShards(NUM_SHARDS)
+        .withTempLocation(FAKE_TEMP_LOCATION)
+        .build();
   }
 
   /**
@@ -78,18 +68,11 @@ public class WriteToGCSTextTest {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("withTempLocation(tempLocation) called with null input. ");
 
-    pipeline
-        .apply(
-            "CreateInput",
-            Create.of(message).withCoder(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-        .apply(
-            "WriteTextFile(s)",
-            WriteToGCSText.newBuilder()
-                .withOutputDirectory(FAKE_DIR)
-                .withOutputFilenamePrefix(TEXT_FILENAME_PREFIX)
-                .setNumShards(NUM_SHARDS)
-                .withTempLocation(null)
-                .build());
-    pipeline.run();
+    WriteToGCSText.newBuilder()
+        .withOutputDirectory(FAKE_DIR)
+        .withOutputFilenamePrefix(TEXT_FILENAME_PREFIX)
+        .setNumShards(NUM_SHARDS)
+        .withTempLocation(null)
+        .build();
   }
 }


### PR DESCRIPTION
There are some tests that fail on the currently `@Rule` for TestPipeline.

Those tests have a prior call `pipeline.apply()`, but can't get into `pipeline.run` as exceptions are expected, and then this failure is triggered ([see this run](https://github.com/GoogleCloudPlatform/DataflowTemplates/runs/7955029507)):

```
org.apache.beam.sdk.testing.TestPipeline$PipelineRunMissingException: The pipeline has not been run.
```


This change will make sure to test the appropriate builders, but no need to append anything to the graph, as it is not the subject of those tests.