### PR TITLE
Use shorter prefix to prevent conflicts

### DIFF
--- a/v1/src/test/java/com/google/cloud/teleport/templates/BigtableToVectorEmbeddingsIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/BigtableToVectorEmbeddingsIT.java
@@ -57,7 +57,7 @@ public class BigtableToVectorEmbeddingsIT extends TemplateTestBase {
   @Before
   public void setUp() throws IOException {
     bigtableResourceManager =
-        BigtableResourceManager.builder(testName, PROJECT, credentialsProvider)
+        BigtableResourceManager.builder(getShortTestName(), PROJECT, credentialsProvider)
             .maybeUseStaticInstance()
             .build();
   }
@@ -70,7 +70,7 @@ public class BigtableToVectorEmbeddingsIT extends TemplateTestBase {
   @Test
   public void testBigtableToVectorEmbeddings() throws IOException {
     // Arrange
-    String tableId = generateTableId(testName);
+    String tableId = generateTableId(getShortTestName());
     bigtableResourceManager.createTable(tableId, ImmutableList.of("cf", "cf1", "cf2"));
 
     long timestamp = System.currentTimeMillis() * 1000;
@@ -198,7 +198,7 @@ public class BigtableToVectorEmbeddingsIT extends TemplateTestBase {
   @Test
   public void testBigtableToVectorEmbeddings_timestamp() throws IOException {
     // Arrange
-    String tableId = generateTableId(testName);
+    String tableId = generateTableId(getShortTestName());
     bigtableResourceManager.createTable(tableId, ImmutableList.of("cf", "cf1", "cf2"));
 
     long timestamp = System.currentTimeMillis() * 1000;
@@ -297,5 +297,9 @@ public class BigtableToVectorEmbeddingsIT extends TemplateTestBase {
 
   static ByteString toByteString(String string) {
     return ByteString.copyFrom(string.getBytes(Charset.forName("UTF-8")));
+  }
+
+  private String getShortTestName() {
+    return testName.replace("BigtableToVectorEmbeddings", "bt2vec");
   }
 }


### PR DESCRIPTION
Some resources were being created with the full test name as the prefix, and being cut-off, which may flake in some of our parallel test runners as methods start at exactly the same time:

> Caused by: com.google.api.gax.rpc.AlreadyExistsException: io.grpc.StatusRuntimeException: ALREADY_EXISTS: Table already exists: projects/cloud-teleport-testing/instances/teleport/tables/testbigtabletovec-20240125-074534