### PR TITLE
Add synchronized annotation to cleanupAll for PipelineLaunchers

### DIFF
--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/dataflow/AbstractPipelineLauncher.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/dataflow/AbstractPipelineLauncher.java
@@ -302,7 +302,7 @@ public abstract class AbstractPipelineLauncher implements PipelineLauncher {
   }
 
   @Override
-  public void cleanupAll() throws IOException {
+  public synchronized void cleanupAll() throws IOException {
     for (String jobId : launchedJobs) {
       try {
         JobState state = getJobStatus(TestProperties.project(), TestProperties.region(), jobId);

--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/dataflow/DirectRunnerClient.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/dataflow/DirectRunnerClient.java
@@ -142,7 +142,7 @@ public class DirectRunnerClient implements PipelineLauncher {
   }
 
   @Override
-  public void cleanupAll() throws IOException {
+  public synchronized void cleanupAll() throws IOException {
     // Cancel / terminate all threads for DirectRunnerClient
     for (DirectRunnerJobThread jobs : managedJobs.values()) {
       jobs.cancel();

--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/pubsub/PubsubResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/pubsub/PubsubResourceManager.java
@@ -289,7 +289,7 @@ public final class PubsubResourceManager implements ResourceManager {
       return;
     }
 
-    LOG.info("Attempting to cleanup manager.");
+    LOG.info("Attempting to cleanup Pub/Sub resource manager.");
 
     try {
       for (SubscriptionName subscription : createdSubscriptions) {


### PR DESCRIPTION
Recently, a test run got into ConcurrentModificationException during cleanups. It is quite uncommon, but can definitely happen.