### PR TITLE
Add support for SSL in Kafka to BigQuery template.

### DIFF
--- a/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/options/KafkaReadOptions.java
+++ b/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/options/KafkaReadOptions.java
@@ -45,4 +45,16 @@ public interface KafkaReadOptions extends PipelineOptions {
   String getKafkaReadTopics();
 
   void setKafkaReadTopics(String inputTopics);
+
+  @TemplateParameter.Text(
+      order = 3,
+      optional = true,
+      regexes = {"^projects\\/[^\\n\\r\\/]+\\/secrets\\/[^\\n\\r\\/]+\\/versions\\/[^\\n\\r\\/]+$"},
+      description = "Secret Manager secret containing kafka consumer properties as json.",
+      helpText =
+          "Secret manager secret Id for kafka consumer config JSON. If provided, config is fetched from Secret Manager and used.",
+      example = "projects/project-id/secrets/secret-id/versions/version-id")
+  String getKafkaConfigSecretId();
+
+  void setKafkaConfigSecretId(String secretId);
 }

--- a/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryTest.java
+++ b/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryTest.java
@@ -51,7 +51,7 @@ public class KafkaToBigQueryTest {
 
   /** Tests the {@link KafkaToBigQuery} pipeline end-to-end. */
   @Test
-  public void testKafkaToBigQueryE2E() throws Exception {
+  public void testKafkaToBigQueryE2E() {
     // Test input
     final String key = "{\"id\": \"1001\"}";
     final String badKey = "{\"id\": \"1002\"}";


### PR DESCRIPTION
After this PR is merged, customers should be able to pass in the SSL configs for the kafka consumer by following the below steps,

1. Save the `truststore.jks` and `keystore.jks` files in a GCS bucket (e.g, test-bucket)
2. Create a file and paste the following,
```
{
   "bucket":"test-bucket",
   "ssl.truststore.location":"truststore.jks",
   "ssl.keystore.location":"keystore.jks",
   "ssl.truststore.password":"truststore-password",
   "ssl.keystore.password":"keystore-password",
   "ssl.key.password":"admin-secret"
}
```
3. Replace the values in the JSON. **Note**, `ssl.truststore.location` and `ssl.keystore.location` should be the path of the truststore and keystore respectively under the `bucket` (In this example, the truststore is stored in gs://test-bucket/truststore.jks)
4. Omit any key-value pairs that are not applicable.
5. Create a Secret manager secret using that file. (https://cloud.google.com/secret-manager)
6. Pass the Secret Manager secret ID using the parameter `kafkaConfigSecretId`