### PR TITLE
Fix comparing row key name

### DIFF
--- a/v2/googlecloud-to-mongodb/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/BigQueryToMongoDb.java
+++ b/v2/googlecloud-to-mongodb/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/BigQueryToMongoDb.java
@@ -83,7 +83,7 @@ public class BigQueryToMongoDb {
                     TableRow row = c.element();
                     row.forEach(
                         (key, value) -> {
-                          if (key != "_id") {
+                          if (!key.equals("_id")) {
                             doc.append(key, value);
                           }
                         });


### PR DESCRIPTION
Hey, it looks like it was intended to check for `_id` content, not String reference