### PR TITLE
[Load tests] Add support for launching pipelines using Pipeline#run

### DIFF
--- a/it/pom.xml
+++ b/it/pom.xml
@@ -292,7 +292,6 @@
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-io-synthetic</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.beam</groupId>
@@ -302,7 +301,6 @@
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.beam</groupId>

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -292,6 +292,7 @@
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-io-synthetic</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.beam</groupId>

--- a/it/src/main/java/com/google/cloud/teleport/it/IOLoadTestBase.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/IOLoadTestBase.java
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.teleport.it;
 
-import com.google.cloud.teleport.it.dataflow.DirectRunnerClient;
+import com.google.cloud.teleport.it.launcher.DefaultPipelineLauncher;
 import com.google.cloud.teleport.it.launcher.PipelineLauncher;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -47,11 +47,6 @@ public class IOLoadTestBase extends LoadTestBase {
 
   @Override
   PipelineLauncher launcher() {
-    // TODO: the return value is a placeholder currently. Return a pipeline launcher object once
-    // there is a generic, non-template launcher available.
-    LOG.warn("launcher not fully supported yet.");
-    // DirectRunnerClient currently requires a template class as argument. Pass the test class for
-    // now.
-    return DirectRunnerClient.builder(this.getClass()).setCredentials(CREDENTIALS).build();
+    return DefaultPipelineLauncher.builder().setCredentials(CREDENTIALS).build();
   }
 }

--- a/it/src/main/java/com/google/cloud/teleport/it/launcher/AbstractPipelineLauncher.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/launcher/AbstractPipelineLauncher.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
  * launching a specific type of template.
  */
 public abstract class AbstractPipelineLauncher implements PipelineLauncher {
+
   private static final Logger LOG = LoggerFactory.getLogger(AbstractPipelineLauncher.class);
   private static final Pattern CURRENT_METRICS = Pattern.compile(".*Current.*");
 
@@ -224,6 +225,8 @@ public abstract class AbstractPipelineLauncher implements PipelineLauncher {
   }
 
   /** Waits until the specified job is not in a pending state. */
+  // TODO(pranavbhandari): This method fails if any request to dataflow fails. Make this method more
+  // robust.
   public JobState waitUntilActive(String project, String region, String jobId) throws IOException {
     JobState state = getJobStatus(project, region, jobId);
     while (PENDING_STATES.contains(state)) {

--- a/it/src/main/java/com/google/cloud/teleport/it/launcher/DefaultPipelineLauncher.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/launcher/DefaultPipelineLauncher.java
@@ -30,28 +30,23 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.beam.runners.dataflow.DataflowPipelineJob;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Default class for implementation of {@link PipelineLauncher} interface. */
 public class DefaultPipelineLauncher extends AbstractPipelineLauncher {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultPipelineLauncher.class);
-  private static final Pattern JOB_ID_PATTERN = Pattern.compile("Submitted job: (?<jobId>\\S+)");
-
-  DefaultPipelineLauncher(Dataflow client) {
-    super(client);
-  }
+  private static final Pattern JOB_ID_PATTERN = Pattern.compile("Submitted job: (\\S+)");
 
   private DefaultPipelineLauncher(DefaultPipelineLauncher.Builder builder) {
-    this(
+    super(
         new Dataflow(
             Utils.getDefaultTransport(),
             Utils.getDefaultJsonFactory(),
-            new HttpCredentialsAdapter(builder.getCredentials())));
-  }
-
-  public static DefaultPipelineLauncher withDataflowClient(Dataflow client) {
-    return new DefaultPipelineLauncher(client);
+            builder.getCredentials() == null
+                ? null
+                : new HttpCredentialsAdapter(builder.getCredentials())));
   }
 
   public static DefaultPipelineLauncher.Builder builder() {
@@ -64,34 +59,44 @@ public class DefaultPipelineLauncher extends AbstractPipelineLauncher {
         options.sdk() != null,
         "Cannot launch a dataflow job "
             + "without sdk specified. Please specify sdk and try again!");
-    checkState(
-        options.executable() != null,
-        "Cannot launch a dataflow job "
-            + "without executable specified. Please specify executable and try again!");
     LOG.info("Getting ready to launch {} in {} under {}", options.jobName(), region, project);
-    LOG.info("Using the executable at {}", options.executable());
     LOG.info("Using parameters:\n{}", formatForLogging(options.parameters()));
     // Create SDK specific command and execute to launch dataflow job
     List<String> cmd = new ArrayList<>();
+    String jobId = null;
     switch (options.sdk()) {
       case JAVA:
         checkState(
-            options.mainClassname() != null,
+            options.pipeline() != null,
             "Cannot launch a dataflow job "
-                + "without classname specified. Please specify classname and try again!");
-        cmd.add("java");
-        cmd.add("-cp");
-        cmd.add(options.executable());
-        cmd.add(options.mainClassname());
+                + "without pipeline specified. Please specify pipeline and try again!");
+        cmd = extractOptions(project, region, options);
+        DataflowPipelineJob job =
+            (DataflowPipelineJob) options.pipeline().runWithAdditionalOptionArgs(cmd);
+        jobId = job.getJobId();
         break;
       case PYTHON:
+        checkState(
+            options.executable() != null,
+            "Cannot launch a dataflow job "
+                + "without executable specified. Please specify executable and try again!");
+        LOG.info("Using the executable at {}", options.executable());
         cmd.add("python3");
         cmd.add(options.executable());
+        cmd.addAll(extractOptions(project, region, options));
+        jobId = executeCommandAndParseResponse(cmd);
         break;
       case GO:
+        checkState(
+            options.executable() != null,
+            "Cannot launch a dataflow job "
+                + "without executable specified. Please specify executable and try again!");
+        LOG.info("Using the executable at {}", options.executable());
         cmd.add("go");
         cmd.add("run");
         cmd.add(options.executable());
+        cmd.addAll(extractOptions(project, region, options));
+        jobId = executeCommandAndParseResponse(cmd);
         break;
       default:
         throw new RuntimeException(
@@ -99,16 +104,20 @@ public class DefaultPipelineLauncher extends AbstractPipelineLauncher {
                 "Invalid sdk %s specified. " + "sdk can be one of java, python, or go.",
                 options.sdk()));
     }
-    for (Map.Entry<String, String> parameter : options.parameters().entrySet()) {
-      cmd.add(String.format("--%s=%s", parameter.getKey(), parameter.getValue()));
-    }
-    cmd.add(String.format("--project=%s", project));
-    cmd.add(String.format("--region=%s", region));
-    String jobId = executeCommandAndParseResponse(cmd);
     // Wait until the job is active to get more information
     JobState state = waitUntilActive(project, region, jobId);
     Job job = getJob(project, region, jobId);
     return getJobInfo(options, state, job, options.getParameter("runner"));
+  }
+
+  private List<String> extractOptions(String project, String region, LaunchConfig options) {
+    List<String> additionalOptions = new ArrayList<>();
+    for (Map.Entry<String, String> parameter : options.parameters().entrySet()) {
+      additionalOptions.add(String.format("--%s=%s", parameter.getKey(), parameter.getValue()));
+    }
+    additionalOptions.add(String.format("--project=%s", project));
+    additionalOptions.add(String.format("--region=%s", region));
+    return additionalOptions;
   }
 
   /** Executes the specified command and parses the response to get the Job ID. */
@@ -123,7 +132,7 @@ public class DefaultPipelineLauncher extends AbstractPipelineLauncher {
                   + "Result from process: %s",
               output));
     }
