### PR TITLE
[PubSubToDatadog]  Modify default batch count, add minimum

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventWriter.java
+++ b/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventWriter.java
@@ -60,7 +60,7 @@ public abstract class DatadogEventWriter
     extends DoFn<KV<Integer, DatadogEvent>, DatadogWriteError> {
 
   private static final Integer MIN_BATCH_COUNT = 10;
-  private static final Integer DEFAULT_BATCH_COUNT = 10;
+  private static final Integer DEFAULT_BATCH_COUNT = 100;
   private static final Integer MAX_BATCH_COUNT = 1000;
   private static final Logger LOG = LoggerFactory.getLogger(DatadogEventWriter.class);
   private static final long DEFAULT_FLUSH_DELAY = 2;

--- a/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventWriter.java
+++ b/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventWriter.java
@@ -59,6 +59,7 @@ import org.slf4j.LoggerFactory;
 public abstract class DatadogEventWriter
     extends DoFn<KV<Integer, DatadogEvent>, DatadogWriteError> {
 
+  private static final Integer MIN_BATCH_COUNT = 10;
   private static final Integer DEFAULT_BATCH_COUNT = 10;
   private static final Integer MAX_BATCH_COUNT = 1000;
   private static final Logger LOG = LoggerFactory.getLogger(DatadogEventWriter.class);
@@ -107,7 +108,12 @@ public abstract class DatadogEventWriter
       new GsonBuilder().setFieldNamingStrategy(f -> f.getName().toLowerCase()).create();
 
   public static Builder newBuilder() {
-    return new AutoValue_DatadogEventWriter.Builder();
+    return newBuilder(null);
+  }
+
+  public static Builder newBuilder(Integer minBatchCount) {
+    return new AutoValue_DatadogEventWriter.Builder()
+        .setMinBatchCount(MoreObjects.firstNonNull(minBatchCount, MIN_BATCH_COUNT));
   }
 
   @Nullable
@@ -115,6 +121,9 @@ public abstract class DatadogEventWriter
 
   @Nullable
   abstract ValueProvider<String> apiKey();
+
+  @Nullable
+  abstract Integer minBatchCount();
 
   @Nullable
   abstract ValueProvider<Integer> inputBatchCount();
@@ -136,6 +145,10 @@ public abstract class DatadogEventWriter
       batchCount = MoreObjects.firstNonNull(batchCount, DEFAULT_BATCH_COUNT);
       LOG.info("Batch count set to: {}", batchCount);
     }
+    checkArgument(
+        batchCount >= minBatchCount(),
+        "batchCount must be greater than or equal to %s",
+        minBatchCount());
     checkArgument(
         batchCount <= MAX_BATCH_COUNT,
         "batchCount must be less than or equal to %s",
@@ -381,6 +394,10 @@ public abstract class DatadogEventWriter
 
     abstract ValueProvider<String> apiKey();
 
+    abstract Builder setMinBatchCount(Integer minBatchCount);
+
+    abstract Integer minBatchCount();
+
     abstract Builder setInputBatchCount(ValueProvider<Integer> inputBatchCount);
 
     abstract DatadogEventWriter autoBuild();
@@ -443,6 +460,10 @@ public abstract class DatadogEventWriter
       if (inputBatchCount != null && inputBatchCount.isAccessible()) {
         Integer batchCount = inputBatchCount.get();
         if (batchCount != null) {
+          checkArgument(
+              batchCount >= minBatchCount(),
+              "inputBatchCount must be greater than or equal to %s",
+              minBatchCount());
           checkArgument(
               batchCount <= MAX_BATCH_COUNT,
               "inputBatchCount must be less than or equal to %s",

--- a/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogIO.java
+++ b/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogIO.java
@@ -44,7 +44,11 @@ public class DatadogIO {
   private DatadogIO() {}
 
   public static Write.Builder writeBuilder() {
-    return new AutoValue_DatadogIO_Write.Builder();
+    return writeBuilder(null);
+  }
+
+  public static Write.Builder writeBuilder(Integer minBatchCount) {
+    return new AutoValue_DatadogIO_Write.Builder().setMinBatchCount(minBatchCount);
   }
 
   /**
@@ -64,6 +68,9 @@ public class DatadogIO {
     abstract ValueProvider<String> apiKey();
 
     @Nullable
+    abstract Integer minBatchCount();
+
+    @Nullable
     abstract ValueProvider<Integer> batchCount();
 
     @Nullable
@@ -74,7 +81,7 @@ public class DatadogIO {
 
       LOG.info("Configuring DatadogEventWriter.");
       DatadogEventWriter.Builder builder =
-          DatadogEventWriter.newBuilder()
+          DatadogEventWriter.newBuilder(minBatchCount())
               .withUrl(url())
               .withInputBatchCount(batchCount())
               .withApiKey(apiKey());
@@ -100,6 +107,8 @@ public class DatadogIO {
       abstract Builder setApiKey(ValueProvider<String> apiKey);
 
       abstract ValueProvider<String> apiKey();
+
+      abstract Builder setMinBatchCount(Integer minBatchCount);
 
       abstract Builder setBatchCount(ValueProvider<Integer> batchCount);
 

--- a/v1/src/test/java/com/google/cloud/teleport/datadog/DatadogEventWriterTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/datadog/DatadogEventWriterTest.java
@@ -133,6 +133,27 @@ public class DatadogEventWriterTest {
     assertThat(writer.inputBatchCount()).isNull();
   }
 
+  /**
+   * Test building {@link DatadogEventWriter} with a batchCount less than the configured minimum.
+   */
+  @Test
+  public void eventWriterBatchCountTooSmall() {
+
+    Exception thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                DatadogEventWriter.newBuilder(7)
+                    .withUrl("http://test-url")
+                    .withApiKey("test-api-key")
+                    .withInputBatchCount(StaticValueProvider.of(6))
+                    .build());
+
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains("inputBatchCount must be greater than or equal to 7");
+  }
+
   /** Test building {@link DatadogEventWriter} with a batchCount greater than 1000. */
   @Test
   public void eventWriterBatchCountTooBig() {
@@ -152,7 +173,7 @@ public class DatadogEventWriterTest {
         .contains("inputBatchCount must be less than or equal to 1000");
   }
 
-  /** Test building {@link DatadogEventWriter} with custom batchcount . */
+  /** Test building {@link DatadogEventWriter} with custom batchCount . */
   @Test
   public void eventWriterCustomBatchCountAndValidation() {
 
@@ -207,7 +228,7 @@ public class DatadogEventWriterTest {
             .apply(
                 "DatadogEventWriter",
                 ParDo.of(
-                    DatadogEventWriter.newBuilder()
+                    DatadogEventWriter.newBuilder(1)
                         .withUrl(Joiner.on(':').join("http://localhost", testPort))
                         .withInputBatchCount(
                             StaticValueProvider.of(1)) // Test one request per DatadogEvent
@@ -265,7 +286,7 @@ public class DatadogEventWriterTest {
             .apply(
                 "DatadogEventWriter",
                 ParDo.of(
-                    DatadogEventWriter.newBuilder()
+                    DatadogEventWriter.newBuilder(1)
                         .withUrl(Joiner.on(':').join("http://localhost", testPort))
                         .withInputBatchCount(
                             StaticValueProvider.of(
@@ -314,7 +335,7 @@ public class DatadogEventWriterTest {
             .apply(
                 "DatadogEventWriter",
                 ParDo.of(
-                    DatadogEventWriter.newBuilder()
+                    DatadogEventWriter.newBuilder(1)
                         .withUrl(Joiner.on(':').join("http://localhost", testPort))
                         .withInputBatchCount(
                             StaticValueProvider.of(

--- a/v1/src/test/java/com/google/cloud/teleport/datadog/DatadogIOTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/datadog/DatadogIOTest.java
@@ -86,7 +86,7 @@ public class DatadogIOTest {
             .apply("Create Input data", Create.of(DATADOG_EVENTS).withCoder(DatadogEventCoder.of()))
             .apply(
                 "DatadogIO",
-                DatadogIO.writeBuilder()
+                DatadogIO.writeBuilder(1)
                     .withParallelism(1)
                     .withBatchCount(DATADOG_EVENTS.size())
                     .withApiKey("test-api-key")
@@ -115,7 +115,7 @@ public class DatadogIOTest {
             .apply("Create Input data", Create.of(DATADOG_EVENTS).withCoder(DatadogEventCoder.of()))
             .apply(
                 "DatadogIO",
-                DatadogIO.writeBuilder()
+                DatadogIO.writeBuilder(1)
                     .withParallelism(TEST_PARALLELISM)
                     .withBatchCount(DATADOG_EVENTS.size())
                     .withApiKey("test-api-key")
@@ -144,7 +144,7 @@ public class DatadogIOTest {
             .apply("Create Input data", Create.of(DATADOG_EVENTS).withCoder(DatadogEventCoder.of()))
             .apply(
                 "DatadogIO",
-                DatadogIO.writeBuilder()
+                DatadogIO.writeBuilder(1)
                     .withParallelism(TEST_PARALLELISM)
                     .withBatchCount(1)
                     .withApiKey("test-api-key")


### PR DESCRIPTION
This PR changes:
- `DEFAULT_BATCH_COUNT` from `10` to `100`
- adds the concept of a `MIN_BATCH_COUNT`, set to `10` (not configurable)

I added a `minBatchCount` to a couple of the builders here, to facilitate testing (i.e. still allow testing of `batchCount=1` by setting `minBatchCount=1` as well. In production code, `minBatchCount` is always configured to `MIN_BATCH_COUNT=10`. Let me know if there's a simpler way, or if you have any questions! 🙏 