### PR TITLE
:sparkles: add postgresql compatibility for datastream-to-bigquery template

### DIFF
--- a/v2/common/src/main/java/com/google/api/services/datastream/v1/model/DiscoverConnectionProfileRequest.java
+++ b/v2/common/src/main/java/com/google/api/services/datastream/v1/model/DiscoverConnectionProfileRequest.java
@@ -52,6 +52,11 @@ public final class DiscoverConnectionProfileRequest extends com.google.api.clien
   @com.google.api.client.util.Key private OracleRdbms oracleRdbms;
 
   /**
+   * PostgreSQL RDBMS to enrich with child data objects and metadata. The value may be {@code null}.
+   */
+  @com.google.api.client.util.Key private PostgresqlRdbms postgresqlRdbms;
+
+  /**
    * An ad-hoc connection profile configuration.
    *
    * @return value or {@code null} for none
@@ -147,6 +152,25 @@ public final class DiscoverConnectionProfileRequest extends com.google.api.clien
    */
   public DiscoverConnectionProfileRequest setMysqlRdbms(MysqlRdbms mysqlRdbms) {
     this.mysqlRdbms = mysqlRdbms;
+    return this;
+  }
+
+  /**
+   * PostgreSQL RDBMS to enrich with child data objects and metadata.
+   *
+   * @return value or {@code null} for none
+   */
+  public PostgresqlRdbms getPostgresqlRdbms() {
+    return postgresqlRdbms;
+  }
+
+  /**
+   * PostgreSQL RDBMS to enrich with child data objects and metadata.
+   *
+   * @param postgresqlRdbms postgresqlRdbms or {@code null} for none
+   */
+  public DiscoverConnectionProfileRequest setPostgresqlRdbms(PostgresqlRdbms postgresqlRdbms) {
+    this.postgresqlRdbms = postgresqlRdbms;
     return this;
   }
 

--- a/v2/common/src/main/java/com/google/api/services/datastream/v1/model/DiscoverConnectionProfileResponse.java
+++ b/v2/common/src/main/java/com/google/api/services/datastream/v1/model/DiscoverConnectionProfileResponse.java
@@ -34,6 +34,9 @@ public final class DiscoverConnectionProfileResponse
   /** Enriched Oracle RDBMS object. The value may be {@code null}. */
   @com.google.api.client.util.Key private OracleRdbms oracleRdbms;
 
+  /** Enriched PsotgreSQL RDBMS object. The value may be {@code null}. */
+  @com.google.api.client.util.Key private PostgresqlRdbms postgresqlRdbms;
+
   /**
    * Enriched MySQL RDBMS object.
    *
@@ -50,6 +53,25 @@ public final class DiscoverConnectionProfileResponse
    */
   public DiscoverConnectionProfileResponse setMysqlRdbms(MysqlRdbms mysqlRdbms) {
     this.mysqlRdbms = mysqlRdbms;
+    return this;
+  }
+
+  /**
+   * Enriched PostgreSQL RDBMS object.
+   *
+   * @return value or {@code null} for none
+   */
+  public PostgresqlRdbms getPostgresqlRdbms() {
+    return postgresqlRdbms;
+  }
+
+  /**
+   * Enriched PostgreSQL RDBMS object.
+   *
+   * @param postgresqlRdbms postgresqlRdbms or {@code null} for none
+   */
+  public DiscoverConnectionProfileResponse setPostgresqlRdbms(PostgresqlRdbms postgresqlRdbms) {
+    this.postgresqlRdbms = postgresqlRdbms;
     return this;
   }
 

