### PR TITLE
Use longer messages for tests writing to Pub/Sub

### DIFF
--- a/v1/src/test/java/com/google/cloud/teleport/templates/PubSubToPubSubIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/PubSubToPubSubIT.java
@@ -34,6 +34,7 @@ import org.apache.beam.it.common.utils.ResourceManagerUtils;
 import org.apache.beam.it.gcp.TemplateTestBase;
 import org.apache.beam.it.gcp.pubsub.PubsubResourceManager;
 import org.apache.beam.it.gcp.pubsub.conditions.PubsubMessagesCheck;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,6 +47,7 @@ import org.junit.runners.JUnit4;
 @TemplateIntegrationTest(PubsubToPubsub.class)
 @RunWith(JUnit4.class)
 public class PubSubToPubSubIT extends TemplateTestBase {
+
   private PubsubResourceManager pubsubResourceManager;
 
   @Before
@@ -70,7 +72,11 @@ public class PubSubToPubSubIT extends TemplateTestBase {
         pubsubResourceManager.createSubscription(outputTopic, "output-subscription");
 
     List<String> expectedMessages =
-        List.of("message1-" + testName, "message2-" + testName, "message3-" + testName);
+        List.of(
+            "message1-" + testName,
+            "message2-" + testName,
+            "message3-" + testName,
+            "message4-" + testName + "-long-" + RandomStringUtils.randomAlphabetic(1000, 2000));
     publishMessages(inputTopic, expectedMessages);
     LaunchConfig.Builder options =
         LaunchConfig.builder(testName, specPath)

--- a/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToPubsubIT.java
+++ b/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToPubsubIT.java
@@ -63,6 +63,7 @@ public class JdbcToPubsubIT extends JDBCBaseIT {
   private static final String AGE = "age";
   private static final String MEMBER = "member";
   private static final String ENTRY_ADDED = "entry_added";
+  private static final String LONG_DESCRIPTION = "long_description";
 
   @Before
   public void setUp() throws IOException {
@@ -87,6 +88,7 @@ public class JdbcToPubsubIT extends JDBCBaseIT {
     columns.put(AGE, "NUMERIC");
     columns.put(MEMBER, "VARCHAR(200)");
     columns.put(ENTRY_ADDED, "VARCHAR(200)");
+    columns.put(LONG_DESCRIPTION, "VARCHAR(2000)");
     JDBCResourceManager.JDBCSchema schema = new JDBCResourceManager.JDBCSchema(columns, ROW_ID);
     mysqlResourceManager.createTable(testName, schema);
     List<Map<String, Object>> generatedData = generateData();
@@ -152,6 +154,7 @@ public class JdbcToPubsubIT extends JDBCBaseIT {
       values.put(AGE, new Random().nextInt(100));
       values.put(MEMBER, i % 2 == 0 ? "Y" : "N");
       values.put(ENTRY_ADDED, Instant.now().toString());
+      values.put(LONG_DESCRIPTION, RandomStringUtils.randomAlphanumeric(100, 2000));
       data.add(values);
     }
 


### PR DESCRIPTION
We missed a regression from PubsubIO (https://github.com/apache/beam/issues/27000) because our tests use very small messages.

Note that this can only be merged after Beam 2.49.0 is out.
