### PR TITLE
[Bug]: TextToPubsubLT and TextToBigQueryLT jobs aren't drained

### DIFF
--- a/v1/src/test/java/com/google/cloud/teleport/templates/TextToBigQueryStreamLT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/TextToBigQueryStreamLT.java
@@ -172,7 +172,13 @@ public class TextToBigQueryStreamLT extends TemplateLoadTestBase {
     PipelineLauncher.LaunchInfo info = pipelineLauncher.launch(project, region, options);
     assertThatPipeline(info).isRunning();
     PipelineOperator.Result result =
-        pipelineOperator.waitForConditionAndFinish(
+        // The method waitForConditionAndCancel was used because the streaming pipeline template
+        // includes a call to Splittable DoFn. Invoking a splittable DoFn causes the job to remain
+        // in the Draining state indefinitely.
+        // @see <a
+        // href="https://cloud.google.com/dataflow/docs/guides/stopping-a-pipeline#important_information_about_draining_a_job">
+        // Important information about draining a job</a>
+        pipelineOperator.waitForConditionAndCancel(
             createConfig(info, Duration.ofMinutes(TIMEOUT_FOR_10_GB_TEST_MINUTES)),
             BigQueryRowsCheck.builder(bigQueryResourceManager, table)
                 .setMinRows(NUM_MESSAGES_FOR_10GB)
@@ -231,7 +237,13 @@ public class TextToBigQueryStreamLT extends TemplateLoadTestBase {
         (int) (dataGenerator.execute(Duration.ofMinutes(TIMEOUT_FOR_1_HOUR_TEST_MINUTES)) * 0.99);
 
     PipelineOperator.Result result =
-        pipelineOperator.waitForConditionAndFinish(
+        // The method waitForConditionAndCancel was used because the streaming pipeline template
+        // includes a call to Splittable DoFn. Invoking a splittable DoFn causes the job to remain
+        // in the Draining state indefinitely.
+        // @see <a
+        // href="https://cloud.google.com/dataflow/docs/guides/stopping-a-pipeline#important_information_about_draining_a_job">
+        // Important information about draining a job</a>
+        pipelineOperator.waitForConditionAndCancel(
             createConfig(info, Duration.ofMinutes(TIMEOUT_FOR_1_HOUR_TEST_MINUTES)),
             BigQueryRowsCheck.builder(bigQueryResourceManager, table)
                 .setMinRows(expectedMessages)

--- a/v1/src/test/java/com/google/cloud/teleport/templates/TextToPubsubStreamLT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/TextToPubsubStreamLT.java
@@ -136,7 +136,13 @@ public class TextToPubsubStreamLT extends TemplateLoadTestBase {
 
     // Waits until a number of messages condition is met
     PipelineOperator.Result result =
-        pipelineOperator.waitForConditionAndFinish(
+        // The method waitForConditionAndCancel was used because the streaming pipeline template
+        // includes a call to Splittable DoFn. Invoking a splittable DoFn causes the job to remain
+        // in the Draining state indefinitely.
+        // @see <a
+        // href="https://cloud.google.com/dataflow/docs/guides/stopping-a-pipeline#important_information_about_draining_a_job">
+        // Important information about draining a job</a>
+        pipelineOperator.waitForConditionAndCancel(
             createConfig(info, Duration.ofMinutes(TIMEOUT_FOR_10_GB_TEST_MINUTES)),
             () -> {
               Long currentMessages =
@@ -192,7 +198,13 @@ public class TextToPubsubStreamLT extends TemplateLoadTestBase {
 
     // Waits until a number of messages condition is met
     PipelineOperator.Result result =
-        pipelineOperator.waitForConditionAndFinish(
+        // The method waitForConditionAndCancel was used because the streaming pipeline template
+        // includes a call to Splittable DoFn. Invoking a splittable DoFn causes the job to remain
+        // in the Draining state indefinitely.
+        // @see <a
+        // href="https://cloud.google.com/dataflow/docs/guides/stopping-a-pipeline#important_information_about_draining_a_job">
+        // Important information about draining a job</a>
+        pipelineOperator.waitForConditionAndCancel(
             createConfig(info, Duration.ofMinutes(TIMEOUT_FOR_1_HOUR_TEST_MINUTES)),
             () -> {
               Long currentMessages =


### PR DESCRIPTION
The method waitForConditionAndCancel was used because the streaming pipeline template includes a call to Splittable DoFn. Invoking a splittable DoFn causes the job to remain in the Draining state indefinitely. See the documentation: https://cloud.google.com/dataflow/docs/guides/stopping-a-pipeline#important_information_about_draining_a_job