### PR TITLE
Use a newer version of maven-compiler-plugin

### DIFF
--- a/plaintext-logging/pom.xml
+++ b/plaintext-logging/pom.xml
@@ -28,7 +28,6 @@
 
   <properties>
     <java.version>11</java.version>
-    <maven-compiler-plugin.version>3.6.2</maven-compiler-plugin.version>
     <surefire.version>2.21.0</surefire.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <!-- Plugins -->
     <maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
-    <maven-compiler-plugin.version>3.6.2</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.6.0</maven-dependency-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>


### PR DESCRIPTION
We're seeing some build instability with maven-compiler-plugin > plexus-compiler > AutoValue, so upgrading stale deps first and seeing if it improves.