### PR TITLE
PubSubToDatadog: replace `site` parameter with `url`

### DIFF
--- a/v1/README_Cloud_PubSub_to_Datadog.md
+++ b/v1/README_Cloud_PubSub_to_Datadog.md
@@ -16,7 +16,7 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 ### Required Parameters
 
 * **inputSubscription** (Pub/Sub input subscription): Pub/Sub subscription to read the input from, in the format of 'projects/your-project-id/subscriptions/your-subscription-name' (Example: projects/your-project-id/subscriptions/your-subscription-name).
-* **site** (Datadog site.): Datadog site. This should be routable from the VPC in which the pipeline runs. See: https://docs.datadoghq.com/getting_started/site (Example: datadoghq.com).
+* **url** (Datadog Logs API URL.): Datadog Logs API URL. This should be routable from the VPC in which the pipeline runs. See: https://docs.datadoghq.com/api/latest/logs/#send-logs (Example: https://http-intake.logs.datadoghq.com).
 * **outputDeadletterTopic** (Output deadletter Pub/Sub topic): The Pub/Sub topic to publish deadletter records to. The name should be in the format of projects/your-project-id/topics/your-topic-name.
 
 ### Optional Parameters
@@ -126,7 +126,7 @@ export TEMPLATE_SPEC_GCSPATH="gs://$BUCKET_NAME/templates/Cloud_PubSub_to_Datado
 
 ### Required
 export INPUT_SUBSCRIPTION=<inputSubscription>
-export SITE=<site>
+export URL=<url>
 export OUTPUT_DEADLETTER_TOPIC=<outputDeadletterTopic>
 
 ### Optional
@@ -146,7 +146,7 @@ gcloud dataflow jobs run "cloud-pubsub-to-datadog-job" \
   --gcs-location "$TEMPLATE_SPEC_GCSPATH" \
   --parameters "inputSubscription=$INPUT_SUBSCRIPTION" \
   --parameters "apiKey=$API_KEY" \
-  --parameters "site=$SITE" \
+  --parameters "url=$URL" \
   --parameters "batchCount=$BATCH_COUNT" \
   --parameters "parallelism=$PARALLELISM" \
   --parameters "includePubsubMessage=$INCLUDE_PUBSUB_MESSAGE" \
@@ -175,7 +175,7 @@ export REGION=us-central1
 
 ### Required
 export INPUT_SUBSCRIPTION=<inputSubscription>
-export SITE=<site>
+export URL=<url>
 export OUTPUT_DEADLETTER_TOPIC=<outputDeadletterTopic>
 
 ### Optional
@@ -196,7 +196,7 @@ mvn clean package -PtemplatesRun \
 -Dregion="$REGION" \
 -DjobName="cloud-pubsub-to-datadog-job" \
 -DtemplateName="Cloud_PubSub_to_Datadog" \
