### PR TITLE
fixed flaky test com.google.cloud.teleport.templates.TextToBigQueryStreamingTest.wrapBigQueryInsertErrorReturnsValidJSON

### DIFF
--- a/v1/src/test/java/com/google/cloud/teleport/templates/TextToBigQueryStreamingTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/TextToBigQueryStreamingTest.java
@@ -25,6 +25,7 @@ import com.google.api.services.bigquery.model.TableRow;
 import com.google.cloud.teleport.values.FailsafeElement;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
+import com.google.gson.JsonParser;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryInsertError;
 import org.junit.Before;
 import org.junit.Test;
@@ -67,8 +68,9 @@ public class TextToBigQueryStreamingTest {
     String actualPayload = wrappedValue.getPayload();
     String actualErrorMessage = wrappedValue.getErrorMessage();
 
-    assertThat(actualOriginalPayload).isEqualTo(expected);
-    assertThat(actualPayload).isEqualTo(expected);
+    assertThat(JsonParser.parseString(actualOriginalPayload))
+        .isEqualTo(JsonParser.parseString(expected));
+    assertThat(JsonParser.parseString(actualPayload)).isEqualTo(JsonParser.parseString(expected));
     assertThat(actualErrorMessage).isEqualTo(GSON.toJson(insertErrors));
   }
 


### PR DESCRIPTION
Fix for the issue raised in https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/1175