### PR TITLE
Set Go version to 1.21

### DIFF
--- a/.github/workflows/go-pr.yml
+++ b/.github/workflows/go-pr.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@44e221478fc6847752e5c574fc7a7b3247b00fbf
         with:
-          go-version: '1.17'
+          go-version: '1.21'
       - name: Run Fmt
         run: |
           cd cicd
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@44e221478fc6847752e5c574fc7a7b3247b00fbf
         with:
-          go-version: '1.17'
+          go-version: '1.21'
       # By nature, this also makes sure that everything builds
       - name: Run Tests
         run: |

--- a/cicd/go.mod
+++ b/cicd/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/DataflowTemplates/cicd
 
-go 1.17
+go 1.21


### PR DESCRIPTION
This PR sets Go version from 1.17 to 1.21.