### PR TITLE
Skip integration tests if unit tests fail

### DIFF
--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -98,7 +98,7 @@ jobs:
         uses: ./.github/actions/cleanup-java-env
   java_integration_smoke_tests_templates:
     name: Dataflow Templates Integration Smoke Tests
-    needs: [spotless_check, checkstyle_check, java_build]
+    needs: [spotless_check, checkstyle_check, java_build, java_unit_tests]
     timeout-minutes: 60
     # Run on any runner that matches all the specified runs-on values.
     runs-on: [self-hosted, it]


### PR DESCRIPTION
Integration tests use a lot of resources, and if UTs failed, there's no point in running them as we'll have to fix it first.
