### PR TITLE
Change zone for Bigtable tests, avoid stockouts

### DIFF
--- a/it/google-cloud-platform/pom.xml
+++ b/it/google-cloud-platform/pom.xml
@@ -133,6 +133,11 @@
             <artifactId>auto-value-annotations</artifactId>
             <version>${autovalue.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+        </dependency>
         <!-- TODO(pranavbhandari): Remove the following dependencies after BigQueryIOLT is moved to the right directory -->
         <dependency>
             <groupId>org.apache.beam</groupId>

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/bigtable/BigtableResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/bigtable/BigtableResourceManager.java
@@ -21,7 +21,7 @@ import static org.apache.beam.it.common.utils.ResourceManagerUtils.checkValidPro
 import static org.apache.beam.it.gcp.bigtable.BigtableResourceManagerUtils.checkValidTableId;
 import static org.apache.beam.it.gcp.bigtable.BigtableResourceManagerUtils.generateDefaultClusters;
 import static org.apache.beam.it.gcp.bigtable.BigtableResourceManagerUtils.generateInstanceId;
-import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.rpc.ServerStream;

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/bigtable/BigtableResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/bigtable/BigtableResourceManager.java
@@ -21,6 +21,7 @@ import static org.apache.beam.it.common.utils.ResourceManagerUtils.checkValidPro
 import static org.apache.beam.it.gcp.bigtable.BigtableResourceManagerUtils.checkValidTableId;
 import static org.apache.beam.it.gcp.bigtable.BigtableResourceManagerUtils.generateDefaultClusters;
 import static org.apache.beam.it.gcp.bigtable.BigtableResourceManagerUtils.generateInstanceId;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.rpc.ServerStream;
@@ -57,7 +58,6 @@ import org.apache.beam.it.common.ResourceManager;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.threeten.bp.Duration;
 
 /**
@@ -76,7 +76,7 @@ import org.threeten.bp.Duration;
 public class BigtableResourceManager implements ResourceManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(BigtableResourceManager.class);
-  private static final String DEFAULT_CLUSTER_ZONE = "us-central1-a";
+  private static final String DEFAULT_CLUSTER_ZONE = "us-central1-b";
   private static final int DEFAULT_CLUSTER_NUM_NODES = 1;
   private static final StorageType DEFAULT_CLUSTER_STORAGE_TYPE = StorageType.SSD;
 
@@ -360,7 +360,7 @@ public class BigtableResourceManager implements ResourceManager {
         }
         tableAdminClient.createTable(createTableRequest);
 
-        Awaitility.await("Waiting for all tables to be replicated.")
+        await("Waiting for all tables to be replicated.")
             .atMost(java.time.Duration.ofMinutes(10))
             .pollInterval(java.time.Duration.ofMillis(5000))
             .until(
@@ -571,9 +571,18 @@ public class BigtableResourceManager implements ResourceManager {
       }
 
       if (usingStaticInstance) {
-        createdTables.forEach(tableAdminClient::deleteTable);
         LOG.info(
             "This manager was configured to use a static instance that will not be cleaned up.");
+
+        // Remove managed tables
+        createdTables.forEach(tableAdminClient::deleteTable);
+
+        // Remove managed app profiles
+        try (BigtableInstanceAdminClient instanceAdminClient =
+            bigtableResourceManagerClientFactory.bigtableInstanceAdminClient()) {
+          createdAppProfiles.forEach(
+              profile -> instanceAdminClient.deleteAppProfile(instanceId, profile, true));
+        }
         return;
       }
     }

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/bigtable/BigtableResourceManagerTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/bigtable/BigtableResourceManagerTest.java
@@ -442,7 +442,8 @@ public class BigtableResourceManagerTest {
     verify(bigtableResourceManagerClientFactory.bigtableTableAdminClient()).deleteTable(TABLE_ID);
     verify(bigtableResourceManagerClientFactory.bigtableTableAdminClient(), new Times(1))
         .deleteTable(anyString());
-    verify(bigtableResourceManagerClientFactory, never()).bigtableInstanceAdminClient();
+    verify(bigtableResourceManagerClientFactory.bigtableInstanceAdminClient(), never())
+        .deleteInstance(any());
   }
 
   private void setupReadyTable() {

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -28,6 +28,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
+    <awaitility.version>4.2.0</awaitility.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <failsafe.version>3.3.0</failsafe.version>
     <testcontainers.version>1.18.3</testcontainers.version>

--- a/it/splunk/pom.xml
+++ b/it/splunk/pom.xml
@@ -27,7 +27,6 @@
     <artifactId>it-splunk</artifactId>
 
     <properties>
-        <awaitility.version>4.2.0</awaitility.version>
         <splunk.version>1.9.4</splunk.version>
     </properties>
 

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ExportPipelineIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ExportPipelineIT.java
@@ -37,13 +37,13 @@ import org.apache.beam.it.gcp.TemplateTestBase;
 import org.apache.beam.it.gcp.artifacts.Artifact;
 import org.apache.beam.it.gcp.artifacts.utils.AvroTestUtil;
 import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
 /** Integration test for {@link ExportPipeline Spanner to GCS Avro} template. */
 @Category(TemplateIntegrationTest.class)

--- a/v1/src/test/java/com/google/cloud/teleport/templates/JdbcToBigQueryIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/JdbcToBigQueryIT.java
@@ -45,6 +45,7 @@ import org.apache.beam.it.jdbc.MSSQLResourceManager;
 import org.apache.beam.it.jdbc.MySQLResourceManager;
 import org.apache.beam.it.jdbc.OracleResourceManager;
 import org.apache.beam.it.jdbc.PostgresResourceManager;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,7 +54,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
 /** Integration test for {@link JdbcToBigQuery} (JdbcToBigQuery). */
 @Category(TemplateIntegrationTest.class)

--- a/v1/src/test/java/com/google/cloud/teleport/templates/PubSubToSplunkIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/PubSubToSplunkIT.java
@@ -45,6 +45,7 @@ import org.apache.beam.it.gcp.pubsub.conditions.PubsubMessagesCheck;
 import org.apache.beam.it.splunk.SplunkResourceManager;
 import org.apache.beam.it.splunk.conditions.SplunkEventsCheck;
 import org.apache.beam.sdk.io.splunk.SplunkEvent;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
@@ -52,7 +53,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
 /** Integration test for {@link PubSubToSplunk} classic template. */
 @Category(TemplateIntegrationTest.class)

--- a/v1/src/test/java/com/google/cloud/teleport/templates/SpannerToTextIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/SpannerToTextIT.java
@@ -34,13 +34,13 @@ import org.apache.beam.it.common.utils.ResourceManagerUtils;
 import org.apache.beam.it.gcp.TemplateTestBase;
 import org.apache.beam.it.gcp.artifacts.Artifact;
 import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
 /** Integration test for {@link SpannerToText Spanner to GCS Text} template. */
 @Category(TemplateIntegrationTest.class)

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/BigtableChangeStreamsToBigQueryIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/BigtableChangeStreamsToBigQueryIT.java
@@ -17,11 +17,11 @@ package com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery;
 
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/BigtableChangeStreamsToBigQueryIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/BigtableChangeStreamsToBigQueryIT.java
@@ -84,7 +84,7 @@ public final class BigtableChangeStreamsToBigQueryIT extends TemplateTestBase {
   public static final String SOURCE_COLUMN_FAMILY = "cf";
   private static final Duration EXPECTED_REPLICATION_MAX_WAIT_TIME = Duration.ofMinutes(10);
   private static final String TEST_REGION = "us-central1";
-  private static final String TEST_ZONE = "us-central1-a";
+  private static final String TEST_ZONE = "us-central1-b";
   private BigtableResourceManager bigtableResourceManager;
   private BigQueryResourceManager bigQueryResourceManager;
 

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangeStreamsToGcsIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangeStreamsToGcsIT.java
@@ -68,7 +68,7 @@ public final class BigtableChangeStreamsToGcsIT extends TemplateTestBase {
 
   public static final String SOURCE_COLUMN_FAMILY = "cf";
   private static final Duration EXPECTED_REPLICATION_MAX_WAIT_TIME = Duration.ofMinutes(10);
-  private static final String TEST_ZONE = "us-central1-a";
+  private static final String TEST_ZONE = "us-central1-b";
   private BigtableResourceManager bigtableResourceManager;
   private GcsResourceManager gcsResourceManager;
   private String outputPath;

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangeStreamsToGcsIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangeStreamsToGcsIT.java
@@ -50,6 +50,7 @@ import org.apache.beam.it.gcp.bigtable.BigtableResourceManager;
 import org.apache.beam.it.gcp.bigtable.BigtableResourceManagerCluster;
 import org.apache.beam.it.gcp.bigtable.BigtableTableSpec;
 import org.apache.beam.it.gcp.storage.GcsResourceManager;
+import org.awaitility.Awaitility;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Assert;
@@ -58,7 +59,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 /** Integration test for {@link BigtableChangeStreamsToGcs}. */
 @Category({TemplateIntegrationTest.class, SkipDirectRunnerTest.class})

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstopubsub/BigtableChangeStreamsToPubSubIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstopubsub/BigtableChangeStreamsToPubSubIT.java
@@ -88,7 +88,7 @@ public final class BigtableChangeStreamsToPubSubIT extends TemplateTestBase {
 
   public static final String SOURCE_COLUMN_FAMILY = "cf";
   private static final Duration EXPECTED_REPLICATION_MAX_WAIT_TIME = Duration.ofMinutes(10);
-  private static final String TEST_ZONE = "us-central1-a";
+  private static final String TEST_ZONE = "us-central1-b";
   private BigtableResourceManager bigtableResourceManager;
   private PubsubResourceManager pubsubResourceManager;
 

--- a/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToPubsubIT.java
+++ b/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToPubsubIT.java
@@ -18,7 +18,7 @@ package com.google.cloud.teleport.v2.templates;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatRecords;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
-import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.await;
 
 import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
 import com.google.pubsub.v1.SubscriptionName;

--- a/v2/mongodb-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQueryIT.java
+++ b/v2/mongodb-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQueryIT.java
@@ -39,6 +39,7 @@ import org.apache.beam.it.gcp.TemplateTestBase;
 import org.apache.beam.it.gcp.bigquery.BigQueryResourceManager;
 import org.apache.beam.it.gcp.bigquery.conditions.BigQueryRowsCheck;
 import org.apache.beam.it.mongodb.MongoDBResourceManager;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.json.JSONObject;
@@ -48,7 +49,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
 /**
  * Integration test for {@link MongoDbToBigQuery} (MongoDB_to_BigQuery).


### PR DESCRIPTION
Avoid stockout error:

> Caused by: com.google.api.gax.rpc.CancelledException: Operation with name "operations/projects/{PROJECT}/instances/testbig-20230821-213804-094699/locations/us-central1-a/operations/{operation-id}" failed with status = GrpcStatusCode{transportCode=CANCELLED} and message = Operation successfully rolled back : Not enough servers to allocate the requested nodes. We have temporarily sold out of Cloud Bigtable in this zone. Our support team has been notified and will be bringing more resources on board. Please try a different zone or try again later.