### PR TITLE
Trigger Java PR workflow when any XML is changed + files are deleted

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -44,7 +44,7 @@ inputs:
 outputs:
   changed-files:
     description: 'Comma-separated list of files that were changed'
-    value: ${{ steps.changed-files.outputs.all_changed_files }}
+    value: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
 
 runs:
   using: 'composite'

--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -22,7 +22,7 @@ on:
       - 'main'
     paths:
       - '**.java'
-      - '**pom.xml'
+      - '**.xml'
       # Include relevant GitHub Action files for running these checks.
       # This will make it easier to verify action changes don't break anything.
       - '.github/actions/setup-env/*'

--- a/cicd/internal/workflows/maven-workflows.go
+++ b/cicd/internal/workflows/maven-workflows.go
@@ -35,6 +35,7 @@ const (
 
 	// regexes
 	javaFileRegex     = "\\.java$"
+	xmlFileRegex      = "\\.xml$"
 	markdownFileRegex = "\\.md$"
 	pomFileRegex      = "pom\\.xml$"
 
@@ -98,7 +99,7 @@ func (*mvnCleanInstallWorkflow) Run(args ...string) error {
 	flags.RegisterCommonFlags()
 	flag.Parse()
 
-	changed := flags.ChangedFiles(javaFileRegex, pomFileRegex)
+	changed := flags.ChangedFiles(javaFileRegex, xmlFileRegex)
 	if len(changed) == 0 {
 		return nil
 	}


### PR DESCRIPTION
The Java PR workflow is not triggering in some cases that it should:
 - Any files are deleted (see https://github.com/marketplace/actions/changed-files#outputs)
 - XML files are changed (i.e., unified-templates.xml, logback.xml)