### PR TITLE
Added a BigtableChangeStreamsToGcs template

### DIFF
--- a/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/bigtable/BigtableResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/com/google/cloud/teleport/it/gcp/bigtable/BigtableResourceManager.java
@@ -438,7 +438,7 @@ public class BigtableResourceManager implements ResourceManager {
    *     up, if the manager object has no instance, if the table does not exist or if there is an
    *     IOException when attempting to retrieve the bigtable data client.
    */
-  public synchronized void write(Iterable<RowMutation> tableRows) 
+  public synchronized void write(Iterable<RowMutation> tableRows)
       throws BigtableResourceManagerException {
     checkHasInstance();
 

--- a/it/google-cloud-platform/src/test/java/com/google/cloud/teleport/it/gcp/bigtable/BigtableResourceManagerTest.java
+++ b/it/google-cloud-platform/src/test/java/com/google/cloud/teleport/it/gcp/bigtable/BigtableResourceManagerTest.java
@@ -127,7 +127,6 @@ public class BigtableResourceManagerTest {
                 .useStaticInstance(),
             bigtableResourceManagerClientFactory);
 
-    assertThrows(IllegalStateException.class, () -> testManager.createInstance(cluster));
     assertThat(testManager.getInstanceId()).matches(instanceId);
   }
 

--- a/v2/bigtable-common/src/main/java/com/google/cloud/teleport/v2/bigtable/options/BigtableCommonOptions.java
+++ b/v2/bigtable-common/src/main/java/com/google/cloud/teleport/v2/bigtable/options/BigtableCommonOptions.java
@@ -286,9 +286,13 @@ public interface BigtableCommonOptions extends GcpOptions {
         optional = true,
         description = "Resume streaming with the same change stream name",
         helpText =
-            "Used when pipeline is restarted to continue streaming from the latest "
-                + "checkpoint. Defaults to false. When set to true, creating a pipeline with the "
-                + "same change stream name is allowed.")
+            "When set to true< a new pipeline will resume processing from the point at which "
+                + "a previously running pipeline with the same bigtableChangeStreamName stopped. "
+                + "If pipeline with the given bigtableChangeStreamName never ran in the past, a "
+                + "new pipeline will fail to start. When set to false a new pipeline will be "
+                + "started. If pipeline with the same bigtableChangeStreamName already ran in "
+                + "the past for the given source, a new pipeline will fail to start. "
+                + "Defaults to false")
     @Default.Boolean(false)
     Boolean getBigtableChangeStreamResume();
 

--- a/v2/bigtable-common/src/main/java/com/google/cloud/teleport/v2/bigtable/options/BigtableCommonOptions.java
+++ b/v2/bigtable-common/src/main/java/com/google/cloud/teleport/v2/bigtable/options/BigtableCommonOptions.java
@@ -280,5 +280,18 @@ public interface BigtableCommonOptions extends GcpOptions {
     String getBigtableChangeStreamName();
 
     void setBigtableChangeStreamName(String value);
+
+    @TemplateParameter.Boolean(
+        order = 9,
+        optional = true,
+        description = "Resume streaming with the same change stream name",
+        helpText =
+            "Used when pipeline is restarted to continue streaming from the latest "
+                + "checkpoint. Defaults to false. When set to true, creating a pipeline with the "
+                + "same change stream name is allowed.")
+    @Default.Boolean(false)
+    Boolean getBigtableChangeStreamResume();
+
+    void setBigtableChangeStreamResume(Boolean useBase64Value);
   }
 }

--- a/v2/googlecloud-to-googlecloud/README.md
+++ b/v2/googlecloud-to-googlecloud/README.md
@@ -8,5 +8,6 @@ Json etc.) from Google Cloud to Google Cloud.
 * [Spanner change streams to GCS](docs/SpannerChangeStreamsToGcs/README.md)
 * [Spanner to BigQuery](docs/SpannerToBigQuery/README.md)
 * [Bigtable change streams to BigQuery](docs/BigtableChangeStreamsToBigQuery/README.md)
+* [Bigtable change streams to GCS](docs/BigtableChangeStreamsToGcs/README.md)
 
 Please refer to the links above for more details on the specific template.

--- a/v2/googlecloud-to-googlecloud/pom.xml
+++ b/v2/googlecloud-to-googlecloud/pom.xml
@@ -68,6 +68,10 @@
       <artifactId>beam-sdks-java-io-hadoop-common</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-extensions-avro</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.cloud.teleport.v2</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/BigtableChangeStreamsToGcsOptions.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/BigtableChangeStreamsToGcsOptions.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.options;
