### PR TITLE
Fix asserts after parameters were added

### DIFF
--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/dataflow/AbstractPipelineLauncher.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/dataflow/AbstractPipelineLauncher.java
@@ -60,6 +60,9 @@ public abstract class AbstractPipelineLauncher implements PipelineLauncher {
   private static final Pattern CURRENT_METRICS = Pattern.compile(".*Current.*");
   public static final String LEGACY_RUNNER = "Dataflow Legacy Runner";
   public static final String RUNNER_V2 = "Dataflow Runner V2";
+  public static final String PARAM_RUNNER = "runner";
+  public static final String PARAM_JOB_TYPE = "jobType";
+  public static final String PARAM_JOB_ID = "jobId";
 
   protected final List<String> launchedJobs = new ArrayList<>();
 
@@ -269,9 +272,9 @@ public abstract class AbstractPipelineLauncher implements PipelineLauncher {
     Map<String, String> parameters = new HashMap<>(options.parameters());
     options.environment().forEach((key, val) -> parameters.put(key, val.toString()));
     // attach basic job info to parameters so that these are exported for load tests
-    parameters.put("runner", runner);
-    parameters.put("jobType", job.getType());
-    parameters.put("jobId", job.getId());
+    parameters.put(PARAM_RUNNER, runner);
+    parameters.put(PARAM_JOB_TYPE, job.getType());
+    parameters.put(PARAM_JOB_ID, job.getId());
     builder.setParameters(ImmutableMap.copyOf(parameters));
     if (labels != null && !labels.isEmpty()) {
       // template job

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/dataflow/ClassicTemplateClientTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/dataflow/ClassicTemplateClientTest.java
@@ -18,6 +18,10 @@
 package org.apache.beam.it.gcp.dataflow;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.apache.beam.it.gcp.dataflow.AbstractPipelineLauncher.LEGACY_RUNNER;
+import static org.apache.beam.it.gcp.dataflow.AbstractPipelineLauncher.PARAM_JOB_ID;
+import static org.apache.beam.it.gcp.dataflow.AbstractPipelineLauncher.PARAM_JOB_TYPE;
+import static org.apache.beam.it.gcp.dataflow.AbstractPipelineLauncher.PARAM_RUNNER;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -154,7 +158,13 @@ public final class ClassicTemplateClientTest {
             .setVersion("2.42.0")
             .setJobType("JOB_TYPE_BATCH")
             .setRunner(AbstractPipelineLauncher.LEGACY_RUNNER)
-            .setParameters(ImmutableMap.of(PARAM_KEY, PARAM_VALUE))
+            .setParameters(
+                ImmutableMap.<String, String>builder()
+                    .put(PARAM_KEY, PARAM_VALUE)
+                    .put(PARAM_JOB_ID, JOB_ID)
+                    .put(PARAM_RUNNER, LEGACY_RUNNER)
+                    .put(PARAM_JOB_TYPE, "JOB_TYPE_BATCH")
+                    .build())
             .build();
     assertThat(actual).isEqualTo(expected);
   }

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/dataflow/FlexTemplateClientTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/dataflow/FlexTemplateClientTest.java
@@ -18,6 +18,10 @@
 package org.apache.beam.it.gcp.dataflow;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.apache.beam.it.gcp.dataflow.AbstractPipelineLauncher.LEGACY_RUNNER;
+import static org.apache.beam.it.gcp.dataflow.AbstractPipelineLauncher.PARAM_JOB_ID;
+import static org.apache.beam.it.gcp.dataflow.AbstractPipelineLauncher.PARAM_JOB_TYPE;
+import static org.apache.beam.it.gcp.dataflow.AbstractPipelineLauncher.PARAM_RUNNER;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -158,8 +162,14 @@ public final class FlexTemplateClientTest {
             .setSdk("Apache Beam Java")
             .setVersion("2.42.0")
             .setJobType("JOB_TYPE_BATCH")
-            .setRunner(AbstractPipelineLauncher.LEGACY_RUNNER)
-            .setParameters(ImmutableMap.of(PARAM_KEY, PARAM_VALUE))
+            .setRunner(LEGACY_RUNNER)
+            .setParameters(
+                ImmutableMap.<String, String>builder()
+                    .put(PARAM_KEY, PARAM_VALUE)
+                    .put(PARAM_JOB_ID, JOB_ID)
+                    .put(PARAM_RUNNER, LEGACY_RUNNER)
+                    .put(PARAM_JOB_TYPE, "JOB_TYPE_BATCH")
+                    .build())
             .build();
     assertThat(actual).isEqualTo(expected);
   }


### PR DESCRIPTION
Tests were failing with:

```
 org.apache.beam.it.gcp.dataflow.ClassicTemplateClientTest.testLaunchNewJob
 Error Details
expected: …e=null, parameters={key=value}}
but was : …e=null, parameters={jobId=test-job-id, runner=Dataflow Legacy Runner, jobType=JOB_TYPE_BATCH, key=value}}
```