### PR TITLE
Create MongoDB Resource Manager

### DIFF
--- a/it/pom.xml
+++ b/it/pom.xml
@@ -32,8 +32,14 @@
     <guava.version>31.0.1-jre</guava.version>
     <mockito.version>3.7.7</mockito.version>
     <mockito-inline.version>4.5.1</mockito-inline.version>
+    <mongodb.version>3.12.10</mongodb.version>
     <puppycrawl.version>8.7</puppycrawl.version>
     <dataflow-api.version>v1b3-rev20220920-2.0.0</dataflow-api.version>
+    <re2j.version>1.5</re2j.version>
+    <slf4j.version>1.7.25</slf4j.version>
+    <surefire.version>2.21.0</surefire.version>
+    <testcontainers.version>1.17.5</testcontainers.version>
+    <truth.version>1.0.1</truth.version>
   </properties>
 
   <dependencies>
@@ -99,6 +105,31 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>
+    </dependency>
+
+    <!-- Test Containers -->
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>${testcontainers.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mongodb</artifactId>
+      <version>${testcontainers.version}</version>
+    </dependency>
+
+    <!-- Third-party drivers -->
+    <dependency>
+      <groupId>org.mongodb</groupId>
+      <artifactId>mongodb-driver-sync</artifactId>
+      <version>${mongodb.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.mongodb</groupId>
+          <artifactId>bson-record-codec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Testing -->

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -33,13 +33,8 @@
     <mockito.version>3.7.7</mockito.version>
     <mockito-inline.version>4.5.1</mockito-inline.version>
     <mongodb.version>3.12.10</mongodb.version>
-    <puppycrawl.version>8.7</puppycrawl.version>
     <dataflow-api.version>v1b3-rev20220920-2.0.0</dataflow-api.version>
-    <re2j.version>1.5</re2j.version>
-    <slf4j.version>1.7.25</slf4j.version>
-    <surefire.version>2.21.0</surefire.version>
     <testcontainers.version>1.17.5</testcontainers.version>
-    <truth.version>1.0.1</truth.version>
   </properties>
 
   <dependencies>

--- a/it/src/main/java/com/google/cloud/teleport/it/TemplateTestBase.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/TemplateTestBase.java
@@ -64,6 +64,7 @@ public abstract class TemplateTestBase {
 
   protected static final String PROJECT = TestProperties.project();
   protected static final String REGION = TestProperties.region();
+  protected static final String HOST_IP = TestProperties.hostIp();
 
   protected String specPath;
   protected Credentials credentials;
@@ -215,7 +216,9 @@ public abstract class TemplateTestBase {
 
   @After
   public void tearDownBase() {
-    artifactClient.cleanupRun();
+    if (artifactClient != null) {
+      artifactClient.cleanupRun();
+    }
   }
 
   protected DataflowTemplateClient getDataflowClient() {

--- a/it/src/main/java/com/google/cloud/teleport/it/TestProperties.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/TestProperties.java
@@ -42,6 +42,7 @@ public final class TestProperties {
   public static final String REGION_KEY = "region";
   public static final String STAGE_BUCKET = "stageBucket";
   public static final String SPEC_PATH_KEY = "specPath";
+  public static final String HOST_IP = "hostIp";
 
   // From environment variables
   public static final String ACCESS_TOKEN_KEY = "DT_IT_ACCESS_TOKEN";
@@ -91,6 +92,10 @@ public final class TestProperties {
 
   public static String stageBucket() {
     return getProperty(STAGE_BUCKET, Type.PROPERTY, false);
+  }
+
+  public static String hostIp() {
+    return getProperty(HOST_IP, "localhost", Type.PROPERTY);
   }
 
   /** Gets a property or throws an exception if it is not found. */

--- a/it/src/main/java/com/google/cloud/teleport/it/bigquery/BigQueryResourceManager.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/bigquery/BigQueryResourceManager.java
@@ -15,10 +15,9 @@
  */
 package com.google.cloud.teleport.it.bigquery;
 
-import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
 import com.google.cloud.bigquery.Schema;
-import com.google.common.collect.ImmutableList;
+import com.google.cloud.bigquery.TableResult;
 import java.util.List;
 
 /** Interface for managing BigQuery resources in integration tests. */
@@ -31,6 +30,13 @@ public interface BigQueryResourceManager {
    * @throws BigQueryResourceManagerException if there is an error creating the dataset in BigQuery.
    */
   void createDataset(String region);
+
+  /**
+   * Return the dataset ID this Resource Manager uses to create and manage tables in.
+   *
+   * @return the dataset ID.
+   */
+  String getDatasetId();
 
   /**
    * Creates a table within the current dataset given a table name and schema.
@@ -87,17 +93,17 @@ public interface BigQueryResourceManager {
   void write(String tableName, List<RowToInsert> tableRows);
 
   /**
-   * Reads all the rows in a table. This method requires {@link
-   * BigQueryResourceManager#createTable(String, Schema)} to be called for the target table
-   * beforehand.
+   * Reads all the rows in a table and returns a TableResult containing a JSON string
+   * representation. This method requires {@link BigQueryResourceManager#createTable(String,
+   * Schema)} to be called for the target table beforehand.
    *
    * @param tableName The name of the table to read rows from.
-   * @return A list containing all the rows in the table.
+   * @return A TableResult containing all the rows in the table in JSON.
    * @throws BigQueryResourceManagerException if method is called after resources have been cleaned
    *     up, if the manager object has no dataset, if the table does not exist or if there is an
    *     Exception when attempting to insert the rows.
    */
-  ImmutableList<FieldValueList> readTable(String tableName);
+  TableResult readTable(String tableName);
 
   /**
    * Deletes all created resources (dataset and tables) and cleans up the BigQuery client, making

--- a/it/src/main/java/com/google/cloud/teleport/it/bigquery/DefaultBigQueryResourceManager.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/bigquery/DefaultBigQueryResourceManager.java
@@ -24,9 +24,9 @@ import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetInfo;
-import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
 import com.google.cloud.bigquery.InsertAllResponse;
+import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.StandardTableDefinition;
 import com.google.cloud.bigquery.Table;
@@ -93,11 +93,6 @@ public final class DefaultBigQueryResourceManager implements BigQueryResourceMan
     return projectId;
   }
 
-  /**
-   * Return the dataset ID this Resource Manager uses to create and manage tables in.
-   *
-   * @return the dataset ID.
-   */
   public String getDatasetId() {
     return datasetId;
   }
@@ -255,32 +250,30 @@ public final class DefaultBigQueryResourceManager implements BigQueryResourceMan
   }
 
   @Override
-  public synchronized ImmutableList<FieldValueList> readTable(String tableName) {
-    Table table = getTableIfExists(tableName);
-
-    // List to store fetched rows
-    ImmutableList.Builder<FieldValueList> immutableListBuilder = ImmutableList.builder();
+  public synchronized TableResult readTable(String tableName) {
+    getTableIfExists(tableName);
 
     LOG.info("Reading all rows from {}.{}", dataset.getDatasetId().getDataset(), tableName);
 
     // Read all the rows from the table given by tableId
+    TableResult results;
     try {
-      TableResult results = bigQuery.listTableData(table.getTableId());
-      for (FieldValueList row : results.getValues()) {
-        immutableListBuilder.add(row);
-      }
+      String query = "SELECT TO_JSON_STRING(t) FROM `";
+      query += String.join(".", projectId, datasetId, tableName);
+      query += "` AS t;";
+      QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(query).build();
+      results = bigQuery.query(queryConfig);
     } catch (Exception e) {
-      throw new BigQueryResourceManagerException("Failed to read from table.", e);
+      throw new BigQueryResourceManagerException("Failed to read from table " + tableName + ".", e);
     }
 
-    ImmutableList<FieldValueList> tableRows = immutableListBuilder.build();
     LOG.info(
         "Loaded {} rows from {}.{}",
-        tableRows.size(),
+        results.getTotalRows(),
         dataset.getDatasetId().getDataset(),
         tableName);
 
-    return tableRows;
+    return results;
   }
 
   @Override

--- a/it/src/main/java/com/google/cloud/teleport/it/bigquery/DefaultBigQueryResourceManager.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/bigquery/DefaultBigQueryResourceManager.java
@@ -258,9 +258,10 @@ public final class DefaultBigQueryResourceManager implements BigQueryResourceMan
     // Read all the rows from the table given by tableId
     TableResult results;
     try {
-      String query = "SELECT TO_JSON_STRING(t) FROM `";
-      query += String.join(".", projectId, datasetId, tableName);
-      query += "` AS t;";
+      String query =
+          "SELECT TO_JSON_STRING(t) FROM `"
+              + String.join(".", projectId, datasetId, tableName)
+              + "` AS t;";
       QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(query).build();
       results = bigQuery.query(queryConfig);
     } catch (Exception e) {

--- a/it/src/main/java/com/google/cloud/teleport/it/bigtable/BigtableResourceManagerUtils.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/bigtable/BigtableResourceManagerUtils.java
@@ -57,7 +57,7 @@ public final class BigtableResourceManagerUtils {
 
     String clusterId =
         generateResourceId(
-            baseString,
+            baseString.toLowerCase(),
             ILLEGAL_CLUSTER_CHARS,
             REPLACE_CLUSTER_CHAR,
             MAX_CLUSTER_ID_LENGTH,
@@ -76,7 +76,7 @@ public final class BigtableResourceManagerUtils {
    */
   static String generateInstanceId(String baseString) {
     return generateResourceId(
-        baseString,
+        baseString.toLowerCase(),
         ILLEGAL_INSTANCE_ID_CHARS,
         REPLACE_INSTANCE_ID_CHAR,
         MAX_INSTANCE_ID_LENGTH,

--- a/it/src/main/java/com/google/cloud/teleport/it/common/ResourceManagerUtils.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/common/ResourceManagerUtils.java
@@ -75,7 +75,8 @@ public class ResourceManagerUtils {
     checkArgument(baseString.length() != 0, "baseString cannot be empty.");
 
     // next, replace all illegal characters from given string with given replacement character
-    String illegalCharsRemoved = illegalChars.matcher(baseString).replaceAll(replaceChar);
+    String illegalCharsRemoved =
+        illegalChars.matcher(baseString.toLowerCase()).replaceAll(replaceChar);
 
     // finally, append the date/time and return the substring that does not exceed the length limit
     LocalDateTime localDateTime = LocalDateTime.now(ZoneId.of(TIME_ZONE));

--- a/it/src/main/java/com/google/cloud/teleport/it/common/ResourceManagerUtils.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/common/ResourceManagerUtils.java
@@ -75,8 +75,7 @@ public class ResourceManagerUtils {
     checkArgument(baseString.length() != 0, "baseString cannot be empty.");
 
     // next, replace all illegal characters from given string with given replacement character
-    String illegalCharsRemoved =
-        illegalChars.matcher(baseString.toLowerCase()).replaceAll(replaceChar);
+    String illegalCharsRemoved = illegalChars.matcher(baseString).replaceAll(replaceChar);
 
     // finally, append the date/time and return the substring that does not exceed the length limit
     LocalDateTime localDateTime = LocalDateTime.now(ZoneId.of(TIME_ZONE));

--- a/it/src/main/java/com/google/cloud/teleport/it/mongodb/DefaultMongoDBResourceManager.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/mongodb/DefaultMongoDBResourceManager.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.mongodb;
+
+import static com.google.cloud.teleport.it.mongodb.MongoDBResourceManagerUtils.checkValidCollectionName;
+import static com.google.cloud.teleport.it.mongodb.MongoDBResourceManagerUtils.generateDatabaseName;
+
+import com.google.cloud.teleport.it.bigtable.DefaultBigtableResourceManager;
+import com.google.cloud.teleport.it.testcontainers.TestContainerResourceManager;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import java.io.IOException;
+import java.util.List;
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Default class for implementation of {@link MongoDBResourceManager} interface.
+ *
+ * <p>The class supports one database and multiple collections per database object. A database is
+ * created when the first collection is created if one has not been created already.
+ *
+ * <p>The database name is formed using testId. The database name will be "{testId}-{ISO8601 time,
+ * microsecond precision}", with additional formatting.
+ *
+ * <p>The class is thread-safe.
+ */
+public class DefaultMongoDBResourceManager extends TestContainerResourceManager<GenericContainer<?>>
+    implements MongoDBResourceManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultBigtableResourceManager.class);
+  private static final String DEFAULT_MONGODB_CONTAINER_NAME = "mongo";
+  private static final String DEFAULT_MONGODB_CONTAINER_TAG = "4.0.10";
+  private static final int MONGODB_INTERNAL_PORT = 27017;
+
+  private final MongoClient mongoClient;
+  private final String databaseName;
+  private final String connectionString;
+  private final boolean usingStaticDatabase;
+
+  private DefaultMongoDBResourceManager(DefaultMongoDBResourceManager.Builder builder) {
+    this(
+        null,
+        new MongoDBContainer(
+            DockerImageName.parse(builder.containerImageName).withTag(builder.containerImageTag)),
+        builder);
+  }
+
+  @VisibleForTesting
+  DefaultMongoDBResourceManager(
+      MongoClient mongoClient,
+      MongoDBContainer container,
+      DefaultMongoDBResourceManager.Builder builder) {
+    super(container, builder);
+
+    this.usingStaticDatabase = builder.databaseName != null;
+    this.databaseName =
+        usingStaticDatabase ? builder.databaseName : generateDatabaseName(builder.testId);
+    this.connectionString =
+        String.format("mongodb://%s:%d", this.getHost(), this.getPort(MONGODB_INTERNAL_PORT));
+    this.mongoClient = mongoClient == null ? MongoClients.create(connectionString) : mongoClient;
+  }
+
+  public static DefaultMongoDBResourceManager.Builder builder(String testId) throws IOException {
+    return new DefaultMongoDBResourceManager.Builder(testId);
+  }
+
+  @Override
+  public synchronized String getUri() {
+    return connectionString;
+  }
+
+  @Override
+  public synchronized String getDatabaseName() {
+    return databaseName;
+  }
+
+  private synchronized MongoDatabase getDatabase() {
+    try {
+      return mongoClient.getDatabase(databaseName);
+    } catch (Exception e) {
+      throw new MongoDBResourceManagerException(
+          "Error retrieving database " + databaseName + " from MongoDB.", e);
+    }
+  }
+
+  private synchronized boolean collectionExists(String collectionName) {
+    // Check collection name
+    checkValidCollectionName(databaseName, collectionName);
+
+    Iterable<String> collectionNames = getDatabase().listCollectionNames();
+    for (String name : collectionNames) {
+      // The Collection already exists in the database, return false.
+      if (collectionName.equals(name)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  @Override
+  public synchronized boolean createCollection(String collectionName) {
+    LOG.info("Creating collection using tableName '{}'.", collectionName);
+
+    try {
+      // Check to see if the Collection exists
+      if (collectionExists(collectionName)) {
+        return false;
+      }
+      // The Collection does not exist in the database, create it and return true.
+      getDatabase().getCollection(collectionName);
+    } catch (Exception e) {
+      throw new MongoDBResourceManagerException("Error creating collection.", e);
+    }
+
+    LOG.info("Successfully created collection {}.{}", databaseName, collectionName);
+
+    return true;
+  }
+
+  /**
+   * Helper method to retrieve a MongoCollection with the given name from the database and return
+   * it.
+   *
+   * @param collectionName The name of the MongoCollection.
+   * @param createCollection A boolean that specifies to create the Collection if it does not exist.
+   * @return A MongoCollection with the given name.
+   */
+  private MongoCollection<Document> getMongoDBCollection(
+      String collectionName, boolean createCollection) {
+    if (!collectionExists(collectionName) && !createCollection) {
+      throw new MongoDBResourceManagerException(
+          "Collection " + collectionName + " does not exists in database " + databaseName);
+    }
+
+    return getDatabase().getCollection(collectionName);
+  }
+
+  /**
+   * Inserts the given Document into a collection.
+   *
+   * <p>A database will be created here, if one does not already exist.
+   *
+   * @param collectionName The name of the collection to insert the document into.
+   * @param document The document to insert into the collection.
+   * @return A boolean indicating whether the Document was inserted successfully.
+   */
+  public synchronized boolean insertDocument(String collectionName, Document document) {
+    return insertDocuments(collectionName, ImmutableList.of(document));
+  }
+
+  @Override
+  public synchronized boolean insertDocuments(String collectionName, List<Document> documents) {
+    LOG.info(
+        "Attempting to write {} documents to {}.{}.",
+        documents.size(),
+        databaseName,
+        collectionName);
+
+    try {
+      getMongoDBCollection(collectionName, true).insertMany(documents);
+    } catch (Exception e) {
+      throw new MongoDBResourceManagerException("Error inserting document.", e);
+    }
+
+    LOG.info(
+        "Successfully wrote {} documents to {}.{}", documents.size(), databaseName, collectionName);
+
+    return true;
+  }
+
+  @Override
+  public synchronized FindIterable<Document> readCollection(String collectionName) {
+    LOG.info("Reading all documents from {}.{}", databaseName, collectionName);
+
+    FindIterable<Document> documents;
+    try {
+      documents = getMongoDBCollection(collectionName, false).find();
+    } catch (Exception e) {
+      throw new MongoDBResourceManagerException("Error reading collection.", e);
+    }
+
+    LOG.info("Successfully loaded documents from {}.{}", databaseName, collectionName);
+
+    return documents;
+  }
+
+  @Override
+  public synchronized boolean cleanupAll() {
+    LOG.info("Attempting to cleanup MongoDB manager.");
+
+    boolean producedError = false;
+
+    // First, delete the database if it was not given as a static argument
+    try {
+      if (!usingStaticDatabase) {
+        mongoClient.getDatabase(databaseName).drop();
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to delete MongoDB database {}. {}", databaseName, e.getMessage());
+      producedError = true;
+    }
+
+    // Next, try to close the MongoDB client connection
+    try {
+      mongoClient.close();
+    } catch (Exception e) {
+      LOG.error("Failed to delete MongoDB client. {}", e.getMessage());
+      producedError = true;
+    }
+
+    // Finally, clean up any containers started by TestContainers
+    producedError |= !super.cleanupAll();
+
+    // Throw Exception at the end if there were any errors
+    if (producedError || !super.cleanupAll()) {
+      throw new MongoDBResourceManagerException(
+          "Failed to delete resources. Check above for errors.");
+    }
+
+    LOG.info("MongoDB manager successfully cleaned up.");
+
+    return true;
+  }
+
+  /** Builder for {@link DefaultMongoDBResourceManager}. */
+  public static final class Builder
+      extends TestContainerResourceManager.Builder<DefaultMongoDBResourceManager> {
+
+    private String databaseName;
+
+    private Builder(String testId) {
+      super(testId);
+      this.containerImageName = DEFAULT_MONGODB_CONTAINER_NAME;
+      this.containerImageTag = DEFAULT_MONGODB_CONTAINER_TAG;
+    }
+
+    /**
+     * Sets the database name to that of a static database instance. Use this method only when
+     * attempting to operate on a pre-existing Mongo database.
+     *
+     * <p>Note: if a database name is set, and a static MongoDB server is being used
+     * (useStaticContainer() is also called on the builder), then a database will be created on the
+     * static server if it does not exist, and it will not be removed when cleanupAll() is called on
+     * the MongoDBResourceManager.
+     *
+     * @param databaseName The database name.
+     * @return this builder object with the database name set.
+     */
+    public Builder setDatabaseName(String databaseName) {
+      this.databaseName = databaseName;
+      return this;
+    }
+
+    @Override
+    public DefaultMongoDBResourceManager build() {
+      return new DefaultMongoDBResourceManager(this);
+    }
+  }
+}

--- a/it/src/main/java/com/google/cloud/teleport/it/mongodb/MongoDBResourceManager.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/mongodb/MongoDBResourceManager.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.mongodb;
+
+import com.mongodb.client.FindIterable;
+import java.util.List;
+import org.bson.Document;
+
+/** Interface for managing MongoDB resources in integration tests. */
+public interface MongoDBResourceManager {
+
+  /**
+   * Returns the name of the Database that this MongoDB manager will operate in.
+   *
+   * @return the name of the MongoDB Database.
+   */
+  String getDatabaseName();
+
+  /** Returns the URI connection string to the MongoDB Database. */
+  String getUri();
+
+  /**
+   * Creates a collection in MongoDB for storing Documents.
+   *
+   * <p>Note: Implementations may do database creation here, if one does not already exist.
+   *
+   * @param collectionName Collection of BigtableResourceManagerCluster objects to associate with
+   *     the given Bigtable instance.
+   * @return A boolean indicating whether the resource was created.
+   * @throws MongoDBResourceManagerException if there is an error creating the collection in
+   *     MongoDB.
+   */
+  boolean createCollection(String collectionName);
+
+  /**
+   * Inserts the given Documents into a collection.
+   *
+   * <p>Note: Implementations may do collection creation here, if one does not already exist.
+   *
+   * @param collectionName The name of the collection to insert the documents into.
+   * @param documents A list of documents to insert into the collection.
+   * @return A boolean indicating whether the Documents were inserted successfully.
+   * @throws MongoDBResourceManagerException if there is an error inserting the documents.
+   */
+  boolean insertDocuments(String collectionName, List<Document> documents);
+
+  /**
+   * Reads all the Documents in a collection.
+   *
+   * @param collectionName The name of the collection to read from.
+   * @return An iterable of all the Documents in the collection.
+   * @throws MongoDBResourceManagerException if there is an error reading the collection.
+   */
+  FindIterable<Document> readCollection(String collectionName);
+
+  /**
+   * Deletes all created resources (databases, collections and documents) and cleans up the MongoDB
+   * client, making the manager object unusable.
+   *
+   * @throws MongoDBResourceManagerException if there is an error deleting the MongoDB resources.
+   */
+  boolean cleanupAll();
+}

--- a/it/src/main/java/com/google/cloud/teleport/it/mongodb/MongoDBResourceManagerException.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/mongodb/MongoDBResourceManagerException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.mongodb;
+
+/**
+ * Custom exception for {@link com.google.cloud.teleport.it.mongodb.MongoDBResourceManager}
+ * implementations.
+ */
+public class MongoDBResourceManagerException extends RuntimeException {
+
+  public MongoDBResourceManagerException(String errorMessage, Throwable err) {
+    super(errorMessage, err);
+  }
+
+  public MongoDBResourceManagerException(String errorMessage) {
+    super(errorMessage);
+  }
+}

--- a/it/src/main/java/com/google/cloud/teleport/it/mongodb/MongoDBResourceManagerUtils.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/mongodb/MongoDBResourceManagerUtils.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.mongodb;
+
+import static com.google.cloud.teleport.it.common.ResourceManagerUtils.generateResourceId;
+
+import com.google.re2j.Pattern;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Utilities for {@link com.google.cloud.teleport.it.mongodb.MongoDBResourceManager}
+ * implementations.
+ */
+final class MongoDBResourceManagerUtils {
+
+  private static final int MAX_DATABASE_NAME_LENGTH = 63;
+  private static final Pattern ILLEGAL_DATABASE_NAME_CHARS =
+      Pattern.compile("[\\/\\\\. \"\0$]"); // i.e. [/\. "$]
+  private static final String REPLACE_DATABASE_NAME_CHAR = "-";
+  private static final int MIN_COLLECTION_NAME_LENGTH = 1;
+  private static final int MAX_COLLECTION_NAME_LENGTH = 99;
+  private static final Pattern ILLEGAL_COLLECTION_CHARS = Pattern.compile("[$\0]");
+  private static final DateTimeFormatter TIME_FORMAT =
+      DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss-SSSSSS");
+
+  private MongoDBResourceManagerUtils() {}
+
+  /**
+   * Generates a MongoDB database name from a given string.
+   *
+   * @param baseString The string to generate the name from.
+   * @return The database name string.
+   */
+  static String generateDatabaseName(String baseString) {
+    return generateResourceId(
+        baseString,
+        ILLEGAL_DATABASE_NAME_CHARS,
+        REPLACE_DATABASE_NAME_CHAR,
+        MAX_DATABASE_NAME_LENGTH,
+        TIME_FORMAT);
+  }
+
+  /**
+   * Checks whether the given collection name is valid according to MongoDB constraints.
+   *
+   * @param databaseName the database name associated with the collection
+   * @param collectionName the collection name to check.
+   * @throws IllegalArgumentException if the collection name is invalid.
+   */
+  static void checkValidCollectionName(String databaseName, String collectionName) {
+    String fullCollectionName = databaseName + "." + collectionName;
+    if (collectionName.length() < MIN_COLLECTION_NAME_LENGTH) {
+      throw new IllegalArgumentException("Collection name cannot be empty.");
+    }
+    if (fullCollectionName.length() > MAX_COLLECTION_NAME_LENGTH) {
+      throw new IllegalArgumentException(
+          "Collection name "
+              + fullCollectionName
+              + " cannot be longer than "
+              + MAX_COLLECTION_NAME_LENGTH
+              + " characters, including the database name and dot.");
+    }
+    if (ILLEGAL_COLLECTION_CHARS.matcher(collectionName).find()) {
+      throw new IllegalArgumentException(
+          "Collection name "
+              + collectionName
+              + " is not a valid name. Only letters, numbers, hyphens, underscores and exclamation points are allowed.");
+    }
+    if (collectionName.charAt(0) != '_' && !Character.isLetter(collectionName.charAt(0))) {
+      throw new IllegalArgumentException(
+          "Collection name " + collectionName + " must start with a letter or an underscore.");
+    }
+    String illegalKeyword = "system.";
+    if (collectionName.startsWith(illegalKeyword)) {
+      throw new IllegalArgumentException(
+          "Collection name "
+              + collectionName
+              + " cannot start with the prefix \""
+              + illegalKeyword
+              + "\".");
+    }
+  }
+}

--- a/it/src/main/java/com/google/cloud/teleport/it/mongodb/MongoDBResourceManagerUtils.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/mongodb/MongoDBResourceManagerUtils.java
@@ -26,6 +26,8 @@ import java.time.format.DateTimeFormatter;
  */
 final class MongoDBResourceManagerUtils {
 
+  // MongoDB Database and Collection naming restrictions can be found at
+  // https://www.mongodb.com/docs/manual/reference/limits/#naming-restrictions
   private static final int MAX_DATABASE_NAME_LENGTH = 63;
   private static final Pattern ILLEGAL_DATABASE_NAME_CHARS =
       Pattern.compile("[\\/\\\\. \"\0$]"); // i.e. [/\. "$]

--- a/it/src/main/java/com/google/cloud/teleport/it/mongodb/package-info.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/mongodb/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/** Package for managing MongoDB resources within integration tests. */
+package com.google.cloud.teleport.it.mongodb;

--- a/it/src/main/java/com/google/cloud/teleport/it/testcontainers/TestContainerResourceManager.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/testcontainers/TestContainerResourceManager.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.testcontainers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+
+/**
+ * Abstract class for managing TestContainers resources in integration tests.
+ *
+ * <p>Resource managers that extend this class will use TestContainers as a backend to spin up
+ * resources.
+ *
+ * <p>Optionally, a static resource can be specified by calling the useStaticContainer() method in
+ * the {@link TestContainerResourceManager.Builder} class. A static resource is a pre-configured
+ * database or other resource that is ready to be connected to by the resource manager. This could
+ * be a pre-existing TestContainer that has not been closed, a local database instance, a remote VM,
+ * or any other source that can be connected to. If a static container is used, the host and port
+ * must also be configured using the Builder's setHost() and setPort() methods, respectively.
+ */
+public abstract class TestContainerResourceManager<T extends GenericContainer<?>> {
+  private static final Logger LOG = LoggerFactory.getLogger(TestContainerResourceManager.class);
+
+  private final T container;
+  private final boolean usingStaticContainer;
+  private final String host;
+  private final int port;
+
+  protected <B extends TestContainerResourceManager.Builder<?>> TestContainerResourceManager(
+      T container, B builder) {
+    this.container = container;
+    this.usingStaticContainer = builder.useStaticContainer;
+    this.host = builder.host;
+    this.port = builder.port;
+
+    if (!usingStaticContainer) {
+      container.start();
+    } else if (this.host == null || this.port < 0) {
+      throw new TestContainerResourceManagerException(
+          "This manager was configured to use a static resource, but the host and port were not properly set.");
+    }
+  }
+
+  /**
+   * Returns the host that the resource is running on. If a host was specified in the builder, then
+   * this method will return that value. Otherwise, the host will default to localhost.
+   *
+   * @return the host that the resource is running on
+   */
+  protected String getHost() {
+    if (host == null) {
+      return container.getHost();
+    }
+    return host;
+  }
+
+  /**
+   * Returns the port that the resource is actually mapped to on the host. When using a non-static
+   * resource, the TestContainers framework will map the resource port to a random port on the host.
+   * This method will return the mapped port that the resource traffic is routed through.
+   *
+   * <p>Note: When using a static container, the port that was specified in the builder will be
+   * returned regardless of what is passed into this method as a parameter.
+   *
+   * @param mappedPort the port the resource was configured to listen on
+   * @return the mapped port on the host
+   */
+  protected int getPort(int mappedPort) {
+    if (port < 0) {
+      return container.getMappedPort(mappedPort);
+    }
+    return port;
+  }
+
+  /**
+   * Deletes all created resources (VM's, etc.) and stops the container, making the manager object
+   * unusable.
+   *
+   * @throws TestContainerResourceManagerException if there is an error deleting the TestContainers
+   *     resources.
+   */
+  protected boolean cleanupAll() {
+    if (usingStaticContainer) {
+      LOG.info("This manager was configured to use a static resource that will not be cleaned up.");
+      return true;
+    }
+
+    LOG.info("Attempting to cleanup TestContainers manager.");
+    try {
+      container.close();
+      LOG.info("TestContainers manager successfully cleaned up.");
+      return true;
+    } catch (Exception e) {
+      LOG.error("Failed to close TestContainer resources. {}", e.getMessage());
+      return false;
+    }
+  }
+
+  /** Builder for {@link TestContainerResourceManager}. */
+  public abstract static class Builder<T extends TestContainerResourceManager<?>> {
+
+    public String testId;
+    public String containerImageName;
+    public String containerImageTag;
+    public String host;
+    public int port;
+    public boolean useStaticContainer;
+
+    public Builder(String testId) {
+      this.testId = testId;
+      this.port = -1;
+    }
+
+    /**
+     * Sets the name of the test container image. The tag is typically the version of the image.
+     *
+     * @param containerName The name of the container image.
+     * @return this builder object with the image name set.
+     */
+    public Builder<T> setContainerImageName(String containerName) {
+      this.containerImageName = containerName;
+      return this;
+    }
+
+    /**
+     * Sets the tag for the test container. The tag is typically the version of the image.
+     *
+     * @param containerTag The tag to use for the container.
+     * @return this builder object with the tag set.
+     */
+    public Builder<T> setContainerImageTag(String containerTag) {
+      this.containerImageTag = containerTag;
+      return this;
+    }
+
+    /**
+     * Sets the host of the resource that the resource manager will connect to. This will default to
+     * localhost if not set.
+     *
+     * @param containerHost the resource host address.
+     * @return this builder object with the host set.
+     */
+    public Builder<T> setHost(String containerHost) {
+      this.host = containerHost;
+      return this;
+    }
+
+    /**
+     * Sets the port that the resource is hosted on.
+     *
+     * @param port the port the resource is hosted on.
+     * @return this builder object with the port set.
+     */
+    public Builder<T> setPort(int port) {
+      this.port = port;
+      return this;
+    }
+
+    /**
+     * Configures the resource manager to use a static resource instead of creating a new
+     * TestContainer instance of the resource. This can be another TestContainer or any other VM or
+     * server hosting the resource.
+     *
+     * <p>Note: When this option is enabled, the setPort() and setHost() methods must also be called
+     * to configure the static resource address.
+     *
+     * @return this builder object with the useStaticContainer option enabled.
+     */
+    public Builder<T> useStaticContainer() {
+      this.useStaticContainer = true;
+      return this;
+    }
+
+    /**
+     * Builds and returns a Resource Manager that extends TestContainerResourceManager.
+     *
+     * @return an instance of TestContainerResourceManager
+     */
+    public abstract T build();
+  }
+}

--- a/it/src/main/java/com/google/cloud/teleport/it/testcontainers/TestContainerResourceManagerException.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/testcontainers/TestContainerResourceManagerException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.testcontainers;
+
+/**
+ * Custom exception for {@link
+ * com.google.cloud.teleport.it.testcontainers.TestContainerResourceManager} implementations.
+ */
+public class TestContainerResourceManagerException extends RuntimeException {
+
+  public TestContainerResourceManagerException(String errorMessage) {
+    super(errorMessage);
+  }
+}

--- a/it/src/main/java/com/google/cloud/teleport/it/testcontainers/package-info.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/testcontainers/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/** Package for managing TestContainers resources within integration tests. */
+package com.google.cloud.teleport.it.testcontainers;

--- a/it/src/test/java/com/google/cloud/teleport/it/bigquery/DefaultBigQueryResourceManagerTest.java
+++ b/it/src/test/java/com/google/cloud/teleport/it/bigquery/DefaultBigQueryResourceManagerTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -33,6 +34,7 @@ import com.google.cloud.bigquery.DatasetInfo;
 import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.InsertAllResponse;
+import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
@@ -302,7 +304,8 @@ public class DefaultBigQueryResourceManagerTest {
   }
 
   @Test
-  public void testReadTableShouldThrowErrorWhenBigQueryFailsToReadRows() {
+  public void testReadTableShouldThrowErrorWhenBigQueryFailsToReadRows()
+      throws InterruptedException {
     // Use mocked dataset object
     when(bigQuery.create(any(DatasetInfo.class))).thenReturn(dataset);
     when(dataset.getDatasetId().getDataset()).thenReturn(DATASET_ID);
@@ -313,13 +316,14 @@ public class DefaultBigQueryResourceManagerTest {
 
     testManager.createTable(TABLE_NAME, schema);
 
-    when(bigQuery.listTableData(any())).thenThrow(BigQueryException.class);
+    doThrow(BigQueryException.class).when(bigQuery).query(any(QueryJobConfiguration.class));
 
     assertThrows(BigQueryResourceManagerException.class, () -> testManager.readTable(TABLE_NAME));
   }
 
   @Test
-  public void testReadTableShouldWorkWhenBigQueryDoesNotThrowAnyError() {
+  public void testReadTableShouldWorkWhenBigQueryDoesNotThrowAnyError()
+      throws InterruptedException {
     // Use mocked dataset object
     when(bigQuery.create(any(DatasetInfo.class))).thenReturn(dataset);
     when(dataset.getDatasetId().getDataset()).thenReturn(DATASET_ID);
@@ -335,7 +339,7 @@ public class DefaultBigQueryResourceManagerTest {
 
     testManager.readTable(TABLE_NAME);
 
-    verify(bigQuery).listTableData(any());
+    verify(bigQuery).query(any(QueryJobConfiguration.class));
   }
 
   @Test

--- a/it/src/test/java/com/google/cloud/teleport/it/bigtable/BigtableResourceManagerUtilsTest.java
+++ b/it/src/test/java/com/google/cloud/teleport/it/bigtable/BigtableResourceManagerUtilsTest.java
@@ -21,18 +21,13 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.bigtable.admin.v2.models.StorageType;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 
 /** Unit tests for {@link com.google.cloud.teleport.it.bigtable.BigtableResourceManagerUtils}. */
 @RunWith(JUnit4.class)
 public class BigtableResourceManagerUtilsTest {
-  @Rule public final MockitoRule mockito = MockitoJUnit.rule();
-
   private static final String TEST_ID = "test-id";
   private static final String ZONE = "us-central1-a";
   private static final int NUM_NODES = 1;

--- a/it/src/test/java/com/google/cloud/teleport/it/common/ResourceManagerUtilsTest.java
+++ b/it/src/test/java/com/google/cloud/teleport/it/common/ResourceManagerUtilsTest.java
@@ -80,7 +80,7 @@ public class ResourceManagerUtilsTest {
   }
 
   @Test
-  public void testGenerateResourceIdShouldReplaceUpperCaseLettersWithLowerCase() {
+  public void testGenerateResourceIdShouldReplaceUpperCaseLettersWithHyphen() {
     String testBaseString = "Test-Instance";
 
     String actual =
@@ -91,7 +91,7 @@ public class ResourceManagerUtilsTest {
             MAX_INSTANCE_ID_LENGTH,
             TIME_FORMAT);
 
-    assertThat(actual).matches("test-instance-\\d{8}-\\d{6}-\\d{6}");
+    assertThat(actual).matches("-est--nstance-\\d{8}-\\d{6}-\\d{6}");
   }
 
   @Test

--- a/it/src/test/java/com/google/cloud/teleport/it/common/ResourceManagerUtilsTest.java
+++ b/it/src/test/java/com/google/cloud/teleport/it/common/ResourceManagerUtilsTest.java
@@ -80,7 +80,7 @@ public class ResourceManagerUtilsTest {
   }
 
   @Test
-  public void testGenerateResourceIdShouldReplaceUpperCaseLettersWithHyphen() {
+  public void testGenerateResourceIdShouldReplaceUpperCaseLettersWithLowerCase() {
     String testBaseString = "Test-Instance";
 
     String actual =
@@ -91,7 +91,7 @@ public class ResourceManagerUtilsTest {
             MAX_INSTANCE_ID_LENGTH,
             TIME_FORMAT);
 
-    assertThat(actual).matches("-est--nstance-\\d{8}-\\d{6}-\\d{6}");
+    assertThat(actual).matches("test-instance-\\d{8}-\\d{6}-\\d{6}");
   }
 
   @Test

--- a/it/src/test/java/com/google/cloud/teleport/it/mongodb/DefaultMongoDBResourceManagerTest.java
+++ b/it/src/test/java/com/google/cloud/teleport/it/mongodb/DefaultMongoDBResourceManagerTest.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.mongodb;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.mongodb.MongoBulkWriteException;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.MongoIterable;
+import java.io.IOException;
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+/** Unit tests for {@link com.google.cloud.teleport.it.mongodb.DefaultMongoDBResourceManager}. */
+@RunWith(JUnit4.class)
+public class DefaultMongoDBResourceManagerTest {
+
+  @Rule public final MockitoRule mockito = MockitoJUnit.rule();
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private MongoIterable<String> collectionIterable;
+
+  @Mock private MongoClient mongoClient;
+  @Mock private MongoDatabase database;
+  @Mock private MongoCursor<String> collectionIterator;
+  @Mock private MongoCollection<Document> collection;
+  @Mock private MongoCursor<String> collectionNames;
+  @Mock private MongoDBContainer container;
+
+  private static final String TEST_ID = "test-id";
+  private static final String COLLECTION_NAME = "collection-name";
+  private static final String STATIC_DATABASE_NAME = "database";
+  private static final String HOST = "localhost";
+  private static final int MONGO_DB_PORT = 27017;
+  private static final int MAPPED_PORT = 10000;
+
+  private DefaultMongoDBResourceManager testManager;
+
+  @Before
+  public void setUp() throws IOException, InterruptedException {
+    when(container.getHost()).thenReturn(HOST);
+    when(container.getMappedPort(MONGO_DB_PORT)).thenReturn(MAPPED_PORT);
+
+    testManager =
+        new DefaultMongoDBResourceManager(
+            mongoClient, container, DefaultMongoDBResourceManager.builder(TEST_ID));
+  }
+
+  @Test
+  public void testCreateResourceManagerBuilderReturnsDefaultMongoDBResourceManager()
+      throws IOException {
+    assertThat(
+            DefaultMongoDBResourceManager.builder(TEST_ID)
+                .useStaticContainer()
+                .setHost(HOST)
+                .setPort(MONGO_DB_PORT)
+                .build())
+        .isInstanceOf(DefaultMongoDBResourceManager.class);
+  }
+
+  @Test
+  public void testGetUriShouldReturnCorrectValue() {
+    assertThat(testManager.getUri()).matches("mongodb://" + HOST + ":" + MAPPED_PORT);
+  }
+
+  @Test
+  public void testGetDatabaseNameShouldReturnCorrectValue() {
+    assertThat(testManager.getDatabaseName()).matches(TEST_ID + "-\\d{8}-\\d{6}-\\d{6}");
+  }
+
+  @Test
+  public void testCreateCollectionShouldThrowErrorWhenCollectionNameIsInvalid() {
+    assertThrows(
+        MongoDBResourceManagerException.class, () -> testManager.createCollection("invalid$name"));
+  }
+
+  @Test
+  public void testCreateCollectionShouldThrowErrorWhenMongoDBFailsToGetDB() {
+    doThrow(IllegalArgumentException.class).when(mongoClient).getDatabase(anyString());
+
+    assertThrows(
+        MongoDBResourceManagerException.class, () -> testManager.createCollection(COLLECTION_NAME));
+  }
+
+  @Test
+  public void testCreateCollectionShouldThrowErrorIfDatabaseFailsToListCollectionNames() {
+    when(mongoClient.getDatabase(anyString())).thenReturn(database);
+    when(database.listCollectionNames()).thenReturn(null);
+
+    assertThrows(
+        MongoDBResourceManagerException.class, () -> testManager.createCollection(COLLECTION_NAME));
+  }
+
+  @Test
+  public void testCreateCollectionShouldThrowErrorWhenMongoDBFailsToCreateCollection() {
+    when(mongoClient.getDatabase(anyString())).thenReturn(database);
+    when(database.listCollectionNames()).thenReturn(collectionIterable);
+    doThrow(IllegalArgumentException.class).when(database).getCollection(anyString());
+
+    assertThrows(
+        MongoDBResourceManagerException.class, () -> testManager.createCollection(COLLECTION_NAME));
+  }
+
+  @Test
+  public void testCreateCollectionShouldReturnTrueIfMongoDBDoesNotThrowAnyError() {
+    when(mongoClient.getDatabase(anyString())).thenReturn(database);
+    when(database.listCollectionNames()).thenReturn(collectionIterable);
+
+    assertThat(testManager.createCollection(COLLECTION_NAME)).isEqualTo(true);
+    verify(database).getCollection(anyString());
+  }
+
+  @Test
+  public void testCreateCollectionShouldReturnFalseIfCollectionAlreadyExists() {
+    when(mongoClient.getDatabase(anyString())).thenReturn(database);
+    when(database.listCollectionNames()).thenReturn(collectionIterable);
+    when(collectionIterable.iterator()).thenReturn(collectionNames);
+    when(collectionNames.hasNext()).thenReturn(true, false);
+    when(collectionNames.next()).thenReturn(COLLECTION_NAME);
+
+    assertThat(testManager.createCollection(COLLECTION_NAME)).isEqualTo(false);
+    verify(database, never()).getCollection(anyString());
+  }
+
+  @Test
+  public void testInsertDocumentsShouldCreateCollectionIfOneDoesNotExist() {
+    when(mongoClient.getDatabase(anyString())).thenReturn(database);
+    when(database.listCollectionNames()).thenReturn(collectionIterable);
+    when(database.getCollection(anyString())).thenReturn(collection);
+
+    assertThat(testManager.insertDocument(COLLECTION_NAME, new Document())).isEqualTo(true);
+
+    verify(database).getCollection(anyString());
+    verify(database).listCollectionNames();
+    verify(collection).insertMany(any());
+  }
+
+  @Test
+  public void
+      testInsertDocumentsShouldCreateCollectionIfUsingStaticDatabaseAndCollectionDoesNotExist()
+          throws IOException {
+    when(mongoClient.getDatabase(anyString())).thenReturn(database);
+    when(database.listCollectionNames()).thenReturn(collectionIterable);
+    when(database.getCollection(anyString())).thenReturn(collection);
+
+    DefaultMongoDBResourceManager.Builder builder =
+        DefaultMongoDBResourceManager.builder(TEST_ID).setDatabaseName(STATIC_DATABASE_NAME);
+    DefaultMongoDBResourceManager tm =
+        new DefaultMongoDBResourceManager(mongoClient, container, builder);
+
+    assertThat(tm.insertDocument(COLLECTION_NAME, new Document())).isEqualTo(true);
+
+    verify(database).getCollection(anyString());
+    verify(database).listCollectionNames();
+    verify(collection).insertMany(any());
+  }
+
+  @Test
+  public void testInsertDocumentsShouldReturnTrueIfUsingStaticDatabaseAndCollectionDoesExist()
+      throws IOException {
+    when(mongoClient.getDatabase(anyString())).thenReturn(database);
+    when(database.listCollectionNames()).thenReturn(collectionIterable);
+    when(collectionIterable.iterator()).thenReturn(collectionNames);
+    when(collectionNames.hasNext()).thenReturn(true, false);
+    when(collectionNames.next()).thenReturn(COLLECTION_NAME);
+    when(database.getCollection(anyString())).thenReturn(collection);
+
+    DefaultMongoDBResourceManager.Builder builder =
+        DefaultMongoDBResourceManager.builder(TEST_ID).setDatabaseName(STATIC_DATABASE_NAME);
+    DefaultMongoDBResourceManager tm =
+        new DefaultMongoDBResourceManager(mongoClient, container, builder);
+
+    assertThat(tm.insertDocument(COLLECTION_NAME, new Document())).isEqualTo(true);
+
+    verify(database).getCollection(anyString());
+    verify(database).listCollectionNames();
+    verify(collection).insertMany(any());
+  }
+
+  @Test
+  public void testInsertDocumentsShouldThrowErrorWhenMongoDBThrowsException() {
+    when(mongoClient.getDatabase(anyString())).thenReturn(database);
+    when(database.listCollectionNames()).thenReturn(collectionIterable);
+    when(collectionIterable.iterator()).thenReturn(collectionNames);
+    when(collectionNames.hasNext()).thenReturn(true, false);
+    when(collectionNames.next()).thenReturn(COLLECTION_NAME);
+    when(database.getCollection(anyString())).thenReturn(collection);
+
+    doThrow(MongoBulkWriteException.class)
+        .when(collection)
+        .insertMany(ImmutableList.of(new Document()));
+
+    assertThrows(
+        MongoDBResourceManagerException.class,
+        () -> testManager.insertDocument(COLLECTION_NAME, new Document()));
+  }
+
+  @Test
+  public void testReadCollectionShouldThrowErrorWhenCollectionDoesNotExist() {
+    when(mongoClient.getDatabase(anyString())).thenReturn(database);
+    when(database.listCollectionNames()).thenReturn(collectionIterable);
+    when(collectionIterable.iterator()).thenReturn(collectionNames);
+    when(collectionNames.hasNext()).thenReturn(true, false);
+    when(collectionNames.next()).thenReturn("fake-collection-name");
+
+    assertThrows(
+        MongoDBResourceManagerException.class, () -> testManager.readCollection(COLLECTION_NAME));
+  }
+
+  @Test
+  public void testReadCollectionShouldThrowErrorWhenMongoDBFailsToFindDocuments() {
+    when(mongoClient.getDatabase(anyString())).thenReturn(database);
+    when(database.listCollectionNames()).thenReturn(collectionIterable);
+    when(collectionIterable.iterator()).thenReturn(collectionNames);
+    when(collectionNames.hasNext()).thenReturn(true, false);
+    when(collectionNames.next()).thenReturn(COLLECTION_NAME);
+    when(database.getCollection(anyString())).thenReturn(collection);
+    doThrow(RuntimeException.class).when(collection).find();
+
+    assertThrows(
+        MongoDBResourceManagerException.class, () -> testManager.readCollection(COLLECTION_NAME));
+  }
+
+  @Test
+  public void testReadCollectionShouldWorkWhenMongoDBDoesNotThrowAnyError() {
+    when(mongoClient.getDatabase(anyString())).thenReturn(database);
+    when(database.listCollectionNames()).thenReturn(collectionIterable);
+    when(collectionIterable.iterator()).thenReturn(collectionNames);
+    when(collectionNames.hasNext()).thenReturn(true, false);
+    when(collectionNames.next()).thenReturn(COLLECTION_NAME);
+    when(database.getCollection(anyString())).thenReturn(collection);
+
+    testManager.readCollection(COLLECTION_NAME);
+
+    verify(collection).find();
+  }
+
+  @Test
+  public void testCleanupAllShouldNotDropStaticDatabase() throws IOException {
+    DefaultMongoDBResourceManager.Builder builder =
+        DefaultMongoDBResourceManager.builder(TEST_ID).setDatabaseName(STATIC_DATABASE_NAME);
+    DefaultMongoDBResourceManager tm =
+        new DefaultMongoDBResourceManager(mongoClient, container, builder);
+
+    assertThat(tm.cleanupAll()).isEqualTo(true);
+
+    verify(mongoClient, never()).getDatabase(anyString());
+    verify(database, never()).drop();
+    verify(mongoClient).close();
+  }
+
+  @Test
+  public void testCleanupShouldDropNonStaticDatabase() {
+    when(mongoClient.getDatabase(anyString())).thenReturn(database);
+
+    assertThat(testManager.cleanupAll()).isEqualTo(true);
+
+    verify(database).drop();
+    verify(mongoClient).close();
+  }
+
+  @Test
+  public void testCleanupAllShouldThrowErrorWhenMongoClientFailsToDropDatabase() {
+    when(mongoClient.getDatabase(anyString())).thenReturn(database);
+    doThrow(RuntimeException.class).when(database).drop();
+
+    assertThrows(MongoDBResourceManagerException.class, () -> testManager.cleanupAll());
+  }
+
+  @Test
+  public void testCleanupAllShouldThrowErrorWhenMongoClientFailsToClose() {
+    doThrow(RuntimeException.class).when(mongoClient).close();
+
+    assertThrows(MongoDBResourceManagerException.class, () -> testManager.cleanupAll());
+  }
+}

--- a/it/src/test/java/com/google/cloud/teleport/it/mongodb/MongoDBResourceManagerUtilsTest.java
+++ b/it/src/test/java/com/google/cloud/teleport/it/mongodb/MongoDBResourceManagerUtilsTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.mongodb;
+
+import static com.google.cloud.teleport.it.mongodb.MongoDBResourceManagerUtils.checkValidCollectionName;
+import static com.google.cloud.teleport.it.mongodb.MongoDBResourceManagerUtils.generateDatabaseName;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link com.google.cloud.teleport.it.mongodb.MongoDBResourceManagerUtils}. */
+@RunWith(JUnit4.class)
+public class MongoDBResourceManagerUtilsTest {
+
+  @Test
+  public void testGenerateDatabaseNameShouldReplaceForwardSlash() {
+    String testBaseString = "Test/DB/Name";
+    String actual = generateDatabaseName(testBaseString);
+    assertThat(actual).matches("Test-DB-Name-\\d{8}-\\d{6}-\\d{6}");
+  }
+
+  @Test
+  public void testGenerateDatabaseNameShouldReplaceBackwardSlash() {
+    String testBaseString = "Test\\DB\\Name";
+    String actual = generateDatabaseName(testBaseString);
+    assertThat(actual).matches("Test-DB-Name-\\d{8}-\\d{6}-\\d{6}");
+  }
+
+  @Test
+  public void testGenerateDatabaseNameShouldReplacePeriod() {
+    String testBaseString = "Test.DB.Name";
+    String actual = generateDatabaseName(testBaseString);
+    assertThat(actual).matches("Test-DB-Name-\\d{8}-\\d{6}-\\d{6}");
+  }
+
+  @Test
+  public void testGenerateDatabaseNameShouldReplaceSpace() {
+    String testBaseString = "Test DB Name";
+    String actual = generateDatabaseName(testBaseString);
+    assertThat(actual).matches("Test-DB-Name-\\d{8}-\\d{6}-\\d{6}");
+  }
+
+  @Test
+  public void testGenerateDatabaseNameShouldReplaceDoubleQuotes() {
+    String testBaseString = "Test\"DB\"Name";
+    String actual = generateDatabaseName(testBaseString);
+    assertThat(actual).matches("Test-DB-Name-\\d{8}-\\d{6}-\\d{6}");
+  }
+
+  @Test
+  public void testGenerateDatabaseNameShouldReplaceDollarSign() {
+    String testBaseString = "Test$DB$Name";
+    String actual = generateDatabaseName(testBaseString);
+    assertThat(actual).matches("Test-DB-Name-\\d{8}-\\d{6}-\\d{6}");
+  }
+
+  @Test
+  public void testGenerateDatabaseNameShouldReplaceNullCharacter() {
+    String testBaseString = "Test\0DB\0Name";
+    String actual = generateDatabaseName(testBaseString);
+    assertThat(actual).matches("Test-DB-Name-\\d{8}-\\d{6}-\\d{6}");
+  }
+
+  @Test
+  public void testCheckValidCollectionNameThrowsErrorWhenNameIsTooShort() {
+    assertThrows(
+        IllegalArgumentException.class, () -> checkValidCollectionName("test-database", ""));
+  }
+
+  @Test
+  public void testCheckValidCollectionNameThrowsErrorWhenNameIsTooLong() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> checkValidCollectionName("a".repeat(1), "b".repeat(100)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> checkValidCollectionName("a".repeat(50), "b".repeat(50)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> checkValidCollectionName("a".repeat(100), "b".repeat(1)));
+  }
+
+  @Test
+  public void testCheckValidCollectionNameThrowsErrorWhenNameContainsDollarSign() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> checkValidCollectionName("test-database", "test$collection"));
+  }
+
+  @Test
+  public void testCheckValidCollectionNameThrowsErrorWhenNameContainsNull() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> checkValidCollectionName("test-database", "test\0collection"));
+  }
+
+  @Test
+  public void testCheckValidCollectionNameThrowsErrorWhenNameBeginsWithSystemKeyword() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> checkValidCollectionName("test-database", "system.test-collection"));
+  }
+
+  @Test
+  public void testCheckValidCollectionNameThrowsErrorWhenNameDoesNotBeginWithLetterOrUnderscore() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> checkValidCollectionName("test-database", "1test-collection"));
+  }
+
+  @Test
+  public void testCheckValidCollectionNameDoesNotThrowErrorWhenNameIsValid() {
+    checkValidCollectionName("test-database", "a collection-name_valid.Test1");
+    checkValidCollectionName("test-database", "_a collection-name_valid.Test1");
+  }
+}

--- a/it/src/test/java/com/google/cloud/teleport/it/mongodb/MongoDBResourceManagerUtilsTest.java
+++ b/it/src/test/java/com/google/cloud/teleport/it/mongodb/MongoDBResourceManagerUtilsTest.java
@@ -32,49 +32,49 @@ public class MongoDBResourceManagerUtilsTest {
   public void testGenerateDatabaseNameShouldReplaceForwardSlash() {
     String testBaseString = "Test/DB/Name";
     String actual = generateDatabaseName(testBaseString);
-    assertThat(actual).matches("Test-DB-Name-\\d{8}-\\d{6}-\\d{6}");
+    assertThat(actual).matches("test-db-name-\\d{8}-\\d{6}-\\d{6}");
   }
 
   @Test
   public void testGenerateDatabaseNameShouldReplaceBackwardSlash() {
     String testBaseString = "Test\\DB\\Name";
     String actual = generateDatabaseName(testBaseString);
-    assertThat(actual).matches("Test-DB-Name-\\d{8}-\\d{6}-\\d{6}");
+    assertThat(actual).matches("test-db-name-\\d{8}-\\d{6}-\\d{6}");
   }
 
   @Test
   public void testGenerateDatabaseNameShouldReplacePeriod() {
     String testBaseString = "Test.DB.Name";
     String actual = generateDatabaseName(testBaseString);
-    assertThat(actual).matches("Test-DB-Name-\\d{8}-\\d{6}-\\d{6}");
+    assertThat(actual).matches("test-db-name-\\d{8}-\\d{6}-\\d{6}");
   }
 
   @Test
   public void testGenerateDatabaseNameShouldReplaceSpace() {
     String testBaseString = "Test DB Name";
     String actual = generateDatabaseName(testBaseString);
-    assertThat(actual).matches("Test-DB-Name-\\d{8}-\\d{6}-\\d{6}");
+    assertThat(actual).matches("test-db-name-\\d{8}-\\d{6}-\\d{6}");
   }
 
   @Test
   public void testGenerateDatabaseNameShouldReplaceDoubleQuotes() {
     String testBaseString = "Test\"DB\"Name";
     String actual = generateDatabaseName(testBaseString);
-    assertThat(actual).matches("Test-DB-Name-\\d{8}-\\d{6}-\\d{6}");
+    assertThat(actual).matches("test-db-name-\\d{8}-\\d{6}-\\d{6}");
   }
 
   @Test
   public void testGenerateDatabaseNameShouldReplaceDollarSign() {
     String testBaseString = "Test$DB$Name";
     String actual = generateDatabaseName(testBaseString);
-    assertThat(actual).matches("Test-DB-Name-\\d{8}-\\d{6}-\\d{6}");
+    assertThat(actual).matches("test-db-name-\\d{8}-\\d{6}-\\d{6}");
   }
 
   @Test
   public void testGenerateDatabaseNameShouldReplaceNullCharacter() {
     String testBaseString = "Test\0DB\0Name";
     String actual = generateDatabaseName(testBaseString);
-    assertThat(actual).matches("Test-DB-Name-\\d{8}-\\d{6}-\\d{6}");
+    assertThat(actual).matches("test-db-name-\\d{8}-\\d{6}-\\d{6}");
   }
 
   @Test

--- a/it/src/test/java/com/google/cloud/teleport/it/testcontainers/TestContainerResourceManagerTest.java
+++ b/it/src/test/java/com/google/cloud/teleport/it/testcontainers/TestContainerResourceManagerTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.testcontainers;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MongoDBContainer;
+
+/**
+ * Unit tests for {@link com.google.cloud.teleport.it.testcontainers.TestContainerResourceManager}.
+ */
+@RunWith(JUnit4.class)
+public class TestContainerResourceManagerTest {
+  @Rule public final MockitoRule mockito = MockitoJUnit.rule();
+
+  @Mock private MongoDBContainer container;
+
+  private static final String TEST_ID = "test-id";
+  private static final String HOST = "localhost";
+  private static final int PORT = 10000;
+
+  private TestContainerResourceManager.Builder<TestContainerResourceManagerImpl> testManagerBuilder;
+
+  @Before
+  public void setUp() {
+    testManagerBuilder =
+        new TestContainerResourceManager.Builder<>(TEST_ID) {
+          @Override
+          public TestContainerResourceManagerImpl build() {
+            return new TestContainerResourceManagerImpl(container, this);
+          }
+        };
+  }
+
+  @Test
+  public void testCreateResourceManagerSetsCorrectDockerImageName() {
+    when(container.getDockerImageName()).thenReturn("mongo-test:test");
+
+    testManagerBuilder.setContainerImageName("mongo-test").setContainerImageTag("test").build();
+
+    assertThat(container.getDockerImageName())
+        .isEqualTo(
+            testManagerBuilder.containerImageName + ":" + testManagerBuilder.containerImageTag);
+  }
+
+  @Test
+  public void testCreateResourceManagerShouldStartContainerWhenNotUsingStaticResource() {
+    testManagerBuilder.build();
+
+    verify(container).start();
+  }
+
+  @Test
+  public void testCreateResourceManagerShouldNotStartContainerWhenUsingStaticResource() {
+    testManagerBuilder.useStaticContainer().setHost(HOST).setPort(PORT).build();
+
+    verify(container, never()).start();
+  }
+
+  @Test
+  public void
+      testCreateResourceManagerShouldThrowErrorWhenUsingStaticResourceWithoutHostOrPortSet() {
+    assertThrows(
+        TestContainerResourceManagerException.class,
+        () -> testManagerBuilder.useStaticContainer().build());
+  }
+
+  @Test
+  public void testCreateResourceManagerShouldThrowErrorWhenUsingStaticResourceWithoutHostSet() {
+    assertThrows(
+        TestContainerResourceManagerException.class,
+        () -> testManagerBuilder.useStaticContainer().setPort(PORT).build());
+  }
+
+  @Test
+  public void testCreateResourceManagerShouldThrowErrorWhenUsingStaticResourceWithoutPortSet() {
+    assertThrows(
+        TestContainerResourceManagerException.class,
+        () -> testManagerBuilder.useStaticContainer().setHost(HOST).build());
+  }
+
+  @Test
+  public void testGetHostShouldReturnCorrectHostWhenManuallySet() {
+    TestContainerResourceManager<?> testManager = testManagerBuilder.setHost(HOST).build();
+
+    assertThat(testManager.getHost()).matches(HOST);
+  }
+
+  @Test
+  public void testGetHostShouldReturnCorrectHostWhenHostNotSet() {
+    String testHost = "testHost";
+    when(container.getHost()).thenReturn(testHost);
+
+    TestContainerResourceManager<?> testManager = testManagerBuilder.build();
+
+    assertThat(testManager.getHost()).matches(testHost);
+  }
+
+  @Test
+  public void testGetPortShouldReturnCorrectPortWhenManuallySet() {
+    TestContainerResourceManager<?> testManager =
+        testManagerBuilder.setHost(HOST).setPort(PORT).build();
+
+    assertThat(testManager.getPort(-1)).isEqualTo(PORT);
+  }
+
+  @Test
+  public void testGetPortShouldReturnContainerHostWhenPortNotSet() {
+    int mappedPort = 5000;
+    when(container.getMappedPort(anyInt())).thenReturn(mappedPort);
+
+    TestContainerResourceManager<?> testManager = testManagerBuilder.build();
+
+    assertThat(testManager.getPort(PORT)).isEqualTo(mappedPort);
+  }
+
+  @Test
+  public void testCleanupAllShouldCloseContainerWhenNotUsingStaticResource() {
+    TestContainerResourceManager<?> testManager = testManagerBuilder.build();
+
+    assertThat(testManager.cleanupAll()).isEqualTo(true);
+    verify(container).close();
+  }
+
+  @Test
+  public void testCleanupAllShouldReturnFalseWhenContainerFailsToClose() {
+    doThrow(RuntimeException.class).when(container).close();
+
+    TestContainerResourceManager<?> testManager = testManagerBuilder.build();
+
+    assertThat(testManager.cleanupAll()).isEqualTo(false);
+  }
+
+  @Test
+  public void testCleanupAllShouldNotCloseContainerWhenUsingStaticResource() {
+    TestContainerResourceManager<?> testManager =
+        testManagerBuilder.useStaticContainer().setHost(HOST).setPort(PORT).build();
+
+    assertThat(testManager.cleanupAll()).isEqualTo(true);
+    verify(container, never()).close();
+  }
+
+  private static class TestContainerResourceManagerImpl
+      extends TestContainerResourceManager<GenericContainer<?>> {
+    protected TestContainerResourceManagerImpl(GenericContainer<?> container, Builder builder) {
+      super(container, builder);
+    }
+  }
+}

--- a/v2/cdc-parent/README.md
+++ b/v2/cdc-parent/README.md
@@ -2,7 +2,7 @@
 
 This directory contains components for a Change-data Capture (CDC) solution to
 capture data from an MySQL database, and sync it into BigQuery. The solution
-relies on Cloud Dataflow, and [Debezium](https://debezium.io/), and excellent
+relies on Cloud Dataflow, and [Debezium](https://debezium.io/), an excellent
 open source project for change data capture.
 
 To implement the CDC solution in this repository:

--- a/v2/mongodb-to-googlecloud/pom.xml
+++ b/v2/mongodb-to-googlecloud/pom.xml
@@ -29,13 +29,16 @@
 
     <artifactId>mongodb-to-googlecloud</artifactId>
 
+    <properties>
+    <google-truth.version>1.0.1</google-truth.version>
+    </properties>
+
     <name>MongoDB To Googlecloud</name>
     <description>
         Stream data from Google PubSub to a hosted MongoDB Database
     </description>
 
     <dependencies>
-
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-io-mongodb</artifactId>
@@ -44,6 +47,14 @@
             <groupId>com.google.cloud.teleport.v2</groupId>
             <artifactId>common</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>com.google.truth</groupId>
+            <artifactId>truth</artifactId>
+            <version>${google-truth.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/v2/mongodb-to-googlecloud/pom.xml
+++ b/v2/mongodb-to-googlecloud/pom.xml
@@ -29,10 +29,6 @@
 
     <artifactId>mongodb-to-googlecloud</artifactId>
 
-    <properties>
-    <google-truth.version>1.0.1</google-truth.version>
-    </properties>
-
     <name>MongoDB To Googlecloud</name>
     <description>
         Stream data from Google PubSub to a hosted MongoDB Database
@@ -53,7 +49,7 @@
         <dependency>
             <groupId>com.google.truth</groupId>
             <artifactId>truth</artifactId>
-            <version>${google-truth.version}</version>
+            <version>${truth.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/v2/mongodb-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQueryIT.java
+++ b/v2/mongodb-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQueryIT.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.mongodb.templates;
+
+import static com.google.cloud.teleport.it.dataflow.DataflowUtils.createJobName;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.TableResult;
+import com.google.cloud.teleport.it.TemplateTestBase;
+import com.google.cloud.teleport.it.TestProperties;
+import com.google.cloud.teleport.it.bigquery.BigQueryResourceManager;
+import com.google.cloud.teleport.it.bigquery.DefaultBigQueryResourceManager;
+import com.google.cloud.teleport.it.bigtable.DefaultBigtableResourceManager;
+import com.google.cloud.teleport.it.dataflow.DataflowOperator;
+import com.google.cloud.teleport.it.dataflow.DataflowTemplateClient;
+import com.google.cloud.teleport.it.dataflow.FlexTemplateClient;
+import com.google.cloud.teleport.it.mongodb.DefaultMongoDBResourceManager;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
+
+/** Integration test for {@link MongoDbToBigQuery} (MongoDB_to_BigQuery).
+ *
+ * <p>Example Usage:
+ *
+ * <pre>
+ * # Set the pipeline vars
+ * export PROJECT=&lt;project id&gt;
+ * export REGION=&lt;dataflow region&gt;
+ * export TEMPLATE_MODULE=v2/mongodb-to-googlecloud
+ * export TEMPLATE_IMAGE_SPEC=gs://dataflow-templates/latest/flex/MongoDB_to_BigQuery
+ * export HOST_IP=&lt;your host ip&gt;
+ *
+ * # To set the host ip to the default external ip
+ * export HOST_IP=$(hostname -I | awk '{print $1}')
+ *
+ * # To set the gcloud project credential
+ * gcloud config set project ${PROJECT}
+ * DT_IT_ACCESS_TOKEN=$(gcloud auth application-default print-access-token)
+ *
+ * # Build and run integration test
+ * mvn verify
+ *   -pl v2/mongodb-to-googlecloud \
+ *   -am \
+ *   -Dtest="MongoDbToBigQueryIT" \
+ *   -Dproject=${PROJECT} \
+ *   -Dregion=${REGION} \
+ *   -DspecPath=${TEMPLATE_IMAGE_SPEC} \
+ *   -DhostIp=${HOST_IP} \
+ *   -Djib.skip \
+ *   -DfailIfNoTests=false
+ *
+ * # Optional mvn flags
+ *   -DnumDocs=&lt;numDocs&gt;                # Sets the number of documents to store in MongoDB
+ *   -DnumFields=&lt;numFields&gt;            # Sets the number of fields to include in each document
+ *   -DmaxEntryLength=&lt;maxEntryLength&gt;  # Sets the maximum length of each document field
+ * </pre>
+ */
+@TemplateIntegrationTest(MongoDbToBigQuery.class)
+@RunWith(JUnit4.class)
+public final class MongoDbToBigQueryIT extends TemplateTestBase {
+
+  @Rule public final TestName testName = new TestName();
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultBigtableResourceManager.class);
+  private static final String HOST_IP = TestProperties.hostIp();
+
+  private static final String MONGO_URI = "mongoDbUri";
+  private static final String MONGO_DB = "database";
+  private static final String MONGO_COLLECTION = "collection";
+  private static final String BIGQUERY_TABLE = "outputTableSpec";
+  private static final String USER_OPTION = "userOption";
+
+  private static final String MONGO_DB_ID = "_id";
+
+  private static DefaultMongoDBResourceManager mongoDbClient;
+  private static BigQueryResourceManager bigQueryClient;
+
+  @Before
+  public void setup() throws IOException {
+    mongoDbClient =
+        DefaultMongoDBResourceManager.builder(testName.getMethodName()).setHost(HOST_IP).build();
+
+    bigQueryClient =
+        DefaultBigQueryResourceManager.builder(testName.getMethodName(), PROJECT)
+            .setCredentials(credentials)
+            .build();
+  }
+
+  @After
+  public void tearDownClass() {
+    boolean producedError = false;
+
+    try {
+      mongoDbClient.cleanupAll();
+    } catch (Exception e) {
+      LOG.error("Failed to delete MongoDB resources. {}", e.getMessage());
+      producedError = true;
+    }
+
+    try {
+      bigQueryClient.cleanupAll();
+    } catch (Exception e) {
+      LOG.error("Failed to delete MongoDB resources. {}", e.getMessage());
+      producedError = true;
+    }
+
+    if (producedError) {
+      throw new IllegalStateException("Failed to delete resources. Check above for errors.");
+    }
+  }
+
+  @Test
+  public void testMongoDbToBigQuery() throws IOException {
+    // Arrange
+    String name = testName.getMethodName();
+    String jobName = createJobName(name);
+
+    String collectionName = testName.getMethodName();
+    List<Document> mongoDocuments = generateDocuments();
+    mongoDbClient.insertDocuments(collectionName, mongoDocuments);
+
+    String bqTable = testName.getMethodName();
+    List<Field> bqSchemaFields = new ArrayList<>();
+    mongoDocuments
+        .get(0)
+        .forEach((key, val) -> bqSchemaFields.add(Field.of(key, StandardSQLTypeName.STRING)));
+    Schema bqSchema = Schema.of(bqSchemaFields);
+
+    bigQueryClient.createDataset(REGION);
+    bigQueryClient.createTable(bqTable, bqSchema);
+    String tableSpec = PROJECT + ":" + bigQueryClient.getDatasetId() + "." + bqTable;
+
+    // Act
+    DataflowTemplateClient.LaunchConfig options =
+        DataflowTemplateClient.LaunchConfig.builder(jobName, specPath)
+            .addParameter(MONGO_URI, mongoDbClient.getUri())
+            .addParameter(MONGO_DB, mongoDbClient.getDatabaseName())
+            .addParameter(MONGO_COLLECTION, collectionName)
+            .addParameter(BIGQUERY_TABLE, tableSpec)
+            .addParameter(USER_OPTION, "FLATTEN")
+            .build();
+    DataflowTemplateClient dataflow =
+        FlexTemplateClient.builder().setCredentials(credentials).build();
+
+    DataflowTemplateClient.JobInfo info = dataflow.launchTemplate(PROJECT, REGION, options);
+    assertThat(info.state()).isIn(DataflowTemplateClient.JobState.ACTIVE_STATES);
+
+    DataflowOperator.Result result =
+        new DataflowOperator(dataflow)
+            .waitForConditionAndFinish(
+                createConfig(info), () -> bigQueryClient.readTable(bqTable).getTotalRows() != 0);
+
+    // Assert
+    assertThat(result).isEqualTo(DataflowOperator.Result.CONDITION_MET);
+
+    Map<String, JSONObject> mongoMap = new HashMap<>();
+    mongoDocuments.forEach(
+        mongoDocument -> {
+          JSONObject mongoDbJson = new JSONObject(mongoDocument.toJson());
+          mongoMap.put(mongoDbJson.getJSONObject(MONGO_DB_ID).getString("$oid"), mongoDbJson);
+        });
+
+    TableResult tableRows = bigQueryClient.readTable(bqTable);
+    tableRows
+        .getValues()
+        .forEach(
+            row ->
+                row.forEach(
+                    val -> {
+                      JSONObject bigQueryJson = new JSONObject(val.getStringValue());
+                      JSONObject bigQueryIdJson =
+                          new JSONObject(
+                              bigQueryJson.getString(MONGO_DB_ID).replaceFirst("=", ":"));
+                      String bigQueryOid = bigQueryIdJson.getString("$oid");
+                      bigQueryJson.put(MONGO_DB_ID, bigQueryIdJson);
+
+                      assertThat(mongoMap.get(bigQueryOid).toString())
+                          .isEqualTo(bigQueryJson.toString());
+                    }));
+  }
+
+  private static DataflowOperator.Config createConfig(DataflowTemplateClient.JobInfo info) {
+    return DataflowOperator.Config.builder()
+        .setJobId(info.jobId())
+        .setProject(PROJECT)
+        .setRegion(REGION)
+        .build();
+  }
+
+  private static List<Document> generateDocuments() {
+    int numDocuments = Integer.parseInt(getProperty("numDocs", "100"));
+    int numFields = Integer.parseInt(getProperty("numFields", "20"));
+    int maxEntryLength = Integer.parseInt(getProperty("maxEntryLength", "20"));
+    List<Document> mongoDocuments = new ArrayList<>();
+
+    List<String> mongoDocumentKeys = new ArrayList<>();
+    for (int j = 0; j < numFields; j++) {
+      mongoDocumentKeys.add(
+          RandomStringUtils.randomAlphabetic(1)
+              + RandomStringUtils.randomAlphanumeric(0, maxEntryLength - 1));
+    }
+
+    for (int i = 0; i < numDocuments; i++) {
+      Document randomDocument = new Document().append(MONGO_DB_ID, new ObjectId());
+
+      for (int j = 0; j < numFields; j++) {
+        randomDocument.append(
+            mongoDocumentKeys.get(j), RandomStringUtils.randomAlphanumeric(0, 20));
+      }
+
+      mongoDocuments.add(randomDocument);
+    }
+
+    return mongoDocuments;
+  }
+
+  private static String getProperty(String name, String defaultValue) {
+    String value = System.getProperty(name);
+    return value != null ? value : defaultValue;
+  }
+}


### PR DESCRIPTION
This PR introduces several changes...
- There is now a MongoDB Resource Manager for writing integration tests.
- There is an integration test for the MongoDBToBigQuery template
- The TestContainers framework has been added for writing resource managers that are not Google Cloud products (i.e. MongoDB)

Signed-off-by: Jeffrey Kinard <jeff@thekinards.com>

Fixes #507 