### PR TITLE
Issue 477: Create Datastream Resource Manager

### DIFF
--- a/it/google-cloud-platform/pom.xml
+++ b/it/google-cloud-platform/pom.xml
@@ -102,6 +102,10 @@
             <artifactId>google-cloud-datastore</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-datastream</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.auto.value</groupId>
             <artifactId>auto-value</artifactId>
             <version>${autovalue.version}</version>

--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/datastream/DatastreamResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/datastream/DatastreamResourceManager.java
@@ -1,0 +1,502 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.gcp.datastream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.cloud.datastream.v1.AvroFileFormat;
+import com.google.cloud.datastream.v1.BigQueryDestinationConfig;
+import com.google.cloud.datastream.v1.BigQueryProfile;
+import com.google.cloud.datastream.v1.ConnectionProfile;
+import com.google.cloud.datastream.v1.ConnectionProfileName;
+import com.google.cloud.datastream.v1.CreateConnectionProfileRequest;
+import com.google.cloud.datastream.v1.CreateStreamRequest;
+import com.google.cloud.datastream.v1.DatastreamClient;
+import com.google.cloud.datastream.v1.DatastreamSettings;
+import com.google.cloud.datastream.v1.DeleteConnectionProfileRequest;
+import com.google.cloud.datastream.v1.DeleteStreamRequest;
+import com.google.cloud.datastream.v1.DestinationConfig;
+import com.google.cloud.datastream.v1.GcsDestinationConfig;
+import com.google.cloud.datastream.v1.GcsProfile;
+import com.google.cloud.datastream.v1.JsonFileFormat;
+import com.google.cloud.datastream.v1.LocationName;
+import com.google.cloud.datastream.v1.MysqlProfile;
+import com.google.cloud.datastream.v1.MysqlSourceConfig;
+import com.google.cloud.datastream.v1.OracleProfile;
+import com.google.cloud.datastream.v1.OracleSourceConfig;
+import com.google.cloud.datastream.v1.PostgresqlProfile;
+import com.google.cloud.datastream.v1.PostgresqlSourceConfig;
+import com.google.cloud.datastream.v1.SourceConfig;
+import com.google.cloud.datastream.v1.StaticServiceIpConnectivity;
+import com.google.cloud.datastream.v1.Stream;
+import com.google.cloud.datastream.v1.StreamName;
+import com.google.cloud.datastream.v1.UpdateStreamRequest;
+import com.google.cloud.teleport.it.common.ResourceManager;
+import com.google.common.base.Strings;
+import com.google.protobuf.Duration;
+import com.google.protobuf.FieldMask;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import org.apache.arrow.util.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Client for Datastream resources.
+ *
+ * <p>This class is thread safe.
+ */
+public final class DatastreamResourceManager implements ResourceManager {
+  private static final Logger LOG = LoggerFactory.getLogger(DatastreamResourceManager.class);
+  private static final String FIELD_STATE = "state";
+  private final DatastreamClient datastreamClient;
+  private final String location;
+  private final String projectId;
+  private final Set<String> createdStreamIds;
+  private final Set<String> createdConnectionProfileIds;
+
+  enum DestinationOutputFormat {
+    AVRO_FILE_FORMAT,
+    JSON_FILE_FORMAT
+  }
+
+  private DatastreamResourceManager(Builder builder) throws IOException {
+    this(
+        DatastreamClient.create(
+            DatastreamSettings.newBuilder()
+                .setCredentialsProvider(builder.credentialsProvider)
+                .build()),
+        builder);
+  }
+
+  @VisibleForTesting
+  public DatastreamResourceManager(DatastreamClient datastreamClient, Builder builder) {
+    this.datastreamClient = datastreamClient;
+    this.location = builder.location;
+    this.projectId = builder.projectId;
+    this.createdStreamIds = Collections.synchronizedSet(new HashSet<>());
+    this.createdConnectionProfileIds = Collections.synchronizedSet(new HashSet<>());
+  }
+
+  public static Builder builder(String projectId, String location) {
+    checkArgument(!Strings.isNullOrEmpty(projectId), "projectID can not be null or empty");
+    checkArgument(!Strings.isNullOrEmpty(location), "location can not be null or empty");
+    return new Builder(projectId, location);
+  }
+
+  /**
+   * @param connectionProfileId The ID of the connection profile.
+   * @param source An object representing the JDBC source.
+   * @return A Datastream JDBC source connection profile.
+   */
+  private synchronized ConnectionProfile createJDBCSourceConnectionProfile(
+      String connectionProfileId, JDBCSource source) {
+    checkArgument(
+        !Strings.isNullOrEmpty(connectionProfileId),
+        "connectionProfileId can not be null or empty");
+    LOG.info(
+        "Creating JDBC Source Connection Profile {} in project {}.",
+        connectionProfileId,
+        projectId);
+    ConnectionProfile.Builder connectionProfileBuilder = ConnectionProfile.newBuilder();
+    JDBCSource.SourceType type = source.type();
+
+    try {
+      switch (type) {
+        case MYSQL:
+          MysqlProfile.Builder mysqlProfileBuilder = MysqlProfile.newBuilder();
+          mysqlProfileBuilder
+              .setHostname(source.hostname())
+              .setUsername(source.username())
+              .setPassword(source.password())
+              .setPort(source.port());
+          connectionProfileBuilder.setMysqlProfile(mysqlProfileBuilder);
+          break;
+        case ORACLE:
+          OracleProfile.Builder oracleProfileBuilder = OracleProfile.newBuilder();
+          oracleProfileBuilder
+              .setHostname(source.hostname())
+              .setUsername(source.username())
+              .setPassword(source.password())
+              .setPort(source.port());
+          connectionProfileBuilder.setOracleProfile(oracleProfileBuilder);
+          break;
+        case POSTGRESQL:
+          PostgresqlProfile.Builder postgresqlProfileBuilder = PostgresqlProfile.newBuilder();
+          postgresqlProfileBuilder
+              .setHostname(source.hostname())
+              .setUsername(source.username())
+              .setPassword(source.password())
+              .setPort(source.port())
+              .setDatabase(((PostgresqlSource) source).database());
+          connectionProfileBuilder.setPostgresqlProfile(postgresqlProfileBuilder);
+          break;
+        default:
+          throw new DatastreamResourceManagerException(
+              "Could not recognize JDBC source type " + type.name());
+      }
+
+      ConnectionProfile connectionProfile =
+          connectionProfileBuilder
+              .setDisplayName(connectionProfileId)
+              .setStaticServiceIpConnectivity(StaticServiceIpConnectivity.getDefaultInstance())
+              .build();
+      CreateConnectionProfileRequest request =
+          CreateConnectionProfileRequest.newBuilder()
+              .setParent(LocationName.of(projectId, location).toString())
+              .setConnectionProfile(connectionProfile)
+              .setConnectionProfileId(connectionProfileId)
+              .build();
+      ConnectionProfile reference = datastreamClient.createConnectionProfileAsync(request).get();
+      createdConnectionProfileIds.add(connectionProfileId);
+
+      LOG.info(
+          "Successfully created JDBC Source Connection Profile {} in project {}.",
+          connectionProfileId,
+          projectId);
+      return reference;
+    } catch (ExecutionException | InterruptedException e) {
+      throw new DatastreamResourceManagerException(
+          "Failed to create JDBC source connection profile. ", e);
+    }
+  }
+
+  /**
+   * @param sourceConnectionProfileId The ID of the connection profile.
+   * @param source An object representing the JDBC source.
+   * @return a SourceConfig object which is required to configure a Stream.
+   */
+  public synchronized SourceConfig buildSourceConfig(
+      String sourceConnectionProfileId, JDBCSource source) {
+
+    createJDBCSourceConnectionProfile(sourceConnectionProfileId, source);
+    SourceConfig.Builder sourceConfigBuilder =
+        SourceConfig.newBuilder()
+            .setSourceConnectionProfile(
+                ConnectionProfileName.format(projectId, location, sourceConnectionProfileId));
+
+    switch (source.type()) {
+      case MYSQL:
+        sourceConfigBuilder.setMysqlSourceConfig((MysqlSourceConfig) source.config());
+        break;
+      case POSTGRESQL:
+        sourceConfigBuilder.setPostgresqlSourceConfig((PostgresqlSourceConfig) source.config());
+        break;
+      case ORACLE:
+        sourceConfigBuilder.setOracleSourceConfig((OracleSourceConfig) source.config());
+        break;
+      default:
+        throw new DatastreamResourceManagerException(
+            "Could not recognize JDBC source type " + source.type().name());
+    }
+
+    return sourceConfigBuilder.build();
+  }
+
+  /**
+   * @param connectionProfileId The ID of the GCS connection profile.
+   * @param gcsBucketName The GCS Bucket to connect to.
+   * @param gcsRootPath The Path prefix to specific gcs location. Can either be empty or must start
+   *     with '/'.
+   * @return A Datastream GCS destination connection profile.
+   */
+  public synchronized ConnectionProfile createGCSDestinationConnectionProfile(
+      String connectionProfileId, String gcsBucketName, String gcsRootPath) {
+    checkArgument(
+        !Strings.isNullOrEmpty(connectionProfileId),
+        "connectionProfileId can not be null or empty");
+    checkArgument(!Strings.isNullOrEmpty(gcsBucketName), "gcsBucketName can not be null or empty");
+    checkArgument(gcsRootPath != null, "gcsRootPath can not be null");
+    checkArgument(
+        gcsRootPath.isEmpty() || gcsRootPath.charAt(0) == '/',
+        "gcsRootPath must either be an empty string or start with a '/'");
+
+    LOG.info(
+        "Creating GCS Destination Connection Profile {} in project {}.",
+        connectionProfileId,
+        projectId);
+
+    try {
+      ConnectionProfile.Builder connectionProfileBuilder =
+          ConnectionProfile.newBuilder()
+              .setDisplayName(connectionProfileId)
+              .setStaticServiceIpConnectivity(StaticServiceIpConnectivity.getDefaultInstance())
+              .setGcsProfile(
+                  GcsProfile.newBuilder().setBucket(gcsBucketName).setRootPath(gcsRootPath));
+
+      CreateConnectionProfileRequest request =
+          CreateConnectionProfileRequest.newBuilder()
+              .setParent(LocationName.of(projectId, location).toString())
+              .setConnectionProfile(connectionProfileBuilder)
+              .setConnectionProfileId(connectionProfileId)
+              .build();
+
+      ConnectionProfile reference = datastreamClient.createConnectionProfileAsync(request).get();
+      createdConnectionProfileIds.add(connectionProfileId);
+      LOG.info(
+          "Successfully created GCS Destination Connection Profile {} in project {}.",
+          connectionProfileId,
+          projectId);
+
+      return reference;
+    } catch (ExecutionException | InterruptedException e) {
+      throw new DatastreamResourceManagerException(
+          "Failed to create GCS source connection profile. ", e);
+    }
+  }
+
+  /**
+   * @param connectionProfileId The ID of the connection profile.
+   * @param path The Path prefix to specific GCS location. Can either be empty or must start with
+   *     '/'.
+   * @param destinationOutputFormat The format of the files written to GCS.
+   * @return A DestinationConfig object representing a GCS destination configuration.
+   */
+  public synchronized DestinationConfig buildGCSDestinationConfig(
+      String connectionProfileId, String path, DestinationOutputFormat destinationOutputFormat) {
+
+    DestinationConfig.Builder destinationConfigBuilder =
+        DestinationConfig.newBuilder()
+            .setDestinationConnectionProfile(
+                ConnectionProfileName.format(projectId, location, connectionProfileId));
+
+    GcsDestinationConfig.Builder gcsDestinationConfigBuilder =
+        GcsDestinationConfig.newBuilder().setPath(path);
+
+    if (destinationOutputFormat == DestinationOutputFormat.AVRO_FILE_FORMAT) {
+      gcsDestinationConfigBuilder.setAvroFileFormat(AvroFileFormat.getDefaultInstance());
+    } else {
+      gcsDestinationConfigBuilder.setJsonFileFormat(JsonFileFormat.getDefaultInstance());
+    }
+
+    destinationConfigBuilder.setGcsDestinationConfig(gcsDestinationConfigBuilder);
+    return destinationConfigBuilder.build();
+  }
+
+  /**
+   * @param connectionProfileId The ID of the connection profile.
+   * @return A Datastream BigQuery destination connection profile.
+   */
+  public synchronized ConnectionProfile createBQDestinationConnectionProfile(
+      String connectionProfileId) {
+
+    LOG.info(
+        "Creating BQ Destination Connection Profile {} in project {}.",
+        connectionProfileId,
+        projectId);
+
+    try {
+      ConnectionProfile.Builder connectionProfileBuilder =
+          ConnectionProfile.newBuilder()
+              .setDisplayName(connectionProfileId)
+              .setStaticServiceIpConnectivity(StaticServiceIpConnectivity.getDefaultInstance())
+              .setBigqueryProfile(BigQueryProfile.newBuilder());
+
+      CreateConnectionProfileRequest request =
+          CreateConnectionProfileRequest.newBuilder()
+              .setParent(LocationName.of(projectId, location).toString())
+              .setConnectionProfile(connectionProfileBuilder)
+              .setConnectionProfileId(connectionProfileId)
+              .build();
+
+      ConnectionProfile reference = datastreamClient.createConnectionProfileAsync(request).get();
+      createdConnectionProfileIds.add(connectionProfileId);
+
+      LOG.info(
+          "Successfully created BQ Destination Connection Profile {} in project {}.",
+          connectionProfileId,
+          projectId);
+      return reference;
+    } catch (ExecutionException | InterruptedException e) {
+      throw new DatastreamResourceManagerException(
+          "Failed to create BQ destination connection profile. ", e);
+    }
+  }
+
+  /**
+   * @param connectionProfileId The ID of the connection profile.
+   * @param stalenessLimitSeconds The desired data freshness in seconds.
+   * @param datasetId The ID of the BigQuery dataset.
+   * @return A DestinationConfig object representing a BigQuery destination configuration.
+   */
+  public synchronized DestinationConfig buildBQDestinationConfig(
+      String connectionProfileId, long stalenessLimitSeconds, String datasetId) {
+
+    DestinationConfig.Builder destinationConfigBuilder =
+        DestinationConfig.newBuilder()
+            .setDestinationConnectionProfile(
+                ConnectionProfileName.format(projectId, location, connectionProfileId));
+
+    BigQueryDestinationConfig.Builder bigQueryDestinationConfig =
+        BigQueryDestinationConfig.newBuilder()
+            .setDataFreshness(Duration.newBuilder().setSeconds(stalenessLimitSeconds).build())
+            .setSingleTargetDataset(
+                BigQueryDestinationConfig.SingleTargetDataset.newBuilder().setDatasetId(datasetId));
+
+    destinationConfigBuilder.setBigqueryDestinationConfig(bigQueryDestinationConfig);
+    return destinationConfigBuilder.build();
+  }
+
+  /**
+   * @param streamId The ID of the stream.
+   * @param sourceConfig A SourceConfig object representing the source configuration.
+   * @param destinationConfig A DestinationConfig object representing the destination configuration.
+   * @return A Datastream stream object.
+   */
+  public synchronized Stream createStream(
+      String streamId, SourceConfig sourceConfig, DestinationConfig destinationConfig) {
+
+    LOG.info("Creating Stream {} in project {}.", streamId, projectId);
+
+    try {
+      CreateStreamRequest request =
+          CreateStreamRequest.newBuilder()
+              .setParent(LocationName.format(projectId, location))
+              .setStreamId(streamId)
+              .setStream(
+                  Stream.newBuilder()
+                      .setSourceConfig(sourceConfig)
+                      .setDisplayName(streamId)
+                      .setDestinationConfig(destinationConfig)
+                      .setBackfillAll(Stream.BackfillAllStrategy.getDefaultInstance())
+                      .build())
+              .build();
+
+      Stream reference = datastreamClient.createStreamAsync(request).get();
+      createdStreamIds.add(streamId);
+
+      LOG.info("Successfully created Stream {} in project {}.", streamId, projectId);
+      return reference;
+    } catch (ExecutionException | InterruptedException e) {
+      throw new DatastreamResourceManagerException("Failed to create stream. ", e);
+    }
+  }
+
+  public synchronized Stream updateStreamState(String streamId, Stream.State state) {
+
+    LOG.info("Updating {}'s state to {} in project {}.", streamId, state.name(), projectId);
+
+    try {
+      Stream.Builder streamBuilder =
+          Stream.newBuilder()
+              .setName(StreamName.format(projectId, location, streamId))
+              .setState(state);
+
+      FieldMask.Builder fieldMaskBuilder = FieldMask.newBuilder().addPaths(FIELD_STATE);
+
+      UpdateStreamRequest request =
+          UpdateStreamRequest.newBuilder()
+              .setStream(streamBuilder)
+              .setUpdateMask(fieldMaskBuilder)
+              .build();
+
+      Stream reference = datastreamClient.updateStreamAsync(request).get();
+
+      LOG.info(
+          "Successfully updated {}'s state to {} in project {}.",
+          streamId,
+          state.name(),
+          projectId);
+      return reference;
+    } catch (InterruptedException | ExecutionException e) {
+      throw new DatastreamResourceManagerException("Failed to update stream. ", e);
+    }
+  }
+
+  public synchronized Stream startStream(String streamId) {
+    LOG.info("Starting Stream {} in project {}.", streamId, projectId);
+    return updateStreamState(streamId, Stream.State.RUNNING);
+  }
+
+  public synchronized Stream pauseStream(String streamId) {
+    LOG.info("Pausing Stream {} in project {}.", streamId, projectId);
+    return updateStreamState(streamId, Stream.State.PAUSED);
+  }
+
+  public synchronized void cleanupAll() {
+    LOG.info("Cleaning up Datastream resource manager.");
+    boolean producedError = false;
+
+    try {
+      for (String stream : createdStreamIds) {
+        datastreamClient
+            .deleteStreamAsync(
+                DeleteStreamRequest.newBuilder()
+                    .setName(StreamName.format(projectId, location, stream))
+                    .build())
+            .get();
+      }
+      LOG.info("Successfully deleted stream(s). ");
+    } catch (InterruptedException | ExecutionException e) {
+      LOG.error("Failed to delete stream(s).");
+      producedError = true;
+    }
+
+    try {
+      for (String connectionProfile : createdConnectionProfileIds) {
+        datastreamClient
+            .deleteConnectionProfileAsync(
+                DeleteConnectionProfileRequest.newBuilder()
+                    .setName(ConnectionProfileName.format(projectId, location, connectionProfile))
+                    .build())
+            .get();
+      }
+      LOG.info("Successfully deleted connection profile(s). ");
+    } catch (InterruptedException | ExecutionException e) {
+      LOG.error("Failed to delete connection profile(s).");
+      producedError = true;
+    }
+
+    try {
+      datastreamClient.close();
+    } catch (Exception e) {
+      LOG.error("Failed to close datastream client. ");
+      producedError = true;
+    }
+
+    if (producedError) {
+      throw new DatastreamResourceManagerException(
+          "Failed to delete resources. Check above for errors.");
+    }
+
+    LOG.info("Successfully cleaned up Datastream resource manager.");
+  }
+
+  /** Builder for {@link DatastreamResourceManager}. */
+  public static final class Builder {
+    private final String projectId;
+    private final String location;
+    private CredentialsProvider credentialsProvider;
+
+    private Builder(String projectId, String location) {
+      this.projectId = projectId;
+      this.location = location;
+    }
+
+    public Builder setCredentialsProvider(CredentialsProvider credentialsProvider) {
+      this.credentialsProvider = credentialsProvider;
+      return this;
+    }
+
+    public DatastreamResourceManager build() throws IOException {
+      return new DatastreamResourceManager(this);
+    }
+  }
+}

