### PR TITLE
Fix `inputTableSpec` to be optional

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java
@@ -164,6 +164,7 @@ public class BigQueryConverters {
   public interface BigQueryReadOptions extends PipelineOptions {
     @TemplateParameter.BigQueryTable(
         order = 1,
+        optional = true,
         description = "BigQuery source table",
         helpText = "BigQuery source table spec.",
         example = "bigquery-project:dataset.input_table")

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java
@@ -207,10 +207,10 @@ public class BigQueryConverters {
     void setUseLegacySql(Boolean useLegacySql);
 
     @TemplateParameter.Text(
-        order = 4,
+        order = 5,
         optional = true,
         regexes = {"[a-zA-Z0-9-]+"},
-        description = "BigQuery geographic location where the query job  will be executed.",
+        description = "BigQuery geographic location where the query job will be executed.",
         helpText =
             "Needed when reading from an authorized view without underlying table's permission.",
         example = "US")


### PR DESCRIPTION
`inputTableSpec` is not required if `query` is provided.
This PR sets `optional` to `inputTableSpec` to be clear.
https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/4524b0a1cd5874aed48c57315d84f3a542a7cf58/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java#L362-L378