### PR TITLE
[PubSubToDatadog] Add origin header

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventPublisher.java
+++ b/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventPublisher.java
@@ -73,6 +73,9 @@ public abstract class DatadogEventPublisher {
 
   private static final String DD_API_KEY_HEADER = "dd-api-key";
 
+  private static final String DD_ORIGIN_HEADER = "dd-evp-origin";
+  private static final String DD_ORIGIN_DATAFLOW = "dataflow";
+
   private static final HttpMediaType MEDIA_TYPE =
       new HttpMediaType("application/json;charset=utf-8");
 
@@ -158,6 +161,7 @@ public abstract class DatadogEventPublisher {
    */
   private void setHeaders(HttpRequest request, String apiKey) {
     request.getHeaders().set(DD_API_KEY_HEADER, apiKey);
+    request.getHeaders().set(DD_ORIGIN_HEADER, DD_ORIGIN_DATAFLOW);
     request.getHeaders().setContentEncoding("gzip");
   }
 

--- a/v1/src/test/java/com/google/cloud/teleport/datadog/DatadogEventWriterTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/datadog/DatadogEventWriterTest.java
@@ -22,7 +22,6 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.List;
 import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
 import org.apache.beam.sdk.coders.KvCoder;
@@ -57,10 +56,7 @@ public class DatadogEventWriterTest {
   @Before
   public void setup() throws IOException {
     ConfigurationProperties.disableSystemOut(true);
-    ServerSocket socket = new ServerSocket(0);
-    int port = socket.getLocalPort();
-    socket.close();
-    mockServer = startClientAndServer(port);
+    mockServer = startClientAndServer();
   }
 
   /** Test building {@link DatadogEventWriter} with missing URL. */

--- a/v1/src/test/java/com/google/cloud/teleport/datadog/DatadogIOTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/datadog/DatadogIOTest.java
@@ -20,7 +20,6 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.List;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
@@ -72,10 +71,7 @@ public class DatadogIOTest {
   @Before
   public void setup() throws IOException {
     ConfigurationProperties.disableSystemOut(true);
-    ServerSocket socket = new ServerSocket(0);
-    int port = socket.getLocalPort();
-    socket.close();
-    mockServer = startClientAndServer(port);
+    mockServer = startClientAndServer();
   }
 
   /** Test successful multi-event POST request for DatadogIO without parallelism. */


### PR DESCRIPTION
Adding an internal HTTP header to all requests sent to Datadog, so that we can tell on our side which requests are coming from Dataflow. Let me know if you have questions/concerns! 🙏 