### PR TITLE
Optimize database reset queries

### DIFF
--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnection.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnection.java
@@ -16,13 +16,12 @@
 package com.google.cloud.teleport.v2.neo4j.database;
 
 import com.google.cloud.teleport.v2.neo4j.model.connection.ConnectionParams;
-import com.google.cloud.teleport.v2.neo4j.model.enums.AuthType;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.Serializable;
-import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.driver.AuthTokens;
-import org.neo4j.driver.Config;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
@@ -36,52 +35,24 @@ import org.slf4j.LoggerFactory;
 public class Neo4jConnection implements AutoCloseable, Serializable {
 
   private static final Logger LOG = LoggerFactory.getLogger(Neo4jConnection.class);
-  private final String username;
-  private final String password;
-  private final String serverUrl;
+  private final Supplier<Driver> driverSupplier;
   private final String database;
-  private final AuthType authType = AuthType.BASIC;
   private Driver driver;
   private Session session;
 
   /** Constructor. */
-  public Neo4jConnection(ConnectionParams connectionParams) {
-    this.username = connectionParams.username;
-    this.password = connectionParams.password;
-    this.database = connectionParams.database;
-    this.serverUrl = connectionParams.serverUrl;
+  public Neo4jConnection(ConnectionParams settings) {
+    this(
+        settings.database,
+        () ->
+            GraphDatabase.driver(
+                settings.serverUrl, AuthTokens.basic(settings.username, settings.password)));
   }
 
-  public Neo4jConnection(
-      String hostName, int port, String database, String username, String password) {
-    this.username = username;
-    this.password = password;
+  @VisibleForTesting
+  Neo4jConnection(String database, Supplier<Driver> driverSupplier) {
     this.database = database;
-    this.serverUrl = getUrl(hostName, port);
-  }
-
-  /** Constructor. */
-  public Neo4jConnection(String serverUrl, String database, String username, String password) {
-    this.username = username;
-    this.password = password;
-    this.database = database;
-    this.serverUrl = serverUrl;
-  }
-
-  private String getUrl(String hostName, int port) {
-    return "neo4j+s://" + hostName + ":" + port;
-  }
-
-  /** Helper method to get the Neo4j driver. */
-  public Driver getDriver() throws URISyntaxException {
-    if (this.authType != AuthType.BASIC) {
-      LOG.error("Unsupported authType: {}", this.authType);
-      throw new RuntimeException("Unsupported authentication type: " + this.authType);
-    }
-    return GraphDatabase.driver(
-        new URI(this.serverUrl),
-        AuthTokens.basic(this.username, this.password),
-        Config.builder().build());
+    this.driverSupplier = driverSupplier;
   }
 
   /** Helper method to get the Neo4j session. */
@@ -106,7 +77,7 @@ public class Neo4jConnection implements AutoCloseable, Serializable {
    */
   public void executeCypher(String cypher) throws URISyntaxException {
     try (Session session = getSession()) {
-      session.run(cypher);
+      session.run(cypher).consume();
     }
   }
 
@@ -124,28 +95,13 @@ public class Neo4jConnection implements AutoCloseable, Serializable {
     // Direct connect utility...
     LOG.info("Resetting database");
     try {
-      String crdeCypher = "CREATE OR REPLACE DATABASE `neo4j`";
-      if (!StringUtils.isEmpty(database)) {
-        StringUtils.replace(crdeCypher, "neo4j", database);
-      }
-      LOG.info("Executing delete DB cypher: {}", crdeCypher);
-      executeCypher(crdeCypher);
-    } catch (Exception crde) {
-      LOG.error(
-          "Error executing reset database using CREATE OR REPLACE: {}, {}",
-          crde,
-          crde.getMessage());
-      // Trying DELETE /DETACH approach
-      try {
-        String ddeCypher = "MATCH (n) DETACH DELETE n";
-        LOG.info("Executing alternate delete cypher: {}", ddeCypher);
-        executeCypher(ddeCypher);
-        String constraintsDeleteCypher =
-            "CALL apoc.schema.assert({},{},true) YIELD label, key RETURN *";
-        executeCypher(constraintsDeleteCypher);
-      } catch (Exception dde) {
-        LOG.error("Error executing detach delete", dde);
-      }
+      String database = !StringUtils.isEmpty(this.database) ? this.database : "neo4j";
+      String cypher = String.format("CREATE OR REPLACE DATABASE `%s`", database);
+      LOG.info("Executing delete DB cypher: {}", cypher);
+      executeCypher(cypher);
+    } catch (Exception ex) {
+      LOG.error("Error executing reset database using CREATE OR REPLACE", ex);
+      fallbackResetDatabase();
     }
   }
 
@@ -158,6 +114,24 @@ public class Neo4jConnection implements AutoCloseable, Serializable {
     if (this.driver != null) {
       this.driver.close();
       this.driver = null;
+    }
+  }
+
+  /** Helper method to get the Neo4j driver. */
+  private Driver getDriver() {
+    return driverSupplier.get();
+  }
+
+  private void fallbackResetDatabase() {
+    try {
+      String ddeCypher = "MATCH (n) CALL { WITH n DETACH DELETE n } IN TRANSACTIONS";
+      LOG.info("Executing alternate delete cypher: {}", ddeCypher);
+      executeCypher(ddeCypher);
+      String constraintsDeleteCypher = "CALL apoc.schema.assert({}, {}, true)";
+      LOG.info("Dropping indices & constraints with query: {}", constraintsDeleteCypher);
+      executeCypher(constraintsDeleteCypher);
+    } catch (Exception dde) {
+      LOG.error("Error executing detach delete", dde);
     }
   }
 }

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnectionTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnectionTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.neo4j.database;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+
+@RunWith(JUnit4.class)
+public class Neo4jConnectionTest {
+
+  @Rule public final MockitoRule mockito = MockitoJUnit.rule();
+
+  @Mock private Driver driver;
+  @Mock private Session session;
+  @Mock private Result result;
+
+  private Neo4jConnection neo4jConnection;
+
+  @Before
+  public void setUp() {
+    when(session.run(anyString())).thenReturn(result);
+    when(driver.session(any())).thenReturn(session);
+    neo4jConnection = new Neo4jConnection("a-database", () -> driver);
+  }
+
+  @Test
+  public void resetsDatabaseByRecreatingIt() {
+    neo4jConnection.resetDatabase();
+
+    verify(session).run("CREATE OR REPLACE DATABASE `a-database`");
+    verify(session, never()).run("MATCH (n) CALL { WITH n DETACH DELETE n } IN TRANSACTIONS");
+    verify(session, never()).run("CALL apoc.schema.assert({}, {}, true)");
+  }
+
+  @Test
+  public void resetsDatabaseWithDeletionQueriesWhenReplacementFails() {
+    when(session.run("CREATE OR REPLACE DATABASE `a-database`")).thenThrow(RuntimeException.class);
+
+    neo4jConnection.resetDatabase();
+
+    InOrder inOrder = inOrder(session);
+    inOrder.verify(session).run("CREATE OR REPLACE DATABASE `a-database`");
+    inOrder.verify(session).run("MATCH (n) CALL { WITH n DETACH DELETE n } IN TRANSACTIONS");
+    inOrder.verify(session).run("CALL apoc.schema.assert({}, {}, true)");
+  }
+}

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnectionTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnectionTest.java
@@ -16,12 +16,14 @@
 package com.google.cloud.teleport.v2.neo4j.database;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,6 +51,7 @@ public class Neo4jConnectionTest {
   @Before
   public void setUp() {
     when(session.run(anyString())).thenReturn(result);
+    when(session.run(anyString(), anyMap())).thenReturn(result);
     when(driver.session(any())).thenReturn(session);
     neo4jConnection = new Neo4jConnection("a-database", () -> driver);
   }
@@ -57,20 +60,23 @@ public class Neo4jConnectionTest {
   public void resetsDatabaseByRecreatingIt() {
     neo4jConnection.resetDatabase();
 
-    verify(session).run("CREATE OR REPLACE DATABASE `a-database`");
+    verify(session).run("CREATE OR REPLACE DATABASE $db", Map.of("db", "a-database"));
     verify(session, never()).run("MATCH (n) CALL { WITH n DETACH DELETE n } IN TRANSACTIONS");
     verify(session, never()).run("CALL apoc.schema.assert({}, {}, true)");
   }
 
   @Test
   public void resetsDatabaseWithDeletionQueriesWhenReplacementFails() {
-    when(session.run("CREATE OR REPLACE DATABASE `a-database`")).thenThrow(RuntimeException.class);
+    when(session.run("CREATE OR REPLACE DATABASE $db", Map.of("db", "a-database")))
+        .thenThrow(RuntimeException.class);
 
     neo4jConnection.resetDatabase();
 
     InOrder inOrder = inOrder(session);
-    inOrder.verify(session).run("CREATE OR REPLACE DATABASE `a-database`");
-    inOrder.verify(session).run("MATCH (n) CALL { WITH n DETACH DELETE n } IN TRANSACTIONS");
-    inOrder.verify(session).run("CALL apoc.schema.assert({}, {}, true)");
+    inOrder.verify(session).run("CREATE OR REPLACE DATABASE $db", Map.of("db", "a-database"));
+    inOrder
+        .verify(session)
+        .run("MATCH (n) CALL { WITH n DETACH DELETE n } IN TRANSACTIONS", Map.of());
+    inOrder.verify(session).run("CALL apoc.schema.assert({}, {}, true)", Map.of());
   }
 }


### PR DESCRIPTION
 - use `CALL IN TRANSACTIONS` for batch deletes
 - do no return results from APOC call
 - always consume results from lazily-executed autocommit queries