### PR TITLE
upgraded protobuf-java to 3.21.9 to resolve the conflicts with bigque…

### DIFF
--- a/syndeo-template/pom.xml
+++ b/syndeo-template/pom.xml
@@ -35,7 +35,7 @@
         <kafka.version>2.4.1</kafka.version>
         <maven-compiler-plugin.version>3.6.2</maven-compiler-plugin.version>
         <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
-        <protobuf.version>3.21.5</protobuf.version>
+        <protobuf.version>3.21.9</protobuf.version>
         <truth.version>1.0.1</truth.version>
         <secretmanager.version>2.1.2</secretmanager.version>
         <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
…ry api

With protobuf-java v3.21.5, got following error when running pipeline to read data from BigQueryIO. Caused by: java.lang.NoSuchMethodError: 'boolean com.google.protobuf.GeneratedMessageV3$Builder.parseUnknownField(com.google.protobuf.CodedInputStream, com.google.protobuf.ExtensionRegistryLite, int)'
	com.google.cloud.bigquery.storage.v1.ReadSession$Builder.mergeFrom(ReadSession.java:4665)