### PR TITLE
Issue 477: Create Datastream Resource Manager

### DIFF
--- a/it/pom.xml
+++ b/it/pom.xml
@@ -114,6 +114,18 @@
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>com.google.api.grpc</groupId>
+          <artifactId>proto-google-cloud-datastream-v1</artifactId>
+          <version>1.2.2</version>
+          <scope>compile</scope>
+      </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-datastream</artifactId>
+      <version>1.2.2</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -124,8 +136,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin.version}</version>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <source>11</source>
+          <target>11</target>
           <!-- <compilerArgument>-parameters</compilerArgument> -->
           <parameters>true</parameters>
           <testCompilerArgument>-parameters</testCompilerArgument>

--- a/it/src/main/java/com/google/cloud/teleport/it/datastream/DatastreamResourceManager.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/datastream/DatastreamResourceManager.java
@@ -1,0 +1,16 @@
+
+package com.google.cloud.teleport.it.datastream;
+
+import com.google.cloud.datastream.v1.*;
+
+import java.util.concurrent.ExecutionException;
+
+public interface DatastreamResourceManager {
+
+    ConnectionProfile createConnectionProfile(String connectionProfileId, String displayName, String hostname, String password) throws ExecutionException, InterruptedException;
+
+//    Stream createStream(String stringId, String requestID);
+
+//    void cleanUpAll();
+
+}

--- a/it/src/main/java/com/google/cloud/teleport/it/datastream/DatastreamResourceManagerTest.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/datastream/DatastreamResourceManagerTest.java
@@ -1,0 +1,26 @@
+package com.google.cloud.teleport.it.datastream;
+
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.datastream.v1.DatastreamClient;
+import com.google.cloud.datastream.v1.DatastreamSettings;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+public class DatastreamResourceManagerTest {
+
+    public static void main(String[] args) throws IOException, ExecutionException, InterruptedException {
+
+        Credentials credentials = ServiceAccountCredentials.fromStream(new FileInputStream("/Users/titodo/credentials/credentials.json")) ;
+        DatastreamSettings datastreamSettings = DatastreamSettings.newBuilder().setCredentialsProvider(FixedCredentialsProvider.create(credentials)).build();
+        DatastreamClient datastreamClient = DatastreamClient.create(datastreamSettings);
+
+
+        DefaultDatastreamResourceManager rm = new DefaultDatastreamResourceManager(datastreamClient, "us-central1", "datastream-rm");
+        rm.createConnectionProfile("jc-connection-profile", "JC Connection Profile", "34.172.27.69", "password");
+
+    }
+}

--- a/it/src/main/java/com/google/cloud/teleport/it/datastream/DefaultDatastreamResourceManager.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/datastream/DefaultDatastreamResourceManager.java
@@ -1,0 +1,44 @@
+package com.google.cloud.teleport.it.datastream;
+
+import com.google.cloud.datastream.v1.*;
+
+import java.util.concurrent.ExecutionException;
+
+public class DefaultDatastreamResourceManager implements DatastreamResourceManager {
+
+    private final DatastreamClient datastreamClient;
+    private final String location;
+    private final String projectId;
+
+    public DefaultDatastreamResourceManager(DatastreamClient datastreamClient, String location, String projectId) {
+        this.datastreamClient = datastreamClient;
+        this.location = location;
+        this.projectId = projectId;
+    }
+
+    @Override
+    public ConnectionProfile createConnectionProfile(String connectionProfileId, String displayName, String hostname, String password) throws ExecutionException, InterruptedException {
+
+        MysqlProfile.Builder setMysqlProfileBuilder = MysqlProfile.newBuilder()
+                .setHostname(hostname)
+                .setPassword(password)
+                .setPort(3306);
+
+        ConnectionProfile connectionProfile = ConnectionProfile.newBuilder()
+                .setDisplayName(displayName)
+                .setMysqlProfile(setMysqlProfileBuilder)
+                .build();
+
+        CreateConnectionProfileRequest request = CreateConnectionProfileRequest.newBuilder()
+                .setParent(LocationName.of(projectId, location).toString())
+                .setConnectionProfile(connectionProfile)
+                .setConnectionProfileId(connectionProfileId)
+                .setValidateOnly(true)
+                .setForce(true)
+                .build();
+
+        return datastreamClient
+                .createConnectionProfileAsync(request)
+                .get();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -357,6 +357,11 @@
       <version>${bigtable-beam-import.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-datastream</artifactId>
+      <version>1.2.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
       <version>${json.version}</version>


### PR DESCRIPTION
#477 

Hey @Polber, I'm experiencing some issues with the Datastream client library and I would appreciate your help debugging it.

I'm trying to create a `createConnectionProfile` method that creates a Datastream MySQL connection profile but I keep getting the below error.

```
Exception in thread "main" java.util.concurrent.ExecutionException: com.google.api.gax.rpc.InvalidArgumentException: io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Request contains an invalid argument.
	at com.google.common.util.concurrent.AbstractFuture.getDoneValue(AbstractFuture.java:588)
	at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:567)
	at com.google.common.util.concurrent.FluentFuture$TrustedFuture.get(FluentFuture.java:92)
	at com.google.common.util.concurrent.ForwardingFuture.get(ForwardingFuture.java:66)
	at com.google.api.gax.longrunning.OperationFutureImpl.get(OperationFutureImpl.java:127)
	at com.google.cloud.teleport.it.datastream.DefaultDatastreamResourceManager.createConnectionProfile(DefaultDatastreamResourceManager.java:42)
```

I'm not entirely sure if this is from my parameters or my datastreamClient credentials settings was not configured properly.

Do you have any thoughts on tips on how to debug this?
