### PR TITLE
[Bugfix] Replace only the last occurrence of Datetime patterns in a directory path

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/io/WindowedFilenamePolicy.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/io/WindowedFilenamePolicy.java
@@ -365,8 +365,8 @@ public abstract class WindowedFilenamePolicy extends FilenamePolicy {
   }
 
   /**
-   * Replaces the last occurrence of a substring. If there are no occurrences,
-   * returns the original string.
+   * Replaces the last occurrence of a substring. If there are no occurrences, returns the original
+   * string.
    */
   private static String replaceLast(String find, String replacement, String str) {
     int lastIndex = str.lastIndexOf(find);

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/io/WindowedFilenamePolicy.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/io/WindowedFilenamePolicy.java
@@ -353,15 +353,32 @@ public abstract class WindowedFilenamePolicy extends FilenamePolicy {
       final DateTimeFormatter hourFormatter = DateTimeFormat.forPattern(jodaHourPattern);
       final DateTimeFormatter minuteFormatter = DateTimeFormat.forPattern(jodaMinutePattern);
 
-      directoryPath = directoryPath.replace(yearPattern(), yearFormatter.print(time));
-      directoryPath = directoryPath.replace(monthPattern(), monthFormatter.print(time));
-      directoryPath = directoryPath.replace(dayPattern(), dayFormatter.print(time));
-      directoryPath = directoryPath.replace(hourPattern(), hourFormatter.print(time));
-      directoryPath = directoryPath.replace(minutePattern(), minuteFormatter.print(time));
+      directoryPath = replaceLast(yearPattern(), yearFormatter.print(time), directoryPath);
+      directoryPath = replaceLast(monthPattern(), monthFormatter.print(time), directoryPath);
+      directoryPath = replaceLast(dayPattern(), dayFormatter.print(time), directoryPath);
+      directoryPath = replaceLast(hourPattern(), hourFormatter.print(time), directoryPath);
+      directoryPath = replaceLast(minutePattern(), minuteFormatter.print(time), directoryPath);
     } catch (IllegalArgumentException e) {
       throw new RuntimeException("Could not resolve custom DateTime pattern. " + e.getMessage(), e);
     }
     return bucket + directoryPath;
+  }
+
+  /**
+   * Replaces the last occurrence of a substring. If there are no occurrences,
+   * returns the original string.
+   */
+  private static String replaceLast(String find, String replacement, String str) {
+    int lastIndex = str.lastIndexOf(find);
+
+    if (lastIndex == -1) {
+      return str;
+    }
+
+    String left = str.substring(0, lastIndex);
+    String right = str.substring(lastIndex + find.length());
+
+    return left + replacement + right;
   }
 
   /**

--- a/v2/common/src/test/java/com/google/cloud/teleport/v2/io/WindowedFilenamePolicyTest.java
+++ b/v2/common/src/test/java/com/google/cloud/teleport/v2/io/WindowedFilenamePolicyTest.java
@@ -284,6 +284,38 @@ public class WindowedFilenamePolicyTest {
     assertThat(filename.getFilename()).isEqualTo("output-001-of-001");
   }
 
+  /**
+   * Tests that windowedFilename() produces the correct directory when it unintentionally
+   * contains {@link DateTime} patterns.
+   */
+  @Test
+  public void testWindowedDirectoryUnintentionalPattern() {
+    IntervalWindow window = mock(IntervalWindow.class);
+    PaneInfo paneInfo = PaneInfo.createPane(false, true, Timing.ON_TIME, 0, 0);
+
+    Instant windowBegin = new DateTime(2017, 1, 8, 10, 55, 0).toInstant();
+    Instant windowEnd = new DateTime(2017, 1, 8, 10, 56, 0).toInstant();
+    when(window.maxTimestamp()).thenReturn(windowEnd);
+    when(window.start()).thenReturn(windowBegin);
+    when(window.end()).thenReturn(windowEnd);
+
+    WindowedFilenamePolicy policy =
+        WindowedFilenamePolicy.writeWindowedFiles()
+            .withOutputDirectory("gs://test-bucket-mmmm/recommmmendations/mmmm/")
+            .withOutputFilenamePrefix("output")
+            .withShardTemplate("-SSS-of-NNN")
+            .withSuffix("")
+            .withMinutePattern("mmmm");
+
+    ResourceId filename =
+        policy.windowedFilename(1, 1, window, paneInfo, new TestOutputFileHints());
+
+    assertThat(filename).isNotNull();
+    assertThat(filename.getCurrentDirectory().toString())
+        .isEqualTo("gs://test-bucket-mmmm/recommmmendations/0056/");
+    assertThat(filename.getFilename()).isEqualTo("output-001-of-001");
+  }
+
   @Test
   public void testWindowedDirectoryWrappedPattern() {
     // Arrange

--- a/v2/common/src/test/java/com/google/cloud/teleport/v2/io/WindowedFilenamePolicyTest.java
+++ b/v2/common/src/test/java/com/google/cloud/teleport/v2/io/WindowedFilenamePolicyTest.java
@@ -285,8 +285,8 @@ public class WindowedFilenamePolicyTest {
   }
 
   /**
-   * Tests that windowedFilename() produces the correct directory when it unintentionally
-   * contains {@link DateTime} patterns.
+   * Tests that windowedFilename() produces the correct directory when it unintentionally contains
+   * {@link DateTime} patterns.
    */
   @Test
   public void testWindowedDirectoryUnintentionalPattern() {


### PR DESCRIPTION
While using a template that utilizes DLQ, found some cases where dead-letter GCS directory names get altered unexpectedly if they contain Datetime patterns.

for example:
DLQ would take `gs://bucket/dead-letter/recommendation`  and add on to it `/YYYY/MM/DD/HH/mm` then resolve for datetime patterns. The resulting path would look like this: `gs://bucket/dead-letter/reco56endation/2023/06/15/14/56`. All occurrences of patterns get replaced. The changes in this PR make a more accurate best effort by only replacing the last occurrence in the path.