### PR TITLE
Fix stale documentation around `batchCount`

### DIFF
--- a/v1/README_Cassandra_To_Cloud_Bigtable.md
+++ b/v1/README_Cassandra_To_Cloud_Bigtable.md
@@ -121,7 +121,7 @@ export BIGTABLE_INSTANCE_ID=<bigtableInstanceId>
 export BIGTABLE_TABLE_ID=<bigtableTableId>
 
 ### Optional
-export CASSANDRA_PORT=9042
+export CASSANDRA_PORT="9042"
 export DEFAULT_COLUMN_FAMILY="default"
 export ROW_KEY_SEPARATOR="#"
 export SPLIT_LARGE_ROWS=<splitLargeRows>
@@ -166,7 +166,7 @@ export BIGTABLE_INSTANCE_ID=<bigtableInstanceId>
 export BIGTABLE_TABLE_ID=<bigtableTableId>
 
 ### Optional
-export CASSANDRA_PORT=9042
+export CASSANDRA_PORT="9042"
 export DEFAULT_COLUMN_FAMILY="default"
 export ROW_KEY_SEPARATOR="#"
 export SPLIT_LARGE_ROWS=<splitLargeRows>

--- a/v1/README_Cloud_BigQuery_to_Cloud_Datastore.md
+++ b/v1/README_Cloud_BigQuery_to_Cloud_Datastore.md
@@ -121,7 +121,7 @@ export READ_ID_COLUMN=<readIdColumn>
 export INVALID_OUTPUT_PATH=<invalidOutputPath>
 export DATASTORE_WRITE_ENTITY_KIND=<datastoreWriteEntityKind>
 export DATASTORE_WRITE_NAMESPACE=<datastoreWriteNamespace>
-export DATASTORE_HINT_NUM_WORKERS=500
+export DATASTORE_HINT_NUM_WORKERS="500"
 
 gcloud dataflow jobs run "cloud-bigquery-to-cloud-datastore-job" \
   --project "$PROJECT" \
@@ -162,7 +162,7 @@ export READ_ID_COLUMN=<readIdColumn>
 export INVALID_OUTPUT_PATH=<invalidOutputPath>
 export DATASTORE_WRITE_ENTITY_KIND=<datastoreWriteEntityKind>
 export DATASTORE_WRITE_NAMESPACE=<datastoreWriteNamespace>
-export DATASTORE_HINT_NUM_WORKERS=500
+export DATASTORE_HINT_NUM_WORKERS="500"
 
 mvn clean package -PtemplatesRun \
 -DskipTests \

--- a/v1/README_Cloud_BigQuery_to_GCS_TensorFlow_Records.md
+++ b/v1/README_Cloud_BigQuery_to_GCS_TensorFlow_Records.md
@@ -119,9 +119,9 @@ export OUTPUT_DIRECTORY=<outputDirectory>
 export READ_ID_COLUMN=<readIdColumn>
 export INVALID_OUTPUT_PATH=<invalidOutputPath>
 export OUTPUT_SUFFIX=".tfrecord"
-export TRAINING_PERCENTAGE=1
-export TESTING_PERCENTAGE=0
-export VALIDATION_PERCENTAGE=0
+export TRAINING_PERCENTAGE="1.0"
+export TESTING_PERCENTAGE="0.0"
+export VALIDATION_PERCENTAGE="0.0"
 
 gcloud dataflow jobs run "cloud-bigquery-to-gcs-tensorflow-records-job" \
   --project "$PROJECT" \
@@ -160,9 +160,9 @@ export OUTPUT_DIRECTORY=<outputDirectory>
 export READ_ID_COLUMN=<readIdColumn>
 export INVALID_OUTPUT_PATH=<invalidOutputPath>
 export OUTPUT_SUFFIX=".tfrecord"
-export TRAINING_PERCENTAGE=1
-export TESTING_PERCENTAGE=0
-export VALIDATION_PERCENTAGE=0
+export TRAINING_PERCENTAGE="1.0"
+export TESTING_PERCENTAGE="0.0"
+export VALIDATION_PERCENTAGE="0.0"
 
 mvn clean package -PtemplatesRun \
 -DskipTests \

--- a/v1/README_Cloud_Bigtable_to_GCS_Parquet.md
+++ b/v1/README_Cloud_Bigtable_to_GCS_Parquet.md
@@ -116,7 +116,7 @@ export OUTPUT_DIRECTORY=<outputDirectory>
 export FILENAME_PREFIX="part"
 
 ### Optional
