### PR TITLE
Syndeo cleanup

### DIFF
--- a/syndeo-template/pom.xml
+++ b/syndeo-template/pom.xml
@@ -27,7 +27,7 @@
         <!-- <avro.version>1.11.1</avro.version> -->
         <awaitility.version>4.2.0</awaitility.version>
         <beam.version>2.48.0</beam.version>
-        <beam.snapshot.version>2.49.0-SNAPSHOT</beam.snapshot.version>
+        <beam.snapshot.version>2.50.0-SNAPSHOT</beam.snapshot.version>
         <!-- <bigtable.version>1.15.0</bigtable.version> -->
         <!-- <bigquery.version>2.9.0</bigquery.version> -->
         <!-- <commons.version>1.8</commons.version> -->

--- a/syndeo-template/src/main/java/com/google/cloud/syndeo/SyndeoTemplate.java
+++ b/syndeo-template/src/main/java/com/google/cloud/syndeo/SyndeoTemplate.java
@@ -113,9 +113,9 @@ public class SyndeoTemplate {
   static {
     SUPPORTED_URNS.putAll(
         Map.of(
-            "syndeo:schematransform:com.google.cloud:pubsub_read:v1",
+            "beam:schematransform:org.apache.beam:pubsub_read:v1",
             Set.of(),
-            "syndeo:schematransform:com.google.cloud:pubsub_write:v1",
+            "beam:schematransform:org.apache.beam:pubsub_write:v1",
             Set.of(),
             "syndeo:schematransform:com.google.cloud:pubsub_dlq_write:v1",
             Set.of(),

--- a/syndeo-template/src/main/java/com/google/cloud/syndeo/common/ProviderUtil.java
+++ b/syndeo-template/src/main/java/com/google/cloud/syndeo/common/ProviderUtil.java
@@ -146,7 +146,7 @@ public class ProviderUtil {
         tuple = PCollectionRowTuple.of(input, tuple.get(priorOutput));
       }
 
-      tuple = tuple.apply(spec.inputId, transform.buildTransform());
+      tuple = tuple.apply(spec.inputId, transform);
 
       if (tuple.getAll().containsKey(ERRORS_TAG)) {
         PCollectionRowTuple.of("input", tuple.get(ERRORS_TAG))
@@ -154,13 +154,12 @@ public class ProviderUtil {
                 new SyndeoStatsSchemaTransformProvider()
                     .from(
                         SyndeoStatsSchemaTransformProvider.SyndeoStatsConfiguration.create(
-                            "errors"))
-                    .buildTransform());
+                            "errors")));
         if (dlqTransformSpec != null) {
           PCollectionRowTuple.of("errors", tuple.get(ERRORS_TAG))
               .apply(
                   dlqTransformSpec.inputId,
-                  dlqTransformSpec.provider.from(dlqTransformSpec.configuration).buildTransform());
+                  dlqTransformSpec.provider.from(dlqTransformSpec.configuration));
         }
       }
     }

--- a/syndeo-template/src/main/java/com/google/cloud/syndeo/common/SchemaUtil.java
+++ b/syndeo-template/src/main/java/com/google/cloud/syndeo/common/SchemaUtil.java
@@ -56,7 +56,7 @@ public class SchemaUtil {
       inputTuple =
           inputTuple.and(entry.getKey(), p.apply(Create.empty(RowCoder.of(entry.getValue()))));
     }
