### PR TITLE
[Debt] Bump ojdbc8 to 23.2.0.0

### DIFF
--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/JDBCBaseIT.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/JDBCBaseIT.java
@@ -44,7 +44,7 @@ public abstract class JDBCBaseIT extends TemplateTestBase {
   // The relative path to the JDBC drivers under Maven's `.m2/repository` directory
   private static final String MYSQL_LOCAL_PATH = "mysql/mysql-connector-java";
   private static final String POSTGRES_LOCAL_PATH = "org/postgresql/postgresql";
-  private static final String ORACLE_LOCAL_PATH = "com/oracle/ojdbc/ojdbc8";
+  private static final String ORACLE_LOCAL_PATH = "com/oracle/database/jdbc/ojdbc8";
   private static final String MSSQL_LOCAL_PATH = "com/microsoft/sqlserver/mssql-jdbc";
 
   // The name of the JDBC driver jars sans the .jar suffix
@@ -57,7 +57,7 @@ public abstract class JDBCBaseIT extends TemplateTestBase {
   // NOTE: These versions must correspond to the versions declared in the `it/pom.xml` file.
   private static final String MYSQL_VERSION = "8.0.30";
   private static final String POSTGRES_VERSION = "42.2.27";
-  private static final String ORACLE_VERSION = "19.3.0.0";
+  private static final String ORACLE_VERSION = "23.2.0.0";
   private static final String MSSQL_VERSION = "6.4.0.jre8";
 
   @Before

--- a/it/jdbc/pom.xml
+++ b/it/jdbc/pom.xml
@@ -63,7 +63,7 @@
             <version>${postgresql.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <version>${ojdbc8.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <!-- should be updated when these versions are changed. -->
     <mysql-connector-java.version>8.0.30</mysql-connector-java.version>
     <postgresql.version>42.2.27</postgresql.version>
-    <ojdbc8.version>19.3.0.0</ojdbc8.version>
+    <ojdbc8.version>23.2.0.0</ojdbc8.version>
     <mssql-jdbc.version>6.4.0.jre8</mssql-jdbc.version>
     <neo4j-driver.version>4.4.12</neo4j-driver.version>
 


### PR DESCRIPTION
We are using a version released in 2019 (https://mvnrepository.com/artifact/com.oracle.ojdbc/ojdbc8/19.3.0.0) for testing.

It is more likely that template users will use new drivers