### PR TITLE
Add enable_cleanup_state experiment to have batch tests finishing faster

### DIFF
--- a/it/common/src/main/java/com/google/cloud/teleport/it/common/PipelineLauncher.java
+++ b/it/common/src/main/java/com/google/cloud/teleport/it/common/PipelineLauncher.java
@@ -73,7 +73,7 @@ public interface PipelineLauncher {
 
     /** States that indicate that the job is done. */
     public static final ImmutableSet<JobState> DONE_STATES =
-        ImmutableSet.of(CANCELLED, DONE, DRAINED, STOPPED);
+        ImmutableSet.of(CANCELLED, DONE, DRAINED, STOPPED, RESOURCE_CLEANING_UP);
 
     /** States that indicate that the job has failed. */
     public static final ImmutableSet<JobState> FAILED_STATES = ImmutableSet.of(FAILED);

--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/TemplateTestBase.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/TemplateTestBase.java
@@ -382,8 +382,13 @@ public abstract class TemplateTestBase {
 
     // Property allows testing with Runner v2 / Unified Worker
     if (System.getProperty("unifiedWorker") != null) {
-      options.addEnvironment("additionalExperiments", Collections.singletonList("use_runner_v2"));
+      options.addEnvironment(
+          "additionalExperiments", List.of("use_runner_v2", "enable_cleanup_state"));
+    } else {
+      options.addEnvironment(
+          "additionalExperiments", Collections.singletonList("enable_cleanup_state"));
     }
+
     // Property allows testing with Streaming Engine Enabled
     if (System.getProperty("enableStreamingEngine") != null) {
       options.addEnvironment("enableStreamingEngine", true);


### PR DESCRIPTION
With this change, ITs will finish without having to wait for instance removal