### PR TITLE
:adhesive_bandage: add quotes around PK partitionning  in BigQuery

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/cdc/merge/MergeStatementBuilder.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/cdc/merge/MergeStatementBuilder.java
@@ -149,7 +149,8 @@ public class MergeStatementBuilder implements Serializable {
       List<String> orderByFields,
       String deletedFieldName) {
     String commaSeparatedFields = joinStringFields(",", allFields, configuration.quoteCharacter());
-    String commaSeparatedPKFields = String.join(", ", primaryKeyFields);
+    String commaSeparatedPKFields =
+        joinStringFields(", ", primaryKeyFields, configuration.quoteCharacter());
     return String.format(
         PARTITION_BY_PK_AND_SORT_TEMPLATE,
         commaSeparatedFields,

--- a/v2/common/src/test/java/com/google/cloud/teleport/v2/cdc/merge/MergeInfoTest.java
+++ b/v2/common/src/test/java/com/google/cloud/teleport/v2/cdc/merge/MergeInfoTest.java
@@ -51,7 +51,7 @@ public final class MergeInfoTest {
   private static final String MERGE_SQL =
       "BEGIN BEGIN TRANSACTION; MERGE `projectId.dataset.table` AS replica USING (SELECT `id,"
           + " cola`,`colb`,`timestamp`,`other` FROM (SELECT `id, cola`,`colb`,`timestamp`,`other`,"
-          + " ROW_NUMBER() OVER (PARTITION BY id ORDER BY timestamp DESC, other DESC,"
+          + " ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY timestamp DESC, other DESC,"
           + " metadata_deleteField ASC) as row_num FROM `projectId.dataset.staging_table` WHERE"
           + " COALESCE(_PARTITIONTIME, CURRENT_TIMESTAMP()) >= TIMESTAMP(DATE_ADD(CURRENT_DATE(),"
           + " INTERVAL -2 DAY)) AND (COALESCE(_PARTITIONTIME, CURRENT_TIMESTAMP()) >="


### PR DESCRIPTION
For BQ Merge statement to avoid issues when reserved word column names.