### PR TITLE
Change default Java version to 11

### DIFF
--- a/.github/actions/setup-java-env/action.yml
+++ b/.github/actions/setup-java-env/action.yml
@@ -30,7 +30,7 @@ inputs:
     type: string
     description: 'The version of Java to install'
     required: false
-    default: '8'
+    default: '11'
 outputs:
   cache-hit:
     description: 'Whether or not there was a cache hit'


### PR DESCRIPTION
The JDK requirements were recently lifted to Java 11. This workflow fails because it still uses Java 8 by default.