### PR TITLE
Expose max transaction retry time as template parameter

### DIFF
--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnection.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnection.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
@@ -43,11 +44,18 @@ public class Neo4jConnection implements AutoCloseable, Serializable {
 
   /** Constructor. */
   public Neo4jConnection(ConnectionParams settings) {
+    this(settings, Config::defaultConfig);
+  }
+
+  /** Constructor. */
+  public Neo4jConnection(ConnectionParams settings, Supplier<Config> configSupplier) {
     this(
         settings.database,
         () ->
             GraphDatabase.driver(
-                settings.serverUrl, AuthTokens.basic(settings.username, settings.password)));
+                settings.serverUrl,
+                AuthTokens.basic(settings.username, settings.password),
+                configSupplier.get()));
   }
 
   @VisibleForTesting

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/InputValidator.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/InputValidator.java
@@ -61,6 +61,10 @@ public class InputValidator {
       validationMessages.add("Job spec URI not provided.");
     }
 
+    if (pipelineOptions.getTransactionMaxRetryTime() <= 0) {
+      validationMessages.add("Import transaction max retry time must be strictly positive");
+    }
+
     return validationMessages;
   }
 

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/helpers/OptionsParamsMapper.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/helpers/OptionsParamsMapper.java
@@ -17,26 +17,16 @@ package com.google.cloud.teleport.v2.neo4j.model.helpers;
 
 import com.google.cloud.teleport.v2.neo4j.model.job.OptionsParams;
 import com.google.cloud.teleport.v2.neo4j.options.Neo4jFlexTemplateOptions;
-import org.apache.commons.lang3.StringUtils;
 
 /** Helper class for parsing json into OptionsParams model object. */
 public class OptionsParamsMapper {
 
   public static OptionsParams fromPipelineOptions(Neo4jFlexTemplateOptions pipelineOptions) {
     OptionsParams optionsParams = new OptionsParams();
-    try {
-      if (StringUtils.isNotEmpty(pipelineOptions.getReadQuery())) {
-        optionsParams.setReadQuery(pipelineOptions.getReadQuery());
-      }
-      if (StringUtils.isNotEmpty(pipelineOptions.getInputFilePattern())) {
-        optionsParams.setInputFilePattern(pipelineOptions.getInputFilePattern());
-      }
-      if (StringUtils.isNotEmpty(pipelineOptions.getOptionsJson())) {
-        optionsParams.overlayTokens(pipelineOptions.getOptionsJson());
-      }
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    optionsParams.setReadQuery(pipelineOptions.getReadQuery());
+    optionsParams.setInputFilePattern(pipelineOptions.getInputFilePattern());
+    optionsParams.overlayTokens(pipelineOptions.getOptionsJson());
+    optionsParams.setMaxTransactionRetryTimeSeconds(pipelineOptions.getTransactionMaxRetryTime());
     return optionsParams;
   }
 }

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/job/OptionsParams.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/job/OptionsParams.java
@@ -34,7 +34,8 @@ public class OptionsParams implements Serializable {
 
   private String readQuery = "";
   private String inputFilePattern = "";
-  private HashMap<String, String> tokenMap = new HashMap<>();
+  private Integer maxTransactionRetryTimeSeconds = 120;
+  private final HashMap<String, String> tokenMap = new HashMap<>();
 
   public OptionsParams() {}
 
@@ -73,5 +74,13 @@ public class OptionsParams implements Serializable {
 
   public Map<String, String> getTokenMap() {
     return tokenMap;
+  }
+
+  public Integer getMaxTransactionRetryTimeSeconds() {
+    return maxTransactionRetryTimeSeconds;
+  }
+
+  public void setMaxTransactionRetryTimeSeconds(Integer maxTransactionRetryTimeSeconds) {
+    this.maxTransactionRetryTimeSeconds = maxTransactionRetryTimeSeconds;
   }
 }

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/options/Neo4jFlexTemplateOptions.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/options/Neo4jFlexTemplateOptions.java
@@ -76,4 +76,14 @@ public interface Neo4jFlexTemplateOptions extends CommonTemplateOptions {
   String getInputFilePattern();
 
   void setInputFilePattern(String value);
+
+  @TemplateParameter.Text(
+      order = 6,
+      optional = true,
+      description = "Import transactions max retry time",
+      helpText = "Specify max retry time in seconds (optional).")
+  @Default.Integer(120)
+  Integer getTransactionMaxRetryTime();
+
+  void setTransactionMaxRetryTime(Integer value);
 }

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/transforms/Neo4jRowWriterTransform.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/transforms/Neo4jRowWriterTransform.java
@@ -21,6 +21,7 @@ import com.google.cloud.teleport.v2.neo4j.model.connection.ConnectionParams;
 import com.google.cloud.teleport.v2.neo4j.model.enums.EdgeNodesMatchMode;
 import com.google.cloud.teleport.v2.neo4j.model.enums.TargetType;
 import com.google.cloud.teleport.v2.neo4j.model.job.JobSpec;
+import com.google.cloud.teleport.v2.neo4j.model.job.OptionsParams;
 import com.google.cloud.teleport.v2.neo4j.model.job.Target;
 import com.google.cloud.teleport.v2.neo4j.utils.DataCastingUtils;
 import java.util.List;
@@ -40,13 +41,19 @@ public class Neo4jRowWriterTransform extends PTransform<PCollection<Row>, PColle
   private static final Logger LOG = LoggerFactory.getLogger(Neo4jRowWriterTransform.class);
   private final JobSpec jobSpec;
   private final ConnectionParams neoConnection;
+  private final OptionsParams optionsParams;
   private final TargetType targetType;
   private final Target target;
 
   public Neo4jRowWriterTransform(
-      JobSpec jobSpec, ConnectionParams neoConnection, TargetType targetType, Target target) {
+      JobSpec jobSpec,
+      ConnectionParams neoConnection,
+      OptionsParams optionsParams,
+      TargetType targetType,
+      Target target) {
     this.jobSpec = jobSpec;
     this.neoConnection = neoConnection;
+    this.optionsParams = optionsParams;
     this.targetType = targetType;
     this.target = target;
   }
@@ -69,7 +76,13 @@ public class Neo4jRowWriterTransform extends PTransform<PCollection<Row>, PColle
 
     Neo4jBlockingUnwindFn neo4jUnwindFn =
         new Neo4jBlockingUnwindFn(
-            neoConnection, unwindCypher, batchSize, false, "rows", getRowCastingFunction());
+            neoConnection,
+            optionsParams,
+            unwindCypher,
+            batchSize,
+            false,
+            "rows",
+            getRowCastingFunction());
 
     return input
         .apply("Create KV pairs", CreateKvTransform.of(parallelism))


### PR DESCRIPTION
This applies only to imports.

The template default is 2 minutes, which overrides the driver's default of 30 seconds.