### PR TITLE
Allow usage of arbitrary hosts in CdcToBigQueryChangeApplierPipelineIT

### DIFF
--- a/v2/cdc-parent/cdc-change-applier/src/test/java/com/google/cloud/dataflow/cdc/applier/CdcToBigQueryChangeApplierPipelineIT.java
+++ b/v2/cdc-parent/cdc-change-applier/src/test/java/com/google/cloud/dataflow/cdc/applier/CdcToBigQueryChangeApplierPipelineIT.java
@@ -88,7 +88,7 @@ public class CdcToBigQueryChangeApplierPipelineIT extends JDBCBaseIT {
   private static final String OWNER = "owner";
 
   private static final Pattern JDBC_PORT_PATTERN =
-      Pattern.compile("^jdbc:mysql://localhost:([0-9]+).*$");
+      Pattern.compile("^jdbc:mysql://(.*?):([0-9]+).*$");
 
   @Before
   public void setUp() throws IOException {
@@ -335,7 +335,7 @@ public class CdcToBigQueryChangeApplierPipelineIT extends JDBCBaseIT {
     if (!match.matches()) {
       throw new IllegalArgumentException(
           String.format(
-              "JDBC URL is not in ^jdbc:mysql://localhost:[0-9]+/.*$ format: \"%s\"", jdbcUrl));
+              "JDBC URL is not in ^jdbc:mysql://(.*?):[0-9]+/.*$ format: \"%s\"", jdbcUrl));
     }
     return match.group(1);
   }


### PR DESCRIPTION
Avoid 
```
java.lang.IllegalArgumentException: JDBC URL is not in ^jdbc:mysql://localhost:[0-9]+/.*$ format: "jdbc:mysql://10.128.0.7:37557/testdeb_20230618_180358_362742"
	at com.google.cloud.dataflow.cdc.applier.CdcToBigQueryChangeApplierPipelineIT.parseJdbcPort(CdcToBigQueryChangeApplierPipelineIT.java:338)
	at com.google.cloud.dataflow.cdc.applier.CdcToBigQueryChangeApplierPipelineIT.testDebeziumCdcToBigQuery(CdcToBigQueryChangeApplierPipelineIT.java:194)
	at com.google.cloud.dataflow.cdc.applier.CdcToBigQueryChangeApplierPipelineIT.testDebeziumCdcToBigQueryMultiTopic(CdcToBigQueryChangeApplierPipelineIT.java:113)

```