### PR TITLE
Keep defaultValue for a parameter spec normalized to string

### DIFF
--- a/plugins/core-plugin/src/main/java/com/google/cloud/teleport/plugin/model/ImageSpecParameter.java
+++ b/plugins/core-plugin/src/main/java/com/google/cloud/teleport/plugin/model/ImageSpecParameter.java
@@ -34,7 +34,7 @@ public class ImageSpecParameter {
   private List<String> regexes;
   private List<ImageSpecParameterEnumOption> enumOptions;
   private ImageSpecParameterType paramType;
-  private Object defaultValue;
+  private String defaultValue;
 
   public String getName() {
     return name;
@@ -100,11 +100,11 @@ public class ImageSpecParameter {
     return isOptional;
   }
 
-  public Object getDefaultValue() {
+  public String getDefaultValue() {
     return defaultValue;
   }
 
-  public void setDefaultValue(Object defaultValue) {
+  public void setDefaultValue(String defaultValue) {
     this.defaultValue = defaultValue;
   }
 

--- a/plugins/core-plugin/src/main/java/com/google/cloud/teleport/plugin/model/TemplateDefinitions.java
+++ b/plugins/core-plugin/src/main/java/com/google/cloud/teleport/plugin/model/TemplateDefinitions.java
@@ -230,7 +230,10 @@ public class TemplateDefinitions {
       }
 
       // Set the default value, if any
-      parameter.setDefaultValue(getDefault(method.getDefiningMethod()));
+      Object defaultVal = getDefault(method.getDefiningMethod());
+      if (defaultVal != null) {
+        parameter.setDefaultValue(String.valueOf(defaultVal));
+      }
 
       if (parameterNames.add(parameter.getName())) {
         metadata.getParameters().add(parameter);


### PR DESCRIPTION
This avoids having to do some type conversions when we'll put in the parameter proto