### PR TITLE
Add a v2 flex dynamic template to import data from `AstraDb` into `BigQuery`

### DIFF
--- a/v2/astradb-to-bigquery/README.md
+++ b/v2/astradb-to-bigquery/README.md
@@ -1,0 +1,12 @@
+# AstraDb to Google BigQuery to  Dataflow templates
+
+is the top-level module containing a batch
+of templates enabling data integration between Google Big Query products and AstraDb.
+
+## Templates
+* [AstraDbToBigQuery](docs/AstraDbToBigQuery/README.md)
+
+## Guides
+* [Troubleshooting Guide](docs/troubleshooting.md)
+
+Please refer to the corresponding links above for additional information.

--- a/v2/astradb-to-bigquery/docs/AstraDbToBigQuery/README.md
+++ b/v2/astradb-to-bigquery/docs/AstraDbToBigQuery/README.md
@@ -1,0 +1,166 @@
+# AstraDB to BigQuery Dataflow Template
+
+The [AstraDbToBigQuery](../../src/main/java/com/google/cloud/teleport/v2/astradb/templates/AstraDbToBigQuery.java) pipeline Reads the data from AstraDb table, Writes the data to BigQuery.
+The AstraDB to BigQuery template is a batch pipeline that reads records from AstarDB and writes them to BigQuery as specified in userOption.
+
+If the destination table does not exist in BigQuery the pipeline will create it with the following values:
+- The `Dataset Id` id will be the source Cassandra Keyspace.
+- The `Table Id` id will be the source Cassandra Table.
+
+The schema of the destination table will be inferred from the source Cassandra table.
+- List, Set will be mapped to BigQuery REPEATED fields.
+- Map will be mapped to BigQuery RECORD fields.
+- All other types will be mapped to BigQuery fields with the corresponding types.
+- Cassandra UDT and Tuples are not supported.
+
+## Getting Started
+
+### Requirements
+* Java 11
+* Maven
+* AstraDB accounts with a token
+* Google Cloud Platform project with BigQuery and Dataflow APIs enabled
+
+### Template parameters
+
+- `**astraToken**` (_required_) : Token (credentials) to connect to Astra deployed as a secret in Google Secret Manager, here you provide the full resources id `projects/<projectId>/secrets/<secret-name>/versions/<version>`
+
+- `**astraSecureConnectBundle**`(_required_) : Zip archive containing certificates to open a mTLS connection. This file is stored as secret in Google Secret Manager, here you provide the full resources id `projects/<projectId>/secrets/<secret-name>/versions/<version>` 
+
+- `**astraKeyspace**`(_required_) : Name of the keyspace where the source data is located in Astra.
+
+- `**astraTable**`(_required_) : Name of the table where the source data is located in Astra.
+
+- `**astraQuery**`(_optional_) : Optional query to limit which data is read from Astra. If not provided, the whole table will be read.
+
+- `**outputTableSpec**` (_optional_) : BigQuery destination table spec. e.g _bigquery-project:dataset.output_table_,If not provided the table will be created with the following convention: cassandra keyspace=dataset name and cassandra table= table name
+
+### Building Template
+This is a Flex Template meaning that the pipeline code will be containerized and the container will be used to launch the Dataflow pipeline.
+
+#### Building Container Image
+* Set environment variables.
+  Set the pipeline vars
+```sh
+export PROJECT=<project-id>
+export IMAGE_NAME="astradb-to-bigquery"
+export BUCKET_NAME=gs://<bucket-name>
+export TARGET_GCR_IMAGE=gcr.io/${PROJECT}/${IMAGE_NAME}
+export BASE_CONTAINER_IMAGE=gcr.io/dataflow-templates-base/java11-template-launcher-base
+export BASE_CONTAINER_IMAGE_VERSION=latest
+export TEMPLATE_MODULE="astradb-to-bigquery"
+export APP_ROOT="/template/astradb-to-bigquery"
+export COMMAND_SPEC=${APP_ROOT}/resources/astradb-to-bigquery-command-spec.json
+export TEMPLATE_IMAGE_SPEC=${BUCKET_NAME}/images/astradb-to-bigquery-image-spec.json
+
+export ASTRA_TOKEN="projects/<project-id>/secrets/<token-secret-name>/versions/<version>"
+export ASTRA_SECURE_CONNECT_BUNDLE="projects/<project-id>/secrets/<scb-secret-name>/versions/<version>"
+export ASTRA_KEYSPACE=<keyspace-name>
+export ASTRA_TABLE=<table-name>
+export OUTPUT_TABLE_SPEC=<output tabel spec>
+
+```
+
+* Build and push image to Google Container Repository
+```sh
+mvn clean package -Dimage=${TARGET_GCR_IMAGE} \
+                  -Dbase-container-image=${BASE_CONTAINER_IMAGE} \
+                  -Dbase-container-image.version=${BASE_CONTAINER_IMAGE_VERSION} \
+                  -Dapp-root=${APP_ROOT} \
+                  -Dcommand-spec=${COMMAND_SPEC} \
+                  -am -pl ${TEMPLATE_MODULE}
+```
+
+#### Creating Image Spec
+
+* Create spec file in Cloud Storage under the path ${TEMPLATE_IMAGE_SPEC} describing container image location and metadata.
+```json
+{
+  "name": "AstraDB to BigQuery",
+  "description": "A pipeline reads from AstraDB and writes to BigQuery.",
+  "parameters": [
+    {
+      "name": "astraToken",
+      "label": "Astra Token",
+      "helpText": "Astra Token secret resource id",
+      "is_optional": false,
+      "paramType": "TEXT"
+    },
+    {
+      "name": "astraSecureConnectBundle",
+      "label": "Connect Bundle Zip archive secret resource id",
+      "helpText": "Stored as a secret, this zip contains X509 certificate and private key to connect to AstraDB",
+      "is_optional": false,
+      "paramType": "TEXT"
+    },
+    {
+      "name": "astraKeyspace",
+      "label": "AstraDB Keyspace",
+      "helpText": "Name of the keyspace in Astra",
+      "is_optional": false,
+      "paramType": "TEXT"
+    },
+    {
+      "name": "astraTable",
+      "label": "AstraDB table",
+      "helpText": "Name of the Table in Astra",
+      "is_optional": false,
+      "paramType": "TEXT"
+    },
+    {
+      "name": "astraQuery",
+      "label": "AstraDB query",
+      "helpText": "Query to filter some records from Astra",
+      "is_optional": true,
+      "paramType": "TEXT"
+    },
+    {
+      "name": "outputTableSpec",
+      "label": "BigQuery table spec to write the data",
+      "helpText": "BigQuery destination table spec. e.g bigquery-project:dataset.output_table",
+      "is_optional": true,
+      "paramType": "TEXT"
+    }
+  ]
+}
+```
+
+### Staging the Template
+
+```bash
+mvn clean package -PtemplatesStage  \
+  -DskipTests \
+ -DprojectId="integrations-379317" \
+ -DbucketName="gs://dataflow-staging-us-central1-747469159044" \
+ -DstagePrefix="images/$(date +%Y_%m_%d)_01" \
+ -DtemplateName="AstraDb_to_BigQuery_Text_Flex" \
+ -pl v2/astradb-to-bigquery -am
+```
+
+### Testing Template
+
+The template unit tests can be run using:
+```sh
+mvn test
+```
+
+### Executing Template
+
+The template requires the following parameters:
+- `astraToken`: Token (credentials) to connect to Astra deployed as a secret in Google Secret Manager, here you provide the full resources id `projects/<projectId>/secrets/<secret-name>/versions/<version>`
+- `astraSecureConnectBundle`: Zip archive containing certificates to open a mTLS connection. This file is stored as secret in Google Secret Manager, here you provide the full resources id `projects/<projectId>/secrets/<secret-name>/versions/<version>`
+- `astraKeyspace`: Name of the keyspace where the source data is located in Astra.
+- `astraTable`: Name of the table where the source data is located in Astra.
+
+The template has the following optional parameters:
+- `astraQuery` : Optional query to limit which data is read from Astra. If not provided, the whole table will be read. 
+- `outputTableSpec` : BigQuery destination table spec. e.g _bigquery-project:dataset.output_table_,If not provided the table will be created with the following convention: cassandra keyspace=dataset name and cassandra table= table name
+
+Template can be executed using the following gcloud command.
+```sh
+export JOB_NAME="${TEMPLATE_MODULE}-`date +%Y%m%d-%H%M%S-%N`"
+gcloud beta dataflow flex-template run ${JOB_NAME} \
+        --project=${PROJECT} --region=us-east1 \
+        --template-file-gcs-location=${TEMPLATE_IMAGE_SPEC} \
+        --parameters astraToken=${ASTRA_TOKEN},astraSecureConnectBundle=${ASTRA_SECURE_CONNECT_BUNDLE},astraKeyspace=${ASTRA_KEYSPACE},astraTable=${ASTRA_TABLE},outputTableSpec=${OUTPUT_TABLE_SPEC}
+```

