### PR TITLE
Reduce the test name to fulfill the 30 chars limit

### DIFF
--- a/v2/postgresql-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLToBigQueryIT.java
+++ b/v2/postgresql-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLToBigQueryIT.java
@@ -77,7 +77,7 @@ public class PostgreSQLToBigQueryIT extends TemplateTestBase {
   }
 
   @Test
-  public void testPostgreSqlToBigQueryDedicated() throws IOException {
+  public void testPostgresToBigQueryBrand() throws IOException {
     // Create postgres Resource manager
     postgresResourceManager = PostgresResourceManager.builder(testName).build();
 


### PR DESCRIPTION
I renamed the test, and they now failed because of a table length limit: java.lang.IllegalArgumentException: Table name testPostgreSqlToBigQueryDedicated cannot be longer than 30 characters.
	at com.google.cloud.teleport.v2.templates.PostgreSQLToBigQueryIT.testPostgreSqlToBigQueryDedicated(PostgreSQLToBigQueryIT.java:95)