### PR TITLE
Enable bytebuddy experimental when running tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,10 @@
           They can be run manually using 'mvn -Dexcluded.spanner.tests="" -Dtest=<testname> test' -->
           <excludedGroups>${integration.tests}</excludedGroups>
           <excludedGroups>${excluded.spanner.tests}</excludedGroups>
+          <systemPropertyVariables>
+            <!-- Allow this project to be tested with JDK 21 -->
+            <net.bytebuddy.experimental>true</net.bytebuddy.experimental>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This is required to run tests on JDK 21