--Dparameters="inputSubscription=$INPUT_SUBSCRIPTION,apiKey=$API_KEY,site=$SITE,batchCount=$BATCH_COUNT,parallelism=$PARALLELISM,includePubsubMessage=$INCLUDE_PUBSUB_MESSAGE,apiKeyKMSEncryptionKey=$API_KEY_KMSENCRYPTION_KEY,apiKeySecretId=$API_KEY_SECRET_ID,apiKeySource=$API_KEY_SOURCE,javascriptTextTransformGcsPath=$JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH,javascriptTextTransformFunctionName=$JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME,outputDeadletterTopic=$OUTPUT_DEADLETTER_TOPIC" \
+-Dparameters="inputSubscription=$INPUT_SUBSCRIPTION,apiKey=$API_KEY,url=$URL,batchCount=$BATCH_COUNT,parallelism=$PARALLELISM,includePubsubMessage=$INCLUDE_PUBSUB_MESSAGE,apiKeyKMSEncryptionKey=$API_KEY_KMSENCRYPTION_KEY,apiKeySecretId=$API_KEY_SECRET_ID,apiKeySource=$API_KEY_SOURCE,javascriptTextTransformGcsPath=$JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH,javascriptTextTransformFunctionName=$JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME,outputDeadletterTopic=$OUTPUT_DEADLETTER_TOPIC" \
 -pl v1 \
 -am
 ```

--- a/v1/src/main/java/com/google/cloud/teleport/templates/PubSubToDatadog.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/PubSubToDatadog.java
@@ -228,7 +228,7 @@ public class PubSubToDatadog {
                             options.getApiKeyKMSEncryptionKey(),
                             options.getApiKey(),
                             options.getApiKeySource()))
-                    .withSite(options.getSite())
+                    .withUrl(options.getUrl())
                     .withBatchCount(options.getBatchCount())
                     .withParallelism(options.getParallelism())
                     .build());

--- a/v1/src/main/java/com/google/cloud/teleport/templates/common/DatadogConverters.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/common/DatadogConverters.java
@@ -119,7 +119,7 @@ public class DatadogConverters {
     void setBatchCount(ValueProvider<Integer> batchCount);
 
     @TemplateParameter.Integer(
-        order = 5,
+        order = 4,
         optional = true,
         description = "Maximum number of parallel requests.",
         helpText = "Maximum number of parallel requests. Default 1 (no parallelism).")
@@ -128,7 +128,7 @@ public class DatadogConverters {
     void setParallelism(ValueProvider<Integer> parallelism);
 
     @TemplateParameter.Boolean(
-        order = 6,
+        order = 5,
         optional = true,
         description = "Include full Pub/Sub message in the payload.",
         helpText =
@@ -139,7 +139,7 @@ public class DatadogConverters {
     void setIncludePubsubMessage(ValueProvider<Boolean> includePubsubMessage);
 
     @TemplateParameter.Text(
-        order = 7,
+        order = 6,
         optional = true,
         regexes = {
           "^projects\\/[^\\n\\r\\/]+\\/locations\\/[^\\n\\r\\/]+\\/keyRings\\/[^\\n\\r\\/]+\\/cryptoKeys\\/[^\\n\\r\\/]+$"
@@ -159,7 +159,7 @@ public class DatadogConverters {
     void setApiKeyKMSEncryptionKey(ValueProvider<String> keyName);
 
     @TemplateParameter.Text(
-        order = 8,
+        order = 7,
         optional = true,
         regexes = {
           "^projects\\/[^\\n\\r\\/]+\\/secrets\\/[^\\n\\r\\/]+\\/versions\\/[^\\n\\r\\/]+$"
@@ -173,7 +173,7 @@ public class DatadogConverters {
     void setApiKeySecretId(ValueProvider<String> secretId);
 
     @TemplateParameter.Enum(
-        order = 9,
+        order = 8,
         optional = true,
         enumOptions = {"PLAINTEXT", "KMS", "SECRET_MANAGER"},
         description = "Source of the API key passed. One of PLAINTEXT, KMS or SECRET_MANAGER.",

--- a/v1/src/main/java/com/google/cloud/teleport/templates/common/DatadogConverters.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/common/DatadogConverters.java
@@ -97,24 +97,16 @@ public class DatadogConverters {
 
     void setApiKey(ValueProvider<String> apiKey);
 
-    @TemplateParameter.Enum(
+    @TemplateParameter.Text(
         order = 2,
-        description = "Datadog site.",
-        enumOptions = {
-          "datadoghq.com",
-          "us3.datadoghq.com",
-          "us5.datadoghq.com",
-          "ap1.datadoghq.com",
-          "datadoghq.eu",
-          "ddog-gov.com",
-        },
+        description = "Datadog Logs API URL.",
         helpText =
-            "Datadog site. This should be routable from the VPC in which the pipeline runs. "
-                + "See: https://docs.datadoghq.com/getting_started/site",
-        example = "datadoghq.com")
-    ValueProvider<String> getSite();
+            "Datadog Logs API URL. This should be routable from the VPC in which the pipeline runs. "
+                + "See: https://docs.datadoghq.com/api/latest/logs/#send-logs",
+        example = "https://http-intake.logs.datadoghq.com")
+    ValueProvider<String> getUrl();
 
-    void setSite(ValueProvider<String> site);
+    void setUrl(ValueProvider<String> url);
 
     @TemplateParameter.Integer(
         order = 3,

--- a/v1/src/test/java/com/google/cloud/teleport/datadog/DatadogIOTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/datadog/DatadogIOTest.java
@@ -15,8 +15,6 @@
  */
 package com.google.cloud.teleport.datadog;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 
 import com.google.common.base.Joiner;
@@ -24,7 +22,6 @@ import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.List;
-import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
@@ -79,57 +76,6 @@ public class DatadogIOTest {
     int port = socket.getLocalPort();
     socket.close();
     mockServer = startClientAndServer(port);
-  }
-
-  /** Test the builder with an invalid site. */
-  @Test
-  public void builderInvalidSite() {
-
-    Exception thrown =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> DatadogIO.writeBuilder().withApiKey("test-api-key").withSite("bad-site").build());
-
-    assertThat(thrown).hasMessageThat().contains(DatadogIO.Write.Builder.INVALID_SITE_MESSAGE);
-  }
-
-  /** Test the builder with an invalid site provider. */
-  @Test
-  public void builderInvalidSiteProvider() {
-
-    Exception thrown =
-        assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                DatadogIO.writeBuilder()
-                    .withApiKey("test-api-key")
-                    .withSite(ValueProvider.StaticValueProvider.of("bad-site"))
-                    .build());
-
-    assertThat(thrown).hasMessageThat().contains(DatadogIO.Write.Builder.INVALID_SITE_MESSAGE);
-  }
-
-  /** Test the builder with a valid site. */
-  @Test
-  public void builderValidSite() {
-
-    DatadogIO.Write writer =
-        DatadogIO.writeBuilder().withApiKey("test-api-key").withSite("datadoghq.com").build();
-
-    assertThat(writer.url().get()).isEqualTo("https://http-intake.logs.datadoghq.com");
-  }
-
-  /** Test the builder with a valid site provider. */
-  @Test
-  public void builderValidSiteProvider() {
-
-    DatadogIO.Write writer =
-        DatadogIO.writeBuilder()
-            .withApiKey("test-api-key")
-            .withSite(ValueProvider.StaticValueProvider.of("datadoghq.com"))
-            .build();
-
-    assertThat(writer.url().get()).isEqualTo("https://http-intake.logs.datadoghq.com");
   }
 
   /** Test successful multi-event POST request for DatadogIO without parallelism. */


### PR DESCRIPTION
Preqreq to: https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/791

When we originally created this template, we decided on using a more specific `site` parameter vs a generic `url` parameter, where `site` referred to a [Datadog site](https://docs.datadoghq.com/getting_started/site/). However, in order to facilitate the type of integration testing that already exists in this repo, we need to move back to a generic `url` parameter, so that integration tests can output to a localized Datadog instance (i.e. a mock server).

Let me know if you have any questions!