--- a/v2/common/src/main/java/com/google/api/services/datastream/v1/model/PostgresqlColumn.java
+++ b/v2/common/src/main/java/com/google/api/services/datastream/v1/model/PostgresqlColumn.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.api.services.datastream.v1.model;
+
+/**
+ * Postgresql Column.
+ *
+ * <p>This is the Java data model class that specifies how to parse/serialize into the JSON that is
+ * transmitted over HTTP when working with the Datastream API. For a detailed explanation see: <a
+ * href="https://developers.google.com/api-client-library/java/google-http-java-client/json">https://developers.google.com/api-client-library/java/google-http-java-client/json</a>
+ *
+ * @author Google, Inc.
+ */
+@SuppressWarnings("javadoc")
+public final class PostgresqlColumn extends com.google.api.client.json.GenericJson {
+
+  /** Column name. The value may be {@code null}. */
+  @com.google.api.client.util.Key private java.lang.String column;
+
+  /** The PostgreSQL data type. The value may be {@code null}. */
+  @com.google.api.client.util.Key private java.lang.String dataType;
+
+  /** Column length. The value may be {@code null}. */
+  @com.google.api.client.util.Key private java.lang.Integer length;
+
+  /** Column precision. The value may be {@code null}. */
+  @com.google.api.client.util.Key private java.lang.Integer precision;
+
+  /** Column scale. The value may be {@code null}. */
+  @com.google.api.client.util.Key private java.lang.Integer scale;
+
+  /** Whether or not the column represents a primary key. The value may be {@code null}. */
+  @com.google.api.client.util.Key private java.lang.Boolean primaryKey;
+
+  /** Whether or not the column can accept a null value. The value may be {@code null}. */
+  @com.google.api.client.util.Key private java.lang.Boolean nullable;
+
+  /** Column encoding. The value may be {@code null}. */
+  @com.google.api.client.util.Key private java.lang.String encoding;
+
+  /** The ordinal position of the column in the table. The value may be {@code null}. */
+  @com.google.api.client.util.Key private java.lang.Integer ordinalPosition;
+
+  /**
+   * Column name.
+   *
+   * @return value or {@code null} for none
+   */
+  public java.lang.String getColumn() {
+    return column;
+  }
+
+  /**
+   * Column name.
+   *
+   * @param column column or {@code null} for none
+   */
+  public PostgresqlColumn setColumn(java.lang.String column) {
+    this.column = column;
+    return this;
+  }
+
+  /**
+   * The PostgreSQL data type.
+   *
+   * @return value or {@code null} for none
+   */
+  public java.lang.String getDataType() {
+    return dataType;
+  }
+
+  /**
+   * The PostgreSQL data type.
+   *
+   * @param dataType dataType or {@code null} for none
+   */
+  public PostgresqlColumn setDataType(java.lang.String dataType) {
+    this.dataType = dataType;
+    return this;
+  }
+
+  /**
+   * Column encoding.
+   *
+   * @return value or {@code null} for none
+   */
+  public java.lang.String getEncoding() {
+    return encoding;
+  }
+
+  /**
+   * Column encoding.
+   *
+   * @param encoding encoding or {@code null} for none
+   */
+  public PostgresqlColumn setEncoding(java.lang.String encoding) {
+    this.encoding = encoding;
+    return this;
+  }
+
+  /**
+   * Column length.
+   *
+   * @return value or {@code null} for none
+   */
+  public java.lang.Integer getLength() {
+    return length;
+  }
+
+  /**
+   * Column length.
+   *
+   * @param length length or {@code null} for none
+   */
+  public PostgresqlColumn setLength(java.lang.Integer length) {
+    this.length = length;
+    return this;
+  }
+
+  /**
+   * Whether or not the column can accept a null value.
+   *
+   * @return value or {@code null} for none
+   */
+  public java.lang.Boolean getNullable() {
+    return nullable;
+  }
+
+  /**
+   * Whether or not the column can accept a null value.
+   *
+   * @param nullable nullable or {@code null} for none
+   */
+  public PostgresqlColumn setNullable(java.lang.Boolean nullable) {
+    this.nullable = nullable;
+    return this;
+  }
+
+  /**
+   * The ordinal position of the column in the table.
+   *
+   * @return value or {@code null} for none
+   */
+  public java.lang.Integer getOrdinalPosition() {
+    return ordinalPosition;
+  }
+
+  /**
+   * The ordinal position of the column in the table.
+   *
+   * @param ordinalPosition ordinalPosition or {@code null} for none
+   */
+  public PostgresqlColumn setOrdinalPosition(java.lang.Integer ordinalPosition) {
+    this.ordinalPosition = ordinalPosition;
+    return this;
+  }
+
+  /**
+   * Column precision.
+   *
+   * @return value or {@code null} for none
+   */
+  public java.lang.Integer getPrecision() {
+    return precision;
+  }
+
+  /**
+   * Column precision.
+   *
+   * @param precision precision or {@code null} for none
+   */
+  public PostgresqlColumn setPrecision(java.lang.Integer precision) {
+    this.precision = precision;
+    return this;
+  }
+
+  /**
+   * Whether or not the column represents a primary key.
+   *
+   * @return value or {@code null} for none
+   */
+  public java.lang.Boolean getPrimaryKey() {
+    return primaryKey;
+  }
+
+  /**
+   * Whether or not the column represents a primary key.
+   *
+   * @param primaryKey primaryKey or {@code null} for none
+   */
+  public PostgresqlColumn setPrimaryKey(java.lang.Boolean primaryKey) {
+    this.primaryKey = primaryKey;
+    return this;
+  }
+
+  /**
+   * Column scale.
+   *
+   * @return value or {@code null} for none
+   */
+  public java.lang.Integer getScale() {
+    return scale;
+  }
+
+  /**
+   * Column scale.
+   *
+   * @param scale scale or {@code null} for none
+   */
+  public PostgresqlColumn setScale(java.lang.Integer scale) {
+    this.scale = scale;
+    return this;
+  }
+
+  @Override
+  public PostgresqlColumn set(String fieldName, Object value) {
+    return (PostgresqlColumn) super.set(fieldName, value);
+  }
+
+  @Override
+  public PostgresqlColumn clone() {
+    return (PostgresqlColumn) super.clone();
+  }
+}

