### PR TITLE
[Security] Upgrade snappy-java to 1.1.10.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
     <re2j.version>1.6</re2j.version>
     <slf4j.version>1.7.36</slf4j.version>
     <snakeyaml.version>2.0</snakeyaml.version>
+    <snappy.version>1.1.10.3</snappy.version>
     <spotless-maven-plugin.version>2.12.1</spotless-maven-plugin.version>
     <surefire.version>2.21.0</surefire.version>
     <truth.version>1.0.1</truth.version>
@@ -174,6 +175,13 @@
         <groupId>org.neo4j.driver</groupId>
         <artifactId>neo4j-java-driver</artifactId>
         <version>${neo4j-driver.version}</version>
+      </dependency>
+
+      <!-- Enforce non-vulnerable version of snappy-java -->
+      <dependency>
+        <groupId>org.xerial.snappy</groupId>
+        <artifactId>snappy-java</artifactId>
+        <version>${snappy.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Current `snappy-java` is within the range for a couple of recent CVEs:

CVE-2023-34455 [High]
CVE-2023-34454 [Moderate]
CVE-2023-34453 [Moderate]

(See https://mvnrepository.com/artifact/org.xerial.snappy/snappy-java/1.1.10.0)
