### PR TITLE
Add default HOST_IP behavior to base Testcontainer class

### DIFF
--- a/it/common/src/test/java/com/google/cloud/teleport/it/common/testcontainers/TestContainerResourceManagerTest.java
+++ b/it/common/src/test/java/com/google/cloud/teleport/it/common/testcontainers/TestContainerResourceManagerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.teleport.it.common.TestProperties;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,7 +42,7 @@ public class TestContainerResourceManagerTest {
   @Mock private GenericContainer<?> container;
 
   private static final String TEST_ID = "test-id";
-  private static final String HOST = "localhost";
+  private static final String HOST = "1.2.3.4";
   private static final int PORT = 10000;
 
   private TestContainerResourceManager.Builder<TestContainerResourceManagerImpl> testManagerBuilder;
@@ -113,12 +114,10 @@ public class TestContainerResourceManagerTest {
 
   @Test
   public void testGetHostShouldReturnCorrectHostWhenHostNotSet() {
-    String testHost = "testHost";
-    when(container.getHost()).thenReturn(testHost);
-
+    String host = TestProperties.hostIp();
     TestContainerResourceManager<?> testManager = testManagerBuilder.build();
 
-    assertThat(testManager.getHost()).matches(testHost);
+    assertThat(testManager.getHost()).matches(host);
   }
 
   @Test

--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/LoadTestBase.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/LoadTestBase.java
@@ -71,7 +71,6 @@ public abstract class LoadTestBase {
       FixedCredentialsProvider.create(CREDENTIALS);
   protected static String project;
   protected static String region;
-  protected static String hostIp;
   protected static MonitoringClient monitoringClient;
   protected static PipelineLauncher pipelineLauncher;
   protected static PipelineOperator pipelineOperator;
@@ -92,7 +91,6 @@ public abstract class LoadTestBase {
   public static void setUpLoadTestBase() {
     project = TestProperties.project();
     region = TestProperties.region();
-    hostIp = TestProperties.hostIp();
   }
 
   @Before

--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/TemplateTestBase.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/TemplateTestBase.java
@@ -92,7 +92,6 @@ public abstract class TemplateTestBase {
 
   protected static final String PROJECT = TestProperties.project();
   protected static final String REGION = TestProperties.region();
-  protected static final String HOST_IP = TestProperties.hostIp();
 
   protected String specPath;
   protected Credentials credentials;

--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/pubsub/DefaultPubsubResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/pubsub/DefaultPubsubResourceManager.java
@@ -268,6 +268,7 @@ public final class DefaultPubsubResourceManager implements PubsubResourceManager
     } finally {
       subscriptionAdminClient.close();
       topicAdminClient.close();
+      schemaServiceClient.close();
     }
 
     LOG.info("Manager successfully cleaned up.");

--- a/it/kafka/src/test/java/com/google/cloud/teleport/it/kafka/KafkaIOLT.java
+++ b/it/kafka/src/test/java/com/google/cloud/teleport/it/kafka/KafkaIOLT.java
@@ -72,7 +72,7 @@ public final class KafkaIOLT extends IOLoadTestBase {
 
   @BeforeClass
   public static void beforeClass() throws IOException {
-    resourceManager = DefaultKafkaResourceManager.builder("io-kafka-lt").setHost(hostIp).build();
+    resourceManager = DefaultKafkaResourceManager.builder("io-kafka-lt").build();
   }
 
   @Before

--- a/v1/src/test/java/com/google/cloud/teleport/bigtable/CassandraToBigtableIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/bigtable/CassandraToBigtableIT.java
@@ -53,8 +53,7 @@ public class CassandraToBigtableIT extends TemplateTestBase {
 
   @Before
   public void setup() throws IOException {
-    cassandraResourceManager =
-        DefaultCassandraResourceManager.builder(testName).setHost(HOST_IP).build();
+    cassandraResourceManager = DefaultCassandraResourceManager.builder(testName).build();
     bigtableResourceManager =
         DefaultBigtableResourceManager.builder(testName, PROJECT)
             .setCredentialsProvider(credentialsProvider)

--- a/v1/src/test/java/com/google/cloud/teleport/templates/JdbcToBigQueryIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/JdbcToBigQueryIT.java
@@ -92,13 +92,10 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
 
   @Test
   public void testMySqlToBigQueryClassic() throws IOException {
-    // Create mySql Resource manager
-    mySQLResourceManager =
-        ((DefaultMySQLResourceManager.Builder)
-                DefaultMySQLResourceManager.builder(testName).setHost(HOST_IP))
-            .build();
+    // Create MySQL Resource manager
+    mySQLResourceManager = DefaultMySQLResourceManager.builder(testName).build();
 
-    // Arrange mySql-compatible schema
+    // Arrange MySQL-compatible schema
     HashMap<String, String> columns = new HashMap<>();
     columns.put(ROW_ID, "NUMERIC NOT NULL");
     columns.put(NAME, "VARCHAR(200)");
@@ -120,10 +117,7 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
   @Test
   public void testPostgresToBigQueryClassic() throws IOException {
     // Create postgres Resource manager
-    postgresResourceManager =
-        ((DefaultPostgresResourceManager.Builder)
-                DefaultPostgresResourceManager.builder(testName).setHost(HOST_IP))
-            .build();
+    postgresResourceManager = DefaultPostgresResourceManager.builder(testName).build();
 
     HashMap<String, String> columns = new HashMap<>();
     columns.put(ROW_ID, "INTEGER NOT NULL");
@@ -152,10 +146,7 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
     }
 
     // Create oracle Resource manager
-    oracleResourceManager =
-        ((DefaultOracleResourceManager.Builder)
-                DefaultOracleResourceManager.builder(testName).setHost(HOST_IP))
-            .build();
+    oracleResourceManager = DefaultOracleResourceManager.builder(testName).build();
 
     // Arrange oracle-compatible schema
     HashMap<String, String> columns = new HashMap<>();
@@ -179,10 +170,7 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
   @Test
   public void testMsSqlToBigQueryClassic() throws IOException {
     // Create msSql Resource manager
-    msSQLResourceManager =
-        ((DefaultMSSQLResourceManager.Builder)
-                DefaultMSSQLResourceManager.builder(testName).setHost(HOST_IP))
-            .build();
+    msSQLResourceManager = DefaultMSSQLResourceManager.builder(testName).build();
 
     // Arrange msSql-compatible schema
     HashMap<String, String> columns = new HashMap<>();
@@ -206,10 +194,7 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
   @Test
   public void testPostgresToBigQueryGcsQuery() throws IOException {
     // Create postgres Resource manager
-    postgresResourceManager =
-        ((DefaultPostgresResourceManager.Builder)
-                DefaultPostgresResourceManager.builder(testName).setHost(HOST_IP))
-            .build();
+    postgresResourceManager = DefaultPostgresResourceManager.builder(testName).build();
     gcsClient.createArtifact("input/query.sql", "SELECT * FROM " + testName);
 
     HashMap<String, String> columns = new HashMap<>();

--- a/v2/googlecloud-to-elasticsearch/src/test/java/com/google/cloud/teleport/v2/elasticsearch/templates/BigQueryToElasticsearchIT.java
+++ b/v2/googlecloud-to-elasticsearch/src/test/java/com/google/cloud/teleport/v2/elasticsearch/templates/BigQueryToElasticsearchIT.java
@@ -76,8 +76,7 @@ public final class BigQueryToElasticsearchIT extends TemplateTestBase {
         DefaultBigQueryResourceManager.builder(testName, PROJECT)
             .setCredentials(credentials)
             .build();
-    elasticsearchResourceManager =
-        DefaultElasticsearchResourceManager.builder(testId).setHost(HOST_IP).build();
+    elasticsearchResourceManager = DefaultElasticsearchResourceManager.builder(testId).build();
   }
 
   @After

--- a/v2/googlecloud-to-elasticsearch/src/test/java/com/google/cloud/teleport/v2/elasticsearch/templates/GCSToElasticsearchIT.java
+++ b/v2/googlecloud-to-elasticsearch/src/test/java/com/google/cloud/teleport/v2/elasticsearch/templates/GCSToElasticsearchIT.java
@@ -57,8 +57,7 @@ public final class GCSToElasticsearchIT extends TemplateTestBase {
         DefaultBigQueryResourceManager.builder(testName, PROJECT)
             .setCredentials(credentials)
             .build();
-    elasticsearchResourceManager =
-        DefaultElasticsearchResourceManager.builder(testId).setHost(HOST_IP).build();
+    elasticsearchResourceManager = DefaultElasticsearchResourceManager.builder(testId).build();
   }
 
   @After

--- a/v2/googlecloud-to-elasticsearch/src/test/java/com/google/cloud/teleport/v2/elasticsearch/templates/PubSubToElasticsearchIT.java
+++ b/v2/googlecloud-to-elasticsearch/src/test/java/com/google/cloud/teleport/v2/elasticsearch/templates/PubSubToElasticsearchIT.java
@@ -64,8 +64,7 @@ public final class PubSubToElasticsearchIT extends TemplateTestBase {
         DefaultPubsubResourceManager.builder(testName, PROJECT)
             .credentialsProvider(credentialsProvider)
             .build();
-    elasticsearchResourceManager =
-        DefaultElasticsearchResourceManager.builder(testId).setHost(HOST_IP).build();
+    elasticsearchResourceManager = DefaultElasticsearchResourceManager.builder(testId).build();
   }
 
   @After

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryIT.java
@@ -93,10 +93,7 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
   @Test
   public void testMySqlToBigQueryFlex() throws IOException {
     // Create MySQL Resource manager
-    mySQLResourceManager =
-        ((DefaultMySQLResourceManager.Builder)
-                DefaultMySQLResourceManager.builder(testName).setHost(HOST_IP))
-            .build();
+    mySQLResourceManager = DefaultMySQLResourceManager.builder(testName).build();
 
     // Arrange MySQL-compatible schema
     HashMap<String, String> columns = new HashMap<>();
@@ -120,10 +117,7 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
   @Test
   public void testPostgresToBigQueryFlex() throws IOException {
     // Create postgres Resource manager
-    postgresResourceManager =
-        ((DefaultPostgresResourceManager.Builder)
-                DefaultPostgresResourceManager.builder(testName).setHost(HOST_IP))
-            .build();
+    postgresResourceManager = DefaultPostgresResourceManager.builder(testName).build();
 
     HashMap<String, String> columns = new HashMap<>();
     columns.put(ROW_ID, "INTEGER NOT NULL");
@@ -152,10 +146,7 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
     }
 
     // Create oracle Resource manager
-    oracleResourceManager =
-        ((DefaultOracleResourceManager.Builder)
-                DefaultOracleResourceManager.builder(testName).setHost(HOST_IP))
-            .build();
+    oracleResourceManager = DefaultOracleResourceManager.builder(testName).build();
 
     // Arrange oracle-compatible schema
     HashMap<String, String> columns = new HashMap<>();
@@ -179,10 +170,7 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
   @Test
   public void testMsSqlToBigQueryFlex() throws IOException {
     // Create msSql Resource manager
-    msSQLResourceManager =
-        ((DefaultMSSQLResourceManager.Builder)
-                DefaultMSSQLResourceManager.builder(testName).setHost(HOST_IP))
-            .build();
+    msSQLResourceManager = DefaultMSSQLResourceManager.builder(testName).build();
 
     // Arrange msSql-compatible schema
     HashMap<String, String> columns = new HashMap<>();

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToPubsubIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToPubsubIT.java
@@ -81,10 +81,7 @@ public class JdbcToPubsubIT extends JDBCBaseIT {
   @Test
   public void testJdbcToPubsub() throws IOException {
     // Arrange
-    mysqlResourceManager =
-        ((DefaultMySQLResourceManager.Builder)
-                DefaultMySQLResourceManager.builder(testName).setHost(HOST_IP))
-            .build();
+    mysqlResourceManager = DefaultMySQLResourceManager.builder(testName).build();
 
     // Arrange MySQL-compatible schema
     HashMap<String, String> columns = new HashMap<>();

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/PubsubToJdbcIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/PubsubToJdbcIT.java
@@ -66,10 +66,7 @@ public final class PubsubToJdbcIT extends JDBCBaseIT {
         DefaultPubsubResourceManager.builder(testName, PROJECT)
             .credentialsProvider(credentialsProvider)
             .build();
-    jdbcResourceManager =
-        ((DefaultMySQLResourceManager.Builder)
-                DefaultMySQLResourceManager.builder(testName).setHost(HOST_IP))
-            .build();
+    jdbcResourceManager = DefaultMySQLResourceManager.builder(testName).build();
   }
 
   @After

--- a/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryIT.java
+++ b/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryIT.java
@@ -73,7 +73,7 @@ public final class KafkaToBigQueryIT extends TemplateTestBase {
             .build();
     bigQueryClient.createDataset(REGION);
 
-    kafkaResourceManager = DefaultKafkaResourceManager.builder(testName).setHost(HOST_IP).build();
+    kafkaResourceManager = DefaultKafkaResourceManager.builder(testName).build();
   }
 
   @After

--- a/v2/mongodb-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQueryIT.java
+++ b/v2/mongodb-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQueryIT.java
@@ -111,7 +111,7 @@ public final class MongoDbToBigQueryIT extends TemplateTestBase {
 
   @Before
   public void setup() throws IOException {
-    mongoDbClient = DefaultMongoDBResourceManager.builder(testName).setHost(HOST_IP).build();
+    mongoDbClient = DefaultMongoDBResourceManager.builder(testName).build();
     bigQueryClient =
         DefaultBigQueryResourceManager.builder(testName, PROJECT)
             .setCredentials(credentials)

--- a/v2/mqtt-to-pubsub/src/test/java/com/google/cloud/teleport/v2/templates/MqttToPubsubTestIT.java
+++ b/v2/mqtt-to-pubsub/src/test/java/com/google/cloud/teleport/v2/templates/MqttToPubsubTestIT.java
@@ -20,6 +20,7 @@ import static com.google.cloud.teleport.it.common.matchers.TemplateAsserts.asser
 
 import com.google.cloud.teleport.it.common.PipelineLauncher;
 import com.google.cloud.teleport.it.common.PipelineOperator;
+import com.google.cloud.teleport.it.common.TestProperties;
 import com.google.cloud.teleport.it.gcp.TemplateTestBase;
 import com.google.cloud.teleport.it.gcp.pubsub.DefaultPubsubResourceManager;
 import com.google.cloud.teleport.it.gcp.pubsub.PubsubResourceManager;
@@ -111,7 +112,9 @@ public class MqttToPubsubTestIT extends TemplateTestBase {
 
     PipelineLauncher.LaunchConfig.Builder options =
         PipelineLauncher.LaunchConfig.builder(jobName, specPath)
-            .addParameter("brokerServer", "tcp://" + HOST_IP + ":" + hiveMQContainer.getMqttPort())
+            .addParameter(
+                "brokerServer",
+                "tcp://" + TestProperties.hostIp() + ":" + hiveMQContainer.getMqttPort())
             .addParameter("inputTopic", inputTopic)
             .addParameter("outputTopic", topicName.toString())
             .addParameter("username", "")

--- a/v2/pubsub-to-kafka/src/test/java/com/google/cloud/teleport/v2/templates/PubsubToKafkaIT.java
+++ b/v2/pubsub-to-kafka/src/test/java/com/google/cloud/teleport/v2/templates/PubsubToKafkaIT.java
@@ -74,7 +74,7 @@ public final class PubsubToKafkaIT extends TemplateTestBase {
             .credentialsProvider(credentialsProvider)
             .build();
 
-    kafkaResourceManager = DefaultKafkaResourceManager.builder(testName).setHost(HOST_IP).build();
+    kafkaResourceManager = DefaultKafkaResourceManager.builder(testName).build();
   }
 
   @After

--- a/v2/streaming-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/StreamingDataGeneratorIT.java
+++ b/v2/streaming-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/StreamingDataGeneratorIT.java
@@ -328,7 +328,7 @@ public final class StreamingDataGeneratorIT extends TemplateTestBase {
 
   @Test
   public void testFakeMessagesToJdbc() throws IOException {
-    jdbcResourceManager = DefaultPostgresResourceManager.builder(testName).setHost(HOST_IP).build();
+    jdbcResourceManager = DefaultPostgresResourceManager.builder(testName).build();
     JDBCSchema jdbcSchema =
         new JDBCSchema(
             Map.of(

--- a/v2/streaming-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/StreamingDataGeneratorLT.java
+++ b/v2/streaming-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/StreamingDataGeneratorLT.java
@@ -268,7 +268,7 @@ public class StreamingDataGeneratorLT extends TemplateLoadTestBase {
   @Test
   public void testGenerateJdbc10gb()
       throws IOException, ParseException, InterruptedException, SQLException {
-    jdbcResourceManager = DefaultPostgresResourceManager.builder(testName).setHost(hostIp).build();
+    jdbcResourceManager = DefaultPostgresResourceManager.builder(testName).build();
     JDBCSchema jdbcSchema =
         new JDBCSchema(
             Map.of(


### PR DESCRIPTION
Adds the default host ip configuration for Testcontainer-based RM's in the base class so that it does not need to be set by the builder in each IT.

Running `mvn verify` with the `-DhostIp` flag will set the default host ip. This is the exact same behavior before, but now the creator of a Testcontainer-based IT will not have to worry about host set-up.