### PR TITLE
Add mandatory password for Neo4jResourceManagerIT

### DIFF
--- a/it/neo4j/src/test/java/com/google/cloud/teleport/it/neo4j/Neo4jResourceManagerIT.java
+++ b/it/neo4j/src/test/java/com/google/cloud/teleport/it/neo4j/Neo4jResourceManagerIT.java
@@ -38,7 +38,10 @@ public class Neo4jResourceManagerIT {
   @Before
   public void setUp() {
     neo4jResourceManager =
-        Neo4jResourceManager.builder("placeholder").setDatabaseName("neo4j").build();
+        Neo4jResourceManager.builder("placeholder")
+            .setDatabaseName("neo4j")
+            .setAdminPassword("password")
+            .build();
   }
 
   @Test


### PR DESCRIPTION
Test is failing with 

```
java.lang.NullPointerException: Password can't be null
	at com.google.cloud.teleport.it.neo4j.Neo4jResourceManagerIT.setUp(Neo4jResourceManagerIT.java:41)
```

Our GitHub CI is not running `TestContainersIntegrationTest`, apparently.