### PR TITLE
Add integration tests for Bigtable CDC to GCS template

### DIFF
--- a/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/changelogentry-text.avsc
+++ b/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/changelogentry-text.avsc
@@ -16,10 +16,10 @@
       { "name": "columnFamily", "type": "string"},
       { "name": "commitTimestamp", "type" : "long"},
       { "name": "lowWatermark", "type" : "long"},
-      { "name": "column", "type" : ["string", "null"]},
-      { "name": "timestamp", "type" : ["long", "null"]},
-      { "name": "timestampFrom", "type" : ["long", "null"]},
-      { "name": "timestampTo", "type" : ["long", "null"]},
-      { "name" : "value", "type" : ["string", "null"]}
+      { "name": "column", "type" : ["null", "string"]},
+      { "name": "timestamp", "type" : ["null", "long"]},
+      { "name": "timestampFrom", "type" : ["null", "long"]},
+      { "name": "timestampTo", "type" : ["null", "long"]},
+      { "name" : "value", "type" : ["null", "string"]}
     ]
 }

--- a/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/changelogentry.avsc
+++ b/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/changelogentry.avsc
@@ -16,10 +16,10 @@
       { "name": "columnFamily", "type": "string"},
       { "name": "commitTimestamp", "type" : "long"},
       { "name": "lowWatermark", "type" : "long"},
