### PR TITLE
feat(elasticsearch-writer): Make trustSelfSignedCerts as parameter

### DIFF
--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
@@ -239,9 +239,9 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
   @TemplateParameter.Boolean(
       order = 22,
       optional = true,
-      description = "trust self-signed certificate",
+      description = "Trust self-signed certificate",
       helpText =
-          "Whether to trust self-signed certificate or not. An elasticsearch instance installed might have a self-signed certificate, Enable this to True to by-pass the validation on SSL certificate. (default is False)")
+          "Whether to trust self-signed certificate or not. An Elasticsearch instance installed might have a self-signed certificate, Enable this to True to by-pass the validation on SSL certificate. (default is False)")
   @Default.Boolean(false)
   Boolean getTrustSelfSignedCerts();
 

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
@@ -235,4 +235,15 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
   BulkInsertMethodOptions getBulkInsertMethod();
 
   void setBulkInsertMethod(BulkInsertMethodOptions bulkInsertMethod);
+
+  @TemplateParameter.Boolean(
+      order = 22,
+      optional = true,
+      description = "trust self-signed certificate",
+      helpText =
+          "Whether to trust self-signed certificate or not. An elasticsearch instance installed might have a self-signed certificate, Enable this to True to by-pass the validation on SSL certificate. (default is False)")
+  @Default.Boolean(false)
+  Boolean getTrustSelfSignedCerts();
+
+  void setTrustSelfSignedCerts(Boolean trustSelfSignedCerts);
 }

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
@@ -125,11 +125,9 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
       config = config.withApiKey(options().getApiKey());
     }
 
-    
-    if (options().getTrustSelfSignedCerts()!= null) {
-      config =
-          config.withTrustSelfSignedCerts(options().getTrustSelfSignedCerts());
-    } 
+    if (options().getTrustSelfSignedCerts() != null) {
+      config = config.withTrustSelfSignedCerts(options().getTrustSelfSignedCerts());
+    }
 
     ElasticsearchIO.Write elasticsearchWriter =
         ElasticsearchIO.write()

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
@@ -125,6 +125,12 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
       config = config.withApiKey(options().getApiKey());
     }
 
+    
+    if (options().getTrustSelfSignedCerts()!= null) {
+      config =
+          config.withTrustSelfSignedCerts(options().getTrustSelfSignedCerts());
+    } 
+
     ElasticsearchIO.Write elasticsearchWriter =
         ElasticsearchIO.write()
             .withConnectionConfiguration(config)


### PR DESCRIPTION
As for #542, This should add the possibility to use `trustSelfSignedCerts` as parameter when using a connection to Elasticsearch. 