--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/datastream/DatastreamResourceManagerException.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/datastream/DatastreamResourceManagerException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.gcp.datastream;
+
+/** Custom exception for {@link DatastreamResourceManager} implementations. */
+public class DatastreamResourceManagerException extends RuntimeException {
+
+  public DatastreamResourceManagerException(String errorMessage, Throwable err) {
+    super(errorMessage, err);
+  }
+
+  public DatastreamResourceManagerException(String errorMessage) {
+    super(errorMessage);
+  }
+}

--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/datastream/JDBCSource.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/datastream/JDBCSource.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.gcp.datastream;
+
+import com.google.protobuf.MessageOrBuilder;
+import java.util.List;
+import java.util.Map;
+
+/** Parent class for JDBC Resources required for configuring Datastream. */
+public abstract class JDBCSource {
+  private final String hostname;
+  private final String username;
+  private final String password;
+  private final int port;
+  private final Map<String, List<String>> allowedTables;
+
+  enum SourceType {
+    ORACLE,
+    MYSQL,
+    POSTGRESQL,
+  }
+
+  JDBCSource(Builder<?> builder) {
+    this.hostname = builder.hostname;
+    this.username = builder.username;
+    this.password = builder.password;
+    this.port = builder.port;
+    this.allowedTables = builder.allowedTables;
+  }
+
+  public abstract SourceType type();
+
+  public abstract MessageOrBuilder config();
+
+  public String hostname() {
+    return this.hostname;
+  }
+
+  public String username() {
+    return this.username;
+  }
+
+  public String password() {
+    return this.password;
+  }
+
+  public int port() {
+    return this.port;
+  }
+
+  public Map<String, List<String>> allowedTables() {
+    return this.allowedTables;
+  }
+
+  public abstract static class Builder<T extends JDBCSource> {
+    private String hostname;
+    private String username;
+    private String password;
+    private int port;
+    private Map<String, List<String>> allowedTables;
+
+    public Builder(
+        String hostname,
+        String username,
+        String password,
+        int port,
+        Map<String, List<String>> allowedTables) {
+      this.hostname = hostname;
+      this.username = username;
+      this.password = password;
+      this.port = port;
+      this.allowedTables = allowedTables;
+    }
+
+    public abstract T build();
+  }
+}