-    PCollectionRowTuple outputTuple = inputTuple.apply(transform.buildTransform());
+    PCollectionRowTuple outputTuple = inputTuple.apply(transform);
     Map<String, Schema> outputSchemas = new HashMap<>();
     for (Entry<String, PCollection<Row>> entry : outputTuple.getAll().entrySet()) {
       outputSchemas.put(entry.getKey(), entry.getValue().getSchema());

--- a/syndeo-template/src/main/java/com/google/cloud/syndeo/dlq/pubsub/PubsubDlqSchemaTransformProvider.java
+++ b/syndeo-template/src/main/java/com/google/cloud/syndeo/dlq/pubsub/PubsubDlqSchemaTransformProvider.java
@@ -31,7 +31,6 @@ import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
 import org.apache.beam.sdk.schemas.transforms.SchemaTransform;
 import org.apache.beam.sdk.schemas.transforms.SchemaTransformProvider;
 import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionRowTuple;
@@ -75,8 +74,7 @@ public class PubsubDlqSchemaTransformProvider
    * An implementation of {@link SchemaTransform} for Pub/Sub writes configured using {@link
    * PubsubDlqWriteConfiguration}.
    */
-  static class PubsubDlqSchemaTransform extends PTransform<PCollectionRowTuple, PCollectionRowTuple>
-      implements SchemaTransform {
+  static class PubsubDlqSchemaTransform extends SchemaTransform {
 
     public static final int PUBSUB_MESSAGE_SIZE = 10 * 1024 * 1024;
     private final PubsubDlqWriteConfiguration configuration;
@@ -89,12 +87,6 @@ public class PubsubDlqSchemaTransformProvider
 
     PubsubDlqSchemaTransform withPubsubClientFactory(PubsubClient.PubsubClientFactory factory) {
       this.pubsubClientFactory = factory;
-      return this;
-    }
-
-    /** Implements {@link SchemaTransform} buildTransform method. */
-    @Override
-    public PTransform<PCollectionRowTuple, PCollectionRowTuple> buildTransform() {
       return this;
     }
 

--- a/syndeo-template/src/main/java/com/google/cloud/syndeo/transforms/SyndeoStatsSchemaTransformProvider.java
+++ b/syndeo-template/src/main/java/com/google/cloud/syndeo/transforms/SyndeoStatsSchemaTransformProvider.java
@@ -30,7 +30,6 @@ import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
 import org.apache.beam.sdk.schemas.transforms.SchemaTransform;
 import org.apache.beam.sdk.schemas.transforms.SchemaTransformProvider;
 import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionRowTuple;
@@ -53,23 +52,15 @@ public class SyndeoStatsSchemaTransformProvider
   public SchemaTransform from(SyndeoStatsConfiguration configuration) {
     return new SchemaTransform() {
       @Override
-      public @UnknownKeyFor @NonNull @Initialized PTransform<
-              @UnknownKeyFor @NonNull @Initialized PCollectionRowTuple,
-              @UnknownKeyFor @NonNull @Initialized PCollectionRowTuple>
-          buildTransform() {
-        return new PTransform<PCollectionRowTuple, PCollectionRowTuple>() {
-          @Override
-          public PCollectionRowTuple expand(PCollectionRowTuple input) {
-            PCollection<Row> inputPcoll = input.get("input");
-            return PCollectionRowTuple.of(
-                "output",
-                inputPcoll
-                    .apply(
-                        String.format("%s_%s", configuration.getParent(), identifier()),
-                        ParDo.of(new StatsDoFn(configuration.getParent())))
-                    .setRowSchema(inputPcoll.getSchema()));
-          }
-        };
+      public PCollectionRowTuple expand(PCollectionRowTuple input) {
+        PCollection<Row> inputPcoll = input.get("input");
+        return PCollectionRowTuple.of(
+            "output",
+            inputPcoll
+                .apply(
+                    String.format("%s_%s", configuration.getParent(), identifier()),
+                    ParDo.of(new StatsDoFn(configuration.getParent())))
+                .setRowSchema(inputPcoll.getSchema()));
       }
     };
   }

--- a/syndeo-template/src/main/java/com/google/cloud/syndeo/transforms/bigtable/BigTableIOWriteSchemaBasedTransform.java
+++ b/syndeo-template/src/main/java/com/google/cloud/syndeo/transforms/bigtable/BigTableIOWriteSchemaBasedTransform.java
@@ -47,8 +47,7 @@ import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class BigTableIOWriteSchemaBasedTransform
-    extends PTransform<PCollectionRowTuple, PCollectionRowTuple> implements SchemaTransform {
+public class BigTableIOWriteSchemaBasedTransform extends SchemaTransform {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(BigTableIOWriteSchemaBasedTransform.class);
@@ -78,7 +77,6 @@ public class BigTableIOWriteSchemaBasedTransform
     this.appProfileId = appProfileId;
   }
 
-  @Override
   public PTransform<PCollectionRowTuple, PCollectionRowTuple> buildTransform() {
     return this;
   }

--- a/syndeo-template/src/test/java/com/google/cloud/syndeo/common/SchemaIOTransformProviderWrapperTest.java
+++ b/syndeo-template/src/test/java/com/google/cloud/syndeo/common/SchemaIOTransformProviderWrapperTest.java
@@ -79,7 +79,7 @@ public class SchemaIOTransformProviderWrapperTest {
     assertTrue(wrapper.outputCollectionNames().size() == 1);
     PCollection<Row> read =
         PCollectionRowTuple.empty(p)
-            .apply(wrapper.from(config).buildTransform())
+            .apply(wrapper.from(config))
             .get(wrapper.outputCollectionNames().get(0));
     // null3 as we have 3 elements, and location is null
     Row expected = Row.withSchema(schema).addValues("null3", "null3").build();
@@ -112,7 +112,7 @@ public class SchemaIOTransformProviderWrapperTest {
                 .withRowSchema(schema));
 
     PCollectionRowTuple.of(wrapper.inputCollectionNames().get(0), toWrite)
-        .apply(wrapper.from(config).buildTransform());
+        .apply(wrapper.from(config));
     p.run().waitUntilFinish();
   }
 

--- a/syndeo-template/src/test/java/com/google/cloud/syndeo/dlq/pubsub/PubsubDlqSchemaTransformProviderTest.java
+++ b/syndeo-template/src/test/java/com/google/cloud/syndeo/dlq/pubsub/PubsubDlqSchemaTransformProviderTest.java
@@ -95,8 +95,7 @@ public class PubsubDlqSchemaTransformProviderTest {
               pipeline.apply(Create.of(generateRow())).setRowSchema(LOCAL_TEST_INPUT_SCHEMA))
           .apply(
               transform(PubsubDlqWriteConfiguration.create(TOPIC))
-                  .withPubsubClientFactory(pubsubFactory)
-                  .buildTransform());
+                  .withPubsubClientFactory(pubsubFactory));
 
       pipeline.run(OPTIONS);
     } catch (Exception e) {

--- a/syndeo-template/src/test/java/com/google/cloud/syndeo/it/ReadFilesTransformIT.java
+++ b/syndeo-template/src/test/java/com/google/cloud/syndeo/it/ReadFilesTransformIT.java
@@ -138,8 +138,7 @@ public class ReadFilesTransformIT {
                             AvroUtils.toAvroSchema(SyndeoLoadTestUtils.NESTED_TABLE_SCHEMA)
                                 .toString())
                         .setPubsubSubscription(pubsubSubscription.toString())
-                        .build())
-                .buildTransform())
+                        .build()))
         .get("output")
         .apply(
             MapElements.into(TypeDescriptors.voids())
@@ -188,8 +187,7 @@ public class ReadFilesTransformIT {
                                 AvroUtils.toAvroSchema(SyndeoLoadTestUtils.NESTED_TABLE_SCHEMA)
                                     .toString())
                             .setPubsubSubscription(pubsubSubscription.toString())
-                            .build())
-                    .buildTransform());
+                            .build()));
 
     Pipeline.PipelineExecutionException e =
         assertThrows(
@@ -223,8 +221,7 @@ public class ReadFilesTransformIT {
                                 AvroUtils.toAvroSchema(SyndeoLoadTestUtils.NESTED_TABLE_SCHEMA)
                                     .toString())
                             .setPubsubSubscription(pubsubSubscription.toString())
-                            .build())
-                    .buildTransform());
+                            .build()));
 
     Pipeline.PipelineExecutionException e =
         assertThrows(
@@ -266,8 +263,7 @@ public class ReadFilesTransformIT {
                                 AvroUtils.toAvroSchema(SyndeoLoadTestUtils.NESTED_TABLE_SCHEMA)
                                     .toString())
                             .setPubsubSubscription(pubsubSubscription.toString())
-                            .build())
-                    .buildTransform());
+                            .build()));
 
     result
         .get("errors")

