### PR TITLE
Drop `@Experimental` annotation following Beam's decision

### DIFF
--- a/syndeo-template/pom.xml
+++ b/syndeo-template/pom.xml
@@ -17,8 +17,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <artifactId>syndeo-template</artifactId>
     <groupId>com.google.cloud.teleport.syndeo</groupId>
+    <artifactId>syndeo-template</artifactId>
     <version>1.0-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
 

--- a/syndeo-template/src/main/java/com/google/cloud/syndeo/transforms/TypedSchemaTransformProvider.java
+++ b/syndeo-template/src/main/java/com/google/cloud/syndeo/transforms/TypedSchemaTransformProvider.java
@@ -34,8 +34,6 @@ package com.google.cloud.syndeo.transforms;
 
 import java.util.List;
 import java.util.Optional;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.schemas.NoSuchSchemaException;
@@ -56,7 +54,6 @@ import org.apache.beam.sdk.values.Row;
  * compatibility guarantees and it should not be implemented outside of the Beam repository.
  */
 @Internal
-@Experimental(Kind.SCHEMAS)
 public abstract class TypedSchemaTransformProvider<ConfigT> implements SchemaTransformProvider {
 
   public abstract Class<ConfigT> configurationClass();

--- a/v1/src/main/java/com/google/cloud/teleport/kafka/connector/KafkaIO.java
+++ b/v1/src/main/java/com/google/cloud/teleport/kafka/connector/KafkaIO.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
@@ -223,7 +222,6 @@ import org.slf4j.LoggerFactory;
  * Kafka cluster. Kafka client usually fails to initialize with a clear error message in case of
  * incompatibility.
  */
-@Experimental(Experimental.Kind.SOURCE_SINK)
 public class KafkaIO {
 
   /**

--- a/v1/src/main/java/com/google/cloud/teleport/splunk/SplunkIO.java
+++ b/v1/src/main/java/com/google/cloud/teleport/splunk/SplunkIO.java
@@ -21,8 +21,6 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import com.google.auto.value.AutoValue;
 import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nullable;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.options.ValueProvider;
@@ -39,7 +37,6 @@ import org.slf4j.LoggerFactory;
  * The {@link SplunkIO} class provides a {@link PTransform} that allows writing {@link SplunkEvent}
  * messages into a Splunk HTTP Event Collector end point.
  */
-@Experimental(Kind.SOURCE_SINK)
 public class SplunkIO {
 
   private static final Logger LOG = LoggerFactory.getLogger(SplunkIO.class);

--- a/v1/src/main/java/org/apache/beam/sdk/io/gcp/spanner/LocalSpannerIO.java
+++ b/v1/src/main/java/org/apache/beam/sdk/io/gcp/spanner/LocalSpannerIO.java
@@ -64,8 +64,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.beam.runners.core.metrics.GcpResourceIdentifiers;
 import org.apache.beam.runners.core.metrics.MonitoringInfoConstants;
 import org.apache.beam.runners.core.metrics.ServiceCallMetric;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.ChangeStreamMetrics;

--- a/v1/src/main/java/org/apache/beam/sdk/io/gcp/spanner/LocalSpannerIO.java
+++ b/v1/src/main/java/org/apache/beam/sdk/io/gcp/spanner/LocalSpannerIO.java
@@ -358,7 +358,6 @@ import org.slf4j.LoggerFactory;
  * <p>{@link Write} can be used as a streaming sink, however as with batch mode note that the write
  * order of individual {@link Mutation}/{@link MutationGroup} objects is not guaranteed.
  */
-@Experimental(Kind.SOURCE_SINK)
 @SuppressWarnings({
   "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
 })
@@ -405,7 +404,6 @@ public class LocalSpannerIO {
    * TimestampBound#strong()} transaction is created, to override this use {@link
    * CreateTransaction#withTimestampBound(TimestampBound)}.
    */
-  @Experimental
   public static CreateTransaction createTransaction() {
     return new AutoValue_LocalSpannerIO_CreateTransaction.Builder()
         .setSpannerConfig(SpannerConfig.create())
@@ -418,7 +416,6 @@ public class LocalSpannerIO {
    * configured with a {@link Write#withInstanceId} and {@link Write#withDatabaseId} that identify
    * the Cloud Spanner database being written.
    */
-  @Experimental
   public static Write write() {
     return new AutoValue_LocalSpannerIO_Write.Builder()
         .setSpannerConfig(SpannerConfig.create())
@@ -436,7 +433,6 @@ public class LocalSpannerIO {
    * Cloud Spanner database being written. It must also be configured with the start time and the
    * change stream name.
    */
-  @Experimental
   public static ReadChangeStream readChangeStream() {
     return new AutoValue_LocalSpannerIO_ReadChangeStream.Builder()
         .setSpannerConfig(SpannerConfig.create())

--- a/v2/datastream-to-postgres/src/main/java/com/google/cloud/teleport/v2/io/CdcJdbcIO.java
+++ b/v2/datastream-to-postgres/src/main/java/com/google/cloud/teleport/v2/io/CdcJdbcIO.java
@@ -31,8 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.sql.DataSource;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
+import org.apache.beam.sdk.io.jdbc.JdbcIO;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -85,7 +84,6 @@ import org.slf4j.LoggerFactory;
  * Consider using <a href="https://en.wikipedia.org/wiki/Merge_(SQL)">MERGE ("upsert")
  * statements</a> supported by your database instead.
  */
-@Experimental(Kind.SOURCE_SINK)
 public class CdcJdbcIO {
 
   private static final Logger LOG = LoggerFactory.getLogger(CdcJdbcIO.class);

--- a/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/io/CdcJdbcIO.java
+++ b/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/io/CdcJdbcIO.java
@@ -31,8 +31,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.sql.DataSource;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -85,7 +83,6 @@ import org.slf4j.LoggerFactory;
  * Consider using <a href="https://en.wikipedia.org/wiki/Merge_(SQL)">MERGE ("upsert")
  * statements</a> supported by your database instead.
  */
-@Experimental(Kind.SOURCE_SINK)
 public class CdcJdbcIO {
 
   private static final Logger LOG = LoggerFactory.getLogger(CdcJdbcIO.class);

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
@@ -48,8 +48,6 @@ import java.util.NoSuchElementException;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.net.ssl.SSLContext;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.BoundedSource;
@@ -157,7 +155,6 @@ import org.slf4j.LoggerFactory;
  * socket timeout of 30000ms. {@code withConnectTimeout()} can be used to override the default
  * connect timeout of 1000ms.
  */
-@Experimental(Kind.SOURCE_SINK)
 @SuppressWarnings({
   "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
 })


### PR DESCRIPTION
Beam has removed `@Experimental` annotations https://github.com/apache/beam/pull/26490, and we are still using it.

Syndeo has failed compilation when fetching the latest snapshot, so making sure that we clean in the entire project to avoid this hitting us back when 2.48.0 is released.