-export NUM_SHARDS=0
+export NUM_SHARDS="0"
 
 gcloud dataflow jobs run "cloud-bigtable-to-gcs-parquet-job" \
   --project "$PROJECT" \
@@ -153,7 +153,7 @@ export OUTPUT_DIRECTORY=<outputDirectory>
 export FILENAME_PREFIX="part"
 
 ### Optional
-export NUM_SHARDS=0
+export NUM_SHARDS="0"
 
 mvn clean package -PtemplatesRun \
 -DskipTests \

--- a/v1/README_Cloud_Bigtable_to_GCS_SequenceFile.md
+++ b/v1/README_Cloud_Bigtable_to_GCS_SequenceFile.md
@@ -123,7 +123,7 @@ export FILENAME_PREFIX="part"
 export BIGTABLE_APP_PROFILE_ID=<bigtableAppProfileId>
 export BIGTABLE_START_ROW=""
 export BIGTABLE_STOP_ROW=""
-export BIGTABLE_MAX_VERSIONS=2147483647
+export BIGTABLE_MAX_VERSIONS="2147483647"
 export BIGTABLE_FILTER=""
 
 gcloud dataflow jobs run "cloud-bigtable-to-gcs-sequencefile-job" \
@@ -168,7 +168,7 @@ export FILENAME_PREFIX="part"
 export BIGTABLE_APP_PROFILE_ID=<bigtableAppProfileId>
 export BIGTABLE_START_ROW=""
 export BIGTABLE_STOP_ROW=""
-export BIGTABLE_MAX_VERSIONS=2147483647
+export BIGTABLE_MAX_VERSIONS="2147483647"
 export BIGTABLE_FILTER=""
 
 mvn clean package -PtemplatesRun \

--- a/v1/README_Cloud_PubSub_to_Datadog.md
+++ b/v1/README_Cloud_PubSub_to_Datadog.md
@@ -22,7 +22,7 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 ### Optional Parameters
 
 * **apiKey** (Logs API key.): Datadog Logs API key. Must be provided if the apiKeySource is set to PLAINTEXT or KMS. See: https://docs.datadoghq.com/account_management/api-app-keys.
-* **batchCount** (Batch size for sending multiple events to Datadog Logs API.): Batch size for sending multiple events to Datadog Logs API. Defaults to 10. Max is 1000.
+* **batchCount** (Batch size for sending multiple events to Datadog Logs API.): Batch size for sending multiple events to Datadog Logs API. Min is 10. Max is 1000. Defaults to 100.
 * **parallelism** (Maximum number of parallel requests.): Maximum number of parallel requests. Default 1 (no parallelism).
 * **includePubsubMessage** (Include full Pub/Sub message in the payload.): Include full Pub/Sub message in the payload (true/false). Defaults to false (only data element is included in the payload).
 * **apiKeyKMSEncryptionKey** (Google Cloud KMS encryption key for the API key): The Cloud KMS key to decrypt the Logs API key. This parameter must be provided if the apiKeySource is set to KMS. If this parameter is provided, apiKey string should be passed in encrypted. Encrypt parameters using the KMS API encrypt endpoint. The Key should be in the format projects/{gcp_project}/locations/{key_region}/keyRings/{key_ring}/cryptoKeys/{kms_key_name}. See: https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys/encrypt  (Example: projects/your-project-id/locations/global/keyRings/your-keyring/cryptoKeys/your-key-name).
@@ -142,7 +142,7 @@ export API_KEY_SOURCE=<apiKeySource>
 export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
 export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
 export JAVASCRIPT_FUNCTION_RELOAD=<javascriptFunctionReload>
-export JAVASCRIPT_RELOAD_INTERVAL_MINUTES=60
+export JAVASCRIPT_RELOAD_INTERVAL_MINUTES="60"
 
 gcloud dataflow jobs run "cloud-pubsub-to-datadog-job" \
   --project "$PROJECT" \
@@ -195,7 +195,7 @@ export API_KEY_SOURCE=<apiKeySource>
 export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
 export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
 export JAVASCRIPT_FUNCTION_RELOAD=<javascriptFunctionReload>
-export JAVASCRIPT_RELOAD_INTERVAL_MINUTES=60
+export JAVASCRIPT_RELOAD_INTERVAL_MINUTES="60"
 
 mvn clean package -PtemplatesRun \
 -DskipTests \

