### PR TITLE
Add instructions to work around `File too large` error when staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Notes:
   as `-DspecPath=gs://.../path`
 - `-DjobName="{name}"` may be informed if a specific name is desirable (
   optional).
+- If you encounter the error `Template run failed: File too large`, try adding `-DskipShade` to the mvn args.
 
 
 ### Running Integration Tests


### PR DESCRIPTION
The error seems to be happening due to the shaded jar file size excluding some limit. Adding `-DskipShade` keeps the jar separate and small.