### PR TITLE
Minor fields rename for consistency

### DIFF
--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableUtils.java
@@ -139,7 +139,7 @@ public class BigtableUtils implements Serializable {
             .setFamily(this.bigtableRowColumnFamilyName)
             .setQualifier(ChangelogColumns.IS_GC.getColumnNameAsByteBuffer(this.charsetObj))
             .setTimestamp(DEFAULT_TIMESTAMP)
-            .setValue(getByteBufferFromString(Boolean.toString(entry.getIsGc())))
+            .setValue(getByteBufferFromString(Boolean.toString(entry.getIsGC())))
             .build());
 
     // tiebreaker
@@ -302,7 +302,7 @@ public class BigtableUtils implements Serializable {
         ChangelogEntry.newBuilder()
             .setRowKey(mutation.getRowKey().asReadOnlyByteBuffer())
             .setModType(getModType(mutationEntry))
-            .setIsGc(mutation.getType() == MutationType.GARBAGE_COLLECTION)
+            .setIsGC(mutation.getType() == MutationType.GARBAGE_COLLECTION)
             .setTieBreaker(mutation.getTieBreaker())
             .setCommitTimestamp(commitMicros)
             .setLowWatermark(0); // TODO: Low watermark is not available yet

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/WriteChangelogEntryAsJson.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/WriteChangelogEntryAsJson.java
@@ -49,7 +49,7 @@ public class WriteChangelogEntryAsJson extends SimpleFunction<ChangelogEntry, St
     jsonType.setTimestamp(record.getTimestamp());
     jsonType.setTimestampTo(record.getTimestampTo());
     jsonType.setTimestampFrom(record.getTimestampFrom());
-    jsonType.setIsGc(record.getIsGc());
+    jsonType.setIsGC(record.getIsGC());
     jsonType.setValue(
         bytesToString(record.getValue(), destination.isValueBase64Encoded(), charset));
     jsonType.setColumnFamily(record.getColumnFamily());

--- a/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/changelogentry-text.avsc
+++ b/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/changelogentry-text.avsc
@@ -11,7 +11,7 @@
           "type": "enum",
           "symbols": ["SET_CELL", "DELETE_FAMILY", "DELETE_CELLS", "UNKNOWN"]}
       },
-      { "name": "isGc", "type": "boolean" },
+      { "name": "isGC", "type": "boolean" },
       { "name": "tieBreaker", "type": "int"},
       { "name": "columnFamily", "type": "string"},
       { "name": "commitTimestamp", "type" : "long"},

--- a/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/changelogentry.avsc
+++ b/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/changelogentry.avsc
@@ -11,7 +11,7 @@
           "type": "enum",
           "symbols": ["SET_CELL", "DELETE_FAMILY", "DELETE_CELLS", "UNKNOWN"]}
       },
-      { "name": "isGc", "type": "boolean" },
+      { "name": "isGC", "type": "boolean" },
       { "name": "tieBreaker", "type": "int"},
       { "name": "columnFamily", "type": "string"},
       { "name": "commitTimestamp", "type" : "long"},


### PR DESCRIPTION
GC is an acronym, we're running with isGC in other templates, hence renaming