### PR TITLE
Issue 582 - MongoDBtoBigQuery with UDF: ScriptObjectMirror cannot be cast to bson.Document

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/JavascriptDocumentTransformer.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/JavascriptDocumentTransformer.java
@@ -147,15 +147,17 @@ public abstract class JavascriptDocumentTransformer {
         throw new RuntimeException("No udf was loaded");
       }
 
-      Object result = getInvocable().invokeFunction(functionName(), data);
+      Object result = getInvocable().invokeFunction(functionName(), data.toJson());
       if (result == null || ScriptObjectMirror.isUndefined(result)) {
         return null;
       } else if (result instanceof Document) {
         return (Document) result;
+      } else if (result instanceof String) {
+        return Document.parse(result.toString());
       } else {
         String className = result.getClass().getName();
         throw new RuntimeException(
-            "UDF Function did not return a String. Instead got: " + className);
+            "UDF Function did not return a valid Mongo Document. Instead got: " + className);
       }
     }
 


### PR DESCRIPTION
This PR fixes #582 by correcting illegal cast to bson.Document in MongoDB templates that utilize UDF's.

Signed-off-by: Jeffrey Kinard <jeff@thekinards.com>