### PR TITLE
Bump Truth to 1.1.5 to match Beam

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <snakeyaml.version>2.0</snakeyaml.version>
     <spotless-maven-plugin.version>2.12.1</spotless-maven-plugin.version>
     <surefire.version>2.21.0</surefire.version>
-    <truth.version>1.0.1</truth.version>
+    <truth.version>1.1.5</truth.version>
 
     <!-- JDBC driver / Connector versions -->
     <!-- Note: File it/src/main/java/com/google/cloud/teleport/it/common/JDBCBaseIT.java -->

--- a/syndeo-template/pom.xml
+++ b/syndeo-template/pom.xml
@@ -38,7 +38,7 @@
         <maven-compiler-plugin.version>3.6.2</maven-compiler-plugin.version>
         <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
         <protobuf.version>3.21.9</protobuf.version>
-        <truth.version>1.0.1</truth.version>
+        <truth.version>1.1.5</truth.version>
         <!-- <secretmanager.version>2.1.2</secretmanager.version> -->
         <!-- <slf4j.version>1.7.25</slf4j.version> -->
         <jib.maven.version>2.6.0</jib.maven.version>

--- a/v2/common/pom.xml
+++ b/v2/common/pom.xml
@@ -30,7 +30,6 @@
         <commons.version>1.8</commons.version>
         <commons-text.version>1.10.0</commons-text.version>
         <nashorn.version>15.4</nashorn.version>
-        <truth-proto-extension.version>1.0.1</truth-proto-extension.version>
     </properties>
 
     <dependencies>
@@ -143,7 +142,7 @@
         <dependency>
             <groupId>com.google.truth.extensions</groupId>
             <artifactId>truth-proto-extension</artifactId>
-            <version>${truth-proto-extension.version}</version>
+            <version>${truth.version}</version>
             <scope>test</scope>
             <exclusions>
               <exclusion>


### PR DESCRIPTION
Truth 1.1.5 uses a newer Guava, and the same update is happening on Beam (https://github.com/apache/beam/pull/27725), so preparing ahead of it.