--- a/v2/common/src/main/java/com/google/api/services/datastream/v1/model/PostgresqlRdbms.java
+++ b/v2/common/src/main/java/com/google/api/services/datastream/v1/model/PostgresqlRdbms.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.api.services.datastream.v1.model;
+
+/**
+ * PostgreSQL database structure.
+ *
+ * <p>This is the Java data model class that specifies how to parse/serialize into the JSON that is
+ * transmitted over HTTP when working with the Datastream API. For a detailed explanation see: <a
+ * href="https://developers.google.com/api-client-library/java/google-http-java-client/json">https://developers.google.com/api-client-library/java/google-http-java-client/json</a>
+ *
+ * @author Google, Inc.
+ */
+@SuppressWarnings("javadoc")
+public final class PostgresqlRdbms extends com.google.api.client.json.GenericJson {
+
+  /** PostgreSQL schemas/databases in the database server. The value may be {@code null}. */
+  @com.google.api.client.util.Key private java.util.List<PostgresqlSchema> postgresqlSchemas;
+
+  /**
+   * PostgreSQL schemas/databases in the database server.
+   *
+   * @return value or {@code null} for none
+   */
+  public java.util.List<PostgresqlSchema> getPostgresqlSchemas() {
+    return postgresqlSchemas;
+  }
+
+  /**
+   * PostgreSQL schemas/databases in the database server.
+   *
+   * @param postgresqlSchemas postgresqlSchemas or {@code null} for none
+   */
+  public PostgresqlRdbms setPostgresqlSchemas(java.util.List<PostgresqlSchema> postgresqlSchemas) {
+    this.postgresqlSchemas = postgresqlSchemas;
+    return this;
+  }
+
+  @Override
+  public PostgresqlRdbms set(String fieldName, Object value) {
+    return (PostgresqlRdbms) super.set(fieldName, value);
+  }
+
+  @Override
+  public PostgresqlRdbms clone() {
+    return (PostgresqlRdbms) super.clone();
+  }
+}

