### PR TITLE
Avoid parallelism conflict for extra_libs folder

### DIFF
--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -517,7 +517,7 @@
               <goal>copy-dependencies</goal>
             </goals>
             <configuration>
-              <outputDirectory>${basedir}/target/extra_libs</outputDirectory>
+              <outputDirectory>${project.build.directory}/extra_libs</outputDirectory>
               <includeArtifactIds>conscrypt-openjdk-uber</includeArtifactIds>
               <stripVersion>true</stripVersion>
             </configuration>
@@ -934,7 +934,7 @@
                 <configuration>
                   <extraDirectories>
                     <paths>
-                      <path>${basedir}/target/extra_libs</path>
+                      <path>${project.build.directory}/extra_libs</path>
                     </paths>
                   </extraDirectories>
                   <createDependencyReducedPom>false</createDependencyReducedPom>

--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -302,7 +302,7 @@
                           <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                          <outputDirectory>${basedir}/target/extra_libs</outputDirectory>
+                          <outputDirectory>${project.build.directory}/extra_libs</outputDirectory>
                           <includeArtifactIds>conscrypt-openjdk-uber</includeArtifactIds>
                           <stripVersion>true</stripVersion>
                         </configuration>
@@ -524,7 +524,7 @@
                                 <configuration>
                                     <extraDirectories>
                                         <paths>
-                                            <path>${basedir}/target/extra_libs</path>
+                                            <path>${project.build.directory}/extra_libs</path>
                                         </paths>
                                     </extraDirectories>
                                     <createDependencyReducedPom>false</createDependencyReducedPom>


### PR DESCRIPTION
When running tests, the ${project.build.directory} is set to a unique id, so it helps to avoid racing conditions such as:

```
2023-07-10 13:38:52 INFO  TemplateTestBase:40 - Caused by: java.io.IOException: Failed to copy full contents from /home/user/.m2/repository/org/conscrypt/conscrypt-openjdk-uber/2.5.2/conscrypt-openjdk-uber-2.5.2.jar to /home/user/workspace/v1/target/extra_libs/conscrypt-openjdk-uber.jar
2023-07-10 13:38:52 INFO  TemplateTestBase:40 -     at org.codehaus.plexus.util.FileUtils.copyFile (FileUtils.java:1087)
```