### PR TITLE
Fix Load Tests.

### DIFF
--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/IOLoadTestBase.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/IOLoadTestBase.java
@@ -63,7 +63,7 @@ public class IOLoadTestBase extends LoadTestBase {
 
   @Override
   PipelineLauncher launcher() {
-    return DefaultPipelineLauncher.builder().build();
+    return DefaultPipelineLauncher.builder(CREDENTIALS).build();
   }
 
   /** A utility DoFn that counts elements passed through. */

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/dataflow/DefaultPipelineLauncher.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/dataflow/DefaultPipelineLauncher.java
@@ -109,8 +109,8 @@ public class DefaultPipelineLauncher extends AbstractPipelineLauncher {
                 : new HttpCredentialsAdapter(builder.getCredentials())));
   }
 
-  public static DefaultPipelineLauncher.Builder builder() {
-    return new DefaultPipelineLauncher.Builder();
+  public static DefaultPipelineLauncher.Builder builder(Credentials credentials) {
+    return new DefaultPipelineLauncher.Builder(credentials);
   }
 
   @Override
@@ -462,15 +462,12 @@ public class DefaultPipelineLauncher extends AbstractPipelineLauncher {
   public static final class Builder {
     private Credentials credentials;
 
-    private Builder() {}
+    private Builder(Credentials credentials) {
+      this.credentials = credentials;
+    }
 
     public Credentials getCredentials() {
       return credentials;
-    }
-
-    public DefaultPipelineLauncher.Builder setCredentials(Credentials value) {
-      credentials = value;
-      return this;
     }
 
     public DefaultPipelineLauncher build() {

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/dataflow/DefaultPipelineLauncherTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/dataflow/DefaultPipelineLauncherTest.java
@@ -41,7 +41,7 @@ public class DefaultPipelineLauncherTest {
 
   @Test
   public void testPipelineMetrics() throws IOException {
-    DefaultPipelineLauncher launcher = DefaultPipelineLauncher.builder().build();
+    DefaultPipelineLauncher launcher = DefaultPipelineLauncher.builder(null).build();
     final String timeMetrics = "run_time";
     final String counterMetrics = "counter";
     final long numElements = 1000L;


### PR DESCRIPTION
All tests which use DefaultPipelineLauncher were broken due to missing credentials.