### PR TITLE
Add Smoke Tests to gitactions

### DIFF
--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -76,9 +76,30 @@ jobs:
         run: ./cicd/run-unit-tests --changed-files="${{ steps.setup-env.outputs.changed-files }}"
       - name: Cleanup Java Environment
         uses: ./.github/actions/cleanup-java-env
+  java_integration_smoke_tests_templates:
+    name: Dataflow Templates Integration Smoke Tests
+    needs: [spotless_check, java_build, java_unit_tests]
+    timeout-minutes: 60
+    # Run on any runner that matches all the specified runs-on values.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2.6.0
+      - name: Setup Environment
+        id: setup-env
+        uses: ./.github/actions/setup-env
+      - name: Run Integration Smoke Tests
+        run: | 
+          ./cicd/run-it-smoke-tests \
+          --changed-files="${{ steps.setup-env.outputs.changed-files }}" \
+          --it-region="us-central1" \
+          --it-project="cloud-teleport-testing" \
+          --it-artifact-bucket="cloud-teleport-testing-it-gitactions"
+      - name: Cleanup Java Environment
+        uses: ./.github/actions/cleanup-java-env
   java_integration_tests_templates:
     name: Dataflow Templates Integration Tests
-    needs: [spotless_check, java_build, java_unit_tests]
+    needs: [java_integration_smoke_tests_templates]
     timeout-minutes: 180
     # Run on any runner that matches all the specified runs-on values.
     runs-on: [self-hosted, it]

--- a/cicd/cmd/run-it-smoke-tests/main.go
+++ b/cicd/cmd/run-it-smoke-tests/main.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ // The run-it-smoke-tests workflow runs all Direct Runner tests.
+package main
+
+import (
+	"flag"
+	"log"
+
+	"github.com/GoogleCloudPlatform/DataflowTemplates/cicd/internal/flags"
+	"github.com/GoogleCloudPlatform/DataflowTemplates/cicd/internal/workflows"
+)
+
+func main() {
+	flags.RegisterCommonFlags()
+	flags.RegisterItFlags()
+	flag.Parse()
+
+	// Run mvn install before running integration tests
+	mvnFlags := workflows.NewMavenFlags()
+	err := workflows.MvnCleanInstall().Run(
+		mvnFlags.IncludeDependencies(),
+		mvnFlags.IncludeDependents(),
+		mvnFlags.SkipDependencyAnalysis(),
+		mvnFlags.SkipCheckstyle(),
+		mvnFlags.SkipJib(),
+		mvnFlags.SkipTests(),
+		mvnFlags.SkipJacoco(),
+		mvnFlags.SkipShade(),
+		mvnFlags.ThreadCount(8))
+	if err != nil {
+		log.Fatalf("%v\n", err)
+	}
+
+	// Run integration tests
+	mvnFlags = workflows.NewMavenFlags()
+	err = workflows.MvnVerify().Run(
+		mvnFlags.IncludeDependencies(),
+		mvnFlags.IncludeDependents(),
+		mvnFlags.SkipDependencyAnalysis(),
+		mvnFlags.SkipCheckstyle(),
+		mvnFlags.SkipJib(),
+		mvnFlags.FailAtTheEnd(),
+		mvnFlags.RunIntegrationSmokeTests(),
+		mvnFlags.ThreadCount(8),
+		mvnFlags.IntegrationTestParallelism(4),
+		flags.Region(),
+		flags.Project(),
+		flags.ArtifactBucket(),
+		flags.StageBucket())
+	if err != nil {
+		log.Fatalf("%v\n", err)
+	}
+	log.Println("Build Successful!")
+}

