### PR TITLE
:construction_worker: add a new parameter form template deployment mojo 

### DIFF
--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
@@ -35,6 +35,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.execution.MavenSession;
@@ -84,6 +85,9 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
 
   @Parameter(defaultValue = "${artifactRegion}", readonly = true, required = false)
   protected String artifactRegion;
+
+  @Parameter(defaultValue = "${artifactRegistry}", readonly = true, required = false)
+  protected String artifactRegistry;
 
   @Parameter(
       name = "baseContainerImage",
@@ -296,7 +300,25 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
     // GCR paths can not contain ":", if the project id has it, it should be converted to "/".
     String projectIdUrl = projectId.replace(':', '/');
     String imagePath =
-        prefix + "gcr.io/" + projectIdUrl + "/" + stagePrefix.toLowerCase() + "/" + containerName;
+        Optional.ofNullable(artifactRegistry)
+            .map(
+                value ->
+                    value
+                        + "/"
+                        + projectIdUrl
+                        + "/"
+                        + stagePrefix.toLowerCase()
+                        + "/"
+                        + containerName)
+            .orElse(
+                prefix
+                    + "gcr.io/"
+                    + projectIdUrl
+                    + "/"
+                    + stagePrefix.toLowerCase()
+                    + "/"
+                    + containerName);
+    ;
     LOG.info("Stage image to GCR: {}", imagePath);
 
     File metadataFile =


### PR DESCRIPTION
In order to define the artifact registry url against organization's locations constraints.

If at your organisation, some constraints about location (like low-carbon region only) are activated, your can't use gcr.io or eu.gcr.io or us.gcr.io which are multi-region could be not allowed.
This allow to define a new parameter to give a one region focused url for the artifact registry used in the flex template .