### PR TITLE
Add SecretManagerUtils in v2 common directory

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/utils/SecretManagerUtils.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/utils/SecretManagerUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.utils;
+
+import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
+import java.io.IOException;
+
+/**
+ * {@link SecretManagerUtils} class is a class that takes in a Secret Version of the form
+ * projects/{project}/secrets/{secret}/versions/{secret_version} and returns the secret value in
+ * Secret Manager.
+ */
+public class SecretManagerUtils {
+
+  /**
+   * Calls Secret Manager with a Secret Version and returns the secret value.
+   *
+   * @param secretVersion Secret Version of the form
+   *     projects/{project}/secrets/{secret}/versions/{secret_version}
+   * @return the secret value in Secret Manager
+   */
+  public static String getSecret(String secretVersion) {
+    SecretVersionName secretVersionName = parseSecretVersion(secretVersion);
+
+    try (SecretManagerServiceClient client = SecretManagerServiceClient.create()) {
+      AccessSecretVersionResponse response = client.accessSecretVersion(secretVersionName);
+      return response.getPayload().getData().toStringUtf8();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Parses a Secret Version and returns a {@link SecretVersionName}.
+   *
+   * @param secretVersion Secret Version of the form
+   *     projects/{project}/secrets/{secret}/versions/{secret_version}
+   * @return {@link SecretVersionName}
+   */
+  private static SecretVersionName parseSecretVersion(String secretVersion) {
+    if (SecretVersionName.isParsableFrom(secretVersion)) {
+      return SecretVersionName.parse(secretVersion);
+    } else {
+      throw new IllegalArgumentException(
+          "Provided Secret must be in the form"
+              + " projects/{project}/secrets/{secret}/versions/{secret_version}");
+    }
+  }
+}

--- a/v2/common/src/test/java/com/google/cloud/teleport/v2/utils/SecretManagerUtilsTest.java
+++ b/v2/common/src/test/java/com/google/cloud/teleport/v2/utils/SecretManagerUtilsTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.utils;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/** Test for SecretManagerUtils. */
+public class SecretManagerUtilsTest {
+  @Rule public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void testGetSecretInvalidSecret() {
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage(
+        "Provided Secret must be in the form"
+            + " projects/{project}/secrets/{secret}/versions/{secret_version}");
+
+    SecretManagerUtils.getSecret("invalid");
+  }
+}


### PR DESCRIPTION
This PR adds a Secret Manager utils file, to be able to fetch secrets from Secret Manager (also to be used by the googlecloud-to-splunk templates). I'm creating a new PR, since some overlapped work was done that added a KMSUtils class and remove ValueProviders in v2, and it's easier to just raise a new PR than reintegrating the new changes to the old PR.

(still not sure if I should be including unit tests for this, since I didn't see unit tests for SecretManagerValueProvider in the v1 folder, and I also was encountering errors when I tried to do SecretManager unit tests in [PR#540](https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/540))