### PR TITLE
Reducing verbosity of unit tests

### DIFF
--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -28,6 +28,9 @@ on:
       - '.github/actions/setup-env/*'
       - '.github/workflows/java-pr.yml'
 
+env:
+  MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade=error
+
 permissions: read-all
 
 jobs:

--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -29,6 +29,7 @@
     <description>
         Cloud Teleport Classic is a collection of Apache Beam pipelines for common tasks, like data movement
         across databases or batch transforms on random datasets. They are released as Dataflow Classic Templates.
+
     </description>
 
     <packaging>pom</packaging>


### PR DESCRIPTION
Unit tests are extremely verbose, mainly due to logs from the shade plugin from maven. This change is to reduce their verbosity.