### PR TITLE
Improving artifacts being imported from syndeo pom file.

### DIFF
--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -23,7 +23,6 @@ on:
     paths:
       - '**.java'
       - '**.xml'
-      - '!syndeo-template/**.xml'
       # Include relevant GitHub Action files for running these checks.
       # This will make it easier to verify action changes don't break anything.
       - '.github/actions/setup-env/*'

--- a/syndeo-template/pom.xml
+++ b/syndeo-template/pom.xml
@@ -79,6 +79,11 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>org.apache.beam</groupId>
+                <artifactId>beam-sdks-java-io-kafka</artifactId>
+                <version>${beam.snapshot.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.api-client</groupId>
                 <artifactId>google-api-client</artifactId>
                 <version>1.35.2</version>
@@ -414,6 +419,18 @@
                                 </includes>
                             </artifactSet>
                             <filters>
+                                <filter>
+                                    <artifact>org.apache.beam:beam-sdks-java-extensions-sql-expansion-service</artifact>
+                                    <excludes>
+                                        <exclude>org/apache/beam/sdk/io/kafka/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.apache.beam:beam-sdks-java-io-kafka</artifact>
+                                    <includes>
+                                        <include>org/apache/beam/sdk/io/kafka/**</include>
+                                    </includes>
+                                </filter>
                                 <filter>
                                     <artifact>*:*</artifact>
                                     <excludes>


### PR DESCRIPTION
The base Beam expansion service includes Beam's Kafka module as a dependency, which causes the classes to clash.

Normally this is not a problem, but it caused me trouble when I was working with snapshot versions of it.