--- a/syndeo-template/src/test/java/com/google/cloud/syndeo/perf/SyndeoLoadTestUtils.java
+++ b/syndeo-template/src/test/java/com/google/cloud/syndeo/perf/SyndeoLoadTestUtils.java
@@ -34,7 +34,6 @@ import org.apache.beam.sdk.schemas.transforms.SchemaTransform;
 import org.apache.beam.sdk.schemas.transforms.SchemaTransformProvider;
 import org.apache.beam.sdk.transforms.FlatMapElements;
 import org.apache.beam.sdk.transforms.MapElements;
-import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.PeriodicImpulse;
 import org.apache.beam.sdk.transforms.Reshuffle;
 import org.apache.beam.sdk.transforms.SerializableFunction;
@@ -110,8 +109,8 @@ public class SyndeoLoadTestUtils {
         .apply(
             new SyndeoStatsSchemaTransformProvider()
                 .from(
-                    SyndeoStatsSchemaTransformProvider.SyndeoStatsConfiguration.create("inputData"))
-                .buildTransform())
+                    SyndeoStatsSchemaTransformProvider.SyndeoStatsConfiguration.create(
+                        "inputData")))
         .get("output");
   }
 
@@ -284,27 +283,18 @@ public class SyndeoLoadTestUtils {
     public SchemaTransform from(GenerateDataSchemaTransformConfiguration configuration) {
       return new SchemaTransform() {
         @Override
-        public @UnknownKeyFor @NonNull @Initialized PTransform<
-                @UnknownKeyFor @NonNull @Initialized PCollectionRowTuple,
-                @UnknownKeyFor @NonNull @Initialized PCollectionRowTuple>
-            buildTransform() {
-          return new PTransform<PCollectionRowTuple, PCollectionRowTuple>() {
-            @Override
-            public PCollectionRowTuple expand(PCollectionRowTuple input) {
-              Schema dataSchema = SIMPLE_TABLE_SCHEMA;
-              if (configuration.getUseNestedSchema() != null
-                  && configuration.getUseNestedSchema()) {
-                dataSchema = NESTED_TABLE_SCHEMA;
-              }
-              return PCollectionRowTuple.of(
-                  "output",
-                  inputData(
-                      input.getPipeline(),
-                      configuration.getNumRows(),
-                      configuration.getRuntimeSeconds(),
-                      dataSchema));
-            }
-          };
+        public PCollectionRowTuple expand(PCollectionRowTuple input) {
+          Schema dataSchema = SIMPLE_TABLE_SCHEMA;
+          if (configuration.getUseNestedSchema() != null && configuration.getUseNestedSchema()) {
+            dataSchema = NESTED_TABLE_SCHEMA;
+          }
+          return PCollectionRowTuple.of(
+              "output",
+              inputData(
+                  input.getPipeline(),
+                  configuration.getNumRows(),
+                  configuration.getRuntimeSeconds(),
+                  dataSchema));
         }
       };
     }

--- a/syndeo-template/src/test/java/com/google/cloud/syndeo/perf/SyndeoPubsubLiteToBigTableLT.java
+++ b/syndeo-template/src/test/java/com/google/cloud/syndeo/perf/SyndeoPubsubLiteToBigTableLT.java
@@ -176,8 +176,7 @@ public class SyndeoPubsubLiteToBigTableLT {
                                     .setTopicName(topicName)
                                     .setLocation(LOCATION)
                                     .setProject(PROJECT)
-                                    .build())))
-                .buildTransform());
+                                    .build()))));
 
     // Build JSON configuration for the template:
     String jsonPayload =

