### PR TITLE
[Integration Tests] Rename 'createTable' function to 'executeDdlStatement'

### DIFF
--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/spanner/SpannerResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/spanner/SpannerResourceManager.java
@@ -191,33 +191,34 @@ public final class SpannerResourceManager implements ResourceManager {
   }
 
   /**
-   * Creates a table given a CREATE TABLE DDL statement.
+   * Executes a DDL statement.
    *
    * <p>Note: Implementations may do instance creation and database creation here.
    *
-   * @param statement The CREATE TABLE DDL statement.
+   * @param statement The DDL statement.
    * @throws IllegalStateException if method is called after resources have been cleaned up.
    */
-  public synchronized void createTable(String statement) throws IllegalStateException {
+  public synchronized void executeDdlStatement(String statement) throws IllegalStateException {
     checkIsUsable();
     maybeCreateInstance();
     maybeCreateDatabase();
 
-    LOG.info("Creating table in database {} using statement '{}'.", databaseId, statement);
+    LOG.info("Executing DDL statement '{}' on database {}.", statement, databaseId);
     try {
       databaseAdminClient
           .updateDatabaseDdl(
               instanceId, databaseId, ImmutableList.of(statement), /* operationId= */ null)
           .get();
-      LOG.info("Successfully created table in database {}.", databaseId);
+      LOG.info("Successfully executed DDL statement '{}' on database {}.", statement, databaseId);
     } catch (ExecutionException | InterruptedException | SpannerException e) {
-      throw new SpannerResourceManagerException("Failed to create table.", e);
+      throw new SpannerResourceManagerException("Failed to execute statement.", e);
     }
   }
 
   /**
    * Writes a given record into a table. This method requires {@link
-   * SpannerResourceManager#createTable(String)} to be called for the target table beforehand.
+   * SpannerResourceManager#executeDdlStatement(String)} to be called for the target table
+   * beforehand.
    *
    * @param tableRecord A mutation object representing the table record.
    * @throws IllegalStateException if method is called after resources have been cleaned up or if
@@ -229,7 +230,8 @@ public final class SpannerResourceManager implements ResourceManager {
 
   /**
    * Writes a collection of table records into one or more tables. This method requires {@link
-   * SpannerResourceManager#createTable(String)} to be called for the target table beforehand.
+   * SpannerResourceManager#executeDdlStatement(String)} to be called for the target table
+   * beforehand.
    *
    * @param tableRecords A collection of mutation objects representing table records.
    * @throws IllegalStateException if method is called after resources have been cleaned up or if
@@ -252,7 +254,8 @@ public final class SpannerResourceManager implements ResourceManager {
 
   /**
    * Reads all the rows in a table. This method requires {@link
-   * SpannerResourceManager#createTable(String)} to be called for the target table beforehand.
+   * SpannerResourceManager#executeDdlStatement(String)} to be called for the target table
+   * beforehand.
    *
    * @param tableId The id of the table to read rows from.
    * @param columnNames The table's column names.
@@ -267,7 +270,8 @@ public final class SpannerResourceManager implements ResourceManager {
 
   /**
    * Reads all the rows in a table.This method requires {@link
-   * SpannerResourceManager#createTable(String)} to be called for the target table beforehand.
+   * SpannerResourceManager#executeDdlStatement(String)} to be called for the target table
+   * beforehand.
    *
    * @param tableId The id of table to read rows from.
    * @param columnNames A collection of the table's column names.

--- a/it/google-cloud-platform/src/test/java/com/google/cloud/teleport/it/gcp/spanner/SpannerResourceManagerTest.java
+++ b/it/google-cloud-platform/src/test/java/com/google/cloud/teleport/it/gcp/spanner/SpannerResourceManagerTest.java
@@ -85,7 +85,7 @@ public final class SpannerResourceManagerTest {
   }
 
   @Test
-  public void testCreateTableShouldThrowExceptionWhenSpannerCreateInstanceFails()
+  public void testExecuteDdlStatementShouldThrowExceptionWhenSpannerCreateInstanceFails()
       throws ExecutionException, InterruptedException {
     // arrange
     when(spanner.getInstanceAdminClient().createInstance(any()).get())
@@ -100,11 +100,12 @@ public final class SpannerResourceManagerTest {
             + ") PRIMARY KEY (SingerId)";
 
     // act & assert
-    assertThrows(SpannerResourceManagerException.class, () -> testManager.createTable(statement));
+    assertThrows(
+        SpannerResourceManagerException.class, () -> testManager.executeDdlStatement(statement));
   }
 
   @Test
-  public void testCreateTableShouldThrowExceptionWhenSpannerCreateDatabaseFails()
+  public void testExecuteDdlStatementShouldThrowExceptionWhenSpannerCreateDatabaseFails()
       throws ExecutionException, InterruptedException {
     // arrange
     prepareCreateInstanceMock();
@@ -119,11 +120,12 @@ public final class SpannerResourceManagerTest {
             + ") PRIMARY KEY (SingerId)";
 
     // act & assert
-    assertThrows(SpannerResourceManagerException.class, () -> testManager.createTable(statement));
+    assertThrows(
+        SpannerResourceManagerException.class, () -> testManager.executeDdlStatement(statement));
   }
 
   @Test
-  public void testCreateTableShouldThrowExceptionWhenSpannerUpdateDatabaseFails()
+  public void testExecuteDdlStatementShouldThrowExceptionWhenSpannerUpdateDatabaseFails()
       throws ExecutionException, InterruptedException {
     // arrange
     prepareCreateInstanceMock();
@@ -138,11 +140,12 @@ public final class SpannerResourceManagerTest {
             + ") PRIMARY KEY (SingerId)";
 
     // act & assert
-    assertThrows(SpannerResourceManagerException.class, () -> testManager.createTable(statement));
+    assertThrows(
+        SpannerResourceManagerException.class, () -> testManager.executeDdlStatement(statement));
   }
 
   @Test
-  public void testCreateTableShouldWorkWhenSpannerDoesntThrowAnyError()
+  public void testExecuteDdlStatementShouldWorkWhenSpannerDoesntThrowAnyError()
       throws ExecutionException, InterruptedException {
     //   arrange
     prepareCreateInstanceMock();
@@ -156,7 +159,7 @@ public final class SpannerResourceManagerTest {
             + ") PRIMARY KEY (SingerId)";
 
     // act
-    testManager.createTable(statement);
+    testManager.executeDdlStatement(statement);
 
     // assert
     // verify createInstance, createDatabase, and updateDatabaseDdl were called twice - once in
@@ -205,7 +208,7 @@ public final class SpannerResourceManagerTest {
   }
 
   @Test
-  public void testWriteSingleRecordShouldThrowExceptionWhenCalledBeforeCreateTable() {
+  public void testWriteSingleRecordShouldThrowExceptionWhenCalledBeforeExecuteDdlStatement() {
     // arrange
     // spotless:off
     Mutation testMutation =
@@ -271,7 +274,7 @@ public final class SpannerResourceManagerTest {
   }
 
   @Test
-  public void testWriteMultipleRecordsShouldThrowExceptionWhenCalledBeforeCreateTable() {
+  public void testWriteMultipleRecordsShouldThrowExceptionWhenCalledBeforeExecuteDdlStatement() {
     // arrange
     // spotless:off
     ImmutableList<Mutation> testMutations =
@@ -378,7 +381,7 @@ public final class SpannerResourceManagerTest {
   }
 
   @Test
-  public void testReadRecordsShouldThrowExceptionWhenCalledBeforeCreateTable() {
+  public void testReadRecordsShouldThrowExceptionWhenCalledBeforeExecuteDdlStatement() {
     ImmutableList<String> columnNames = ImmutableList.of("SingerId");
 
     assertThrows(
@@ -456,7 +459,7 @@ public final class SpannerResourceManagerTest {
     ImmutableList<String> columnNames = ImmutableList.of("SingerId");
 
     // act & assert
-    assertThrows(IllegalStateException.class, () -> testManager.createTable(statement));
+    assertThrows(IllegalStateException.class, () -> testManager.executeDdlStatement(statement));
     assertThrows(
         IllegalStateException.class, () -> testManager.readTableRecords("Singers", "SingerId"));
     assertThrows(
@@ -482,6 +485,6 @@ public final class SpannerResourceManagerTest {
     prepareCreateInstanceMock();
     prepareCreateDatabaseMock();
     prepareUpdateDatabaseMock();
-    testManager.createTable("");
+    testManager.executeDdlStatement("");
   }
 }

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ExportPipelineIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ExportPipelineIT.java
@@ -112,8 +112,8 @@ public class ExportPipelineIT extends TemplateTestBase {
                 + ") PRIMARY KEY(Id)",
             testName);
 
-    googleSqlResourceManager.createTable(createEmptyTableStatement);
-    googleSqlResourceManager.createTable(createSingersTableStatement);
+    googleSqlResourceManager.executeDdlStatement(createEmptyTableStatement);
+    googleSqlResourceManager.executeDdlStatement(createSingersTableStatement);
     List<Mutation> expectedData = generateTableRows(String.format("%s_Singers", testName));
     googleSqlResourceManager.write(expectedData);
     PipelineLauncher.LaunchConfig.Builder options =
@@ -164,8 +164,8 @@ public class ExportPipelineIT extends TemplateTestBase {
                 + "PRIMARY KEY(\"Id\"))",
             testName);
 
-    postgresResourceManager.createTable(createEmptyTableStatement);
-    postgresResourceManager.createTable(createSingersTableStatement);
+    postgresResourceManager.executeDdlStatement(createEmptyTableStatement);
+    postgresResourceManager.executeDdlStatement(createSingersTableStatement);
     List<Mutation> expectedData = generateTableRows(String.format("%s_Singers", testName));
     postgresResourceManager.write(expectedData);
     PipelineLauncher.LaunchConfig.Builder options =

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ExportPipelineLT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ExportPipelineLT.java
@@ -103,7 +103,7 @@ public class ExportPipelineLT extends TemplateLoadTestBase {
                 + "  completed BOOL,\n"
                 + ") PRIMARY KEY(eventId)",
             name);
-    spannerResourceManager.createTable(createTableStatement);
+    spannerResourceManager.executeDdlStatement(createTableStatement);
     DataGenerator dataGenerator =
         DataGenerator.builderWithSchemaTemplate(testName, "GAME_EVENT")
             .setQPS("1000000")

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ImportPipelineIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ImportPipelineIT.java
@@ -103,7 +103,7 @@ public class ImportPipelineIT extends TemplateTestBase {
     uploadImportPipelineArtifacts("googlesql");
     String createEmptyTableStatement =
         "CREATE TABLE EmptyTable (\n" + "  id INT64 NOT NULL,\n" + ") PRIMARY KEY(id)";
-    googleSqlResourceManager.createTable(createEmptyTableStatement);
+    googleSqlResourceManager.executeDdlStatement(createEmptyTableStatement);
 
     String createSingersTableStatement =
         "CREATE TABLE Singers (\n"
@@ -111,7 +111,7 @@ public class ImportPipelineIT extends TemplateTestBase {
             + "  FirstName STRING(MAX),\n"
             + "  LastName STRING(MAX),\n"
             + ") PRIMARY KEY(Id)";
-    googleSqlResourceManager.createTable(createSingersTableStatement);
+    googleSqlResourceManager.executeDdlStatement(createSingersTableStatement);
 
     PipelineLauncher.LaunchConfig.Builder options =
         PipelineLauncher.LaunchConfig.builder(testName, specPath)
@@ -145,7 +145,7 @@ public class ImportPipelineIT extends TemplateTestBase {
     uploadImportPipelineArtifacts("postgres");
     String createEmptyTableStatement =
         "CREATE TABLE \"EmptyTable\" (\n" + "  id bigint NOT NULL,\nPRIMARY KEY(id)\n" + ")";
-    postgresResourceManager.createTable(createEmptyTableStatement);
+    postgresResourceManager.executeDdlStatement(createEmptyTableStatement);
 
     String createSingersTableStatement =
         "CREATE TABLE \"Singers\" (\n"
@@ -153,7 +153,7 @@ public class ImportPipelineIT extends TemplateTestBase {
             + "  \"FirstName\" character varying(256),\n"
             + "  \"LastName\" character varying(256),\n"
             + "PRIMARY KEY(\"Id\"))";
-    postgresResourceManager.createTable(createSingersTableStatement);
+    postgresResourceManager.executeDdlStatement(createSingersTableStatement);
 
     PipelineLauncher.LaunchConfig.Builder options =
         PipelineLauncher.LaunchConfig.builder(testName, specPath)

--- a/v1/src/test/java/com/google/cloud/teleport/templates/SpannerToTextIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/SpannerToTextIT.java
@@ -77,7 +77,7 @@ public class SpannerToTextIT extends TemplateTestBase {
                 + "  LastName String(1024),\n"
                 + ") PRIMARY KEY(Id)",
             testName);
-    googleSqlResourceManager.createTable(createTableStatement);
+    googleSqlResourceManager.executeDdlStatement(createTableStatement);
     List<Mutation> expectedData = generateTableRows(String.format("%s", testName));
     googleSqlResourceManager.write(expectedData);
 
@@ -136,7 +136,7 @@ public class SpannerToTextIT extends TemplateTestBase {
                 + "  \"LastName\" character varying(256),\n"
                 + " PRIMARY KEY(\"Id\"))",
             testName);
-    postgresResourceManager.createTable(createTableStatement);
+    postgresResourceManager.executeDdlStatement(createTableStatement);
     List<Mutation> expectedData = generateTableRows(String.format("%s", testName));
     postgresResourceManager.write(expectedData);
 

--- a/v1/src/test/java/com/google/cloud/teleport/templates/SpannerToTextLT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/SpannerToTextLT.java
@@ -101,7 +101,7 @@ public class SpannerToTextLT extends TemplateLoadTestBase {
                 + "  completed BOOL,\n"
                 + ") PRIMARY KEY(eventId)",
             name);
-    spannerResourceManager.createTable(createTableStatement);
+    spannerResourceManager.executeDdlStatement(createTableStatement);
     DataGenerator dataGenerator =
         DataGenerator.builderWithSchemaTemplate(testName, "GAME_EVENT")
             .setQPS("1000000")

--- a/v1/src/test/java/com/google/cloud/teleport/templates/TextImportPipelineIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/TextImportPipelineIT.java
@@ -87,7 +87,7 @@ public final class TextImportPipelineIT extends TemplateTestBase {
             + "  BirthDate     DATE,\n"
             + "  LastModified  TIMESTAMP,\n"
             + ") PRIMARY KEY (SingerId)";
-    googleSqlResourceManager.createTable(statement);
+    googleSqlResourceManager.executeDdlStatement(statement);
 
     String manifestJson =
         "{\n"
@@ -178,7 +178,7 @@ public final class TextImportPipelineIT extends TemplateTestBase {
             + "  BirthDate     DATE,\n"
             + "  LastModified  TIMESTAMP,\n"
             + ") PRIMARY KEY (SingerId)";
-    googleSqlResourceManager.createTable(statement);
+    googleSqlResourceManager.executeDdlStatement(statement);
 
     String manifestJson =
         "{\n"
@@ -267,7 +267,7 @@ public final class TextImportPipelineIT extends TemplateTestBase {
             + "  \"BirthDate\"     date,\n"
             + "  \"LastModified\"  timestamp with time zone,\n"
             + " PRIMARY KEY (\"SingerId\"))";
-    postgresResourceManager.createTable(statement);
+    postgresResourceManager.executeDdlStatement(statement);
 
     String manifestJson =
         "{\n"

--- a/v2/streaming-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/StreamingDataGeneratorIT.java
+++ b/v2/streaming-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/StreamingDataGeneratorIT.java
@@ -288,7 +288,7 @@ public final class StreamingDataGeneratorIT extends TemplateTestBase {
             "quest",
             "score",
             "completed");
-    spannerResourceManager.createTable(createTableStatement);
+    spannerResourceManager.executeDdlStatement(createTableStatement);
 
     LaunchConfig.Builder options =
         LaunchConfig.builder(testName, specPath)

--- a/v2/streaming-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/StreamingDataGeneratorLT.java
+++ b/v2/streaming-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/StreamingDataGeneratorLT.java
@@ -233,7 +233,7 @@ public class StreamingDataGeneratorLT extends TemplateLoadTestBase {
             "quest",
             "score",
             "completed");
-    spannerResourceManager.createTable(createTableStatement);
+    spannerResourceManager.executeDdlStatement(createTableStatement);
     // Arrange
     LaunchConfig options =
         LaunchConfig.builder(testName, SPEC_PATH)


### PR DESCRIPTION
The main purpose of doing so is that, for Spanner ChangeStream tests, ChangeStreams are created by executing a DDL statement, just like how creating a table works. Renaming the function to something more generic seems to make more sense to execute more custom DDL statements on the Spanner Resource Manager