--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/datastream/MySQLSource.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/datastream/MySQLSource.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.gcp.datastream;
+
+import com.google.cloud.datastream.v1.MysqlDatabase;
+import com.google.cloud.datastream.v1.MysqlRdbms;
+import com.google.cloud.datastream.v1.MysqlSourceConfig;
+import com.google.cloud.datastream.v1.MysqlTable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Client for MySQL resource used by Datastream.
+ *
+ * <p>Subclass of {@link JDBCSource}.
+ */
+public class MySQLSource extends JDBCSource {
+
+  MySQLSource(Builder builder) {
+    super(builder);
+  }
+
+  @Override
+  public SourceType type() {
+    return SourceType.MYSQL;
+  }
+
+  @Override
+  public MysqlSourceConfig config() {
+    MysqlRdbms.Builder mysqlRdmsBuilder = MysqlRdbms.newBuilder();
+    for (String db : this.allowedTables().keySet()) {
+      MysqlDatabase.Builder mysqlDbBuilder = MysqlDatabase.newBuilder().setDatabase(db);
+      for (String table : this.allowedTables().get(db)) {
+        mysqlDbBuilder.addMysqlTables(MysqlTable.newBuilder().setTable(table));
+      }
+      mysqlRdmsBuilder.addMysqlDatabases(mysqlDbBuilder);
+    }
+    return MysqlSourceConfig.newBuilder().setIncludeObjects(mysqlRdmsBuilder).build();
+  }
+
+  public static Builder builder(
+      String hostname,
+      String username,
+      String password,
+      int port,
+      Map<String, List<String>> allowedTables) {
+    return new Builder(hostname, username, password, port, allowedTables);
+  }
+
+  public static class Builder extends JDBCSource.Builder<MySQLSource> {
+    public Builder(
+        String hostname,
+        String username,
+        String password,
+        int port,
+        Map<String, List<String>> allowedTables) {
+      super(hostname, username, password, port, allowedTables);
+    }
+
+    @Override
+    public MySQLSource build() {
+      return new MySQLSource(this);
+    }
+  }
+}

