### PR TITLE
[Security] Bump postgresql to 42.6.0

### DIFF
--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/JDBCBaseIT.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/JDBCBaseIT.java
@@ -56,7 +56,7 @@ public abstract class JDBCBaseIT extends TemplateTestBase {
   // The versions of each of the JDBC drivers to use.
   // NOTE: These versions must correspond to the versions declared in the `it/pom.xml` file.
   private static final String MYSQL_VERSION = "8.0.30";
-  private static final String POSTGRES_VERSION = "42.2.27";
+  private static final String POSTGRES_VERSION = "42.6.0";
   private static final String ORACLE_VERSION = "19.3.0.0";
   private static final String MSSQL_VERSION = "6.4.0.jre8";
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <!-- Note: File it/src/main/java/com/google/cloud/teleport/it/common/JDBCBaseIT.java -->
     <!-- should be updated when these versions are changed. -->
     <mysql-connector-java.version>8.0.30</mysql-connector-java.version>
-    <postgresql.version>42.2.27</postgresql.version>
+    <postgresql.version>42.6.0</postgresql.version>
     <ojdbc8.version>19.3.0.0</ojdbc8.version>
     <mssql-jdbc.version>6.4.0.jre8</mssql-jdbc.version>
     <neo4j-driver.version>4.4.12</neo4j-driver.version>

--- a/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryLT.java
+++ b/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryLT.java
@@ -151,7 +151,7 @@ public class JdbcToBigQueryLT extends TemplateLoadTestBase {
             .apply(
                 LaunchConfig.builder(testName, SPEC_PATH)
                     .addParameter(
-                        "driverJars", "gs://apache-beam-pranavbhandari/postgresql-42.2.27.jar")
+                        "driverJars", "gs://apache-beam-pranavbhandari/postgresql-42.6.0.jar")
                     .addParameter("table", testName)
                     .addParameter("partitionColumn", "score")
                     .addParameter("driverClassName", DRIVER_CLASS_NAME)


### PR DESCRIPTION
42.2.27 is within the range for CVE-2022-26520