### PR TITLE
Avoid conflict in Cassandra's table name

### DIFF
--- a/v1/src/test/java/com/google/cloud/teleport/bigtable/CassandraToBigtableIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/bigtable/CassandraToBigtableIT.java
@@ -68,14 +68,16 @@ public class CassandraToBigtableIT extends TemplateTestBase {
   @Test
   public void testCassandraToBigtable() throws IOException {
     // Arrange
+    String sourceTableName =
+        "source_table_" + RandomStringUtils.randomAlphanumeric(8).toLowerCase();
     String tableName = "test_table_" + RandomStringUtils.randomAlphanumeric(8);
     List<Map<String, Object>> records = new ArrayList<>();
     records.add(Map.of("id", 1, "company", "Google"));
     records.add(Map.of("id", 2, "company", "Alphabet"));
 
     cassandraResourceManager.executeStatement(
-        "CREATE TABLE source_data ( id int PRIMARY KEY, company text )");
-    cassandraResourceManager.insertDocuments("source_data", records);
+        "CREATE TABLE " + sourceTableName + " ( id int PRIMARY KEY, company text )");
+    cassandraResourceManager.insertDocuments(sourceTableName, records);
 
     String colFamily = "names";
     bigtableResourceManager.createTable(tableName, ImmutableList.of(colFamily));
@@ -85,7 +87,7 @@ public class CassandraToBigtableIT extends TemplateTestBase {
             .addParameter("cassandraHosts", cassandraResourceManager.getHost())
             .addParameter("cassandraPort", String.valueOf(cassandraResourceManager.getPort()))
             .addParameter("cassandraKeyspace", cassandraResourceManager.getKeyspaceName())
-            .addParameter("cassandraTable", "source_data")
+            .addParameter("cassandraTable", sourceTableName)
             .addParameter("bigtableProjectId", PROJECT)
             .addParameter("bigtableInstanceId", bigtableResourceManager.getInstanceId())
             .addParameter("bigtableTableId", tableName)


### PR DESCRIPTION
Prevent error:
```
Caused by: com.datastax.oss.driver.api.core.servererrors.AlreadyExistsException: Object testcassandratobigtable_20231016_194749.source_data already exists
	at com.datastax.oss.driver.api.core.servererrors.AlreadyExistsException.copy(AlreadyExistsException.java:65)
	at com.datastax.oss.driver.internal.core.util.concurrent.CompletableFutures.getUninterruptibly(CompletableFutures.java:149)
	at com.datastax.oss.driver.internal.core.cql.CqlRequestSyncProcessor.process(CqlRequestSyncProcessor.java:53)
	at com.datastax.oss.driver.internal.core.cql.CqlRequestSyncProcessor.process(CqlRequestSyncProcessor.java:30)
	at com.datastax.oss.driver.internal.core.session.DefaultSession.execute(DefaultSession.java:230)
	at com.datastax.oss.driver.api.core.cql.SyncCqlSession.execute(SyncCqlSession.java:54)
```