--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/datastream/OracleSource.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/datastream/OracleSource.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.gcp.datastream;
+
+import com.google.cloud.datastream.v1.OracleRdbms;
+import com.google.cloud.datastream.v1.OracleSchema;
+import com.google.cloud.datastream.v1.OracleSourceConfig;
+import com.google.cloud.datastream.v1.OracleTable;
+import com.google.protobuf.MessageOrBuilder;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Client for Oracle resource used by Datastream.
+ *
+ * <p>Subclass of {@link JDBCSource}.
+ */
+public class OracleSource extends JDBCSource {
+
+  OracleSource(Builder builder) {
+    super(builder);
+  }
+
+  public static Builder builder(
+      String hostname,
+      String username,
+      String password,
+      int port,
+      Map<String, List<String>> allowedTables) {
+    return new Builder(hostname, username, password, port, allowedTables);
+  }
+
+  @Override
+  public SourceType type() {
+    return SourceType.ORACLE;
+  }
+
+  @Override
+  public MessageOrBuilder config() {
+    OracleRdbms.Builder oracleRdmsBuilder = OracleRdbms.newBuilder();
+    for (String schema : this.allowedTables().keySet()) {
+      OracleSchema.Builder oracleSchemaBuilder = OracleSchema.newBuilder().setSchema(schema);
+      for (String table : this.allowedTables().get(schema)) {
+        oracleSchemaBuilder.addOracleTables(OracleTable.newBuilder().setTable(table));
+      }
+      oracleRdmsBuilder.addOracleSchemas(oracleSchemaBuilder);
+    }
+    return OracleSourceConfig.newBuilder().setIncludeObjects(oracleRdmsBuilder);
+  }
+
+  public static class Builder extends JDBCSource.Builder<OracleSource> {
+    public Builder(
+        String hostname,
+        String username,
+        String password,
+        int port,
+        Map<String, List<String>> allowedTables) {
+      super(hostname, username, password, port, allowedTables);
+    }
+
+    @Override
+    public OracleSource build() {
+      return new OracleSource(this);
+    }
+  }
+}

