### PR TITLE
Fix cascading NPE when there was a failure launching the pipeline

### DIFF
--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
@@ -346,7 +346,11 @@ public abstract class TemplateTestBase {
   public void tearDownBase() throws IOException {
     LOG.info("Invoking tearDownBase cleanups for {} - {}", testName, testId);
 
-    pipelineLauncher.cleanupAll();
+    if (pipelineLauncher != null) {
+      pipelineLauncher.cleanupAll();
+    } else {
+      LOG.error("pipelineLauncher was not initialized, there was an error triggering {}", testName);
+    }
     if (gcsClient != null) {
       gcsClient.cleanupAll();
     }


### PR DESCRIPTION
Today errors are always duplicated when the launch failed:

![image](https://github.com/GoogleCloudPlatform/DataflowTemplates/assets/3207647/8a3374ff-584b-4223-b27c-6d4dd6a9961d)

This will make the results a bit more realistic