--- a/v2/common/src/main/java/com/google/api/services/datastream/v1/model/PostgresqlSchema.java
+++ b/v2/common/src/main/java/com/google/api/services/datastream/v1/model/PostgresqlSchema.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.api.services.datastream.v1.model;
+
+/**
+ * PostgreSQL schema.
+ *
+ * <p>This is the Java data model class that specifies how to parse/serialize into the JSON that is
+ * transmitted over HTTP when working with the Datastream API. For a detailed explanation see: <a
+ * href="https://developers.google.com/api-client-library/java/google-http-java-client/json">https://developers.google.com/api-client-library/java/google-http-java-client/json</a>
+ *
+ * @author Google, Inc.
+ */
+@SuppressWarnings("javadoc")
+public final class PostgresqlSchema extends com.google.api.client.json.GenericJson {
+
+  /** Tables in the schema. The value may be {@code null}. */
+  @com.google.api.client.util.Key private java.util.List<PostgresqlTable> postgresqlTables;
+
+  /** Schema name. The value may be {@code null}. */
+  @com.google.api.client.util.Key private String schema;
+
+  /**
+   * Tables in the schema.
+   *
+   * @return value or {@code null} for none
+   */
+  public java.util.List<PostgresqlTable> getPostgresqlTables() {
+    return postgresqlTables;
+  }
+
+  /**
+   * Tables in the schema.
+   *
+   * @param postgresqlTables postgresqlTables or {@code null} for none
+   */
+  public PostgresqlSchema setOracleTables(java.util.List<PostgresqlTable> postgresqlTables) {
+    this.postgresqlTables = postgresqlTables;
+    return this;
+  }
+
+  /**
+   * Schema name.
+   *
+   * @return value or {@code null} for none
+   */
+  public String getSchema() {
+    return schema;
+  }
+
+  /**
+   * Schema name.
+   *
+   * @param schema schema or {@code null} for none
+   */
+  public PostgresqlSchema setSchema(String schema) {
+    this.schema = schema;
+    return this;
+  }
+
+  @Override
+  public PostgresqlSchema set(String fieldName, Object value) {
+    return (PostgresqlSchema) super.set(fieldName, value);
+  }
+
+  @Override
+  public PostgresqlSchema clone() {
+    return (PostgresqlSchema) super.clone();
+  }
+}