--- a/syndeo-template/src/test/java/com/google/cloud/syndeo/perf/SyndeoPubsubToBigQueryLT.java
+++ b/syndeo-template/src/test/java/com/google/cloud/syndeo/perf/SyndeoPubsubToBigQueryLT.java
@@ -164,8 +164,7 @@ public class SyndeoPubsubToBigQueryLT {
             new SyndeoPubsubWriteSchemaTransformProvider()
                 .from(
                     SyndeoPubsubWriteSchemaTransformProvider.SyndeoPubsubWriteConfiguration.create(
-                        "AVRO", topicPath.toString()))
-                .buildTransform());
+                        "AVRO", topicPath.toString())));
 
     // Build JSON configuration for the template:
     String jsonPayload =

--- a/syndeo-template/src/test/java/com/google/cloud/syndeo/transforms/BigTableSchemaTransformTest.java
+++ b/syndeo-template/src/test/java/com/google/cloud/syndeo/transforms/BigTableSchemaTransformTest.java
@@ -159,8 +159,7 @@ public class BigTableSchemaTransformTest {
                         .setTableId("anytable")
                         .setKeyColumns(Arrays.asList("name"))
                         .setEndpoint(bigTableContainer.getEmulatorEndpoint())
-                        .build())
-                .buildTransform());
+                        .build()));
 
     setupP.run().waitUntilFinish();
   }

