### PR TITLE
Use "verify" instead of "install" for unit tests workflow

### DIFF
--- a/cicd/cmd/run-unit-tests/main.go
+++ b/cicd/cmd/run-unit-tests/main.go
@@ -24,15 +24,14 @@ import (
 
 func main() {
 	mvnFlags := workflows.NewMavenFlags()
-	err := workflows.MvnCleanInstall().Run(
+	err := workflows.MvnCleanVerify().Run(
 		mvnFlags.IncludeDependencies(),
 		mvnFlags.IncludeDependents(),
 		mvnFlags.SkipCheckstyle(),
-		mvnFlags.SkipDependencyAnalysis(),
 		mvnFlags.SkipJib(),
 		mvnFlags.FailAtTheEnd())
 	if err != nil {
 		log.Fatalf("%v\n", err)
 	}
-	log.Println("Build Successful!")
+	log.Println("Verification Successful!")
 }

--- a/cicd/internal/workflows/maven-workflows.go
+++ b/cicd/internal/workflows/maven-workflows.go
@@ -31,6 +31,7 @@ import (
 const (
 	// mvn commands
 	cleanInstallCmd  = "clean install"
+	cleanVerifyCmd   = "clean verify"
 	spotlessCheckCmd = "spotless:check"
 
 	// regexes
@@ -96,6 +97,20 @@ func MvnCleanInstall() Workflow {
 }
 
 func (*mvnCleanInstallWorkflow) Run(args ...string) error {
+	return RunForChangedModules(cleanInstallCmd, args...)
+}
+
+type mvnCleanVerifyWorkflow struct{}
+
+func MvnCleanVerify() Workflow {
+	return &mvnCleanVerifyWorkflow{}
+}
+
+func (*mvnCleanVerifyWorkflow) Run(args ...string) error {
+	return RunForChangedModules(cleanVerifyCmd, args...)
+}
+
+func RunForChangedModules(cmd string, args ...string) error {
 	flags.RegisterCommonFlags()
 	flag.Parse()
 
@@ -139,7 +154,7 @@ func (*mvnCleanInstallWorkflow) Run(args ...string) error {
 		return nil
 	}
 
-	return op.RunMavenOnModule(unifiedPom, cleanInstallCmd, strings.Join(modules, ","), args...)
+	return op.RunMavenOnModule(unifiedPom, cmd, strings.Join(modules, ","), args...)
 }
 
 type spotlessCheckWorkflow struct{}


### PR DESCRIPTION
Important verifications are done (for example, maven-dependency-plugin checks)