### PR TITLE
Use customizable output folder to avoid racing conditions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <derby.version>10.14.2.0</derby.version>
+    <grpc.gen.version>1.13.1</grpc.gen.version>
     <guava.version>32.0.1-jre</guava.version>
     <hadoop.version>3.3.6</hadoop.version>
     <hamcrest.version>2.1</hamcrest.version>

--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -46,7 +46,6 @@
     <codehaus-jackson.version>1.9.13</codehaus-jackson.version>
     <commons-csv.version>1.8</commons-csv.version>
     <commons-text.version>1.10.0</commons-text.version>
-    <grpc.gen.version>1.13.1</grpc.gen.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
     <threetenbp.version>1.4.4</threetenbp.version>
     <spring.version>5.2.22.RELEASE</spring.version>
@@ -834,7 +833,7 @@
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>0.5.1</version>
+        <version>0.6.1</version>
         <configuration>
           <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>

--- a/v2/googlecloud-to-googlecloud/pom.xml
+++ b/v2/googlecloud-to-googlecloud/pom.xml
@@ -42,7 +42,7 @@
         <configuration>
           <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
-          <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.13.1:exe:${os.detected.classifier}</pluginArtifact>
+          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.gen.version}:exe:${os.detected.classifier}</pluginArtifact>
         </configuration>
         <executions>
           <execution>

--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -255,7 +255,7 @@
                     <includeDependenciesInDescriptorSet>true</includeDependenciesInDescriptorSet>
                     <descriptorSetFileName>schema.pb</descriptorSetFileName>
                     <!-- This path must be unique, or else it may delete existing files. -->
-                    <descriptorSetOutputDirectory>${basedir}/target/generated-test-sources/protobuf/schema</descriptorSetOutputDirectory>
+                    <descriptorSetOutputDirectory>${project.build.directory}/generated-test-sources/protobuf/schema</descriptorSetOutputDirectory>
                     <additionalProtoPathElements>
                         <additionalProtoPathElement>${basedir}/src/test/proto</additionalProtoPathElement>
                     </additionalProtoPathElements>


### PR DESCRIPTION
When running tests on CI, some tests fail with:
- Unable to clean descriptor set output directory
- File .../DataflowTemplates/v2/googlecloud-to-googlecloud/target/generated-test-sources/protobuf/schema/schema.pb unable to be deleted.

This should help since we have logic to customize `${project.build.directory}` if the invocation comes from the Maven plugin.