--- a/v1/README_Cloud_PubSub_to_Splunk.md
+++ b/v1/README_Cloud_PubSub_to_Splunk.md
@@ -145,12 +145,12 @@ export TOKEN_KMSENCRYPTION_KEY=<tokenKMSEncryptionKey>
 export TOKEN_SECRET_ID=<tokenSecretId>
 export TOKEN_SOURCE=<tokenSource>
 export ROOT_CA_CERTIFICATE_PATH=<rootCaCertificatePath>
-export ENABLE_BATCH_LOGS=true
-export ENABLE_GZIP_HTTP_COMPRESSION=true
+export ENABLE_BATCH_LOGS="true"
+export ENABLE_GZIP_HTTP_COMPRESSION="true"
 export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
 export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
 export JAVASCRIPT_FUNCTION_RELOAD=<javascriptFunctionReload>
-export JAVASCRIPT_RELOAD_INTERVAL_MINUTES=60
+export JAVASCRIPT_RELOAD_INTERVAL_MINUTES="60"
 
 gcloud dataflow jobs run "cloud-pubsub-to-splunk-job" \
   --project "$PROJECT" \
@@ -206,12 +206,12 @@ export TOKEN_KMSENCRYPTION_KEY=<tokenKMSEncryptionKey>
 export TOKEN_SECRET_ID=<tokenSecretId>
 export TOKEN_SOURCE=<tokenSource>
 export ROOT_CA_CERTIFICATE_PATH=<rootCaCertificatePath>
-export ENABLE_BATCH_LOGS=true
-export ENABLE_GZIP_HTTP_COMPRESSION=true
+export ENABLE_BATCH_LOGS="true"
+export ENABLE_GZIP_HTTP_COMPRESSION="true"
 export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
 export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
 export JAVASCRIPT_FUNCTION_RELOAD=<javascriptFunctionReload>
-export JAVASCRIPT_RELOAD_INTERVAL_MINUTES=60
+export JAVASCRIPT_RELOAD_INTERVAL_MINUTES="60"
 
 mvn clean package -PtemplatesRun \
 -DskipTests \

--- a/v1/README_Cloud_Spanner_to_GCS_Avro.md
+++ b/v1/README_Cloud_Spanner_to_GCS_Avro.md
@@ -124,11 +124,11 @@ export AVRO_TEMP_DIRECTORY=<avroTempDirectory>
 export SPANNER_HOST="https://batch-spanner.googleapis.com"
 export SNAPSHOT_TIME=""
 export SPANNER_PROJECT_ID=<spannerProjectId>
-export SHOULD_EXPORT_TIMESTAMP_AS_LOGICAL_TYPE=false
+export SHOULD_EXPORT_TIMESTAMP_AS_LOGICAL_TYPE="false"
 export TABLE_NAMES=""
-export SHOULD_EXPORT_RELATED_TABLES=false
+export SHOULD_EXPORT_RELATED_TABLES="false"
 export SPANNER_PRIORITY=<spannerPriority>
-export DATA_BOOST_ENABLED=false
+export DATA_BOOST_ENABLED="false"
 
 gcloud dataflow jobs run "cloud-spanner-to-gcs-avro-job" \
   --project "$PROJECT" \
@@ -173,11 +173,11 @@ export AVRO_TEMP_DIRECTORY=<avroTempDirectory>
 export SPANNER_HOST="https://batch-spanner.googleapis.com"
 export SNAPSHOT_TIME=""
 export SPANNER_PROJECT_ID=<spannerProjectId>
-export SHOULD_EXPORT_TIMESTAMP_AS_LOGICAL_TYPE=false
+export SHOULD_EXPORT_TIMESTAMP_AS_LOGICAL_TYPE="false"
 export TABLE_NAMES=""
-export SHOULD_EXPORT_RELATED_TABLES=false
+export SHOULD_EXPORT_RELATED_TABLES="false"
 export SPANNER_PRIORITY=<spannerPriority>
-export DATA_BOOST_ENABLED=false
+export DATA_BOOST_ENABLED="false"
 
 mvn clean package -PtemplatesRun \
 -DskipTests \

--- a/v1/README_Datastore_to_Datastore_Delete.md
+++ b/v1/README_Datastore_to_Datastore_Delete.md
@@ -128,7 +128,7 @@ export DATASTORE_DELETE_PROJECT_ID=<datastoreDeleteProjectId>
 export DATASTORE_READ_NAMESPACE=<datastoreReadNamespace>
 export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
 export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
