### PR TITLE
Revert auto-value version to 1.8.2, intermittently getting "Stream closed"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <jackson.version>2.14.1</jackson.version>
 
     <!-- Common dependency versions -->
-    <autovalue.version>1.10.2</autovalue.version>
+    <autovalue.version>1.8.2</autovalue.version>
     <avro.version>1.11.1</avro.version>
     <checkstyle.version>10.7.0</checkstyle.version>
     <commons-codec.version>1.15</commons-codec.version>


### PR DESCRIPTION
Filed https://github.com/google/auto/issues/1572 and rolling it back for now