### PR TITLE
Add Hbase testing dependencies in the submodule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
     <derby.version>10.14.2.0</derby.version>
     <hadoop.version>3.3.5</hadoop.version>
     <hamcrest.version>2.1</hamcrest.version>
+    <hbase.client.version>2.5.3-hadoop3</hbase.client.version>
     <guava.version>31.0.1-jre</guava.version>
     <mockito.version>4.11.0</mockito.version>
     <log4j-2.version>2.17.2</log4j-2.version>

--- a/v2/bigtable-cdc-to-hbase/pom.xml
+++ b/v2/bigtable-cdc-to-hbase/pom.xml
@@ -72,5 +72,13 @@
       <version>1.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
+
+    <!--  Hbase test dependencies  -->
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-shaded-testing-util</artifactId>
+      <version>${hbase.client.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/v2/bigtable-common/pom.xml
+++ b/v2/bigtable-common/pom.xml
@@ -27,7 +27,6 @@
 
     <properties>
         <bigtable.version>2.7.0</bigtable.version>
-        <hbase.client.version>2.5.3-hadoop3</hbase.client.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
It does not get `<scope>test</scope>` transitively