--- a/v2/common/src/main/java/com/google/api/services/datastream/v1/model/PostgresqlSourceConfig.java
+++ b/v2/common/src/main/java/com/google/api/services/datastream/v1/model/PostgresqlSourceConfig.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.api.services.datastream.v1.model;
+
+/**
+ * /** data source configuration
+ *
+ * <p>This is the Java data model class that specifies how to parse/serialize into the JSON that is
+ * transmitted over HTTP when working with the Datastream API. For a detailed explanation see: <a
+ * href="https://developers.google.com/api-client-library/java/google-http-java-client/json">https://developers.google.com/api-client-library/java/google-http-java-client/json</a>
+ *
+ * @author Google, Inc.
+ */
+@SuppressWarnings("javadoc")
+public final class PostgresqlSourceConfig extends com.google.api.client.json.GenericJson {
+
+  /** PostgreSQL objects to exclude from the stream. The value may be {@code null}. */
+  @com.google.api.client.util.Key private PostgresqlRdbms excludeObjects;
+
+  /** PostgreSQL objects to include in the stream. The value may be {@code null}. */
+  @com.google.api.client.util.Key private PostgresqlRdbms includeObjects;
+
+  /** The name of the logical replication slot that's configured with the pgoutput plugin. */
+  @com.google.api.client.util.Key private String replicationSlot;
+
+  /**
+   * The name of the publication that includes the set of all tables that are defined in the
+   * stream's include_objects.
+   */
+  @com.google.api.client.util.Key private String publication;
+
+  /**
+   * PostgreSQL objects to exclude from the stream.
+   *
+   * @return value or {@code null} for none
+   */
+  public PostgresqlRdbms getExcludeObjects() {
+    return excludeObjects;
+  }
+
+  /**
+   * PostgreSQL objects to exclude from the stream.
+   *
+   * @param excludeObjects excludeObjects or {@code null} for none
+   */
+  public PostgresqlSourceConfig setExcludeObjects(PostgresqlRdbms excludeObjects) {
+    this.excludeObjects = excludeObjects;
+    return this;
+  }
+
+  /**
+   * PostgreSQL objects to include in the stream.
+   *
+   * @return value or {@code null} for none
+   */
+  public PostgresqlRdbms getIncludeObjects() {
+    return includeObjects;
+  }
+
+  /**
+   * PostgreSQL objects to include in the stream.
+   *
+   * @param includeObjects includeObjects or {@code null} for none
+   */
+  public PostgresqlSourceConfig setIncludeObjects(PostgresqlRdbms includeObjects) {
+    this.includeObjects = includeObjects;
+    return this;
+  }
+
+  /**
+   * PostgreSQL name of the publication that includes the set of all tables that are defined in the
+   * stream's include_objects.
+   *
+   * @return value
+   */
+  public String getPublication() {
+    return publication;
+  }
+
+  /**
+   * PostgreSQL name of the publication that includes the set of all tables that are defined in the
+   * stream's include_objects.
+   *
+   * @param publication publication
+   */
+  public PostgresqlSourceConfig setPublication(String publication) {
+    this.publication = publication;
+    return this;
+  }
+
+  /**
+   * PostgreSQL name of the logical replication slot that's configured with the pgoutput plugin.
+   *
+   * @return value
+   */
+  public String getReplicationSlot() {
+    return replicationSlot;
+  }
+
+  /**
+   * PostgreSQL name of the logical replication slot that's configured with the pgoutput plugin.
+   *
+   * @param replicationSlot replicationSlot
+   */
+  public PostgresqlSourceConfig setReplicationSlot(String replicationSlot) {
+    this.replicationSlot = replicationSlot;
+    return this;
+  }
+
+  @Override
+  public PostgresqlSourceConfig set(String fieldName, Object value) {
+    return (PostgresqlSourceConfig) super.set(fieldName, value);
+  }
+
+  @Override
+  public PostgresqlSourceConfig clone() {
+    return (PostgresqlSourceConfig) super.clone();
+  }
+}

--- a/v2/common/src/main/java/com/google/api/services/datastream/v1/model/PostgresqlTable.java
+++ b/v2/common/src/main/java/com/google/api/services/datastream/v1/model/PostgresqlTable.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.api.services.datastream.v1.model;
+
+/**
+ * PostgreSQL table.
+ *
+ * <p>This is the Java data model class that specifies how to parse/serialize into the JSON that is
+ * transmitted over HTTP when working with the Datastream API. For a detailed explanation see: <a
+ * href="https://developers.google.com/api-client-library/java/google-http-java-client/json">https://developers.google.com/api-client-library/java/google-http-java-client/json</a>
+ *
+ * @author Google, Inc.
+ */
+@SuppressWarnings("javadoc")
+public final class PostgresqlTable extends com.google.api.client.json.GenericJson {
+
+  /**
+   * Postgresql columns in the schema. When unspecified as part of include/exclude objects,
+   * includes/excludes everything. The value may be {@code null}.
+   */
+  @com.google.api.client.util.Key private java.util.List<PostgresqlColumn> postgresqlColumns;
+
+  /** Table name. The value may be {@code null}. */
+  @com.google.api.client.util.Key private String table;
+
+  /**
+   * Postgresql columns in the schema. When unspecified as part of include/exclude objects,
+   * includes/excludes everything.
+   *
+   * @return value or {@code null} for none
+   */
+  public java.util.List<PostgresqlColumn> getPostgresqlColumns() {
+    return postgresqlColumns;
+  }
+
+  /**
+   * Postgresql columns in the schema. When unspecified as part of include/exclude objects,
+   * includes/excludes everything.
+   *
+   * @param postgresqlColumns postgresqlColumns or {@code null} for none
+   */
+  public PostgresqlTable setPostgresqlColumns(java.util.List<PostgresqlColumn> postgresqlColumns) {
+    this.postgresqlColumns = postgresqlColumns;
+    return this;
+  }
+
+  /**
+   * Table name.
+   *
+   * @return value or {@code null} for none
+   */
+  public String getTable() {
+    return table;
+  }
+
+  /**
+   * Table name.
+   *
+   * @param table table or {@code null} for none
+   */
+  public PostgresqlTable setTable(String table) {
+    this.table = table;
+    return this;
+  }
+
+  @Override
+  public PostgresqlTable set(String fieldName, Object value) {
+    return (PostgresqlTable) super.set(fieldName, value);
+  }
+
+  @Override
+  public PostgresqlTable clone() {
+    return (PostgresqlTable) super.clone();
+  }
+}

