### PR TITLE
Allow usage of a different project id when doing merge

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/cdc/merge/BigQueryMerger.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/cdc/merge/BigQueryMerger.java
@@ -171,7 +171,12 @@ public class BigQueryMerger extends PTransform<PCollection<MergeInfo>, PCollecti
     @Setup
     public void setUp() {
       if (bigQueryClient == null) {
-        bigQueryClient = BigQueryOptions.getDefaultInstance().getService();
+        BigQueryOptions.Builder optionsBuilder = BigQueryOptions.newBuilder();
+        if (mergeConfiguration.projectId() != null
+            && !mergeConfiguration.projectId().isEmpty()) {
+          optionsBuilder = optionsBuilder.setProjectId(mergeConfiguration.projectId());
+        }
+        bigQueryClient = optionsBuilder.build().getService();
       }
     }
 

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/cdc/merge/BigQueryMerger.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/cdc/merge/BigQueryMerger.java
@@ -172,8 +172,7 @@ public class BigQueryMerger extends PTransform<PCollection<MergeInfo>, PCollecti
     public void setUp() {
       if (bigQueryClient == null) {
         BigQueryOptions.Builder optionsBuilder = BigQueryOptions.newBuilder();
-        if (mergeConfiguration.projectId() != null
-            && !mergeConfiguration.projectId().isEmpty()) {
+        if (mergeConfiguration.projectId() != null && !mergeConfiguration.projectId().isEmpty()) {
           optionsBuilder = optionsBuilder.setProjectId(mergeConfiguration.projectId());
         }
         bigQueryClient = optionsBuilder.build().getService();

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/cdc/merge/MergeConfiguration.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/cdc/merge/MergeConfiguration.java
@@ -19,6 +19,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;
+import javax.annotation.Nullable;
 import org.joda.time.Duration;
 
 /** Class {@link MergeConfiguration}. */
@@ -64,6 +65,9 @@ public abstract class MergeConfiguration implements Serializable {
   // BigQuery-specific properties
   public static final String BIGQUERY_QUOTE_CHARACTER = "`";
 
+  @Nullable
+  public abstract String projectId();
+
   public abstract String quoteCharacter();
 
   public abstract Boolean supportPartitionedTables();
@@ -80,6 +84,10 @@ public abstract class MergeConfiguration implements Serializable {
 
   public static MergeConfiguration bigQueryConfiguration() {
     return MergeConfiguration.builder().setQuoteCharacter(BIGQUERY_QUOTE_CHARACTER).build();
+  }
+
+  public MergeConfiguration withProjectId(String projectId) {
+    return this.toBuilder().setProjectId(projectId).build();
   }
 
   public MergeConfiguration withPartitionRetention(int partitionRetention) {
@@ -115,6 +123,8 @@ public abstract class MergeConfiguration implements Serializable {
 
   @AutoValue.Builder
   abstract static class Builder {
+    abstract Builder setProjectId(String projectId);
+
     abstract Builder setQuoteCharacter(String quote);
 
     abstract Builder setSupportPartitionedTables(Boolean supportPartitionedTables);

--- a/v2/datastream-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToBigQuery.java
+++ b/v2/datastream-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToBigQuery.java
@@ -571,6 +571,7 @@ public class DataStreamToBigQuery {
               "BigQuery Merge/Merge into Replica Tables",
               BigQueryMerger.of(
                   MergeConfiguration.bigQueryConfiguration()
+                      .withProjectId(bigqueryProjectId)
                       .withMergeWindowDuration(
                           Duration.standardMinutes(options.getMergeFrequencyMinutes()))
                       .withMergeConcurrency(options.getMergeConcurrency())


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/464


`bigQueryProjectId` being passed to the template wasn't being used by the `BigQueryMerger`, which causes the bug mentioned by the issue above:

> Merge Job Failed: Exception: com.google.cloud.bigquery.BigQueryException: Access Denied: Project projectA: User does not have bigquery.jobs.create permission in project projectA. Statement: MERGE `projectB.datastream_final.table_name` ...

