### PR TITLE
[Security] Bump auto dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,8 @@
     <jackson.version>2.14.1</jackson.version>
 
     <!-- Common dependency versions -->
-    <autovalue.version>1.8.2</autovalue.version>
+    <autovalue.version>1.10.3</autovalue.version>
+    <autovalue.service.version>1.1.1</autovalue.service.version>
     <avro.version>1.11.1</avro.version>
     <checkstyle.version>10.7.0</checkstyle.version>
     <commons-codec.version>1.16.0</commons-codec.version>

--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -34,7 +34,6 @@
   </description>
 
   <properties>
-    <autovalue.service.version>1.0-rc6</autovalue.service.version>
     <extra.enforcer.rules.version>1.3</extra.enforcer.rules.version>
     <mock-server-netty.version>5.14.0</mock-server-netty.version>
     <open-census.version>0.24.0</open-census.version>

--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -35,7 +35,6 @@
     <packaging>pom</packaging>
 
     <properties>
-        <autovalue.service.version>1.0-rc6</autovalue.service.version>
         <jib.maven.version>2.6.0</jib.maven.version>
         <opencensus.version>0.31.0</opencensus.version>
         <protoc.version>3.21.12</protoc.version>


### PR DESCRIPTION
Current versions are within range for CVE-2020-13936