-      { "name": "column", "type" : ["bytes", "null"]},
-      { "name": "timestamp", "type" : ["long", "null"]},
-      { "name": "timestampFrom", "type" : ["long", "null"]},
-      { "name": "timestampTo", "type" : ["long", "null"]},
-      { "name" : "value", "type" : ["bytes", "null"]}
+      { "name": "column", "type" : ["null", "bytes"]},
+      { "name": "timestamp", "type" : ["null", "long"]},
+      { "name": "timestampFrom", "type" : ["null", "long"]},
+      { "name": "timestampTo", "type" : ["null", "long"]},
+      { "name" : "value", "type" : ["null", "bytes"]}
     ]
 }

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangeStreamsToGcsIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangeStreamsToGcsIT.java
@@ -1,0 +1,608 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.bigtable.admin.v2.models.StorageType;
+import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.teleport.bigtable.ChangelogEntry;
+import com.google.cloud.teleport.bigtable.ChangelogEntryJson;
+import com.google.cloud.teleport.bigtable.ModType;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import com.google.common.collect.Lists;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Predicate;
+import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
+import org.apache.beam.it.common.PipelineLauncher.LaunchInfo;
+import org.apache.beam.it.common.PipelineOperator;
+import org.apache.beam.it.common.PipelineOperator.Config;
+import org.apache.beam.it.common.TestProperties;
+import org.apache.beam.it.common.utils.ResourceManagerUtils;
+import org.apache.beam.it.gcp.TemplateTestBase;
+import org.apache.beam.it.gcp.bigtable.BigtableResourceManager;
+import org.apache.beam.it.gcp.bigtable.BigtableResourceManagerCluster;
+import org.apache.beam.it.gcp.bigtable.BigtableTableSpec;
+import org.apache.beam.it.gcp.storage.GcsResourceManager;
+import org.jetbrains.annotations.NotNull;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Integration test for {@link BigtableChangeStreamsToGcs}. */
+@Category(TemplateIntegrationTest.class)
+@TemplateIntegrationTest(BigtableChangeStreamsToGcs.class)
+@RunWith(JUnit4.class)
+public final class BigtableChangeStreamsToGcsIT extends TemplateTestBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BigtableChangeStreamsToGcsIT.class);
+  public static final String SOURCE_COLUMN_FAMILY = "cf";
+  private static final Duration EXPECTED_REPLICATION_MAX_WAIT_TIME = Duration.ofMinutes(10);
+  private static final String TEST_ZONE = "us-central1-a";
+  private static BigtableResourceManager bigtableResourceManager;
+  private static GcsResourceManager gcsResourceManager;
+
+  private String outputPath;
+  private String outputPrefix;
+  private String outputPath2;
+  private String outputPrefix2;
+  private String appProfileId;
+  private String srcTable;
+
+  @Test
+  public void testSingleMutationChangelogEntryJsonE2E() throws Exception {
+    LaunchInfo launchInfo =
+        launchTemplate(
+            LaunchConfig.builder(testName, specPath)
+                .addParameter("bigtableReadTableId", srcTable)
+                .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                .addParameter("bigtableChangeStreamCharset", "KOI8-R")
+                .addParameter("outputFileFormat", "TEXT")
+                .addParameter("windowDuration", "10s")
+                .addParameter("gcsOutputDirectory", outputPath)
+                .addParameter("schemaOutputFormat", "CHANGELOG_ENTRY"));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    String rowkey = UUID.randomUUID().toString();
+    String column = UUID.randomUUID().toString();
+
+    // https://en.wikipedia.org/wiki/KOI8-R
+    byte[] valueRussianLetterBinKoi8R = new byte[] {(byte) 0xc2};
+
+    long nowMillis = System.currentTimeMillis();
+    long timestampMicros = nowMillis * 1000;
+
+    RowMutation rowMutation =
+        RowMutation.create(srcTable, rowkey)
+            .setCell(
+                SOURCE_COLUMN_FAMILY,
+                ByteString.copyFrom(column, Charset.defaultCharset()),
+                timestampMicros,
+                ByteString.copyFrom(valueRussianLetterBinKoi8R));
+
+    ChangelogEntryJson expected = new ChangelogEntryJson();
+    expected.setRowKey(rowkey);
+    expected.setTimestamp(timestampMicros);
+    expected.setCommitTimestamp(nowMillis - 10000); // clock skew tolerance
+    expected.setLowWatermark(0);
+    expected.setColumn(column);
+    expected.setValue(new String(valueRussianLetterBinKoi8R, Charset.forName("KOI8-R")));
+    expected.setColumnFamily(SOURCE_COLUMN_FAMILY);
+    expected.setModType(ModType.SET_CELL);
+    expected.setIsGC(false);
+
+    bigtableResourceManager.write(rowMutation);
+
+    if (!waitForFilesToShowUpAtPath(
+        outputPath,
+        outputPrefix,
+        Duration.ofMinutes(10),
+        new LookForChangelogEntryJsonRecord(expected))) {
+      Assert.fail("Unable to find output file containing row mutation: " + expected);
+    }
+  }
+
+  @Test
+  public void testSingleMutationChangelogEntryJsonBase64E2E() throws Exception {
+    LaunchInfo launchInfo =
+        launchTemplate(
+            LaunchConfig.builder(testName, specPath)
+                .addParameter("bigtableReadTableId", srcTable)
+                .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                .addParameter("outputFileFormat", "TEXT")
+                .addParameter("useBase64Rowkeys", "true")
+                .addParameter("useBase64ColumnQualifiers", "true")
+                .addParameter("useBase64Values", "true")
+                .addParameter("windowDuration", "10s")
+                .addParameter("gcsOutputDirectory", outputPath)
+                .addParameter("schemaOutputFormat", "CHANGELOG_ENTRY"));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    String rowkey = UUID.randomUUID().toString();
+    String column = UUID.randomUUID().toString();
+    String value = UUID.randomUUID().toString();
+
+    long nowMillis = System.currentTimeMillis();
+    long timestampMicros = nowMillis * 1000;
+
+    RowMutation rowMutation =
+        RowMutation.create(srcTable, rowkey)
+            .setCell(SOURCE_COLUMN_FAMILY, column, timestampMicros, value);
+
+    ChangelogEntry expected = new ChangelogEntry();
+    expected.setRowKey(bb(rowkey));
+    expected.setTimestamp(timestampMicros);
+    expected.setCommitTimestamp(nowMillis - 10000); // clock skew tolerance
+    expected.setLowWatermark(0);
+    expected.setColumn(bb(column));
+    expected.setValue(bb(value));
+    expected.setColumnFamily(SOURCE_COLUMN_FAMILY);
+    expected.setModType(ModType.SET_CELL);
+    expected.setIsGC(false);
+
+    bigtableResourceManager.write(rowMutation);
+
+    if (!waitForFilesToShowUpAtPath(
+        outputPath,
+        outputPrefix,
+        Duration.ofMinutes(10),
+        new LookForChangelogEntryJsonBase64Record(expected))) {
+      Assert.fail("Unable to find output file containing row mutation: " + expected);
+    }
+  }
+
+  @Test
+  public void testSingleMutationChangelogEntryAvroE2E() throws Exception {
+    LaunchInfo launchInfo =
+        launchTemplate(
+            LaunchConfig.builder(testName, specPath)
+                .addParameter("bigtableReadTableId", srcTable)
+                .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                .addParameter("outputFileFormat", "AVRO")
+                .addParameter("windowDuration", "10s")
+                .addParameter("gcsOutputDirectory", outputPath)
+                .addParameter("schemaOutputFormat", "CHANGELOG_ENTRY"));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    String rowkey = UUID.randomUUID().toString();
+    String column = UUID.randomUUID().toString();
+    String value = UUID.randomUUID().toString();
+
+    long nowMillis = System.currentTimeMillis();
+    long timestampMicros = nowMillis * 1000;
+
+    RowMutation rowMutation =
+        RowMutation.create(srcTable, rowkey)
+            .setCell(SOURCE_COLUMN_FAMILY, column, timestampMicros, value);
+
+    ChangelogEntry expected = new ChangelogEntry();
+
+    expected.setRowKey(bb(rowkey));
+    expected.setTimestamp(timestampMicros);
+    expected.setCommitTimestamp(nowMillis - 10000); // clock skew tolerance
+    expected.setLowWatermark(0);
+    expected.setColumn(bb(column));
+    expected.setValue(bb(value));
+    expected.setColumnFamily(SOURCE_COLUMN_FAMILY);
+    expected.setModType(ModType.SET_CELL);
+    expected.setIsGC(false);
+
+    bigtableResourceManager.write(rowMutation);
+
+    if (!waitForFilesToShowUpAtPath(
+        outputPath,
+        outputPrefix,
+        Duration.ofMinutes(10),
+        new LookForChangelogEntryAvroRecord(expected))) {
+      Assert.fail("Unable to find output file containing row mutation: " + expected);
+    }
+  }
+
+  @Test
+  public void testSingleMutationBigtableRowAvroE2E() throws Exception {
+    LaunchInfo launchInfo =
+        launchTemplate(
+            LaunchConfig.builder(testName, specPath)
+                .addParameter("bigtableReadTableId", srcTable)
+                .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                .addParameter("outputFileFormat", "AVRO")
+                .addParameter("windowDuration", "10s")
+                .addParameter("gcsOutputDirectory", outputPath)
+                .addParameter("schemaOutputFormat", "BIGTABLE_ROW"));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    String rowkey = UUID.randomUUID().toString();
+    String column = UUID.randomUUID().toString();
+    String value = UUID.randomUUID().toString();
+
+    long nowMillis = System.currentTimeMillis();
+    long timestampMicros = nowMillis * 1000;
+
+    RowMutation rowMutation =
+        RowMutation.create(srcTable, rowkey)
+            .setCell(SOURCE_COLUMN_FAMILY, column, timestampMicros, value);
+
+    ChangelogEntry expected = new ChangelogEntry();
+
+    expected.setRowKey(bb(rowkey));
+    expected.setTimestamp(timestampMicros);
+    expected.setCommitTimestamp(nowMillis - 10000); // clock skew tolerance
+    expected.setLowWatermark(0);
+    expected.setColumn(bb(column));
+    expected.setValue(bb(value));
+    expected.setColumnFamily(SOURCE_COLUMN_FAMILY);
+    expected.setModType(ModType.SET_CELL);
+    expected.setIsGC(false);
+
+    bigtableResourceManager.write(rowMutation);
+
+    if (!waitForFilesToShowUpAtPath(
+        outputPath,
+        outputPrefix,
+        Duration.ofMinutes(10),
+        new LookForBigtableRowAvroRecord(expected))) {
+      Assert.fail("Unable to find output file containing row mutation: " + expected);
+    }
+  }
+
+  @Test
+  public void testSingleMutationBigtableRowAvroWithStartTimeE2E() throws Exception {
+    LaunchInfo launchInfo =
+        launchTemplate(
+            LaunchConfig.builder(testName, specPath)
+                .addParameter("bigtableReadTableId", srcTable)
+                .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                .addParameter("outputFileFormat", "AVRO")
+                .addParameter("windowDuration", "10s")
+                .addParameter("gcsOutputDirectory", outputPath)
+                .addParameter("schemaOutputFormat", "BIGTABLE_ROW"));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    String rowkey = UUID.randomUUID().toString();
+    String column = UUID.randomUUID().toString();
+    String value = UUID.randomUUID().toString();
+
+    long nowMillis = System.currentTimeMillis();
+    long timestampMicros = nowMillis * 1000;
+
+    RowMutation rowMutation =
+        RowMutation.create(srcTable, rowkey)
+            .setCell(SOURCE_COLUMN_FAMILY, column, timestampMicros, value);
+
+    ChangelogEntry expected = new ChangelogEntry();
+
+    expected.setRowKey(bb(rowkey));
+    expected.setTimestamp(timestampMicros);
+    expected.setCommitTimestamp(timestampMicros - 10000000); // clock skew tolerance
+    expected.setLowWatermark(0);
+    expected.setColumn(bb(column));
+    expected.setValue(bb(value));
+    expected.setColumnFamily(SOURCE_COLUMN_FAMILY);
+    expected.setModType(ModType.SET_CELL);
+    expected.setIsGC(false);
+
+    bigtableResourceManager.write(rowMutation);
+
+    Thread.sleep(10000);
+
+    bigtableResourceManager.write(rowMutation);
+
+    var predicate = new LookForBigtableRowAvroRecord(expected);
+    if (!waitForFilesToShowUpAtPath(outputPath, outputPrefix, Duration.ofMinutes(10), predicate)) {
+      Assert.fail("Unable to find output file containing row mutation: " + expected);
+    }
+
+    // Adding 1.5s just to make sure we don't capture this earliest record
+    long microsCutoff = predicate.getEarliestCommitTime() + 1500000L;
+
+    pipelineLauncher.cancelJob(launchInfo.projectId(), launchInfo.region(), launchInfo.jobId());
+
+    launchInfo =
+        launchTemplate(
+            LaunchConfig.builder(testName, specPath)
+                .addParameter("bigtableReadTableId", srcTable)
+                .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                .addParameter("outputFileFormat", "AVRO")
+                .addParameter("bigtableChangeStreamStartTimestamp", formatTimeMicros(microsCutoff))
+                .addParameter("windowDuration", "10s")
+                .addParameter("gcsOutputDirectory", outputPath2)
+                .addParameter("schemaOutputFormat", "BIGTABLE_ROW"));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    var latestPredicate = new LookForBigtableRowAvroRecord(expected);
+    if (!waitForFilesToShowUpAtPath(
+        outputPath2, outputPrefix2, Duration.ofMinutes(10), latestPredicate)) {
+      Assert.fail("Unable to find latest mutation: " + expected);
+    }
+    Assert.assertTrue(latestPredicate.getEarliestCommitTime() >= microsCutoff);
+  }
+
+  @Test
+  public void testSingleMutationBigtableRowAvroWStopAndResumeE2E() throws Exception {
+    String persistentName = UUID.randomUUID().toString();
+    LaunchInfo launchInfo =
+        launchTemplate(
+            LaunchConfig.builder(testName, specPath)
+                .addParameter("bigtableChangeStreamName", persistentName)
+                .addParameter("bigtableChangeStreamResume", "false")
+                .addParameter("bigtableReadTableId", srcTable)
+                .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                .addParameter("outputFileFormat", "AVRO")
+                .addParameter("windowDuration", "10s")
+                .addParameter("gcsOutputDirectory", outputPath)
+                .addParameter("schemaOutputFormat", "BIGTABLE_ROW"));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    String rowkey = UUID.randomUUID().toString();
+    String column = UUID.randomUUID().toString();
+    String value = UUID.randomUUID().toString();
+
+    long nowMillis = System.currentTimeMillis();
+    long timestampMicros = nowMillis * 1000;
+
+    RowMutation rowMutation =
+        RowMutation.create(srcTable, rowkey)
+            .setCell(SOURCE_COLUMN_FAMILY, column, timestampMicros, value);
+
+    ChangelogEntry expected = new ChangelogEntry();
+
+    expected.setRowKey(bb(rowkey));
+    expected.setTimestamp(timestampMicros);
+    expected.setCommitTimestamp(timestampMicros - 10000000); // clock skew tolerance
+    expected.setLowWatermark(0);
+    expected.setColumn(bb(column));
+    expected.setValue(bb(value));
+    expected.setColumnFamily(SOURCE_COLUMN_FAMILY);
+    expected.setModType(ModType.SET_CELL);
+    expected.setIsGC(false);
+
+    bigtableResourceManager.write(rowMutation);
+
+    if (!waitForFilesToShowUpAtPath(
+        outputPath,
+        outputPrefix,
+        Duration.ofMinutes(10),
+        new LookForBigtableRowAvroRecord(expected))) {
+      Assert.fail("Unable to find output file containing row mutation: " + expected);
+    }
+
+    pipelineLauncher.cancelJob(launchInfo.projectId(), launchInfo.region(), launchInfo.jobId());
+
+    waitUntilCancelled(launchInfo, Duration.ofMinutes(10));
+
+    // Scanning the dir one more time to capture the latest commit time
+    var predicate = new LookForBigtableRowAvroRecord(expected);
+    if (!waitForFilesToShowUpAtPath(outputPath, outputPrefix, Duration.ofMinutes(10), predicate)) {
+      Assert.fail("Unable to find output file containing row mutation: " + expected);
+    }
+
+    bigtableResourceManager.write(rowMutation);
+
+    launchInfo =
+        launchTemplate(
+            LaunchConfig.builder(testName, specPath)
+                .addParameter("bigtableChangeStreamName", persistentName)
+                .addParameter("bigtableChangeStreamResume", "true")
+                .addParameter("bigtableReadTableId", srcTable)
+                .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                .addParameter("outputFileFormat", "AVRO")
+                .addParameter(
+                    "bigtableChangeStreamStartTimestamp",
+                    formatTimeMicros(predicate.getEarliestCommitTime() - 1000000))
+                .addParameter("windowDuration", "10s")
+                .addParameter("gcsOutputDirectory", outputPath2)
+                .addParameter("schemaOutputFormat", "BIGTABLE_ROW"));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    var latestPredicate = new LookForBigtableRowAvroRecord(expected);
+    if (!waitForFilesToShowUpAtPath(
+        outputPath2, outputPrefix2, Duration.ofMinutes(10), latestPredicate)) {
+      Assert.fail("Unable to find latest mutation: " + expected);
+    }
+    Assert.assertTrue(latestPredicate.getEarliestCommitTime() > predicate.getLatestCommitTime());
+  }
+
+  private String generateClusterName() {
+    return "teleport-c1";
+  }
+
+  private String generateTableName() {
+    return "table" + System.nanoTime();
+  }
+
+  private void waitUntilCancelled(LaunchInfo launchInfo, Duration maxWait) {
+    long started = System.currentTimeMillis();
+    while (System.currentTimeMillis() < started + maxWait.toMillis()) {
+      try {
+        var state =
+            pipelineLauncher.getJobStatus(
+                TestProperties.project(), TestProperties.region(), launchInfo.jobId());
+        switch (state) {
+          case CANCELLED:
+            LOG.info("Job is finally CANCELLED!");
+            return;
+          case CANCELLING:
+          case RUNNING:
+            LOG.info("Job is not cancelled yet: " + state);
+            continue;
+          default:
+            throw new RuntimeException("Unexpected job state: " + state);
+        }
+      } catch (Exception e) {
+        LOG.warn("failed to obtain job state: ", e);
+      }
+    }
+  }
+
+  @Test
+  public void testSingleMutationBigtableRowTextE2E() throws Exception {
+    String srcTable = generateTableName();
+
+    try {
+      launchTemplate(
+          LaunchConfig.builder(testName, specPath)
+              .addParameter("bigtableReadTableId", srcTable)
+              .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+              .addParameter("bigtableChangeStreamAppProfile", "anything")
+              .addParameter("outputFileFormat", "TEXT")
+              .addParameter("windowDuration", "10s")
+              .addParameter("gcsOutputDirectory", outputPath)
+              .addParameter("schemaOutputFormat", "BIGTABLE_ROW"));
+    } catch (RuntimeException e) {
+      Assert.assertTrue(e.getMessage().contains("The job failed before launch"));
+    }
+  }
+
+  private ByteBuffer bb(String value) {
+    return ByteBuffer.wrap(value.getBytes(Charset.defaultCharset()));
+  }
+
+  private boolean waitForFilesToShowUpAtPath(
+      String outputPath, String outputPrefix, Duration howLong, Predicate<? super Blob> checkFile)
+      throws Exception {
+    long polUntil = System.currentTimeMillis() + howLong.toMillis();
+
+    Storage storage =
+        StorageOptions.newBuilder().setProjectId(TestProperties.project()).build().getService();
+
+    boolean found = false;
+    while (System.currentTimeMillis() < polUntil && !found) {
+      LOG.info("Looking for files at " + outputPath);
+
+      Page<Blob> blobPa =
+          storage.list(TestProperties.artifactBucket(), BlobListOption.prefix(outputPrefix));
+      found = blobPa.streamAll().anyMatch(checkFile);
+      if (!found) {
+        Thread.sleep(1000);
+      }
+    }
+    return found;
+  }
+
+  @NotNull
+  private static String generateAppProfileId() {
+    return "cdc_app_profile_" + System.nanoTime();
+  }
+
+  @Before
+  public void setup() throws IOException {
+    gcsResourceManager =
+        GcsResourceManager.builder(
+                TestProperties.artifactBucket(),
+                getClass().getSimpleName(),
+                TestProperties.googleCredentials())
+            .build();
+
+    String outputDir = generateSafeDirectoryName();
+    gcsResourceManager.registerTempDir(outputDir);
+    outputPath = String.format("gs://%s/%s/output", TestProperties.artifactBucket(), outputDir);
+    outputPrefix = String.format("%s/output", outputDir);
+
+    outputPath2 = String.format("gs://%s/%s/output2", TestProperties.artifactBucket(), outputDir);
+    outputPrefix2 = String.format("%s/output2", outputDir);
+
+    BigtableResourceManager.Builder rmBuilder =
+        BigtableResourceManager.builder(testName, PROJECT, credentialsProvider);
+
+    bigtableResourceManager = rmBuilder.maybeUseStaticInstance().build();
+
+    appProfileId = generateAppProfileId();
+    String clusterName = generateClusterName();
+    srcTable = generateTableName();
+
+    List<BigtableResourceManagerCluster> clusters = new ArrayList<>();
+    clusters.add(BigtableResourceManagerCluster.create(clusterName, TEST_ZONE, 1, StorageType.HDD));
+
+    bigtableResourceManager.createInstance(clusters);
+
+    bigtableResourceManager.createAppProfile(
+        appProfileId, true, Lists.asList(clusterName, new String[] {}));
+
+    BigtableTableSpec cdcTableSpec = new BigtableTableSpec();
+    cdcTableSpec.setCdcEnabled(true);
+    cdcTableSpec.setColumnFamilies(Lists.asList(SOURCE_COLUMN_FAMILY, new String[] {}));
+    bigtableResourceManager.createTable(srcTable, cdcTableSpec);
+  }
+
+  @After
+  public void tearDownClass() {
+    ResourceManagerUtils.cleanResources(bigtableResourceManager, gcsResourceManager);
+  }
+
+  @Override
+  protected PipelineOperator.Config createConfig(LaunchInfo info) {
+    Config.Builder configBuilder =
+        Config.builder().setJobId(info.jobId()).setProject(PROJECT).setRegion(REGION);
+
+    // For DirectRunner tests, reduce the max time and the interval, as there is no worker required
+    if (System.getProperty("directRunnerTest") != null) {
+      configBuilder =
+          configBuilder
+              .setTimeoutAfter(EXPECTED_REPLICATION_MAX_WAIT_TIME.minus(Duration.ofMinutes(3)))
+              .setCheckAfter(Duration.ofSeconds(5));
+    } else {
+      configBuilder.setTimeoutAfter(EXPECTED_REPLICATION_MAX_WAIT_TIME);
+    }
+
+    return configBuilder.build();
+  }
+
+  // We don't want any unexpected date format characters in the dir name
+  private String generateSafeDirectoryName() {
+    return UUID.randomUUID().toString().replaceAll("[da]", "x");
+  }
+
+  private String formatTimeMicros(long microsCutoff) {
+    SimpleDateFormat format = new SimpleDateFormat("yyy-MM-dd'T'HH:mm:ssXXX");
+    return format.format(new Date(microsCutoff / 1000));
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableUtilsTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableUtilsTest.java
@@ -1,0 +1,493 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.Timestamp;
+import com.google.cloud.bigtable.data.v2.models.ChangeStreamMutation;
+import com.google.cloud.bigtable.data.v2.models.SetCell;
+import com.google.cloud.teleport.bigtable.BigtableCell;
+import com.google.cloud.teleport.bigtable.BigtableRow;
+import com.google.cloud.teleport.bigtable.ChangelogEntry;
+import com.google.cloud.teleport.bigtable.ModType;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.model.ChangelogColumns;
+import com.google.cloud.teleport.v2.utils.BigtableSource;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Random;
+import org.joda.time.Instant;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+/** Test class for {@link BigtableUtils}. */
+@RunWith(JUnit4.class)
+public class BigtableUtilsTest {
+
+  /**
+   * {@link com.google.cloud.bigtable.data.v2.models.ChangeStreamMutation} fields to be used
+   * throughout the tests.
+   */
+  static final int TIE_BREAKER = 1000;
+
+  static final boolean IS_GC = true;
+  static final String COLUMN_FAMILY = "CF";
+  static final Timestamp COMMIT_TIMESTAMP = Timestamp.now();
+  static final Timestamp LOW_WATERMARK = Timestamp.MIN_VALUE;
+  static final Charset CHARSET = StandardCharsets.UTF_8;
+  static final ByteBuffer COLUMN = getByteBufferFromString("COLUMN", CHARSET);
+  static final Timestamp TIMESTAMP = Timestamp.now();
+  static final Timestamp TIMESTAMP_FROM = Timestamp.MIN_VALUE;
+  static final Timestamp TIMESTAMP_TO = Timestamp.MAX_VALUE;
+  static final ByteBuffer VALUE = getByteBufferFromString("VALUE", CHARSET);
+  static final ByteBuffer ROW_KEY = getByteBufferFromString("ROW_KEY", CHARSET);
+
+  // Pipeline specific variables to be used throughout testing of BigtableUtils
+  static final String FAKE_INSTANCE_ID = "fakeinstance";
+
+  static final String FAKE_TABLE_ID = "faketableid";
+  static final String IGNORE_COLUMN_FAMILIES = "cf1, cf2, cf3";
+  static final String IGNORE_COLUMNS = "cf1:c1, cf2:c2";
+  static final String WORKER_ID = "workerid";
+  static final Long COUNTER = 1000L;
+
+  /**
+   * Test whether {@link BigtableUtils} can create {@link
+   * com.google.cloud.teleport.bigtable.BigtableRow} objects appropriately from a {@link
+   * com.google.cloud.teleport.bigtable.ChangelogEntry} of type SET_CELL.
+   */
+  @Test
+  public void testCreateBigtableRowSetCellEntry() {
+    /* Initial setup, may vary across different */
+    BigtableUtils utils = initBigtableUtils(IGNORE_COLUMN_FAMILIES, IGNORE_COLUMNS);
+
+    /* Create {@link ChangelogEntry} of type {@link ModType.SET_CELL} */
+    ChangelogEntry setCellEntry = createChangelogEntry(ModType.SET_CELL, COLUMN_FAMILY, COLUMN);
+
+    BigtableRow setCellRow = utils.createBigtableRow(setCellEntry, WORKER_ID, COUNTER);
+    HashMap<ByteBuffer, ByteBuffer> changelogEntryHashMap =
+        getHashMapFromChangelogEntry(setCellEntry, CHARSET);
+
+    ByteBuffer bigtableRowExpectedRowKey =
+        createChangelogRowKey(
+            utils, setCellEntry.getCommitTimestamp(), WORKER_ID, COUNTER, CHARSET);
+    assertEquals(setCellRow.getKey(), bigtableRowExpectedRowKey);
+
+    for (BigtableCell cell : setCellRow.getCells()) {
+      assertTrue(changelogEntryHashMap.containsKey(cell.getQualifier()));
+      ByteBuffer expectedCellValue = changelogEntryHashMap.get(cell.getQualifier());
+      assertTrue(expectedCellValue.compareTo(cell.getValue()) == 0);
+    }
+  }
+
+  /**
+   * Test whether {@link BigtableUtils} can create {@link
+   * com.google.cloud.teleport.bigtable.BigtableRow} objects appropriately from a {@link
+   * com.google.cloud.teleport.bigtable.ChangelogEntry} of type DELETE_CELLS.
+   */
+  @Test
+  public void testCreateBigtableRowDeleteCellsEntry() {
+    /* Initial setup, may vary across different */
+    BigtableUtils utils = initBigtableUtils(IGNORE_COLUMN_FAMILIES, IGNORE_COLUMNS);
+
+    /* Create {@link ChangelogEntry} of type {@link ModType.DELETE_CELLS}*/
+    ChangelogEntry deleteCellsEntry =
+        createChangelogEntry(ModType.DELETE_CELLS, COLUMN_FAMILY, COLUMN);
+
+    BigtableRow deleteCellsRow = utils.createBigtableRow(deleteCellsEntry, WORKER_ID, COUNTER);
+    HashMap<ByteBuffer, ByteBuffer> changelogEntryHashMap =
+        getHashMapFromChangelogEntry(deleteCellsEntry, CHARSET);
+
+    ByteBuffer bigtableRowExpectedRowKey =
+        createChangelogRowKey(
+            utils, deleteCellsEntry.getCommitTimestamp(), WORKER_ID, COUNTER, CHARSET);
+    assertEquals(deleteCellsRow.getKey(), bigtableRowExpectedRowKey);
+
+    for (BigtableCell cell : deleteCellsRow.getCells()) {
+      assertTrue(changelogEntryHashMap.containsKey(cell.getQualifier()));
+      ByteBuffer expectedCellValue = changelogEntryHashMap.get(cell.getQualifier());
+      assertTrue(expectedCellValue.compareTo(cell.getValue()) == 0);
+    }
+  }
+
+  /**
+   * Test whether {@link BigtableUtils} can create {@link
+   * com.google.cloud.teleport.bigtable.BigtableRow} objects appropriately from a {@link
+   * com.google.cloud.teleport.bigtable.ChangelogEntry} of type DELETE_FAMILY.
+   */
+  @Test
+  public void testCreateBigtableRowDeleteFamilyEntry() {
+    /* Initial setup, may vary across different */
+    BigtableUtils utils = initBigtableUtils(IGNORE_COLUMN_FAMILIES, IGNORE_COLUMNS);
+
+    /* Create {@link ChangelogEntry} of type {@link ModType.DELETE_FAMILY} */
+    ChangelogEntry deleteFamilyEntry =
+        createChangelogEntry(ModType.DELETE_FAMILY, COLUMN_FAMILY, COLUMN);
+
+    BigtableRow deleteFamilyRow = utils.createBigtableRow(deleteFamilyEntry, WORKER_ID, COUNTER);
+    HashMap<ByteBuffer, ByteBuffer> changelogEntryHashMap =
+        getHashMapFromChangelogEntry(deleteFamilyEntry, CHARSET);
+
+    ByteBuffer bigtableRowExpectedRowKey =
+        createChangelogRowKey(
+            utils, deleteFamilyEntry.getCommitTimestamp(), WORKER_ID, COUNTER, CHARSET);
+    assertEquals(deleteFamilyRow.getKey(), bigtableRowExpectedRowKey);
+
+    for (BigtableCell cell : deleteFamilyRow.getCells()) {
+      assertTrue(changelogEntryHashMap.containsKey(cell.getQualifier()));
+      ByteBuffer expectedCellValue = changelogEntryHashMap.get(cell.getQualifier());
+      assertTrue(expectedCellValue.compareTo(cell.getValue()) == 0);
+    }
+  }
+
+  @Test
+  public void tesCopyByteBuffer() {
+    // Generate random bytes
+    byte[] byteArray = new byte[1000];
+    new Random().nextBytes(byteArray);
+
+    ByteBuffer bbOriginal = ByteBuffer.wrap(byteArray);
+    ByteBuffer bbCopy = BigtableUtils.copyByteBuffer(bbOriginal);
+
+    assertTrue(bbOriginal.compareTo(bbCopy) == 0);
+  }
+
+  @Test
+  public void testGetValidEntriesAllEntriesAreValid() {
+    BigtableUtils utils = initBigtableUtils("cf1,cf2", "cf1:c1,cf2:c2");
+
+    SetCell entry1 = Mockito.mock(SetCell.class);
+    // mock a few entries, one of each instance of Entry
+    Mockito.when(entry1.getValue())
+        .thenReturn(ByteString.copyFrom("value1", Charset.defaultCharset()));
+    Mockito.when(entry1.getQualifier())
+        .thenReturn(ByteString.copyFrom("column1", Charset.defaultCharset()));
+    Mockito.when(entry1.getFamilyName()).thenReturn("family1");
+    Mockito.when(entry1.getTimestamp()).thenReturn(10000000L);
+
+    SetCell entry2 = Mockito.mock(SetCell.class);
+    // mock a few entries, one of each instance of Entry
+    Mockito.when(entry2.getValue())
+        .thenReturn(ByteString.copyFrom("value2", Charset.defaultCharset()));
+    Mockito.when(entry2.getQualifier())
+        .thenReturn(ByteString.copyFrom("column2", Charset.defaultCharset()));
+    Mockito.when(entry2.getFamilyName()).thenReturn("family2");
+    Mockito.when(entry2.getTimestamp()).thenReturn(10000000L);
+
+    ChangeStreamMutation mutation = Mockito.mock(ChangeStreamMutation.class);
+    Mockito.when(mutation.getRowKey())
+        .thenReturn(ByteString.copyFrom("rowkey", Charset.defaultCharset()));
+    Mockito.when(mutation.getEntries()).thenReturn(ImmutableList.of(entry1, entry2));
+    Mockito.when(mutation.getType()).thenReturn(ChangeStreamMutation.MutationType.USER);
+    Mockito.when(mutation.getCommitTimestamp()).thenReturn(org.threeten.bp.Instant.now());
+
+    List<ChangelogEntry> actualEntries = utils.getValidEntries(mutation);
+
+    Assert.assertEquals(2, actualEntries.size());
+
+    ChangelogEntry logEntry1 = actualEntries.get(0);
+    ChangelogEntry logEntry2 = actualEntries.get(1);
+    Assert.assertEquals(
+        "rowkey", Charset.defaultCharset().decode(logEntry1.getRowKey()).toString());
+    Assert.assertEquals("family1", logEntry1.getColumnFamily());
+    Assert.assertEquals(
+        "column1", Charset.defaultCharset().decode(logEntry1.getColumn()).toString());
+
+    Assert.assertEquals(
+        "rowkey", Charset.defaultCharset().decode(logEntry2.getRowKey()).toString());
+    Assert.assertEquals("family2", logEntry2.getColumnFamily());
+    Assert.assertEquals(
+        "column2", Charset.defaultCharset().decode(logEntry2.getColumn()).toString());
+  }
+
+  @Test
+  public void testGetValidEntriesWithIgnoredColumnFamilies() {
+    BigtableUtils utils = initBigtableUtils("cf1,cf2", "cf1:c1,cf2:c2");
+
+    SetCell entry1 = Mockito.mock(SetCell.class);
+    // mock a few entries, one of each instance of Entry
+    Mockito.when(entry1.getValue())
+        .thenReturn(ByteString.copyFrom("value1", Charset.defaultCharset()));
+    Mockito.when(entry1.getQualifier())
+        .thenReturn(ByteString.copyFrom("column1", Charset.defaultCharset()));
+    Mockito.when(entry1.getFamilyName()).thenReturn("cf1");
+    Mockito.when(entry1.getTimestamp()).thenReturn(10000000L);
+
+    SetCell entry2 = Mockito.mock(SetCell.class);
+    // mock a few entries, one of each instance of Entry
+    Mockito.when(entry2.getValue())
+        .thenReturn(ByteString.copyFrom("value2", Charset.defaultCharset()));
+    Mockito.when(entry2.getQualifier())
+        .thenReturn(ByteString.copyFrom("column2", Charset.defaultCharset()));
+    Mockito.when(entry2.getFamilyName()).thenReturn("family2");
+    Mockito.when(entry2.getTimestamp()).thenReturn(10000000L);
+
+    ChangeStreamMutation mutation = Mockito.mock(ChangeStreamMutation.class);
+    Mockito.when(mutation.getRowKey())
+        .thenReturn(ByteString.copyFrom("rowkey", Charset.defaultCharset()));
+    Mockito.when(mutation.getEntries()).thenReturn(ImmutableList.of(entry1, entry2));
+    Mockito.when(mutation.getType()).thenReturn(ChangeStreamMutation.MutationType.USER);
+    Mockito.when(mutation.getCommitTimestamp()).thenReturn(org.threeten.bp.Instant.now());
+
+    List<ChangelogEntry> actualEntries = utils.getValidEntries(mutation);
+
+    Assert.assertEquals(1, actualEntries.size());
+
+    ChangelogEntry logEntry = actualEntries.get(0);
+
+    Assert.assertEquals("rowkey", Charset.defaultCharset().decode(logEntry.getRowKey()).toString());
+    Assert.assertEquals("family2", logEntry.getColumnFamily());
+    Assert.assertEquals(
+        "column2", Charset.defaultCharset().decode(logEntry.getColumn()).toString());
+  }
+
+  @Test
+  public void testGetValidEntriesWithIgnoredColumns() {
+    BigtableUtils utils = initBigtableUtils("cf1,cf2", "cf1:c1,cf2:c2");
+
+    SetCell entry1 = Mockito.mock(SetCell.class);
+    // mock a few entries, one of each instance of Entry
+    Mockito.when(entry1.getValue())
+        .thenReturn(ByteString.copyFrom("value1", Charset.defaultCharset()));
+    Mockito.when(entry1.getQualifier())
+        .thenReturn(ByteString.copyFrom("column1", Charset.defaultCharset()));
+    Mockito.when(entry1.getFamilyName()).thenReturn("family1");
+    Mockito.when(entry1.getTimestamp()).thenReturn(10000000L);
+
+    SetCell entry2 = Mockito.mock(SetCell.class);
+    // mock a few entries, one of each instance of Entry
+    Mockito.when(entry2.getValue())
+        .thenReturn(ByteString.copyFrom("value2", Charset.defaultCharset()));
+    Mockito.when(entry2.getQualifier())
+        .thenReturn(ByteString.copyFrom("c2", Charset.defaultCharset()));
+    Mockito.when(entry2.getFamilyName()).thenReturn("cf2");
+    Mockito.when(entry2.getTimestamp()).thenReturn(10000000L);
+
+    ChangeStreamMutation mutation = Mockito.mock(ChangeStreamMutation.class);
+    Mockito.when(mutation.getRowKey())
+        .thenReturn(ByteString.copyFrom("rowkey", Charset.defaultCharset()));
+    Mockito.when(mutation.getEntries()).thenReturn(ImmutableList.of(entry1, entry2));
+    Mockito.when(mutation.getType()).thenReturn(ChangeStreamMutation.MutationType.USER);
+    Mockito.when(mutation.getCommitTimestamp()).thenReturn(org.threeten.bp.Instant.now());
+
+    List<ChangelogEntry> actualEntries = utils.getValidEntries(mutation);
+
+    Assert.assertEquals(1, actualEntries.size());
+
+    ChangelogEntry logEntry = actualEntries.get(0);
+
+    Assert.assertEquals("rowkey", Charset.defaultCharset().decode(logEntry.getRowKey()).toString());
+    Assert.assertEquals("family1", logEntry.getColumnFamily());
+    Assert.assertEquals(
+        "column1", Charset.defaultCharset().decode(logEntry.getColumn()).toString());
+  }
+
+  private ByteBuffer createChangelogRowKey(
+      BigtableUtils utils, Long commitTimestamp, String workerId, Long counter, Charset charset) {
+    String rowKey =
+        (commitTimestamp.toString()
+            + utils.bigtableRowKeyDelimiter
+            + workerId
+            + utils.bigtableRowKeyDelimiter
+            + counter);
+
+    return BigtableUtils.copyByteBuffer(ByteBuffer.wrap(rowKey.getBytes(charset)));
+  }
+
+  private HashMap<ByteBuffer, ByteBuffer> getHashMapFromChangelogEntry(
+      ChangelogEntry entry, Charset charset) {
+    HashMap<ByteBuffer, ByteBuffer> qualifierToCellValueMap = new HashMap<>();
+    addCommonEntryProperties(qualifierToCellValueMap, entry, charset);
+    if (entry.getModType() == ModType.SET_CELL) {
+      addSetCellEntryProperties(qualifierToCellValueMap, entry, charset);
+    } else if (entry.getModType() == ModType.DELETE_CELLS) {
+      addDeleteCellsEntryProperties(qualifierToCellValueMap, entry, charset);
+    } else if (entry.getModType() == ModType.DELETE_FAMILY) {
+      addDeleteFamilyEntryProperties(qualifierToCellValueMap, entry, charset);
+    } else {
+      // should never reach here
+      Assert.fail();
+    }
+    return qualifierToCellValueMap;
+  }
+
+  private void addCommonEntryProperties(
+      HashMap<ByteBuffer, ByteBuffer> entryMap, ChangelogEntry entry, Charset charset) {
+    entryMap.put(
+        ChangelogColumns.ROW_KEY.getColumnNameAsByteBuffer(charset),
+        BigtableUtils.copyByteBuffer(entry.getRowKey()));
+    entryMap.put(
+        ChangelogColumns.MOD_TYPE.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(entry.getModType().toString(), charset));
+    entryMap.put(
+        ChangelogColumns.IS_GC.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(Boolean.toString(entry.getIsGC()), charset));
+    entryMap.put(
+        ChangelogColumns.TIEBREAKER.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(Integer.toString(entry.getTieBreaker()), charset));
+    entryMap.put(
+        ChangelogColumns.COMMIT_TIMESTAMP.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(Long.toString(entry.getCommitTimestamp()), charset));
+    entryMap.put(
+        ChangelogColumns.LOW_WATERMARK.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(Long.toString(entry.getLowWatermark()), charset));
+  }
+
+  private void addSetCellEntryProperties(
+      HashMap<ByteBuffer, ByteBuffer> entryMap, ChangelogEntry entry, Charset charset) {
+    entryMap.put(
+        ChangelogColumns.COLUMN_FAMILY.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(entry.getColumnFamily().toString(), charset));
+    entryMap.put(
+        ChangelogColumns.COLUMN.getColumnNameAsByteBuffer(charset),
+        BigtableUtils.copyByteBuffer(entry.getColumn()));
+    entryMap.put(
+        ChangelogColumns.TIMESTAMP.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(entry.getTimestamp().toString(), charset));
+    entryMap.put(
+        ChangelogColumns.VALUE.getColumnNameAsByteBuffer(charset),
+        BigtableUtils.copyByteBuffer(entry.getValue()));
+    entryMap.put(ChangelogColumns.TIMESTAMP_TO.getColumnNameAsByteBuffer(charset), null);
+    entryMap.put(ChangelogColumns.TIMESTAMP_FROM.getColumnNameAsByteBuffer(charset), null);
+  }
+
+  private void addDeleteCellsEntryProperties(
+      HashMap<ByteBuffer, ByteBuffer> entryMap, ChangelogEntry entry, Charset charset) {
+    entryMap.put(
+        ChangelogColumns.COLUMN_FAMILY.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(entry.getColumnFamily().toString(), charset));
+    entryMap.put(
+        ChangelogColumns.COLUMN.getColumnNameAsByteBuffer(charset),
+        BigtableUtils.copyByteBuffer(entry.getColumn()));
+    entryMap.put(ChangelogColumns.TIMESTAMP.getColumnNameAsByteBuffer(charset), null);
+    entryMap.put(ChangelogColumns.VALUE.getColumnNameAsByteBuffer(charset), null);
+    entryMap.put(
+        ChangelogColumns.TIMESTAMP_TO.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(entry.getTimestampTo().toString(), charset));
+    entryMap.put(
+        ChangelogColumns.TIMESTAMP_FROM.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(entry.getTimestampFrom().toString(), charset));
+  }
+
+  private void addDeleteFamilyEntryProperties(
+      HashMap<ByteBuffer, ByteBuffer> entryMap, ChangelogEntry entry, Charset charset) {
+    entryMap.put(
+        ChangelogColumns.COLUMN_FAMILY.getColumnNameAsByteBuffer(charset),
+        getByteBufferFromString(entry.getColumnFamily().toString(), charset));
+    entryMap.put(ChangelogColumns.COLUMN.getColumnNameAsByteBuffer(charset), null);
+    entryMap.put(ChangelogColumns.TIMESTAMP.getColumnNameAsByteBuffer(charset), null);
+    entryMap.put(ChangelogColumns.VALUE.getColumnNameAsByteBuffer(charset), null);
+    entryMap.put(ChangelogColumns.TIMESTAMP_TO.getColumnNameAsByteBuffer(charset), null);
+    entryMap.put(ChangelogColumns.TIMESTAMP_FROM.getColumnNameAsByteBuffer(charset), null);
+  }
+
+  private static ByteBuffer getByteBufferFromString(String s, Charset charset) {
+    return BigtableUtils.copyByteBuffer(ByteBuffer.wrap(s.getBytes(charset)));
+  }
+
+  private BigtableUtils initBigtableUtils(String ignoreColumnFamilies, String ignoreColumns) {
+    BigtableSource source =
+        new BigtableSource(
+            FAKE_INSTANCE_ID,
+            FAKE_TABLE_ID,
+            CHARSET.toString(),
+            ignoreColumnFamilies,
+            ignoreColumns,
+            Instant.now());
+
+    return new BigtableUtils(source);
+  }
+
+  private ChangelogEntry createChangelogEntry(
+      ModType modType, String columnFamily, ByteBuffer qualifier) {
+    if (modType == ModType.SET_CELL) {
+      return createSetCellChangelogEntry(columnFamily, qualifier);
+    }
+
+    if (modType == ModType.DELETE_CELLS) {
+      return createDeleteCellsChangelogEntry(columnFamily, qualifier);
+    }
+
+    if (modType == ModType.DELETE_FAMILY) {
+      return createDeleteFamilyChangelogEntry(columnFamily, qualifier);
+    }
+
+    // Should never reach here.
+    return null;
+  }
+
+  private ChangelogEntry createSetCellChangelogEntry(String columnFamily, ByteBuffer qualifier) {
+    return ChangelogEntry.newBuilder()
+        .setRowKey(ROW_KEY)
+        .setIsGC(IS_GC)
+        .setTieBreaker(TIE_BREAKER)
+        .setCommitTimestamp(COMMIT_TIMESTAMP.getNanos() / 1000)
+        .setLowWatermark(LOW_WATERMARK.getNanos() / 1000)
+        .setModType(ModType.SET_CELL)
+        .setColumnFamily(COLUMN_FAMILY)
+        .setColumn(COLUMN)
+        .setTimestamp((long) (TIMESTAMP.getNanos() / 1000))
+        .setValue(VALUE)
+        .setTimestampFrom(null)
+        .setTimestampTo(null)
+        .build();
+  }
+
+  private ChangelogEntry createDeleteCellsChangelogEntry(
+      String columnFamily, ByteBuffer qualifier) {
+    return ChangelogEntry.newBuilder()
+        .setRowKey(ROW_KEY)
+        .setIsGC(IS_GC)
+        .setTieBreaker(TIE_BREAKER)
+        .setCommitTimestamp((long) (COMMIT_TIMESTAMP.getNanos() / 1000))
+        .setLowWatermark((long) (LOW_WATERMARK.getNanos() / 1000))
+        .setColumnFamily(COLUMN_FAMILY)
+        .setColumn(COLUMN)
+        .setModType(ModType.DELETE_CELLS)
+        .setTimestamp(null)
+        .setValue(null)
+        .setTimestampFrom((long) (TIMESTAMP_FROM.getNanos() / 1000))
+        .setTimestampTo((long) (TIMESTAMP_TO.getNanos() / 1000))
+        .build();
+  }
+
+  private ChangelogEntry createDeleteFamilyChangelogEntry(
+      String columnFamily, ByteBuffer qualifier) {
+    return ChangelogEntry.newBuilder()
+        .setRowKey(ROW_KEY)
+        .setIsGC(IS_GC)
+        .setTieBreaker(TIE_BREAKER)
+        .setCommitTimestamp((long) (COMMIT_TIMESTAMP.getNanos() / 1000))
+        .setLowWatermark((long) (LOW_WATERMARK.getNanos() / 1000))
+        .setColumnFamily(COLUMN_FAMILY)
+        .setModType(ModType.DELETE_FAMILY)
+        .setColumn(null)
+        .setTimestamp(null)
+        .setValue(null)
+        .setTimestampFrom(null)
+        .setTimestampTo(null)
+        .build();
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/CharSequenceTypeAdapter.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/CharSequenceTypeAdapter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+
+public class CharSequenceTypeAdapter extends TypeAdapter<CharSequence> {
+  @Override
+  public void write(JsonWriter out, CharSequence value) throws IOException {
+    if (value == null) {
+      out.nullValue();
+    } else {
+      // Assumes that value complies with CharSequence.toString() contract
+      out.value(value.toString());
+    }
+  }
+
+  @Override
+  public CharSequence read(JsonReader in) throws IOException {
+    if (in.peek() == JsonToken.NULL) {
+      // Skip the JSON null
+      in.skipValue();
+      return null;
+    } else {
+      return in.nextString();
+    }
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/CommitTimeAwarePredicate.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/CommitTimeAwarePredicate.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import com.google.cloud.storage.Blob;
+import java.util.function.Predicate;
+
+public abstract class CommitTimeAwarePredicate implements Predicate<Blob> {
+
+  private Long min = null;
+  private Long max = null;
+
+  public void observeCommitTime(long commitTimeMicros) {
+    if (min == null || max == null) {
+      max = min = commitTimeMicros;
+    } else {
+      if (min > commitTimeMicros) {
+        min = commitTimeMicros;
+      }
+      if (max < commitTimeMicros) {
+        max = commitTimeMicros;
+      }
+    }
+  }
+
+  public Long getEarliestCommitTime() {
+    return min;
+  }
+
+  public Long getLatestCommitTime() {
+    return max;
+  }
+
+  public boolean found() {
+    return min != null;
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/LookForBigtableRowAvroRecord.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/LookForBigtableRowAvroRecord.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import static com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.Tools.bbToString;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.teleport.bigtable.BigtableCell;
+import com.google.cloud.teleport.bigtable.BigtableRow;
+import com.google.cloud.teleport.bigtable.ChangelogEntry;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.SeekableByteArrayInput;
+import org.apache.avro.reflect.ReflectData;
+import org.apache.avro.reflect.ReflectDatumReader;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LookForBigtableRowAvroRecord extends CommitTimeAwarePredicate {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LookForBigtableRowAvroRecord.class);
+  private final ChangelogEntry expected;
+
+  public LookForBigtableRowAvroRecord(ChangelogEntry expected) {
+    this.expected = expected;
+  }
+
+  @Override
+  public boolean test(Blob o) {
+    byte[] content = o.getContent();
+
+    try (DataFileReader<BigtableRow> reader =
+        new DataFileReader<>(
+            new SeekableByteArrayInput(content),
+            new ReflectDatumReader<>(ReflectData.get().getSchema(BigtableRow.class)))) {
+      for (BigtableRow row : reader) {
+        LOG.info("Object read: {}", row);
+
+        for (BigtableCell cell : row.getCells()) {
+          String qualifier = bbToString(cell.getQualifier());
+          String value = bbToString(cell.getValue());
+          long timestamp = cell.getTimestamp();
+
+          // Bigtable rows describing changelog has 0 timestamps
+          Assert.assertEquals(0, timestamp);
+
+          switch (qualifier) {
+            case "row_key":
+              Assert.assertEquals(bbToString(expected.getRowKey()), value);
+              break;
+            case "mod_type":
+              Assert.assertEquals(expected.getModType().toString(), value);
+              break;
+            case "is_gc":
+              Assert.assertEquals(Boolean.toString(expected.getIsGC()), value);
+              break;
+            case "column":
+              Assert.assertEquals(bbToString(expected.getColumn()), value);
+              break;
+            case "value":
+              Assert.assertEquals(bbToString(expected.getValue()), value);
+              break;
+            case "tiebreaker":
+              Assert.assertEquals(expected.getTieBreaker(), Integer.parseInt(value));
+              break;
+            case "timestamp":
+              Assert.assertEquals(expected.getTimestamp(), (Long) Long.parseLong(value));
+              break;
+            case "column_family":
+              Assert.assertEquals(expected.getColumnFamily().toString(), value);
+              break;
+            case "commit_timestamp":
+              observeCommitTime(Long.parseLong(value));
+              Assert.assertTrue(expected.getCommitTimestamp() <= Long.parseLong(value));
+              break;
+            case "low_watermark":
+              Assert.assertEquals(expected.getLowWatermark(), Long.parseLong(value));
+              break;
+            case "timestamp_from":
+              Assert.assertEquals(
+                  expected.getTimestampFrom(), (value == null ? null : Long.parseLong(value)));
+              break;
+            case "timestamp_to":
+              Assert.assertEquals(
+                  expected.getTimestampTo(), (value == null ? null : Long.parseLong(value)));
+              break;
+            default:
+              throw new IllegalStateException("Unexpected column qualifier: " + qualifier);
+          }
+        }
+      }
+      return true;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/LookForChangelogEntryAvroRecord.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/LookForChangelogEntryAvroRecord.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.teleport.bigtable.ChangelogEntry;
+import java.nio.charset.Charset;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.SeekableByteArrayInput;
+import org.apache.avro.reflect.ReflectData;
+import org.apache.avro.reflect.ReflectDatumReader;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LookForChangelogEntryAvroRecord extends CommitTimeAwarePredicate {
+  private static final Logger LOG = LoggerFactory.getLogger(LookForChangelogEntryAvroRecord.class);
+  private final ChangelogEntry expected;
+
+  public LookForChangelogEntryAvroRecord(ChangelogEntry expected) {
+    this.expected = expected;
+  }
+
+  @Override
+  public boolean test(Blob o) {
+    byte[] content = o.getContent();
+    LOG.info(
+        "Read from GCS file ({}): {}",
+        o.asBlobInfo(),
+        new String(content, Charset.defaultCharset()));
+
+    try (DataFileReader<ChangelogEntry> reader =
+        new DataFileReader<>(
+            new SeekableByteArrayInput(content),
+            new ReflectDatumReader<>(ReflectData.get().getSchema(ChangelogEntry.class)))) {
+
+      for (ChangelogEntry changelogEntry : reader) {
+        Assert.assertEquals(expected.getTimestamp(), changelogEntry.getTimestamp());
+        Assert.assertEquals(expected.getIsGC(), changelogEntry.getIsGC());
+        Assert.assertEquals(expected.getModType(), changelogEntry.getModType());
+        Assert.assertEquals(expected.getRowKey().toString(), changelogEntry.getRowKey().toString());
+        Assert.assertEquals(
+            expected.getColumnFamily().toString(), changelogEntry.getColumnFamily().toString());
+        Assert.assertEquals(
+            expected.getLowWatermark(),
+            changelogEntry.getLowWatermark()); // Low watermark is not working yet
+        Assert.assertEquals(expected.getColumn().toString(), changelogEntry.getColumn().toString());
+        Assert.assertTrue(expected.getCommitTimestamp() <= changelogEntry.getCommitTimestamp());
+        observeCommitTime(changelogEntry.getCommitTimestamp());
+        Assert.assertTrue(changelogEntry.getTieBreaker() >= 0);
+        Assert.assertEquals(expected.getTimestampFrom(), changelogEntry.getTimestampFrom());
+        Assert.assertEquals(expected.getTimestampFrom(), changelogEntry.getTimestampTo());
+        Assert.assertEquals(expected.getValue(), changelogEntry.getValue());
+      }
+      return true;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/LookForChangelogEntryJsonBase64Record.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/LookForChangelogEntryJsonBase64Record.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import static com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs.Tools.bbToBase64String;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.teleport.bigtable.ChangelogEntry;
+import com.google.cloud.teleport.bigtable.ChangelogEntryJson;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.nio.charset.Charset;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LookForChangelogEntryJsonBase64Record extends CommitTimeAwarePredicate {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(LookForChangelogEntryJsonBase64Record.class);
+  private final ChangelogEntry expected;
+
+  public LookForChangelogEntryJsonBase64Record(ChangelogEntry expected) {
+    this.expected = expected;
+  }
+
+  @Override
+  public boolean test(Blob o) {
+    byte[] content = o.getContent();
+    LOG.info(
+        "Read from GCS file ({}): {}",
+        o.asBlobInfo(),
+        new String(content, Charset.defaultCharset()));
+
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(CharSequence.class, new CharSequenceTypeAdapter())
+            .create();
+
+    ChangelogEntryJson changelogEntry =
+        gson.fromJson(new String(content), ChangelogEntryJson.class);
+
+    Assert.assertEquals(expected.getTimestamp(), changelogEntry.getTimestamp());
+    Assert.assertEquals(expected.getIsGC(), changelogEntry.getIsGC());
+    Assert.assertEquals(expected.getModType(), changelogEntry.getModType());
+    Assert.assertEquals(
+        bbToBase64String(expected.getRowKey()), changelogEntry.getRowKey().toString());
+    Assert.assertEquals(
+        expected.getColumnFamily().toString(), changelogEntry.getColumnFamily().toString());
+    Assert.assertEquals(
+        expected.getLowWatermark(),
+        changelogEntry.getLowWatermark()); // Low watermark is not working yet
+    Assert.assertEquals(
+        bbToBase64String(expected.getColumn()), changelogEntry.getColumn().toString());
+    Assert.assertTrue(expected.getCommitTimestamp() <= changelogEntry.getCommitTimestamp());
+    observeCommitTime(changelogEntry.getCommitTimestamp());
+    Assert.assertTrue(changelogEntry.getTieBreaker() >= 0);
+    Assert.assertEquals(expected.getTimestampFrom(), changelogEntry.getTimestampFrom());
+    Assert.assertEquals(expected.getTimestampFrom(), changelogEntry.getTimestampTo());
+    Assert.assertEquals(
+        bbToBase64String(expected.getValue()), changelogEntry.getValue().toString());
+
+    return true;
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/LookForChangelogEntryJsonRecord.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/LookForChangelogEntryJsonRecord.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.teleport.bigtable.ChangelogEntryJson;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.nio.charset.Charset;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LookForChangelogEntryJsonRecord extends CommitTimeAwarePredicate {
+  private static final Logger LOG = LoggerFactory.getLogger(LookForChangelogEntryJsonRecord.class);
+  private final ChangelogEntryJson expected;
+
+  public LookForChangelogEntryJsonRecord(ChangelogEntryJson expected) {
+    this.expected = expected;
+  }
+
+  @Override
+  public boolean test(Blob o) {
+    byte[] content = o.getContent();
+    LOG.info(
+        "Read from GCS file ({}): {}",
+        o.asBlobInfo(),
+        new String(content, Charset.defaultCharset()));
+
+    Gson gson =
+        new GsonBuilder()
+            .registerTypeAdapter(CharSequence.class, new CharSequenceTypeAdapter())
+            .create();
+
+    ChangelogEntryJson changelogEntry =
+        gson.fromJson(new String(content), ChangelogEntryJson.class);
+
+    Assert.assertEquals(expected.getTimestamp(), changelogEntry.getTimestamp());
+    Assert.assertEquals(expected.getIsGC(), changelogEntry.getIsGC());
+    Assert.assertEquals(expected.getModType(), changelogEntry.getModType());
+    Assert.assertEquals(expected.getRowKey().toString(), changelogEntry.getRowKey().toString());
+    Assert.assertEquals(
+        expected.getColumnFamily().toString(), changelogEntry.getColumnFamily().toString());
+    Assert.assertEquals(
+        expected.getLowWatermark(),
+        changelogEntry.getLowWatermark()); // Low watermark is not working yet
+    Assert.assertEquals(expected.getColumn().toString(), changelogEntry.getColumn().toString());
+    Assert.assertTrue(expected.getCommitTimestamp() <= changelogEntry.getCommitTimestamp());
+    observeCommitTime(changelogEntry.getCommitTimestamp());
+    Assert.assertTrue(changelogEntry.getTieBreaker() >= 0);
+    Assert.assertEquals(expected.getTimestampFrom(), changelogEntry.getTimestampFrom());
+    Assert.assertEquals(expected.getTimestampFrom(), changelogEntry.getTimestampTo());
+    Assert.assertEquals(expected.getValue(), changelogEntry.getValue());
+
+    return true;
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/Tools.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/Tools.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.Base64;
+
+public class Tools {
+  private Tools() {
+    // don't create
+  }
+
+  public static String bbToString(ByteBuffer val) {
+    if (val == null) {
+      return null;
+    }
+    return new String(val.array(), Charset.defaultCharset());
+  }
+
+  public static String bbToBase64String(ByteBuffer val) {
+    if (val == null) {
+      return null;
+    }
+    return Base64.getEncoder().encodeToString(val.array());
+  }
+}


### PR DESCRIPTION
A number of tests added to cover miscellaneous formats and modes configurable for the template