### PR TITLE
Change JVM config to prefer IPv4 stack

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -4,3 +4,4 @@
 --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
 --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
 --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+-Djava.net.preferIPv4Stack=true


### PR DESCRIPTION
Observed a couple of

```
java.net.ConnectException: Network is unreachable (connect failed)
```

When running integration tests, and it seems to be linked to GCE instances trying to use IPv6 stack.