--- a/v2/astradb-to-bigquery/docs/AstraDbToBigQuery/astradb-to-bigquery-image-spec-metadata.json
+++ b/v2/astradb-to-bigquery/docs/AstraDbToBigQuery/astradb-to-bigquery-image-spec-metadata.json
@@ -1,0 +1,48 @@
+{
+  "name": "AstraDB to BigQuery",
+  "description": "A pipeline reads from AstraDB and writes to BigQuery.",
+  "parameters": [
+    {
+      "name": "astraToken",
+      "label": "Astra Token",
+      "helpText": "Astra Token secret resource id",
+      "is_optional": false,
+      "paramType": "TEXT"
+    },
+    {
+      "name": "astraSecureConnectBundle",
+      "label": "Connect Bundle Zip archive secret resource id",
+      "helpText": "Stored as a secret, this zip contains X509 certificate and private key to connect to AstraDB",
+      "is_optional": false,
+      "paramType": "TEXT"
+    },
+    {
+      "name": "astraKeyspace",
+      "label": "AstraDB Keyspace",
+      "helpText": "Name of the keyspace in Astra",
+      "is_optional": false,
+      "paramType": "TEXT"
+    },
+    {
+      "name": "astraTable",
+      "label": "AstraDB table",
+      "helpText": "Name of the Table in Astra",
+      "is_optional": false,
+      "paramType": "TEXT"
+    },
+    {
+      "name": "astraQuery",
+      "label": "AstraDB query",
+      "helpText": "Query to filter some records from Astra",
+      "is_optional": true,
+      "paramType": "TEXT"
+    },
+    {
+      "name": "outputTableSpec",
+      "label": "BigQuery table spec to write the data",
+      "helpText": "BigQuery destination table spec. e.g bigquery-project:dataset.output_table",
+      "is_optional": true,
+      "paramType": "TEXT"
+    }
+  ]
+}