--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/datastream/PostgresqlSource.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/datastream/PostgresqlSource.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.gcp.datastream;
+
+import com.google.cloud.datastream.v1.PostgresqlRdbms;
+import com.google.cloud.datastream.v1.PostgresqlSchema;
+import com.google.cloud.datastream.v1.PostgresqlSourceConfig;
+import com.google.cloud.datastream.v1.PostgresqlTable;
+import com.google.protobuf.MessageOrBuilder;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Client for Postgresql resource used by Datastream.
+ *
+ * <p>Subclass of {@link JDBCSource}.
+ */
+public class PostgresqlSource extends JDBCSource {
+  private final String database;
+  private final String publication;
+  private final String replicationSlot;
+
+  PostgresqlSource(Builder builder) {
+    super(builder);
+    this.database = builder.database;
+    this.publication = builder.publication;
+    this.replicationSlot = builder.replicationSlot;
+  }
+
+  public static Builder builder(
+      String hostname,
+      String username,
+      String password,
+      int port,
+      Map<String, List<String>> allowedTables,
+      String database,
+      String replicationSlot,
+      String publication) {
+    return new Builder(
+        hostname, username, password, port, allowedTables, database, replicationSlot, publication);
+  }
+
+  @Override
+  public SourceType type() {
+    return SourceType.POSTGRESQL;
+  }
+
+  @Override
+  public MessageOrBuilder config() {
+    PostgresqlRdbms.Builder postgresqlRdbmsBuilder = PostgresqlRdbms.newBuilder();
+
+    for (String schema : this.allowedTables().keySet()) {
+      PostgresqlSchema.Builder postgresqlSchemaBuilder =
+          PostgresqlSchema.newBuilder().setSchema(schema);
+      for (String table : allowedTables().get(schema)) {
+        postgresqlSchemaBuilder.addPostgresqlTables(PostgresqlTable.newBuilder().setTable(table));
+      }
+      postgresqlRdbmsBuilder.addPostgresqlSchemas(postgresqlSchemaBuilder);
+    }
+    return PostgresqlSourceConfig.newBuilder()
+        .setIncludeObjects(postgresqlRdbmsBuilder)
+        .setPublication(this.publication)
+        .setReplicationSlot(this.replicationSlot);
+  }
+
+  public String database() {
+    return this.database;
+  }
+
+  public static class Builder extends JDBCSource.Builder<PostgresqlSource> {
+    private String database;
+    private String publication;
+    private String replicationSlot;
+
+    public Builder(
+        String hostname,
+        String username,
+        String password,
+        int port,
+        Map<String, List<String>> allowedTables,
+        String database,
+        String replicationSlot,
+        String publication) {
+      super(hostname, username, password, port, allowedTables);
+      this.database = database;
+      this.replicationSlot = replicationSlot;
+      this.publication = publication;
+    }
+
+    @Override
+    public PostgresqlSource build() {
+      return new PostgresqlSource(this);
+    }
+  }
+}

