### PR TITLE
Enforce non-vulnerable version of jettison dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <guava.version>31.0.1-jre</guava.version>
     <mockito.version>4.11.0</mockito.version>
     <log4j-2.version>2.17.2</log4j-2.version>
+    <jettison.version>1.5.4</jettison.version>
     <json.version>20230227</json.version>
     <junit.version>4.13.2</junit.version>
     <re2j.version>1.6</re2j.version>
@@ -158,6 +159,14 @@
         <artifactId>snakeyaml</artifactId>
         <version>${snakeyaml.version}</version>
       </dependency>
+
+      <!-- Enforce non-vulnerable version of jettison -->
+      <dependency>
+        <groupId>org.codehaus.jettison</groupId>
+        <artifactId>jettison</artifactId>
+        <version>${jettison.version}</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
It is used by jersey-json at version 1.1 (https://mvnrepository.com/artifact/org.codehaus.jettison/jettison/1.1), and it brings together a bunch of CVEs.

[CVE-2023-1436](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1436)
[CVE-2022-45693](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-45693)
[CVE-2022-45685](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-45685)
[CVE-2022-40150](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40150)
[CVE-2022-40149](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40149)