### PR TITLE
Synchronize JavaScript invokeFunction call, prevent global var issues

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/templates/common/JavascriptTextTransformer.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/common/JavascriptTextTransformer.java
@@ -256,7 +256,10 @@ public abstract class JavascriptTextTransformer {
         throw new RuntimeException("No UDF was loaded");
       }
 
-      Object result = invocable.invokeFunction(functionName(), data);
+      Object result;
+      synchronized (invocable) {
+        result = invocable.invokeFunction(functionName(), data);
+      }
       if (result == null || ScriptObjectMirror.isUndefined(result)) {
         return null;
       } else if (result instanceof String) {

--- a/v1/src/test/java/com/google/cloud/teleport/templates/common/JavascriptTextTransformerTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/common/JavascriptTextTransformerTest.java
@@ -287,10 +287,10 @@ public class JavascriptTextTransformerTest {
     List<String> inJson = Arrays.asList("A,B", "C,D", "E,F", "G,H");
     List<String> expectedJson =
         Arrays.asList(
-            "{\"name\":\"A\",\"model\":\"B\",\"sum\":50005000}",
-            "{\"name\":\"C\",\"model\":\"D\",\"sum\":50005000}",
-            "{\"name\":\"E\",\"model\":\"F\",\"sum\":50005000}",
-            "{\"name\":\"G\",\"model\":\"H\",\"sum\":50005000}");
+            "{\"name\":\"A\",\"model\":\"B\",\"sum\":499999500000}",
+            "{\"name\":\"C\",\"model\":\"D\",\"sum\":499999500000}",
+            "{\"name\":\"E\",\"model\":\"F\",\"sum\":499999500000}",
+            "{\"name\":\"G\",\"model\":\"H\",\"sum\":499999500000}");
 
     PCollection<String> transformedJson =
         pipeline
@@ -301,6 +301,32 @@ public class JavascriptTextTransformerTest {
                     .setFunctionName(StaticValueProvider.of("transformSlow"))
                     .setReloadIntervalMinutes(StaticValueProvider.of(0))
                     .build());
+
+    PAssert.that(transformedJson).containsInAnyOrder(expectedJson);
+
+    pipeline.run();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testDoFnWithComputationAndReload() {
+    List<String> inJson = Arrays.asList("A,B", "C,D", "E,F", "G,H");
+    List<String> expectedJson =
+            Arrays.asList(
+                    "{\"name\":\"A\",\"model\":\"B\",\"sum\":499999500000}",
+                    "{\"name\":\"C\",\"model\":\"D\",\"sum\":499999500000}",
+                    "{\"name\":\"E\",\"model\":\"F\",\"sum\":499999500000}",
+                    "{\"name\":\"G\",\"model\":\"H\",\"sum\":499999500000}");
+
+    PCollection<String> transformedJson =
+            pipeline
+                    .apply("Create", Create.of(inJson))
+                    .apply(
+                            TransformTextViaJavascript.newBuilder()
+                                    .setFileSystemPath(StaticValueProvider.of(TRANSFORM_FILE_PATH))
+                                    .setFunctionName(StaticValueProvider.of("transformSlow"))
+                                    .setReloadIntervalMinutes(StaticValueProvider.of(1))
+                                    .build());
 
     PAssert.that(transformedJson).containsInAnyOrder(expectedJson);
 

--- a/v1/src/test/java/com/google/cloud/teleport/templates/common/JavascriptTextTransformerTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/common/JavascriptTextTransformerTest.java
@@ -312,21 +312,21 @@ public class JavascriptTextTransformerTest {
   public void testDoFnWithComputationAndReload() {
     List<String> inJson = Arrays.asList("A,B", "C,D", "E,F", "G,H");
     List<String> expectedJson =
-            Arrays.asList(
-                    "{\"name\":\"A\",\"model\":\"B\",\"sum\":499999500000}",
-                    "{\"name\":\"C\",\"model\":\"D\",\"sum\":499999500000}",
-                    "{\"name\":\"E\",\"model\":\"F\",\"sum\":499999500000}",
-                    "{\"name\":\"G\",\"model\":\"H\",\"sum\":499999500000}");
+        Arrays.asList(
+            "{\"name\":\"A\",\"model\":\"B\",\"sum\":499999500000}",
+            "{\"name\":\"C\",\"model\":\"D\",\"sum\":499999500000}",
+            "{\"name\":\"E\",\"model\":\"F\",\"sum\":499999500000}",
+            "{\"name\":\"G\",\"model\":\"H\",\"sum\":499999500000}");
 
     PCollection<String> transformedJson =
-            pipeline
-                    .apply("Create", Create.of(inJson))
-                    .apply(
-                            TransformTextViaJavascript.newBuilder()
-                                    .setFileSystemPath(StaticValueProvider.of(TRANSFORM_FILE_PATH))
-                                    .setFunctionName(StaticValueProvider.of("transformSlow"))
-                                    .setReloadIntervalMinutes(StaticValueProvider.of(1))
-                                    .build());
+        pipeline
+            .apply("Create", Create.of(inJson))
+            .apply(
+                TransformTextViaJavascript.newBuilder()
+                    .setFileSystemPath(StaticValueProvider.of(TRANSFORM_FILE_PATH))
+                    .setFunctionName(StaticValueProvider.of("transformSlow"))
+                    .setReloadIntervalMinutes(StaticValueProvider.of(1))
+                    .build());
 
     PAssert.that(transformedJson).containsInAnyOrder(expectedJson);
 

--- a/v1/src/test/resources/JavascriptTextTransformerTest/transform.js
+++ b/v1/src/test/resources/JavascriptTextTransformerTest/transform.js
@@ -37,3 +37,24 @@ function transformWithFilter(inJson) {
     return JSON.stringify(obj);
   }
 }
+/**
+ * A transform function which copies data to another attribute, with computation in the middle.
+ * @param {string} inJson
+ * @return {string} outJson
+ */
+function transformSlow(inData) {
+
+  var row = inData.split(',');
+  var obj = new Object();
+
+  obj.name = row[0];
+
+  sum = 0;
+  for (let i = 0; i <= 10000; i++) {
+    sum += i;
+  }
+  obj.model = row[1];
+  obj.sum = sum;
+
+  return JSON.stringify(obj);
+}

--- a/v1/src/test/resources/JavascriptTextTransformerTest/transform.js
+++ b/v1/src/test/resources/JavascriptTextTransformerTest/transform.js
@@ -50,7 +50,7 @@ function transformSlow(inData) {
   obj.name = row[0];
 
   sum = 0;
-  for (let i = 0; i <= 10000; i++) {
+  for (let i = 0; i < 1000000; i++) {
     sum += i;
   }
   obj.model = row[1];

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/JavascriptTextTransformer.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/JavascriptTextTransformer.java
@@ -262,7 +262,10 @@ public abstract class JavascriptTextTransformer {
         throw new RuntimeException("No UDF was loaded");
       }
 
-      Object result = invocable.invokeFunction(functionName(), data);
+      Object result;
+      synchronized (invocable) {
+        result = invocable.invokeFunction(functionName(), data);
+      }
       if (result == null || ScriptObjectMirror.isUndefined(result)) {
         return null;
       } else if (result instanceof String) {


### PR DESCRIPTION
Ran some performance tests, and there was no considerable consequence applying the lock.

In fact, it presented better performance than having multiple runtimes without the synchronization. In a very long period of time, they both converge to the same performance, likely because of JIT.

