### PR TITLE
Fix support of multiple key definitions for edge source/target nodes

### DIFF
--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/helpers/TransposedMappingMapper.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/helpers/TransposedMappingMapper.java
@@ -96,9 +96,11 @@ public class TransposedMappingMapper {
 
     if (edgeMappingsObject.has("source")) {
       JSONObject sourceObj = edgeMappingsObject.getJSONObject("source");
-      FieldNameTuple keyTuple = getFieldAndNameTuple(sourceObj.get("key"));
-      Mapping keyMapping = new Mapping(FragmentType.source, RoleType.key, keyTuple);
-      mappings.add(keyMapping);
+      List<FieldNameTuple> keyTuples = getFieldAndNameTuples(sourceObj.get("key"));
+      for (FieldNameTuple keyTuple : keyTuples) {
+        Mapping keyMapping = new Mapping(FragmentType.source, RoleType.key, keyTuple);
+        mappings.add(keyMapping);
+      }
 
       // support dynamic labels on source
       List<FieldNameTuple> labels = getFieldAndNameTuples(sourceObj.get("label"));
@@ -110,13 +112,14 @@ public class TransposedMappingMapper {
     }
 
     if (edgeMappingsObject.has("target")) {
-      JSONObject sourceObj = edgeMappingsObject.getJSONObject("target");
-      FieldNameTuple keyTuple = getFieldAndNameTuple(sourceObj.get("key"));
-      Mapping keyMapping = new Mapping(FragmentType.target, RoleType.key, keyTuple);
+      JSONObject targetObj = edgeMappingsObject.getJSONObject("target");
+      List<FieldNameTuple> keyTuples = getFieldAndNameTuples(targetObj.get("key"));
+      for (FieldNameTuple keyTuple : keyTuples) {
+        Mapping keyMapping = new Mapping(FragmentType.target, RoleType.key, keyTuple);
+        mappings.add(keyMapping);
+      }
 
-      mappings.add(keyMapping);
-
-      List<FieldNameTuple> labels = getFieldAndNameTuples(sourceObj.get("label"));
+      List<FieldNameTuple> labels = getFieldAndNameTuples(targetObj.get("label"));
       for (FieldNameTuple f : labels) {
         Mapping mapping = new Mapping(FragmentType.target, RoleType.label, f);
         mapping.setIndexed(true);
@@ -266,22 +269,6 @@ public class TransposedMappingMapper {
       tuples.add(createFieldNameTuple(String.valueOf(tuplesObj), String.valueOf(tuplesObj)));
     }
     return tuples;
-  }
-
-  private static FieldNameTuple getFieldAndNameTuple(Object tuplesObj) {
-    FieldNameTuple tuple = new FieldNameTuple();
-    if (tuplesObj instanceof JSONObject) {
-      JSONObject jsonObject = (JSONObject) tuplesObj;
-      // {field:name} or {field1:name,field2:name} tuples
-      Iterator<String> it = jsonObject.keys();
-      while (it.hasNext()) {
-        String key = it.next();
-        tuple = createFieldNameTuple(key, jsonObject.getString(key));
-      }
-    } else {
-      tuple = createFieldNameTuple(String.valueOf(tuplesObj), String.valueOf(tuplesObj));
-    }
-    return tuple;
   }
 
   private static FieldNameTuple createFieldNameTuple(String field) {

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/job/Mapping.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/job/Mapping.java
@@ -21,6 +21,7 @@ import com.google.cloud.teleport.v2.neo4j.model.enums.RoleType;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /** Field to Neo4j property mapping. */
 public class Mapping implements Serializable {
@@ -136,5 +137,80 @@ public class Mapping implements Serializable {
 
   public void setFragmentType(FragmentType fragmentType) {
     this.fragmentType = fragmentType;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Mapping mapping = (Mapping) o;
+    return mandatory == mapping.mandatory
+        && unique == mapping.unique
+        && indexed == mapping.indexed
+        && Objects.equals(constant, mapping.constant)
+        && role == mapping.role
+        && type == mapping.type
+        && Objects.equals(name, mapping.name)
+        && Objects.equals(labels, mapping.labels)
+        && Objects.equals(field, mapping.field)
+        && Objects.equals(description, mapping.description)
+        && Objects.equals(defaultValue, mapping.defaultValue)
+        && fragmentType == mapping.fragmentType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        constant,
+        role,
+        type,
+        name,
+        labels,
+        field,
+        description,
+        defaultValue,
+        mandatory,
+        unique,
+        indexed,
+        fragmentType);
+  }
+
+  @Override
+  public String toString() {
+    return "Mapping{"
+        + "constant='"
+        + constant
+        + '\''
+        + ", role="
+        + role
+        + ", type="
+        + type
+        + ", name='"
+        + name
+        + '\''
+        + ", labels="
+        + labels
+        + ", field='"
+        + field
+        + '\''
+        + ", description='"
+        + description
+        + '\''
+        + ", defaultValue='"
+        + defaultValue
+        + '\''
+        + ", mandatory="
+        + mandatory
+        + ", unique="
+        + unique
+        + ", indexed="
+        + indexed
+        + ", fragmentType="
+        + fragmentType
+        + '}';
   }
 }

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/job/Mapping.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/job/Mapping.java
@@ -158,7 +158,6 @@ public class Mapping implements Serializable {
         && Objects.equals(labels, mapping.labels)
         && Objects.equals(field, mapping.field)
         && Objects.equals(description, mapping.description)
-        && Objects.equals(defaultValue, mapping.defaultValue)
         && fragmentType == mapping.fragmentType;
   }
 
@@ -172,7 +171,6 @@ public class Mapping implements Serializable {
         labels,
         field,
         description,
-        defaultValue,
         mandatory,
         unique,
         indexed,
@@ -199,9 +197,6 @@ public class Mapping implements Serializable {
         + '\''
         + ", description='"
         + description
-        + '\''
-        + ", defaultValue='"
-        + defaultValue
         + '\''
         + ", mandatory="
         + mandatory

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/model/helpers/TransposedMappingMapperTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/model/helpers/TransposedMappingMapperTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.neo4j.model.helpers;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.stream.Collectors.toList;
+
+import com.google.cloud.teleport.v2.neo4j.model.enums.FragmentType;
+import com.google.cloud.teleport.v2.neo4j.model.enums.RoleType;
+import com.google.cloud.teleport.v2.neo4j.model.enums.TargetType;
+import com.google.cloud.teleport.v2.neo4j.model.job.FieldNameTuple;
+import com.google.cloud.teleport.v2.neo4j.model.job.Mapping;
+import com.google.cloud.teleport.v2.neo4j.model.job.Target;
+import java.util.List;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class TransposedMappingMapperTest {
+
+  @Test
+  public void parsesMultipleKeyMappingsFromObjectForEdgeSourceNode() {
+    Target target = edgeTarget();
+    JSONObject mappings = new JSONObject();
+    mappings.put("type", "PLACEHOLDER");
+    JSONObject sourceKeys = new JSONObject();
+    sourceKeys.put("key1", "value1");
+    sourceKeys.put("key2", "value2");
+    JSONObject sourceMapping = new JSONObject();
+    sourceMapping.put("label", "Placeholder");
+    sourceMapping.put("key", sourceKeys);
+    mappings.put("source", sourceMapping);
+
+    List<Mapping> result =
+        TransposedMappingMapper.parseMappings(target, mappings).stream()
+            .filter(mapping -> mapping.getRole() == RoleType.key)
+            .collect(toList());
+
+    assertThat(result)
+        .isEqualTo(
+            List.of(
+                new Mapping(FragmentType.source, RoleType.key, field("key1", "value1")),
+                new Mapping(FragmentType.source, RoleType.key, field("key2", "value2"))));
+  }
+
+  @Test
+  public void parsesMultipleKeyMappingsFromObjectArrayForEdgeSourceNode() {
+    Target target = edgeTarget();
+    JSONObject mappings = new JSONObject();
+    mappings.put("type", "PLACEHOLDER");
+    JSONArray sourceKeys = new JSONArray();
+    sourceKeys.put(Map.of("key1", "value1", "key2", "value2"));
+    sourceKeys.put(Map.of("key3", "value3", "key4", "value4"));
+    JSONObject sourceMapping = new JSONObject();
+    sourceMapping.put("label", "Placeholder");
+    sourceMapping.put("key", sourceKeys);
+    mappings.put("source", sourceMapping);
+
+    List<Mapping> result =
+        TransposedMappingMapper.parseMappings(target, mappings).stream()
+            .filter(mapping -> mapping.getRole() == RoleType.key)
+            .collect(toList());
+
+    assertThat(result)
+        .isEqualTo(
+            List.of(
+                new Mapping(FragmentType.source, RoleType.key, field("key1", "value1")),
+                new Mapping(FragmentType.source, RoleType.key, field("key2", "value2")),
+                new Mapping(FragmentType.source, RoleType.key, field("key3", "value3")),
+                new Mapping(FragmentType.source, RoleType.key, field("key4", "value4"))));
+  }
+
+  @Test
+  public void parsesMultipleKeyMappingsFromStringArrayForEdgeSourceNode() {
+    Target target = edgeTarget();
+    JSONObject mappings = new JSONObject();
+    mappings.put("type", "PLACEHOLDER");
+    JSONArray sourceKeys = new JSONArray();
+    sourceKeys.put("value1");
+    sourceKeys.put("value2");
+    JSONObject sourceMapping = new JSONObject();
+    sourceMapping.put("label", "Placeholder");
+    sourceMapping.put("key", sourceKeys);
+    mappings.put("source", sourceMapping);
+
+    List<Mapping> result =
+        TransposedMappingMapper.parseMappings(target, mappings).stream()
+            .filter(mapping -> mapping.getRole() == RoleType.key)
+            .collect(toList());
+
+    assertThat(result)
+        .isEqualTo(
+            List.of(
+                new Mapping(FragmentType.source, RoleType.key, field("value1", "value1")),
+                new Mapping(FragmentType.source, RoleType.key, field("value2", "value2"))));
+  }
+
+  @Test
+  public void parsesMultipleKeyMappingsFromMixedArrayForEdgeSourceNode() {
+    Target target = edgeTarget();
+    JSONObject mappings = new JSONObject();
+    mappings.put("type", "PLACEHOLDER");
+    JSONArray sourceKeys = new JSONArray();
+    sourceKeys.put("value1");
+    sourceKeys.put(Map.of("key2", "value2"));
+    JSONObject sourceMapping = new JSONObject();
+    sourceMapping.put("label", "Placeholder");
+    sourceMapping.put("key", sourceKeys);
+    mappings.put("source", sourceMapping);
+
+    List<Mapping> result =
+        TransposedMappingMapper.parseMappings(target, mappings).stream()
+            .filter(mapping -> mapping.getRole() == RoleType.key)
+            .collect(toList());
+
+    assertThat(result)
+        .isEqualTo(
+            List.of(
+                new Mapping(FragmentType.source, RoleType.key, field("value1", "value1")),
+                new Mapping(FragmentType.source, RoleType.key, field("key2", "value2"))));
+  }
+
+  @Test
+  public void parsesMultipleKeyMappingsFromObjectForEdgeTargetNode() {
+    Target target = edgeTarget();
+    JSONObject mappings = new JSONObject();
+    mappings.put("type", "PLACEHOLDER");
+    JSONObject targetKeys = new JSONObject();
+    targetKeys.put("key1", "value1");
+    targetKeys.put("key2", "value2");
+    JSONObject targetMapping = new JSONObject();
+    targetMapping.put("label", "Placeholder");
+    targetMapping.put("key", targetKeys);
+    mappings.put("target", targetMapping);
+
+    List<Mapping> result =
+        TransposedMappingMapper.parseMappings(target, mappings).stream()
+            .filter(mapping -> mapping.getRole() == RoleType.key)
+            .collect(toList());
+
+    assertThat(result)
+        .isEqualTo(
+            List.of(
+                new Mapping(FragmentType.target, RoleType.key, field("key1", "value1")),
+                new Mapping(FragmentType.target, RoleType.key, field("key2", "value2"))));
+  }
+
+  @Test
+  public void parsesMultipleKeyMappingsFromObjectArrayForEdgeTargetNode() {
+    Target target = edgeTarget();
+    JSONObject mappings = new JSONObject();
+    mappings.put("type", "PLACEHOLDER");
+    JSONArray targetKeys = new JSONArray();
+    targetKeys.put(Map.of("key1", "value1", "key2", "value2"));
+    targetKeys.put(Map.of("key3", "value3", "key4", "value4"));
+    JSONObject sourceMapping = new JSONObject();
+    sourceMapping.put("label", "Placeholder");
+    sourceMapping.put("key", targetKeys);
+    mappings.put("target", sourceMapping);
+
+    List<Mapping> result =
+        TransposedMappingMapper.parseMappings(target, mappings).stream()
+            .filter(mapping -> mapping.getRole() == RoleType.key)
+            .collect(toList());
+
+    assertThat(result)
+        .isEqualTo(
+            List.of(
+                new Mapping(FragmentType.target, RoleType.key, field("key1", "value1")),
+                new Mapping(FragmentType.target, RoleType.key, field("key2", "value2")),
+                new Mapping(FragmentType.target, RoleType.key, field("key3", "value3")),
+                new Mapping(FragmentType.target, RoleType.key, field("key4", "value4"))));
+  }
+
+  @Test
+  public void parsesMultipleKeyMappingsFromStringArrayForEdgeTargetNode() {
+    Target target = edgeTarget();
+    JSONObject mappings = new JSONObject();
+    mappings.put("type", "PLACEHOLDER");
+    JSONArray targetKeys = new JSONArray();
+    targetKeys.put("value1");
+    targetKeys.put("value2");
+    JSONObject sourceMapping = new JSONObject();
+    sourceMapping.put("label", "Placeholder");
+    sourceMapping.put("key", targetKeys);
+    mappings.put("target", sourceMapping);
+
+    List<Mapping> result =
+        TransposedMappingMapper.parseMappings(target, mappings).stream()
+            .filter(mapping -> mapping.getRole() == RoleType.key)
+            .collect(toList());
+
+    assertThat(result)
+        .isEqualTo(
+            List.of(
+                new Mapping(FragmentType.target, RoleType.key, field("value1", "value1")),
+                new Mapping(FragmentType.target, RoleType.key, field("value2", "value2"))));
+  }
+
+  @Test
+  public void parsesMultipleKeyMappingsFromMixedArrayForEdgeTargetNode() {
+    Target target = edgeTarget();
+    JSONObject mappings = new JSONObject();
+    mappings.put("type", "PLACEHOLDER");
+    JSONArray targetKeys = new JSONArray();
+    targetKeys.put(Map.of("key1", "value1"));
+    targetKeys.put("value2");
+    JSONObject sourceMapping = new JSONObject();
+    sourceMapping.put("label", "Placeholder");
+    sourceMapping.put("key", targetKeys);
+    mappings.put("target", sourceMapping);
+
+    List<Mapping> result =
+        TransposedMappingMapper.parseMappings(target, mappings).stream()
+            .filter(mapping -> mapping.getRole() == RoleType.key)
+            .collect(toList());
+
+    assertThat(result)
+        .isEqualTo(
+            List.of(
+                new Mapping(FragmentType.target, RoleType.key, field("key1", "value1")),
+                new Mapping(FragmentType.target, RoleType.key, field("value2", "value2"))));
+  }
+
+  @NotNull
+  private static Target edgeTarget() {
+    Target target = new Target();
+    target.setType(TargetType.edge);
+    return target;
+  }
+
+  @NotNull
+  private static FieldNameTuple field(String field, String name) {
+    FieldNameTuple fieldNameTuple = new FieldNameTuple();
+    fieldNameTuple.setField(field);
+    fieldNameTuple.setName(name);
+    return fieldNameTuple;
+  }
+}


### PR DESCRIPTION
This only concerns the "transposed" spec syntax.

If the keys for the source/target node of the edge were encoded as a JSON object, the existing implementation would only pick the "first" key and define a mapping only for that one.

JSON objects are deserialized into Java's HashMap instances, and these do not provide any guarantees for the iteration order, which makes the key definition very difficult to reason about.

Moreover, the "verbose" syntax allows to define multiple keys and these are properly mapped to multiple mappings.

This commit aligns the behavior between the two syntaxes' mappers.