--- a/v2/common/src/main/java/com/google/api/services/datastream/v1/model/SourceConfig.java
+++ b/v2/common/src/main/java/com/google/api/services/datastream/v1/model/SourceConfig.java
@@ -33,6 +33,9 @@ public final class SourceConfig extends com.google.api.client.json.GenericJson {
   /** Oracle data source configuration. The value may be {@code null}. */
   @com.google.api.client.util.Key private OracleSourceConfig oracleSourceConfig;
 
+  /** PostgreSQL data source configuration. The value may be {@code null}. */
+  @com.google.api.client.util.Key private PostgresqlSourceConfig postgresqlSourceConfig;
+
   /**
    * Required. Source connection profile resoource. Format:
    * `projects/{project}/locations/{location}/connectionProfiles/{name}` The value may be {@code
@@ -75,6 +78,25 @@ public final class SourceConfig extends com.google.api.client.json.GenericJson {
    */
   public SourceConfig setOracleSourceConfig(OracleSourceConfig oracleSourceConfig) {
     this.oracleSourceConfig = oracleSourceConfig;
+    return this;
+  }
+
+  /**
+   * Postgresql data source configuration.
+   *
+   * @return value or {@code null} for none
+   */
+  public PostgresqlSourceConfig getPostgresqlSourceConfig() {
+    return postgresqlSourceConfig;
+  }
+
+  /**
+   * Postgresql data source configuration.
+   *
+   * @param postgresqlSourceConfig postgresqlSourceConfig or {@code null} for none
+   */
+  public SourceConfig setPostgresqlSourceConfig(PostgresqlSourceConfig postgresqlSourceConfig) {
+    this.postgresqlSourceConfig = postgresqlSourceConfig;
     return this;
   }
 

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/utils/DataStreamClient.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/utils/DataStreamClient.java
@@ -124,8 +124,6 @@ public class DataStreamClient implements Serializable {
       return getMysqlObjectSchema(streamName, schemaName, tableName, sourceConnProfile);
     } else if (sourceConnProfile.getOracleSourceConfig() != null) {
       return getOracleObjectSchema(streamName, schemaName, tableName, sourceConnProfile);
-    } else if (sourceConnProfile.getOracleSourceConfig() != null) {
-      return getOracleObjectSchema(streamName, schemaName, tableName, sourceConnProfile);
     } else if (sourceConnProfile.getPostgresqlSourceConfig() != null) {
       return getPostgresqlObjectSchema(streamName, schemaName, tableName, sourceConnProfile);
     } else {

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/values/DatastreamRow.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/values/DatastreamRow.java
@@ -165,6 +165,8 @@ public class DatastreamRow {
   public List<String> getSortFields() {
     if (this.getSourceType().equals("mysql")) {
       return Arrays.asList("_metadata_timestamp", "_metadata_log_file", "_metadata_log_position");
+    } else if (this.getSourceType().equals("postgresql")) {
+      return Arrays.asList("_metadata_timestamp", "_metadata_lsn", "_metadata_uuid");
     } else {
       // Current default is oracle.
       return Arrays.asList(


### PR DESCRIPTION
Add PostgreSQL compatibility for the template Datastream to Bigquery :

- Add the metadata_lsn in the metadata columns
- Create a complete PostgreSQL mapping with BigQuery for the merge

Fix #583