### PR TITLE
Cleanup ModelColumn builder TODOs.

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/ModelColumn.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/ModelColumn.java
@@ -65,11 +65,7 @@ public abstract class ModelColumn implements Serializable {
         .append(typeString());
 
     if (columnOptions() != null && !columnOptions().isEmpty()) {
-      // TODO(adrw-google): Print required option once 29.6 is deployed to PROD.
-      String optionsString =
-          columnOptions().stream()
-              .filter(option -> !"required=TRUE".equals(option))
-              .collect(Collectors.joining(", "));
+      String optionsString = columnOptions().stream().collect(Collectors.joining(", "));
       if (!optionsString.isEmpty()) {
         appendable.append(" OPTIONS (").append(optionsString).append(")");
       }

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/AvroSchemaToDdlConverterTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/AvroSchemaToDdlConverterTest.java
@@ -439,7 +439,7 @@ public class AvroSchemaToDdlConverterTest {
                 + "  `i2` STRING(MAX),"
                 + " )"
                 + " OUTPUT ("
-                + " `o1` INT64,"
+                + " `o1` INT64 OPTIONS (required=TRUE),"
                 + " `o2` FLOAT64,"
                 + " )"
                 + " REMOTE OPTIONS (endpoint=\"test\")"

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/DdlTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/DdlTest.java
@@ -586,7 +586,7 @@ public class DdlTest {
         equalToCompressingWhiteSpace(
             "CREATE MODEL `user_model`"
                 + " INPUT ( `i1` BOOL OPTIONS (required=FALSE), `i2` STRING(MAX), )"
-                + " OUTPUT ( `o1` INT64, `o2` FLOAT64, )"
+                + " OUTPUT ( `o1` INT64 OPTIONS (required=TRUE), `o2` FLOAT64, )"
                 + " REMOTE OPTIONS (endpoint=\"test\")"));
   }
 


### PR DESCRIPTION
Required option is available in PROD now and the workaround is not needed anymore.