-export DATASTORE_HINT_NUM_WORKERS=500
+export DATASTORE_HINT_NUM_WORKERS="500"
 
 gcloud dataflow jobs run "datastore-to-datastore-delete-job" \
   --project "$PROJECT" \
@@ -167,7 +167,7 @@ export DATASTORE_DELETE_PROJECT_ID=<datastoreDeleteProjectId>
 export DATASTORE_READ_NAMESPACE=<datastoreReadNamespace>
 export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
 export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
-export DATASTORE_HINT_NUM_WORKERS=500
+export DATASTORE_HINT_NUM_WORKERS="500"
 
 mvn clean package -PtemplatesRun \
 -DskipTests \

--- a/v1/README_Datastore_to_GCS_Text.md
+++ b/v1/README_Datastore_to_GCS_Text.md
@@ -128,7 +128,7 @@ export TEXT_WRITE_PREFIX=<textWritePrefix>
 export DATASTORE_READ_NAMESPACE=<datastoreReadNamespace>
 export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
 export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
-export JAVASCRIPT_RELOAD_INTERVAL_MINUTES=60
+export JAVASCRIPT_RELOAD_INTERVAL_MINUTES="60"
 
 gcloud dataflow jobs run "datastore-to-gcs-text-job" \
   --project "$PROJECT" \
@@ -167,7 +167,7 @@ export TEXT_WRITE_PREFIX=<textWritePrefix>
 export DATASTORE_READ_NAMESPACE=<datastoreReadNamespace>
 export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
 export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
-export JAVASCRIPT_RELOAD_INTERVAL_MINUTES=60
+export JAVASCRIPT_RELOAD_INTERVAL_MINUTES="60"
 
 mvn clean package -PtemplatesRun \
 -DskipTests \

--- a/v1/README_Firestore_to_Firestore_Delete.md
+++ b/v1/README_Firestore_to_Firestore_Delete.md
@@ -126,7 +126,7 @@ export FIRESTORE_DELETE_PROJECT_ID=<firestoreDeleteProjectId>
 
 ### Optional
 export FIRESTORE_READ_NAMESPACE=<firestoreReadNamespace>
-export FIRESTORE_HINT_NUM_WORKERS=500
+export FIRESTORE_HINT_NUM_WORKERS="500"
 export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
 export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
 
@@ -165,7 +165,7 @@ export FIRESTORE_DELETE_PROJECT_ID=<firestoreDeleteProjectId>
 
 ### Optional
 export FIRESTORE_READ_NAMESPACE=<firestoreReadNamespace>
-export FIRESTORE_HINT_NUM_WORKERS=500
+export FIRESTORE_HINT_NUM_WORKERS="500"
 export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
 export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
 

--- a/v1/README_GCS_Avro_to_Cloud_Spanner.md
+++ b/v1/README_GCS_Avro_to_Cloud_Spanner.md
@@ -25,6 +25,7 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 * **waitForIndexes** (Wait for Indexes): By default the import pipeline is not blocked on index creation, and it may complete with indexes still being created in the background. In testing, it may be useful to set this option to false so that the pipeline waits until indexes are finished.
 * **waitForForeignKeys** (Wait for Foreign Keys): By default the import pipeline is not blocked on foreign key creation, and it may complete with foreign keys still being created in the background. In testing, it may be useful to set this option to false so that the pipeline waits until foreign keys are finished.
 * **waitForChangeStreams** (Wait for Foreign Keys): By default the import pipeline is blocked on change stream creation. If false, it may complete with change streams still being created in the background.
+* **waitForSequences** (Wait for Sequences): By default the import pipeline is blocked on sequence creation. If false, it may complete with sequences still being created in the background.
 * **earlyIndexCreateFlag** (Create Indexes early): Flag to turn off early index creation if there are many indexes. Indexes and Foreign keys are created after dataload. If there are more than 40 DDL statements to be executed after dataload, it is preferable to create the indexes before datalod. This is the flag to turn the feature off. Defaults to: true.
 * **spannerProjectId** (Cloud Spanner Project Id): The project id of the Cloud Spanner instance.
 * **ddlCreationTimeoutInMinutes** (DDL Creation timeout in minutes): DDL Creation timeout in minutes. Defaults to: 30.