--- a/syndeo-template/src/test/java/com/google/cloud/syndeo/transforms/SyndeoPubsubReadSchemaTransformProviderTest.java
+++ b/syndeo-template/src/test/java/com/google/cloud/syndeo/transforms/SyndeoPubsubReadSchemaTransformProviderTest.java
@@ -111,8 +111,7 @@ public class SyndeoPubsubReadSchemaTransformProviderTest {
                         SyndeoPubsubReadSchemaTransformConfiguration.builder()
                             .setSchema(SCHEMA)
                             .setFormat("AVRO")
-                            .build())
-                    .buildTransform()));
+                            .build())));
     p.run().waitUntilFinish();
   }
 
@@ -130,8 +129,7 @@ public class SyndeoPubsubReadSchemaTransformProviderTest {
                             .setFormat("AVRO")
                             .setTopic(TOPIC)
                             .setSubscription(SUBSCRIPTION)
-                            .build())
-                    .buildTransform()));
+                            .build())));
     p.run().waitUntilFinish();
   }
 
@@ -148,8 +146,7 @@ public class SyndeoPubsubReadSchemaTransformProviderTest {
                             .setSchema(SCHEMA)
                             .setFormat("BadFormat")
                             .setSubscription(SUBSCRIPTION)
-                            .build())
-                    .buildTransform()));
+                            .build())));
     p.run().waitUntilFinish();
   }
 
@@ -165,8 +162,7 @@ public class SyndeoPubsubReadSchemaTransformProviderTest {
                         SyndeoPubsubReadSchemaTransformConfiguration.builder()
                             .setSubscription(SUBSCRIPTION)
                             .setFormat("AVRO")
-                            .build())
-                    .buildTransform()));
+                            .build())));
     p.run().waitUntilFinish();
   }
 
@@ -184,7 +180,7 @@ public class SyndeoPubsubReadSchemaTransformProviderTest {
               .setClock(CLOCK)
               .build();
       SchemaTransform transform = new SyndeoPubsubReadSchemaTransformProvider().from(config);
-      PCollectionRowTuple reads = begin.apply(transform.buildTransform());
+      PCollectionRowTuple reads = begin.apply(transform);
 
       PAssert.that(reads.get("output")).containsInAnyOrder(ROWS);
 
@@ -208,7 +204,7 @@ public class SyndeoPubsubReadSchemaTransformProviderTest {
               .setClock(CLOCK)
               .build();
       SchemaTransform transform = new SyndeoPubsubReadSchemaTransformProvider().from(config);
-      PCollectionRowTuple reads = begin.apply(transform.buildTransform());
+      PCollectionRowTuple reads = begin.apply(transform);
 
       PAssert.that(reads.get("output")).empty();
 

--- a/syndeo-template/src/test/java/com/google/cloud/syndeo/transforms/datagenerator/DataGeneratorSchemaTransformTest.java
+++ b/syndeo-template/src/test/java/com/google/cloud/syndeo/transforms/datagenerator/DataGeneratorSchemaTransformTest.java
@@ -45,8 +45,7 @@ public class DataGeneratorSchemaTransformTest {
                     .setSecondsToRun(5L)
                     .setRecordsPerSecond(100L)
                     .build());
-    PTransform<PCollectionRowTuple, PCollectionRowTuple> transform =
-        schemaTransform.buildTransform();
+    PTransform<PCollectionRowTuple, PCollectionRowTuple> transform = schemaTransform;
     Pipeline p = Pipeline.create();
     PCollectionRowTuple input = PCollectionRowTuple.empty(p);
     transform.expand(input);


### PR DESCRIPTION
Cleanup:
1. SchemaTransform has been converted from an interface to an abstract class. Making the corresponding changes on the syndeo side.
2. SchemaTransform no longer supports buildTransform(), instead it requires to overriding expand() directly. Changing that and the tests to correctly call the methods.