### PR TITLE
Do not fail validation on branded template (hidden parameter)

### DIFF
--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/dataflow/DirectRunnerClient.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/dataflow/DirectRunnerClient.java
@@ -206,7 +206,7 @@ public class DirectRunnerClient implements PipelineLauncher {
 
       try {
         String[] args = commandLines.toArray(new String[0]);
-        Method mainMethod = mainClass.getDeclaredMethod("main", String[].class);
+        Method mainMethod = mainClass.getMethod("main", String[].class);
         currentJob.setCurrentState(JobState.RUNNING.toString());
 
         LOG.info("Starting job {}...", currentJob.getId());


### PR DESCRIPTION
Some static calls done through reflection fail without having a "main" method:

```
java.lang.NoSuchMethodException: com.google.cloud.teleport.v2.templates.MySQLToBigQuery.main([Ljava.lang.String;)
	at java.base/java.lang.Class.getDeclaredMethod(Class.java:2475)
	at com.google.cloud.teleport.it.gcp.dataflow.DirectRunnerClient$DirectRunnerJobThread.run(DirectRunnerClient.java:209)
```