### PR TITLE
Increase integration test parallelism

### DIFF
--- a/cicd/cmd/run-build/main.go
+++ b/cicd/cmd/run-build/main.go
@@ -33,7 +33,8 @@ func main() {
 		mvnFlags.SkipDependencyAnalysis(), // TODO(zhoufek): Fix our dependencies then remove this flag
 		mvnFlags.SkipJib(),
 		mvnFlags.SkipShade(),
-		mvnFlags.SkipTests())
+		mvnFlags.SkipTests(),
+		mvnFlags.ThreadCount(8))
 	if err != nil {
 		log.Fatalf("%v\n", err)
 	}

--- a/cicd/cmd/run-it-smoke-tests/main.go
+++ b/cicd/cmd/run-it-smoke-tests/main.go
@@ -41,7 +41,7 @@ func main() {
 		mvnFlags.SkipTests(),
 		mvnFlags.SkipJacoco(),
 		mvnFlags.SkipShade(),
-		mvnFlags.ThreadCount(4))
+		mvnFlags.ThreadCount(8))
 	if err != nil {
 		log.Fatalf("%v\n", err)
 	}
@@ -56,8 +56,8 @@ func main() {
 		mvnFlags.SkipJib(),
 		mvnFlags.FailAtTheEnd(),
 		mvnFlags.RunIntegrationSmokeTests(),
-		mvnFlags.ThreadCount(4),
-		mvnFlags.IntegrationTestParallelism(2),
+		mvnFlags.ThreadCount(8),
+		mvnFlags.IntegrationTestParallelism(4),
 		mvnFlags.StaticBigtableInstance("teleport"),
 		flags.Region(),
 		flags.Project(),

--- a/cicd/cmd/run-it-tests/main.go
+++ b/cicd/cmd/run-it-tests/main.go
@@ -57,7 +57,7 @@ func main() {
 		mvnFlags.FailAtTheEnd(),
 		mvnFlags.RunIntegrationTests(),
 		mvnFlags.ThreadCount(4),
-		mvnFlags.IntegrationTestParallelism(4),
+		mvnFlags.IntegrationTestParallelism(3),
 		mvnFlags.StaticBigtableInstance("teleport"),
 		flags.Region(),
 		flags.Project(),

--- a/cicd/cmd/run-it-tests/main.go
+++ b/cicd/cmd/run-it-tests/main.go
@@ -40,7 +40,7 @@ func main() {
 		mvnFlags.SkipTests(),
 		mvnFlags.SkipJacoco(),
 		mvnFlags.SkipShade(),
-		mvnFlags.ThreadCount(4))
+		mvnFlags.ThreadCount(8))
 	if err != nil {
 		log.Fatalf("%v\n", err)
 	}
@@ -57,7 +57,7 @@ func main() {
 		mvnFlags.FailAtTheEnd(),
 		mvnFlags.RunIntegrationTests(),
 		mvnFlags.ThreadCount(4),
-		mvnFlags.IntegrationTestParallelism(2),
+		mvnFlags.IntegrationTestParallelism(4),
 		mvnFlags.StaticBigtableInstance("teleport"),
 		flags.Region(),
 		flags.Project(),

--- a/cicd/cmd/run-unit-tests/main.go
+++ b/cicd/cmd/run-unit-tests/main.go
@@ -36,7 +36,8 @@ func main() {
 		mvnFlags.SkipJib(),
 		mvnFlags.SkipShade(),
 		mvnFlags.SkipIntegrationTests(),
-		mvnFlags.FailAtTheEnd())
+		mvnFlags.FailAtTheEnd(),
+		mvnFlags.ThreadCount(8))
 	if err != nil {
 		log.Fatalf("%v\n", err)
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,6 @@
         <version>${neo4j-driver.version}</version>
       </dependency>
     </dependencies>
-
   </dependencyManagement>
 
   <build>
@@ -464,8 +463,7 @@
     </profile>
     <!-- The following snapshot profile allows us to test Templates with
      unreleased Apache Beam versions, for example:
-     mvn test -Psnapshot -Dbeam.version=2.48.0-SNAPSHOT
-  -->
+     mvn test -Psnapshot -Dbeam.version=2.50.0-SNAPSHOT -->
     <profile>
       <id>snapshot</id>
       <repositories>


### PR DESCRIPTION
Build time 7m -> 2m
Unit tests 11m -> 4m
Smoke tests 12m -> 9m
Integration tests 82m -> 80m