### PR TITLE
Fix pipeline name record in metrics

### DIFF
--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/dataflow/DefaultPipelineLauncher.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/dataflow/DefaultPipelineLauncher.java
@@ -410,9 +410,9 @@ public class DefaultPipelineLauncher extends AbstractPipelineLauncher {
     // config pipelineName
     String pipelineName = PipelineUtils.extractJobName(options.jobName());
     String overrideName = null;
-    if (pipelineName.endsWith("write")) {
+    if (pipelineName.startsWith("write")) {
       overrideName = System.getProperty(WRITE_PIPELINE_NAME_OVERWRITE);
-    } else if (pipelineName.endsWith("read")) {
+    } else if (pipelineName.startsWith("read")) {
       overrideName = System.getProperty(READ_PIPELINE_NAME_OVERWRITE);
     }
     if (!Strings.isNullOrEmpty(overrideName)) {


### PR DESCRIPTION
Sync with https://github.com/apache/beam/pull/29876 

At some point we renamed the pipeline from e.g. test_bigquery_write to write_bigquery, but missed this place.

In the last a few Beam versions, pipeline name override for non-default configuration actually did not work as expected, causing dashboard actually reporting an averaged number of metrics from different configurations (e.g. different number of worker, column size, legacy runner/runner v2)