### PR TITLE
Prevent casting to TemporalAccessor when reading datetimes from MSSQL

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/templates/common/JdbcConverters.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/common/JdbcConverters.java
@@ -222,9 +222,18 @@ public class JdbcConverters {
                 DATE_FORMATTER.format(resultSet.getDate(i).toLocalDate()));
             break;
           case "datetime":
-            outputTableRow.set(
-                getColumnRef(metaData, i),
-                DATETIME_FORMATTER.format((TemporalAccessor) resultSet.getObject(i)));
+            Object timeObject = resultSet.getObject(i);
+
+            if (timeObject instanceof TemporalAccessor) {
+              outputTableRow.set(
+                  getColumnRef(metaData, i),
+                  DATETIME_FORMATTER.format((TemporalAccessor) timeObject));
+            } else {
+              Timestamp ts = resultSet.getTimestamp(i);
+              // getTimestamp() returns timestamps in the default (JVM) time zone by default:
+              OffsetDateTime odt = ts.toInstant().atZone(DEFAULT_TIME_ZONE_ID).toOffsetDateTime();
+              outputTableRow.set(getColumnRef(metaData, i), TIMESTAMP_FORMATTER.format(odt));
+            }
             break;
           case "timestamp":
             Timestamp ts = resultSet.getTimestamp(i);

--- a/v1/src/test/java/com/google/cloud/teleport/templates/common/JdbcConvertersTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/common/JdbcConvertersTest.java
@@ -166,6 +166,36 @@ public class JdbcConvertersTest {
   }
 
   @Test
+  public void testMSSQLDateTime() throws Exception {
+    // Must use TimeZone.getDefault() time zone here because JdbcConverters will convert timestamps
+    // to string in the *default* time zone, which we don't know (may be different depending on the
+    // time zone of the machine that runs the test).
+    ZonedDateTime zdt =
+        LocalDateTime.parse("2023-01-02T13:14:15.666777888")
+            .atZone(TimeZone.getDefault().toZoneId());
+
+    Timestamp timestampObj = Timestamp.from(zdt.toInstant());
+
+    when(resultSet.getObject(1)).thenReturn(timestampObj);
+    when(resultSet.getTimestamp(1)).thenReturn(timestampObj);
+    when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
+
+    when(resultSetMetaData.getColumnCount()).thenReturn(1);
+    when(resultSetMetaData.getColumnName(1)).thenReturn("datetime_column");
+    when(resultSetMetaData.getColumnTypeName(1)).thenReturn("datetime");
+
+    expectedTableRow = new TableRow();
+    expectedTableRow.set("datetime_column", "2023-01-02 13:14:15.666777" + zdt.getOffset().getId());
+
+    JdbcIO.RowMapper<TableRow> resultSetConverters =
+        JdbcConverters.getResultSetToTableRow(StaticValueProvider.of(false));
+    TableRow actualTableRow = resultSetConverters.mapRow(resultSet);
+
+    assertThat(expectedTableRow.size(), equalTo(actualTableRow.size()));
+    assertThat(actualTableRow, equalTo(expectedTableRow));
+  }
+
+  @Test
   public void testNullFields() throws Exception {
     when(resultSet.getObject(1)).thenReturn(null);
     when(resultSet.getObject(2)).thenReturn(null);

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/utils/JdbcConverters.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/utils/JdbcConverters.java
@@ -85,9 +85,18 @@ public class JdbcConverters {
                 DATE_FORMATTER.format(resultSet.getDate(i).toLocalDate()));
             break;
           case "datetime":
-            outputTableRow.set(
-                getColumnRef(metaData, i),
-                DATETIME_FORMATTER.format((TemporalAccessor) resultSet.getObject(i)));
+            Object timeObject = resultSet.getObject(i);
+
+            if (timeObject instanceof TemporalAccessor) {
+              outputTableRow.set(
+                  getColumnRef(metaData, i),
+                  DATETIME_FORMATTER.format((TemporalAccessor) timeObject));
+            } else {
+              Timestamp ts = resultSet.getTimestamp(i);
+              // getTimestamp() returns timestamps in the default (JVM) time zone by default:
+              OffsetDateTime odt = ts.toInstant().atZone(DEFAULT_TIME_ZONE_ID).toOffsetDateTime();
+              outputTableRow.set(getColumnRef(metaData, i), TIMESTAMP_FORMATTER.format(odt));
+            }
             break;
           case "timestamp":
             Timestamp ts = resultSet.getTimestamp(i);


### PR DESCRIPTION
Band-aid fix to prevent TemporalAccessor casting on datetime columns when using the MSSQL driver. Won't be merged until more validation is done