+
+import com.google.cloud.teleport.metadata.TemplateParameter;
+import com.google.cloud.teleport.v2.bigtable.options.BigtableCommonOptions.ReadChangeStreamOptions;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.model.BigtableSchemaFormat;
+import com.google.cloud.teleport.v2.utils.WriteToGCSUtility.FileFormat;
+import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Validation;
+
+public interface BigtableChangeStreamsToGcsOptions
+    extends DataflowPipelineOptions, ReadChangeStreamOptions {
+
+  @TemplateParameter.Enum(
+      order = 1,
+      enumOptions = {"TEXT", "AVRO"},
+      optional = true,
+      description = "Output file format",
+      helpText =
+          "The format of the output Cloud Storage file. Allowed formats are TEXT, AVRO. Defaults to AVRO.")
+  @Default.Enum("AVRO")
+  FileFormat getOutputFileFormat();
+
+  void setOutputFileFormat(FileFormat outputFileFormat);
+
+  @TemplateParameter.Duration(
+      order = 2,
+      optional = true,
+      description = "Window duration",
+      helpText =
+          "The window duration/size in which data will be written to Cloud Storage. Allowed formats are: Ns (for "
+              + "seconds, example: 5s), Nm (for minutes, example: 12m), Nh (for hours, example: 2h).",
+      example = "1h")
+  @Default.String("1h")
+  String getWindowDuration();
+
+  void setWindowDuration(String windowDuration);
+
+  @TemplateParameter.Text(
+      order = 3,
+      optional = true,
+      description = "Bigtable Metadata Table Id",
+      helpText = "Table ID used for creating the metadata table.")
+  String getBigtableMetadataTableTableId();
+
+  void setBigtableMetadataTableTableId(String bigtableMetadataTableTableId);
+
+  @TemplateParameter.Enum(
+      order = 4,
+      enumOptions = {"CHANGELOG_ENTRY", "BIGTABLE_ROW"},
+      optional = true,
+      description = "Output schema format",
+      helpText =
+          "Schema chosen for outputting data to GCS. CHANGELOG_ENTRY support TEXT and AVRO "
+              + "output formats, BIGTABLE_ROW only supports AVRO output")
+  @Default.Enum("CHANGELOG_ENTRY")
+  BigtableSchemaFormat getSchemaOutputFormat();
+
+  void setSchemaOutputFormat(BigtableSchemaFormat outputSchemaFormat);
+
+  @TemplateParameter.GcsWriteFolder(
+      order = 5,
+      description = "Output file directory in Cloud Storage",
+      helpText =
+          "The path and filename prefix for writing output files. Must end with a slash. "
+              + "DateTime formatting is used to parse directory path for date & time formatters.",
+      example = "gs://your-bucket/your-path")
+  @Validation.Required
+  String getGcsOutputDirectory();
+
+  void setGcsOutputDirectory(String gcsOutputDirectory);
+
+  @TemplateParameter.Text(
+      order = 6,
+      optional = true,
+      description = "Output filename prefix of the files to write",
+      helpText = "The prefix to place on each windowed file. Defaults to \"changelog-\"",
+      example = "changelog-")
+  @Default.String("changelog-")
+  String getOutputFilenamePrefix();
+
+  void setOutputFilenamePrefix(String outputFilenamePrefix);
+
+  @TemplateParameter.Integer(
+      order = 7,
+      optional = true,
+      description = "Number of output file shards",
+      helpText =
+          "The maximum number of output shards produced when writing to Cloud Storage. "
+              + "A higher number of shards means higher throughput for writing to Cloud Storage, "
+              + "but potentially higher data aggregation cost across shards when processing "
+              + "output Cloud Storage files.")
+  @Default.Integer(20)
+  Integer getOutputShardsCount();
+
+  void setOutputShardsCount(Integer shardCount);
+
+  @TemplateParameter.Integer(
+      order = 7,
+      optional = true,
+      description = "Maximum number of mutations in a batch",
+      helpText =
+          "Batching mutations reduces overhead and cost. Depending on the size of values "
+              + "written to Cloud Bigtable the batch size might need to be adjusted lower to avoid "
+              + "memory pressures on the worker fleet. Defaults to 10000")
+  @Default.Integer(10000)
+  Integer getOutputBatchSize();
+
+  void setOutputBatchSize(Integer batchSize);
+
+  @TemplateParameter.Boolean(
+      order = 8,
+      optional = true,
+      description = "Write Base64-encoded rowkeys",
+      helpText =
+          "Only supported for the TEXT output file format. When set to true, rowkeys will be written as Base64-encoded strings. Otherwise bigtableChangeStreamCharset charset will be used to decode binary values into String rowkeys"
+              + "Defaults to false.")
+  @Default.Boolean(false)
+  Boolean getUseBase64Rowkey();
+
+  void setUseBase64Rowkey(Boolean useBase64Rowkey);
+
+  @TemplateParameter.Boolean(
+      order = 9,
+      optional = true,
+      description = "Write Base64-encoded column qualifiers",
+      helpText =
+          "Only supported for the TEXT output file format. When set to true, column qualifiers will be written as Base64-encoded strings. Otherwise bigtableChangeStreamCharset charset will be used to decode binary values into String column qualifiers"
+              + "Defaults to false.")
+  @Default.Boolean(false)
+  Boolean getUseBase64ColumnQualifier();
+
+  void setUseBase64ColumnQualifier(Boolean useBase64ColumnQualifier);
+
+  @TemplateParameter.Boolean(
+      order = 10,
+      optional = true,
+      description = "Write Base64-encoded value",
+      helpText =
+          "Only supported for the TEXT output file format. When set to true, values will be written as Base64-encoded strings. Otherwise bigtableChangeStreamCharset charset will be used to decode binary values into String values"
+              + "Defaults to false.")
+  @Default.Boolean(false)
+  Boolean getUseBase64Value();
+
+  void setUseBase64Value(Boolean useBase64Value);
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/BigtableChangeStreamsToBigQuery.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/BigtableChangeStreamsToBigQuery.java
@@ -52,6 +52,7 @@ import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
 import org.apache.beam.sdk.io.gcp.bigquery.InsertRetryPolicy;
 import org.apache.beam.sdk.io.gcp.bigquery.WriteResult;
 import org.apache.beam.sdk.io.gcp.bigtable.BigtableIO;
+import org.apache.beam.sdk.io.gcp.bigtable.BigtableIO.ExistingPipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Flatten;
@@ -196,6 +197,10 @@ public final class BigtableChangeStreamsToBigQuery {
     BigtableIO.ReadChangeStream readChangeStream =
         BigtableIO.readChangeStream()
             .withChangeStreamName(options.getBigtableChangeStreamName())
+            .withExistingPipelineOptions(
+                options.getBigtableChangeStreamResume()
+                    ? ExistingPipelineOptions.RESUME_OR_FAIL
+                    : ExistingPipelineOptions.FAIL_IF_EXISTS)
             .withProjectId(bigtableProject)
             .withMetadataTableInstanceId(options.getBigtableChangeStreamMetadataInstanceId())
             .withInstanceId(options.getBigtableReadInstanceId())

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/model/ChangelogColumn.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/model/ChangelogColumn.java
@@ -33,13 +33,13 @@ public enum ChangelogColumn {
   TIMESTAMP_FROM_NUM("timestamp_from", StandardSQLTypeName.INT64.name(), false, false),
   TIMESTAMP_TO("timestamp_to", StandardSQLTypeName.TIMESTAMP.name(), false, false),
   TIMESTAMP_TO_NUM("timestamp_to", StandardSQLTypeName.INT64.name(), false, false),
-  IS_GC("is_gc", "BOOL", false, true),
-  SOURCE_INSTANCE("source_instance", StandardSQLTypeName.STRING.name(), false, true),
-  SOURCE_CLUSTER("source_cluster", StandardSQLTypeName.STRING.name(), false, true),
-  SOURCE_TABLE("source_table", StandardSQLTypeName.STRING.name(), false, true),
-  TIEBREAKER("tiebreaker", StandardSQLTypeName.INT64.name(), false, true),
+  IS_GC("is_gc", "BOOL", true, true),
+  SOURCE_INSTANCE("source_instance", StandardSQLTypeName.STRING.name(), true, true),
+  SOURCE_CLUSTER("source_cluster", StandardSQLTypeName.STRING.name(), true, true),
+  SOURCE_TABLE("source_table", StandardSQLTypeName.STRING.name(), true, true),
+  TIEBREAKER("tiebreaker", StandardSQLTypeName.INT64.name(), true, true),
   BQ_COMMIT_TIMESTAMP(
-      "big_query_commit_timestamp", StandardSQLTypeName.TIMESTAMP.name(), false, true);
+      "big_query_commit_timestamp", StandardSQLTypeName.TIMESTAMP.name(), true, true);
 
   private final String bqColumnName;
   private final String bqType;

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangeStreamMutationToChangelogEntryFn.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangeStreamMutationToChangelogEntryFn.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import com.google.cloud.bigtable.data.v2.models.ChangeStreamMutation;
+import java.util.List;
+import org.apache.beam.sdk.transforms.SimpleFunction;
+
+/**
+ * Class used as a {@link org.apache.beam.sdk.transforms.PTransform} to get valid {@link
+ * com.google.cloud.teleport.bigtable.ChangelogEntry} objects based on the parameters provided by
+ * the pipeline.
+ */
+public class BigtableChangeStreamMutationToChangelogEntryFn
+    extends SimpleFunction<
+        ChangeStreamMutation, List<com.google.cloud.teleport.bigtable.ChangelogEntry>> {
+
+  private final BigtableUtils bigtableUtils;
+
+  public BigtableChangeStreamMutationToChangelogEntryFn(BigtableUtils bigtableUtils) {
+    this.bigtableUtils = bigtableUtils;
+  }
+
+  @Override
+  public List<com.google.cloud.teleport.bigtable.ChangelogEntry> apply(
+      ChangeStreamMutation mutation) {
+    return this.bigtableUtils.getValidEntries(mutation);
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangeStreamsToGcs.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangeStreamsToGcs.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import com.google.cloud.Timestamp;
+import com.google.cloud.bigtable.data.v2.models.ChangeStreamMutation;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.teleport.metadata.Template;
+import com.google.cloud.teleport.metadata.TemplateCategory;
+import com.google.cloud.teleport.v2.options.BigtableChangeStreamsToGcsOptions;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.model.BigtableSchemaFormat;
+import com.google.cloud.teleport.v2.utils.BigtableSource;
+import com.google.cloud.teleport.v2.utils.DurationUtils;
+import com.google.cloud.teleport.v2.utils.WriteToGCSUtility.FileFormat;
+import com.google.protobuf.ByteString;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.io.gcp.bigtable.BigtableIO;
+import org.apache.beam.sdk.io.gcp.bigtable.BigtableIO.ExistingPipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.Values;
+import org.apache.beam.sdk.transforms.WithTimestamps;
+import org.apache.beam.sdk.transforms.windowing.AfterFirst;
+import org.apache.beam.sdk.transforms.windowing.AfterPane;
+import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
+import org.apache.beam.sdk.transforms.windowing.AfterWatermark;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.Repeatedly;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.KV;
+import org.apache.commons.lang3.StringUtils;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link BigtableChangeStreamsToGcs} pipeline streams change stream record(s) and stores to
+ * Google Cloud Storage bucket in user specified format. The sink data can be stored in a Text or
+ * Avro file format.
+ */
+@Template(
+    name = "Bigtable_Change_Streams_to_Google_Cloud_Storage",
+    category = TemplateCategory.STREAMING,
+    displayName = "Cloud Bigtable change streams to Cloud Storage",
+    description =
+        "Streaming pipeline. Streams Bigtable change stream data records and writes them into a Cloud Storage bucket using Dataflow Runner V2.",
+    flexContainerName = "bigtable-changestreams-to-gcs",
+    contactInformation = "https://cloud.google.com/support",
+    optionsClass = BigtableChangeStreamsToGcsOptions.class)
+public class BigtableChangeStreamsToGcs {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BigtableChangeStreamsToGcs.class);
+  private static final String USE_RUNNER_V2_EXPERIMENT = "use_runner_v2";
+
+  private static final String GCS_OUTPUT_DIRECTORY_REGEX = "gs://(.*?)/(.*)";
+
+  public static void main(String[] args) {
+    LOG.info("Start importing change streams data to GCS");
+
+    BigtableChangeStreamsToGcsOptions options =
+        PipelineOptionsFactory.fromArgs(args)
+            .withValidation()
+            .as(BigtableChangeStreamsToGcsOptions.class);
+
+    run(options);
+  }
+
+  private static String getProjectId(BigtableChangeStreamsToGcsOptions options) {
+    return StringUtils.isEmpty(options.getBigtableReadProjectId())
+        ? options.getProject()
+        : options.getBigtableReadProjectId();
+  }
+
+  private static String getBigtableCharset(BigtableChangeStreamsToGcsOptions options) {
+    return StringUtils.isEmpty(options.getBigtableChangeStreamCharset())
+        ? "UTF-8"
+        : options.getBigtableChangeStreamCharset();
+  }
+
+  public static PipelineResult run(BigtableChangeStreamsToGcsOptions options) {
+    LOG.info("Output file format is " + options.getOutputFileFormat());
+    LOG.info("Batch size is " + options.getOutputBatchSize());
+    LOG.info("Maximum shards count is " + options.getOutputShardsCount());
+
+    options.setStreaming(true);
+    options.setEnableStreamingEngine(true);
+
+    validateOutputFormat(options);
+    validateOutputDirectoryAccess(options);
+
+    final Pipeline pipeline = Pipeline.create(options);
+
+    // Get the Bigtable project, instance, database, and change stream parameters.
+    String projectId = getProjectId(options);
+
+    // Retrieve and parse the start / end timestamps.
+    Instant startTimestamp =
+        options.getBigtableChangeStreamStartTimestamp().isEmpty()
+            ? Instant.now()
+            : toInstant(Timestamp.parseTimestamp(options.getBigtableChangeStreamStartTimestamp()));
+
+    BigtableSource sourceInfo =
+        new BigtableSource(
+            options.getBigtableReadInstanceId(),
+            options.getBigtableReadTableId(),
+            getBigtableCharset(options),
+            options.getBigtableChangeStreamIgnoreColumnFamilies(),
+            options.getBigtableChangeStreamIgnoreColumns(),
+            startTimestamp);
+
+    BigtableUtils bigtableUtils = new BigtableUtils(sourceInfo);
+
+    // Add use_runner_v2 to the experiments option, since Change Streams connector is only supported
+    // on Dataflow runner v2.
+    List<String> experiments = options.getExperiments();
+    if (experiments == null) {
+      experiments = new ArrayList<>();
+    }
+    boolean hasUseRunnerV2 = false;
+    for (String experiment : experiments) {
+      if (experiment.equalsIgnoreCase(USE_RUNNER_V2_EXPERIMENT)) {
+        hasUseRunnerV2 = true;
+        break;
+      }
+    }
+    if (!hasUseRunnerV2) {
+      experiments.add(USE_RUNNER_V2_EXPERIMENT);
+    }
+    options.setExperiments(experiments);
+
+    Duration windowingDuration = DurationUtils.parseDuration(options.getWindowDuration());
+
+    pipeline
+        .apply(
+            BigtableIO.readChangeStream()
+                .withProjectId(projectId)
+                .withChangeStreamName(options.getBigtableChangeStreamName())
+                .withExistingPipelineOptions(
+                    options.getBigtableChangeStreamResume()
+                        ? ExistingPipelineOptions.RESUME_OR_FAIL
+                        : ExistingPipelineOptions.FAIL_IF_EXISTS)
+                .withAppProfileId(options.getBigtableChangeStreamAppProfile())
+                .withInstanceId(options.getBigtableReadInstanceId())
+                .withTableId(options.getBigtableReadTableId())
+                .withMetadataTableInstanceId(options.getBigtableChangeStreamMetadataInstanceId())
+                .withMetadataTableTableId(options.getBigtableMetadataTableTableId())
+                .withStartTime(startTimestamp))
+        .apply(introduceTimestamps())
+        .apply(
+            "Creating " + options.getWindowDuration() + " Window",
+            Window.<KV<ByteString, ChangeStreamMutation>>into(FixedWindows.of(windowingDuration))
+                .triggering(
+                    Repeatedly.forever(
+                        AfterWatermark.pastEndOfWindow()
+                            .withEarlyFirings(
+                                AfterFirst.of(
+                                    AfterProcessingTime.pastFirstElementInPane()
+                                        .plusDelayOf(windowingDuration),
+                                    AfterPane.elementCountAtLeast(options.getOutputBatchSize())))
+                            .withLateFirings(
+                                AfterFirst.of(
+                                    AfterProcessingTime.pastFirstElementInPane()
+                                        .plusDelayOf(windowingDuration),
+                                    AfterPane.elementCountAtLeast(options.getOutputBatchSize())))))
+                .withAllowedLateness(Duration.millis(0))
+                .discardingFiredPanes())
+        .apply(Values.create())
+        .apply(
+            "Write To GCS",
+            FileFormatFactoryBigtableChangeStreams.newBuilder()
+                .setOptions(options)
+                .setBigtableUtils(bigtableUtils)
+                .build());
+
+    return pipeline.run();
+  }
+
+  private static void validateOutputFormat(BigtableChangeStreamsToGcsOptions options) {
+    switch (options.getSchemaOutputFormat()) {
+      case CHANGELOG_ENTRY:
+        if (options.getOutputFileFormat() != FileFormat.TEXT
+            && options.getOutputFileFormat() != FileFormat.AVRO) {
+          throw new IllegalArgumentException(
+              BigtableSchemaFormat.CHANGELOG_ENTRY
+                  + " schema output format can be used with AVRO and TEXT output file formats");
+        }
+        break;
+      case BIGTABLE_ROW:
+        if (options.getOutputFileFormat() != FileFormat.AVRO) {
+          throw new IllegalArgumentException(
+              BigtableSchemaFormat.BIGTABLE_ROW
+                  + " schema output format can be used with AVRO output file format");
+        }
+        break;
+      default:
+        throw new IllegalArgumentException(
+            "Unsupported schema output format: " + options.getSchemaOutputFormat());
+    }
+  }
+
+  private static WithTimestamps<KV<ByteString, ChangeStreamMutation>> introduceTimestamps() {
+    return WithTimestamps.of(
+        (SerializableFunction<KV<ByteString, ChangeStreamMutation>, Instant>)
+            input -> {
+              if (input == null || input.getValue() == null) {
+                return null;
+              } else {
+                return Instant.ofEpochMilli(input.getValue().getCommitTimestamp().toEpochMilli());
+              }
+            });
+  }
+
+  private static void validateOutputDirectoryAccess(BigtableChangeStreamsToGcsOptions options)
+      throws IllegalArgumentException {
+    Matcher matcher =
+        Pattern.compile(GCS_OUTPUT_DIRECTORY_REGEX).matcher(options.getGcsOutputDirectory());
+
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException(
+          "--gcsOutputDirectory is expected in a format matching "
+              + "the following regular expression: "
+              + GCS_OUTPUT_DIRECTORY_REGEX);
+    }
+    String bucket = matcher.group(1);
+    String path = matcher.group(2);
+
+    if (!path.endsWith("/")) {
+      path += "/";
+    }
+
+    Storage storage =
+        StorageOptions.newBuilder().setProjectId(options.getProject()).build().getService();
+
+    String testFile = path + UUID.randomUUID();
+
+    boolean fileCreated = false;
+    try {
+      BlobInfo blobInfo = BlobInfo.newBuilder(bucket, testFile).build();
+      storage.create(blobInfo, new byte[0]);
+      fileCreated = true;
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          "Unable to ensure write access for the output directory: "
+              + options.getGcsOutputDirectory());
+    } finally {
+      if (fileCreated) {
+        try {
+          storage.delete(BlobId.of(bucket, testFile));
+        } catch (Exception e) {
+          LOG.warn("Unable to clean up a test file from the GCS output directory: " + path);
+        }
+      }
+    }
+  }
+
+  private static Instant toInstant(Timestamp timestamp) {
+    if (timestamp == null) {
+      return null;
+    } else {
+      return Instant.ofEpochMilli(timestamp.getSeconds() * 1000 + timestamp.getNanos() / 1000000);
+    }
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangelogEntryToBigtableRowFn.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangelogEntryToBigtableRowFn.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.beam.sdk.transforms.SimpleFunction;
+
+/**
+ * A {@link org.apache.beam.sdk.transforms.PTransform} which converts items in a {@link
+ * org.apache.beam.sdk.values.PCollection} from {@link
+ * com.google.cloud.teleport.bigtable.ChangelogEntry} to {@link
+ * com.google.cloud.teleport.bigtable.BigtableRow}.
+ */
+public class BigtableChangelogEntryToBigtableRowFn
+    extends SimpleFunction<
+        com.google.cloud.teleport.bigtable.ChangelogEntry,
+        com.google.cloud.teleport.bigtable.BigtableRow> {
+
+  private final String workerId;
+  private final AtomicLong counter;
+  private final BigtableUtils bigtableUtils;
+
+  public BigtableChangelogEntryToBigtableRowFn(
+      String workerId, AtomicLong counter, BigtableUtils bigtableUtils) {
+    this.workerId = workerId;
+    this.counter = counter;
+    this.bigtableUtils = bigtableUtils;
+  }
+
+  @Override
+  public com.google.cloud.teleport.bigtable.BigtableRow apply(
+      com.google.cloud.teleport.bigtable.ChangelogEntry entry) {
+    return this.bigtableUtils.createBigtableRow(entry, workerId, counter.incrementAndGet());
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangelogEntryToBigtableRowFn.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangelogEntryToBigtableRowFn.java
@@ -15,10 +15,10 @@
  */
 package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
 
+import com.google.cloud.teleport.bigtable.BigtableRow;
+import com.google.cloud.teleport.bigtable.ChangelogEntry;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.beam.sdk.transforms.SimpleFunction;
-import com.google.cloud.teleport.bigtable.ChangelogEntry;
-import com.google.cloud.teleport.bigtable.BigtableRow;
 
 /**
  * A {@link org.apache.beam.sdk.transforms.PTransform} which converts items in a {@link

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangelogEntryToBigtableRowFn.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangelogEntryToBigtableRowFn.java
@@ -17,6 +17,8 @@ package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
 
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.beam.sdk.transforms.SimpleFunction;
+import com.google.cloud.teleport.bigtable.ChangelogEntry;
+import com.google.cloud.teleport.bigtable.BigtableRow;
 
 /**
  * A {@link org.apache.beam.sdk.transforms.PTransform} which converts items in a {@link
@@ -25,9 +27,7 @@ import org.apache.beam.sdk.transforms.SimpleFunction;
  * com.google.cloud.teleport.bigtable.BigtableRow}.
  */
 public class BigtableChangelogEntryToBigtableRowFn
-    extends SimpleFunction<
-        com.google.cloud.teleport.bigtable.ChangelogEntry,
-        com.google.cloud.teleport.bigtable.BigtableRow> {
+    extends SimpleFunction<ChangelogEntry, BigtableRow> {
 
   private final String workerId;
   private final AtomicLong counter;
@@ -41,8 +41,7 @@ public class BigtableChangelogEntryToBigtableRowFn
   }
 
   @Override
-  public com.google.cloud.teleport.bigtable.BigtableRow apply(
-      com.google.cloud.teleport.bigtable.ChangelogEntry entry) {
+  public BigtableRow apply(ChangelogEntry entry) {
     return this.bigtableUtils.createBigtableRow(entry, workerId, counter.incrementAndGet());
   }
 }

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableUtils.java
@@ -1,0 +1,394 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import com.google.cloud.bigtable.data.v2.models.ChangeStreamMutation;
+import com.google.cloud.bigtable.data.v2.models.ChangeStreamMutation.MutationType;
+import com.google.cloud.bigtable.data.v2.models.DeleteCells;
+import com.google.cloud.bigtable.data.v2.models.DeleteFamily;
+import com.google.cloud.bigtable.data.v2.models.Entry;
+import com.google.cloud.bigtable.data.v2.models.SetCell;
+import com.google.cloud.teleport.bigtable.BigtableRow;
+import com.google.cloud.teleport.bigtable.ChangelogEntry;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.model.ChangelogColumns;
+import com.google.cloud.teleport.v2.utils.BigtableSource;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** {@link BigtableUtils} provides a set of helper functions and classes for Bigtable. */
+public class BigtableUtils implements Serializable {
+
+  public static final String ANY_COLUMN_FAMILY = "*";
+  private static final Logger LOG = LoggerFactory.getLogger(BigtableUtils.class);
+
+  private final long serialVersionUID = 6360056103639788953L;
+  public String bigtableRowColumnFamilyName = "changelog";
+  public String bigtableRowKeyDelimiter = "#";
+  private final BigtableSource source;
+  private transient Charset charsetObj;
+  private final Map<String, Set<String>> ignoredColumnsMap;
+  private final Long DEFAULT_TIMESTAMP = 0L;
+
+  public BigtableUtils(BigtableSource sourceInfo) {
+    this.source = sourceInfo;
+    this.charsetObj = Charset.forName(sourceInfo.getCharset());
+
+    ignoredColumnsMap = new HashMap<>();
+    for (String columnFamilyAndColumn : sourceInfo.getColumnsToIgnore()) {
+      int indexOfColon = columnFamilyAndColumn.indexOf(':');
+      String columnFamily = ANY_COLUMN_FAMILY;
+      String columnName = columnFamilyAndColumn;
+      if (indexOfColon > 0) {
+        columnFamily = columnFamilyAndColumn.substring(0, indexOfColon);
+        if (StringUtils.isBlank(columnFamily)) {
+          columnFamily = ANY_COLUMN_FAMILY;
+        }
+        columnName = columnFamilyAndColumn.substring(indexOfColon + 1);
+      }
+
+      Set<String> appliedToColumnFamilies =
+          ignoredColumnsMap.computeIfAbsent(columnName, k -> new HashSet<>());
+      appliedToColumnFamilies.add(columnFamily);
+    }
+  }
+
+  private boolean hasIgnoredColumnFamilies() {
+    return this.source.getColumnFamiliesToIgnore().size() > 0;
+  }
+
+  private boolean isIgnoredColumnFamily(String columnFamily) {
+    return this.source.getColumnFamiliesToIgnore().contains(columnFamily);
+  }
+
+  private boolean hasIgnoredColumns() {
+    return this.source.getColumnsToIgnore().size() > 0;
+  }
+
+  private boolean isIgnoredColumn(String columnFamily, String column) {
+    Set<String> columnFamilies = ignoredColumnsMap.get(column);
+    if (columnFamilies == null) {
+      return false;
+    }
+    return columnFamilies.contains(columnFamily) || columnFamilies.contains(ANY_COLUMN_FAMILY);
+  }
+
+  private Boolean isValidEntry(String familyName, String qualifierName) {
+    if (hasIgnoredColumnFamilies() && isIgnoredColumnFamily(familyName)) {
+      return false;
+    }
+
+    if (hasIgnoredColumns()
+        && !StringUtils.isBlank(qualifierName)
+        && isIgnoredColumn(familyName, qualifierName)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  public com.google.cloud.teleport.bigtable.BigtableRow createBigtableRow(
+      ChangelogEntry entry, String workerId, Long counter) {
+    java.util.List<com.google.cloud.teleport.bigtable.BigtableCell> cells = new ArrayList<>();
+
+    // row_key
+    cells.add(
+        com.google.cloud.teleport.bigtable.BigtableCell.newBuilder()
+            .setFamily(this.bigtableRowColumnFamilyName)
+            .setQualifier(ChangelogColumns.ROW_KEY.getColumnNameAsByteBuffer(this.charsetObj))
+            .setTimestamp(DEFAULT_TIMESTAMP)
+            .setValue(entry.getRowKey())
+            .build());
+
+    // mod_type
+    cells.add(
+        com.google.cloud.teleport.bigtable.BigtableCell.newBuilder()
+            .setFamily(this.bigtableRowColumnFamilyName)
+            .setQualifier(ChangelogColumns.MOD_TYPE.getColumnNameAsByteBuffer(this.charsetObj))
+            .setTimestamp(DEFAULT_TIMESTAMP)
+            .setValue(getByteBufferFromString(entry.getModType().toString()))
+            .build());
+
+    // is_gc
+    cells.add(
+        com.google.cloud.teleport.bigtable.BigtableCell.newBuilder()
+            .setFamily(this.bigtableRowColumnFamilyName)
+            .setQualifier(ChangelogColumns.IS_GC.getColumnNameAsByteBuffer(this.charsetObj))
+            .setTimestamp(DEFAULT_TIMESTAMP)
+            .setValue(getByteBufferFromString(Boolean.toString(entry.getIsGc())))
+            .build());
+
+    // tiebreaker
+    cells.add(
+        com.google.cloud.teleport.bigtable.BigtableCell.newBuilder()
+            .setFamily(this.bigtableRowColumnFamilyName)
+            .setQualifier(ChangelogColumns.TIEBREAKER.getColumnNameAsByteBuffer(this.charsetObj))
+            .setTimestamp(DEFAULT_TIMESTAMP)
+            .setValue(getByteBufferFromString(String.valueOf(entry.getTieBreaker())))
+            .build());
+
+    // commit_timestamp
+    cells.add(
+        com.google.cloud.teleport.bigtable.BigtableCell.newBuilder()
+            .setFamily(this.bigtableRowColumnFamilyName)
+            .setQualifier(
+                ChangelogColumns.COMMIT_TIMESTAMP.getColumnNameAsByteBuffer(this.charsetObj))
+            .setTimestamp(DEFAULT_TIMESTAMP)
+            .setValue(getByteBufferFromString(String.valueOf(entry.getCommitTimestamp())))
+            .build());
+
+    // column_family
+    cells.add(
+        com.google.cloud.teleport.bigtable.BigtableCell.newBuilder()
+            .setFamily(this.bigtableRowColumnFamilyName)
+            .setQualifier(ChangelogColumns.COLUMN_FAMILY.getColumnNameAsByteBuffer(this.charsetObj))
+            .setTimestamp(DEFAULT_TIMESTAMP)
+            .setValue(getByteBufferFromString(String.valueOf(entry.getColumnFamily())))
+            .build());
+
+    // low_watermark
+    cells.add(
+        com.google.cloud.teleport.bigtable.BigtableCell.newBuilder()
+            .setFamily(this.bigtableRowColumnFamilyName)
+            .setQualifier(ChangelogColumns.LOW_WATERMARK.getColumnNameAsByteBuffer(this.charsetObj))
+            .setTimestamp(DEFAULT_TIMESTAMP)
+            .setValue(getByteBufferFromString(String.valueOf(entry.getLowWatermark())))
+            .build());
+
+    if (entry.getColumn() != null) {
+      // column
+      cells.add(
+          com.google.cloud.teleport.bigtable.BigtableCell.newBuilder()
+              .setFamily(this.bigtableRowColumnFamilyName)
+              .setQualifier(ChangelogColumns.COLUMN.getColumnNameAsByteBuffer(this.charsetObj))
+              .setTimestamp(DEFAULT_TIMESTAMP)
+              .setValue(entry.getColumn())
+              .build());
+    }
+
+    if (entry.getTimestamp() != null) {
+      // timestamp
+      cells.add(
+          com.google.cloud.teleport.bigtable.BigtableCell.newBuilder()
+              .setFamily(this.bigtableRowColumnFamilyName)
+              .setQualifier(ChangelogColumns.TIMESTAMP.getColumnNameAsByteBuffer(this.charsetObj))
+              .setTimestamp(DEFAULT_TIMESTAMP)
+              .setValue(getByteBufferFromString(String.valueOf(entry.getTimestamp())))
+              .build());
+    }
+
+    if (entry.getTimestampFrom() != null) {
+      // timestamp_from
+      cells.add(
+          com.google.cloud.teleport.bigtable.BigtableCell.newBuilder()
+              .setFamily(this.bigtableRowColumnFamilyName)
+              .setQualifier(
+                  ChangelogColumns.TIMESTAMP_FROM.getColumnNameAsByteBuffer(this.charsetObj))
+              .setTimestamp(DEFAULT_TIMESTAMP)
+              .setValue(getByteBufferFromString(String.valueOf(entry.getTimestampFrom())))
+              .build());
+    }
+
+    if (entry.getTimestampTo() != null) {
+      // timestamp_to
+      cells.add(
+          com.google.cloud.teleport.bigtable.BigtableCell.newBuilder()
+              .setFamily(this.bigtableRowColumnFamilyName)
+              .setQualifier(
+                  ChangelogColumns.TIMESTAMP_TO.getColumnNameAsByteBuffer(this.charsetObj))
+              .setTimestamp(DEFAULT_TIMESTAMP)
+              .setValue(getByteBufferFromString(String.valueOf(entry.getTimestampTo())))
+              .build());
+    }
+
+    if (entry.getValue() != null) {
+      // value
+      cells.add(
+          com.google.cloud.teleport.bigtable.BigtableCell.newBuilder()
+              .setFamily(this.bigtableRowColumnFamilyName)
+              .setQualifier(ChangelogColumns.VALUE.getColumnNameAsByteBuffer(this.charsetObj))
+              .setTimestamp(DEFAULT_TIMESTAMP)
+              .setValue(entry.getValue())
+              .build());
+    }
+
+    return new BigtableRow(
+        createChangelogRowKey(entry.getCommitTimestamp(), workerId, counter), cells);
+  }
+
+  private ByteBuffer getByteBufferFromString(String s) {
+    return ByteBuffer.wrap(s.getBytes(this.charsetObj));
+  }
+
+  private ByteBuffer createChangelogRowKey(Long commitTimestamp, String workerId, Long counter) {
+    String rowKey =
+        (commitTimestamp.toString()
+            + this.bigtableRowKeyDelimiter
+            + workerId
+            + this.bigtableRowKeyDelimiter
+            + counter);
+
+    return copyByteBuffer(ByteBuffer.wrap(rowKey.getBytes(this.charsetObj)));
+  }
+
+  /**
+   * @param mutation
+   * @return {@link ChangelogEntry} with valid entries based on {@param ignoreColumn} and {@param
+   *     ignoreColumnFamilies}
+   */
+  public List<ChangelogEntry> getValidEntries(ChangeStreamMutation mutation) {
+    // filter first and then format
+    List<ChangelogEntry> validEntries = new ArrayList<>(mutation.getEntries().size());
+    for (Entry entry : mutation.getEntries()) {
+      if (entry instanceof SetCell) {
+        SetCell setCell = (SetCell) entry;
+        String familyName = setCell.getFamilyName();
+        String qualifierName;
+        qualifierName = setCell.getQualifier().toString(this.charsetObj);
+        if (isValidEntry(familyName, qualifierName)) {
+          validEntries.add(createChangelogEntry(mutation, entry));
+        }
+      } else if (entry instanceof DeleteCells) {
+        DeleteCells deleteCells = (DeleteCells) entry;
+        String familyName = deleteCells.getFamilyName();
+        String qualifierName;
+        qualifierName = deleteCells.getQualifier().toString(this.charsetObj);
+        if (isValidEntry(familyName, qualifierName)) {
+          validEntries.add(createChangelogEntry(mutation, entry));
+        }
+      } else if (entry instanceof DeleteFamily) {
+        DeleteFamily deleteFamily = (DeleteFamily) entry;
+        String familyName = deleteFamily.getFamilyName();
+        if (isValidEntry(familyName, null)) {
+          validEntries.add(createChangelogEntry(mutation, entry));
+        }
+      }
+    }
+    return validEntries;
+  }
+
+  private com.google.cloud.teleport.bigtable.ChangelogEntry createChangelogEntry(
+      ChangeStreamMutation mutation, Entry mutationEntry) {
+    // TODO: this seems like a precision loss, we should keep it precise
+    long commitMicros =
+        mutation.getCommitTimestamp().toEpochMilli() * 1000
+            + mutation.getCommitTimestamp().getNano() / 1000;
+
+    com.google.cloud.teleport.bigtable.ChangelogEntry.Builder changelogEntry =
+        ChangelogEntry.newBuilder()
+            .setRowKey(mutation.getRowKey().asReadOnlyByteBuffer())
+            .setModType(getModType(mutationEntry))
+            .setIsGc(mutation.getType() == MutationType.GARBAGE_COLLECTION)
+            .setTieBreaker(mutation.getTieBreaker())
+            .setCommitTimestamp(commitMicros)
+            .setLowWatermark(0); // TODO: Low watermark is not available yet
+
+    if (mutationEntry instanceof SetCell) {
+      setCellEntryProperties(mutationEntry, changelogEntry);
+    } else if (mutationEntry instanceof DeleteCells) {
+      setDeleteCellEntryProperties(mutationEntry, changelogEntry);
+    } else if (mutationEntry instanceof DeleteFamily) {
+      setDeleteFamilyEntryProperties(mutationEntry, changelogEntry);
+    } else {
+      // Unknown ModType, logging a warning
+      LOG.warn("Unknown ChangelogEntry ModType, not setting properties in ChangelogEntry.");
+    }
+    return changelogEntry.build();
+  }
+
+  private void setCellEntryProperties(Entry mutationEntry, ChangelogEntry.Builder changelogEntry) {
+    SetCell cell = (SetCell) mutationEntry;
+    changelogEntry
+        .setColumnFamily(cell.getFamilyName())
+        .setColumn(cell.getQualifier().asReadOnlyByteBuffer())
+        .setTimestamp(cell.getTimestamp())
+        .setValue(cell.getValue().asReadOnlyByteBuffer())
+        .setTimestampFrom(null)
+        .setTimestampTo(null);
+  }
+
+  private void setDeleteCellEntryProperties(
+      Entry mutationEntry, ChangelogEntry.Builder changelogEntry) {
+    DeleteCells cell = (DeleteCells) mutationEntry;
+    changelogEntry
+        .setColumnFamily(cell.getFamilyName())
+        .setColumn(cell.getQualifier().asReadOnlyByteBuffer())
+        .setTimestamp(null)
+        .setValue(null)
+        .setTimestampFrom(cell.getTimestampRange().getStart())
+        .setTimestampTo(cell.getTimestampRange().getEnd());
+  }
+
+  private void setDeleteFamilyEntryProperties(
+      Entry mutationEntry, ChangelogEntry.Builder changelogEntry) {
+    DeleteFamily cell = (DeleteFamily) mutationEntry;
+    changelogEntry
+        .setColumnFamily(cell.getFamilyName())
+        .setColumn(null)
+        .setTimestamp(null)
+        .setValue(null)
+        .setTimestampFrom(null)
+        .setTimestampTo(null);
+  }
+
+  private com.google.cloud.teleport.bigtable.ModType getModType(Entry entry) {
+    if (entry instanceof SetCell) {
+      return com.google.cloud.teleport.bigtable.ModType.SET_CELL;
+    } else if (entry instanceof DeleteCells) {
+      return com.google.cloud.teleport.bigtable.ModType.DELETE_CELLS;
+    } else if (entry instanceof DeleteFamily) {
+      return com.google.cloud.teleport.bigtable.ModType.DELETE_FAMILY;
+    }
+    // UNKNOWN Entry, making this future-proof
+    LOG.warn("Unknown ChangelogEntry ModType, return ModType.Unknown");
+    return com.google.cloud.teleport.bigtable.ModType.UNKNOWN;
+  }
+
+  public static ByteBuffer copyByteBuffer(ByteBuffer bb) {
+    int capacity = bb.limit();
+    int pos = bb.position();
+    ByteOrder order = bb.order();
+    ByteBuffer copy;
+    copy = ByteBuffer.allocateDirect(capacity);
+
+    bb.rewind();
+
+    copy.order(order);
+    copy.put(bb);
+    copy.position(pos);
+
+    bb.position(pos);
+
+    return copy;
+  }
+
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    charsetObj = Charset.forName(source.getCharset());
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableUtils.java
@@ -53,7 +53,7 @@ public class BigtableUtils implements Serializable {
   private final BigtableSource source;
   private transient Charset charsetObj;
   private final Map<String, Set<String>> ignoredColumnsMap;
-  private final Long DEFAULT_TIMESTAMP = 0L;
+  private static final Long DEFAULT_TIMESTAMP = 0L;
 
   public BigtableUtils(BigtableSource sourceInfo) {
     this.source = sourceInfo;

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/FileFormatFactoryBigtableChangeStreams.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/FileFormatFactoryBigtableChangeStreams.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.bigtable.data.v2.models.ChangeStreamMutation;
+import com.google.cloud.teleport.v2.options.BigtableChangeStreamsToGcsOptions;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.model.DestinationInfo;
+import com.google.cloud.teleport.v2.utils.WriteToGCSUtility.FileFormat;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.POutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link FileFormatFactoryBigtableChangeStreams} class is a {@link PTransform} that takes in
+ * {@link PCollection} of ChangeStreamMutations. The transform writes these records to GCS file(s)
+ * in user specified format.
+ */
+@AutoValue
+public abstract class FileFormatFactoryBigtableChangeStreams
+    extends PTransform<PCollection<ChangeStreamMutation>, POutput> {
+
+  /** Logger for class. */
+  private static final Logger LOG =
+      LoggerFactory.getLogger(FileFormatFactoryBigtableChangeStreams.class);
+
+  public static WriteToGcsBuilder newBuilder() {
+    return new com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs
+        .AutoValue_FileFormatFactoryBigtableChangeStreams.Builder();
+  }
+
+  public abstract BigtableChangeStreamsToGcsOptions options();
+
+  public abstract FileFormat outputFileFormat();
+
+  public abstract BigtableUtils bigtableUtils();
+
+  @Override
+  public POutput expand(PCollection<ChangeStreamMutation> mutations) {
+    POutput output;
+
+    /*
+     * Calls appropriate class Builder to performs PTransform based on user provided File Format.
+     */
+    switch (outputFileFormat()) {
+      case AVRO:
+        output =
+            mutations.apply(
+                "Write Avro File(s)",
+                WriteChangeStreamMutationToGcsAvro.newBuilder()
+                    .withGcsOutputDirectory(options().getGcsOutputDirectory())
+                    .withOutputFilenamePrefix(options().getOutputFilenamePrefix())
+                    .setNumShards(options().getOutputShardsCount())
+                    .withTempLocation(options().getTempLocation())
+                    .withSchemaOutputFormat(options().getSchemaOutputFormat())
+                    .withBigtableUtils(bigtableUtils())
+                    .build());
+        break;
+      case TEXT:
+        output =
+            mutations.apply(
+                "Write Text File(s)",
+                WriteChangeStreamMutationsToGcsText.newBuilder()
+                    .withGcsOutputDirectory(options().getGcsOutputDirectory())
+                    .withOutputFilenamePrefix(options().getOutputFilenamePrefix())
+                    .setNumShards(options().getOutputShardsCount())
+                    .withTempLocation(options().getTempLocation())
+                    .withSchemaOutputFormat(options().getSchemaOutputFormat())
+                    .withDestinationInfo(newDestinationInfo(options()))
+                    .withBigtableUtils(bigtableUtils())
+                    .build());
+        break;
+
+      default:
+        throw new IllegalArgumentException(
+            "Invalid output format:"
+                + outputFileFormat()
+                + ". Supported output formats: TEXT, AVRO");
+    }
+    return output;
+  }
+
+  private DestinationInfo newDestinationInfo(BigtableChangeStreamsToGcsOptions options) {
+    return new DestinationInfo(
+        options.getBigtableChangeStreamCharset(),
+        options.getUseBase64Rowkey(),
+        options.getUseBase64ColumnQualifier(),
+        options.getUseBase64Value());
+  }
+
+  /** Builder for {@link FileFormatFactoryBigtableChangeStreams}. */
+  @AutoValue.Builder
+  public abstract static class WriteToGcsBuilder {
+
+    public abstract WriteToGcsBuilder setOptions(BigtableChangeStreamsToGcsOptions options);
+
+    public abstract WriteToGcsBuilder setOutputFileFormat(FileFormat outputFileFormat);
+
+    public abstract WriteToGcsBuilder setBigtableUtils(BigtableUtils bigtableUtils);
+
+    abstract BigtableChangeStreamsToGcsOptions options();
+
+    abstract FileFormatFactoryBigtableChangeStreams autoBuild();
+
+    public FileFormatFactoryBigtableChangeStreams build() {
+      setOutputFileFormat(options().getOutputFileFormat());
+      return autoBuild();
+    }
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/WriteChangeStreamMutationToGcsAvro.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/WriteChangeStreamMutationToGcsAvro.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.bigtable.data.v2.models.ChangeStreamMutation;
+import com.google.cloud.teleport.v2.io.WindowedFilenamePolicy;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.model.BigtableSchemaFormat;
+import com.google.cloud.teleport.v2.utils.WriteToGCSUtility;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.beam.sdk.extensions.avro.io.AvroIO;
+import org.apache.beam.sdk.io.FileBasedSink;
+import org.apache.beam.sdk.transforms.FlatMapElements;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link WriteChangeStreamMutationToGcsAvro} class is a {@link PTransform} that takes in {@link
+ * PCollection} of Bigtable Change Stream Mutations. The transform converts and writes these records
+ * to GCS in avro file format.
+ */
+@AutoValue
+public abstract class WriteChangeStreamMutationToGcsAvro
+    extends PTransform<PCollection<ChangeStreamMutation>, PDone> {
+  @VisibleForTesting protected static final String DEFAULT_OUTPUT_FILE_PREFIX = "output";
+  /* Logger for class. */
+  private static final Logger LOG =
+      LoggerFactory.getLogger(WriteChangeStreamMutationToGcsAvro.class);
+  private static final long serialVersionUID = 825905520835363852L;
+
+  private static final AtomicLong counter = new AtomicLong(0);
+
+  private static final String workerId = UUID.randomUUID().toString();
+
+  public static WriteToGcsBuilder newBuilder() {
+    return new com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs
+        .AutoValue_WriteChangeStreamMutationToGcsAvro.Builder();
+  }
+
+  public abstract String gcsOutputDirectory();
+
+  public abstract String outputFilenamePrefix();
+
+  public abstract String tempLocation();
+
+  public abstract Integer numShards();
+
+  public abstract BigtableSchemaFormat schemaOutputFormat();
+
+  public abstract BigtableUtils bigtableUtils();
+
+  @Override
+  public PDone expand(PCollection<ChangeStreamMutation> mutations) {
+    PCollection<com.google.cloud.teleport.bigtable.ChangelogEntry> changelogEntry =
+        mutations.apply(
+            "ChangeStreamMutation to ChangelogEntry",
+            FlatMapElements.via(
+                new BigtableChangeStreamMutationToChangelogEntryFn(bigtableUtils())));
+    /*
+     * Writing as avro file using {@link AvroIO}.
+     *
+     * The {@link WindowedFilenamePolicy} class specifies the file path for writing the file.
+     * The {@link withNumShards} option specifies the number of shards passed by the user.
+     * The {@link withTempDirectory} option sets the base directory used to generate temporary files.
+     */
+    if (schemaOutputFormat() == BigtableSchemaFormat.BIGTABLE_ROW) {
+      return changelogEntry
+          .apply(
+              "ChangelogEntry To BigtableRow",
+              MapElements.via(
+                  new BigtableChangelogEntryToBigtableRowFn(workerId, counter, bigtableUtils())))
+          .apply(
+              "Writing as Avro",
+              AvroIO.write(com.google.cloud.teleport.bigtable.BigtableRow.class)
+                  .to(
+                      WindowedFilenamePolicy.writeWindowedFiles()
+                          .withOutputDirectory(gcsOutputDirectory())
+                          .withOutputFilenamePrefix(outputFilenamePrefix())
+                          .withShardTemplate(WriteToGCSUtility.SHARD_TEMPLATE)
+                          .withSuffix(
+                              WriteToGCSUtility.FILE_SUFFIX_MAP.get(
+                                  WriteToGCSUtility.FileFormat.AVRO)))
+                  .withTempDirectory(
+                      FileBasedSink.convertToFileResourceIfPossible(tempLocation())
+                          .getCurrentDirectory())
+                  .withWindowedWrites()
+                  .withNumShards(numShards()));
+    }
+
+    return changelogEntry.apply(
+        AvroIO.write(com.google.cloud.teleport.bigtable.ChangelogEntry.class)
+            .to(
+                WindowedFilenamePolicy.writeWindowedFiles()
+                    .withOutputDirectory(gcsOutputDirectory())
+                    .withOutputFilenamePrefix(outputFilenamePrefix())
+                    .withShardTemplate(WriteToGCSUtility.SHARD_TEMPLATE)
+                    .withSuffix(
+                        WriteToGCSUtility.FILE_SUFFIX_MAP.get(WriteToGCSUtility.FileFormat.AVRO)))
+            .withTempDirectory(
+                FileBasedSink.convertToFileResourceIfPossible(tempLocation()).getCurrentDirectory())
+            .withWindowedWrites()
+            .withNumShards(numShards()));
+  }
+
+  /** Builder for {@link WriteChangeStreamMutationToGcsAvro}. */
+  @AutoValue.Builder
+  public abstract static class WriteToGcsBuilder {
+    abstract WriteToGcsBuilder setGcsOutputDirectory(String gcsOutputDirectory);
+
+    abstract String gcsOutputDirectory();
+
+    abstract WriteToGcsBuilder setTempLocation(String tempLocation);
+
+    abstract String tempLocation();
+
+    abstract WriteToGcsBuilder setOutputFilenamePrefix(String outputFilenamePrefix);
+
+    abstract WriteToGcsBuilder setNumShards(Integer numShards);
+
+    abstract WriteChangeStreamMutationToGcsAvro autoBuild();
+
+    abstract WriteToGcsBuilder setBigtableUtils(BigtableUtils bigtableUtils);
+
+    public WriteToGcsBuilder withBigtableUtils(BigtableUtils bigtableUtils) {
+      return setBigtableUtils(bigtableUtils);
+    }
+
+    abstract WriteToGcsBuilder setSchemaOutputFormat(BigtableSchemaFormat schema);
+
+    public WriteToGcsBuilder withSchemaOutputFormat(BigtableSchemaFormat schema) {
+      return setSchemaOutputFormat(schema);
+    }
+
+    public WriteToGcsBuilder withGcsOutputDirectory(String gcsOutputDirectory) {
+      checkArgument(
+          gcsOutputDirectory != null,
+          "withGcsOutputDirectory(gcsOutputDirectory) called with null input.");
+      return setGcsOutputDirectory(gcsOutputDirectory);
+    }
+
+    public WriteToGcsBuilder withTempLocation(String tempLocation) {
+      checkArgument(tempLocation != null, "withTempLocation(tempLocation) called with null input.");
+      return setTempLocation(tempLocation);
+    }
+
+    public WriteToGcsBuilder withOutputFilenamePrefix(String outputFilenamePrefix) {
+      if (outputFilenamePrefix == null) {
+        LOG.info("Defaulting output filename prefix to: {}", DEFAULT_OUTPUT_FILE_PREFIX);
+        outputFilenamePrefix = DEFAULT_OUTPUT_FILE_PREFIX;
+      }
+      return setOutputFilenamePrefix(outputFilenamePrefix);
+    }
+
+    public WriteChangeStreamMutationToGcsAvro build() {
+      checkNotNull(gcsOutputDirectory(), "Provide output directory to write to. ");
+      checkNotNull(tempLocation(), "Temporary directory needs to be provided. ");
+      return autoBuild();
+    }
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/WriteChangeStreamMutationsToGcsText.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/WriteChangeStreamMutationsToGcsText.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.bigtable.data.v2.models.ChangeStreamMutation;
+import com.google.cloud.teleport.v2.io.WindowedFilenamePolicy;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.model.BigtableSchemaFormat;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.model.DestinationInfo;
+import com.google.cloud.teleport.v2.utils.WriteToGCSUtility;
+import com.google.gson.Gson;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.beam.sdk.io.FileBasedSink;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.transforms.FlatMapElements;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link WriteChangeStreamMutationsToGcsText} class is a {@link PTransform} that takes in
+ * {@link PCollection} of Bigtable change stream mutations. The transform converts and writes these
+ * records to GCS in JSON text file format.
+ */
+@AutoValue
+public abstract class WriteChangeStreamMutationsToGcsText
+    extends PTransform<PCollection<ChangeStreamMutation>, PDone> {
+  private static final Gson gson = new Gson();
+
+  private static final AtomicLong counter = new AtomicLong(0);
+
+  private static final String workerId = UUID.randomUUID().toString();
+
+  @VisibleForTesting protected static final String DEFAULT_OUTPUT_FILE_PREFIX = "output";
+
+  /* Logger for class. */
+  private static final Logger LOG =
+      LoggerFactory.getLogger(WriteChangeStreamMutationsToGcsText.class);
+
+  public static WriteToGcsBuilder newBuilder() {
+    return new com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs
+        .AutoValue_WriteChangeStreamMutationsToGcsText.Builder();
+  }
+
+  public abstract String gcsOutputDirectory();
+
+  public abstract String outputFilenamePrefix();
+
+  public abstract String tempLocation();
+
+  public abstract Integer numShards();
+
+  public abstract BigtableUtils bigtableUtils();
+
+  public abstract BigtableSchemaFormat schemaOutputFormat();
+
+  public abstract DestinationInfo destinationInfo();
+
+  @Override
+  public PDone expand(PCollection<ChangeStreamMutation> mutations) {
+    PCollection<com.google.cloud.teleport.bigtable.ChangelogEntry> changelogEntry =
+        mutations.apply(
+            "ChangeStreamMutation to ChangelogEntry",
+            FlatMapElements.via(
+                new BigtableChangeStreamMutationToChangelogEntryFn(bigtableUtils())));
+
+    return changelogEntry
+        .apply(MapElements.via(new WriteChangelogEntryAsJson(destinationInfo())))
+        .apply(
+            "Writing as Text",
+            TextIO.write()
+                .to(
+                    WindowedFilenamePolicy.writeWindowedFiles()
+                        .withOutputDirectory(gcsOutputDirectory())
+                        .withOutputFilenamePrefix(outputFilenamePrefix())
+                        .withShardTemplate(WriteToGCSUtility.SHARD_TEMPLATE)
+                        .withSuffix(
+                            WriteToGCSUtility.FILE_SUFFIX_MAP.get(
+                                WriteToGCSUtility.FileFormat.TEXT)))
+                .withTempDirectory(
+                    FileBasedSink.convertToFileResourceIfPossible(tempLocation())
+                        .getCurrentDirectory())
+                .withWindowedWrites()
+                .withNumShards(numShards()));
+  }
+
+  /** Builder for {@link WriteChangeStreamMutationsToGcsText}. */
+  @AutoValue.Builder
+  public abstract static class WriteToGcsBuilder {
+
+    abstract WriteToGcsBuilder setGcsOutputDirectory(String gcsOutputDirectory);
+
+    abstract String gcsOutputDirectory();
+
+    abstract WriteToGcsBuilder setTempLocation(String tempLocation);
+
+    abstract String tempLocation();
+
+    abstract WriteToGcsBuilder setOutputFilenamePrefix(String outputFilenamePrefix);
+
+    abstract WriteToGcsBuilder setNumShards(Integer numShards);
+
+    abstract WriteToGcsBuilder setSchemaOutputFormat(BigtableSchemaFormat schema);
+
+    abstract WriteToGcsBuilder setDestinationInfo(DestinationInfo destinationInfo);
+
+    abstract WriteChangeStreamMutationsToGcsText autoBuild();
+
+    abstract WriteToGcsBuilder setBigtableUtils(BigtableUtils bigtableUtils);
+
+    public WriteToGcsBuilder withBigtableUtils(BigtableUtils bigtableUtils) {
+      return setBigtableUtils(bigtableUtils);
+    }
+
+    public WriteToGcsBuilder withGcsOutputDirectory(String gcsOutputDirectory) {
+      checkArgument(
+          gcsOutputDirectory != null,
+          "withGcsOutputDirectory(gcsOutputDirectory) called with null input.");
+      return setGcsOutputDirectory(gcsOutputDirectory);
+    }
+
+    public WriteToGcsBuilder withTempLocation(String tempLocation) {
+      checkArgument(tempLocation != null, "withTempLocation(tempLocation) called with null input.");
+      return setTempLocation(tempLocation);
+    }
+
+    public WriteToGcsBuilder withOutputFilenamePrefix(String outputFilenamePrefix) {
+      if (outputFilenamePrefix == null) {
+        LOG.info("Defaulting output filename prefix to: {}", DEFAULT_OUTPUT_FILE_PREFIX);
+        outputFilenamePrefix = DEFAULT_OUTPUT_FILE_PREFIX;
+      }
+      return setOutputFilenamePrefix(outputFilenamePrefix);
+    }
+
+    public WriteToGcsBuilder withSchemaOutputFormat(BigtableSchemaFormat schema) {
+      return setSchemaOutputFormat(schema);
+    }
+
+    public WriteToGcsBuilder withDestinationInfo(DestinationInfo destinationInfo) {
+      return setDestinationInfo(destinationInfo);
+    }
+
+    public WriteChangeStreamMutationsToGcsText build() {
+      checkNotNull(gcsOutputDirectory(), "Provide output directory to write to.");
+      checkNotNull(tempLocation(), "Temporary directory needs to be provided.");
+      return autoBuild();
+    }
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/WriteChangelogEntryAsJson.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/WriteChangelogEntryAsJson.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import com.google.cloud.teleport.bigtable.ChangelogEntry;
+import com.google.cloud.teleport.bigtable.ChangelogEntryJson;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.model.DestinationInfo;
+import com.google.gson.Gson;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.Base64;
+import org.apache.beam.sdk.transforms.SimpleFunction;
+
+public class WriteChangelogEntryAsJson extends SimpleFunction<ChangelogEntry, String> {
+  private static final ThreadLocal<Gson> gsonThreadLocal = ThreadLocal.withInitial(Gson::new);
+  private final DestinationInfo destination;
+  private transient Charset charset;
+
+  public WriteChangelogEntryAsJson(DestinationInfo destination) {
+    this.destination = destination;
+    this.charset = Charset.forName(destination.getCharsetName());
+  }
+
+  @Override
+  public String apply(ChangelogEntry record) {
+    if (record == null) {
+      return null;
+    }
+
+    ChangelogEntryJson jsonType = new ChangelogEntryJson();
+    jsonType.setColumn(
+        bytesToString(record.getColumn(), destination.isColumnQualifierBase64Encoded(), charset));
+    jsonType.setModType(record.getModType());
+    jsonType.setTimestamp(record.getTimestamp());
+    jsonType.setTimestampTo(record.getTimestampTo());
+    jsonType.setTimestampFrom(record.getTimestampFrom());
+    jsonType.setIsGc(record.getIsGc());
+    jsonType.setValue(
+        bytesToString(record.getValue(), destination.isValueBase64Encoded(), charset));
+    jsonType.setColumnFamily(record.getColumnFamily());
+    jsonType.setCommitTimestamp(record.getCommitTimestamp());
+    jsonType.setLowWatermark(record.getLowWatermark());
+    jsonType.setRowKey(
+        bytesToString(record.getRowKey(), destination.isRowkeyBase64Encoded(), charset));
+    jsonType.setTieBreaker(record.getTieBreaker());
+    return gsonThreadLocal.get().toJson(jsonType, ChangelogEntryJson.class);
+  }
+
+  private String bytesToString(ByteBuffer bytes, boolean useBase64, Charset charset) {
+    if (bytes == null) {
+      return null;
+    } else {
+      if (useBase64) {
+        return charset.decode(Base64.getEncoder().encode(bytes)).toString();
+      } else {
+        return charset.decode(bytes).toString();
+      }
+    }
+  }
+
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    charset = Charset.forName(destination.getCharsetName());
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/model/BigtableSchemaFormat.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/model/BigtableSchemaFormat.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.model;
+
+/** Set Enum BigtableSchemaFormat for all supported schema formats. */
+public enum BigtableSchemaFormat {
+  CHANGELOG_ENTRY,
+  BIGTABLE_ROW;
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/model/ChangelogColumns.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/model/ChangelogColumns.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.model;
+
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.BigtableUtils;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+
+/**
+ * The {@link ChangelogColumns} contains all the available properties that are present in a a row
+ * which will be written into GCS. Note that these properties are present in {@link
+ * com.google.cloud.teleport.bigtable.ChangelogEntry} and may or may not be required.
+ */
+public enum ChangelogColumns {
+  ROW_KEY("row_key"),
+  MOD_TYPE("mod_type"),
+  IS_GC("is_gc"),
+  TIEBREAKER("tiebreaker"),
+  COMMIT_TIMESTAMP("commit_timestamp"),
+  COLUMN_FAMILY("column_family"),
+  LOW_WATERMARK("low_watermark"),
+  COLUMN("column"),
+  TIMESTAMP("timestamp"),
+  TIMESTAMP_FROM("timestamp_from"),
+  TIMESTAMP_TO("timestamp_to"),
+  VALUE("value");
+
+  ChangelogColumns(String columnName) {
+    this.columnName = columnName;
+  }
+
+  private String columnName;
+
+  public String getColumnName() {
+    return this.columnName;
+  }
+
+  public ByteBuffer getColumnNameAsByteBuffer(Charset charset) {
+    return BigtableUtils.copyByteBuffer(ByteBuffer.wrap(this.columnName.getBytes(charset)));
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/model/DestinationInfo.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/model/DestinationInfo.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.model;
+
+import java.io.Serializable;
+
+public class DestinationInfo implements Serializable {
+
+  private final String bigtableChangeStreamCharset;
+  private final boolean useBase64Rowkey;
+  private final boolean useBase64ColumnQualifier;
+  private final boolean useBase64Value;
+
+  public DestinationInfo(
+      String bigtableChangeStreamCharset,
+      boolean useBase64Rowkey,
+      boolean useBase64ColumnQualifier,
+      boolean useBase64Value) {
+
+    this.bigtableChangeStreamCharset = bigtableChangeStreamCharset;
+    this.useBase64Rowkey = useBase64Rowkey;
+    this.useBase64ColumnQualifier = useBase64ColumnQualifier;
+    this.useBase64Value = useBase64Value;
+  }
+
+  public String getCharsetName() {
+    return bigtableChangeStreamCharset;
+  }
+
+  public boolean isColumnQualifierBase64Encoded() {
+    return useBase64ColumnQualifier;
+  }
+
+  public boolean isValueBase64Encoded() {
+    return useBase64Value;
+  }
+
+  public boolean isRowkeyBase64Encoded() {
+    return useBase64Rowkey;
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/model/ModType.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/model/ModType.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.model;
+
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.BigtableUtils;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+
+/**
+ * {@link ModType} represents the type of Modification that CDC {@link
+ * com.google.cloud.bigtable.data.v2.models.ChangeStreamMutation} entries represent.
+ */
+public enum ModType {
+  SET_CELL("SET_CELL"),
+  DELETE_FAMILY("DELETE_FAMILY"),
+  DELETE_CELLS("DELETE_CELLS"),
+  UNKNOWN("UNKNOWN");
+
+  ModType(String propertyName) {
+    this.propertyName = propertyName;
+  }
+
+  private String propertyName;
+
+  public String getPropertyName() {
+    return this.propertyName;
+  }
+
+  public ByteBuffer getPropertyNameAsByteBuffer(Charset charset) {
+    return BigtableUtils.copyByteBuffer(ByteBuffer.wrap(this.propertyName.getBytes(charset)));
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/model/package-info.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/model/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/** Google Cloud Teleport templates that process data within Google Cloud. */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.model;

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/package-info.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/** Google Cloud Teleport templates that process data within Google Cloud. */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/utils/BigtableSource.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/utils/BigtableSource.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.utils;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.joda.time.Instant;
+
+/** Descriptor of the Cloud Bigtable source table where changes are captured from. */
+public class BigtableSource implements Serializable {
+
+  private final String instanceId;
+  private final String tableId;
+  private final String charset;
+  private final Set<String> columnFamiliesToIgnore;
+  private final Set<String> columnsToIgnore;
+
+  private final Instant startTimestamp;
+
+  public BigtableSource(
+      String instanceId,
+      String tableId,
+      String charset,
+      String ignoreColumnFamilies,
+      String ignoreColumns,
+      Instant startTimestamp) {
+    this.startTimestamp = startTimestamp;
+    this.instanceId = instanceId;
+    this.tableId = tableId;
+    this.charset = charset;
+
+    if (StringUtils.isBlank(ignoreColumnFamilies)) {
+      this.columnFamiliesToIgnore = Collections.emptySet();
+    } else {
+      this.columnFamiliesToIgnore =
+          Arrays.stream(ignoreColumnFamilies.trim().split("[\\s]*,[\\s]*"))
+              .collect(Collectors.toSet());
+    }
+
+    if (StringUtils.isBlank(ignoreColumns)) {
+      this.columnsToIgnore = Collections.emptySet();
+    } else {
+      this.columnsToIgnore =
+          Arrays.stream(ignoreColumns.trim().split("[\\s]*,[\\s]*")).collect(Collectors.toSet());
+    }
+  }
+
+  public String getInstanceId() {
+    return instanceId;
+  }
+
+  public String getTableId() {
+    return tableId;
+  }
+
+  public String getCharset() {
+    return charset;
+  }
+
+  public Set<String> getColumnFamiliesToIgnore() {
+    return columnFamiliesToIgnore;
+  }
+
+  public Set<String> getColumnsToIgnore() {
+    return columnsToIgnore;
+  }
+
+  public Instant getStartTimestamp() {
+    return startTimestamp;
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/resources/bigtable-changestreams-to-gcs-command-spec.json
+++ b/v2/googlecloud-to-googlecloud/src/main/resources/bigtable-changestreams-to-gcs-command-spec.json
@@ -1,0 +1,7 @@
+{
+  "mainClass": "com.google.cloud.teleport.v2.templates.BigtableChangeStreamsToGcs",
+  "classPath": "/template/bigtable-changestreams-to-gcs/*:/template/bigtable-changestreams-to-gcs/libs/*:/template/bigtable-changestreams-to-gcs/classes",
+  "defaultParameterValues": {
+    "labels": "{\"goog-dataflow-provided-template-type\":\"flex\", \"goog-dataflow-provided-template-name\":\"bigtable-changestreams-to-gcs\"}"
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/bigtablerow.avsc
+++ b/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/bigtablerow.avsc
@@ -1,0 +1,23 @@
+{
+    "name" : "BigtableRow",
+    "type" : "record",
+    "namespace" : "com.google.cloud.teleport.bigtable",
+    "fields" : [
+      { "name" : "key", "type" : "bytes"},
+      { "name" : "cells",
+        "type" : {
+          "type" : "array",
+          "items": {
+            "name": "BigtableCell",
+            "type": "record",
+            "fields": [
+              { "name" : "family", "type" : "string"},
+              { "name" : "qualifier", "type" : "bytes"},
+              { "name" : "timestamp", "type" : "long"},
+              { "name" : "value", "type" : "bytes"}
+            ]
+          }
+        }
+      }
+   ]
+}

--- a/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/changelogentry-text.avsc
+++ b/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/changelogentry-text.avsc
@@ -1,0 +1,25 @@
+{
+    "name" : "ChangelogEntryJson",
+    "type" : "record",
+    "namespace" : "com.google.cloud.teleport.bigtable",
+    "fields" : [
+      { "name" : "rowKey", "type" : "string"},
+      {
+        "name" : "modType",
+        "type" : {
+          "name": "ModType",
+          "type": "enum",
+          "symbols": ["SET_CELL", "DELETE_FAMILY", "DELETE_CELLS", "UNKNOWN"]}
+      },
+      { "name": "isGc", "type": "boolean" },
+      { "name": "tieBreaker", "type": "int"},
+      { "name": "columnFamily", "type": "string"},
+      { "name": "commitTimestamp", "type" : "long"},
+      { "name": "lowWatermark", "type" : "long"},
+      { "name": "column", "type" : ["string", "null"]},
+      { "name": "timestamp", "type" : ["long", "null"]},
+      { "name": "timestampFrom", "type" : ["long", "null"]},
+      { "name": "timestampTo", "type" : ["long", "null"]},
+      { "name" : "value", "type" : ["string", "null"]}
+    ]
+}

--- a/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/changelogentry.avsc
+++ b/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/changelogentry.avsc
@@ -1,0 +1,25 @@
+{
+    "name" : "ChangelogEntry",
+    "type" : "record",
+    "namespace" : "com.google.cloud.teleport.bigtable",
+    "fields" : [
+      { "name" : "rowKey", "type" : "bytes"},
+      {
+        "name" : "modType",
+        "type" : {
+          "name": "ModType",
+          "type": "enum",
+          "symbols": ["SET_CELL", "DELETE_FAMILY", "DELETE_CELLS", "UNKNOWN"]}
+      },
+      { "name": "isGc", "type": "boolean" },
+      { "name": "tieBreaker", "type": "int"},
+      { "name": "columnFamily", "type": "string"},
+      { "name": "commitTimestamp", "type" : "long"},
+      { "name": "lowWatermark", "type" : "long"},
+      { "name": "column", "type" : ["bytes", "null"]},
+      { "name": "timestamp", "type" : ["long", "null"]},
+      { "name": "timestampFrom", "type" : ["long", "null"]},
+      { "name": "timestampTo", "type" : ["long", "null"]},
+      { "name" : "value", "type" : ["bytes", "null"]}
+    ]
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangeStreamsToGcsIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangeStreamsToGcsIT.java
@@ -1,0 +1,745 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import static com.google.cloud.teleport.it.truthmatchers.PipelineAsserts.assertThatPipeline;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.bigtable.admin.v2.models.StorageType;
+import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.teleport.bigtable.ChangelogEntry;
+import com.google.cloud.teleport.bigtable.ChangelogEntryJson;
+import com.google.cloud.teleport.bigtable.ModType;
+import com.google.cloud.teleport.it.common.PipelineLauncher.LaunchConfig;
+import com.google.cloud.teleport.it.common.PipelineLauncher.LaunchInfo;
+import com.google.cloud.teleport.it.common.PipelineOperator;
+import com.google.cloud.teleport.it.common.PipelineOperator.Config;
+import com.google.cloud.teleport.it.common.TestProperties;
+import com.google.cloud.teleport.it.common.utils.ResourceManagerUtils;
+import com.google.cloud.teleport.it.gcp.TemplateTestBase;
+import com.google.cloud.teleport.it.gcp.bigtable.BigtableResourceManager;
+import com.google.cloud.teleport.it.gcp.bigtable.BigtableResourceManagerCluster;
+import com.google.cloud.teleport.it.gcp.bigtable.BigtableTableSpec;
+import com.google.cloud.teleport.it.gcp.storage.GcsResourceManager;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import com.google.common.collect.Lists;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Integration test for {@link BigtableChangeStreamsToGcs}. */
+@Category(TemplateIntegrationTest.class)
+@TemplateIntegrationTest(BigtableChangeStreamsToGcs.class)
+@RunWith(JUnit4.class)
+public final class BigtableChangeStreamsToGcsIT extends TemplateTestBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BigtableChangeStreamsToGcsIT.class);
+
+  public static final String SOURCE_CDC_TABLE = "source_cdc_table";
+  public static final String SOURCE_COLUMN_FAMILY = "cf";
+  private static final Duration EXPECTED_REPLICATION_MAX_WAIT_TIME = Duration.ofMinutes(10);
+  private static final String TEST_REGION = "us-central1";
+  private static final String TEST_ZONE = "us-central1-a";
+  public static final String BIGTABLE_STATIC_INSTANCE_ID_ENV_PROPERTY = "staticBigtableInstanceId";
+  private static final String CLUSTER_NAME = "alexeyku-prod-c1";
+  private static BigtableResourceManager bigtableResourceManager;
+  private static GcsResourceManager gcsResourceManager;
+
+  private LaunchInfo launchInfo;
+  private String outputPath;
+  private String outputPrefix;
+
+  private String outputPath2;
+  private String outputPrefix2;
+
+  @Test
+  // @Ignore(
+  //     "Test is not ready for CI/CD purposes because it doesn't provision CBT resources and "
+  //         + "relies on pre-existing static resources until a new admin API client is available
+  // for "
+  //         + "us to set up CDC-enabled resources")
+  public void testSingleMutationChangelogEntryJsonE2E() throws Exception {
+    String appProfileId = generateAppProfileId();
+
+    List<BigtableResourceManagerCluster> clusters = new ArrayList<>();
+    clusters.add(
+        BigtableResourceManagerCluster.create(CLUSTER_NAME, TEST_ZONE, 1, StorageType.HDD));
+
+    bigtableResourceManager.createInstance(clusters);
+
+    BigtableTableSpec cdcTableSpec = new BigtableTableSpec();
+    cdcTableSpec.setCdcEnabled(true);
+    cdcTableSpec.setColumnFamilies(Lists.asList(SOURCE_COLUMN_FAMILY, new String[] {}));
+    // bigtableResourceManager.createTable(SOURCE_CDC_TABLE, cdcTableSpec);
+
+    bigtableResourceManager.createAppProfile(
+        appProfileId, true, Lists.asList(CLUSTER_NAME, new String[] {}));
+
+    Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder = Function.identity();
+    launchInfo =
+        launchTemplate(
+            paramsAdder.apply(
+                LaunchConfig.builder(testName, specPath)
+                    .addParameter("bigtableReadTableId", SOURCE_CDC_TABLE)
+                    .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                    .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                    .addParameter("bigtableChangeStreamCharset", "KOI8-R")
+                    .addParameter("outputFileFormat", "TEXT")
+                    .addParameter("windowDuration", "10s")
+                    .addParameter("gcsOutputDirectory", outputPath)
+                    .addParameter("schemaOutputFormat", "CHANGELOG_ENTRY")));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    String rowkey = UUID.randomUUID().toString();
+    String column = UUID.randomUUID().toString();
+
+    // https://en.wikipedia.org/wiki/KOI8-R
+    byte[] value_russian_letter_b_in_koi8_r = new byte[] {(byte) 0xc2};
+
+    long nowMillis = System.currentTimeMillis();
+    long timestampMicros = nowMillis * 1000;
+
+    RowMutation rowMutation =
+        RowMutation.create(SOURCE_CDC_TABLE, rowkey)
+            .setCell(
+                SOURCE_COLUMN_FAMILY,
+                ByteString.copyFrom(column, Charset.defaultCharset()),
+                timestampMicros,
+                ByteString.copyFrom(value_russian_letter_b_in_koi8_r));
+
+    ChangelogEntryJson expected = new ChangelogEntryJson();
+    expected.setRowKey(rowkey);
+    expected.setTimestamp(timestampMicros);
+    expected.setCommitTimestamp(nowMillis - 10000); // clock skew tolerance
+    expected.setLowWatermark(0);
+    expected.setColumn(column);
+    expected.setValue(new String(value_russian_letter_b_in_koi8_r, Charset.forName("KOI8-R")));
+    expected.setColumnFamily(SOURCE_COLUMN_FAMILY);
+    expected.setModType(ModType.SET_CELL);
+    expected.setIsGc(false);
+
+    bigtableResourceManager.write(rowMutation);
+
+    if (!waitForFilesToShowUpAt(
+        outputPath,
+        outputPrefix,
+        Duration.ofMinutes(10),
+        new LookForChangelogEntryJsonRecord(expected))) {
+      Assert.fail("Unable to find output file containing row mutation: " + expected);
+    }
+  }
+
+  @Test
+  // @Ignore(
+  //     "Test is not ready for CI/CD purposes because it doesn't provision CBT resources and "
+  //         + "relies on pre-existing static resources until a new admin API client is available
+  // for "
+  //         + "us to set up CDC-enabled resources")
+  public void testSingleMutationChangelogEntryJsonBase64E2E() throws Exception {
+    String appProfileId = generateAppProfileId();
+
+    List<BigtableResourceManagerCluster> clusters = new ArrayList<>();
+    clusters.add(
+        BigtableResourceManagerCluster.create(CLUSTER_NAME, TEST_ZONE, 1, StorageType.HDD));
+
+    bigtableResourceManager.createInstance(clusters);
+
+    BigtableTableSpec cdcTableSpec = new BigtableTableSpec();
+    cdcTableSpec.setCdcEnabled(true);
+    cdcTableSpec.setColumnFamilies(Lists.asList(SOURCE_COLUMN_FAMILY, new String[] {}));
+    // bigtableResourceManager.createTable(SOURCE_CDC_TABLE, cdcTableSpec);
+
+    bigtableResourceManager.createAppProfile(
+        appProfileId, true, Lists.asList(CLUSTER_NAME, new String[] {}));
+
+    Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder = Function.identity();
+    launchInfo =
+        launchTemplate(
+            paramsAdder.apply(
+                LaunchConfig.builder(testName, specPath)
+                    .addParameter("bigtableReadTableId", SOURCE_CDC_TABLE)
+                    .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                    .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                    .addParameter("outputFileFormat", "TEXT")
+                    .addParameter("useBase64Rowkey", "true")
+                    .addParameter("useBase64ColumnQualifier", "true")
+                    .addParameter("useBase64Value", "true")
+                    .addParameter("windowDuration", "10s")
+                    .addParameter("gcsOutputDirectory", outputPath)
+                    .addParameter("schemaOutputFormat", "CHANGELOG_ENTRY")));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    String rowkey = UUID.randomUUID().toString();
+    String column = UUID.randomUUID().toString();
+    String value = UUID.randomUUID().toString();
+
+    long nowMillis = System.currentTimeMillis();
+    long timestampMicros = nowMillis * 1000;
+
+    RowMutation rowMutation =
+        RowMutation.create(SOURCE_CDC_TABLE, rowkey)
+            .setCell(SOURCE_COLUMN_FAMILY, column, timestampMicros, value);
+
+    ChangelogEntry expected = new ChangelogEntry();
+    expected.setRowKey(bb(rowkey));
+    expected.setTimestamp(timestampMicros);
+    expected.setCommitTimestamp(nowMillis - 10000); // clock skew tolerance
+    expected.setLowWatermark(0);
+    expected.setColumn(bb(column));
+    expected.setValue(bb(value));
+    expected.setColumnFamily(SOURCE_COLUMN_FAMILY);
+    expected.setModType(ModType.SET_CELL);
+    expected.setIsGc(false);
+
+    bigtableResourceManager.write(rowMutation);
+
+    if (!waitForFilesToShowUpAt(
+        outputPath,
+        outputPrefix,
+        Duration.ofMinutes(10),
+        new LookForChangelogEntryJsonBase64Record(expected))) {
+      Assert.fail("Unable to find output file containing row mutation: " + expected);
+    }
+  }
+
+  @Test
+  // @Ignore(
+  //     "Test is not ready for CI/CD purposes because it doesn't provision CBT resources and "
+  //         + "relies on pre-existing static resources until a new admin API client is available
+  // for "
+  //         + "us to set up CDC-enabled resources")
+  public void testSingleMutationChangelogEntryAvroE2E() throws Exception {
+    String appProfileId = generateAppProfileId();
+
+    List<BigtableResourceManagerCluster> clusters = new ArrayList<>();
+    clusters.add(
+        BigtableResourceManagerCluster.create(CLUSTER_NAME, TEST_ZONE, 1, StorageType.HDD));
+
+    bigtableResourceManager.createInstance(clusters);
+
+    BigtableTableSpec cdcTableSpec = new BigtableTableSpec();
+    cdcTableSpec.setCdcEnabled(true);
+    cdcTableSpec.setColumnFamilies(Lists.asList(SOURCE_COLUMN_FAMILY, new String[] {}));
+    // bigtableResourceManager.createTable(SOURCE_CDC_TABLE, cdcTableSpec);
+
+    bigtableResourceManager.createAppProfile(
+        appProfileId, true, Lists.asList(CLUSTER_NAME, new String[] {}));
+
+    Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder = Function.identity();
+    launchInfo =
+        launchTemplate(
+            paramsAdder.apply(
+                LaunchConfig.builder(testName, specPath)
+                    .addParameter("bigtableReadTableId", SOURCE_CDC_TABLE)
+                    .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                    .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                    .addParameter("outputFileFormat", "AVRO")
+                    .addParameter("windowDuration", "10s")
+                    .addParameter("gcsOutputDirectory", outputPath)
+                    .addParameter("schemaOutputFormat", "CHANGELOG_ENTRY")));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    String rowkey = UUID.randomUUID().toString();
+    String column = UUID.randomUUID().toString();
+    String value = UUID.randomUUID().toString();
+
+    long nowMillis = System.currentTimeMillis();
+    long timestampMicros = nowMillis * 1000;
+
+    RowMutation rowMutation =
+        RowMutation.create(SOURCE_CDC_TABLE, rowkey)
+            .setCell(SOURCE_COLUMN_FAMILY, column, timestampMicros, value);
+
+    ChangelogEntry expected = new ChangelogEntry();
+
+    expected.setRowKey(bb(rowkey));
+    expected.setTimestamp(timestampMicros);
+    expected.setCommitTimestamp(nowMillis - 10000); // clock skew tolerance
+    expected.setLowWatermark(0);
+    expected.setColumn(bb(column));
+    expected.setValue(bb(value));
+    expected.setColumnFamily(SOURCE_COLUMN_FAMILY);
+    expected.setModType(ModType.SET_CELL);
+    expected.setIsGc(false);
+
+    bigtableResourceManager.write(rowMutation);
+
+    if (!waitForFilesToShowUpAt(
+        outputPath,
+        outputPrefix,
+        Duration.ofMinutes(10),
+        new LookForChangelogEntryAvroRecord(expected))) {
+      Assert.fail("Unable to find output file containing row mutation: " + expected);
+    }
+  }
+
+  @Test
+  // @Ignore(
+  //     "Test is not ready for CI/CD purposes because it doesn't provision CBT resources and "
+  //         + "relies on pre-existing static resources until a new admin API client is available
+  // for "
+  //         + "us to set up CDC-enabled resources")
+  public void testSingleMutationBigtableRowAvroE2E() throws Exception {
+    String appProfileId = generateAppProfileId();
+
+    List<BigtableResourceManagerCluster> clusters = new ArrayList<>();
+    clusters.add(
+        BigtableResourceManagerCluster.create(CLUSTER_NAME, TEST_ZONE, 1, StorageType.HDD));
+
+    bigtableResourceManager.createInstance(clusters);
+
+    BigtableTableSpec cdcTableSpec = new BigtableTableSpec();
+    cdcTableSpec.setCdcEnabled(true);
+    cdcTableSpec.setColumnFamilies(Lists.asList(SOURCE_COLUMN_FAMILY, new String[] {}));
+    // bigtableResourceManager.createTable(SOURCE_CDC_TABLE, cdcTableSpec);
+
+    bigtableResourceManager.createAppProfile(
+        appProfileId, true, Lists.asList(CLUSTER_NAME, new String[] {}));
+
+    Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder = Function.identity();
+    launchInfo =
+        launchTemplate(
+            paramsAdder.apply(
+                LaunchConfig.builder(testName, specPath)
+                    .addParameter("bigtableReadTableId", SOURCE_CDC_TABLE)
+                    .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                    .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                    .addParameter("outputFileFormat", "AVRO")
+                    .addParameter("windowDuration", "10s")
+                    .addParameter("gcsOutputDirectory", outputPath)
+                    .addParameter("schemaOutputFormat", "BIGTABLE_ROW")));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    String rowkey = UUID.randomUUID().toString();
+    String column = UUID.randomUUID().toString();
+    String value = UUID.randomUUID().toString();
+
+    long nowMillis = System.currentTimeMillis();
+    long timestampMicros = nowMillis * 1000;
+
+    RowMutation rowMutation =
+        RowMutation.create(SOURCE_CDC_TABLE, rowkey)
+            .setCell(SOURCE_COLUMN_FAMILY, column, timestampMicros, value);
+
+    ChangelogEntry expected = new ChangelogEntry();
+
+    expected.setRowKey(bb(rowkey));
+    expected.setTimestamp(timestampMicros);
+    expected.setCommitTimestamp(nowMillis - 10000); // clock skew tolerance
+    expected.setLowWatermark(0);
+    expected.setColumn(bb(column));
+    expected.setValue(bb(value));
+    expected.setColumnFamily(SOURCE_COLUMN_FAMILY);
+    expected.setModType(ModType.SET_CELL);
+    expected.setIsGc(false);
+
+    bigtableResourceManager.write(rowMutation);
+
+    if (!waitForFilesToShowUpAt(
+        outputPath,
+        outputPrefix,
+        Duration.ofMinutes(10),
+        new LookForBigtableRowAvroRecord(expected))) {
+      Assert.fail("Unable to find output file containing row mutation: " + expected);
+    }
+  }
+
+  @Test
+  // @Ignore(
+  //     "Test is not ready for CI/CD purposes because it doesn't provision CBT resources and "
+  //         + "relies on pre-existing static resources until a new admin API client is available
+  // for "
+  //         + "us to set up CDC-enabled resources")
+  public void testSingleMutationBigtableRowAvroWithStartTimeE2E() throws Exception {
+    String appProfileId = generateAppProfileId();
+
+    List<BigtableResourceManagerCluster> clusters = new ArrayList<>();
+    clusters.add(
+        BigtableResourceManagerCluster.create(CLUSTER_NAME, TEST_ZONE, 1, StorageType.HDD));
+
+    bigtableResourceManager.createInstance(clusters);
+
+    BigtableTableSpec cdcTableSpec = new BigtableTableSpec();
+    cdcTableSpec.setCdcEnabled(true);
+    cdcTableSpec.setColumnFamilies(Lists.asList(SOURCE_COLUMN_FAMILY, new String[] {}));
+    // bigtableResourceManager.createTable(SOURCE_CDC_TABLE, cdcTableSpec);
+
+    bigtableResourceManager.createAppProfile(
+        appProfileId, true, Lists.asList(CLUSTER_NAME, new String[] {}));
+
+    Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder = Function.identity();
+    launchInfo =
+        launchTemplate(
+            paramsAdder.apply(
+                LaunchConfig.builder(testName, specPath)
+                    .addParameter("bigtableReadTableId", SOURCE_CDC_TABLE)
+                    .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                    .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                    .addParameter("outputFileFormat", "AVRO")
+                    .addParameter("windowDuration", "10s")
+                    .addParameter("gcsOutputDirectory", outputPath)
+                    .addParameter("schemaOutputFormat", "BIGTABLE_ROW")));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    String rowkey = UUID.randomUUID().toString();
+    String column = UUID.randomUUID().toString();
+    String value = UUID.randomUUID().toString();
+
+    long nowMillis = System.currentTimeMillis();
+    long timestampMicros = nowMillis * 1000;
+
+    RowMutation rowMutation =
+        RowMutation.create(SOURCE_CDC_TABLE, rowkey)
+            .setCell(SOURCE_COLUMN_FAMILY, column, timestampMicros, value);
+
+    ChangelogEntry expected = new ChangelogEntry();
+
+    expected.setRowKey(bb(rowkey));
+    expected.setTimestamp(timestampMicros);
+    expected.setCommitTimestamp(timestampMicros - 10000000); // clock skew tolerance
+    expected.setLowWatermark(0);
+    expected.setColumn(bb(column));
+    expected.setValue(bb(value));
+    expected.setColumnFamily(SOURCE_COLUMN_FAMILY);
+    expected.setModType(ModType.SET_CELL);
+    expected.setIsGc(false);
+
+    bigtableResourceManager.write(rowMutation);
+
+    Thread.sleep(10000);
+
+    bigtableResourceManager.write(rowMutation);
+
+    var predicate = new LookForBigtableRowAvroRecord(expected);
+    if (!waitForFilesToShowUpAt(outputPath, outputPrefix, Duration.ofMinutes(10), predicate)) {
+      Assert.fail("Unable to find output file containing row mutation: " + expected);
+    }
+
+    // Adding 1.5s just to make sure we don't capture this earliest record
+    long microsCutoff = predicate.getEarliestCommitTime() + 1500000L;
+
+    pipelineLauncher.cancelJob(launchInfo.projectId(), launchInfo.region(), launchInfo.jobId());
+
+    Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder2 = Function.identity();
+    launchInfo =
+        launchTemplate(
+            paramsAdder2.apply(
+                LaunchConfig.builder(testName, specPath)
+                    .addParameter("bigtableReadTableId", SOURCE_CDC_TABLE)
+                    .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                    .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                    .addParameter("outputFileFormat", "AVRO")
+                    .addParameter(
+                        "bigtableChangeStreamStartTimestamp", formatTimeMicros(microsCutoff))
+                    .addParameter("windowDuration", "10s")
+                    .addParameter("gcsOutputDirectory", outputPath2)
+                    .addParameter("schemaOutputFormat", "BIGTABLE_ROW")));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    var latestPredicate = new LookForBigtableRowAvroRecord(expected);
+    if (!waitForFilesToShowUpAt(
+        outputPath2, outputPrefix2, Duration.ofMinutes(10), latestPredicate)) {
+      Assert.fail("Unable to find latest mutation: " + expected);
+    }
+    Assert.assertTrue(latestPredicate.getEarliestCommitTime() >= microsCutoff);
+  }
+
+  @Test
+  // @Ignore(
+  //     "Test is not ready for CI/CD purposes because it doesn't provision CBT resources and "
+  //         + "relies on pre-existing static resources until a new admin API client is available
+  // for "
+  //         + "us to set up CDC-enabled resources")
+  public void testSingleMutationBigtableRowAvroWStopAndResumeE2E() throws Exception {
+    String appProfileId = generateAppProfileId();
+
+    List<BigtableResourceManagerCluster> clusters = new ArrayList<>();
+    clusters.add(
+        BigtableResourceManagerCluster.create(CLUSTER_NAME, TEST_ZONE, 1, StorageType.HDD));
+
+    bigtableResourceManager.createInstance(clusters);
+
+    BigtableTableSpec cdcTableSpec = new BigtableTableSpec();
+    cdcTableSpec.setCdcEnabled(true);
+    cdcTableSpec.setColumnFamilies(Lists.asList(SOURCE_COLUMN_FAMILY, new String[] {}));
+    // bigtableResourceManager.createTable(SOURCE_CDC_TABLE, cdcTableSpec);
+
+    bigtableResourceManager.createAppProfile(
+        appProfileId, true, Lists.asList(CLUSTER_NAME, new String[] {}));
+
+    String persistentName = UUID.randomUUID().toString();
+
+    Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder = Function.identity();
+    launchInfo =
+        launchTemplate(
+            paramsAdder.apply(
+                LaunchConfig.builder(testName, specPath)
+                    .addParameter("bigtableChangeStreamName", persistentName)
+                    .addParameter("bigtableChangeStreamResume", "false")
+                    .addParameter("bigtableReadTableId", SOURCE_CDC_TABLE)
+                    .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                    .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                    .addParameter("outputFileFormat", "AVRO")
+                    .addParameter("windowDuration", "10s")
+                    .addParameter("gcsOutputDirectory", outputPath)
+                    .addParameter("schemaOutputFormat", "BIGTABLE_ROW")));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    String rowkey = UUID.randomUUID().toString();
+    String column = UUID.randomUUID().toString();
+    String value = UUID.randomUUID().toString();
+
+    long nowMillis = System.currentTimeMillis();
+    long timestampMicros = nowMillis * 1000;
+
+    RowMutation rowMutation =
+        RowMutation.create(SOURCE_CDC_TABLE, rowkey)
+            .setCell(SOURCE_COLUMN_FAMILY, column, timestampMicros, value);
+
+    ChangelogEntry expected = new ChangelogEntry();
+
+    expected.setRowKey(bb(rowkey));
+    expected.setTimestamp(timestampMicros);
+    expected.setCommitTimestamp(timestampMicros - 10000000); // clock skew tolerance
+    expected.setLowWatermark(0);
+    expected.setColumn(bb(column));
+    expected.setValue(bb(value));
+    expected.setColumnFamily(SOURCE_COLUMN_FAMILY);
+    expected.setModType(ModType.SET_CELL);
+    expected.setIsGc(false);
+
+    bigtableResourceManager.write(rowMutation);
+
+    if (!waitForFilesToShowUpAt(
+        outputPath,
+        outputPrefix,
+        Duration.ofMinutes(10),
+        new LookForBigtableRowAvroRecord(expected))) {
+      Assert.fail("Unable to find output file containing row mutation: " + expected);
+    }
+
+    pipelineLauncher.cancelJob(launchInfo.projectId(), launchInfo.region(), launchInfo.jobId());
+
+    waitUntilCancelled(launchInfo, Duration.ofMinutes(10));
+
+    // Scanning the dir one more time to capture the latest commit time
+    var predicate = new LookForBigtableRowAvroRecord(expected);
+    if (!waitForFilesToShowUpAt(outputPath, outputPrefix, Duration.ofMinutes(10), predicate)) {
+      Assert.fail("Unable to find output file containing row mutation: " + expected);
+    }
+
+    bigtableResourceManager.write(rowMutation);
+
+    Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder2 = Function.identity();
+    launchInfo =
+        launchTemplate(
+            paramsAdder2.apply(
+                LaunchConfig.builder(testName, specPath)
+                    .addParameter("bigtableChangeStreamName", persistentName)
+                    .addParameter("bigtableChangeStreamResume", "true")
+                    .addParameter("bigtableReadTableId", SOURCE_CDC_TABLE)
+                    .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                    .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                    .addParameter("outputFileFormat", "AVRO")
+                    .addParameter(
+                        "bigtableChangeStreamStartTimestamp",
+                        formatTimeMicros(predicate.getEarliestCommitTime() - 1000000))
+                    .addParameter("windowDuration", "10s")
+                    .addParameter("gcsOutputDirectory", outputPath2)
+                    .addParameter("schemaOutputFormat", "BIGTABLE_ROW")));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    var latestPredicate = new LookForBigtableRowAvroRecord(expected);
+    if (!waitForFilesToShowUpAt(
+        outputPath2, outputPrefix2, Duration.ofMinutes(10), latestPredicate)) {
+      Assert.fail("Unable to find latest mutation: " + expected);
+    }
+    Assert.assertTrue(latestPredicate.getEarliestCommitTime() > predicate.getLatestCommitTime());
+  }
+
+  private void waitUntilCancelled(LaunchInfo launchInfo, Duration maxWait) {
+    long started = System.currentTimeMillis();
+    while (System.currentTimeMillis() < started + maxWait.toMillis()) {
+      try {
+        var state =
+            pipelineLauncher.getJobStatus(
+                TestProperties.project(), TestProperties.region(), launchInfo.jobId());
+        switch (state) {
+          case CANCELLED:
+            LOG.info("Job is finally CANCELLED!");
+            return;
+          case CANCELLING:
+          case RUNNING:
+            LOG.info("Job is not cancelled yet: " + state);
+            continue;
+          default:
+            throw new RuntimeException("Unexpected job state: " + state);
+        }
+      } catch (Exception e) {
+        LOG.warn("failed to obtain job state: ", e);
+      }
+    }
+  }
+
+  @Test
+  // @Ignore(
+  //     "Test is not ready for CI/CD purposes because it doesn't provision CBT resources and "
+  //         + "relies on pre-existing static resources until a new admin API client is available
+  // for "
+  //         + "us to set up CDC-enabled resources")
+  public void testSingleMutationBigtableRowTextE2E() throws Exception {
+    Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder = Function.identity();
+    try {
+      launchInfo =
+          launchTemplate(
+              paramsAdder.apply(
+                  LaunchConfig.builder(testName, specPath)
+                      .addParameter("bigtableReadTableId", SOURCE_CDC_TABLE)
+                      .addParameter(
+                          "bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                      .addParameter("bigtableChangeStreamAppProfile", "anything")
+                      .addParameter("outputFileFormat", "TEXT")
+                      .addParameter("windowDuration", "10s")
+                      .addParameter("gcsOutputDirectory", outputPath)
+                      .addParameter("schemaOutputFormat", "BIGTABLE_ROW")));
+    } catch (RuntimeException e) {
+      Assert.assertTrue(e.getMessage().contains("The job failed before launch"));
+    }
+  }
+
+  private ByteBuffer bb(String value) {
+    return ByteBuffer.wrap(value.getBytes(Charset.defaultCharset()));
+  }
+
+  private boolean waitForFilesToShowUpAt(
+      String outputPath, String outputPrefix, Duration howLong, Predicate<? super Blob> checkFile)
+      throws Exception {
+    long polUntil = System.currentTimeMillis() + howLong.toMillis();
+
+    Storage storage =
+        StorageOptions.newBuilder().setProjectId(TestProperties.project()).build().getService();
+
+    boolean found = false;
+    while (System.currentTimeMillis() < polUntil && !found) {
+      LOG.info("Looking for files at " + outputPath);
+
+      Page<Blob> blobPa =
+          storage.list(TestProperties.artifactBucket(), BlobListOption.prefix(outputPrefix));
+      found = blobPa.streamAll().anyMatch(checkFile);
+      if (!found) {
+        Thread.sleep(1000);
+      }
+    }
+    return found;
+  }
+
+  @NotNull
+  private static String generateAppProfileId() {
+    return "cdc_app_profile_" + System.nanoTime();
+  }
+
+  @Before
+  public void setup() throws IOException {
+    gcsResourceManager =
+        GcsResourceManager.builder(TestProperties.artifactBucket(), getClass().getSimpleName())
+            .setCredentials(TestProperties.googleCredentials())
+            .build();
+
+    String outputDir = generateSafeDirectoryName();
+    gcsResourceManager.registerTempDir(outputDir);
+    outputPath = String.format("gs://%s/%s/output", TestProperties.artifactBucket(), outputDir);
+    outputPrefix = String.format("%s/output", outputDir);
+
+    outputPath2 = String.format("gs://%s/%s/output2", TestProperties.artifactBucket(), outputDir);
+    outputPrefix2 = String.format("%s/output2", outputDir);
+
+    String staticInstanceId = System.getProperty(BIGTABLE_STATIC_INSTANCE_ID_ENV_PROPERTY);
+
+    BigtableResourceManager.Builder rmBuilder =
+        BigtableResourceManager.builder(testName, PROJECT)
+            .setCredentialsProvider(credentialsProvider);
+
+    if (StringUtils.isNoneBlank(staticInstanceId)) {
+      rmBuilder = rmBuilder.useStaticInstance().setInstanceId(staticInstanceId);
+    }
+    bigtableResourceManager = rmBuilder.build();
+  }
+
+  @After
+  public void tearDownClass() {
+    ResourceManagerUtils.cleanResources(bigtableResourceManager, gcsResourceManager);
+  }
+
+  @Override
+  protected PipelineOperator.Config createConfig(LaunchInfo info) {
+    Config.Builder configBuilder =
+        Config.builder().setJobId(info.jobId()).setProject(PROJECT).setRegion(REGION);
+
+    // For DirectRunner tests, reduce the max time and the interval, as there is no worker required
+    if (System.getProperty("directRunnerTest") != null) {
+      configBuilder =
+          configBuilder
+              .setTimeoutAfter(EXPECTED_REPLICATION_MAX_WAIT_TIME.minus(Duration.ofMinutes(3)))
+              .setCheckAfter(Duration.ofSeconds(5));
+    } else {
+      configBuilder.setTimeoutAfter(EXPECTED_REPLICATION_MAX_WAIT_TIME);
+    }
+
+    return configBuilder.build();
+  }
+
+  // We don't want any unexpected date format characters in the dir name
+  private String generateSafeDirectoryName() {
+    return UUID.randomUUID().toString().replaceAll("[da]", "x");
+  }
+
+  private String formatTimeMicros(long microsCutoff) {
+    SimpleDateFormat format = new SimpleDateFormat("yyy-MM-dd'T'HH:mm:ssXXX");
+    return format.format(new Date(microsCutoff / 1000));
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangeStreamsToGcsIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangeStreamsToGcsIT.java
@@ -132,7 +132,7 @@ public final class BigtableChangeStreamsToGcsIT extends TemplateTestBase {
     String column = UUID.randomUUID().toString();
 
     // https://en.wikipedia.org/wiki/KOI8-R
-    byte[] value_russian_letter_b_in_koi8_r = new byte[] {(byte) 0xc2};
+    byte[] valueRussianLetterBinKoi8R = new byte[] {(byte) 0xc2};
 
     long nowMillis = System.currentTimeMillis();
     long timestampMicros = nowMillis * 1000;
@@ -143,7 +143,7 @@ public final class BigtableChangeStreamsToGcsIT extends TemplateTestBase {
                 SOURCE_COLUMN_FAMILY,
                 ByteString.copyFrom(column, Charset.defaultCharset()),
                 timestampMicros,
-                ByteString.copyFrom(value_russian_letter_b_in_koi8_r));
+                ByteString.copyFrom(valueRussianLetterBinKoi8R));
 
     ChangelogEntryJson expected = new ChangelogEntryJson();
     expected.setRowKey(rowkey);
@@ -151,7 +151,7 @@ public final class BigtableChangeStreamsToGcsIT extends TemplateTestBase {
     expected.setCommitTimestamp(nowMillis - 10000); // clock skew tolerance
     expected.setLowWatermark(0);
     expected.setColumn(column);
-    expected.setValue(new String(value_russian_letter_b_in_koi8_r, Charset.forName("KOI8-R")));
+    expected.setValue(new String(valueRussianLetterBinKoi8R, Charset.forName("KOI8-R")));
     expected.setColumnFamily(SOURCE_COLUMN_FAMILY);
     expected.setModType(ModType.SET_CELL);
     expected.setIsGc(false);

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableUtilsTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableUtilsTest.java
@@ -257,8 +257,7 @@ public class BigtableUtilsTest {
 
     ChangelogEntry logEntry = actualEntries.get(0);
 
-    Assert.assertEquals(
-        "rowkey", Charset.defaultCharset().decode(logEntry.getRowKey()).toString());
+    Assert.assertEquals("rowkey", Charset.defaultCharset().decode(logEntry.getRowKey()).toString());
     Assert.assertEquals("family2", logEntry.getColumnFamily());
     Assert.assertEquals(
         "column2", Charset.defaultCharset().decode(logEntry.getColumn()).toString());
@@ -299,8 +298,7 @@ public class BigtableUtilsTest {
 
     ChangelogEntry logEntry = actualEntries.get(0);
 
-    Assert.assertEquals(
-        "rowkey", Charset.defaultCharset().decode(logEntry.getRowKey()).toString());
+    Assert.assertEquals("rowkey", Charset.defaultCharset().decode(logEntry.getRowKey()).toString());
     Assert.assertEquals("family1", logEntry.getColumnFamily());
     Assert.assertEquals(
         "column1", Charset.defaultCharset().decode(logEntry.getColumn()).toString());

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableUtilsTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableUtilsTest.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.Timestamp;
+import com.google.cloud.bigtable.data.v2.models.ChangeStreamMutation;
+import com.google.cloud.bigtable.data.v2.models.Entry;
+import com.google.cloud.teleport.bigtable.BigtableCell;
+import com.google.cloud.teleport.bigtable.BigtableRow;
+import com.google.cloud.teleport.bigtable.ChangelogEntry;
+import com.google.cloud.teleport.bigtable.ModType;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.model.ChangelogColumns;
+import com.google.cloud.teleport.v2.utils.BigtableSource;
+import com.google.common.collect.ImmutableList;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Random;
+import org.joda.time.Instant;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+/** Test class for {@link BigtableUtils} */
+@RunWith(JUnit4.class)
+public class BigtableUtilsTest {
+
+  /**
+   * {@link com.google.cloud.bigtable.data.v2.models.ChangeStreamMutation} fields to be used
+   * throughout the tests
+   */
+  final int TIE_BREAKER = 1000;
+
+  final boolean IS_GC = true;
+  final String COLUMN_FAMILY = "CF";
+  final Timestamp COMMIT_TIMESTAMP = Timestamp.now();
+  final Timestamp LOW_WATERMARK = Timestamp.MIN_VALUE;
+  final Charset CHARSET = StandardCharsets.UTF_8;
+  final ByteBuffer COLUMN = getByteBufferFromString("COLUMN", CHARSET);
+  final Timestamp TIMESTAMP = Timestamp.now();
+  final Timestamp TIMESTAMP_FROM = Timestamp.MIN_VALUE;
+  final Timestamp TIMESTAMP_TO = Timestamp.MAX_VALUE;
+  final ByteBuffer VALUE = getByteBufferFromString("VALUE", CHARSET);
+  final ByteBuffer ROW_KEY = getByteBufferFromString("ROW_KEY", CHARSET);
+
+  /** Pipeline specific variables to be used throughout testing of {@link BigtableUtils} */
+  final String FAKE_INSTANCE_ID = "fakeinstance";
+
+  final String FAKE_TABLE_ID = "faketableid";
+  final String IGNORE_COLUMN_FAMILIES = "cf1, cf2, cf3";
+  final String IGNORE_COLUMNS = "cf1:c1, cf2:c2";
+  final String WORKER_ID = "workerid";
+  final Long COUNTER = 1000L;
+
+  /**
+   * Test whether {@link BigtableUtils} can create {@link
+   * com.google.cloud.teleport.bigtable.BigtableRow} objects appropriately from a {@link
+   * com.google.cloud.teleport.bigtable.ChangelogEntry} of type SET_CELL.
+   */
+  @Test
+  public void testCreateBigtableRowSetCellEntry() {
+    /* Initial setup, may vary across different */
+    BigtableUtils utils = initBigtableUtils(IGNORE_COLUMN_FAMILIES, IGNORE_COLUMNS);
+
+    /* Create {@link ChangelogEntry} of type {@link ModType.SET_CELL} */
+    ChangelogEntry setCellEntry = createChangelogEntry(ModType.SET_CELL, COLUMN_FAMILY, COLUMN);
+
+    BigtableRow setCellRow = utils.createBigtableRow(setCellEntry, WORKER_ID, COUNTER);
+    HashMap<ByteBuffer, ByteBuffer> changelogEntryHashMap =
+        getHashMapFromChangelogEntry(setCellEntry, CHARSET);
+
+    ByteBuffer bigtableRowExpectedRowKey =
+        createChangelogRowKey(
+            utils, setCellEntry.getCommitTimestamp(), WORKER_ID, COUNTER, CHARSET);
+    assertEquals(setCellRow.getKey(), bigtableRowExpectedRowKey);
+
+    for (BigtableCell cell : setCellRow.getCells()) {
+      assertTrue(changelogEntryHashMap.containsKey(cell.getQualifier()));
+      ByteBuffer expectedCellValue = changelogEntryHashMap.get(cell.getQualifier());
+      assertTrue(expectedCellValue.compareTo(cell.getValue()) == 0);
+    }
+  }
+
+  /**
+   * Test whether {@link BigtableUtils} can create {@link
+   * com.google.cloud.teleport.bigtable.BigtableRow} objects appropriately from a {@link
+   * com.google.cloud.teleport.bigtable.ChangelogEntry} of type DELETE_CELLS.
+   */
+  @Test
+  public void testCreateBigtableRowDeleteCellsEntry() {
+    /* Initial setup, may vary across different */
+    BigtableUtils utils = initBigtableUtils(IGNORE_COLUMN_FAMILIES, IGNORE_COLUMNS);
+
+    /* Create {@link ChangelogEntry} of type {@link ModType.DELETE_CELLS}*/
+    ChangelogEntry deleteCellsEntry =
+        createChangelogEntry(ModType.DELETE_CELLS, COLUMN_FAMILY, COLUMN);
+
+    BigtableRow deleteCellsRow = utils.createBigtableRow(deleteCellsEntry, WORKER_ID, COUNTER);
+    HashMap<ByteBuffer, ByteBuffer> changelogEntryHashMap =
+        getHashMapFromChangelogEntry(deleteCellsEntry, CHARSET);
+
+    ByteBuffer bigtableRowExpectedRowKey =
+        createChangelogRowKey(
+            utils, deleteCellsEntry.getCommitTimestamp(), WORKER_ID, COUNTER, CHARSET);
+    assertEquals(deleteCellsRow.getKey(), bigtableRowExpectedRowKey);
+
+    for (BigtableCell cell : deleteCellsRow.getCells()) {
+      assertTrue(changelogEntryHashMap.containsKey(cell.getQualifier()));
+      ByteBuffer expectedCellValue = changelogEntryHashMap.get(cell.getQualifier());
+      assertTrue(expectedCellValue.compareTo(cell.getValue()) == 0);
+    }
+  }
+
+  /**
+   * Test whether {@link BigtableUtils} can create {@link
+   * com.google.cloud.teleport.bigtable.BigtableRow} objects appropriately from a {@link
+   * com.google.cloud.teleport.bigtable.ChangelogEntry} of type DELETE_FAMILY.
+   */
+  @Test
+  public void testCreateBigtableRowDeleteFamilyEntry() {
+    /* Initial setup, may vary across different */
+    BigtableUtils utils = initBigtableUtils(IGNORE_COLUMN_FAMILIES, IGNORE_COLUMNS);
+
+    /* Create {@link ChangelogEntry} of type {@link ModType.DELETE_FAMILY} */
+    ChangelogEntry deleteFamilyEntry =
+        createChangelogEntry(ModType.DELETE_FAMILY, COLUMN_FAMILY, COLUMN);
+
+    BigtableRow deleteFamilyRow = utils.createBigtableRow(deleteFamilyEntry, WORKER_ID, COUNTER);
+    HashMap<ByteBuffer, ByteBuffer> changelogEntryHashMap =
+        getHashMapFromChangelogEntry(deleteFamilyEntry, CHARSET);
+
+    ByteBuffer bigtableRowExpectedRowKey =
+        createChangelogRowKey(
+            utils, deleteFamilyEntry.getCommitTimestamp(), WORKER_ID, COUNTER, CHARSET);
+    assertEquals(deleteFamilyRow.getKey(), bigtableRowExpectedRowKey);
+
+    for (BigtableCell cell : deleteFamilyRow.getCells()) {
+      assertTrue(changelogEntryHashMap.containsKey(cell.getQualifier()));
+      ByteBuffer expectedCellValue = changelogEntryHashMap.get(cell.getQualifier());
+      assertTrue(expectedCellValue.compareTo(cell.getValue()) == 0);
+    }
+  }
+
+  @Test
+  public void tesCopyByteBuffer() {
+    // Generate random bytes
+    byte[] byteArray = new byte[1000];
+    new Random().nextBytes(byteArray);
+
+    ByteBuffer bbOriginal = ByteBuffer.wrap(byteArray);
+    ByteBuffer bbCopy = BigtableUtils.copyByteBuffer(bbOriginal);
+
+    assertTrue(bbOriginal.compareTo(bbCopy) == 0);
+  }
+
+  @Test
+  public void testGetValidEntriesAllEntriesAreValid() {
+    // IGNORE_COLUMN_FAMILIES = "cf1, cf2, cf3";
+    // IGNORE_COLUMNS = "cf1:c1, cf2:c2";
+    BigtableUtils utils = initBigtableUtils("", "");
+
+    Entry entry1 = Mockito.mock(Entry.class);
+    // mock a few entries, one of each instance of Entry
+
+    ChangeStreamMutation mutation = Mockito.mock(ChangeStreamMutation.class);
+    Mockito.when(mutation.getEntries()).thenReturn(ImmutableList.of(entry1));
+
+    Mockito.when(mutation.getType()).thenReturn(ChangeStreamMutation.MutationType.USER);
+
+    List<ChangelogEntry> actualEntries = utils.getValidEntries(mutation);
+
+    // validate that they are all there
+    throw new IllegalArgumentException("Hmm");
+  }
+
+  @Test
+  public void testGetValidEntriesWithIgnoredColumns() {}
+
+  @Test
+  public void testGetValidEntriesWithIgnoredColumnFamilies() {}
+
+  private ByteBuffer createChangelogRowKey(
+      BigtableUtils utils, Long commitTimestamp, String workerId, Long counter, Charset charset) {
+    String rowKey =
+        (commitTimestamp.toString()
+            + utils.bigtableRowKeyDelimiter
+            + workerId
+            + utils.bigtableRowKeyDelimiter
+            + counter);
+
+    return BigtableUtils.copyByteBuffer(ByteBuffer.wrap(rowKey.getBytes(charset)));
+  }
+
+  private HashMap<ByteBuffer, ByteBuffer> getHashMapFromChangelogEntry(
+      ChangelogEntry entry, Charset charset) {
+    HashMap<ByteBuffer, ByteBuffer> qualifierToCellValueMap = new HashMap<>();
+    addCommonEntryProperties(qualifierToCellValueMap, entry, charset);
+    if (entry.getModType() == ModType.SET_CELL) {
+      addSetCellEntryProperties(qualifierToCellValueMap, entry, charset);
+    } else if (entry.getModType() == ModType.DELETE_CELLS) {
+      addDeleteCellsEntryProperties(qualifierToCellValueMap, entry, charset);
+    } else if (entry.getModType() == ModType.DELETE_FAMILY) {
+      addDeleteFamilyEntryProperties(qualifierToCellValueMap, entry, charset);
+    } else {
+      // should never reach here
+      Assert.fail();
+    }
+    return qualifierToCellValueMap;
+  }
+
+  private void addCommonEntryProperties(
+      HashMap<ByteBuffer, ByteBuffer> entryMap, ChangelogEntry entry, Charset charset) {
+    entryMap.put(
+        ChangelogColumns.ROW_KEY.getColumnNameAsByteBuffer(charset),
+        BigtableUtils.copyByteBuffer(entry.getRowKey()));
+    entryMap.put(
+        ChangelogColumns.MOD_TYPE.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(entry.getModType().toString(), charset));
+    entryMap.put(
+        ChangelogColumns.IS_GC.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(Boolean.toString(entry.getIsGc()), charset));
+    entryMap.put(
+        ChangelogColumns.TIEBREAKER.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(Integer.toString(entry.getTieBreaker()), charset));
+    entryMap.put(
+        ChangelogColumns.COMMIT_TIMESTAMP.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(Long.toString(entry.getCommitTimestamp()), charset));
+    entryMap.put(
+        ChangelogColumns.LOW_WATERMARK.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(Long.toString(entry.getLowWatermark()), charset));
+  }
+
+  private void addSetCellEntryProperties(
+      HashMap<ByteBuffer, ByteBuffer> entryMap, ChangelogEntry entry, Charset charset) {
+    entryMap.put(
+        ChangelogColumns.COLUMN_FAMILY.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(entry.getColumnFamily().toString(), charset));
+    entryMap.put(
+        ChangelogColumns.COLUMN.getColumnNameAsByteBuffer(charset),
+        BigtableUtils.copyByteBuffer(entry.getColumn()));
+    entryMap.put(
+        ChangelogColumns.TIMESTAMP.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(entry.getTimestamp().toString(), charset));
+    entryMap.put(
+        ChangelogColumns.VALUE.getColumnNameAsByteBuffer(charset),
+        BigtableUtils.copyByteBuffer(entry.getValue()));
+    entryMap.put(ChangelogColumns.TIMESTAMP_TO.getColumnNameAsByteBuffer(charset), null);
+    entryMap.put(ChangelogColumns.TIMESTAMP_FROM.getColumnNameAsByteBuffer(charset), null);
+  }
+
+  private void addDeleteCellsEntryProperties(
+      HashMap<ByteBuffer, ByteBuffer> entryMap, ChangelogEntry entry, Charset charset) {
+    entryMap.put(
+        ChangelogColumns.COLUMN_FAMILY.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(entry.getColumnFamily().toString(), charset));
+    entryMap.put(
+        ChangelogColumns.COLUMN.getColumnNameAsByteBuffer(charset),
+        BigtableUtils.copyByteBuffer(entry.getColumn()));
+    entryMap.put(ChangelogColumns.TIMESTAMP.getColumnNameAsByteBuffer(charset), null);
+    entryMap.put(ChangelogColumns.VALUE.getColumnNameAsByteBuffer(charset), null);
+    entryMap.put(
+        ChangelogColumns.TIMESTAMP_TO.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(entry.getTimestampTo().toString(), charset));
+    entryMap.put(
+        ChangelogColumns.TIMESTAMP_FROM.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(entry.getTimestampFrom().toString(), charset));
+  }
+
+  private void addDeleteFamilyEntryProperties(
+      HashMap<ByteBuffer, ByteBuffer> entryMap, ChangelogEntry entry, Charset charset) {
+    entryMap.put(
+        ChangelogColumns.COLUMN_FAMILY.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(entry.getColumnFamily().toString(), charset));
+    entryMap.put(ChangelogColumns.COLUMN.getColumnNameAsByteBuffer(charset), null);
+    entryMap.put(ChangelogColumns.TIMESTAMP.getColumnNameAsByteBuffer(charset), null);
+    entryMap.put(ChangelogColumns.VALUE.getColumnNameAsByteBuffer(charset), null);
+    entryMap.put(ChangelogColumns.TIMESTAMP_TO.getColumnNameAsByteBuffer(charset), null);
+    entryMap.put(ChangelogColumns.TIMESTAMP_FROM.getColumnNameAsByteBuffer(charset), null);
+  }
+
+  private ByteBuffer getByteBufferFromString(String s, Charset charset) {
+    return BigtableUtils.copyByteBuffer(ByteBuffer.wrap(s.getBytes(charset)));
+  }
+
+  private BigtableUtils initBigtableUtils(String ignoreColumnFamilies, String ignoreColumns) {
+    BigtableSource source =
+        new BigtableSource(
+            FAKE_INSTANCE_ID,
+            FAKE_TABLE_ID,
+            CHARSET.toString(),
+            ignoreColumnFamilies,
+            ignoreColumns,
+            Instant.now());
+
+    return new BigtableUtils(source);
+  }
+
+  private ChangelogEntry createChangelogEntry(
+      ModType modType, String columnFamily, ByteBuffer qualifier) {
+    if (modType == ModType.SET_CELL) {
+      return createSetCellChangelogEntry(columnFamily, qualifier);
+    }
+
+    if (modType == ModType.DELETE_CELLS) {
+      return createDeleteCellsChangelogEntry(columnFamily, qualifier);
+    }
+
+    if (modType == ModType.DELETE_FAMILY) {
+      return createDeleteFamilyChangelogEntry(columnFamily, qualifier);
+    }
+
+    // Should never reach here.
+    return null;
+  }
+
+  private ChangelogEntry createSetCellChangelogEntry(String columnFamily, ByteBuffer qualifier) {
+    return ChangelogEntry.newBuilder()
+        .setRowKey(ROW_KEY)
+        .setIsGc(IS_GC)
+        .setTieBreaker(TIE_BREAKER)
+        .setCommitTimestamp(COMMIT_TIMESTAMP.getNanos() / 1000)
+        .setLowWatermark(LOW_WATERMARK.getNanos() / 1000)
+        .setModType(ModType.SET_CELL)
+        .setColumnFamily(COLUMN_FAMILY)
+        .setColumn(COLUMN)
+        .setTimestamp((long) (TIMESTAMP.getNanos() / 1000))
+        .setValue(VALUE)
+        .setTimestampFrom(null)
+        .setTimestampTo(null)
+        .build();
+  }
+
+  private ChangelogEntry createDeleteCellsChangelogEntry(
+      String columnFamily, ByteBuffer qualifier) {
+    return ChangelogEntry.newBuilder()
+        .setRowKey(ROW_KEY)
+        .setIsGc(IS_GC)
+        .setTieBreaker(TIE_BREAKER)
+        .setCommitTimestamp((long) (COMMIT_TIMESTAMP.getNanos() / 1000))
+        .setLowWatermark((long) (LOW_WATERMARK.getNanos() / 1000))
+        .setColumnFamily(COLUMN_FAMILY)
+        .setColumn(COLUMN)
+        .setModType(ModType.DELETE_CELLS)
+        .setTimestamp(null)
+        .setValue(null)
+        .setTimestampFrom((long) (TIMESTAMP_FROM.getNanos() / 1000))
+        .setTimestampTo((long) (TIMESTAMP_TO.getNanos() / 1000))
+        .build();
+  }
+
+  private ChangelogEntry createDeleteFamilyChangelogEntry(
+      String columnFamily, ByteBuffer qualifier) {
+    return ChangelogEntry.newBuilder()
+        .setRowKey(ROW_KEY)
+        .setIsGc(IS_GC)
+        .setTieBreaker(TIE_BREAKER)
+        .setCommitTimestamp((long) (COMMIT_TIMESTAMP.getNanos() / 1000))
+        .setLowWatermark((long) (LOW_WATERMARK.getNanos() / 1000))
+        .setColumnFamily(COLUMN_FAMILY)
+        .setModType(ModType.DELETE_FAMILY)
+        .setColumn(null)
+        .setTimestamp(null)
+        .setValue(null)
+        .setTimestampFrom(null)
+        .setTimestampTo(null)
+        .build();
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/CharSequenceTypeAdapter.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/CharSequenceTypeAdapter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+
+public class CharSequenceTypeAdapter extends TypeAdapter<CharSequence> {
+  @Override
+  public void write(JsonWriter out, CharSequence value) throws IOException {
+    if (value == null) {
+      out.nullValue();
+    } else {
+      // Assumes that value complies with CharSequence.toString() contract
+      out.value(value.toString());
+    }
+  }
+
+  @Override
+  public CharSequence read(JsonReader in) throws IOException {
+    if (in.peek() == JsonToken.NULL) {
+      // Skip the JSON null
+      in.skipValue();
+      return null;
+    } else {
+      return in.nextString();
+    }
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/CommitTimeAwarePredicate.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/CommitTimeAwarePredicate.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import com.google.cloud.storage.Blob;
+import java.util.function.Predicate;
+
+public abstract class CommitTimeAwarePredicate implements Predicate<Blob> {
+
+  private Long min = null;
+  private Long max = null;
+
+  public void observeCommitTime(long commitTimeMicros) {
+    if (min == null || max == null) {
+      max = min = commitTimeMicros;
+    } else {
+      if (min > commitTimeMicros) {
+        min = commitTimeMicros;
+      }
+      if (max < commitTimeMicros) {
+        max = commitTimeMicros;
+      }
+    }
+  }
+
+  public Long getEarliestCommitTime() {
+    return min;
+  }
+
+  public Long getLatestCommitTime() {
+    return max;
+  }
+
+  public boolean found() {
+    return min != null;
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/LookForBigtableRowAvroRecord.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/LookForBigtableRowAvroRecord.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import static com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.Tools.bbToString;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.teleport.bigtable.BigtableCell;
+import com.google.cloud.teleport.bigtable.BigtableRow;
+import com.google.cloud.teleport.bigtable.ChangelogEntry;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.SeekableByteArrayInput;
+import org.apache.avro.reflect.ReflectData;
+import org.apache.avro.reflect.ReflectDatumReader;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LookForBigtableRowAvroRecord extends CommitTimeAwarePredicate {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LookForBigtableRowAvroRecord.class);
+  private final ChangelogEntry expected;
+
+  public LookForBigtableRowAvroRecord(ChangelogEntry expected) {
+    this.expected = expected;
+  }
+
+  @Override
+  public boolean test(Blob o) {
+    byte[] content = o.getContent();
+
+    try (DataFileReader<BigtableRow> reader =
+        new DataFileReader<>(
+            new SeekableByteArrayInput(content),
+            new ReflectDatumReader<>(ReflectData.get().getSchema(BigtableRow.class)))) {
+      for (BigtableRow row : reader) {
+        LOG.info("Object read: {}", row);
+
+        for (BigtableCell cell : row.getCells()) {
+          String qualifier = bbToString(cell.getQualifier());
+          String value = bbToString(cell.getValue());
+          long timestamp = cell.getTimestamp();
+
+          // Bigtable rows describing changelog has 0 timestamps
+          Assert.assertEquals(0, timestamp);
+
+          switch (qualifier) {
+            case "row_key":
+              Assert.assertEquals(bbToString(expected.getRowKey()), value);
+              break;
+            case "mod_type":
+              Assert.assertEquals(expected.getModType().toString(), value);
+              break;
+            case "is_gc":
+              Assert.assertEquals(Boolean.toString(expected.getIsGc()), value);
+              break;
+            case "column":
+              Assert.assertEquals(bbToString(expected.getColumn()), value);
+              break;
+            case "value":
+              Assert.assertEquals(bbToString(expected.getValue()), value);
+              break;
+            case "tiebreaker":
+              Assert.assertEquals(expected.getTieBreaker(), Integer.parseInt(value));
+              break;
+            case "timestamp":
+              Assert.assertEquals(expected.getTimestamp(), (Long) Long.parseLong(value));
+              break;
+            case "column_family":
+              Assert.assertEquals(expected.getColumnFamily().toString(), value);
+              break;
+            case "commit_timestamp":
+              observeCommitTime(Long.parseLong(value));
+              Assert.assertTrue(expected.getCommitTimestamp() <= Long.parseLong(value));
+              break;
+            case "low_watermark":
+              Assert.assertEquals(expected.getLowWatermark(), Long.parseLong(value));
+              break;
+            case "timestamp_from":
+              Assert.assertEquals(
+                  expected.getTimestampFrom(), (value == null ? null : Long.parseLong(value)));
+              break;
+            case "timestamp_to":
+              Assert.assertEquals(
+                  expected.getTimestampTo(), (value == null ? null : Long.parseLong(value)));
+              break;
+            default:
+              throw new IllegalStateException("Unexpected column qualifier: " + qualifier);
+          }
+        }
+      }
+      return true;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/LookForChangelogEntryAvroRecord.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/LookForChangelogEntryAvroRecord.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.teleport.bigtable.ChangelogEntry;
+import java.nio.charset.Charset;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.SeekableByteArrayInput;
+import org.apache.avro.reflect.ReflectData;
+import org.apache.avro.reflect.ReflectDatumReader;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LookForChangelogEntryAvroRecord extends CommitTimeAwarePredicate {
+  private static final Logger LOG = LoggerFactory.getLogger(LookForChangelogEntryAvroRecord.class);
+  private final ChangelogEntry expected;
+
+  public LookForChangelogEntryAvroRecord(ChangelogEntry expected) {
+    this.expected = expected;
+  }
+
+  @Override
+  public boolean test(Blob o) {
+    byte[] content = o.getContent();
+    LOG.info(
+        "Read from GCS file ({}): {}",
+        o.asBlobInfo(),
+        new String(content, Charset.defaultCharset()));
+
+    try (DataFileReader<ChangelogEntry> reader =
+        new DataFileReader<>(
+            new SeekableByteArrayInput(content),
+            new ReflectDatumReader<>(ReflectData.get().getSchema(ChangelogEntry.class)))) {
+
+      for (ChangelogEntry changelogEntry : reader) {
+        Assert.assertEquals(expected.getTimestamp(), changelogEntry.getTimestamp());
+        Assert.assertEquals(expected.getIsGc(), changelogEntry.getIsGc());
+        Assert.assertEquals(expected.getModType(), changelogEntry.getModType());
+        Assert.assertEquals(expected.getRowKey().toString(), changelogEntry.getRowKey().toString());
+        Assert.assertEquals(
+            expected.getColumnFamily().toString(), changelogEntry.getColumnFamily().toString());
+        Assert.assertEquals(
+            expected.getLowWatermark(),
+            changelogEntry.getLowWatermark()); // Low watermark is not working yet
+        Assert.assertEquals(expected.getColumn().toString(), changelogEntry.getColumn().toString());
+        Assert.assertTrue(expected.getCommitTimestamp() <= changelogEntry.getCommitTimestamp());
+        observeCommitTime(changelogEntry.getCommitTimestamp());
+        Assert.assertTrue(changelogEntry.getTieBreaker() >= 0);
+        Assert.assertEquals(expected.getTimestampFrom(), changelogEntry.getTimestampFrom());
+        Assert.assertEquals(expected.getTimestampFrom(), changelogEntry.getTimestampTo());
+        Assert.assertEquals(expected.getValue(), changelogEntry.getValue());
+      }
+      return true;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/LookForChangelogEntryJsonBase64Record.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/LookForChangelogEntryJsonBase64Record.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import static com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.Tools.bbToBase64String;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.teleport.bigtable.ChangelogEntry;
+import com.google.cloud.teleport.bigtable.ChangelogEntryJson;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.nio.charset.Charset;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LookForChangelogEntryJsonBase64Record extends CommitTimeAwarePredicate {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(LookForChangelogEntryJsonBase64Record.class);
+  private final ChangelogEntry expected;
+
+  public LookForChangelogEntryJsonBase64Record(ChangelogEntry expected) {
+    this.expected = expected;
+  }
+
+  @Override
+  public boolean test(Blob o) {
+    byte[] content = o.getContent();
+    LOG.info(
+        "Read from GCS file ({}): {}",
+        o.asBlobInfo(),
+        new String(content, Charset.defaultCharset()));
+
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(CharSequence.class, new CharSequenceTypeAdapter())
+            .create();
+
+    ChangelogEntryJson changelogEntry =
+        gson.fromJson(new String(content), ChangelogEntryJson.class);
+
+    Assert.assertEquals(expected.getTimestamp(), changelogEntry.getTimestamp());
+    Assert.assertEquals(expected.getIsGc(), changelogEntry.getIsGc());
+    Assert.assertEquals(expected.getModType(), changelogEntry.getModType());
+    Assert.assertEquals(
+        bbToBase64String(expected.getRowKey()), changelogEntry.getRowKey().toString());
+    Assert.assertEquals(
+        expected.getColumnFamily().toString(), changelogEntry.getColumnFamily().toString());
+    Assert.assertEquals(
+        expected.getLowWatermark(),
+        changelogEntry.getLowWatermark()); // Low watermark is not working yet
+    Assert.assertEquals(
+        bbToBase64String(expected.getColumn()), changelogEntry.getColumn().toString());
+    Assert.assertTrue(expected.getCommitTimestamp() <= changelogEntry.getCommitTimestamp());
+    observeCommitTime(changelogEntry.getCommitTimestamp());
+    Assert.assertTrue(changelogEntry.getTieBreaker() >= 0);
+    Assert.assertEquals(expected.getTimestampFrom(), changelogEntry.getTimestampFrom());
+    Assert.assertEquals(expected.getTimestampFrom(), changelogEntry.getTimestampTo());
+    Assert.assertEquals(
+        bbToBase64String(expected.getValue()), changelogEntry.getValue().toString());
+
+    return true;
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/LookForChangelogEntryJsonRecord.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/LookForChangelogEntryJsonRecord.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.teleport.bigtable.ChangelogEntryJson;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.nio.charset.Charset;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LookForChangelogEntryJsonRecord extends CommitTimeAwarePredicate {
+  private static final Logger LOG = LoggerFactory.getLogger(LookForChangelogEntryJsonRecord.class);
+  private final ChangelogEntryJson expected;
+
+  public LookForChangelogEntryJsonRecord(ChangelogEntryJson expected) {
+    this.expected = expected;
+  }
+
+  @Override
+  public boolean test(Blob o) {
+    byte[] content = o.getContent();
+    LOG.info(
+        "Read from GCS file ({}): {}",
+        o.asBlobInfo(),
+        new String(content, Charset.defaultCharset()));
+
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(CharSequence.class, new CharSequenceTypeAdapter())
+            .create();
+
+    ChangelogEntryJson changelogEntry =
+        gson.fromJson(new String(content), ChangelogEntryJson.class);
+
+    Assert.assertEquals(expected.getTimestamp(), changelogEntry.getTimestamp());
+    Assert.assertEquals(expected.getIsGc(), changelogEntry.getIsGc());
+    Assert.assertEquals(expected.getModType(), changelogEntry.getModType());
+    Assert.assertEquals(expected.getRowKey().toString(), changelogEntry.getRowKey().toString());
+    Assert.assertEquals(
+        expected.getColumnFamily().toString(), changelogEntry.getColumnFamily().toString());
+    Assert.assertEquals(
+        expected.getLowWatermark(),
+        changelogEntry.getLowWatermark()); // Low watermark is not working yet
+    Assert.assertEquals(expected.getColumn().toString(), changelogEntry.getColumn().toString());
+    Assert.assertTrue(expected.getCommitTimestamp() <= changelogEntry.getCommitTimestamp());
+    observeCommitTime(changelogEntry.getCommitTimestamp());
+    Assert.assertTrue(changelogEntry.getTieBreaker() >= 0);
+    Assert.assertEquals(expected.getTimestampFrom(), changelogEntry.getTimestampFrom());
+    Assert.assertEquals(expected.getTimestampFrom(), changelogEntry.getTimestampTo());
+    Assert.assertEquals(expected.getValue(), changelogEntry.getValue());
+
+    return true;
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/Tools.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/Tools.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.Base64;
+
+public class Tools {
+  private Tools() {
+    // don't create
+  }
+
+  public static String bbToString(ByteBuffer val) {
+    if (val == null) {
+      return null;
+    }
+    return new String(val.array(), Charset.defaultCharset());
+  }
+
+  public static String bbToBase64String(ByteBuffer val) {
+    if (val == null) {
+      return null;
+    }
+    return Base64.getEncoder().encodeToString(val.array());
+  }
+}


### PR DESCRIPTION
A new template adds Bigtable Changestreams to GCS integration. 

This PR also contains minor fixes to resume-streaming functionality for CDC->BigQuery