### PR TITLE
Jdbc To BigQuery Flex Template : New Option For Data loading strategy

### DIFF
--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/JdbcToBigQueryOptions.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/JdbcToBigQueryOptions.java
@@ -87,4 +87,11 @@ public interface JdbcToBigQueryOptions extends CommonTemplateOptions, BigQueryOp
   Boolean getUseColumnAlias();
 
   void setUseColumnAlias(Boolean useColumnAlias);
+
+  @Description(
+      "If enabled (set to true) the pipeline will truncate/load data into BigQuery, else by default, it will Append.")
+  @Default.Boolean(false)
+  Boolean getIsTruncate();
+
+  void setIsTruncate(Boolean isTruncate);
 }

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/JdbcToBigQuery.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/JdbcToBigQuery.java
@@ -111,13 +111,18 @@ public class JdbcToBigQuery {
     return pipeline.run();
   }
 
-  /** Create the {@link Write} transform that outputs the collection to BigQuery. */
+  /**
+   * Create the {@link Write} transform that outputs the collection to BigQuery as per input option.
+   */
   @VisibleForTesting
   static Write<TableRow> writeToBQTransform(JdbcToBigQueryOptions options) {
     return BigQueryIO.writeTableRows()
         .withoutValidation()
         .withCreateDisposition(Write.CreateDisposition.CREATE_NEVER)
-        .withWriteDisposition(Write.WriteDisposition.WRITE_APPEND)
+        .withWriteDisposition(
+            options.getIsTruncate()
+                ? Write.WriteDisposition.WRITE_TRUNCATE
+                : Write.WriteDisposition.WRITE_APPEND)
         .withCustomGcsTempLocation(
             StaticValueProvider.of(options.getBigQueryLoadingTemporaryDirectory()))
         .to(options.getOutputTable());


### PR DESCRIPTION
Added New Option For Data loading strategy into Jdbc To BigQuery Flex Template. Requesting approval and review for Merge into Main branch followed by GA in Google Cloud. 