### PR TITLE
Log Avro File Read Failure with stack trace

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/cdc/sources/ReadFileRangesFn.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/cdc/sources/ReadFileRangesFn.java
@@ -104,7 +104,7 @@ public class ReadFileRangesFn<T> extends DoFn<ReadableFile, T> implements Serial
      * if the exception should be thrown.
      */
     public boolean apply(ReadableFile file, OffsetRange range, Exception e) {
-      LOG.error("Avro File Read Failure {}", file.getMetadata().resourceId().toString());
+      LOG.error("Avro File Read Failure {}", file.getMetadata().resourceId(), e);
       return false;
       // return true;
     }


### PR DESCRIPTION
Will help on bug https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/450, at least to understand what's going on.

Currently, the customer reports that the following log is issued:
```
2022-08-04 01:24:52.616 PDT Avro File Read Failure gs://<REDACTED>
```

But there's no way to know what exactly is going on. This one-liner change will print the stacktrace/cause to the log, so we can further troubleshoot if it happens again.