-    String jobId = m.group("jobId");
+    String jobId = m.group(1);
     LOG.info("Submitted job: {}", jobId);
     return jobId;
   }

--- a/it/src/main/java/com/google/cloud/teleport/it/launcher/PipelineLauncher.java
+++ b/it/src/main/java/com/google/cloud/teleport/it/launcher/PipelineLauncher.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.testing.TestPipeline;
 
 /** Client for working with Cloud Dataflow. */
 public interface PipelineLauncher {
@@ -110,7 +111,7 @@ public interface PipelineLauncher {
     @Nullable private final String specPath;
     @Nullable private final Sdk sdk;
     @Nullable private final String executable;
-    @Nullable private final String mainClassname;
+    @Nullable private final TestPipeline pipeline;
 
     private LaunchConfig(Builder builder) {
       this.jobName = builder.jobName;
@@ -119,7 +120,7 @@ public interface PipelineLauncher {
       this.specPath = builder.specPath;
       this.sdk = builder.sdk;
       this.executable = builder.executable;
-      this.mainClassname = builder.mainClassname;
+      this.pipeline = builder.pipeline;
     }
 
     public String jobName() {
@@ -151,8 +152,8 @@ public interface PipelineLauncher {
       return executable;
     }
 
-    public String mainClassname() {
-      return mainClassname;
+    public TestPipeline pipeline() {
+      return pipeline;
     }
 
     public static Builder builderWithName(String jobName, String specPath) {
@@ -175,7 +176,7 @@ public interface PipelineLauncher {
       private Map<String, String> parameters;
       private Sdk sdk;
       private String executable;
-      private String mainClassname;
+      private TestPipeline pipeline;
 
       private Builder(String jobName, String specPath) {
         this.jobName = jobName;
@@ -239,12 +240,12 @@ public interface PipelineLauncher {
       }
 
       @Nullable
-      public String getMainClassname() {
-        return mainClassname;
+      public TestPipeline getPipeline() {
+        return pipeline;
       }
 
-      public Builder setMainClassname(String mainClassname) {
-        this.mainClassname = mainClassname;
+      public Builder setPipeline(TestPipeline pipeline) {
+        this.pipeline = pipeline;
         return this;
       }
 
@@ -404,4 +405,6 @@ public interface PipelineLauncher {
    * @throws IOException if there is an issue sending the request
    */
   Map<String, Double> getMetrics(String project, String region, String jobId) throws IOException;
+
+  JobState waitUntilActive(String project, String region, String jobId) throws IOException;
 }

--- a/it/src/test/java/com/google/cloud/teleport/it/WordCountIT.java
+++ b/it/src/test/java/com/google/cloud/teleport/it/WordCountIT.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.it;
+
+import static com.google.cloud.teleport.it.matchers.TemplateAsserts.assertThatPipeline;
+import static com.google.cloud.teleport.it.matchers.TemplateAsserts.assertThatResult;
+
+import com.google.cloud.teleport.it.launcher.PipelineLauncher.LaunchConfig;
+import com.google.cloud.teleport.it.launcher.PipelineLauncher.LaunchInfo;
+import com.google.cloud.teleport.it.launcher.PipelineLauncher.Sdk;
+import com.google.cloud.teleport.it.launcher.PipelineOperator.Result;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.transforms.Filter;
+import org.apache.beam.sdk.transforms.FlatMapElements;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.TypeDescriptors;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class WordCountIT extends IOLoadTestBase {
+
+  @Rule public TestPipeline wcPipeline = TestPipeline.create();
+
+  @Before
+  public void setup() {
+    buildPipeline();
+  }
+
+  @Test
+  public void testWordCountDataflow() throws IOException {
+    LaunchConfig options =
+        LaunchConfig.builder("test-wordcount")
+            .setSdk(Sdk.JAVA)
+            .setPipeline(wcPipeline)
+            .addParameter("runner", "DataflowRunner")
+            .build();
+
+    LaunchInfo launchInfo = pipelineLauncher.launch(project, region, options);
+    assertThatPipeline(launchInfo).isRunning();
+    Result result =
+        pipelineOperator.waitUntilDone(createConfig(launchInfo, Duration.ofMinutes(20)));
+    assertThatResult(result).isLaunchFinished();
+  }
+
+  /** Build WordCount pipeline. */
+  private void buildPipeline() {
+    wcPipeline
+        .apply(TextIO.read().from("gs://apache-beam-samples/shakespeare/kinglear.txt"))
+        .apply(
+            FlatMapElements.into(TypeDescriptors.strings())
+                .via((String line) -> Arrays.asList(line.split("[^\\p{L}]+"))))
+        .apply(Filter.by((String word) -> !word.isEmpty()))
+        .apply(Count.perElement())
+        .apply(
+            MapElements.into(TypeDescriptors.strings())
+                .via(
+                    (KV<String, Long> wordCount) ->
+                        wordCount.getKey() + ": " + wordCount.getValue()))
+        .apply(TextIO.write().to("wordcounts"));
+  }
+}

--- a/it/src/test/java/com/google/cloud/teleport/it/bigquery/BigQueryIOLT.java
+++ b/it/src/test/java/com/google/cloud/teleport/it/bigquery/BigQueryIOLT.java
@@ -89,10 +89,10 @@ public class BigQueryIOLT extends IOLoadTestBase {
   @BeforeClass
   public static void beforeClass() {
     resourceManager =
-        DefaultBigQueryResourceManager.builder("io-bigquery-lt", PROJECT)
+        DefaultBigQueryResourceManager.builder("io-bigquery-lt", project)
             .setCredentials(CREDENTIALS)
             .build();
-    resourceManager.createDataset(REGION);
+    resourceManager.createDataset(region);
   }
 
   @Before
@@ -103,7 +103,7 @@ public class BigQueryIOLT extends IOLoadTestBase {
                 .withZone(ZoneId.of("UTC"))
                 .format(java.time.Instant.now())
             + UUID.randomUUID().toString().substring(0, 10);
-    tableQualifier = String.format("%s:%s.%s", PROJECT, resourceManager.getDatasetId(), tableName);
+    tableQualifier = String.format("%s:%s.%s", project, resourceManager.getDatasetId(), tableName);
 
     String testConfig =
         TestProperties.getProperty("configuration", "local", TestProperties.Type.PROPERTY);

--- a/pom.xml
+++ b/pom.xml
@@ -287,9 +287,7 @@
       <properties>
         <!-- Skip coverage checks, unit tests are skipped -->
         <jacoco.skip>true</jacoco.skip>
-        <!-- Skip shade for faster runs -->
-        <skipShade>true</skipShade>
-        <!-- Some modules may yield no integration tests -->
+        <!-- Some modules may yield no load tests -->
         <failIfNoTests>false</failIfNoTests>
       </properties>
       <build>

--- a/v1/src/test/java/com/google/cloud/teleport/bigtable/AvroToBigtableLT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/bigtable/AvroToBigtableLT.java
@@ -45,10 +45,12 @@ import java.util.function.Function;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Performance tests for {@link AvroToBigtable GCS Avro to Bigtable} template. */
+@Category(TemplateLoadTest.class)
 @TemplateLoadTest(AvroToBigtable.class)
 @RunWith(JUnit4.class)
 public class AvroToBigtableLT extends TemplateLoadTestBase {
@@ -71,7 +73,7 @@ public class AvroToBigtableLT extends TemplateLoadTestBase {
   @Before
   public void setup() throws IOException {
     // Set up resource managers
-    bigtableResourceManager = DefaultBigtableResourceManager.builder(testName, PROJECT).build();
+    bigtableResourceManager = DefaultBigtableResourceManager.builder(testName, project).build();
     Storage storageClient = createStorageClient(CREDENTIALS);
     gcsClient = GcsArtifactClient.builder(storageClient, ARTIFACT_BUCKET, TEST_ROOT_DIR).build();
     // upload schema files and save path
@@ -81,7 +83,7 @@ public class AvroToBigtableLT extends TemplateLoadTestBase {
             gcsClient
                 .uploadArtifact(
                     "input/schema.json",
-                    Resources.getResource("AvroToBigtablePerformanceIT/schema.json").getPath())
+                    Resources.getResource("AvroToBigtableLT/schema.json").getPath())
                 .name());
     avroSchemaPath =
         getFullGcsPath(
@@ -127,14 +129,14 @@ public class AvroToBigtableLT extends TemplateLoadTestBase {
         paramsAdder
             .apply(
                 LaunchConfig.builder(testName, SPEC_PATH)
-                    .addParameter("bigtableProjectId", PROJECT)
+                    .addParameter("bigtableProjectId", project)
                     .addParameter("bigtableInstanceId", bigtableResourceManager.getInstanceId())
                     .addParameter("bigtableTableId", tableId)
                     .addParameter("inputFilePattern", getTestMethodDirPath() + "/*"))
             .build();
 
     // Act
-    LaunchInfo info = pipelineLauncher.launch(PROJECT, REGION, options);
+    LaunchInfo info = pipelineLauncher.launch(project, region, options);
     assertThatPipeline(info).isRunning();
     Result result = pipelineOperator.waitUntilDone(createConfig(info, Duration.ofMinutes(60)));
 

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ExportPipelineLT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ExportPipelineLT.java
@@ -43,10 +43,12 @@ import java.util.function.Function;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Performance tests for {@link ExportPipeline Spanner to GCS Avro} template. */
+@Category(TemplateLoadTest.class)
 @TemplateLoadTest(ExportPipeline.class)
 @RunWith(JUnit4.class)
 public class ExportPipelineLT extends TemplateLoadTestBase {
@@ -69,7 +71,7 @@ public class ExportPipelineLT extends TemplateLoadTestBase {
   public void setup() throws IOException {
     // Set up resource managers
     spannerResourceManager =
-        DefaultSpannerResourceManager.builder(testName, PROJECT, REGION).build();
+        DefaultSpannerResourceManager.builder(testName, project, region).build();
     Storage storageClient = createStorageClient(CREDENTIALS);
     gcsClient = GcsArtifactClient.builder(storageClient, ARTIFACT_BUCKET, TEST_ROOT_DIR).build();
   }
@@ -109,7 +111,7 @@ public class ExportPipelineLT extends TemplateLoadTestBase {
             .setQPS("1000000")
             .setMessagesLimit(NUM_MESSAGES)
             .setSinkType("SPANNER")
-            .setProjectId(PROJECT)
+            .setProjectId(project)
             .setSpannerInstanceName(spannerResourceManager.getInstanceId())
             .setSpannerDatabaseName(spannerResourceManager.getDatabaseId())
             .setSpannerTableName(name)
@@ -127,13 +129,13 @@ public class ExportPipelineLT extends TemplateLoadTestBase {
             .build();
 
     // Act
-    LaunchInfo info = pipelineLauncher.launch(PROJECT, REGION, options);
+    LaunchInfo info = pipelineLauncher.launch(project, region, options);
     assertThatPipeline(info).isRunning();
     Result result = pipelineOperator.waitUntilDone(createConfig(info, Duration.ofMinutes(60)));
 
     // Assert
     assertThatResult(result).isLaunchFinished();
-    // check to see if messages reached the output topic
+    // check to see if messages reached the output bucket
     assertThat(gcsClient.listArtifacts(name, Pattern.compile(".*"))).isNotEmpty();
 
     // export results

--- a/v1/src/test/java/com/google/cloud/teleport/templates/PubsubToBigQueryLT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/PubsubToBigQueryLT.java
@@ -103,7 +103,7 @@ public class PubsubToBigQueryLT extends TemplateLoadTestBase {
     testBacklog10gb(Function.identity());
   }
 
-  @Ignore
+  @Ignore("Ignore Streaming Engine tests by default.")
   @Test
   public void testBacklog10gbUsingStreamingEngine()
       throws IOException, ParseException, InterruptedException {
@@ -115,7 +115,7 @@ public class PubsubToBigQueryLT extends TemplateLoadTestBase {
     testSteadyState1hr(Function.identity());
   }
 
-  @Ignore
+  @Ignore("Ignore Streaming Engine tests by default.")
   @Test
   public void testSteadyState1hrUsingStreamingEngine()
       throws ParseException, IOException, InterruptedException {

--- a/v1/src/test/java/com/google/cloud/teleport/templates/PubsubToBigQueryLT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/PubsubToBigQueryLT.java
@@ -45,11 +45,14 @@ import java.time.Duration;
 import java.util.function.Function;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Performance tests for {@link PubSubToBigQuery PubSub to BigQuery} template. */
+@Category(TemplateLoadTest.class)
 @TemplateLoadTest(PubSubToBigQuery.class)
 @RunWith(JUnit4.class)
 public class PubsubToBigQueryLT extends TemplateLoadTestBase {
@@ -81,11 +84,11 @@ public class PubsubToBigQueryLT extends TemplateLoadTestBase {
   @Before
   public void setup() throws IOException {
     pubsubResourceManager =
-        DefaultPubsubResourceManager.builder(testName, PROJECT)
+        DefaultPubsubResourceManager.builder(testName, project)
             .credentialsProvider(CREDENTIALS_PROVIDER)
             .build();
     bigQueryResourceManager =
-        DefaultBigQueryResourceManager.builder(testName, PROJECT)
+        DefaultBigQueryResourceManager.builder(testName, project)
             .setCredentials(CREDENTIALS)
             .build();
   }
@@ -100,6 +103,7 @@ public class PubsubToBigQueryLT extends TemplateLoadTestBase {
     testBacklog10gb(Function.identity());
   }
 
+  @Ignore
   @Test
   public void testBacklog10gbUsingStreamingEngine()
       throws IOException, ParseException, InterruptedException {
@@ -111,6 +115,7 @@ public class PubsubToBigQueryLT extends TemplateLoadTestBase {
     testSteadyState1hr(Function.identity());
   }
 
+  @Ignore
   @Test
   public void testSteadyState1hrUsingStreamingEngine()
       throws ParseException, IOException, InterruptedException {
@@ -140,11 +145,11 @@ public class PubsubToBigQueryLT extends TemplateLoadTestBase {
                 LaunchConfig.builder(testName, SPEC_PATH)
                     .addEnvironment("maxWorkers", 100)
                     .addParameter("inputSubscription", backlogSubscription.toString())
-                    .addParameter("outputTableSpec", toTableSpec(PROJECT, table)))
+                    .addParameter("outputTableSpec", toTableSpec(project, table)))
             .build();
 
     // Act
-    LaunchInfo info = pipelineLauncher.launch(PROJECT, REGION, options);
+    LaunchInfo info = pipelineLauncher.launch(project, region, options);
     assertThatPipeline(info).isRunning();
     Result result =
         pipelineOperator.waitForConditionAndFinish(
@@ -182,11 +187,11 @@ public class PubsubToBigQueryLT extends TemplateLoadTestBase {
                 LaunchConfig.builder(testName, SPEC_PATH)
                     .addEnvironment("maxWorkers", 100)
                     .addParameter("inputSubscription", inputSubscription.toString())
-                    .addParameter("outputTableSpec", toTableSpec(PROJECT, table)))
+                    .addParameter("outputTableSpec", toTableSpec(project, table)))
             .build();
 
     // Act
-    LaunchInfo info = pipelineLauncher.launch(PROJECT, REGION, options);
+    LaunchInfo info = pipelineLauncher.launch(project, region, options);
     assertThatPipeline(info).isRunning();
     // ElementCount metric in dataflow is approximate, allow for 1% difference
     Integer expectedMessages = (int) (dataGenerator.execute(Duration.ofMinutes(60)) * 0.99);

--- a/v1/src/test/java/com/google/cloud/teleport/templates/PubsubToPubsubLT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/PubsubToPubsubLT.java
@@ -79,7 +79,7 @@ public class PubsubToPubsubLT extends TemplateLoadTestBase {
     testBacklog10gb(Function.identity());
   }
 
-  @Ignore
+  @Ignore("Ignore Streaming Engine tests by default.")
   @Test
   public void testBacklog10gbUsingStreamingEngine()
       throws IOException, ParseException, InterruptedException {
@@ -91,7 +91,7 @@ public class PubsubToPubsubLT extends TemplateLoadTestBase {
     testSteadyState1hr(Function.identity());
   }
 
-  @Ignore
+  @Ignore("Ignore Streaming Engine tests by default.")
   @Test
   public void testSteadyState1hrUsingStreamingEngine()
       throws IOException, ParseException, InterruptedException {

--- a/v1/src/test/java/com/google/cloud/teleport/templates/PubsubToPubsubLT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/PubsubToPubsubLT.java
@@ -37,13 +37,16 @@ import java.time.Duration;
 import java.util.function.Function;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Performance tests for {@link PubsubToPubsub PubSub to PubSub} template. */
+@Category(TemplateLoadTest.class)
 @TemplateLoadTest(PubsubToPubsub.class)
 @RunWith(JUnit4.class)
 public class PubsubToPubsubLT extends TemplateLoadTestBase {
@@ -61,7 +64,7 @@ public class PubsubToPubsubLT extends TemplateLoadTestBase {
   @Before
   public void setup() throws IOException {
     pubsubResourceManager =
-        DefaultPubsubResourceManager.builder(testName, PROJECT)
+        DefaultPubsubResourceManager.builder(testName, project)
             .credentialsProvider(CREDENTIALS_PROVIDER)
             .build();
   }
@@ -76,6 +79,7 @@ public class PubsubToPubsubLT extends TemplateLoadTestBase {
     testBacklog10gb(Function.identity());
   }
 
+  @Ignore
   @Test
   public void testBacklog10gbUsingStreamingEngine()
       throws IOException, ParseException, InterruptedException {
@@ -87,6 +91,7 @@ public class PubsubToPubsubLT extends TemplateLoadTestBase {
     testSteadyState1hr(Function.identity());
   }
 
+  @Ignore
   @Test
   public void testSteadyState1hrUsingStreamingEngine()
       throws IOException, ParseException, InterruptedException {
@@ -122,7 +127,7 @@ public class PubsubToPubsubLT extends TemplateLoadTestBase {
             .build();
 
     // Act
-    LaunchInfo info = pipelineLauncher.launch(PROJECT, REGION, options);
+    LaunchInfo info = pipelineLauncher.launch(project, region, options);
     assertThatPipeline(info).isRunning();
     Result result =
         pipelineOperator.waitForConditionAndFinish(
@@ -130,7 +135,7 @@ public class PubsubToPubsubLT extends TemplateLoadTestBase {
             () -> {
               Long currentMessages =
                   monitoringClient.getNumMessagesInSubscription(
-                      PROJECT, outputSubscription.getSubscription());
+                      project, outputSubscription.getSubscription());
               LOG.info(
                   "Found {} messages in output subscription, expected {} messages.",
                   currentMessages,
@@ -171,7 +176,7 @@ public class PubsubToPubsubLT extends TemplateLoadTestBase {
             .build();
 
     // Act
-    LaunchInfo info = pipelineLauncher.launch(PROJECT, REGION, options);
+    LaunchInfo info = pipelineLauncher.launch(project, region, options);
     assertThatPipeline(info).isRunning();
     // ElementCount metric in dataflow is approximate, allow for 1% difference
     Integer expectedMessages = (int) (dataGenerator.execute(Duration.ofMinutes(60)) * 0.99);
@@ -181,7 +186,7 @@ public class PubsubToPubsubLT extends TemplateLoadTestBase {
             () -> {
               Long currentMessages =
                   monitoringClient.getNumMessagesInSubscription(
-                      PROJECT, outputSubscription.getSubscription());
+                      project, outputSubscription.getSubscription());
               LOG.info(
                   "Found {} messages in output subscription, expected {} messages.",
                   currentMessages,

--- a/v1/src/test/java/com/google/cloud/teleport/templates/SpannerToTextLT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/SpannerToTextLT.java
@@ -42,10 +42,12 @@ import java.util.function.Function;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Performance test for {@link SpannerToText Spanner to GCS Text} template. */
+@Category(TemplateLoadTest.class)
 @TemplateLoadTest(SpannerToText.class)
 @RunWith(JUnit4.class)
 public class SpannerToTextLT extends TemplateLoadTestBase {
@@ -67,7 +69,7 @@ public class SpannerToTextLT extends TemplateLoadTestBase {
   public void setup() throws IOException {
     // Set up resource managers
     spannerResourceManager =
-        DefaultSpannerResourceManager.builder(testName, PROJECT, REGION).build();
+        DefaultSpannerResourceManager.builder(testName, project, region).build();
     Storage storageClient = createStorageClient(CREDENTIALS);
     gcsClient = GcsArtifactClient.builder(storageClient, ARTIFACT_BUCKET, TEST_ROOT_DIR).build();
   }
@@ -107,7 +109,7 @@ public class SpannerToTextLT extends TemplateLoadTestBase {
             .setQPS("1000000")
             .setMessagesLimit(NUM_MESSAGES)
             .setSinkType("SPANNER")
-            .setProjectId(PROJECT)
+            .setProjectId(project)
             .setSpannerInstanceName(spannerResourceManager.getInstanceId())
             .setSpannerDatabaseName(spannerResourceManager.getDatabaseId())
             .setSpannerTableName(name)
@@ -119,7 +121,7 @@ public class SpannerToTextLT extends TemplateLoadTestBase {
         paramsAdder
             .apply(
                 LaunchConfig.builder(testName, SPEC_PATH)
-                    .addParameter("spannerProjectId", PROJECT)
+                    .addParameter("spannerProjectId", project)
                     .addParameter("spannerInstanceId", spannerResourceManager.getInstanceId())
                     .addParameter("spannerDatabaseId", spannerResourceManager.getDatabaseId())
                     .addParameter("spannerTable", name)
@@ -127,7 +129,7 @@ public class SpannerToTextLT extends TemplateLoadTestBase {
             .build();
 
     // Act
-    LaunchInfo info = pipelineLauncher.launch(PROJECT, REGION, options);
+    LaunchInfo info = pipelineLauncher.launch(project, region, options);
     assertThatPipeline(info).isRunning();
     Result result = pipelineOperator.waitUntilDone(createConfig(info, Duration.ofMinutes(60)));
 

--- a/v1/src/test/resources/AvroToBigtableLT/schema.json
+++ b/v1/src/test/resources/AvroToBigtableLT/schema.json
@@ -1,5 +1,5 @@
 {
-  "key": "server{{integer(1,50)}}",
+  "key": "server{{integer(1,500)}}",
   "cells": [{
       "family": "SystemMetrics",
       "qualifier": "{{random("cpu", "memory")}}",

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryIT.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates;
+
+import static com.google.cloud.teleport.it.matchers.TemplateAsserts.assertThatPipeline;
+import static com.google.cloud.teleport.it.matchers.TemplateAsserts.assertThatResult;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.teleport.it.TemplateTestBase;
+import com.google.cloud.teleport.it.bigquery.BigQueryResourceManager;
+import com.google.cloud.teleport.it.bigquery.DefaultBigQueryResourceManager;
+import com.google.cloud.teleport.it.common.ResourceManagerUtils;
+import com.google.cloud.teleport.it.jdbc.DefaultPostgresResourceManager;
+import com.google.cloud.teleport.it.jdbc.JDBCResourceManager;
+import com.google.cloud.teleport.it.jdbc.JDBCResourceManager.JDBCSchema;
+import com.google.cloud.teleport.it.launcher.PipelineLauncher.LaunchConfig;
+import com.google.cloud.teleport.it.launcher.PipelineLauncher.LaunchInfo;
+import com.google.cloud.teleport.it.launcher.PipelineOperator.Result;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class JdbcToBigQueryIT extends TemplateTestBase {
+
+  private static final String QUERY = "select * from %s";
+  private static final String DRIVER_CLASS_NAME = "org.postgresql.Driver";
+  private static JDBCResourceManager jdbcResourceManager;
+  private static BigQueryResourceManager bigQueryResourceManager;
+
+  @Before
+  public void setup() {
+    jdbcResourceManager =
+        DefaultPostgresResourceManager.builder(testName)
+            // Have to manually set username and password since sometimes, the password characters
+            // are not supported by the driver
+            .setUsername("test")
+            .setPassword("Password")
+            .setHost(HOST_IP)
+            .build();
+    bigQueryResourceManager =
+        DefaultBigQueryResourceManager.builder(testName, PROJECT)
+            .setCredentials(credentials)
+            .build();
+  }
+
+  @After
+  public void teardown() {
+    ResourceManagerUtils.cleanResources(jdbcResourceManager, bigQueryResourceManager);
+  }
+
+  @Test
+  public void testJdbcToBigQuery() throws IOException {
+    JDBCSchema jdbcSchema =
+        new JDBCSchema(
+            Map.of(
+                "id", "INTEGER",
+                "name", "VARCHAR(100)"),
+            "id");
+    jdbcResourceManager.createTable(testName, jdbcSchema);
+    jdbcResourceManager.write(
+        testName, Map.of(1, List.of("Jake Peralta"), 2, List.of("Amy Santiago")));
+    Schema bqSchema =
+        Schema.of(
+            Field.of("id", StandardSQLTypeName.INT64),
+            Field.of("name", StandardSQLTypeName.STRING));
+    TableId table = bigQueryResourceManager.createTable(testName, bqSchema);
+    LaunchConfig.Builder options =
+        LaunchConfig.builder(testName, specPath)
+            // TODO(pranavbhandari): Change this, find a way to not hardcode
+            .addParameter("driverJars", "gs://cloud-teleport-testing-it/postgresql-42.2.27.jar")
+            .addParameter("driverClassName", DRIVER_CLASS_NAME)
+            .addParameter("username", jdbcResourceManager.getUsername())
+            .addParameter("password", jdbcResourceManager.getPassword())
+            .addParameter("connectionURL", jdbcResourceManager.getUri())
+            .addParameter("query", String.format(QUERY, testName))
+            .addParameter("outputTable", toTableSpecLegacy(table))
+            .addParameter("bigQueryLoadingTemporaryDirectory", getGcsPath(testName));
+
+    // Act
+    LaunchInfo info = launchTemplate(options);
+    assertThatPipeline(info).isRunning();
+    Result result = pipelineOperator().waitUntilDone(createConfig(info));
+
+    // Assert
+    assertThatResult(result).isLaunchFinished();
+    assertThat(bigQueryResourceManager.getRowCount(table.getTable())).isAtLeast(2);
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/TextIOtoBigQueryLT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/TextIOtoBigQueryLT.java
@@ -106,14 +106,14 @@ public class TextIOtoBigQueryLT extends TemplateLoadTestBase {
     testBacklog10gb(Function.identity());
   }
 
-  @Ignore
+  @Ignore("Test fails, sickbay")
   @Test
   public void testBacklog10gbUsingRunnerV2()
       throws IOException, ParseException, InterruptedException {
     testBacklog10gb(config -> config.addParameter("experiments", "use_runner_v2"));
   }
 
-  @Ignore
+  @Ignore("Test fails, sickbay")
   @Test
   public void testBacklog10gbUsingPrime() throws IOException, ParseException, InterruptedException {
     testBacklog10gb(config -> config.addParameter("experiments", "enable_prime"));

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/TextIOtoBigQueryLT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/TextIOtoBigQueryLT.java
@@ -47,11 +47,14 @@ import java.time.Duration;
 import java.util.function.Function;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Performance test for {@link TextIOToBigQuery TextIOToBigQuery} template. */
+@Category(TemplateLoadTest.class)
 @TemplateLoadTest(TextIOToBigQuery.class)
 @RunWith(JUnit4.class)
 public class TextIOtoBigQueryLT extends TemplateLoadTestBase {
@@ -88,7 +91,7 @@ public class TextIOtoBigQueryLT extends TemplateLoadTestBase {
     Storage gcsClient = createStorageClient(CREDENTIALS);
     artifactClient = GcsArtifactClient.builder(gcsClient, ARTIFACT_BUCKET, TEST_ROOT_DIR).build();
     bigQueryResourceManager =
-        DefaultBigQueryResourceManager.builder(testName, PROJECT)
+        DefaultBigQueryResourceManager.builder(testName, project)
             .setCredentials(CREDENTIALS)
             .build();
   }
@@ -103,12 +106,14 @@ public class TextIOtoBigQueryLT extends TemplateLoadTestBase {
     testBacklog10gb(Function.identity());
   }
 
+  @Ignore
   @Test
   public void testBacklog10gbUsingRunnerV2()
       throws IOException, ParseException, InterruptedException {
     testBacklog10gb(config -> config.addParameter("experiments", "use_runner_v2"));
   }
 
+  @Ignore
   @Test
   public void testBacklog10gbUsingPrime() throws IOException, ParseException, InterruptedException {
     testBacklog10gb(config -> config.addParameter("experiments", "enable_prime"));
@@ -151,7 +156,7 @@ public class TextIOtoBigQueryLT extends TemplateLoadTestBase {
                 LaunchConfig.builder(testName, SPEC_PATH)
                     .addParameter("JSONPath", jsonPath)
                     .addParameter("inputFilePattern", getTestMethodDirPath() + "/*")
-                    .addParameter("outputTable", toTableSpec(PROJECT, table))
+                    .addParameter("outputTable", toTableSpec(project, table))
                     .addParameter("javascriptTextTransformGcsPath", udfPath)
                     .addParameter("javascriptTextTransformFunctionName", "identity")
                     .addParameter(
@@ -159,7 +164,7 @@ public class TextIOtoBigQueryLT extends TemplateLoadTestBase {
             .build();
 
     // Act
-    LaunchInfo info = pipelineLauncher.launch(PROJECT, REGION, options);
+    LaunchInfo info = pipelineLauncher.launch(project, region, options);
     assertThatPipeline(info).isRunning();
 
     Result result = pipelineOperator.waitUntilDone(createConfig(info, Duration.ofMinutes(30)));

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/pubsubtotext/PubsubToTextLT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/pubsubtotext/PubsubToTextLT.java
@@ -101,21 +101,21 @@ public final class PubsubToTextLT extends TemplateLoadTestBase {
     testBacklog10gb(Function.identity());
   }
 
-  @Ignore
+  @Ignore("Ignore Streaming Engine tests by default.")
   @Test
   public void testBacklog10gbUsingStreamingEngine()
       throws IOException, InterruptedException, ParseException {
     testBacklog10gb(config -> config.addEnvironment("enableStreamingEngine", true));
   }
 
-  @Ignore
+  @Ignore("Test fails, sickbay")
   @Test
   public void testBacklog10gbUsingRunnerV2()
       throws IOException, ParseException, InterruptedException {
     testBacklog10gb(config -> config.addParameter("experiments", "use_runner_v2"));
   }
 
-  @Ignore
+  @Ignore("Test fails, sickbay")
   @Test
   public void testBacklog10gbUsingPrime() throws IOException, ParseException, InterruptedException {
     testBacklog10gb(config -> config.addParameter("experiments", "enable_prime"));
@@ -126,21 +126,21 @@ public final class PubsubToTextLT extends TemplateLoadTestBase {
     testSteadyState1hr(Function.identity());
   }
 
-  @Ignore
+  @Ignore("Ignore Streaming Engine tests by default.")
   @Test
   public void testSteadyState1hrUsingStreamingEngine()
       throws IOException, InterruptedException, ParseException {
     testSteadyState1hr(config -> config.addEnvironment("enableStreamingEngine", true));
   }
 
-  @Ignore
+  @Ignore("Test fails, sickbay")
   @Test
   public void testSteadyState1hrUsingRunnerV2()
       throws IOException, ParseException, InterruptedException {
     testSteadyState1hr(config -> config.addParameter("experiments", "use_runner_v2"));
   }
 
-  @Ignore
+  @Ignore("Test fails, sickbay")
   @Test
   public void testSteadyState1hrUsingPrime()
       throws IOException, ParseException, InterruptedException {

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/pubsubtotext/PubsubToTextLT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/pubsubtotext/PubsubToTextLT.java
@@ -44,11 +44,14 @@ import java.time.Duration;
 import java.util.function.Function;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Performance tests for {@link PubsubToText PubSub to GCS Text} Flex template. */
+@Category(TemplateLoadTest.class)
 @TemplateLoadTest(PubsubToText.class)
 @RunWith(JUnit4.class)
 public final class PubsubToTextLT extends TemplateLoadTestBase {
@@ -81,7 +84,7 @@ public final class PubsubToTextLT extends TemplateLoadTestBase {
   public void setup() throws IOException {
     // Set up resource managers
     pubsubResourceManager =
-        DefaultPubsubResourceManager.builder(testName, PROJECT)
+        DefaultPubsubResourceManager.builder(testName, project)
             .credentialsProvider(CREDENTIALS_PROVIDER)
             .build();
     Storage storageClient = createStorageClient(CREDENTIALS);
@@ -98,18 +101,21 @@ public final class PubsubToTextLT extends TemplateLoadTestBase {
     testBacklog10gb(Function.identity());
   }
 
+  @Ignore
   @Test
   public void testBacklog10gbUsingStreamingEngine()
       throws IOException, InterruptedException, ParseException {
     testBacklog10gb(config -> config.addEnvironment("enableStreamingEngine", true));
   }
 
+  @Ignore
   @Test
   public void testBacklog10gbUsingRunnerV2()
       throws IOException, ParseException, InterruptedException {
     testBacklog10gb(config -> config.addParameter("experiments", "use_runner_v2"));
   }
 
+  @Ignore
   @Test
   public void testBacklog10gbUsingPrime() throws IOException, ParseException, InterruptedException {
     testBacklog10gb(config -> config.addParameter("experiments", "enable_prime"));
@@ -120,18 +126,21 @@ public final class PubsubToTextLT extends TemplateLoadTestBase {
     testSteadyState1hr(Function.identity());
   }
 
+  @Ignore
   @Test
   public void testSteadyState1hrUsingStreamingEngine()
       throws IOException, InterruptedException, ParseException {
     testSteadyState1hr(config -> config.addEnvironment("enableStreamingEngine", true));
   }
 
+  @Ignore
   @Test
   public void testSteadyState1hrUsingRunnerV2()
       throws IOException, ParseException, InterruptedException {
     testSteadyState1hr(config -> config.addParameter("experiments", "use_runner_v2"));
   }
 
+  @Ignore
   @Test
   public void testSteadyState1hrUsingPrime()
       throws IOException, ParseException, InterruptedException {
@@ -169,7 +178,7 @@ public final class PubsubToTextLT extends TemplateLoadTestBase {
             .build();
 
     // Act
-    LaunchInfo info = pipelineLauncher.launch(PROJECT, REGION, options);
+    LaunchInfo info = pipelineLauncher.launch(project, region, options);
     assertThatPipeline(info).isRunning();
     Result result =
         pipelineOperator.waitForConditionAndFinish(
@@ -211,7 +220,7 @@ public final class PubsubToTextLT extends TemplateLoadTestBase {
             .build();
 
     // Act
-    LaunchInfo info = pipelineLauncher.launch(PROJECT, REGION, options);
+    LaunchInfo info = pipelineLauncher.launch(project, region, options);
     assertThatPipeline(info).isRunning();
     // ElementCount metric in dataflow is approximate, allow for 1% difference
     long expectedMessages = (long) (dataGenerator.execute(Duration.ofMinutes(60)) * 0.99);

--- a/v2/streaming-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/StreamingDataGenerator.java
+++ b/v2/streaming-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/StreamingDataGenerator.java
@@ -60,9 +60,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The {@link StreamingDataGenerator} is a streaming pipeline which generates messages at a
- * specified rate to either Pub/Sub topic or BigQuery/GCS. The messages are generated according to a
- * schema template which instructs the pipeline how to populate the messages with fake data
- * compliant to constraints.
+ * specified rate to either Pub/Sub, BigQuery, GCS, JDBC, or Spanner. The messages are generated
+ * according to a schema template which instructs the pipeline how to populate the messages with
+ * fake data compliant to constraints.
  *
  * <p>The number of workers executing the pipeline must be large enough to support the supplied QPS.
  * Use a general rule of 2,500 QPS per core in the worker pool.

--- a/v2/streaming-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/StreamingDataGeneratorIT.java
+++ b/v2/streaming-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/StreamingDataGeneratorIT.java
@@ -28,6 +28,9 @@ import com.google.cloud.teleport.it.bigquery.BigQueryResourceManager;
 import com.google.cloud.teleport.it.bigquery.DefaultBigQueryResourceManager;
 import com.google.cloud.teleport.it.common.ResourceManagerUtils;
 import com.google.cloud.teleport.it.conditions.BigQueryRowsCheck;
+import com.google.cloud.teleport.it.jdbc.DefaultPostgresResourceManager;
+import com.google.cloud.teleport.it.jdbc.JDBCResourceManager;
+import com.google.cloud.teleport.it.jdbc.JDBCResourceManager.JDBCSchema;
 import com.google.cloud.teleport.it.launcher.PipelineLauncher.LaunchConfig;
 import com.google.cloud.teleport.it.launcher.PipelineLauncher.LaunchInfo;
 import com.google.cloud.teleport.it.launcher.PipelineOperator.Result;
@@ -45,6 +48,7 @@ import com.google.pubsub.v1.TopicName;
 import com.google.re2j.Pattern;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -82,11 +86,16 @@ public final class StreamingDataGeneratorIT extends TemplateTestBase {
   private PubsubResourceManager pubsubResourceManager;
   private BigQueryResourceManager bigQueryResourceManager;
   private SpannerResourceManager spannerResourceManager;
+  private JDBCResourceManager jdbcResourceManager;
 
   @After
   public void tearDown() {
     ResourceManagerUtils.cleanResources(
-        pubsubResourceManager, gcsClient, bigQueryResourceManager, spannerResourceManager);
+        pubsubResourceManager,
+        gcsClient,
+        bigQueryResourceManager,
+        spannerResourceManager,
+        jdbcResourceManager);
   }
 
   @Test
@@ -310,6 +319,53 @@ public final class StreamingDataGeneratorIT extends TemplateTestBase {
             .waitForConditionAndFinish(
                 createConfig(info),
                 () -> !spannerResourceManager.readTableRecords(testName, columnNames).isEmpty());
+
+    // Assert
+    assertThatResult(result).meetsConditions();
+  }
+
+  @Test
+  public void testFakeMessagesToJdbc() throws IOException {
+    jdbcResourceManager = DefaultPostgresResourceManager.builder(testName).setHost(HOST_IP).build();
+    JDBCSchema jdbcSchema =
+        new JDBCSchema(
+            Map.of(
+                "eventId", "VARCHAR(100)",
+                "eventTimestamp", "TIMESTAMP",
+                "ipv4", "VARCHAR(100)",
+                "ipv6", "VARCHAR(100)",
+                "country", "VARCHAR(100)",
+                "username", "VARCHAR(100)",
+                "quest", "VARCHAR(100)",
+                "score", "INTEGER",
+                "completed", "BOOLEAN"),
+            "eventId");
+    jdbcResourceManager.createTable(testName, jdbcSchema);
+    String statement =
+        String.format(
+            "INSERT INTO %s (eventId,eventTimestamp,ipv4,ipv6,country,username,quest,score,completed) VALUES (?,to_timestamp(?/1000),?,?,?,?,?,?,?)",
+            testName);
+    String driverClassName = "org.postgresql.Driver";
+
+    LaunchConfig.Builder options =
+        LaunchConfig.builder(testName, specPath)
+            .addParameter(SCHEMA_TEMPLATE_KEY, SchemaTemplate.GAME_EVENT.name())
+            .addParameter(QPS_KEY, DEFAULT_QPS)
+            .addParameter(SINK_TYPE_KEY, SinkType.JDBC.name())
+            .addParameter("driverClassName", driverClassName)
+            .addParameter("connectionUrl", jdbcResourceManager.getUri())
+            .addParameter("statement", statement)
+            .addParameter("username", jdbcResourceManager.getUsername())
+            .addParameter("password", jdbcResourceManager.getPassword());
+
+    // Act
+    LaunchInfo info = launchTemplate(options);
+    assertThatPipeline(info).isRunning();
+
+    Result result =
+        pipelineOperator()
+            .waitForConditionAndFinish(
+                createConfig(info), () -> !jdbcResourceManager.readTable(testName).isEmpty());
 
     // Assert
     assertThatResult(result).meetsConditions();


### PR DESCRIPTION
This PR does the following changes, 

* Add support for launching pipelines using Pipeline#run
* [Load test] Ignore Streaming Engine, Runner V2, and Dataflow Prime tests by default
* [Load test] Add Streaming Data Generator to JDBC Load test
* [Integration test] Add JDBC to BigQuery Integration test
* [Integration test] Add Streaming Data Generator to JDBC Integration test
* [Integration test] Add Word Count Integration test