### PR TITLE
Update syndeo pom file

### DIFF
--- a/syndeo-template/pom.xml
+++ b/syndeo-template/pom.xml
@@ -208,7 +208,6 @@
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-io-kafka</artifactId>
-            <version>${beam.snapshot.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -218,7 +217,6 @@
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-extensions-google-cloud-platform-core</artifactId>
-            <version>${beam.snapshot.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.beam</groupId>

--- a/syndeo-template/pom.xml
+++ b/syndeo-template/pom.xml
@@ -52,11 +52,11 @@
             <dependency>
                 <groupId>org.apache.beam</groupId>
                 <artifactId>beam-sdks-java-google-cloud-platform-bom</artifactId>
-                <version>${beam.version}</version>
+                <version>${beam.snapshot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
+            <!-- <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>google-cloud-pubsublite</artifactId>
                 <version>1.11.1</version>
@@ -70,7 +70,7 @@
                 <groupId>com.google.api.grpc</groupId>
                 <artifactId>proto-google-cloud-pubsublite-v1</artifactId>
                 <version>1.11.1</version>
-            </dependency>
+            </dependency> -->
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp-bom</artifactId>
@@ -208,6 +208,7 @@
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-io-kafka</artifactId>
+            <version>${beam.snapshot.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -217,6 +218,7 @@
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-extensions-google-cloud-platform-core</artifactId>
+            <version>${beam.snapshot.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.beam</groupId>


### PR DESCRIPTION
Update the syndeo pom to point to Beam 2.48-SNAPSHOT. Also remove explicit dependency of pubsub Lite so to use the bom defined version. These changes are mainly needed to update the latest grpc vendor change in Beam 2.48-SNAPSHOT.

The commented out test needs an update from @Dippatel98 as the OutgoingMessages.of() function interface has changed from a recent update.