### PR TITLE
docs: Adding link to template Guide in SpannerVectorEmbeddingExport docs.

### DIFF
--- a/v1/README_Cloud_Spanner_vectors_to_Cloud_Storage.md
+++ b/v1/README_Cloud_Spanner_vectors_to_Cloud_Storage.md
@@ -14,7 +14,7 @@ Search Format Structure</a> for additional details.
 
 
 :memo: This is a Google-provided template! Please
-check [Provided templates documentation](https://cloud.google.com/dataflow/docs/guides/templates/provided-templates/cloud-spanner-to-vertex-vector-search)
+check [Provided templates documentation](https://cloud.google.com/dataflow/docs/guides/templates/provided/cloud-spanner-to-vertex-vector-search)
 on how to use it without having to build from sources using [Create job from template](https://console.cloud.google.com/dataflow/createjob?template=Cloud_Spanner_vectors_to_Cloud_Storage).
 
 :bulb: This is a generated documentation based

--- a/v1/src/main/java/com/google/cloud/teleport/templates/SpannerVectorEmbeddingExport.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/SpannerVectorEmbeddingExport.java
@@ -71,7 +71,7 @@ import org.slf4j.LoggerFactory;
       "Check <a href=\"https://cloud.google.com/vertex-ai/docs/vector-search/setup/format-structure#json\">Vector Search Format Structure</a> for additional details."
     },
     documentation =
-        "https://cloud.google.com/dataflow/docs/guides/templates/provided-templates/cloud-spanner-to-vertex-vector-search",
+        "https://cloud.google.com/dataflow/docs/guides/templates/provided/cloud-spanner-to-vertex-vector-search",
     contactInformation = "https://cloud.google.com/support",
     requirements = {
       "The Cloud Spanner database must exist.",


### PR DESCRIPTION
Add link to template guide in function doc: https://cloud.google.com/dataflow/docs/guides/templates/provided/cloud-spanner-to-vertex-vector-search