@@ -120,12 +121,13 @@ export INPUT_DIR=<inputDir>
 
 ### Optional
 export SPANNER_HOST="https://batch-spanner.googleapis.com"
-export WAIT_FOR_INDEXES=false
-export WAIT_FOR_FOREIGN_KEYS=false
-export WAIT_FOR_CHANGE_STREAMS=true
-export EARLY_INDEX_CREATE_FLAG=true
+export WAIT_FOR_INDEXES="false"
+export WAIT_FOR_FOREIGN_KEYS="false"
+export WAIT_FOR_CHANGE_STREAMS="true"
+export WAIT_FOR_SEQUENCES="true"
+export EARLY_INDEX_CREATE_FLAG="true"
 export SPANNER_PROJECT_ID=<spannerProjectId>
-export DDL_CREATION_TIMEOUT_IN_MINUTES=30
+export DDL_CREATION_TIMEOUT_IN_MINUTES="30"
 export SPANNER_PRIORITY=<spannerPriority>
 
 gcloud dataflow jobs run "gcs-avro-to-cloud-spanner-job" \
@@ -139,6 +141,7 @@ gcloud dataflow jobs run "gcs-avro-to-cloud-spanner-job" \
   --parameters "waitForIndexes=$WAIT_FOR_INDEXES" \
   --parameters "waitForForeignKeys=$WAIT_FOR_FOREIGN_KEYS" \
   --parameters "waitForChangeStreams=$WAIT_FOR_CHANGE_STREAMS" \
+  --parameters "waitForSequences=$WAIT_FOR_SEQUENCES" \
   --parameters "earlyIndexCreateFlag=$EARLY_INDEX_CREATE_FLAG" \
   --parameters "spannerProjectId=$SPANNER_PROJECT_ID" \
   --parameters "ddlCreationTimeoutInMinutes=$DDL_CREATION_TIMEOUT_IN_MINUTES" \
@@ -167,12 +170,13 @@ export INPUT_DIR=<inputDir>
 
 ### Optional
 export SPANNER_HOST="https://batch-spanner.googleapis.com"
-export WAIT_FOR_INDEXES=false
-export WAIT_FOR_FOREIGN_KEYS=false
-export WAIT_FOR_CHANGE_STREAMS=true
-export EARLY_INDEX_CREATE_FLAG=true
+export WAIT_FOR_INDEXES="false"
+export WAIT_FOR_FOREIGN_KEYS="false"
+export WAIT_FOR_CHANGE_STREAMS="true"
+export WAIT_FOR_SEQUENCES="true"
+export EARLY_INDEX_CREATE_FLAG="true"
 export SPANNER_PROJECT_ID=<spannerProjectId>
-export DDL_CREATION_TIMEOUT_IN_MINUTES=30
+export DDL_CREATION_TIMEOUT_IN_MINUTES="30"
 export SPANNER_PRIORITY=<spannerPriority>
 
 mvn clean package -PtemplatesRun \
@@ -182,7 +186,7 @@ mvn clean package -PtemplatesRun \
 -Dregion="$REGION" \
 -DjobName="gcs-avro-to-cloud-spanner-job" \
 -DtemplateName="GCS_Avro_to_Cloud_Spanner" \
