### PR TITLE
Converge hbase dependencies at bigtable-common, and exclude htrace transient dependency

### DIFF
--- a/v2/bigtable-cdc-to-hbase/pom.xml
+++ b/v2/bigtable-cdc-to-hbase/pom.xml
@@ -45,20 +45,6 @@
       <version>${beam.version}</version>
     </dependency>
 
-    <!--Most Hbase dependencies -->
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-shaded-client</artifactId>
-      <version>2.3.6</version>
-    </dependency>
-    <!--  Hbase test dependencies  -->
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-shaded-testing-util</artifactId>
-      <version>2.3.6</version>
-      <scope>test</scope>
-    </dependency>
-
     <!-- Provide hadoop library  -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/v2/bigtable-common/pom.xml
+++ b/v2/bigtable-common/pom.xml
@@ -55,7 +55,18 @@
                     <groupId>log4j</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.htrace</groupId>
+                    <artifactId>htrace-core4</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <!--  Hbase test dependencies  -->
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-shaded-testing-util</artifactId>
+            <version>${hbase.client.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.truth</groupId>


### PR DESCRIPTION
Doing for security / no longer maintained reasons. 