### PR TITLE
Add command spec file to syndeo template

### DIFF
--- a/syndeo-template/src/main/resources/syndeo-template-command-spec.json
+++ b/syndeo-template/src/main/resources/syndeo-template-command-spec.json
@@ -1,0 +1,7 @@
+{
+    "mainClass": "com.google.cloud.syndeo.SyndeoTemplate",
+    "classPath": "/templates/syndeo-template/*:/templates/syndeo-template/libs/*:/template/syndeo-template/classes",
+    "defaultParameterValues": {
+        "labels": "{\"goog-dataflow-provided-template-type\":\"flex\", \"goog-dataflow-provided-template-name\":\"syndeo_template\"}"
+    }
+}


### PR DESCRIPTION
Maven jib plugin needs a command spec to be specified to package templates. Added this under syndeo-template/resources.