### PR TITLE
Fixing Exceptions for PG SPANNER.COMMIT_TIMESTAMP

### DIFF
--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventConvertor.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventConvertor.java
@@ -193,6 +193,7 @@ public class ChangeEventConvertor {
                     changeEvent, keyColName, /* requiredField= */ true));
             break;
           case TIMESTAMP:
+          case PG_COMMIT_TIMESTAMP:
           case PG_TIMESTAMPTZ:
             pk.append(
                 ChangeEventTypeConvertor.toTimestamp(
@@ -308,6 +309,7 @@ public class ChangeEventConvertor {
                   ChangeEventTypeConvertor.toByteArray(changeEvent, colName, requiredField));
           break;
         case TIMESTAMP:
+        case PG_COMMIT_TIMESTAMP:
         case PG_TIMESTAMPTZ:
           columnValue =
               Value.timestamp(

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/type/Type.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/type/Type.java
@@ -303,7 +303,7 @@ public final class Type implements Serializable {
     PG_TIMESTAMPTZ("timestamp with time zone", Dialect.POSTGRESQL),
     PG_DATE("date", Dialect.POSTGRESQL),
     PG_ARRAY("array", Dialect.POSTGRESQL),
-    PG_COMMIT_TIMESTAMP("SPANNER.COMMIT_TIMESTAMP", Dialect.POSTGRESQL);
+    PG_COMMIT_TIMESTAMP("spanner.commit_timestamp", Dialect.POSTGRESQL);
 
     private final String name;
     private final Dialect dialect;


### PR DESCRIPTION
# Fixing an issue of `UserCodeException` for `spanner.commit_timestamp`
## exception
```
Error message from worker: generic::unknown: org.apache.beam.sdk.util.UserCodeException: java.lang.IllegalArgumentException: Unknown spanner type spanner.commit_timestamp\n\torg.apache.beam.sdk.util.UserCodeException.wrap(UserCodeException.java:39)
```
## Test run
End to end migration from PG-SQL to Spanner via datastream-dataflow pipeline with the above type in spanner.