### PR TITLE
 Cloud Spanner to Vector Search JSON format template

### DIFF
--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/artifacts/utils/JsonTestUtil.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/artifacts/utils/JsonTestUtil.java
@@ -18,13 +18,22 @@
 package org.apache.beam.it.gcp.artifacts.utils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 /**
  * The {@link JsonTestUtil} class provides common utilities used for executing tests that involve
@@ -57,6 +66,67 @@ public class JsonTestUtil {
   }
 
   /**
+   * Reads NDJSON (Newline Delimited JSON) data from a byte array and returns a list of parsed JSON
+   * objects. Each JSON object is represented as a Map of String keys to Object values.
+   *
+   * @param jsonBytes A byte array containing NDJSON data.
+   * @return A list of parsed JSON objects as {@code Map<String, Object>}.
+   * @throws IOException if there's an issue reading or parsing the data.
+   */
+  public static List<Map<String, Object>> readNDJSON(byte[] jsonBytes) throws IOException {
+    try (ByteArrayInputStream inputStream = new ByteArrayInputStream(jsonBytes)) {
+      InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+      JsonMapper mapper = new JsonMapper();
+
+      return new BufferedReader(reader)
+          .lines()
+          .map(
+              line -> {
+                try {
+                  // Deserialize each line as a Map<String, Object>
+                  return mapper.readValue(line, mapTypeRef);
+                } catch (IOException e) {
+                  throw new RuntimeException(e);
+                }
+              })
+          .collect(Collectors.toList());
+    }
+  }
+
+  /**
+   * Recursively sorts the keys of a nested JSON represented as a Map.
+   *
+   * @param jsonMap A {@code Map<String, Object>} representing the nested JSON.
+   * @return A sorted {@code Map<String, Object>} where the keys are sorted in natural order.
+   */
+  public static Map<String, Object> sortJsonMap(Map<String, Object> jsonMap) {
+    return jsonMap.entrySet().stream()
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> {
+                  Object value = entry.getValue();
+                  if (value instanceof Map) {
+                    return sortJsonMap((Map<String, Object>) value);
+                  } else if (value instanceof List) {
+                    return ((List<Object>) value)
+                        .stream()
+                            .map(
+                                item ->
+                                    item instanceof Map
+                                        ? sortJsonMap((Map<String, Object>) item)
+                                        : item)
+                            .collect(Collectors.toList());
+                  } else {
+                    return value;
+                  }
+                },
+                (a, b) -> a, // Merge function (not needed for a TreeMap)
+                TreeMap::new // Resulting map is a TreeMap
+                ));
+  }
+
+  /**
    * Read JSON records to a list of Maps.
    *
    * @param contents String with contents to read.
@@ -85,5 +155,83 @@ public class JsonTestUtil {
    */
   public static Map<String, Object> readRecord(String contents) throws IOException {
     return readRecord(contents.getBytes(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Parses a JSON string and returns either a List of Maps or a Map, depending on whether the JSON
+   * represents an array or an object.
+   *
+   * @param jsonString The JSON string to parse.
+   * @return A List of Maps if the JSON is an array, or a Map if it's an object.
+   * @throws IOException If there's an error while parsing the JSON string.
+   */
+  public static Object parseJsonString(String jsonString) throws IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    JsonNode jsonNode = objectMapper.readTree(jsonString);
+    if (jsonNode.isArray()) {
+      return parseJsonArray((ArrayNode) jsonNode);
+    } else if (jsonNode.isObject()) {
+      return parseJsonObject(jsonNode);
+    } else {
+      throw new IllegalArgumentException("Input is not a valid JSON object or array.");
+    }
+  }
+
+  /**
+   * Parses a JSON array represented by an ArrayNode and returns a List of Maps.
+   *
+   * @param arrayNode The JSON array to parse.
+   * @return A List of Maps containing the parsed data.
+   */
+  private static List<Object> parseJsonArray(ArrayNode arrayNode) {
+    List<Object> result = new ArrayList<>();
+    for (JsonNode element : arrayNode) {
+      if (element.isObject()) {
+        result.add(parseJsonObject(element));
+      } else {
+        result.add(parseSimpleNode(element));
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Parses a JSON object represented by a JsonNode and returns a Map.
+   *
+   * @param objectNode The JSON object to parse.
+   * @return A Map containing the parsed data.
+   */
+  private static Map<String, Object> parseJsonObject(JsonNode objectNode) {
+    Map<String, Object> result = new HashMap<>();
+    objectNode
+        .fields()
+        .forEachRemaining(
+            entry -> {
+              String key = entry.getKey();
+              JsonNode value = entry.getValue();
+              if (value.isObject()) {
+                result.put(key, parseJsonObject(value));
+              } else if (value.isArray()) {
+                result.put(key, parseJsonArray((ArrayNode) value));
+              } else {
+                result.put(key, parseSimpleNode(value));
+              }
+            });
+    return result;
+  }
+
+  /** Parse following value from JSON node: text, number, boolean, null. */
+  private static Object parseSimpleNode(JsonNode element) {
+    if (element.isTextual()) {
+      return element.asText();
+    } else if (element.isNumber()) {
+      return element.numberValue();
+    } else if (element.isBoolean()) {
+      return element.asBoolean();
+    } else if (element.isNull()) {
+      return null;
+    } else {
+      throw new IllegalArgumentException("Element is not a valid JSON object or array.");
+    }
   }
 }

--- a/v1/README_Cloud_Spanner_vectors_to_Cloud_Storage.md
+++ b/v1/README_Cloud_Spanner_vectors_to_Cloud_Storage.md
@@ -1,0 +1,199 @@
+
+Cloud Spanner vectors to Cloud Storage for Vertex Vector Search template
+---
+The Cloud Spanner to Vector Embeddings on Cloud Storage template is a batch
+pipeline that exports vector embeddings data from Cloud Spanner's table to Cloud
+Storage in JSON format. Vector embeddings are exported to a Cloud Storage folder
+specified by the user via parameter setting along with other template parameters.
+The Cloud Storage folder will contain the list of exported `.json` files
+representing vector embeddings in a format supported by Vertex AI Vector Search
+Index.
+
+Please check <a
+href="https://cloud.google.com/vertex-ai/docs/vector-search/setup/format-structure#json">Vector
+Search Format Structure</a> for additional details.
+
+
+:memo: This is a Google-provided template! Please
+check [Provided templates documentation](https://cloud.google.com/dataflow/docs/guides/templates/provided-templates)
+on how to use it without having to build from sources using [Create job from template](https://console.cloud.google.com/dataflow/createjob?template=Cloud_Spanner_vectors_to_Cloud_Storage).
+
+:bulb: This is a generated documentation based
+on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplates#metadata-annotations)
+. Do not change this file directly.
+
+## Parameters
+
+### Required Parameters
+
+* **spannerProjectId** (Cloud Spanner Project Id): The project id of the Cloud Spanner instance.
+* **spannerInstanceId** (Cloud Spanner instance id): The instance id of the Cloud Spanner from which you want to export the vector embeddings.
+* **spannerDatabaseId** (Cloud Spanner database id): The database id of the Cloud Spanner from which you want to export the vector embeddings.
+* **spannerTable** (Spanner Table): Spanner Table to read from.
+* **spannerColumnsToExport** (Columns to Export from Spanner Table): Comma separated list of columns which are required for Vertex AI Vector Search Index. The `id` & `embedding` are required columns for Vertex Vector Search.  If the column names don't precisely align with the Vertex AI Vector Search Index input structure, you can establish column mappings using aliases. For e.g. if you have columns id and my_embedding i.e. the id column matches what vertex expects but the embedding column is named differently, you can specify the following `id, my_embedding:embedding`.
+* **gcsOutputFolder** (Output files folder in Cloud Storage): The Cloud Storage folder for writing output files. Must end with a slash. (Example: gs://your-bucket/folder1/).
+* **gcsOutputFilePrefix** (Output files prefix in Cloud Storage): The filename prefix for writing output files. (Example: vector-embeddings).
+
+### Optional Parameters
+
+* **spannerHost** (Cloud Spanner Endpoint to call): The Cloud Spanner endpoint to call in the template. The default is set to https://batch-spanner.googleapis.com. (Example: https://batch-spanner.googleapis.com).
+* **spannerVersionTime** (Timestamp to read stale data from a version in the past.): If set, specifies the time when the database version must be taken. String is in the RFC 3339 format in UTC time.  Timestamp must be in the past and maximum timestamp staleness applies; see <a href="https://cloud.google.com/spanner/docs/timestamp-bounds#maximum_timestamp_staleness">Maximum Timestamp Staleness</a>. If not set, strong bound is used to read the latest data; see <a href="https://cloud.google.com/spanner/docs/timestamp-bounds#strong">Timestamp Strong Bounds</a>. (Example: 1990-12-31T23:59:60Z). Defaults to empty.
+* **spannerDataBoostEnabled** (Use independent compute resource (Spanner DataBoost).): Use Spanner on-demand compute so the export job will run on independent compute resources and have no impact to current Spanner workloads. This will incur additional charges in Spanner. Refer <a href=" https://cloud.google.com/spanner/docs/databoost/databoost-overview">Data Boost Overview</a>. Defaults to: false.
+* **spannerPriority** (Priority for Spanner RPC invocations): The request priority for Cloud Spanner calls. The value must be one of: [HIGH,MEDIUM,LOW]. Defaults to: MEDIUM.
+
+
+
+## Getting Started
+
+### Requirements
+
+* Java 11
+* Maven
+* [gcloud CLI](https://cloud.google.com/sdk/gcloud), and execution of the
+  following commands:
+  * `gcloud auth login`
+  * `gcloud auth application-default login`
+
+:star2: Those dependencies are pre-installed if you use Google Cloud Shell!
+[![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2FDataflowTemplates.git&cloudshell_open_in_editor=v1/src/main/java/com/google/cloud/teleport/templates/SpannerVectorEmbeddingExport.java)
+
+### Templates Plugin
+
+This README provides instructions using
+the [Templates Plugin](https://github.com/GoogleCloudPlatform/DataflowTemplates#templates-plugin)
+. Install the plugin with the following command before proceeding:
+
+```shell
+mvn clean install -pl plugins/templates-maven-plugin -am
+```
+
+### Building Template
+
+This template is a Classic Template, meaning that the pipeline code will be
+executed only once and the pipeline will be saved to Google Cloud Storage for
+further reuse. Please check [Creating classic Dataflow templates](https://cloud.google.com/dataflow/docs/guides/templates/creating-templates)
+and [Running classic templates](https://cloud.google.com/dataflow/docs/guides/templates/running-templates)
+for more information.
+
+#### Staging the Template
+
+If the plan is to just stage the template (i.e., make it available to use) by
+the `gcloud` command or Dataflow "Create job from template" UI,
+the `-PtemplatesStage` profile should be used:
+
+```shell
+export PROJECT=<my-project>
+export BUCKET_NAME=<bucket-name>
+
+mvn clean package -PtemplatesStage  \
+-DskipTests \
+-DprojectId="$PROJECT" \
+-DbucketName="$BUCKET_NAME" \
+-DstagePrefix="templates" \
+-DtemplateName="Cloud_Spanner_vectors_to_Cloud_Storage" \
+-pl v1 \
+-am
+```
+
+The `-DgcpTempLocation=<temp-bucket-name>` parameter can be specified to set the GCS bucket used by the DataflowRunner to write
+temp files to during serialization. The path used will be `gs://<temp-bucket-name>/temp/`.
+
+The command should build and save the template to Google Cloud, and then print
+the complete location on Cloud Storage:
+
+```
+Classic Template was staged! gs://<bucket-name>/templates/Cloud_Spanner_vectors_to_Cloud_Storage
+```
+
+The specific path should be copied as it will be used in the following steps.
+
+#### Running the Template
+
+**Using the staged template**:
+
+You can use the path above run the template (or share with others for execution).
+
+To start a job with the template at any time using `gcloud`, you are going to
+need valid resources for the required parameters.
+
+Provided that, the following command line can be used:
+
+```shell
+export PROJECT=<my-project>
+export BUCKET_NAME=<bucket-name>
+export REGION=us-central1
+export TEMPLATE_SPEC_GCSPATH="gs://$BUCKET_NAME/templates/Cloud_Spanner_vectors_to_Cloud_Storage"
+
+### Required
+export SPANNER_PROJECT_ID=<spannerProjectId>
+export SPANNER_INSTANCE_ID=<spannerInstanceId>
+export SPANNER_DATABASE_ID=<spannerDatabaseId>
+export SPANNER_TABLE=<spannerTable>
+export SPANNER_COLUMNS_TO_EXPORT=<spannerColumnsToExport>
+export GCS_OUTPUT_FOLDER=<gcsOutputFolder>
+export GCS_OUTPUT_FILE_PREFIX=<gcsOutputFilePrefix>
+
+### Optional
+export SPANNER_HOST=https://batch-spanner.googleapis.com
+export SPANNER_VERSION_TIME=""
+export SPANNER_DATA_BOOST_ENABLED=false
+export SPANNER_PRIORITY=<spannerPriority>
+
+gcloud dataflow jobs run "cloud-spanner-vectors-to-cloud-storage-job" \
+  --project "$PROJECT" \
+  --region "$REGION" \
+  --gcs-location "$TEMPLATE_SPEC_GCSPATH" \
+  --parameters "spannerProjectId=$SPANNER_PROJECT_ID" \
+  --parameters "spannerInstanceId=$SPANNER_INSTANCE_ID" \
+  --parameters "spannerDatabaseId=$SPANNER_DATABASE_ID" \
+  --parameters "spannerTable=$SPANNER_TABLE" \
+  --parameters "spannerColumnsToExport=$SPANNER_COLUMNS_TO_EXPORT" \
+  --parameters "gcsOutputFolder=$GCS_OUTPUT_FOLDER" \
+  --parameters "gcsOutputFilePrefix=$GCS_OUTPUT_FILE_PREFIX" \
+  --parameters "spannerHost=$SPANNER_HOST" \
+  --parameters "spannerVersionTime=$SPANNER_VERSION_TIME" \
+  --parameters "spannerDataBoostEnabled=$SPANNER_DATA_BOOST_ENABLED" \
+  --parameters "spannerPriority=$SPANNER_PRIORITY"
+```
+
+For more information about the command, please check:
+https://cloud.google.com/sdk/gcloud/reference/dataflow/jobs/run
+
+
+**Using the plugin**:
+
+Instead of just generating the template in the folder, it is possible to stage
+and run the template in a single command. This may be useful for testing when
+changing the templates.
+
+```shell
+export PROJECT=<my-project>
+export BUCKET_NAME=<bucket-name>
+export REGION=us-central1
+
+### Required
+export SPANNER_PROJECT_ID=<spannerProjectId>
+export SPANNER_INSTANCE_ID=<spannerInstanceId>
+export SPANNER_DATABASE_ID=<spannerDatabaseId>
+export SPANNER_TABLE=<spannerTable>
+export SPANNER_COLUMNS_TO_EXPORT=<spannerColumnsToExport>
+export GCS_OUTPUT_FOLDER=<gcsOutputFolder>
+export GCS_OUTPUT_FILE_PREFIX=<gcsOutputFilePrefix>
+
+### Optional
+export SPANNER_HOST=https://batch-spanner.googleapis.com
+export SPANNER_VERSION_TIME=""
+export SPANNER_DATA_BOOST_ENABLED=false
+export SPANNER_PRIORITY=<spannerPriority>
+
+mvn clean package -PtemplatesRun \
+-DskipTests \
+-DprojectId="$PROJECT" \
+-DbucketName="$BUCKET_NAME" \
+-Dregion="$REGION" \
+-DjobName="cloud-spanner-vectors-to-cloud-storage-job" \
+-DtemplateName="Cloud_Spanner_vectors_to_Cloud_Storage" \
+-Dparameters="spannerProjectId=$SPANNER_PROJECT_ID,spannerInstanceId=$SPANNER_INSTANCE_ID,spannerDatabaseId=$SPANNER_DATABASE_ID,spannerTable=$SPANNER_TABLE,spannerColumnsToExport=$SPANNER_COLUMNS_TO_EXPORT,gcsOutputFolder=$GCS_OUTPUT_FOLDER,gcsOutputFilePrefix=$GCS_OUTPUT_FILE_PREFIX,spannerHost=$SPANNER_HOST,spannerVersionTime=$SPANNER_VERSION_TIME,spannerDataBoostEnabled=$SPANNER_DATA_BOOST_ENABLED,spannerPriority=$SPANNER_PRIORITY" \
+-pl v1 \
+-am
+```

--- a/v1/README_GCS_SequenceFile_to_Cloud_Bigtable.md
+++ b/v1/README_GCS_SequenceFile_to_Cloud_Bigtable.md
@@ -22,11 +22,11 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 * **bigtableInstanceId** (Instance ID): The ID of the Cloud Bigtable instance that contains the table.
 * **bigtableTableId** (Table ID): The ID of the Cloud Bigtable table to import.
 * **sourcePattern** (Source path pattern): Cloud Storage path pattern where data is located. (Example: gs://your-bucket/your-path/prefix*).
-* **mutationThrottleLatencyMs** (Mutation Throttle Latency): Optional Set mutation latency throttling (enables the feature). Value in milliseconds. Defaults to: 0.
 
 ### Optional Parameters
 
 * **bigtableAppProfileId** (Application profile ID): The ID of the Cloud Bigtable application profile to be used for the import.
+* **mutationThrottleLatencyMs** (Mutation Throttle Latency): Optional Set mutation latency throttling (enables the feature). Value in milliseconds. Defaults to: 0.
 
 
 
@@ -116,10 +116,10 @@ export BIGTABLE_PROJECT=<bigtableProject>
 export BIGTABLE_INSTANCE_ID=<bigtableInstanceId>
 export BIGTABLE_TABLE_ID=<bigtableTableId>
 export SOURCE_PATTERN=<sourcePattern>
-export MUTATION_THROTTLE_LATENCY_MS=0
 
 ### Optional
 export BIGTABLE_APP_PROFILE_ID=<bigtableAppProfileId>
+export MUTATION_THROTTLE_LATENCY_MS=0
 
 gcloud dataflow jobs run "gcs-sequencefile-to-cloud-bigtable-job" \
   --project "$PROJECT" \
@@ -153,10 +153,10 @@ export BIGTABLE_PROJECT=<bigtableProject>
 export BIGTABLE_INSTANCE_ID=<bigtableInstanceId>
 export BIGTABLE_TABLE_ID=<bigtableTableId>
 export SOURCE_PATTERN=<sourcePattern>
-export MUTATION_THROTTLE_LATENCY_MS=0
 
 ### Optional
 export BIGTABLE_APP_PROFILE_ID=<bigtableAppProfileId>
+export MUTATION_THROTTLE_LATENCY_MS=0
 
 mvn clean package -PtemplatesRun \
 -DskipTests \

--- a/v1/src/main/java/com/google/cloud/teleport/templates/SpannerVectorEmbeddingExport.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/SpannerVectorEmbeddingExport.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.templates;
+
+import com.google.cloud.spanner.Options.RpcPriority;
+import com.google.cloud.teleport.metadata.Template;
+import com.google.cloud.teleport.metadata.TemplateCategory;
+import com.google.cloud.teleport.metadata.TemplateParameter;
+import com.google.cloud.teleport.metadata.TemplateParameter.TemplateEnumOption;
+import com.google.cloud.teleport.templates.SpannerVectorEmbeddingExport.SpannerToVectorEmbeddingJsonOptions;
+import com.google.cloud.teleport.templates.common.SpannerConverters;
+import com.google.cloud.teleport.templates.common.SpannerConverters.CreateTransactionFnWithTimestamp;
+import com.google.cloud.teleport.templates.common.SpannerConverters.VectorSearchStructValidator;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.io.gcp.spanner.LocalSpannerIO;
+import org.apache.beam.sdk.io.gcp.spanner.ReadOperation;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
+import org.apache.beam.sdk.io.gcp.spanner.Transaction;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.View;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TypeDescriptors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Dataflow template which export vector embeddings from Spanner to GCS in json format. It exports a
+ * Spanner table using <a
+ * href="https://cloud.google.com/spanner/docs/reads#read_data_in_parallel">Batch API</a>, which
+ * creates multiple workers in parallel for better performance. The result is written to a JSON file
+ * in Google Cloud Storage.
+ *
+ * <p>Check out <a
+ * href="https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v1/README_Cloud_Spanner_to_Vector_Embedding.md">README</a>
+ * for instructions on how to use or modify this template.
+ */
+@Template(
+    name = "Cloud_Spanner_vectors_to_Cloud_Storage",
+    category = TemplateCategory.BATCH,
+    displayName = "Cloud Spanner vectors to Cloud Storage for Vertex Vector Search",
+    optionsClass = SpannerToVectorEmbeddingJsonOptions.class,
+    description = {
+      "The Cloud Spanner to Vector Embeddings on Cloud Storage template is a batch pipeline that exports vector embeddings data from Cloud Spanner's table to Cloud Storage in JSON format. "
+          + "Vector embeddings are exported to a Cloud Storage folder specified by the user via parameter setting along with other template parameters."
+          + " The Cloud Storage folder will contain the list of exported `.json` files representing vector embeddings in a format supported by Vertex AI Vector Search Index.\n",
+      "Please check <a href=\"https://cloud.google.com/vertex-ai/docs/vector-search/setup/format-structure#json\">Vector Search Format Structure</a> for additional details."
+    },
+    // ToDo: Update the documentation
+    documentation = "https://cloud.google.com/dataflow/docs/guides/templates/provided-templates",
+    contactInformation = "https://cloud.google.com/support",
+    requirements = {
+      "The Cloud Spanner database must exist.",
+      "The output Cloud Storage bucket must exist.",
+      "In addition to the Identity and Access Management (IAM) roles necessary to run Dataflow jobs, you must also have the <a href=\"https://cloud.google.com/spanner/docs/export#iam\">appropriate IAM roles</a> for reading your Cloud Spanner data and writing to your Cloud Storage bucket."
+    })
+@SuppressWarnings("unused")
+public class SpannerVectorEmbeddingExport {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SpannerVectorEmbeddingExport.class);
+
+  /** Custom PipelineOptions. */
+  public interface SpannerToVectorEmbeddingJsonOptions extends PipelineOptions {
+    @TemplateParameter.ProjectId(
+        order = 10,
+        description = "Cloud Spanner Project Id",
+        helpText = "The project id of the Cloud Spanner instance.")
+    ValueProvider<String> getSpannerProjectId();
+
+    void setSpannerProjectId(ValueProvider<String> value);
+
+    @TemplateParameter.Text(
+        order = 20,
+        regexes = {"[a-z][a-z0-9\\-]*[a-z0-9]"},
+        description = "Cloud Spanner instance id",
+        helpText =
+            "The instance id of the Cloud Spanner from which you want to export the vector embeddings.")
+    ValueProvider<String> getSpannerInstanceId();
+
+    void setSpannerInstanceId(ValueProvider<String> spannerInstanceId);
+
+    @TemplateParameter.Text(
+        order = 30,
+        regexes = {"[a-z][a-z0-9_\\-]*[a-z0-9]"},
+        description = "Cloud Spanner database id",
+        helpText =
+            "The database id of the Cloud Spanner from which you want to export the vector embeddings.")
+    ValueProvider<String> getSpannerDatabaseId();
+
+    void setSpannerDatabaseId(ValueProvider<String> spannerDatabaseId);
+
+    @TemplateParameter.Text(
+        order = 40,
+        regexes = {"^.+$"},
+        description = "Spanner Table",
+        helpText = "Spanner Table to read from")
+    ValueProvider<String> getSpannerTable();
+
+    void setSpannerTable(ValueProvider<String> table);
+
+    @TemplateParameter.Text(
+        order = 50,
+        description = "Columns to Export from Spanner Table",
+        helpText =
+            "Comma separated list of columns which are required for Vertex AI Vector Search Index."
+                + " The `id` & `embedding` are required columns for Vertex Vector Search. "
+                + " If the column names don't precisely align with the Vertex AI Vector Search Index input structure, you can establish column mappings using aliases."
+                + " For e.g. if you have columns id and my_embedding i.e. the id column matches what vertex expects but the embedding column is named differently,"
+                + " you can specify the following `id, my_embedding:embedding`.")
+    ValueProvider<String> getSpannerColumnsToExport();
+
+    void setSpannerColumnsToExport(ValueProvider<String> value);
+
+    @TemplateParameter.GcsWriteFolder(
+        order = 60,
+        description = "Output files folder in Cloud Storage",
+        helpText = "The Cloud Storage folder for writing output files. Must end with a slash.",
+        example = "gs://your-bucket/folder1/")
+    ValueProvider<String> getGcsOutputFolder();
+
+    void setGcsOutputFolder(ValueProvider<String> value);
+
+    @TemplateParameter.Text(
+        order = 70,
+        description = "Output files prefix in Cloud Storage",
+        helpText = "The filename prefix for writing output files.",
+        example = "vector-embeddings")
+    ValueProvider<String> getGcsOutputFilePrefix();
+
+    void setGcsOutputFilePrefix(ValueProvider<String> textWritePrefix);
+
+    @TemplateParameter.Text(
+        order = 80,
+        optional = true,
+        description = "Cloud Spanner Endpoint to call",
+        helpText =
+            "The Cloud Spanner endpoint to call in the template. The default is set to https://batch-spanner.googleapis.com.",
+        example = "https://batch-spanner.googleapis.com")
+    @Default.String("https://batch-spanner.googleapis.com")
+    ValueProvider<String> getSpannerHost();
+
+    void setSpannerHost(ValueProvider<String> value);
+
+    @TemplateParameter.Text(
+        order = 90,
+        optional = true,
+        regexes = {
+          "^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):(([0-9]{2})(\\.[0-9]+)?)Z$"
+        },
+        description = "Timestamp to read stale data from a version in the past.",
+        helpText =
+            "If set, specifies the time when the database version must be taken."
+                + " String is in the RFC 3339 format in UTC time. "
+                + " Timestamp must be in the past and maximum timestamp staleness applies; see "
+                + "<a href=\"https://cloud.google.com/spanner/docs/timestamp-bounds#maximum_timestamp_staleness\">Maximum Timestamp Staleness</a>."
+                + " If not set, strong bound is used to read the latest data; see "
+                + "<a href=\"https://cloud.google.com/spanner/docs/timestamp-bounds#strong\">Timestamp Strong Bounds</a>.",
+        example = "1990-12-31T23:59:60Z")
+    @Default.String(value = "")
+    ValueProvider<String> getSpannerVersionTime();
+
+    void setSpannerVersionTime(ValueProvider<String> value);
+
+    @TemplateParameter.Boolean(
+        order = 100,
+        optional = true,
+        description = "Use independent compute resource (Spanner DataBoost).",
+        helpText =
+            "Use Spanner on-demand compute so the export job will run on independent compute"
+                + " resources and have no impact to current Spanner workloads. This will incur"
+                + " additional charges in Spanner."
+                + " Refer <a href=\" https://cloud.google.com/spanner/docs/databoost/databoost-overview\">Data Boost Overview</a>.")
+    @Default.Boolean(false)
+    ValueProvider<Boolean> getSpannerDataBoostEnabled();
+
+    void setSpannerDataBoostEnabled(ValueProvider<Boolean> value);
+
+    @TemplateParameter.Enum(
+        order = 110,
+        enumOptions = {
+          @TemplateEnumOption("LOW"),
+          @TemplateEnumOption("MEDIUM"),
+          @TemplateEnumOption("HIGH")
+        },
+        optional = true,
+        description = "Priority for Spanner RPC invocations",
+        helpText =
+            "The request priority for Cloud Spanner calls. The value must be one of:"
+                + " [HIGH,MEDIUM,LOW]. Defaults to: MEDIUM.")
+    ValueProvider<RpcPriority> getSpannerPriority();
+
+    void setSpannerPriority(ValueProvider<RpcPriority> value);
+  }
+
+  /**
+   * Runs a pipeline which reads in vector embeddings records from Spanner, and writes the JSON to
+   * TextIO sink.
+   *
+   * @param args arguments to the pipeline
+   */
+  public static void main(String[] args) {
+    LOG.info("Starting pipeline setup");
+    PipelineOptionsFactory.register(SpannerToVectorEmbeddingJsonOptions.class);
+
+    SpannerToVectorEmbeddingJsonOptions options =
+        PipelineOptionsFactory.fromArgs(args)
+            .withValidation()
+            .as(SpannerToVectorEmbeddingJsonOptions.class);
+
+    FileSystems.setDefaultPipelineOptions(options);
+    Pipeline pipeline = Pipeline.create(options);
+
+    SpannerConfig spannerConfig =
+        SpannerConfig.create()
+            .withHost(options.getSpannerHost())
+            .withProjectId(options.getSpannerProjectId())
+            .withInstanceId(options.getSpannerInstanceId())
+            .withDatabaseId(options.getSpannerDatabaseId())
+            .withRpcPriority(options.getSpannerPriority())
+            .withDataBoostEnabled(options.getSpannerDataBoostEnabled());
+
+    ValueProvider<String> gcsOutputFilePrefix = options.getGcsOutputFilePrefix();
+
+    // Concatenating cloud storage folder with file prefix to get complete path
+    ValueProvider<String> gcsOutputFilePathWithPrefix =
+        ValueProvider.NestedValueProvider.of(
+            options.getGcsOutputFolder(),
+            (SerializableFunction<String, String>)
+                folder -> {
+                  if (!folder.endsWith("/")) {
+                    // Appending the slash if not provided by user
+                    folder = folder + "/";
+                  }
+                  return folder + gcsOutputFilePrefix.get();
+                });
+
+    PTransform<PBegin, PCollection<ReadOperation>> spannerExport =
+        SpannerConverters.ExportTransformFactory.create(
+            options.getSpannerTable(),
+            spannerConfig,
+            gcsOutputFilePathWithPrefix,
+            options.getSpannerVersionTime(),
+            options.getSpannerColumnsToExport(),
+            ValueProvider.StaticValueProvider.of(/* disable_schema_export= */ false));
+
+    /* CreateTransaction and CreateTransactionFn classes in LocalSpannerIO
+     * only take a timestamp object for exact staleness which works when
+     * parameters are provided during template compile time. They do not work with
+     * a Timestamp valueProvider which can take parameters at runtime. Hence a new
+     * ParDo class CreateTransactionFnWithTimestamp had to be created for this
+     * purpose.
+     */
+    PCollectionView<Transaction> tx =
+        pipeline
+            .apply("Setup for Transaction", Create.of(1))
+            .apply(
+                "Create transaction",
+                ParDo.of(
+                    new CreateTransactionFnWithTimestamp(
+                        spannerConfig, options.getSpannerVersionTime())))
+            .apply("As PCollectionView", View.asSingleton());
+
+    PCollection<String> json =
+        pipeline
+            .apply("Create export", spannerExport)
+            // We need to use LocalSpannerIO.readAll() instead of LocalSpannerIO.read()
+            // because ValueProvider parameters such as table name required for
+            // LocalSpannerIO.read() can be read only inside DoFn but LocalSpannerIO.read() is of
+            // type PTransform<PBegin, Struct>, which prevents prepending it with DoFn that reads
+            // these parameters at the pipeline execution time.
+            .apply(
+                "Read all records",
+                LocalSpannerIO.readAll().withTransaction(tx).withSpannerConfig(spannerConfig))
+            .apply(
+                "Struct To JSON",
+                MapElements.into(TypeDescriptors.strings())
+                    .via(
+                        struct ->
+                            (new SpannerConverters.StructJSONPrinter(
+                                    new VectorSearchStructValidator()))
+                                .print(struct)));
+
+    json.apply(
+        "Write to storage", TextIO.write().to(gcsOutputFilePathWithPrefix).withSuffix(".json"));
+
+    pipeline.run();
+    LOG.info("Completed pipeline setup");
+  }
+}

--- a/v1/src/main/java/com/google/cloud/teleport/templates/common/SpannerConverters.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/common/SpannerConverters.java
@@ -32,19 +32,23 @@ import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Type.Code;
 import com.google.cloud.spanner.Type.StructField;
 import com.google.cloud.teleport.metadata.TemplateParameter;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.io.FileSystems;
@@ -64,6 +68,8 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.QuoteMode;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -167,13 +173,31 @@ public class SpannerConverters {
         ValueProvider<String> table,
         SpannerConfig spannerConfig,
         ValueProvider<String> textWritePrefix,
-        ValueProvider<String> timestamp) {
+        ValueProvider<String> timestamp,
+        ValueProvider<String> columnsToExport,
+        ValueProvider<Boolean> exportSchema) {
       return ExportTransform.builder()
           .table(table)
           .spannerConfig(spannerConfig)
           .textWritePrefix(textWritePrefix)
           .timestamp(timestamp)
+          .columnsToExport(columnsToExport)
+          .exportSchema(exportSchema)
           .build();
+    }
+
+    public static ExportTransform create(
+        ValueProvider<String> table,
+        SpannerConfig spannerConfig,
+        ValueProvider<String> textWritePrefix,
+        ValueProvider<String> timestamp) {
+      return create(
+          table,
+          spannerConfig,
+          textWritePrefix,
+          timestamp,
+          ValueProvider.StaticValueProvider.of(null),
+          ValueProvider.StaticValueProvider.of(true));
     }
   }
 
@@ -184,7 +208,11 @@ public class SpannerConverters {
 
     abstract ValueProvider<String> table();
 
+    abstract ValueProvider<String> columnsToExport();
+
     abstract SpannerConfig spannerConfig();
+
+    abstract ValueProvider<Boolean> exportSchema();
 
     abstract ValueProvider<String> textWritePrefix();
 
@@ -203,6 +231,10 @@ public class SpannerConverters {
     @AutoValue.Builder
     public abstract static class Builder {
       public abstract Builder table(ValueProvider<String> table);
+
+      public abstract Builder columnsToExport(ValueProvider<String> columnsToExport);
+
+      public abstract Builder exportSchema(ValueProvider<Boolean> exportSchema);
 
       public abstract Builder spannerConfig(SpannerConfig spannerConfig);
 
@@ -278,8 +310,11 @@ public class SpannerConverters {
             LOG.info("Reading schema information");
             columns = getAllColumns(context, table().get(), dialect);
             String columnJson = SpannerConverters.GSON.toJson(columns);
-            LOG.info("Saving schema information");
-            saveSchema(columnJson, textWritePrefix().get() + SCHEMA_SUFFIX);
+
+            if (BooleanUtils.isTrue(exportSchema().get())) {
+              LOG.info("Saving schema information");
+              saveSchema(columnJson, textWritePrefix().get() + SCHEMA_SUFFIX);
+            }
           }
         } finally {
           closeSpannerAccessor();
@@ -288,11 +323,20 @@ public class SpannerConverters {
         PartitionOptions partitionOptions =
             PartitionOptions.newBuilder().setMaxPartitions(maxPartitions).build();
 
-        String columnsListAsString =
-            columns.entrySet().stream()
-                .map(x -> createColumnExpression(x.getKey(), x.getValue(), dialect))
-                .collect(Collectors.joining(","));
+        String columnsListAsString;
+
+        if (StringUtils.isNotBlank(columnsToExport().get())) {
+          LOG.info("Exporting selected columns passed by user: {}", columnsToExport().get());
+          columnsListAsString = prepareColumnExpression(columnsToExport().get());
+        } else {
+          columnsListAsString =
+              columns.entrySet().stream()
+                  .map(x -> createColumnExpression(x.getKey(), x.getValue(), dialect))
+                  .collect(Collectors.joining(","));
+        }
+
         ReadOperation read;
+
         switch (dialect) {
           case GOOGLE_STANDARD_SQL:
             read =
@@ -322,7 +366,7 @@ public class SpannerConverters {
           return "CAST(`" + columnName + "` AS STRING) AS " + columnName;
         }
         if (columnType.equals("JSON")) {
-          return "TO_JSON_STRING(`" + columnName + "`) AS " + columnName;
+          return "`" + columnName + "`";
         }
 
         if (columnType.equals("ARRAY<NUMERIC>")) {
@@ -394,11 +438,53 @@ public class SpannerConverters {
   }
 
   /**
+   * Generate a column expression for use in a query based on user-supplied column and alias values.
+   *
+   * @param columnsToExport User-provided data in the format of "column1: alias1, column2, column3:
+   *     alias3".
+   * @return A prepared column expression suitable for use in a Data Query Language (DQL) statement.
+   */
+  @VisibleForTesting
+  static String prepareColumnExpression(String columnsToExport) {
+    String[] columnsList = columnsToExport.split(",");
+    StringBuilder columnExpressionBuilder = new StringBuilder();
+
+    for (String columnWithAlias : columnsList) {
+      if (StringUtils.isBlank(columnWithAlias)) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Please provide a valid comma-separated list of columns to be extracted. The received input is not valid: %s",
+                columnsToExport));
+      }
+      // Split around ":" to check if alias is present
+      String[] columnMap = columnWithAlias.trim().split(":");
+      columnExpressionBuilder.append(columnMap[0].trim());
+      if (columnMap.length > 1) {
+        columnExpressionBuilder.append(" AS ");
+        columnExpressionBuilder.append(columnMap[1].trim());
+      }
+      columnExpressionBuilder.append(",");
+    }
+
+    // Removing the last character which is ','
+    if (columnExpressionBuilder.length() > 0) {
+      columnExpressionBuilder.deleteCharAt(columnExpressionBuilder.length() - 1);
+    }
+
+    return columnExpressionBuilder.toString();
+  }
+
+  /** Interface for all the Struct Printers. */
+  interface StructPrinter {
+    String print(Struct struct);
+  }
+
+  /**
    * Struct printer for converting a Spanner Struct to CSV. See {@link this#parseArrayValue(Struct,
    * String)} for data type conversions. It uses a standard comma separated format as for RFC4180
    * but allowing empty lines.
    */
-  public static class StructCsvPrinter {
+  public static class StructCsvPrinter implements StructPrinter {
 
     /**
      * Prints Struct as a CSV String.
@@ -406,6 +492,7 @@ public class SpannerConverters {
      * @param struct Spanner Struct.
      * @return Spanner Struct encoded as a CSV String.
      */
+    @Override
     public String print(Struct struct) {
       StringWriter stringWriter = new StringWriter();
       try {
@@ -439,6 +526,125 @@ public class SpannerConverters {
         result.add(parsers.get(columnName).apply(struct, columnName));
       }
       return result;
+    }
+  }
+
+  /** Struct printer for converting a Spanner Struct to JSON. */
+  public static class StructJSONPrinter implements StructPrinter {
+    private StructValidator structValidator = null;
+
+    public StructJSONPrinter(StructValidator structValidator) {
+      this.structValidator = structValidator;
+    }
+
+    public StructJSONPrinter() {}
+
+    /**
+     * To get string in json format from Struct.
+     *
+     * @param struct Spanner Struct.
+     * @return Spanner Struct encoded as a JSON String.
+     */
+    @Override
+    public String print(Struct struct) {
+      if (structValidator != null) {
+        structValidator.validate(struct);
+      }
+
+      StringWriter stringWriter = new StringWriter();
+      try {
+        JsonWriter jsonWriter = new JsonWriter(stringWriter);
+        LinkedHashMap<String, BiFunction<Struct, String, String>> parsers = Maps.newLinkedHashMap();
+        parsers.putAll(mapColumnParsers(struct.getType().getStructFields()));
+        parseResultSet(jsonWriter, struct, parsers);
+      } catch (IOException e) {
+        throw new RuntimeException("Error parsing the Spanner struct to JSON", e);
+      }
+      return stringWriter.toString();
+    }
+
+    /**
+     * To parse Struct using different parsers for different type and process it using JSONWriter.
+     *
+     * @param jsonWriter JSON Writer
+     * @param struct Data from Spanner
+     * @param parsers Map from Column Name to their parser
+     * @throws IOException
+     */
+    private static void parseResultSet(
+        JsonWriter jsonWriter,
+        Struct struct,
+        LinkedHashMap<String, BiFunction<Struct, String, String>> parsers)
+        throws IOException {
+      // Start the JSON object
+      jsonWriter.beginObject();
+
+      for (String columnName : parsers.keySet()) {
+        String columnValue = parsers.get(columnName).apply(struct, columnName);
+
+        // If null value then ignoring it and not exporting to JSON file
+        if (columnValue == null) {
+          continue;
+        }
+
+        if (Arrays.asList(Code.JSON, Code.PG_JSONB)
+            .contains(struct.getColumnType(columnName).getCode())) {
+          // If the column is of type JSON or PG_JSON
+          jsonWriter.name(columnName).jsonValue(columnValue);
+        } else if (struct.getColumnType(columnName).getCode() == Code.ARRAY) {
+          // If the column is of type ARRAY
+          List<? extends Object> values = parseArrayValueAsObjectList(struct, columnName);
+          jsonWriter.name(columnName);
+          jsonWriter.beginArray();
+          for (Object value : values) {
+            jsonWriter.value(value != null ? value.toString() : null);
+          }
+          jsonWriter.endArray();
+        } else {
+          jsonWriter.name(columnName).value(columnValue);
+        }
+      }
+      jsonWriter.endObject();
+    }
+  }
+
+  /**
+   * To parse array value as list of derived objects.
+   *
+   * @param currentRow Struct
+   * @param columnName Column Name
+   * @return List of generic objects
+   */
+  private static List<? extends Object> parseArrayValueAsObjectList(
+      Struct currentRow, String columnName) {
+    Code code = currentRow.getColumnType(columnName).getArrayElementType().getCode();
+    switch (code) {
+      case BOOL:
+        return currentRow.getBooleanList(columnName);
+      case INT64:
+        return currentRow.getLongList(columnName);
+      case FLOAT64:
+        return currentRow.getDoubleList(columnName);
+      case STRING:
+      case PG_NUMERIC:
+      case JSON:
+        return currentRow.getStringList(columnName);
+      case PG_JSONB:
+        return currentRow.getPgJsonbList(columnName);
+      case BYTES:
+        return currentRow.getBytesList(columnName).stream()
+            .map(byteArray -> Base64.getEncoder().encodeToString(byteArray.toByteArray()))
+            .collect(Collectors.toList());
+      case DATE:
+        return currentRow.getDateList(columnName).stream()
+            .map(Date::toString)
+            .collect(Collectors.toList());
+      case TIMESTAMP:
+        return currentRow.getTimestampList(columnName).stream()
+            .map(Timestamp::toString)
+            .collect(Collectors.toList());
+      default:
+        throw new RuntimeException("Unsupported type: " + code);
     }
   }
 
@@ -482,6 +688,10 @@ public class SpannerConverters {
       case STRING:
       case PG_NUMERIC:
         return nullSafeColumnParser(Struct::getString);
+      case JSON:
+        return nullSafeColumnParser(Struct::getJson);
+      case PG_JSONB:
+        return nullSafeColumnParser(Struct::getPgJsonb);
       case BYTES:
         return nullSafeColumnParser(
             (currentRow, columnName) ->
@@ -604,6 +814,76 @@ public class SpannerConverters {
        */
 
       return TimestampBound.ofReadTimestamp(tsVal);
+    }
+  }
+
+  /** Interface to validate Struct. If validation fails then throws RuntimeException */
+  interface StructValidator {
+    void validate(Struct struct);
+  }
+
+  /**
+   * To validate struct and check whether data can be exported in the format supported by Vertex AI
+   * Vector Search Index.
+   */
+  public static class VectorSearchStructValidator implements StructValidator {
+    private static final String ID = "id";
+    private static final String EMBEDDING = "embedding";
+    private static final String RESTRICTS = "restricts";
+    private static final String CROWDING_TAG = "crowding_tag";
+
+    Map<String, List<Type>> fieldExpectedTypesMap =
+        Map.of(
+            EMBEDDING, List.of(Type.array(Type.float64())),
+            RESTRICTS, List.of(Type.json(), Type.pgJsonb()),
+            CROWDING_TAG, List.of(Type.string()));
+
+    @Override
+    public void validate(Struct struct) {
+      // Not Null
+      validateNotNull(struct, ID);
+      validateNotNull(struct, EMBEDDING);
+
+      // Type Check
+      validateType(struct, EMBEDDING, fieldExpectedTypesMap.get(EMBEDDING));
+      validateTypeIfExists(struct, RESTRICTS, fieldExpectedTypesMap.get(RESTRICTS));
+      validateTypeIfExists(struct, CROWDING_TAG, fieldExpectedTypesMap.get(CROWDING_TAG));
+    }
+
+    /** To validate type of the column in struct. */
+    private void validateType(Struct struct, String columnName, List<Type> expectedTypes) {
+      if (!expectedTypes.contains(struct.getColumnType(columnName))) {
+        throw new RuntimeException(
+            String.format(
+                "Expected %s column to be one of the following type: %s but received %s",
+                columnName, expectedTypes, struct.getColumnType(columnName)));
+      }
+    }
+
+    /** To validate type of the column if it exists in struct. */
+    private void validateTypeIfExists(Struct struct, String columnName, List<Type> expectedTypes) {
+      boolean columnExists = true;
+      try {
+        struct.getColumnType(columnName);
+      } catch (IllegalArgumentException e) {
+        if (e.getMessage().startsWith("Field not found: ")) {
+          columnExists = false;
+        }
+      }
+
+      if (!columnExists) {
+        // validating type if it exists
+        return;
+      }
+
+      validateType(struct, columnName, expectedTypes);
+    }
+
+    /** To validate whether the required columns are not null. */
+    private void validateNotNull(Struct struct, String columnName) {
+      if (struct.isNull(columnName)) {
+        throw new RuntimeException(String.format("Expected %s column to be not null", columnName));
+      }
     }
   }
 }

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/SpannerVectorEmbeddingExportIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/SpannerVectorEmbeddingExportIT.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.spanner;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.apache.beam.it.gcp.spanner.matchers.SpannerAsserts.mutationsToRecords;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatRecords;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Value;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import com.google.cloud.teleport.templates.SpannerVectorEmbeddingExport;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.beam.it.common.PipelineLauncher;
+import org.apache.beam.it.common.PipelineOperator;
+import org.apache.beam.it.common.utils.ResourceManagerUtils;
+import org.apache.beam.it.gcp.TemplateTestBase;
+import org.apache.beam.it.gcp.artifacts.Artifact;
+import org.apache.beam.it.gcp.artifacts.utils.JsonTestUtil;
+import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Integration test for {@link SpannerVectorEmbeddingExportIT Spanner to GCS JSON} template. */
+@Category(TemplateIntegrationTest.class)
+@TemplateIntegrationTest(SpannerVectorEmbeddingExport.class)
+@RunWith(JUnit4.class)
+public class SpannerVectorEmbeddingExportIT extends TemplateTestBase {
+
+  private static final int MESSAGES_COUNT = 100;
+
+  private SpannerResourceManager googleSqlResourceManager;
+  private SpannerResourceManager postgresResourceManager;
+
+  @Before
+  public void setup() throws IOException {
+    // Set up resource managers
+    googleSqlResourceManager =
+        SpannerResourceManager.builder(testName, PROJECT, REGION).maybeUseStaticInstance().build();
+    postgresResourceManager =
+        SpannerResourceManager.builder(testName, PROJECT, REGION, Dialect.POSTGRESQL)
+            .maybeUseStaticInstance()
+            .build();
+  }
+
+  @After
+  public void teardown() {
+    ResourceManagerUtils.cleanResources(googleSqlResourceManager, postgresResourceManager);
+  }
+
+  @Test
+  public void testSpannerToGCSJSON() throws IOException {
+    String tableName = testName + "_Documents";
+    String createDocumentsTableStatement =
+        String.format(
+            "CREATE TABLE `%s` (\n"
+                + "  id INT64 NOT NULL,\n"
+                + "  text STRING(MAX),\n"
+                + "  embedding ARRAY<FLOAT64>,\n"
+                + "  restricts JSON,\n"
+                + ") PRIMARY KEY(id)\n",
+            tableName);
+
+    googleSqlResourceManager.executeDdlStatement(createDocumentsTableStatement);
+    List<Mutation> expectedData = generateTableRows(tableName);
+    googleSqlResourceManager.write(expectedData);
+    PipelineLauncher.LaunchConfig.Builder options =
+        PipelineLauncher.LaunchConfig.builder(testName, specPath)
+            .addParameter("spannerProjectId", PROJECT)
+            .addParameter("spannerInstanceId", googleSqlResourceManager.getInstanceId())
+            .addParameter("spannerDatabaseId", googleSqlResourceManager.getDatabaseId())
+            .addParameter("spannerTable", tableName)
+            .addParameter("spannerColumnsToExport", "id,embedding: embedding, restricts")
+            .addParameter("gcsOutputFilePrefix", "vectors-")
+            .addParameter("gcsOutputFolder", getGcsPath("output/"));
+
+    PipelineLauncher.LaunchInfo info = launchTemplate(options);
+    assertThatPipeline(info).isRunning();
+    PipelineOperator.Result result = pipelineOperator().waitUntilDone(createConfig(info));
+
+    // Assert
+    assertThatResult(result).isLaunchFinished();
+
+    List<Artifact> exportedArtifacts =
+        gcsClient.listArtifacts("output/", Pattern.compile(".*json"));
+    assertThat(exportedArtifacts).isNotEmpty();
+
+    List<Map<String, Object>> recordsFromGCS = extractArtifacts(exportedArtifacts);
+
+    assertThatRecords(recordsFromGCS)
+        .hasRecordsUnorderedCaseInsensitiveColumns(
+            mutationsToRecords(expectedData, List.of("id", "embedding", "restricts")));
+  }
+
+  @Test
+  public void testPostgresSpannerToGCSJSON() throws IOException {
+    // converting to lowercase for PG
+    String tableName = StringUtils.lowerCase(testName + "_Documents");
+    String createDocumentsTableStatement =
+        String.format(
+            "CREATE TABLE %s (\n"
+                + "  id int8 NOT NULL PRIMARY KEY,\n"
+                + "  text text,\n"
+                + "  embedding float8[],\n"
+                + "  restricts JSONB\n"
+                + ")\n",
+            tableName);
+
+    postgresResourceManager.executeDdlStatement(createDocumentsTableStatement);
+    List<Mutation> expectedData = generateTableRows(tableName);
+    postgresResourceManager.write(expectedData);
+    PipelineLauncher.LaunchConfig.Builder options =
+        PipelineLauncher.LaunchConfig.builder(testName, specPath)
+            .addParameter("spannerProjectId", PROJECT)
+            .addParameter("spannerInstanceId", postgresResourceManager.getInstanceId())
+            .addParameter("spannerDatabaseId", postgresResourceManager.getDatabaseId())
+            .addParameter("spannerTable", tableName)
+            .addParameter("spannerColumnsToExport", "id,embedding: embedding, restricts")
+            .addParameter("gcsOutputFilePrefix", "vectors-")
+            .addParameter("gcsOutputFolder", getGcsPath("output/"));
+
+    PipelineLauncher.LaunchInfo info = launchTemplate(options);
+    assertThatPipeline(info).isRunning();
+    PipelineOperator.Result result = pipelineOperator().waitUntilDone(createConfig(info));
+
+    // Assert
+    assertThatResult(result).isLaunchFinished();
+
+    List<Artifact> exportedArtifacts =
+        gcsClient.listArtifacts("output/", Pattern.compile(".*json"));
+    assertThat(exportedArtifacts).isNotEmpty();
+
+    List<Map<String, Object>> recordsFromGCS = extractArtifacts(exportedArtifacts);
+
+    recordsFromGCS =
+        recordsFromGCS.stream().map(JsonTestUtil::sortJsonMap).collect(Collectors.toList());
+
+    assertThatRecords(recordsFromGCS)
+        .hasRecordsUnorderedCaseInsensitiveColumns(
+            mutationsToRecords(expectedData, List.of("id", "embedding", "restricts")));
+  }
+
+  private static List<Mutation> generateTableRows(String tableId) {
+    List<Mutation> mutations = new ArrayList<>();
+    for (int i = 0; i < MESSAGES_COUNT; i++) {
+      Mutation.WriteBuilder mutation = Mutation.newInsertBuilder(tableId);
+      mutation
+          .set("id")
+          .to(i)
+          .set("text")
+          .to(RandomStringUtils.randomAlphanumeric(1, 200))
+          .set("embedding")
+          .to(Value.float64Array(ThreadLocalRandom.current().doubles(128, -10000, 10000).toArray()))
+          .set("restricts")
+          .to(Value.json("[{\"allow_list\": [\"even\"], \"namespace\": \"class\"}]"))
+          .build();
+
+      mutations.add(mutation.build());
+    }
+    return mutations;
+  }
+
+  private static List<Map<String, Object>> extractArtifacts(List<Artifact> artifacts) {
+    List<Map<String, Object>> records = new ArrayList<>();
+    artifacts.forEach(
+        artifact -> {
+          try {
+            records.addAll(JsonTestUtil.readNDJSON(artifact.contents()));
+          } catch (IOException e) {
+            throw new RuntimeException("Error reading " + artifact.name() + " as JSON.", e);
+          }
+        });
+
+    return records;
+  }
+}


### PR DESCRIPTION
Adding a template to export vector embeddings data from Spanner to GCS in the json format supported by Vertex AI Vector Search.