### PR TITLE
Reduce verbosity of integration test logs

### DIFF
--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/dataflow/AbstractPipelineLauncher.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/dataflow/AbstractPipelineLauncher.java
@@ -71,22 +71,16 @@ public abstract class AbstractPipelineLauncher implements PipelineLauncher {
 
   @Override
   public Job getJob(String project, String region, String jobId, String view) {
-    LOG.info("Getting the status of {} under {}", jobId, project);
-
-    Job job =
-        Failsafe.with(clientRetryPolicy())
-            .get(
-                () ->
-                    client
-                        .projects()
-                        .locations()
-                        .jobs()
-                        .get(project, region, jobId)
-                        .setView(view)
-                        .execute());
-
-    LOG.info("Received job on get request for {}:\n{}", jobId, formatForLogging(job));
-    return job;
+    return Failsafe.with(clientRetryPolicy())
+        .get(
+            () ->
+                client
+                    .projects()
+                    .locations()
+                    .jobs()
+                    .get(project, region, jobId)
+                    .setView(view)
+                    .execute());
   }
 
   @Override

--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/dataflow/ClassicTemplateClient.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/dataflow/ClassicTemplateClient.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 /** Client for interacting with Dataflow Classic Templates using the Dataflow SDK. */
 public final class ClassicTemplateClient extends AbstractPipelineLauncher {
+
   private static final Logger LOG = LoggerFactory.getLogger(ClassicTemplateClient.class);
 
   private ClassicTemplateClient(Builder builder) {
@@ -88,6 +89,8 @@ public final class ClassicTemplateClient extends AbstractPipelineLauncher {
     // Wait until the job is active to get more information
     JobState state = waitUntilActive(project, region, job.getId());
     job = getJob(project, region, job.getId(), "JOB_VIEW_DESCRIPTION");
+    LOG.info("Received classic template job {}: {}", job.getId(), formatForLogging(job));
+
     launchedJobs.add(job.getId());
     return getJobInfo(options, state, job);
   }
@@ -100,6 +103,7 @@ public final class ClassicTemplateClient extends AbstractPipelineLauncher {
 
   /** Builder for {@link ClassicTemplateClient}. */
   public static final class Builder {
+
     private Credentials credentials;
 
     private Builder() {}

--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/dataflow/DefaultPipelineLauncher.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/dataflow/DefaultPipelineLauncher.java
@@ -379,6 +379,8 @@ public class DefaultPipelineLauncher extends AbstractPipelineLauncher {
     // Wait until the job is active to get more information
     JobState state = waitUntilActive(project, region, jobId);
     Job job = getJob(project, region, jobId, "JOB_VIEW_DESCRIPTION");
+    LOG.info("Received Dataflow job {}: {}", job.getId(), formatForLogging(job));
+
     return getJobInfo(options, state, job);
   }
 

--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/dataflow/FlexTemplateClient.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/dataflow/FlexTemplateClient.java
@@ -94,6 +94,8 @@ public final class FlexTemplateClient extends AbstractPipelineLauncher {
     // Wait until the job is active to get more information
     JobState state = waitUntilActive(project, region, job.getId());
     job = getJob(project, region, job.getId(), "JOB_VIEW_DESCRIPTION");
+    LOG.info("Received flex template job {}: {}", job.getId(), formatForLogging(job));
+
     launchedJobs.add(job.getId());
     return getJobInfo(options, state, job);
   }


### PR DESCRIPTION
We poll the job in a 5s interval, and printing all the information (besides of only the status) isn't helpful at all.