### PR TITLE
[Debt] Bump mssql-jdbc to 12.2.0.jre11

### DIFF
--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/JDBCBaseIT.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/JDBCBaseIT.java
@@ -58,7 +58,7 @@ public abstract class JDBCBaseIT extends TemplateTestBase {
   private static final String MYSQL_VERSION = "8.0.30";
   private static final String POSTGRES_VERSION = "42.2.27";
   private static final String ORACLE_VERSION = "19.3.0.0";
-  private static final String MSSQL_VERSION = "6.4.0.jre8";
+  private static final String MSSQL_VERSION = "12.2.0.jre11";
 
   @Before
   public void setUpJDBC() throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <mysql-connector-java.version>8.0.30</mysql-connector-java.version>
     <postgresql.version>42.2.27</postgresql.version>
     <ojdbc8.version>19.3.0.0</ojdbc8.version>
-    <mssql-jdbc.version>6.4.0.jre8</mssql-jdbc.version>
+    <mssql-jdbc.version>12.2.0.jre11</mssql-jdbc.version>
     <neo4j-driver.version>4.4.12</neo4j-driver.version>
 
     <integration.tests>


### PR DESCRIPTION
We are using https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc/6.4.0.jre8, a version which was released in 2018.

Customers are unlikely to use such old drivers.

Documentation for the driver is very likely to be stale since then.