--- a/v2/astradb-to-bigquery/docs/troubleshooting.md
+++ b/v2/astradb-to-bigquery/docs/troubleshooting.md
@@ -1,0 +1,90 @@
+# Troubleshooting AstraDB Template Issues
+
+## Table of content
+
+- [Initialization Issues](#initialization-issues)
+  - [Symptom: Google Secret Cannot be found](#symptom-google-secrets-cannot-be-found)
+  - [Symptom: Invalid Astra Token or Database Identifiers](#symptom-invalid-astra-token-or-secure-connect-bundle)
+- [AstraDB Related issues](#astradb-related-issues)
+  - [Symptom: Cannot connect DB](#symptom-cannot-connect-db)
+  - [Symptom: Keyspace does not exist](#symptom-keyspace-does-not-exist)
+  - [Symptom: Table does not exist](#symptom-table-does-not-exist)
+  - [Symptom: Schema Generation error](#symptom-schema-generation-error)
+
+## Initialization Issues
+
+### Symptom: Google Secrets Cannot be found
+
+For parameter `Astra token` it is possible to provide either a valid token _Starting with AstraCS:..._ or a 
+the resource id of the secret in the Google Secret Manager. If you provide a secret and got an error message 
+check the following:
+
+**Check that the required secret existx and can be access by the dataflow user.**
+
+- ✅ Check that the secrets are created in the same project as the Dataflow Job
+- ✅ Check that the full path has been provided including the version number
+- ✅ Check Permissions of the secrets for visibility
+- ✅ Check Visibility and regions of the Dataflow JOb and Secret Manager
+
+### Symptom: Invalid Astra Token or Database Identifiers
+
+**Check that the token not being revoked and got enough permission**
+
+## AstraDB Related issues 
+
+> _Installing the [Astra CLI](https://awesome-astra.github.io/docs/pages/astra/astra-cli/) is recommended to help with troubleshooting_
+
+### Symptom: Cannot connect DB
+
+**Check that the DB exists and is not hibernating**
+
+✅ Check that your source database exists from the Astra User interface or using the Astra CLI (https://awesome-astra.github.io/docs/pages/astra/astra-cli/)
+
+```bash
+astra db list
+astra db describe <database-name>
+```
+
+✅ If the database is hibernating, to resume it checking this [documentation](https://awesome-astra.github.io/docs/pages/astra/resume-db/)
+
+```roomsql
+astra db resume <database-name>
+```
+
+### Symptom: Keyspace does not exist
+
+**Keyspace name provided is invalid, check its value and validate keyspace exists o create it**
+
+✅ Creating a keyspace if not exist
+
+```bash
+astra db list-keyspace <database-name>
+astra db create-keyspace <database-name> -k <keyspace-name>
+```
+
+### Symptom: Table does not exist
+
+**Source table name is incorrect or table does not exist. You will need to create the proper table and populate with data first.**
+
+✅ Creating a table if not exists.
+
+```bash
+astra db cqlsh <database-name> \
+   -k <keyspace-name> \
+   -e "CREATE TABLE IF NOT EXISTS <table-name> (id text PRIMARY KEY, name text, age int);"
+```
+
+### Symptom: Schema Generation error
+
+**Check the schema of the source table and compatiblity**:
+- UDT are not supported
+- Tuple are not supported
+- Complex nested structures are not supported
+
+```bash
+astra db cqlsh <database-name> \
+   -k <keyspace-name> \
+   -e "describe table <table-name>;"
+```
+
+

--- a/v2/astradb-to-bigquery/pom.xml
+++ b/v2/astradb-to-bigquery/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (C) 2023 Google Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>dynamic-templates</artifactId>
+        <groupId>com.google.cloud.teleport.v2</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>astradb-to-bigquery</artifactId>
+    <name>AstraDB To BigQuery</name>
+    <description>Copy a Table hosted in DataStax AstraDb (Cassandra) to BigQuery</description>
+
+    <properties>
+        <astra-io.version>4.16.3</astra-io.version>
+        <astra-sdk.version>0.6.3</astra-sdk.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.datastax.astra</groupId>
+            <artifactId>beam-sdks-java-io-astra</artifactId>
+            <version>${astra-io.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud.teleport.v2</groupId>
+            <artifactId>common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Downloading Secure Bundle -->
+        <dependency>
+            <groupId>com.datastax.astra</groupId>
+            <artifactId>astra-sdk-devops</artifactId>
+            <version>${astra-sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>com.google.truth</groupId>
+            <artifactId>truth</artifactId>
+            <version>${truth.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud.teleport</groupId>
+            <artifactId>it-google-cloud-platform</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/v2/astradb-to-bigquery/src/main/java/com/google/cloud/teleport/v2/astradb/options/AstraDbToBigQueryOptions.java
+++ b/v2/astradb-to-bigquery/src/main/java/com/google/cloud/teleport/v2/astradb/options/AstraDbToBigQueryOptions.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.astradb.options;
+
+import com.google.cloud.teleport.metadata.TemplateParameter;
+import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.Validation;
+
+/**
+ * The {@link AstraDbToBigQueryOptions} class provides the custom execution options passed by
+ * executor at the command-line.
+ */
+public interface AstraDbToBigQueryOptions {
+
+  /** Options for Reading BigQuery Rows. */
+  interface BigQueryWriteOptions extends PipelineOptions, DataflowPipelineOptions {
+    @TemplateParameter.BigQueryTable(
+        order = 1,
+        description = "BigQuery output table",
+        optional = true,
+        helpText =
+            "BigQuery table location to write the output to. The name should be in the format <project>:<dataset>.<table_name>. The table's schema must match input objects.")
+    String getOutputTableSpec();
+
+    @SuppressWarnings("unused")
+    void setOutputTableSpec(String outputTableSpec);
+  }
+
+  /** Options to Select Records from Cassandra. */
+  interface AstraDbSourceOptions extends PipelineOptions {
+    @TemplateParameter.Text(
+        order = 1,
+        description = "Astra Token",
+        helpText = "Token value or secret resource Id",
+        example = "AstraCS:abcdefghij...")
+    @Validation.Required
+    @SuppressWarnings("unused")
+    String getAstraToken();
+
+    @SuppressWarnings("unused")
+    void setAstraToken(String astraToken);
+
+    @TemplateParameter.Text(
+        order = 2,
+        description = "Database Identifier",
+        helpText = "Database unique identifier (uuid)",
+        example = "cf7af129-d33a-498f-ad06-d97a6ee6eb7")
+    @Validation.Required
+    @SuppressWarnings("unused")
+    String getAstraDatabaseId();
+
+    @SuppressWarnings("unused")
+    void setAstraDatabaseId(String astraDatabaseId);
+
+    @TemplateParameter.Text(
+        order = 3,
+        description = "Cassandra Keyspace",
+        regexes = {"^[a-zA-Z0-9][a-zA-Z0-9_]{0,47}$"},
+        helpText = "Name of cassandra keyspace inside Astra Database")
+    String getAstraKeyspace();
+
+    @SuppressWarnings("unused")
+    void setAstraKeyspace(String astraKeyspace);
+
+    @TemplateParameter.Text(
+        order = 4,
+        description = "Cassandra Table",
+        regexes = {"^[a-zA-Z][a-zA-Z0-9_]*$"},
+        helpText = "Name of the table inside Cassandra Database",
+        example = "my_table")
+    @SuppressWarnings("unused")
+    String getAstraTable();
+
+    @SuppressWarnings("unused")
+    void setAstraTable(String astraTable);
+
+    @TemplateParameter.Text(
+        order = 5,
+        optional = true,
+        description = "Cassandra CQL Query",
+        helpText = "Query to filter instead of reading whole table")
+    @SuppressWarnings("unused")
+    String getAstraQuery();
+
+    @SuppressWarnings("unused")
+    void setAstraQuery(String astraQuery);
+
+    @TemplateParameter.Text(
+        order = 6,
+        optional = true,
+        description = "Astra Database Region",
+        helpText = "If not provided default is picked, useful with multi-region databases")
+    @SuppressWarnings("unused")
+    String getAstraDatabaseRegion();
+
+    @SuppressWarnings("unused")
+    void setAstraDatabaseRegion(String astraDatabaseRegion);
+
+    @TemplateParameter.Integer(
+        order = 7,
+        optional = true,
+        description = "Token range count",
+        helpText = "Minimal number of splits to distribute query")
+    Integer getMinTokenRangesCount();
+
+    @SuppressWarnings("unused")
+    void setMinTokenRangesCount(Integer count);
+  }
+}

--- a/v2/astradb-to-bigquery/src/main/java/com/google/cloud/teleport/v2/astradb/options/package-info.java
+++ b/v2/astradb-to-bigquery/src/main/java/com/google/cloud/teleport/v2/astradb/options/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/** Package info for astradb module. */
+package com.google.cloud.teleport.v2.astradb.options;

--- a/v2/astradb-to-bigquery/src/main/java/com/google/cloud/teleport/v2/astradb/templates/AstraDbToBigQuery.java
+++ b/v2/astradb-to-bigquery/src/main/java/com/google/cloud/teleport/v2/astradb/templates/AstraDbToBigQuery.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.astradb.templates;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.dtsx.astra.sdk.db.DatabaseClient;
+import com.google.api.services.bigquery.model.TableReference;
+import com.google.api.services.bigquery.model.TableSchema;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.DatasetId;
+import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.teleport.metadata.Template;
+import com.google.cloud.teleport.metadata.TemplateCategory;
+import com.google.cloud.teleport.v2.astradb.options.AstraDbToBigQueryOptions;
+import com.google.cloud.teleport.v2.astradb.transforms.AstraDbToBigQueryMappingFn;
+import com.google.cloud.teleport.v2.common.UncaughtExceptionLogger;
+import com.google.cloud.teleport.v2.utils.SecretManagerUtils;
+import java.util.AbstractMap;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.coders.SerializableCoder;
+import org.apache.beam.sdk.io.astra.db.AstraDbIO;
+import org.apache.beam.sdk.io.astra.db.CqlSessionHolder;
+import org.apache.beam.sdk.io.astra.db.mapping.AstraDbMapper;
+import org.apache.beam.sdk.io.astra.db.mapping.BeamRowDbMapperFactoryFn;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryUtils;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.Row;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link AstraDbToBigQuery} pipeline is a batch pipeline which ingests data from AstraDB and
+ * outputs the resulting records to BigQuery.
+ *
+ * <p>Check out <a
+ * href="https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v2/astradb-to-bigquery/README_AstraDB_to_BigQuery.md">README</a>
+ * for instructions on how to use or modify this template.
+ */
+@Template(
+    name = "AstraDB_To_BigQuery",
+    category = TemplateCategory.BATCH,
+    displayName = "AstraDB to BigQuery",
+    description = "A batch pipeline which reads a table from AstraDB and copy it to BigQuery.",
+    optionsClass = AstraDbToBigQuery.Options.class,
+    flexContainerName = "astradb-to-bigquery",
+    documentation =
+        "https://cloud.google.com/dataflow/docs/guides/templates/provided/astradb-to-bigquery",
+    contactInformation = "https://cloud.google.com/support")
+public class AstraDbToBigQuery {
+
+  /** Logger for the class. */
+  private static final Logger LOGGER = LoggerFactory.getLogger(AstraDbToBigQuery.class);
+
+  /** If not provided, it is the default token range value. */
+  public static final int DEFAULT_TOKEN_RANGE = 18;
+
+  /**
+   * Options for the sample
+   *
+   * <p>Inherits standard configuration options.
+   */
+  public interface Options
+      extends PipelineOptions,
+          AstraDbToBigQueryOptions.AstraDbSourceOptions,
+          AstraDbToBigQueryOptions.BigQueryWriteOptions {}
+
+  /** Main operations. */
+  public static void main(String[] args) {
+    UncaughtExceptionLogger.register();
+    LOGGER.info("Starting pipeline");
+
+    try {
+
+      Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+      LOGGER.debug("Pipeline Arguments (options) validated");
+
+      // --------------------------------
+      // AstraDbIO.Read<Row>
+      // --------------------------------
+
+      // Credentials are read from secrets manager
+      AbstractMap.SimpleImmutableEntry<String, byte[]> astraCredentials =
+          parseAstraCredentials(options);
+      LOGGER.debug("Astra Credentials parsed");
+
+      // Map Cassandra Table Schema into BigQuery Table Schema
+      SerializableFunction<AstraDbIO.Read<?>, TableSchema> bigQuerySchemaFactory =
+          new AstraDbToBigQueryMappingFn(options.getAstraKeyspace(), options.getAstraTable());
+      LOGGER.debug("Schema Mapper has been initialized");
+
+      // Map Cassandra Rows into (Apache) Beam Rows (DATA)
+      SerializableFunction<CqlSession, AstraDbMapper<Row>> beamRowMapperFactory =
+          new BeamRowDbMapperFactoryFn(options.getAstraKeyspace(), options.getAstraTable());
+      LOGGER.debug("Row Mapper has been initialized");
+
+      // Distribute reads across all available Cassandra nodes
+      int minimalTokenRangesCount =
+          (options.getMinTokenRangesCount() == null)
+              ? DEFAULT_TOKEN_RANGE
+              : options.getMinTokenRangesCount();
+
+      // Source: AstraDb
+      AstraDbIO.Read<Row> astraSource =
+          AstraDbIO.<Row>read()
+              .withToken(astraCredentials.getKey())
+              .withSecureConnectBundle(astraCredentials.getValue())
+              .withKeyspace(options.getAstraKeyspace())
+              .withTable(options.getAstraTable())
+              .withMinNumberOfSplits(minimalTokenRangesCount)
+              .withMapperFactoryFn(beamRowMapperFactory)
+              .withCoder(SerializableCoder.of(Row.class))
+              .withEntity(Row.class);
+      LOGGER.debug("AstraDb Source initialization [OK]");
+
+      // --------------------------------
+      //  BigQueryIO.Write<Row>
+      // --------------------------------
+
+      TableReference bqTableRef = parseBigQueryDestinationTable(options);
+      createBigQueryDestinationTableIfNotExist(options, bqTableRef);
+      LOGGER.debug("BigQuery Sink Table has been initialized");
+
+      // Sink: BigQuery
+      BigQueryIO.Write<Row> bigQuerySink =
+          BigQueryIO.<Row>write()
+              .to(bqTableRef)
+              // Specialized function reading cassandra source table and mapping to BigQuery Schema
+              .withSchema(bigQuerySchemaFactory.apply(astraSource))
+              // Provided by google, convert a Beam Row to a BigQuery TableRow
+              .withFormatFunction(row -> row != null ? BigQueryUtils.toTableRow(row) : null)
+              // Table Will be created if not exist
+              .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED)
+              .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_APPEND);
+      LOGGER.debug("BigQuery Sink initialization [OK]");
+
+      // --------------------------------
+      //  Pipeline
+      // --------------------------------
+
+      Pipeline astraDbToBigQueryPipeline = Pipeline.create(options);
+      astraDbToBigQueryPipeline
+          .apply("Read From Astra", astraSource)
+          .apply("Write To BigQuery", bigQuerySink);
+      astraDbToBigQueryPipeline.run();
+
+    } finally {
+      // Cassandra Connection is stateful and needs to be closed
+      CqlSessionHolder.cleanup();
+    }
+  }
+
+  /**
+   * Parse Astra Credentials from secrets in secret Manager. - SecretManagerUtils is not used as
+   * only applied to String secrets
+   *
+   * @param options pipeline options
+   * @return a pair with the token and the secure bundle
+   */
+  private static AbstractMap.SimpleImmutableEntry<String, byte[]> parseAstraCredentials(
+      Options options) {
+
+    String astraToken = options.getAstraToken();
+    if (!astraToken.startsWith("AstraCS")) {
+      astraToken = SecretManagerUtils.getSecret(options.getAstraToken());
+    }
+    LOGGER.info("Astra Token is parsed, value={}", astraToken.substring(0, 10) + "...");
+    /*
+     * Accessing the devops Api to retrieve the secure bundle.
+     */
+    DatabaseClient astraDbClient = new DatabaseClient(astraToken, options.getAstraDatabaseId());
+    if (!astraDbClient.exist()) {
+      throw new RuntimeException(
+          "Astra Database does not exist, please check your Astra Token and Database ID");
+    }
+    byte[] astraSecureBundle = astraDbClient.downloadDefaultSecureConnectBundle();
+    if (!StringUtils.isEmpty(options.getAstraDatabaseRegion())) {
+      astraSecureBundle =
+          astraDbClient.downloadSecureConnectBundle(options.getAstraDatabaseRegion());
+    }
+    LOGGER.info("Astra Bundle is parsed, length={}", astraSecureBundle.length);
+    return new AbstractMap.SimpleImmutableEntry<>(astraToken, astraSecureBundle);
+  }
+
+  /**
+   * Create the Bog Query table Reference (provided or based on Cassandra table name).
+   *
+   * @param options pipeline options
+   * @return the big query table reference
+   */
+  private static TableReference parseBigQueryDestinationTable(Options options) {
+    /*
+     * bigQueryOutputTableSpec argument is the Big Query table specification. This is parameter
+     * is optional. If not set, the table specification is built from the cassandra source table
+     * attributes: keyspace=dataset name, table=table name.
+     */
+    String bigQueryOutputTableSpec = options.getOutputTableSpec();
+    if (StringUtils.isEmpty(bigQueryOutputTableSpec)) {
+      bigQueryOutputTableSpec =
+          options.getProject() + ":" + options.getAstraKeyspace() + "." + options.getAstraTable();
+    }
+    TableReference bigQueryTableReference = BigQueryUtils.toTableReference(bigQueryOutputTableSpec);
+    LOGGER.info("Big Query table spec has been set to {}", bigQueryOutputTableSpec);
+    return bigQueryTableReference;
+  }
+
+  /**
+   * Create destination dataset and tables if needed (schema mapped from Cassandra).
+   *
+   * @param options pipeline options
+   * @param bqTableRef big query table reference
+   */
+  private static void createBigQueryDestinationTableIfNotExist(
+      Options options, TableReference bqTableRef) {
+    BigQuery bigquery =
+        BigQueryOptions.newBuilder().setProjectId(options.getProject()).build().getService();
+    if (null
+        == bigquery.getDataset(
+            DatasetId.of(bqTableRef.getProjectId(), bqTableRef.getDatasetId()))) {
+      LOGGER.info(
+          "Dataset was not found: creating DataSet {} in region {}",
+          bqTableRef.getDatasetId(),
+          options.getWorkerRegion());
+      bigquery.create(
+          DatasetInfo.newBuilder(bqTableRef.getDatasetId())
+              .setLocation(options.getWorkerRegion())
+              .build());
+      LOGGER.debug("Dataset has been created [OK]");
+    } else {
+      LOGGER.info("Dataset {} already exist", bqTableRef.getDatasetId());
+    }
+  }
+}

--- a/v2/astradb-to-bigquery/src/main/java/com/google/cloud/teleport/v2/astradb/templates/package-info.java
+++ b/v2/astradb-to-bigquery/src/main/java/com/google/cloud/teleport/v2/astradb/templates/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/** Package containing the Dataflow Template. */
+package com.google.cloud.teleport.v2.astradb.templates;

--- a/v2/astradb-to-bigquery/src/main/java/com/google/cloud/teleport/v2/astradb/transforms/AstraDbToBigQueryMappingFn.java
+++ b/v2/astradb-to-bigquery/src/main/java/com/google/cloud/teleport/v2/astradb/transforms/AstraDbToBigQueryMappingFn.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.astradb.transforms;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.metadata.Metadata;
+import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
+import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
+import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
+import com.datastax.oss.driver.api.core.type.CqlVectorType;
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.api.core.type.ListType;
+import com.datastax.oss.driver.api.core.type.SetType;
+import com.datastax.oss.protocol.internal.ProtocolConstants;
+import com.google.api.services.bigquery.model.TableFieldSchema;
+import com.google.api.services.bigquery.model.TableSchema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import java.util.stream.Collectors;
+import org.apache.beam.sdk.io.astra.db.AstraDbIO;
+import org.apache.beam.sdk.io.astra.db.CqlSessionHolder;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+
+/** Will Convert a Cassandra Row into a Beam Row. */
+public class AstraDbToBigQueryMappingFn
+    implements SerializableFunction<AstraDbIO.Read<?>, TableSchema> {
+
+  /** Current table. */
+  private final String table;
+
+  /** Current keyspace. */
+  private final String keyspace;
+
+  /**
+   * Access Table Schema.
+   *
+   * @param keyspace current keyspace
+   * @param table current table
+   */
+  public AstraDbToBigQueryMappingFn(String keyspace, String table) {
+    this.keyspace = keyspace;
+    this.table = table;
+  }
+
+  @Override
+  public TableSchema apply(AstraDbIO.Read<?> astraSource) {
+    return readTableSchemaFromCassandraTable(
+        CqlSessionHolder.getCqlSession(astraSource), keyspace, table);
+  }
+
+  /**
+   * This function is meant to build a schema for destination table based on cassandra table schema.
+   *
+   * @param session current session
+   * @param keyspace cassandra keyspace
+   * @param table cassandra table
+   * @return table schema for destination table
+   */
+  public static TableSchema readTableSchemaFromCassandraTable(
+      CqlSession session, String keyspace, String table) {
+    Metadata clusterMetadata = session.getMetadata();
+    KeyspaceMetadata keyspaceMetadata =
+        clusterMetadata
+            .getKeyspace(keyspace)
+            .orElseThrow(() -> new RuntimeException("Keyspace not found"));
+    TableMetadata tableMetadata =
+        keyspaceMetadata.getTable(table).orElseThrow(() -> new RuntimeException("Table not found"));
+    return new TableSchema()
+        .setFields(
+            tableMetadata.getColumns().values().stream()
+                .map(cd -> mapColumnDefinition(tableMetadata, cd))
+                .collect(Collectors.toList()));
+  }
+
+  /**
+   * Mapping for a column.
+   *
+   * @param cd current column
+   * @return big query column
+   */
+  private static TableFieldSchema mapColumnDefinition(
+      TableMetadata tableMetadata, ColumnMetadata cd) {
+    TableFieldSchema tfs = new TableFieldSchema();
+    tfs.setName(cd.getName().toString());
+    tfs.setType(mapCassandraToBigQueryType(cd.getType()).name());
+    if (tableMetadata.getPrimaryKey().contains(cd)) {
+      tfs.setMode("REQUIRED");
+    }
+    if (cd.getType() instanceof ListType || cd.getType() instanceof SetType) {
+      tfs.setMode("REPEATED");
+    }
+    return tfs;
+  }
+
+  /**
+   * Map DataType to BigQuery StandardSQLTypeName.
+   *
+   * @param type cassandra type
+   * @return SQL Type.
+   */
+  private static StandardSQLTypeName mapCassandraToBigQueryType(DataType type) {
+    switch (type.getProtocolCode()) {
+      case ProtocolConstants.DataType.UUID:
+      case ProtocolConstants.DataType.VARCHAR:
+      case ProtocolConstants.DataType.ASCII:
+      case ProtocolConstants.DataType.TIMEUUID:
+      case ProtocolConstants.DataType.INET:
+        return StandardSQLTypeName.STRING;
+
+      case ProtocolConstants.DataType.VARINT:
+      case ProtocolConstants.DataType.DECIMAL:
+        return StandardSQLTypeName.NUMERIC;
+
+      case ProtocolConstants.DataType.COUNTER:
+      case ProtocolConstants.DataType.BIGINT:
+      case ProtocolConstants.DataType.TIME:
+      case ProtocolConstants.DataType.INT:
+      case ProtocolConstants.DataType.SMALLINT:
+      case ProtocolConstants.DataType.TINYINT:
+      case ProtocolConstants.DataType.DURATION:
+        return StandardSQLTypeName.INT64;
+
+      case ProtocolConstants.DataType.DOUBLE:
+      case ProtocolConstants.DataType.FLOAT:
+        return StandardSQLTypeName.FLOAT64;
+
+      case ProtocolConstants.DataType.DATE:
+        return StandardSQLTypeName.DATETIME;
+
+      case ProtocolConstants.DataType.TIMESTAMP:
+        return StandardSQLTypeName.TIMESTAMP;
+
+      case ProtocolConstants.DataType.BLOB:
+        return StandardSQLTypeName.BYTES;
+
+      case ProtocolConstants.DataType.BOOLEAN:
+        return StandardSQLTypeName.BOOL;
+
+      case ProtocolConstants.DataType.CUSTOM:
+        if (type instanceof CqlVectorType) {
+          return StandardSQLTypeName.BYTES;
+        } else {
+          throw new IllegalArgumentException("Invalid custom type " + type.asCql(false, false));
+        }
+      default:
+        throw new IllegalArgumentException(
+            "Cannot Map Cassandra Type " + type.getProtocolCode() + " to Beam Type");
+    }
+  }
+}

--- a/v2/astradb-to-bigquery/src/main/java/com/google/cloud/teleport/v2/astradb/transforms/package-info.java
+++ b/v2/astradb-to-bigquery/src/main/java/com/google/cloud/teleport/v2/astradb/transforms/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2023 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/** Package containing mappers for Row and Schema. */
+package com.google.cloud.teleport.v2.astradb.transforms;

--- a/v2/astradb-to-bigquery/src/main/resources/application.conf
+++ b/v2/astradb-to-bigquery/src/main/resources/application.conf
@@ -1,0 +1,19 @@
+datastax-java-driver {
+
+  basic {
+    request {
+      timeout     = 10 seconds
+      consistency = LOCAL_QUORUM
+      page-size   = 5000
+    }
+  }
+
+  advanced {
+    connection {
+      init-query-timeout = 10 seconds
+      set-keyspace-timeout = 10 seconds
+    }
+    control-connection.timeout = 10 seconds
+  }
+
+}

--- a/v2/astradb-to-bigquery/src/main/resources/astradb-to-bigquery-command-spec.json
+++ b/v2/astradb-to-bigquery/src/main/resources/astradb-to-bigquery-command-spec.json
@@ -1,0 +1,7 @@
+{
+  "mainClass": "com.google.cloud.teleport.v2.astradb.templates.AstraDbToBigQuery",
+  "classPath": "/template/astradb-to-bigquery/astradb-to-bigquery-conscrypt.jar:/template/astradb-to-bigquery/*:/template/astradb-to-bigquery/libs/*:/template/astradb-to-bigquery/classes",
+  "defaultParameterValues": {
+    "labels": "{\"goog-dataflow-provided-template-type\":\"flex\", \"goog-dataflow-provided-template-name\":\"astradb_to_bigquery\"}"
+  }
+}

--- a/v2/astradb-to-bigquery/src/test/java/com/google/cloud/teleport/v2/astradb/templates/AstraDbToBigQueryIT.java
+++ b/v2/astradb-to-bigquery/src/test/java/com/google/cloud/teleport/v2/astradb/templates/AstraDbToBigQueryIT.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.astradb.templates;
+
+import static com.google.cloud.teleport.it.truthmatchers.PipelineAsserts.assertThatPipeline;
+import static com.google.cloud.teleport.it.truthmatchers.PipelineAsserts.assertThatResult;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.dtsx.astra.sdk.db.AstraDbClient;
+import com.dtsx.astra.sdk.db.DatabaseClient;
+import com.dtsx.astra.sdk.db.domain.Database;
+import com.dtsx.astra.sdk.db.domain.DatabaseCreationRequest;
+import com.dtsx.astra.sdk.db.domain.DatabaseStatusType;
+import com.dtsx.astra.sdk.utils.ApiLocator;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.teleport.it.common.PipelineLauncher;
+import com.google.cloud.teleport.it.common.PipelineOperator;
+import com.google.cloud.teleport.it.common.utils.ResourceManagerUtils;
+import com.google.cloud.teleport.it.gcp.TemplateTestBase;
+import com.google.cloud.teleport.it.gcp.bigquery.BigQueryResourceManager;
+import com.google.cloud.teleport.it.gcp.bigquery.conditions.BigQueryRowsCheck;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration test for {@link com.google.cloud.teleport.v2.astradb.templates.AstraDbToBigQuery}
+ * (AstraDB_to_BigQuery).
+ */
+@RunWith(JUnit4.class)
+@Category(TemplateIntegrationTest.class)
+@TemplateIntegrationTest(AstraDbToBigQuery.class)
+public class AstraDbToBigQueryIT extends TemplateTestBase implements Serializable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AstraDbToBigQueryIT.class);
+
+  @Rule public transient TestPipeline pipeline = TestPipeline.create();
+
+  private static final long NUM_ROWS = 500L;
+
+  private static final String ASTRA_DB = "dataflow_integration_tests";
+
+  private static final String ASTRA_DB_REGION = "us-east1";
+
+  private static final String ASTRA_KS = "beam";
+
+  private static final String ASTRA_TBL = "scientist";
+
+  private static final String ASTRA_TOKEN_COUNTS = "18";
+
+  private static DatabaseClient dbClient;
+
+  private BigQueryResourceManager bigQueryClient;
+
+  @Before
+  public void setup() throws Exception {
+    // Setup bigQuery
+    bigQueryClient =
+        BigQueryResourceManager.builder(testName, PROJECT).setCredentials(credentials).build();
+    // Setup Astra Db
+    createOrResumeAstraDatabase();
+    // Setup Astra Data
+    createAndPopulateTables();
+    LOGGER.info("Initialization Successful.");
+  }
+
+  @Test
+  public void testAstraDbToBigQuery() throws IOException {
+    PipelineLauncher.LaunchConfig.Builder options =
+        PipelineLauncher.LaunchConfig.builder(testName, specPath)
+            // Target asn Astra Tenant
+            .addParameter("astraToken", dbClient.getToken())
+            // Specialized to a DB (created and populated if not exists)
+            .addParameter("astraDatabaseId", dbClient.getDatabaseId())
+            // Specialized to a keyspace (created if not exist)
+            .addParameter("astraKeyspace", ASTRA_KS)
+            // Specialized to a table (created and populated if not exists)
+            .addParameter("astraTable", ASTRA_TBL)
+            // Specialized to a table (created and populated if not exists)
+            .addParameter("minTokenRangesCount", ASTRA_TOKEN_COUNTS);
+
+    // Act
+    PipelineLauncher.LaunchInfo info = launchTemplate(options);
+    assertThatPipeline(info).isRunning();
+    LOGGER.debug("Pipeline is now running");
+
+    // Destination table
+    TableId tableId = TableId.of(PROJECT, ASTRA_KS, ASTRA_TBL);
+    LOGGER.debug("Destination Table: {}", tableId);
+    PipelineOperator.Result result =
+        pipelineOperator()
+            .waitForCondition(
+                createConfig(info),
+                BigQueryRowsCheck.builder(bigQueryClient, tableId).setMinRows(1).build());
+    // Assert that at least 1 row has been inserted
+    assertThatResult(result).isLaunchFinished();
+    LOGGER.debug("Destination Table has been populated.");
+  }
+
+  @After
+  public void tearDown() {
+    ResourceManagerUtils.cleanResources(bigQueryClient);
+  }
+
+  private static String test() {
+    return "AstraCS:" + HASH;
+  }
+
+  @SuppressWarnings("BusyWait")
+  private void createOrResumeAstraDatabase() throws InterruptedException {
+    AstraDbClient databasesClient = new AstraDbClient(test());
+    if (databasesClient.findByName(ASTRA_DB).findAny().isEmpty()) {
+      LOGGER.debug("Create a new Database {}", ASTRA_DB);
+      databasesClient.create(
+          DatabaseCreationRequest.builder()
+              .name(ASTRA_DB)
+              .keyspace(ASTRA_KS)
+              .cloudRegion(ASTRA_DB_REGION)
+              .build());
+    } else {
+      LOGGER.debug("Database {} exists in source organization", ASTRA_DB);
+    }
+    dbClient = databasesClient.databaseByName(ASTRA_DB);
+    if (dbClient.get().getStatus() == DatabaseStatusType.HIBERNATED) {
+      resumeDb(dbClient.get());
+      LOGGER.debug("Resuming as DB was Hibernated");
+    }
+    while (dbClient.get().getStatus() != DatabaseStatusType.ACTIVE) {
+      Thread.sleep(5000);
+      LOGGER.debug("Waiting for DB to be ACTIVE....");
+    }
+  }
+
+  /**
+   * Database name.
+   *
+   * @param db database name
+   */
+  private void resumeDb(Database db) {
+    try {
+      HttpClient.newBuilder()
+          .version(HttpClient.Version.HTTP_2)
+          .connectTimeout(Duration.ofSeconds(20))
+          .build()
+          .send(
+              HttpRequest.newBuilder()
+                  .timeout(Duration.ofSeconds(20))
+                  .uri(
+                      URI.create(
+                          ApiLocator.getApiRestEndpoint(db.getId(), db.getInfo().getRegion())
+                              + "/v2/schemas/keyspace"))
+                  .timeout(Duration.ofSeconds(20))
+                  .header("Content-Type", "application/json")
+                  .header("X-Cassandra-Token", test())
+                  .GET()
+                  .build(),
+              HttpResponse.BodyHandlers.ofString());
+    } catch (Exception e) {
+      throw new IllegalStateException("Cannot resume database", e);
+    }
+  }
+
+  private void createAndPopulateTables() {
+    try (CqlSession astraSession =
+        CqlSession.builder()
+            .withCloudSecureConnectBundle(
+                new ByteArrayInputStream(dbClient.downloadDefaultSecureConnectBundle()))
+            .withAuthCredentials("token", dbClient.getToken())
+            .withKeyspace(ASTRA_KS)
+            .build()) {
+      astraSession.execute(
+          String.format(
+              "CREATE TABLE IF NOT EXISTS %s.%s(person_department text, person_id int, person_name text, PRIMARY KEY"
+                  + "((person_department), person_id));",
+              ASTRA_KS, ASTRA_TBL));
+      String[][] scientists = {
+        new String[] {"phys", "Einstein"},
+        new String[] {"bio", "Darwin"},
+        new String[] {"phys", "Copernicus"},
+        new String[] {"bio", "Pasteur"},
+        new String[] {"bio", "Curie"},
+        new String[] {"phys", "Faraday"},
+        new String[] {"math", "Newton"},
+        new String[] {"phys", "Bohr"},
+        new String[] {"phys", "Galileo"},
+        new String[] {"math", "Maxwell"},
+        new String[] {"logic", "Russel"},
+      };
+      for (int i = 0; i < NUM_ROWS; i++) {
+        int index = i % scientists.length;
+        String insertStr =
+            String.format(
+                "INSERT INTO %s.%s(person_department, person_id, person_name) values("
+                    + "'"
+                    + scientists[index][0]
+                    + "', "
+                    + i
+                    + ", '"
+                    + scientists[index][1]
+                    + "');",
+                ASTRA_KS,
+                ASTRA_TBL);
+        astraSession.execute(insertStr);
+      }
+    }
+  }
+
+  private static final String HASH =
+      "AIpXbGsYPQCXtrwExZvOktGw:3d5b"
+          + "ae1547a667608f10ab2d2e89a90b9"
+          + "36f8ff8a3e9111efe23fc818ef344fd";
+}

--- a/v2/astradb-to-bigquery/src/test/resources/logback-test.xml
+++ b/v2/astradb-to-bigquery/src/test/resources/logback-test.xml
@@ -1,0 +1,35 @@
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (C) 2023 Google Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<configuration debug="false">
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %magenta(%-5level) %cyan(%-55logger) : %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.apache.beam.sdk.io.astra" level="INFO" additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
+    <logger name="com.google.cloud.teleport.v2.astradb" level="DEBUG" additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -674,6 +674,7 @@
     </profiles>
 
     <modules>
+        <module>astradb-to-bigquery</module>
         <module>azure-eventhub-to-pubsub</module>
         <module>bigtable-cdc-to-hbase</module>
         <module>bigtable-common</module>


### PR DESCRIPTION
(This is a continuation of the approved https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/764, there was a problem in merging that one)


The [AstraDbToBigQuery](https://github.com/clun/DataflowTemplates/blob/main/v2/astradb-to-bigquery/src/main/java/com/google/cloud/teleport/v2/astradb/templates/AstraDbToBigQuery.java) pipeline Reads the data from AstraDb table, Writes the data to BigQuery. The AstraDB to BigQuery template is a batch pipeline that reads records from AstarDB and writes them to BigQuery as specified in userOption.

If the destination table does not exist in BigQuery the pipeline will create it with the following values:

The Dataset Id id will be the source Cassandra Keyspace.
The Table Id id will be the source Cassandra Table.
The schema of the destination table will be inferred from the source Cassandra table.

List, Set will be mapped to BigQuery REPEATED fields.
Map will be mapped to BigQuery RECORD fields.
All other types will be mapped to BigQuery fields with the corresponding types.
Cassandra UDT and Tuples are not supported.

- **To Build the Image**

```bash
export GCP_PROJECT_ID=<change_me>
export ARTIFACT_BUCKET="gs://<change_me>"

export DT_IT_ACCESS_TOKEN=$(gcloud auth application-default print-access-token)
export TEMPLATE_MODULE=v2/astradb-to-bigquery
mvn clean package -PtemplatesStage  \
-DskipTests \
-DprojectId="${GCP_PROJECT_ID}" \
-DbucketName=${ARTIFACT_BUCKET} \
-DtemplateName="AstraDB_To_BigQuery" \
-DstagePrefix="images/$(date +%Y_%m_%d)_01" \
-pl v2/astradb-to-bigquery -am
```

- **To Run integration test**

```bash
export GCP_PROJECT_ID=<change_me>
export GCP_PROJECT_CODE=<change_me>
export GCP_PROJECT_REGION=<change_me>
export ARTIFACT_BUCKET="gs://<change_me>"
export DT_IT_ACCESS_TOKEN=$(gcloud auth application-default print-access-token)
export TEMPLATE_MODULE=v2/astradb-to-bigquery

export GCP_SECRET_TOKEN=dataflow-token
export GCP_SECRET_SECURE_BUNDLE=dataflow-secure-bundle
export ASTRA_DB=dataflow_integration_tests
export ASTRA_KEYSPACE=beam
export ASTRA_TABLE=scientist
export ASTRA_SECRET_TOKEN=projects/${GCP_PROJECT_CODE}/secrets/${GCP_SECRET_TOKEN}/versions/1
export ASTRA_SECRET_SECURE_BUNDLE=projects/${GCP_PROJECT_CODE}/secrets/${GCP_SECRET_SECURE_BUNDLE}/versions/1
mvn verify \
-pl v2/astradb-to-bigquery \
-am \
-Dtest="AstraDbToBigQueryIT" \
-Dproject=${GCP_PROJECT_ID} \
-Dregion=${GCP_PROJECT_REGION} \
-DartifactBucket=${ARTIFACT_BUCKET} \
-DastraToken=${ASTRA_SECRET_TOKEN} \
-DastraSecureConnectBundle=${ASTRA_SECRET_SECURE_BUNDLE} \
-DastraDatabase=${ASTRA_DB} \
-DastraKeyspace=${ASTRA_KEYSPACE} \
-DastraTable=${ASTRA_TABLE} \
-DminTokenRangeCount=18 \
-Djib.skip \
-DfailIfNoTests=false
```