### PR TITLE
Fix date/time pattern

### DIFF
--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/utils/DataCastingUtils.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/utils/DataCastingUtils.java
@@ -68,8 +68,8 @@ public class DataCastingUtils {
   private static final Logger LOG = LoggerFactory.getLogger(DataCastingUtils.class);
 
   private static final DateTimeFormatter jsDateTimeFormatter =
-      DateTimeFormat.forPattern("YYYY-MM-DD HH:mm:ssZ");
-  private static final DateTimeFormatter jsDateFormatter = DateTimeFormat.forPattern("YYYY-MM-DD");
+      DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ssZ");
+  private static final DateTimeFormatter jsDateFormatter = DateTimeFormat.forPattern("YYYY-MM-dd");
 
   public static List<Object> sourceTextToTargetObjects(Row row, Target target) {
     Schema targetSchema = BeamUtils.toBeamSchema(target);

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/utils/DataCastingUtilsTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/utils/DataCastingUtilsTest.java
@@ -214,15 +214,6 @@ public class DataCastingUtilsTest {
         .containsExactly(1L, "neo4j", new BigDecimal("15.5"), true, true, expectedDate);
   }
 
-  private static Mapping mapping(String field, PropertyType type) {
-    FieldNameTuple tuple = new FieldNameTuple();
-    tuple.setName(field);
-    tuple.setField(field);
-    Mapping mapping = new Mapping(FragmentType.node, RoleType.property, tuple);
-    mapping.setType(type);
-    return mapping;
-  }
-
   @Test
   public void testStringConversionToDateAndDateTime() {
     Schema schema =
@@ -241,8 +232,8 @@ public class DataCastingUtilsTest {
     target.setFieldNames(ImmutableList.of("hireDate", "hireDateTime"));
     target.setMappings(
         ImmutableList.of(
-            new Mapping("hireDate", PropertyType.Date),
-            new Mapping("hireDateTime", PropertyType.DateTime)));
+            mapping("hireDate", PropertyType.Date),
+            mapping("hireDateTime", PropertyType.DateTime)));
 
     List<Object> convertedList = DataCastingUtils.sourceTextToTargetObjects(row, target);
 
@@ -251,5 +242,18 @@ public class DataCastingUtilsTest {
             ZonedDateTime.of(LocalDate.of(2022, 8, 15), LocalTime.MIDNIGHT, ZoneId.systemDefault())
                 .withZoneSameInstant(utcZone),
             ZonedDateTime.of(2022, 8, 15, 1, 2, 3, 0, utcZone));
+  }
+
+  private static Mapping mapping(String field, PropertyType type) {
+    Mapping mapping = new Mapping(FragmentType.node, RoleType.property, tuple(field, field));
+    mapping.setType(type);
+    return mapping;
+  }
+
+  private static FieldNameTuple tuple(String name, String field) {
+    FieldNameTuple tuple = new FieldNameTuple();
+    tuple.setName(name);
+    tuple.setField(field);
+    return tuple;
   }
 }

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/utils/DataCastingUtilsTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/utils/DataCastingUtilsTest.java
@@ -36,6 +36,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -219,5 +221,35 @@ public class DataCastingUtilsTest {
     Mapping mapping = new Mapping(FragmentType.node, RoleType.property, tuple);
     mapping.setType(type);
     return mapping;
+  }
+
+  @Test
+  public void testStringConversionToDateAndDateTime() {
+    Schema schema =
+        Schema.of(
+            Field.of("hireDate", FieldType.STRING), Field.of("hireDateTime", FieldType.STRING));
+    ZoneId utcZone = ZoneId.of("UTC", ZoneId.SHORT_IDS);
+    Row row =
+        Row.withSchema(schema)
+            .withFieldValue(
+                "hireDate",
+                "2022-08-15") // note: this is a *local* date, it depends on the system TZ
+            .withFieldValue("hireDateTime", "2022-08-15 01:02:03Z")
+            .build();
+    Target target = new Target();
+    target.setName("neo4j-target");
+    target.setFieldNames(ImmutableList.of("hireDate", "hireDateTime"));
+    target.setMappings(
+        ImmutableList.of(
+            new Mapping("hireDate", PropertyType.Date),
+            new Mapping("hireDateTime", PropertyType.DateTime)));
+
+    List<Object> convertedList = DataCastingUtils.sourceTextToTargetObjects(row, target);
+
+    assertThat(convertedList)
+        .containsExactly(
+            ZonedDateTime.of(LocalDate.of(2022, 8, 15), LocalTime.MIDNIGHT, ZoneId.systemDefault())
+                .withZoneSameInstant(utcZone),
+            ZonedDateTime.of(2022, 8, 15, 1, 2, 3, 0, utcZone));
   }
 }


### PR DESCRIPTION
This was using `D` (day of year) instead of `d` (day of month).

This had the effect of overwriting whichever month was parsed from the `M` (month of year) component.