### PR TITLE
Sort to avoid flaky tests on Neo4j MappingMapperTest

### DIFF
--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/model/helpers/MappingMapperTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/model/helpers/MappingMapperTest.java
@@ -25,6 +25,7 @@ import com.google.cloud.teleport.v2.neo4j.model.enums.TargetType;
 import com.google.cloud.teleport.v2.neo4j.model.job.FieldNameTuple;
 import com.google.cloud.teleport.v2.neo4j.model.job.Mapping;
 import com.google.cloud.teleport.v2.neo4j.model.job.Target;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
@@ -49,6 +50,7 @@ public class MappingMapperTest {
     List<Mapping> result =
         MappingMapper.parseMappings(target, mappings).stream()
             .filter(mapping -> mapping.getRole() == RoleType.key)
+            .sorted(Comparator.comparing(Mapping::getField))
             .collect(toList());
 
     assertThat(result)
@@ -101,6 +103,7 @@ public class MappingMapperTest {
     List<Mapping> result =
         MappingMapper.parseMappings(target, mappings).stream()
             .filter(mapping -> mapping.getRole() == RoleType.key)
+            .sorted(Comparator.comparing(Mapping::getField))
             .collect(toList());
 
     assertThat(result)
@@ -126,13 +129,14 @@ public class MappingMapperTest {
     List<Mapping> result =
         MappingMapper.parseMappings(target, mappings).stream()
             .filter(mapping -> mapping.getRole() == RoleType.key)
+            .sorted(Comparator.comparing(Mapping::getField))
             .collect(toList());
 
     assertThat(result)
         .isEqualTo(
             List.of(
-                new Mapping(FragmentType.source, RoleType.key, fieldTuple("value1", "value1")),
-                new Mapping(FragmentType.source, RoleType.key, fieldTuple("key2", "value2"))));
+                new Mapping(FragmentType.source, RoleType.key, fieldTuple("key2", "value2")),
+                new Mapping(FragmentType.source, RoleType.key, fieldTuple("value1", "value1"))));
   }
 
   @Test
@@ -151,6 +155,7 @@ public class MappingMapperTest {
     List<Mapping> result =
         MappingMapper.parseMappings(target, mappings).stream()
             .filter(mapping -> mapping.getRole() == RoleType.key)
+            .sorted(Comparator.comparing(Mapping::getField))
             .collect(toList());
 
     assertThat(result)
@@ -176,6 +181,7 @@ public class MappingMapperTest {
     List<Mapping> result =
         MappingMapper.parseMappings(target, mappings).stream()
             .filter(mapping -> mapping.getRole() == RoleType.key)
+            .sorted(Comparator.comparing(Mapping::getField))
             .collect(toList());
 
     assertThat(result)
@@ -203,6 +209,7 @@ public class MappingMapperTest {
     List<Mapping> result =
         MappingMapper.parseMappings(target, mappings).stream()
             .filter(mapping -> mapping.getRole() == RoleType.key)
+            .sorted(Comparator.comparing(Mapping::getField))
             .collect(toList());
 
     assertThat(result)
@@ -228,6 +235,7 @@ public class MappingMapperTest {
     List<Mapping> result =
         MappingMapper.parseMappings(target, mappings).stream()
             .filter(mapping -> mapping.getRole() == RoleType.key)
+            .sorted(Comparator.comparing(Mapping::getField))
             .collect(toList());
 
     assertThat(result)


### PR DESCRIPTION
We run tests dozens of times a day, and this is happening quite often:

```
[ERROR]   MappingMapperTest.parsesMultipleKeyMappingsFromObjectArrayForEdgeTargetNode:182 contents match, but order was wrong
expected: [Mapping{constant='null', role=key, type=null, name='value1', labels=[], field='key1', description='', mandatory=false, unique=false, indexed=true, fragmentType=target}, Mapping{constant='null', role=key, type=null, name='value2', labels=[], field='key2', description='', mandatory=false, unique=false, indexed=true, fragmentType=target}, Mapping{constant='null', role=key, type=null, name='value3', labels=[], field='key3', description='', mandatory=false, unique=false, indexed=true, fragmentType=target}, Mapping{constant='null', role=key, type=null, name='value4', labels=[], field='key4', description='', mandatory=false, unique=false, indexed=true, fragmentType=target}]
but was : [Mapping{constant='null', role=key, type=null, name='value2', labels=[], field='key2', description='', mandatory=false, unique=false, indexed=true, fragmentType=target}, Mapping{constant='null', role=key, type=null, name='value1', labels=[], field='key1', description='', mandatory=false, unique=false, indexed=true, fragmentType=target}, Mapping{constant='null', role=key, type=null, name='value4', labels=[], field='key4', description='', mandatory=false, unique=false, indexed=true, fragmentType=target}, Mapping{constant='null', role=key, type=null, name='value3', labels=[], field='key3', description='', mandatory=false, unique=false, indexed=true, fragmentType=target}]
[ERROR]   MappingMapperTest.parsesMultipleKeyMappingsFromObjectForEdgeSourceNode:55 contents match, but order was wrong
expected: [Mapping{constant='null', role=key, type=null, name='value1', labels=[], field='key1', description='', mandatory=false, unique=false, indexed=true, fragmentType=source}, Mapping{constant='null', role=key, type=null, name='value2', labels=[], field='key2', description='', mandatory=false, unique=false, indexed=true, fragmentType=source}]
but was : [Mapping{constant='null', role=key, type=null, name='value2', labels=[], field='key2', description='', mandatory=false, unique=false, indexed=true, fragmentType=source}, Mapping{constant='null', role=key, type=null, name='value1', labels=[], field='key1', description='', mandatory=false, unique=false, indexed=true, fragmentType=source}]
[ERROR]   MappingMapperTest.parsesMultipleKeyMappingsFromObjectForEdgeTargetNode:157 contents match, but order was wrong
expected: [Mapping{constant='null', role=key, type=null, name='value1', labels=[], field='key1', description='', mandatory=false, unique=false, indexed=true, fragmentType=target}, Mapping{constant='null', role=key, type=null, name='value2', labels=[], field='key2', description='', mandatory=false, unique=false, indexed=true, fragmentType=target}]
but was : [Mapping{constant='null', role=key, type=null, name='value2', labels=[], field='key2', description='', mandatory=false, unique=false, indexed=true, fragmentType=target}, Mapping{constant='null', role=key, type=null, name='value1', labels=[], field='key1', description='', mandatory=false, unique=false, indexed=true, fragmentType=target}]
[INFO] 
[ERROR] Tests run: 48, Failures: 4, Errors: 0, Skipped: 0

```