--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/datastream/package-info.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/datastream/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.gcp.datastream;

--- a/it/google-cloud-platform/src/test/java/com/google/cloud/teleport/it/gcp/datastream/DatastreamResourceManagerTest.java
+++ b/it/google-cloud-platform/src/test/java/com/google/cloud/teleport/it/gcp/datastream/DatastreamResourceManagerTest.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it.gcp.datastream;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.cloud.datastream.v1.ConnectionProfile;
+import com.google.cloud.datastream.v1.CreateConnectionProfileRequest;
+import com.google.cloud.datastream.v1.CreateStreamRequest;
+import com.google.cloud.datastream.v1.DatastreamClient;
+import com.google.cloud.datastream.v1.DeleteConnectionProfileRequest;
+import com.google.cloud.datastream.v1.DeleteStreamRequest;
+import com.google.cloud.datastream.v1.DestinationConfig;
+import com.google.cloud.datastream.v1.SourceConfig;
+import com.google.cloud.datastream.v1.Stream;
+import com.google.cloud.datastream.v1.UpdateStreamRequest;
+import com.google.protobuf.Empty;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/** Unit test for {@link DatastreamResourceManager}. */
+@RunWith(JUnit4.class)
+public class DatastreamResourceManagerTest {
+  @Rule public final MockitoRule mockito = MockitoJUnit.rule();
+  private static final String CONNECTION_PROFILE_ID = "test-connection-profile-id";
+  private static final String STREAM_ID = "test-stream-id";
+  private static final String PROJECT_ID = "test-project";
+  private static final String LOCATION = "test-location";
+  private static final String HOST = "test-host";
+  private static final String USER = "test-user";
+  private static final String PASSWORD = "test-password";
+  private static final int PORT = 1234;
+  private static final String BUCKET = "test-bucket";
+  private static final String ROOT_PATH = "/test-root-path";
+  private static final String STREAM_STATE = "test-stream-state";
+  private static final int RESOURCE_COUNT = 5;
+  private JDBCSource jdbcSource;
+  private Map<String, List<String>> allowedTables;
+  @Mock private DatastreamClient datastreamClient;
+  @Mock private OperationFuture request;
+  @Mock private OperationFuture createStreamRequest;
+  @Mock private OperationFuture createConnectionProfileRequest;
+  @Mock private OperationFuture deleteRequest;
+  @Mock private ConnectionProfile connectionProfile;
+  @Mock private SourceConfig sourceConfig;
+  @Mock private DestinationConfig destinationConfig;
+  @Mock private Stream stream;
+  @Mock private Stream.State streamState;
+  @Mock private Empty emptyReference;
+
+  private DatastreamResourceManager testManager;
+
+  @Before
+  public void setup() {
+    testManager =
+        new DatastreamResourceManager(
+            datastreamClient, DatastreamResourceManager.builder(PROJECT_ID, LOCATION));
+    jdbcSource = MySQLSource.builder(HOST, USER, PASSWORD, PORT, allowedTables).build();
+  }
+
+  @Test
+  public void testBuilderWithInvalidProjectShouldFail() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class, () -> DatastreamResourceManager.builder("", LOCATION));
+    assertThat(exception).hasMessageThat().contains("projectID can not be null or empty");
+  }
+
+  @Test
+  public void testBuilderWithInvalidLocationShouldFail() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> DatastreamResourceManager.builder(PROJECT_ID, ""));
+    assertThat(exception).hasMessageThat().contains("location can not be null or empty");
+  }
+
+  @Test
+  public void testCreateBQDestinationConnectionProfileExecutionExceptionShouldFail()
+      throws ExecutionException, InterruptedException {
+    when(datastreamClient.createConnectionProfileAsync(any(CreateConnectionProfileRequest.class)))
+        .thenReturn(request);
+    when(request.get()).thenThrow(ExecutionException.class);
+    DatastreamResourceManagerException exception =
+        assertThrows(
+            DatastreamResourceManagerException.class,
+            () -> testManager.createBQDestinationConnectionProfile(CONNECTION_PROFILE_ID));
+    assertThat(exception)
+        .hasMessageThat()
+        .contains("Failed to create BQ destination connection profile.");
+  }
+
+  @Test
+  public void testCreateBQDestinationConnectionInterruptedExceptionShouldFail()
+      throws ExecutionException, InterruptedException {
+    when(datastreamClient.createConnectionProfileAsync(any(CreateConnectionProfileRequest.class)))
+        .thenReturn(request);
+    when(request.get()).thenThrow(InterruptedException.class);
+    DatastreamResourceManagerException exception =
+        assertThrows(
+            DatastreamResourceManagerException.class,
+            () -> testManager.createBQDestinationConnectionProfile(CONNECTION_PROFILE_ID));
+    assertThat(exception)
+        .hasMessageThat()
+        .contains("Failed to create BQ destination connection profile.");
+  }
+
+  @Test
+  public void testCreateBQDestinationConnectionShouldCreateSuccessfully()
+      throws ExecutionException, InterruptedException {
+    when(datastreamClient.createConnectionProfileAsync(any(CreateConnectionProfileRequest.class)))
+        .thenReturn(request);
+    when(request.get()).thenReturn(connectionProfile);
+    assertThat(testManager.createBQDestinationConnectionProfile(CONNECTION_PROFILE_ID))
+        .isEqualTo(connectionProfile);
+  }
+
+  @Test
+  public void testCreateGCSDestinationConnectionProfileWithInvalidGCSRootPathShouldFail() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                testManager.createGCSDestinationConnectionProfile(
+                    CONNECTION_PROFILE_ID, BUCKET, "invalid"));
+    assertThat(exception)
+        .hasMessageThat()
+        .contains("gcsRootPath must either be an empty string or start with a '/'");
+  }
+
+  @Test
+  public void testCreateGCSDestinationConnectionProfileExecutionExceptionShouldFail()
+      throws ExecutionException, InterruptedException {
+    when(datastreamClient.createConnectionProfileAsync(any(CreateConnectionProfileRequest.class)))
+        .thenReturn(request);
+    when(request.get()).thenThrow(ExecutionException.class);
+    DatastreamResourceManagerException exception =
+        assertThrows(
+            DatastreamResourceManagerException.class,
+            () ->
+                testManager.createGCSDestinationConnectionProfile(
+                    CONNECTION_PROFILE_ID, BUCKET, ROOT_PATH));
+    assertThat(exception)
+        .hasMessageThat()
+        .contains("Failed to create GCS source connection profile.");
+  }
+
+  @Test
+  public void testCreateGCSDestinationConnectionProfileInterruptedExceptionShouldFail()
+      throws ExecutionException, InterruptedException {
+    when(datastreamClient.createConnectionProfileAsync(any(CreateConnectionProfileRequest.class)))
+        .thenReturn(request);
+    when(request.get()).thenThrow(InterruptedException.class);
+    DatastreamResourceManagerException exception =
+        assertThrows(
+            DatastreamResourceManagerException.class,
+            () ->
+                testManager.createGCSDestinationConnectionProfile(
+                    CONNECTION_PROFILE_ID, BUCKET, ROOT_PATH));
+    assertThat(exception)
+        .hasMessageThat()
+        .contains("Failed to create GCS source connection profile.");
+  }
+
+  @Test
+  public void testCreateGCSDestinationConnectionShouldCreateSuccessfully()
+      throws ExecutionException, InterruptedException {
+    when(datastreamClient.createConnectionProfileAsync((any(CreateConnectionProfileRequest.class))))
+        .thenReturn(request);
+    when(request.get()).thenReturn(connectionProfile);
+    assertThat(
+            testManager.createGCSDestinationConnectionProfile(
+                CONNECTION_PROFILE_ID, BUCKET, ROOT_PATH))
+        .isEqualTo(connectionProfile);
+  }
+
+  @Test
+  public void testCreateStreamExecutionExceptionShouldFail()
+      throws ExecutionException, InterruptedException {
+    when(datastreamClient.createStreamAsync(any(CreateStreamRequest.class))).thenReturn(request);
+    when(request.get()).thenThrow(ExecutionException.class);
+    DatastreamResourceManagerException exception =
+        assertThrows(
+            DatastreamResourceManagerException.class,
+            () -> testManager.createStream(STREAM_ID, sourceConfig, destinationConfig));
+    assertThat(exception).hasMessageThat().contains("Failed to create stream.");
+  }
+
+  @Test
+  public void testCreateStreamInterruptedExceptionShouldFail()
+      throws ExecutionException, InterruptedException {
+    when(datastreamClient.createStreamAsync(any(CreateStreamRequest.class))).thenReturn(request);
+    when(request.get()).thenThrow(InterruptedException.class);
+    DatastreamResourceManagerException exception =
+        assertThrows(
+            DatastreamResourceManagerException.class,
+            () -> testManager.createStream(STREAM_ID, sourceConfig, destinationConfig));
+    assertThat(exception).hasMessageThat().contains("Failed to create stream.");
+  }
+
+  @Test
+  public void testCreateStreamShouldCreateSuccessfully()
+      throws ExecutionException, InterruptedException {
+    when(datastreamClient.createStreamAsync(any(CreateStreamRequest.class))).thenReturn(request);
+    when(request.get()).thenReturn(stream);
+    assertThat(testManager.createStream(STREAM_ID, sourceConfig, destinationConfig))
+        .isEqualTo(stream);
+  }
+
+  @Test
+  public void testUpdateStreamStateInterruptedExceptionShouldFail()
+      throws ExecutionException, InterruptedException {
+    when(datastreamClient.updateStreamAsync(any(UpdateStreamRequest.class))).thenReturn(request);
+    when(request.get()).thenThrow(InterruptedException.class);
+    when(streamState.name()).thenReturn(STREAM_STATE);
+    DatastreamResourceManagerException exception =
+        assertThrows(
+            DatastreamResourceManagerException.class,
+            () -> testManager.updateStreamState(STREAM_ID, streamState));
+    assertThat(exception).hasMessageThat().contains("Failed to update stream.");
+  }
+
+  @Test
+  public void testUpdateStreamStateExecutionExceptionShouldFail()
+      throws ExecutionException, InterruptedException {
+    when(datastreamClient.updateStreamAsync(any(UpdateStreamRequest.class))).thenReturn(request);
+    when(request.get()).thenThrow(ExecutionException.class);
+    when(streamState.name()).thenReturn(STREAM_STATE);
+    DatastreamResourceManagerException exception =
+        assertThrows(
+            DatastreamResourceManagerException.class,
+            () -> testManager.updateStreamState(STREAM_ID, streamState));
+    assertThat(exception).hasMessageThat().contains("Failed to update stream.");
+  }
+
+  @Test
+  public void testUpdateStreamStateShouldCreateSuccessfully()
+      throws ExecutionException, InterruptedException {
+    when(datastreamClient.updateStreamAsync(any(UpdateStreamRequest.class))).thenReturn(request);
+    when(request.get()).thenReturn(stream);
+    when(streamState.name()).thenReturn(STREAM_STATE);
+    assertThat(testManager.updateStreamState(STREAM_ID, streamState)).isEqualTo(stream);
+  }
+
+  @Test
+  public void testCleanupAllShouldDeleteSuccessfullyWhenNoErrorIsThrown()
+      throws ExecutionException, InterruptedException {
+
+    when(datastreamClient.createConnectionProfileAsync(any(CreateConnectionProfileRequest.class)))
+        .thenReturn(createConnectionProfileRequest);
+    when(createConnectionProfileRequest.get()).thenReturn(connectionProfile);
+    when(datastreamClient.createStreamAsync(any(CreateStreamRequest.class)))
+        .thenReturn(createStreamRequest);
+    when(createStreamRequest.get()).thenReturn(stream);
+
+    when(datastreamClient.deleteStreamAsync(any(DeleteStreamRequest.class)))
+        .thenReturn(deleteRequest);
+    when(datastreamClient.deleteConnectionProfileAsync((any(DeleteConnectionProfileRequest.class))))
+        .thenReturn(deleteRequest);
+    when(deleteRequest.get()).thenReturn(emptyReference);
+    doNothing().when(datastreamClient).close();
+
+    for (int i = 0; i < RESOURCE_COUNT; i++) {
+      testManager.createGCSDestinationConnectionProfile(
+          "gcs-" + CONNECTION_PROFILE_ID + i, BUCKET, ROOT_PATH);
+      testManager.createBQDestinationConnectionProfile("bq-" + CONNECTION_PROFILE_ID + i);
+      testManager.createStream(STREAM_ID + i, sourceConfig, destinationConfig);
+    }
+
+    testManager.cleanupAll();
+    verify(datastreamClient, times(RESOURCE_COUNT))
+        .deleteStreamAsync(any(DeleteStreamRequest.class));
+    verify(datastreamClient, times(RESOURCE_COUNT * 2))
+        .deleteConnectionProfileAsync(any(DeleteConnectionProfileRequest.class));
+    verify(datastreamClient).close();
+  }
+}


### PR DESCRIPTION
Draft PR as suggested by @bvolpato 

#477 

This PR attempts to create Datastream Resource Manager for Dataflow Template Integration Testing

The RM would be able 
- Create Source Connection Profile (MySQL, PostgresSQL, Oracle)
- Create Destination Profile (GCS)
- Create a Stream
- Start/Stop a Stream by updating Stream State
- Clean up all resources.

Currently a work in progress