### PR TITLE
Added support for Fine-Grained Access Control (FGAC) on Change Streams

### DIFF
--- a/v2/datastream-to-spanner/src/main/java/org/apache/beam/sdk/io/gcp/spanner/ExposedSpannerConfig.java
+++ b/v2/datastream-to-spanner/src/main/java/org/apache/beam/sdk/io/gcp/spanner/ExposedSpannerConfig.java
@@ -62,6 +62,8 @@ public class ExposedSpannerConfig extends SpannerConfig {
 
   private final ValueProvider<RpcPriority> rpcPriority;
 
+  private final String databaseRole;
+
   private final ServiceFactory<Spanner, SpannerOptions> serviceFactory;
 
   private ExposedSpannerConfig(
@@ -78,6 +80,7 @@ public class ExposedSpannerConfig extends SpannerConfig {
       @Nullable RetrySettings commitRetrySettings,
       @Nullable ImmutableSet<Code> retryableCodes,
       @Nullable ValueProvider<RpcPriority> rpcPriority,
+      @Nullable String databaseRole,
       @Nullable ServiceFactory<Spanner, SpannerOptions> serviceFactory) {
     this.projectId = projectId;
     this.instanceId = instanceId;
@@ -92,6 +95,7 @@ public class ExposedSpannerConfig extends SpannerConfig {
     this.commitRetrySettings = commitRetrySettings;
     this.retryableCodes = retryableCodes;
     this.rpcPriority = rpcPriority;
+    this.databaseRole = databaseRole;
     this.serviceFactory = serviceFactory;
   }
 
@@ -170,6 +174,12 @@ public class ExposedSpannerConfig extends SpannerConfig {
   @Override
   public ValueProvider<RpcPriority> getRpcPriority() {
     return rpcPriority;
+  }
+
+  @Nullable
+  @Override
+  public String getDatabaseRole() {
+    return databaseRole;
   }
 
   @Nullable
@@ -303,6 +313,7 @@ public class ExposedSpannerConfig extends SpannerConfig {
     private RetrySettings commitRetrySettings;
     private ImmutableSet<Code> retryableCodes;
     private ValueProvider<RpcPriority> rpcPriority;
+    private String databaseRole;
     private ServiceFactory<Spanner, SpannerOptions> serviceFactory;
 
     Builder() {}
@@ -321,6 +332,7 @@ public class ExposedSpannerConfig extends SpannerConfig {
       this.commitRetrySettings = source.getCommitRetrySettings();
       this.retryableCodes = source.getRetryableCodes();
       this.rpcPriority = source.getRpcPriority();
+      this.databaseRole = source.getDatabaseRole();
       this.serviceFactory = source.getServiceFactory();
     }
 
@@ -404,6 +416,12 @@ public class ExposedSpannerConfig extends SpannerConfig {
     }
 
     @Override
+    SpannerConfig.Builder setDatabaseRole(String databaseRole) {
+      this.databaseRole = databaseRole;
+      return this;
+    }
+
+    @Override
     ExposedSpannerConfig.Builder setServiceFactory(
         ServiceFactory<Spanner, SpannerOptions> serviceFactory) {
       this.serviceFactory = serviceFactory;
@@ -426,6 +444,7 @@ public class ExposedSpannerConfig extends SpannerConfig {
           this.commitRetrySettings,
           this.retryableCodes,
           this.rpcPriority,
+          this.databaseRole,
           this.serviceFactory);
     }
   }

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerChangeStreamsToBigQueryOptions.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerChangeStreamsToBigQueryOptions.java
@@ -98,6 +98,17 @@ public interface SpannerChangeStreamsToBigQueryOptions extends DataflowPipelineO
 
   void setSpannerChangeStreamName(String value);
 
+  @Description(
+      "Database role user assumes while reading from the change stream. The database role should"
+          + " have required privileges to read from change stream. If a database role is not"
+          + " specified, the user should have required IAM permissions to read from the database.")
+  String getSpannerDatabaseRole();
+
+  void setSpannerDatabaseRole(String spannerDatabaseRole);
+
+  @Description(
+      "Priority for Spanner RPC invocations. Defaults to HIGH. Allowed priorites are LOW, MEDIUM,"
+          + " HIGH.")
   @TemplateParameter.Enum(
       order = 8,
       enumOptions = {"LOW", "MEDIUM", "HIGH"},

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerChangeStreamsToGcsOptions.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerChangeStreamsToGcsOptions.java
@@ -104,6 +104,17 @@ public interface SpannerChangeStreamsToGcsOptions
 
   void setSpannerChangeStreamName(String spannerChangeStreamName);
 
+  @Description(
+      "Database role user assumes while reading from the change stream. The database role should"
+          + " have required privileges to read from change stream. If a database role is not"
+          + " specified, the user should have required IAM permissions to read from the database.")
+  String getSpannerDatabaseRole();
+
+  void setSpannerDatabaseRole(String spannerDatabaseRole);
+
+  @Description(
+      "The starting DateTime to use for reading change streams"
+          + " (https://tools.ietf.org/html/rfc3339). Defaults to now.")
   @TemplateParameter.DateTime(
       order = 8,
       optional = true,

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SpannerChangeStreamsToBigQuery.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SpannerChangeStreamsToBigQuery.java
@@ -179,6 +179,10 @@ public final class SpannerChangeStreamsToBigQuery {
             .withInstanceId(options.getSpannerInstanceId())
             .withDatabaseId(options.getSpannerDatabase())
             .withRpcPriority(options.getRpcPriority());
+    // Propagate database role for fine-grained access control on change stream.
+    if (options.getSpannerDatabaseRole() != null){
+      spannerConfig = spannerConfig.withDatabaseRole(options.getSpannerDatabaseRole());
+    }
 
     SpannerIO.ReadChangeStream readChangeStream =
         SpannerIO.readChangeStream()

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToGcsTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToGcsTest.java
@@ -73,8 +73,6 @@ public final class SpannerChangeStreamsToGcsTest {
   private static final String AVRO_FILENAME_PREFIX = "avro-output-";
   private static final String TEXT_FILENAME_PREFIX = "text-output-";
   private static final Integer NUM_SHARDS = 1;
-  private static final String TEST_PROJECT = "span-cloud-testing";
-  private static final String TEST_INSTANCE = "changestream";
   private static final String TEST_DATABASE_PREFIX = "testdbchangestreams";
   private static final String TEST_TABLE = "Users";
   private static final String TEST_CHANGE_STREAM = "UsersStream";
@@ -281,15 +279,108 @@ public final class SpannerChangeStreamsToGcsTest {
     spannerServer.getDbClient(testDatabase).write(mutations);
 
     Timestamp endTimestamp = Timestamp.now();
+    SpannerConfig spannerConfig = spannerServer.getSpannerConfig(testDatabase);
 
     SpannerChangeStreamsToGcsOptions options =
         PipelineOptionsFactory.create().as(SpannerChangeStreamsToGcsOptions.class);
-    options.setSpannerProjectId(TEST_PROJECT);
-    options.setSpannerInstanceId(TEST_INSTANCE);
+    options.setSpannerHost(spannerConfig.getHost().get());
+    options.setSpannerProjectId(spannerConfig.getProjectId().get());
+    options.setSpannerInstanceId(spannerConfig.getInstanceId().get());
     options.setSpannerDatabase(testDatabase);
-    options.setSpannerMetadataInstanceId(TEST_INSTANCE);
+    options.setSpannerMetadataInstanceId(spannerConfig.getInstanceId().get());
     options.setSpannerMetadataDatabase(testDatabase);
     options.setSpannerChangeStreamName(TEST_CHANGE_STREAM);
+
+    options.setStartTimestamp(startTimestamp.toString());
+    options.setEndTimestamp(endTimestamp.toString());
+    List<String> experiments = new ArrayList<String>();
+    options.setExperiments(experiments);
+
+    options.setOutputFileFormat(FileFormat.AVRO);
+    options.setGcsOutputDirectory(fakeDir);
+    options.setOutputFilenamePrefix(AVRO_FILENAME_PREFIX);
+    options.setNumShards(NUM_SHARDS);
+    options.setTempLocation(fakeTempLocation);
+
+    // Run the pipeline.
+    PipelineResult result = run(options);
+    result.waitUntilFinish();
+
+    // Read from the output Avro file to assert that 1 data change record has been generated.
+    PCollection<com.google.cloud.teleport.v2.DataChangeRecord> dataChangeRecords =
+        pipeline.apply(
+            "readRecords",
+            AvroIO.read(com.google.cloud.teleport.v2.DataChangeRecord.class)
+                .from(fakeDir + "/avro-output-*.avro"));
+    PAssert.that(dataChangeRecords).satisfies(new VerifyDataChangeRecordAvro());
+    pipeline.run();
+
+    // Drop the database.
+    spannerServer.dropDatabase(testDatabase);
+  }
+
+  @Test
+  @Category(IntegrationTest.class)
+  // This test can only be run locally with the following command:
+  // mvn -Dexcluded.spanner.tests="" -Dtest=SpannerChangeStreamsToGcsTest test
+  public void testWriteToGCSAvroWithDatabaseRole() throws Exception {
+    // Create a test database.
+    String testDatabase = generateDatabaseName();
+    fakeDir = tmpDir.newFolder("output").getAbsolutePath();
+    fakeTempLocation = tmpDir.newFolder("temporaryLocation").getAbsolutePath();
+
+    spannerServer.dropDatabase(testDatabase);
+
+    // Define test role.
+    final String testRole = "test_role";
+
+    // Create a table.
+    List<String> statements = new ArrayList<String>();
+    final String createTable =
+        "CREATE TABLE "
+            + TEST_TABLE
+            + " ("
+            + "user_id INT64 NOT NULL,"
+            + "name STRING(MAX) "
+            + ") PRIMARY KEY(user_id)";
+    final String createChangeStream = "CREATE CHANGE STREAM " + TEST_CHANGE_STREAM + " FOR Users";
+
+    // Set up roles and privileges.
+    final String createRole = "CREATE ROLE " + testRole;
+    final String grantCSPrivilege = "GRANT SELECT ON CHANGE STREAM " + TEST_CHANGE_STREAM + " TO ROLE " + testRole;
+    final String grantTVFPrivilege = "GRANT EXECUTE ON TABLE FUNCTION READ_" + TEST_CHANGE_STREAM + " TO ROLE " + testRole;
+    statements.add(createTable);
+    statements.add(createChangeStream);
+    statements.add(createRole);
+    statements.add(grantCSPrivilege);
+    statements.add(grantTVFPrivilege);
+
+    spannerServer.createDatabase(testDatabase, statements);
+
+    Timestamp startTimestamp = Timestamp.now();
+
+    // Create a mutation for the table that will generate 1 data change record.
+    List<Mutation> mutations = new ArrayList<>();
+    mutations.add(
+        Mutation.newInsertBuilder(TEST_TABLE).set("user_id").to(1).set("name").to("Name1").build());
+    mutations.add(
+        Mutation.newInsertBuilder(TEST_TABLE).set("user_id").to(2).set("name").to("Name2").build());
+
+    spannerServer.getDbClient(testDatabase).write(mutations);
+
+    Timestamp endTimestamp = Timestamp.now();
+    SpannerConfig spannerConfig = spannerServer.getSpannerConfig(testDatabase);
+
+    SpannerChangeStreamsToGcsOptions options =
+        PipelineOptionsFactory.create().as(SpannerChangeStreamsToGcsOptions.class);
+    options.setSpannerHost(spannerConfig.getHost().get());
+    options.setSpannerProjectId(spannerConfig.getProjectId().get());
+    options.setSpannerInstanceId(spannerConfig.getInstanceId().get());
+    options.setSpannerDatabase(testDatabase);
+    options.setSpannerMetadataInstanceId(spannerConfig.getInstanceId().get());
+    options.setSpannerMetadataDatabase(testDatabase);
+    options.setSpannerChangeStreamName(TEST_CHANGE_STREAM);
+    options.setSpannerDatabaseRole(testRole);
 
     options.setStartTimestamp(startTimestamp.toString());
     options.setEndTimestamp(endTimestamp.toString());
@@ -357,13 +448,15 @@ public final class SpannerChangeStreamsToGcsTest {
     spannerServer.getDbClient(testDatabase).write(mutations);
 
     Timestamp endTimestamp = Timestamp.now();
+    SpannerConfig spannerConfig = spannerServer.getSpannerConfig(testDatabase);
 
     SpannerChangeStreamsToGcsOptions options =
         PipelineOptionsFactory.create().as(SpannerChangeStreamsToGcsOptions.class);
-    options.setSpannerProjectId(TEST_PROJECT);
-    options.setSpannerInstanceId(TEST_INSTANCE);
+    options.setSpannerHost(spannerConfig.getHost().get());
+    options.setSpannerProjectId(spannerConfig.getProjectId().get());
+    options.setSpannerInstanceId(spannerConfig.getInstanceId().get());
     options.setSpannerDatabase(testDatabase);
-    options.setSpannerMetadataInstanceId(TEST_INSTANCE);
+    options.setSpannerMetadataInstanceId(spannerConfig.getInstanceId().get());
     options.setSpannerMetadataDatabase(testDatabase);
     options.setSpannerChangeStreamName(TEST_CHANGE_STREAM);
 

--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -59,6 +59,13 @@
                 <version>2.3.0</version>
             </dependency>
             <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-spanner-bom</artifactId>
+                <version>6.30.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.google.api</groupId>
                 <artifactId>gax-grpc</artifactId>
                 <version>2.3.0</version>


### PR DESCRIPTION
This change adds Fine-grained access control for change streams.  NOTE: it is dependent on the (yet-to-be-released) Apache Beam 2.44.0.