### PR TITLE
Bug template: ask template version instead of Beam version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.yml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yml
@@ -13,7 +13,14 @@ body:
     id: template
     attributes:
       label: Related Template(s)
-      description: "Which template(s) is this bug affecting?"
+      description: "Which template(s) is this bug affecting? (Job label 'goog-dataflow-provided-template-name')"
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Template Version
+      description: What version of the template are you using? (Job label 'goog-dataflow-provided-template-version')
     validations:
       required: true
   - type: textarea
@@ -22,25 +29,6 @@ body:
       label: What happened?
       description: Please share what you expected and what happened!
       placeholder: Tell us what you see!
-    validations:
-      required: true
-  - type: dropdown
-    id: version
-    attributes:
-      label: Beam Version
-      description: What version of beam are you using?
-      options:
-        - Newer than 2.46.0
-        - 2.46.0
-        - 2.45.0
-        - 2.44.0
-        - 2.43.0
-        - 2.42.0
-        - 2.41.0
-        - 2.40.0
-        - 2.39.0
-        - 2.38.0
-        - Older than 2.38.0
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
There's not a lot of point in asking for Beam version, and this list gets stale frequently. If we know what's the version of template, we are able to easily figure out the Beam version. Also, the template version might tell us more about the code that is being executed, since we have about 10 template releases per Beam version.