--Dparameters="instanceId=$INSTANCE_ID,databaseId=$DATABASE_ID,inputDir=$INPUT_DIR,spannerHost=$SPANNER_HOST,waitForIndexes=$WAIT_FOR_INDEXES,waitForForeignKeys=$WAIT_FOR_FOREIGN_KEYS,waitForChangeStreams=$WAIT_FOR_CHANGE_STREAMS,earlyIndexCreateFlag=$EARLY_INDEX_CREATE_FLAG,spannerProjectId=$SPANNER_PROJECT_ID,ddlCreationTimeoutInMinutes=$DDL_CREATION_TIMEOUT_IN_MINUTES,spannerPriority=$SPANNER_PRIORITY" \
+-Dparameters="instanceId=$INSTANCE_ID,databaseId=$DATABASE_ID,inputDir=$INPUT_DIR,spannerHost=$SPANNER_HOST,waitForIndexes=$WAIT_FOR_INDEXES,waitForForeignKeys=$WAIT_FOR_FOREIGN_KEYS,waitForChangeStreams=$WAIT_FOR_CHANGE_STREAMS,waitForSequences=$WAIT_FOR_SEQUENCES,earlyIndexCreateFlag=$EARLY_INDEX_CREATE_FLAG,spannerProjectId=$SPANNER_PROJECT_ID,ddlCreationTimeoutInMinutes=$DDL_CREATION_TIMEOUT_IN_MINUTES,spannerPriority=$SPANNER_PRIORITY" \
 -pl v1 \
 -am
 ```

--- a/v1/README_GCS_SequenceFile_to_Cloud_Bigtable.md
+++ b/v1/README_GCS_SequenceFile_to_Cloud_Bigtable.md
@@ -113,7 +113,7 @@ export BIGTABLE_PROJECT=<bigtableProject>
 export BIGTABLE_INSTANCE_ID=<bigtableInstanceId>
 export BIGTABLE_TABLE_ID=<bigtableTableId>
 export SOURCE_PATTERN=<sourcePattern>
-export MUTATION_THROTTLE_LATENCY_MS=0
+export MUTATION_THROTTLE_LATENCY_MS="0"
 
 ### Optional
 export BIGTABLE_APP_PROFILE_ID=<bigtableAppProfileId>
@@ -150,7 +150,7 @@ export BIGTABLE_PROJECT=<bigtableProject>
 export BIGTABLE_INSTANCE_ID=<bigtableInstanceId>
 export BIGTABLE_TABLE_ID=<bigtableTableId>
 export SOURCE_PATTERN=<sourcePattern>
-export MUTATION_THROTTLE_LATENCY_MS=0
+export MUTATION_THROTTLE_LATENCY_MS="0"
 
 ### Optional
 export BIGTABLE_APP_PROFILE_ID=<bigtableAppProfileId>

--- a/v1/README_GCS_Text_to_Cloud_Spanner.md
+++ b/v1/README_GCS_Text_to_Cloud_Spanner.md
@@ -126,14 +126,14 @@ export IMPORT_MANIFEST=<importManifest>
 export SPANNER_HOST="https://batch-spanner.googleapis.com"
 export COLUMN_DELIMITER=","
 export FIELD_QUALIFIER="\""
-export TRAILING_DELIMITER=true
+export TRAILING_DELIMITER="true"
 export ESCAPE=<escape>
 export NULL_STRING=<nullString>
 export DATE_FORMAT=<dateFormat>
 export TIMESTAMP_FORMAT=<timestampFormat>
 export SPANNER_PROJECT_ID=<spannerProjectId>
 export SPANNER_PRIORITY=<spannerPriority>
-export HANDLE_NEW_LINE=false
+export HANDLE_NEW_LINE="false"
 export INVALID_OUTPUT_PATH=""
 
 gcloud dataflow jobs run "gcs-text-to-cloud-spanner-job" \
@@ -181,14 +181,14 @@ export IMPORT_MANIFEST=<importManifest>
 export SPANNER_HOST="https://batch-spanner.googleapis.com"
 export COLUMN_DELIMITER=","
 export FIELD_QUALIFIER="\""
-export TRAILING_DELIMITER=true
+export TRAILING_DELIMITER="true"
 export ESCAPE=<escape>
 export NULL_STRING=<nullString>
 export DATE_FORMAT=<dateFormat>
 export TIMESTAMP_FORMAT=<timestampFormat>
 export SPANNER_PROJECT_ID=<spannerProjectId>
 export SPANNER_PRIORITY=<spannerPriority>
-export HANDLE_NEW_LINE=false
+export HANDLE_NEW_LINE="false"
 export INVALID_OUTPUT_PATH=""
 
 mvn clean package -PtemplatesRun \

--- a/v1/README_GCS_Text_to_Datastore.md
+++ b/v1/README_GCS_Text_to_Datastore.md
@@ -131,10 +131,10 @@ export ERROR_WRITE_PATH=<errorWritePath>
 export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
 export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
 export JAVASCRIPT_FUNCTION_RELOAD=<javascriptFunctionReload>
-export JAVASCRIPT_RELOAD_INTERVAL_MINUTES=60
+export JAVASCRIPT_RELOAD_INTERVAL_MINUTES="60"
 export DATASTORE_WRITE_ENTITY_KIND=<datastoreWriteEntityKind>
 export DATASTORE_WRITE_NAMESPACE=<datastoreWriteNamespace>
-export DATASTORE_HINT_NUM_WORKERS=500
+export DATASTORE_HINT_NUM_WORKERS="500"
 
 gcloud dataflow jobs run "gcs-text-to-datastore-job" \
   --project "$PROJECT" \
@@ -176,10 +176,10 @@ export ERROR_WRITE_PATH=<errorWritePath>
 export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
 export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
 export JAVASCRIPT_FUNCTION_RELOAD=<javascriptFunctionReload>
-export JAVASCRIPT_RELOAD_INTERVAL_MINUTES=60
+export JAVASCRIPT_RELOAD_INTERVAL_MINUTES="60"
 export DATASTORE_WRITE_ENTITY_KIND=<datastoreWriteEntityKind>
 export DATASTORE_WRITE_NAMESPACE=<datastoreWriteNamespace>
-export DATASTORE_HINT_NUM_WORKERS=500
+export DATASTORE_HINT_NUM_WORKERS="500"
 
 mvn clean package -PtemplatesRun \
 -DskipTests \

--- a/v1/README_Jdbc_to_BigQuery.md
+++ b/v1/README_Jdbc_to_BigQuery.md
@@ -129,7 +129,7 @@ export CONNECTION_PROPERTIES=<connectionProperties>
 export USERNAME=<username>
 export PASSWORD=<password>
 export KMSENCRYPTION_KEY=<KMSEncryptionKey>
-export USE_COLUMN_ALIAS=false
+export USE_COLUMN_ALIAS="false"
 export DISABLED_ALGORITHMS=<disabledAlgorithms>
 export EXTRA_FILES_TO_STAGE=<extraFilesToStage>
 
@@ -180,7 +180,7 @@ export CONNECTION_PROPERTIES=<connectionProperties>
 export USERNAME=<username>
 export PASSWORD=<password>
 export KMSENCRYPTION_KEY=<KMSEncryptionKey>
-export USE_COLUMN_ALIAS=false
+export USE_COLUMN_ALIAS="false"
 export DISABLED_ALGORITHMS=<disabledAlgorithms>
 export EXTRA_FILES_TO_STAGE=<extraFilesToStage>
 

--- a/v1/README_PubSub_Subscription_to_BigQuery.md
+++ b/v1/README_PubSub_Subscription_to_BigQuery.md
@@ -128,7 +128,7 @@ export OUTPUT_DEADLETTER_TABLE=<outputDeadletterTable>
 export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
 export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
 export JAVASCRIPT_FUNCTION_RELOAD=<javascriptFunctionReload>
-export JAVASCRIPT_RELOAD_INTERVAL_MINUTES=60
+export JAVASCRIPT_RELOAD_INTERVAL_MINUTES="60"
 
 gcloud dataflow jobs run "pubsub-subscription-to-bigquery-job" \
   --project "$PROJECT" \
@@ -167,7 +167,7 @@ export OUTPUT_DEADLETTER_TABLE=<outputDeadletterTable>
 export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
 export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
 export JAVASCRIPT_FUNCTION_RELOAD=<javascriptFunctionReload>
-export JAVASCRIPT_RELOAD_INTERVAL_MINUTES=60
+export JAVASCRIPT_RELOAD_INTERVAL_MINUTES="60"
 
 mvn clean package -PtemplatesRun \
 -DskipTests \

--- a/v1/README_PubSub_to_BigQuery.md
+++ b/v1/README_PubSub_to_BigQuery.md
@@ -128,7 +128,7 @@ export OUTPUT_DEADLETTER_TABLE=<outputDeadletterTable>
 export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
 export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
 export JAVASCRIPT_FUNCTION_RELOAD=<javascriptFunctionReload>
-export JAVASCRIPT_RELOAD_INTERVAL_MINUTES=60
+export JAVASCRIPT_RELOAD_INTERVAL_MINUTES="60"
 
 gcloud dataflow jobs run "pubsub-to-bigquery-job" \
   --project "$PROJECT" \
@@ -167,7 +167,7 @@ export OUTPUT_DEADLETTER_TABLE=<outputDeadletterTable>
 export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
 export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
 export JAVASCRIPT_FUNCTION_RELOAD=<javascriptFunctionReload>
-export JAVASCRIPT_RELOAD_INTERVAL_MINUTES=60
+export JAVASCRIPT_RELOAD_INTERVAL_MINUTES="60"
 
 mvn clean package -PtemplatesRun \
 -DskipTests \

--- a/v1/README_Spanner_to_GCS_Text.md
+++ b/v1/README_Spanner_to_GCS_Text.md
@@ -124,7 +124,7 @@ export CSV_TEMP_DIRECTORY=<csvTempDirectory>
 export SPANNER_PRIORITY=<spannerPriority>
 export SPANNER_HOST="https://batch-spanner.googleapis.com"
 export SPANNER_SNAPSHOT_TIME=""
-export DATA_BOOST_ENABLED=false
+export DATA_BOOST_ENABLED="false"
 
 gcloud dataflow jobs run "spanner-to-gcs-text-job" \
   --project "$PROJECT" \
@@ -169,7 +169,7 @@ export CSV_TEMP_DIRECTORY=<csvTempDirectory>
 export SPANNER_PRIORITY=<spannerPriority>
 export SPANNER_HOST="https://batch-spanner.googleapis.com"
 export SPANNER_SNAPSHOT_TIME=""
-export DATA_BOOST_ENABLED=false
+export DATA_BOOST_ENABLED="false"
 
 mvn clean package -PtemplatesRun \
 -DskipTests \

--- a/v1/README_Stream_GCS_Text_to_BigQuery.md
+++ b/v1/README_Stream_GCS_Text_to_BigQuery.md
@@ -155,7 +155,7 @@ export OUTPUT_DEADLETTER_TABLE=<outputDeadletterTable>
 export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
 export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
 export JAVASCRIPT_FUNCTION_RELOAD=<javascriptFunctionReload>
-export JAVASCRIPT_RELOAD_INTERVAL_MINUTES=60
+export JAVASCRIPT_RELOAD_INTERVAL_MINUTES="60"
 
 gcloud dataflow jobs run "stream-gcs-text-to-bigquery-job" \
   --project "$PROJECT" \
@@ -198,7 +198,7 @@ export OUTPUT_DEADLETTER_TABLE=<outputDeadletterTable>
 export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
 export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
 export JAVASCRIPT_FUNCTION_RELOAD=<javascriptFunctionReload>
-export JAVASCRIPT_RELOAD_INTERVAL_MINUTES=60
+export JAVASCRIPT_RELOAD_INTERVAL_MINUTES="60"
 
 mvn clean package -PtemplatesRun \
 -DskipTests \

--- a/v1/src/main/java/com/google/cloud/teleport/templates/common/DatadogConverters.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/common/DatadogConverters.java
@@ -114,7 +114,7 @@ public class DatadogConverters {
         optional = true,
         description = "Batch size for sending multiple events to Datadog Logs API.",
         helpText =
-            "Batch size for sending multiple events to Datadog Logs API. Defaults to 10. Max is 1000.")
+            "Batch size for sending multiple events to Datadog Logs API. Min is 10. Max is 1000. Defaults to 100.")
     ValueProvider<Integer> getBatchCount();
 
     void setBatchCount(ValueProvider<Integer> batchCount);


### PR DESCRIPTION
Follow-up to https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/854

Just fixing the documentation to reflect the code, my fault I missed it the first pass.

Just FYI, re-generating the markdown docs ended up with a lot of changes (around quoting shell variables), only committing the relevant ones but wanted to mention it.

```
	modified:   v1/README_Cassandra_To_Cloud_Bigtable.md
	modified:   v1/README_Cloud_BigQuery_to_Cloud_Datastore.md
	modified:   v1/README_Cloud_BigQuery_to_GCS_TensorFlow_Records.md
	modified:   v1/README_Cloud_Bigtable_to_GCS_Parquet.md
	modified:   v1/README_Cloud_Bigtable_to_GCS_SequenceFile.md
	modified:   v1/README_Cloud_PubSub_to_Splunk.md
	modified:   v1/README_Cloud_Spanner_to_GCS_Avro.md
	modified:   v1/README_Datastore_to_Datastore_Delete.md
	modified:   v1/README_Datastore_to_GCS_Text.md
	modified:   v1/README_Firestore_to_Firestore_Delete.md
	modified:   v1/README_GCS_Avro_to_Cloud_Spanner.md
	modified:   v1/README_GCS_SequenceFile_to_Cloud_Bigtable.md
	modified:   v1/README_GCS_Text_to_Cloud_Spanner.md
	modified:   v1/README_GCS_Text_to_Datastore.md
	modified:   v1/README_Jdbc_to_BigQuery.md
	modified:   v1/README_PubSub_Subscription_to_BigQuery.md
	modified:   v1/README_PubSub_to_BigQuery.md
	modified:   v1/README_Spanner_to_GCS_Text.md
	modified:   v1/README_Stream_GCS_Text_to_BigQuery.md
```