--- a/cicd/internal/flags/it-flags.go
+++ b/cicd/internal/flags/it-flags.go
@@ -60,12 +60,12 @@ func StageBucket() string {
 }
 
 func HostIp() string {
-	if dHostIp == "" {
+	if len(dHostIp) == 0 {
 		gcloudCmd := "gcloud compute instances list | grep $(hostname) | awk '{print $4}'"
-		if hostIp, err := exec.Command("bash", "-c", gcloudCmd).Output(); err != nil {
+		if hostIP, err := exec.Command("bash", "-c", gcloudCmd).Output(); err != nil || len(hostIP) == 0 {
 			panic(fmt.Errorf("failed to get gitactions runner host ip: %v", err))
 		} else {
-			return "-DhostIp=" + string(hostIp)[:len(hostIp)-1]
+			return "-DhostIp=" + string(hostIP)[:len(hostIP)-1]
 		}
 	}
 	return "-DhostIp=" + dHostIp

--- a/cicd/internal/workflows/maven-workflows.go
+++ b/cicd/internal/workflows/maven-workflows.go
@@ -60,6 +60,7 @@ type MavenFlags interface {
 	SkipIntegrationTests() string
 	FailAtTheEnd() string
 	RunIntegrationTests() string
+	RunIntegrationSmokeTests() string
 	RunLoadTests() string
 	ThreadCount(int) string
 	IntegrationTestParallelism(int) string
@@ -109,6 +110,10 @@ func (*mvnFlags) FailAtTheEnd() string {
 
 func (*mvnFlags) RunIntegrationTests() string {
 	return "-PtemplatesIntegrationTests"
+}
+
+func (*mvnFlags) RunIntegrationSmokeTests() string {
+	return "-PtemplatesIntegrationSmokeTests"
 }
 
 func (*mvnFlags) RunLoadTests() string {

--- a/metadata/src/main/java/com/google/cloud/teleport/metadata/DirectRunnerTest.java
+++ b/metadata/src/main/java/com/google/cloud/teleport/metadata/DirectRunnerTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.metadata;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface DirectRunnerTest {}

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,9 @@
     <integration.tests>
       com.google.cloud.teleport.metadata.TemplateIntegrationTest
     </integration.tests>
+    <direct-runner.tests>
+      com.google.cloud.teleport.metadata.DirectRunnerTest
+    </direct-runner.tests>
     <excluded.spanner.tests></excluded.spanner.tests>
 
     <licenseHeaderFile>JAVA_LICENSE_HEADER</licenseHeaderFile>
@@ -288,7 +291,7 @@
               <includes>
                 <include>**/*IT.java</include>
               </includes>
-              <excludedGroups></excludedGroups>
+              <excludedGroups>${direct-runner.tests}</excludedGroups>
               <groups>
                 ${integration.tests}
                 com.google.cloud.teleport.it.testcontainers.TestContainersIntegrationTest
@@ -359,6 +362,7 @@
               </excludedGroups>
               <groups>
                 ${integration.tests}
+                ${direct-runner.tests}
               </groups>
               <systemProperties>
                 <!-- Pass on the flag directRunnerTest to the templates test base -->
@@ -367,6 +371,37 @@
                   <value>true</value>
                 </property>
               </systemProperties>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>templatesIntegrationSmokeTests</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <!-- Skip coverage checks, unit tests are skipped -->
+        <jacoco.skip>true</jacoco.skip>
+        <!-- Skip shade for faster runs -->
+        <skipShade>true</skipShade>
+        <!-- Some modules may yield no integration tests -->
+        <failIfNoTests>false</failIfNoTests>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${surefire.version}</version>
+            <configuration combine.self="override">
+              <includes>
+                <include>**/*IT.java</include>
+              </includes>
+              <groups>
+                ${direct-runner.tests}
+              </groups>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Adds `-PtemplatesIntegrationSmokeTests` maven profile to trigger IT's marked with `@Category(DirectRunnerTest.class)`.

This also adds a `java_integration_smoke_tests_templates` gitactions workflow to trigger direct runner smoke tests and verify they are successful before running the full `java_integration_tests_templates` suite on Dataflow.