### PR TITLE
[PubSubToDatadog] Send batches before exceeding 5MB payload limit

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventPublisher.java
+++ b/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventPublisher.java
@@ -35,8 +35,6 @@ import com.google.api.client.util.Sleeper;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.KeyManagementException;
@@ -68,9 +66,6 @@ public abstract class DatadogEventPublisher {
   private static final Logger LOG = LoggerFactory.getLogger(DatadogEventPublisher.class);
 
   private static final int DEFAULT_MAX_CONNECTIONS = 1;
-
-  private static final Gson GSON =
-      new GsonBuilder().setFieldNamingStrategy(f -> f.getName().toLowerCase()).create();
 
   @VisibleForTesting protected static final String DD_URL_PATH = "api/v2/logs";
 
@@ -171,20 +166,9 @@ public abstract class DatadogEventPublisher {
    */
   @VisibleForTesting
   protected HttpContent getContent(List<DatadogEvent> events) {
-    String payload = getStringPayload(events);
+    String payload = DatadogEventSerializer.getPayloadString(events);
     LOG.debug("Payload content: {}", payload);
     return ByteArrayContent.fromString(CONTENT_TYPE, payload);
-  }
-
-  /** Utility method to get payload string from a list of {@link DatadogEvent}s. */
-  @VisibleForTesting
-  String getStringPayload(List<DatadogEvent> events) {
-    return GSON.toJson(events);
-  }
-
-  /** Utility method to get payload string from a {@link DatadogEvent}. */
-  String getStringPayload(DatadogEvent event) {
-    return GSON.toJson(event);
   }
 
   static class HttpSendLogsUnsuccessfulResponseHandler implements HttpUnsuccessfulResponseHandler {

--- a/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventPublisher.java
+++ b/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventPublisher.java
@@ -182,6 +182,11 @@ public abstract class DatadogEventPublisher {
     return GSON.toJson(events);
   }
 
+  /** Utility method to get payload string from a {@link DatadogEvent}. */
+  String getStringPayload(DatadogEvent event) {
+    return GSON.toJson(event);
+  }
+
   static class HttpSendLogsUnsuccessfulResponseHandler implements HttpUnsuccessfulResponseHandler {
     /*
       See: https://docs.datadoghq.com/api/latest/logs/#send-logs

--- a/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventSerializer.java
+++ b/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventSerializer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.datadog;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class DatadogEventSerializer {
+  private static final Gson GSON =
+      new GsonBuilder().setFieldNamingStrategy(f -> f.getName().toLowerCase()).create();
+
+  private DatadogEventSerializer() {}
+
+  /** Utility method to get payload string from a list of {@link DatadogEvent}s. */
+  public static String getPayloadString(List<DatadogEvent> events) {
+    return GSON.toJson(events);
+  }
+
+  /** Utility method to get payload string from a {@link DatadogEvent}. */
+  public static String getPayloadString(DatadogEvent event) {
+    return GSON.toJson(event);
+  }
+
+  /** Utility method to get payload size from a string. */
+  public static long getPayloadSize(String payload) {
+    return payload.getBytes(StandardCharsets.UTF_8).length;
+  }
+}

--- a/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventWriter.java
+++ b/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventWriter.java
@@ -27,7 +27,6 @@ import com.google.common.collect.Lists;
 import com.google.common.net.InetAddresses;
 import com.google.common.net.InternetDomainName;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
@@ -188,8 +187,8 @@ public abstract class DatadogEventWriter
     DatadogEvent event = input.getValue();
     INPUT_COUNTER.inc();
 
-    String eventPayload = publisher.getStringPayload(event);
-    long eventPayloadSize = eventPayload.getBytes(StandardCharsets.UTF_8).length;
+    String eventPayload = DatadogEventSerializer.getPayloadString(event);
+    long eventPayloadSize = DatadogEventSerializer.getPayloadSize(eventPayload);
     if (eventPayloadSize > maxBufferSize) {
       LOG.error(
           "Error processing event of size {} due to exceeding max buffer size", eventPayloadSize);
@@ -391,7 +390,7 @@ public abstract class DatadogEventWriter
     }
 
     for (DatadogEvent event : events) {
-      String payload = publisher.getStringPayload(event);
+      String payload = DatadogEventSerializer.getPayloadString(event);
       DatadogWriteError error = builder.withPayload(payload).build();
       receiver.output(error);
     }

--- a/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventWriter.java
+++ b/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventWriter.java
@@ -521,8 +521,6 @@ public abstract class DatadogEventWriter
      * @return {@link Builder}
      */
     public Builder withMaxBufferSize(Long maxBufferSize) {
-      checkArgument(
-          maxBufferSize != null, "withMaxBufferSize(maxBufferSize) called with null input.");
       return setMaxBufferSize(maxBufferSize);
     }
 

--- a/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventWriter.java
+++ b/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventWriter.java
@@ -26,9 +26,8 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 import com.google.common.net.InetAddresses;
 import com.google.common.net.InternetDomainName;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
@@ -64,6 +63,7 @@ public abstract class DatadogEventWriter
   private static final Integer MAX_BATCH_COUNT = 1000;
   private static final Logger LOG = LoggerFactory.getLogger(DatadogEventWriter.class);
   private static final long DEFAULT_FLUSH_DELAY = 2;
+  private static final Long MAX_BUFFER_SIZE = 5L * 1000 * 1000; // 5MB
   private static final Counter INPUT_COUNTER =
       Metrics.counter(DatadogEventWriter.class, "inbound-events");
   private static final Counter SUCCESS_WRITES =
@@ -82,8 +82,11 @@ public abstract class DatadogEventWriter
       Metrics.distribution(DatadogEventWriter.class, "unsuccessful_write_to_datadog_latency_ms");
   private static final Distribution SUCCESSFUL_WRITE_BATCH_SIZE =
       Metrics.distribution(DatadogEventWriter.class, "write_to_datadog_batch");
+  private static final Distribution SUCCESSFUL_WRITE_PAYLOAD_SIZE =
+      Metrics.distribution(DatadogEventWriter.class, "write_to_datadog_bytes");
   private static final String BUFFER_STATE_NAME = "buffer";
   private static final String COUNT_STATE_NAME = "count";
+  private static final String BUFFER_SIZE_STATE_NAME = "buffer_size";
   private static final String TIME_ID_NAME = "expiry";
   private static final Pattern URL_PATTERN = Pattern.compile("^http(s?)://([^:]+)(:[0-9]+)?$");
 
@@ -98,14 +101,15 @@ public abstract class DatadogEventWriter
   @StateId(COUNT_STATE_NAME)
   private final StateSpec<ValueState<Long>> count = StateSpecs.value();
 
+  @StateId(BUFFER_SIZE_STATE_NAME)
+  private final StateSpec<ValueState<Long>> bufferSize = StateSpecs.value();
+
   @TimerId(TIME_ID_NAME)
   private final TimerSpec expirySpec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
 
   private Integer batchCount;
+  private Long maxBufferSize;
   private DatadogEventPublisher publisher;
-
-  private static final Gson GSON =
-      new GsonBuilder().setFieldNamingStrategy(f -> f.getName().toLowerCase()).create();
 
   public static Builder newBuilder() {
     return newBuilder(null);
@@ -128,6 +132,9 @@ public abstract class DatadogEventWriter
   @Nullable
   abstract ValueProvider<Integer> inputBatchCount();
 
+  @Nullable
+  abstract Long maxBufferSize();
+
   @Setup
   public void setup() {
 
@@ -135,16 +142,16 @@ public abstract class DatadogEventWriter
     checkArgument(isValidUrlFormat(url().get()), INVALID_URL_FORMAT_MESSAGE);
     checkArgument(apiKey().isAccessible(), "API Key is required for writing events.");
 
-    // Either user supplied or default batchCount.
-    if (batchCount == null) {
-
-      if (inputBatchCount() != null) {
-        batchCount = inputBatchCount().get();
-      }
-
-      batchCount = MoreObjects.firstNonNull(batchCount, DEFAULT_BATCH_COUNT);
-      LOG.info("Batch count set to: {}", batchCount);
+    if (inputBatchCount() != null) {
+      batchCount = inputBatchCount().get();
     }
+    batchCount = MoreObjects.firstNonNull(batchCount, DEFAULT_BATCH_COUNT);
+    LOG.info("Batch count set to: {}", batchCount);
+
+    maxBufferSize = maxBufferSize();
+    maxBufferSize = MoreObjects.firstNonNull(maxBufferSize, MAX_BUFFER_SIZE);
+    LOG.info("Max buffer size set to: {}", maxBufferSize);
+
     checkArgument(
         batchCount >= minBatchCount(),
         "batchCount must be greater than or equal to %s",
@@ -174,20 +181,46 @@ public abstract class DatadogEventWriter
       BoundedWindow window,
       @StateId(BUFFER_STATE_NAME) BagState<DatadogEvent> bufferState,
       @StateId(COUNT_STATE_NAME) ValueState<Long> countState,
+      @StateId(BUFFER_SIZE_STATE_NAME) ValueState<Long> bufferSizeState,
       @TimerId(TIME_ID_NAME) Timer timer)
       throws IOException {
 
-    Long count = MoreObjects.<Long>firstNonNull(countState.read(), 0L);
     DatadogEvent event = input.getValue();
     INPUT_COUNTER.inc();
-    bufferState.add(event);
-    count += 1;
-    countState.write(count);
+
+    String eventPayload = publisher.getStringPayload(event);
+    long eventPayloadSize = eventPayload.getBytes(StandardCharsets.UTF_8).length;
+    if (eventPayloadSize > maxBufferSize) {
+      LOG.error(
+          "Error processing event of size {} due to exceeding max buffer size", eventPayloadSize);
+      DatadogWriteError error = DatadogWriteError.newBuilder().withPayload(eventPayload).build();
+      receiver.output(error);
+      return;
+    }
+
     timer.offset(Duration.standardSeconds(DEFAULT_FLUSH_DELAY)).setRelative();
 
+    long count = MoreObjects.<Long>firstNonNull(countState.read(), 0L);
+    long bufferSize = MoreObjects.<Long>firstNonNull(bufferSizeState.read(), 0L);
+    if (bufferSize + eventPayloadSize > maxBufferSize) {
+      LOG.debug("Flushing batch of {} events of size {} due to max buffer size", count, bufferSize);
+      flush(receiver, bufferState, countState, bufferSizeState);
+
+      count = 0L;
+      bufferSize = 0L;
+    }
+
+    bufferState.add(event);
+
+    count = count + 1L;
+    countState.write(count);
+
+    bufferSize = bufferSize + eventPayloadSize;
+    bufferSizeState.write(bufferSize);
+
     if (count >= batchCount) {
-      LOG.debug("Flushing batch of {} events", count);
-      flush(receiver, bufferState, countState);
+      LOG.debug("Flushing batch of {} events of size {} due to batch count", count, bufferSize);
+      flush(receiver, bufferState, countState, bufferSizeState);
     }
   }
 
@@ -195,12 +228,16 @@ public abstract class DatadogEventWriter
   public void onExpiry(
       OutputReceiver<DatadogWriteError> receiver,
       @StateId(BUFFER_STATE_NAME) BagState<DatadogEvent> bufferState,
-      @StateId(COUNT_STATE_NAME) ValueState<Long> countState)
+      @StateId(COUNT_STATE_NAME) ValueState<Long> countState,
+      @StateId(BUFFER_SIZE_STATE_NAME) ValueState<Long> bufferSizeState)
       throws IOException {
 
-    if (MoreObjects.<Long>firstNonNull(countState.read(), 0L) > 0) {
-      LOG.debug("Flushing window with {} events", countState.read());
-      flush(receiver, bufferState, countState);
+    long count = MoreObjects.<Long>firstNonNull(countState.read(), 0L);
+    long bufferSize = MoreObjects.<Long>firstNonNull(bufferSizeState.read(), 0L);
+
+    if (count > 0) {
+      LOG.debug("Flushing batch of {} events of size {} due to timer", count, bufferSize);
+      flush(receiver, bufferState, countState, bufferSizeState);
     }
   }
 
@@ -225,7 +262,8 @@ public abstract class DatadogEventWriter
   private void flush(
       OutputReceiver<DatadogWriteError> receiver,
       @StateId(BUFFER_STATE_NAME) BagState<DatadogEvent> bufferState,
-      @StateId(COUNT_STATE_NAME) ValueState<Long> countState)
+      @StateId(COUNT_STATE_NAME) ValueState<Long> countState,
+      @StateId(BUFFER_SIZE_STATE_NAME) ValueState<Long> bufferSizeState)
       throws IOException {
 
     if (!bufferState.isEmpty().read()) {
@@ -259,6 +297,7 @@ public abstract class DatadogEventWriter
           SUCCESS_WRITES.inc(countState.read());
           VALID_REQUESTS.inc();
           SUCCESSFUL_WRITE_BATCH_SIZE.update(countState.read());
+          SUCCESSFUL_WRITE_PAYLOAD_SIZE.update(bufferSizeState.read());
 
           LOG.debug("Successfully wrote {} events", countState.read());
         }
@@ -289,6 +328,7 @@ public abstract class DatadogEventWriter
         // write failed events to an output PCollection.
         bufferState.clear();
         countState.clear();
+        bufferSizeState.clear();
 
         // We've observed cases where errors at this point can cause the pipeline to keep retrying
         // the same events over and over (e.g. from Dataflow Runner's Pub/Sub implementation). Since
@@ -332,7 +372,7 @@ public abstract class DatadogEventWriter
    * @param statusCode Status code to be added to {@link DatadogWriteError}
    * @param receiver Receiver to write {@link DatadogWriteError}s to
    */
-  private static void flushWriteFailures(
+  private void flushWriteFailures(
       List<DatadogEvent> events,
       String statusMessage,
       Integer statusCode,
@@ -351,9 +391,8 @@ public abstract class DatadogEventWriter
     }
 
     for (DatadogEvent event : events) {
-      String payload = GSON.toJson(event);
+      String payload = publisher.getStringPayload(event);
       DatadogWriteError error = builder.withPayload(payload).build();
-
       receiver.output(error);
     }
   }
@@ -399,6 +438,8 @@ public abstract class DatadogEventWriter
     abstract Integer minBatchCount();
 
     abstract Builder setInputBatchCount(ValueProvider<Integer> inputBatchCount);
+
+    abstract Builder setMaxBufferSize(Long maxBufferSize);
 
     abstract DatadogEventWriter autoBuild();
 
@@ -471,6 +512,18 @@ public abstract class DatadogEventWriter
         }
       }
       return setInputBatchCount(inputBatchCount);
+    }
+
+    /**
+     * Method to set the maxBufferSize.
+     *
+     * @param maxBufferSize for batching post requests.
+     * @return {@link Builder}
+     */
+    public Builder withMaxBufferSize(Long maxBufferSize) {
+      checkArgument(
+          maxBufferSize != null, "withMaxBufferSize(maxBufferSize) called with null input.");
+      return setMaxBufferSize(maxBufferSize);
     }
 
     /** Build a new {@link DatadogEventWriter} objects based on the configuration. */

--- a/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogIO.java
+++ b/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogIO.java
@@ -74,6 +74,9 @@ public class DatadogIO {
     abstract ValueProvider<Integer> batchCount();
 
     @Nullable
+    abstract Long maxBufferSize();
+
+    @Nullable
     abstract ValueProvider<Integer> parallelism();
 
     @Override
@@ -82,6 +85,7 @@ public class DatadogIO {
       LOG.info("Configuring DatadogEventWriter.");
       DatadogEventWriter.Builder builder =
           DatadogEventWriter.newBuilder(minBatchCount())
+              .withMaxBufferSize(maxBufferSize())
               .withUrl(url())
               .withInputBatchCount(batchCount())
               .withApiKey(apiKey());
@@ -111,6 +115,8 @@ public class DatadogIO {
       abstract Builder setMinBatchCount(Integer minBatchCount);
 
       abstract Builder setBatchCount(ValueProvider<Integer> batchCount);
+
+      abstract Builder setMaxBufferSize(Long maxBufferSize);
 
       abstract Builder setParallelism(ValueProvider<Integer> parallelism);
 
@@ -180,6 +186,18 @@ public class DatadogIO {
       public Builder withBatchCount(Integer batchCount) {
         checkArgument(batchCount != null, "withBatchCount(batchCount) called with null input.");
         return setBatchCount(ValueProvider.StaticValueProvider.of(batchCount));
+      }
+
+      /**
+       * Method to set the Max Buffer Size.
+       *
+       * @param maxBufferSize for batching post requests.
+       * @return {@link Builder}
+       */
+      public Builder withMaxBufferSize(Long maxBufferSize) {
+        checkArgument(
+            maxBufferSize != null, "withMaxBufferSize(maxBufferSize) called with null input.");
+        return setMaxBufferSize(maxBufferSize);
       }
 
       /**

--- a/v1/src/test/java/com/google/cloud/teleport/datadog/DatadogEventPublisherTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/datadog/DatadogEventPublisherTest.java
@@ -64,32 +64,6 @@ public class DatadogEventPublisherTest {
   private static final List<DatadogEvent> DATADOG_EVENTS =
       ImmutableList.of(DATADOG_TEST_EVENT_1, DATADOG_TEST_EVENT_2);
 
-  /** Test whether payload is stringified as expected. */
-  @Test
-  public void stringPayloadTest()
-      throws NoSuchAlgorithmException, KeyManagementException, IOException {
-
-    DatadogEventPublisher publisher =
-        DatadogEventPublisher.newBuilder()
-            .withUrl("http://example.com")
-            .withApiKey("test-api-key")
-            .build();
-
-    String actual = publisher.getStringPayload(DATADOG_EVENTS);
-
-    String expected =
-        "["
-            + "{\"ddsource\":\"test-source-1\",\"ddtags\":\"test-tags-1\","
-            + "\"hostname\":\"test-hostname-1\",\"service\":\"test-service-1\","
-            + "\"message\":\"test-message-1\"},"
-            + "{\"ddsource\":\"test-source-2\",\"ddtags\":\"test-tags-2\","
-            + "\"hostname\":\"test-hostname-2\",\"service\":\"test-service-2\","
-            + "\"message\":\"test-message-2\"}"
-            + "]";
-
-    assertThat(expected, is(equalTo(actual)));
-  }
-
   /** Test whether {@link HttpContent} is created from the list of {@link DatadogEvent}s. */
   @Test
   public void contentTest() throws NoSuchAlgorithmException, KeyManagementException, IOException {

--- a/v1/src/test/java/com/google/cloud/teleport/datadog/DatadogEventSerializerTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/datadog/DatadogEventSerializerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.datadog;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Test;
+
+public class DatadogEventSerializerTest {
+
+  private static final DatadogEvent DATADOG_TEST_EVENT_1 =
+      DatadogEvent.newBuilder()
+          .withSource("test-source-1")
+          .withTags("test-tags-1")
+          .withHostname("test-hostname-1")
+          .withService("test-service-1")
+          .withMessage("test-message-1")
+          .build();
+
+  private static final DatadogEvent DATADOG_TEST_EVENT_2 =
+      DatadogEvent.newBuilder()
+          .withSource("test-source-2")
+          .withTags("test-tags-2")
+          .withHostname("test-hostname-2")
+          .withService("test-service-2")
+          .withMessage("test-message-2")
+          .build();
+
+  private static final List<DatadogEvent> DATADOG_EVENTS =
+      ImmutableList.of(DATADOG_TEST_EVENT_1, DATADOG_TEST_EVENT_2);
+
+  /** Test whether payload is stringified as expected. */
+  @Test
+  public void stringPayloadTest_list() {
+    String actual = DatadogEventSerializer.getPayloadString(DATADOG_EVENTS);
+
+    String expected =
+        "["
+            + "{\"ddsource\":\"test-source-1\",\"ddtags\":\"test-tags-1\","
+            + "\"hostname\":\"test-hostname-1\",\"service\":\"test-service-1\","
+            + "\"message\":\"test-message-1\"},"
+            + "{\"ddsource\":\"test-source-2\",\"ddtags\":\"test-tags-2\","
+            + "\"hostname\":\"test-hostname-2\",\"service\":\"test-service-2\","
+            + "\"message\":\"test-message-2\"}"
+            + "]";
+
+    assertThat(expected, is(equalTo(actual)));
+  }
+
+  /** Test whether payload is stringified as expected. */
+  @Test
+  public void stringPayloadTest_single() {
+    String actual = DatadogEventSerializer.getPayloadString(DATADOG_TEST_EVENT_1);
+
+    String expected =
+        "{\"ddsource\":\"test-source-1\",\"ddtags\":\"test-tags-1\","
+            + "\"hostname\":\"test-hostname-1\",\"service\":\"test-service-1\","
+            + "\"message\":\"test-message-1\"}";
+
+    assertThat(expected, is(equalTo(actual)));
+  }
+
+  /** Test payload size calculation for a payload string. */
+  @Test
+  public void stringPayloadSizeTest() {
+    long actual =
+        DatadogEventSerializer.getPayloadSize(
+            "{\"ddsource\":\"test-source-1\",\"ddtags\":\"test-tags-1\","
+                + "\"hostname\":\"test-hostname-1\",\"service\":\"test-service-1\","
+                + "\"message\":\"test-message-1\"}");
+
+    long expected = 134L;
+
+    assertThat(expected, is(equalTo(actual)));
+  }
+}

--- a/v1/src/test/java/com/google/cloud/teleport/datadog/DatadogEventWriterTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/datadog/DatadogEventWriterTest.java
@@ -22,6 +22,9 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
 import org.apache.beam.sdk.coders.KvCoder;
@@ -190,6 +193,34 @@ public class DatadogEventWriterTest {
     assertThat(writer.inputBatchCount().get()).isEqualTo(batchCount);
   }
 
+  /** Test building {@link DatadogEventWriter} with default maxBufferSize . */
+  @Test
+  public void eventWriterDefaultMaxBufferSize() {
+
+    DatadogEventWriter writer =
+        DatadogEventWriter.newBuilder()
+            .withUrl("http://test-url")
+            .withApiKey("test-api-key")
+            .build();
+
+    assertThat(writer.maxBufferSize()).isNull();
+  }
+
+  /** Test building {@link DatadogEventWriter} with custom maxBufferSize . */
+  @Test
+  public void eventWriterCustomMaxBufferSizeAndValidation() {
+
+    Long maxBufferSize = 1_427_841L;
+    DatadogEventWriter writer =
+        DatadogEventWriter.newBuilder()
+            .withUrl("http://test-url")
+            .withMaxBufferSize(maxBufferSize)
+            .withApiKey("test-api-key")
+            .build();
+
+    assertThat(writer.maxBufferSize()).isEqualTo(maxBufferSize);
+  }
+
   /** Test successful POST request for single batch. */
   @Test
   @Category(NeedsRunner.class)
@@ -306,6 +337,59 @@ public class DatadogEventWriterTest {
     mockServer.verify(HttpRequest.request(EXPECTED_PATH), VerificationTimes.once());
   }
 
+  /** Test successful POST requests for batch exceeding max buffer size. */
+  @Test
+  @Category(NeedsRunner.class)
+  public void successfulDatadogWriteExceedingMaxBufferSize() {
+
+    // Create server expectation for success.
+    addRequestExpectation(202);
+
+    int testPort = mockServer.getPort();
+
+    String payloadFormat = "{\"message\":\"%s\"}";
+    long jsonSize = calculateByteSize(String.format(payloadFormat, ""));
+
+    long maxBufferSize = 100;
+    long msgSize = 50;
+
+    char[] bunchOfAs = new char[(int) (msgSize - jsonSize)];
+    Arrays.fill(bunchOfAs, 'a');
+
+    List<KV<Integer, DatadogEvent>> testEvents = new ArrayList<>();
+    for (int i = 1; i <= 3; i++) {
+      testEvents.add(
+          KV.of(123, DatadogEvent.newBuilder().withMessage(new String(bunchOfAs)).build()));
+    }
+
+    PCollection<DatadogWriteError> actual =
+        pipeline
+            .apply(
+                "Create Input data",
+                Create.of(testEvents)
+                    .withCoder(KvCoder.of(BigEndianIntegerCoder.of(), DatadogEventCoder.of())))
+            .apply(
+                "DatadogEventWriter",
+                ParDo.of(
+                    DatadogEventWriter.newBuilder()
+                        .withUrl(Joiner.on(':').join("http://localhost", testPort))
+                        .withInputBatchCount(StaticValueProvider.of(testEvents.size()))
+                        .withMaxBufferSize(maxBufferSize)
+                        .withApiKey("test-api-key")
+                        .build()))
+            .setCoder(DatadogWriteErrorCoder.of());
+
+    // All successful responses.
+    PAssert.that(actual).empty();
+
+    pipeline.run();
+
+    // Server received exactly two POST requests:
+    // 1st batch of size=2 due to next msg exceeding max buffer size
+    // 2nd batch of size=1 due to timer
+    mockServer.verify(HttpRequest.request(EXPECTED_PATH), VerificationTimes.exactly(2));
+  }
+
   /** Test failed POST request. */
   @Test
   @Category(NeedsRunner.class)
@@ -362,6 +446,57 @@ public class DatadogEventWriterTest {
 
     // Server received exactly one POST request.
     mockServer.verify(HttpRequest.request(EXPECTED_PATH), VerificationTimes.once());
+  }
+
+  /** Test failed due to single event exceeding max buffer size. */
+  @Test
+  @Category(NeedsRunner.class)
+  public void failedDatadogEventTooBig() {
+
+    // Create server expectation for FAILURE.
+    addRequestExpectation(404);
+
+    int testPort = mockServer.getPort();
+
+    String payloadFormat = "{\"message\":\"%s\"}";
+
+    long maxBufferSize = 100;
+    char[] bunchOfAs =
+        new char[(int) (maxBufferSize + 1L - calculateByteSize(String.format(payloadFormat, "")))];
+    Arrays.fill(bunchOfAs, 'a');
+    String messageTooBig = new String(bunchOfAs);
+
+    String expectedPayload = String.format(payloadFormat, messageTooBig);
+    long expectedPayloadSize = calculateByteSize(expectedPayload);
+    assertThat(expectedPayloadSize).isEqualTo(maxBufferSize + 1L);
+
+    List<KV<Integer, DatadogEvent>> testEvents =
+        ImmutableList.of(KV.of(123, DatadogEvent.newBuilder().withMessage(messageTooBig).build()));
+
+    PCollection<DatadogWriteError> actual =
+        pipeline
+            .apply(
+                "Create Input data",
+                Create.of(testEvents)
+                    .withCoder(KvCoder.of(BigEndianIntegerCoder.of(), DatadogEventCoder.of())))
+            .apply(
+                "DatadogEventWriter",
+                ParDo.of(
+                    DatadogEventWriter.newBuilder()
+                        .withUrl(Joiner.on(':').join("http://localhost", testPort))
+                        .withMaxBufferSize(maxBufferSize)
+                        .withApiKey("test-api-key")
+                        .build()))
+            .setCoder(DatadogWriteErrorCoder.of());
+
+    // Expect a single DatadogWriteError due to exceeding max buffer size
+    PAssert.that(actual)
+        .containsInAnyOrder(DatadogWriteError.newBuilder().withPayload(expectedPayload).build());
+
+    pipeline.run();
+
+    // Server did not receive any requests.
+    mockServer.verify(HttpRequest.request(EXPECTED_PATH), VerificationTimes.never());
   }
 
   /** Test retryable POST request. */
@@ -425,5 +560,9 @@ public class DatadogEventWriterTest {
     mockServer
         .when(HttpRequest.request(EXPECTED_PATH), times)
         .respond(HttpResponse.response().withStatusCode(statusCode));
+  }
+
+  private static long calculateByteSize(String payload) {
+    return payload.getBytes(StandardCharsets.UTF_8).length;
   }
 }

--- a/v1/src/test/java/com/google/cloud/teleport/datadog/DatadogEventWriterTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/datadog/DatadogEventWriterTest.java
@@ -370,7 +370,7 @@ public class DatadogEventWriterTest {
             .apply(
                 "DatadogEventWriter",
                 ParDo.of(
-                    DatadogEventWriter.newBuilder()
+                    DatadogEventWriter.newBuilder(1)
                         .withUrl(Joiner.on(':').join("http://localhost", testPort))
                         .withInputBatchCount(StaticValueProvider.of(testEvents.size()))
                         .withMaxBufferSize(maxBufferSize)


### PR DESCRIPTION
See: https://docs.datadoghq.com/api/latest/logs/#send-logs

Relevant pieces from the link above are:
`Maximum content size per payload (uncompressed): 5MB`
`413: Payload too large (batch is above 5MB uncompressed)`

This PR attempts to change when requests are sent to Datadog to avoid sending requests that will be rejected due to payload exceeding the max limit of `5MB`, as defined in our API docs.

So with these changes, a batch is sent when:
- `currentEventSize + currentBatchSize > maxPayloadSize` (current event excluded)
- `count >= batchCount` (current event included)
- timer exceeds 2s timeout (current event N/A)

We're new to Beam @ Datadog, so we're not 100% certain this is the best way to achieve what we're looking to accomplish, so any guidance is appreciated.

Please let me know if you have questions! 🙏 