### PR TITLE
[MQTT to Pub/Sub] Fix username/password validation logic.

### DIFF
--- a/v2/mqtt-to-pubsub/src/main/java/com/google/cloud/teleport/v2/templates/MqttToPubsub.java
+++ b/v2/mqtt-to-pubsub/src/main/java/com/google/cloud/teleport/v2/templates/MqttToPubsub.java
@@ -69,8 +69,8 @@ public class MqttToPubsub {
 
   public static void validate(MqttToPubsubOptions options) {
     if (options != null) {
-        if ((options.getUsername() != null && !options.getUsername().isEmpty())
-            && (options.getPassword() == null || options.getPassword().isBlank())) {
+      if ((options.getUsername() != null && !options.getUsername().isEmpty())
+          && (options.getPassword() == null || options.getPassword().isBlank())) {
         throw new IllegalArgumentException(
             "While username is provided, password is required for authentication");
       }

--- a/v2/mqtt-to-pubsub/src/main/java/com/google/cloud/teleport/v2/templates/MqttToPubsub.java
+++ b/v2/mqtt-to-pubsub/src/main/java/com/google/cloud/teleport/v2/templates/MqttToPubsub.java
@@ -69,11 +69,8 @@ public class MqttToPubsub {
 
   public static void validate(MqttToPubsubOptions options) {
     if (options != null) {
-      if ((options.getUsername() != null
-              && (!options.getUsername().isEmpty() || !options.getUsername().isBlank()))
-          && (options.getPassword() != null
-              || options.getPassword().isBlank()
-              || options.getPassword().isEmpty())) {
+        if ((options.getUsername() != null && !options.getUsername().isEmpty())
+            && (options.getPassword() == null || options.getPassword().isBlank())) {
         throw new IllegalArgumentException(
             "While username is provided, password is required for authentication");
       }

--- a/v2/mqtt-to-pubsub/src/test/java/com/google/cloud/teleport/v2/templates/MqttToPubsubTest.java
+++ b/v2/mqtt-to-pubsub/src/test/java/com/google/cloud/teleport/v2/templates/MqttToPubsubTest.java
@@ -51,11 +51,22 @@ public class MqttToPubsubTest {
   }
 
   @Test
-  public void testValidation() {
+  public void testValidationFail() {
     MqttToPubsub.MqttToPubsubOptions options =
         PipelineOptionsFactory.create().as(MqttToPubsub.MqttToPubsubOptions.class);
     options.setUsername("test");
     options.setPassword("");
     assertThrows(IllegalArgumentException.class, () -> MqttToPubsub.validate(options));
+  }
+
+  @Test
+  public void testValidationSuccess() {
+    MqttToPubsub.MqttToPubsubOptions options =
+        PipelineOptionsFactory.create().as(MqttToPubsub.MqttToPubsubOptions.class);
+    options.setUsername("test");
+    options.setPassword("test");
+
+    // Expected to not throw an exception:
+    MqttToPubsub.validate(options);
   }
 }


### PR DESCRIPTION
This is to fix a bug in the username/password validation logic: it was supposed to throw an exception when the username is provided but the password isn't, but the validation would fail even if both are provided because of the incorrect `options.getPassword() != null` check.

I also simplified the validation logic a little bit (e.g. no need to check for `password.isEmpty` if we're checking for `password.isBlank`).