### PR TITLE
[TextToDatastore Template] Remove unused parameters from metadata.

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/templates/TextToDatastore.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/TextToDatastore.java
@@ -60,7 +60,11 @@ import org.apache.beam.sdk.values.TupleTag;
         "firestoreWriteEntityKind",
         "firestoreWriteNamespace",
         "firestoreHintNumWorkers",
-        "javascriptTextTransformReloadIntervalMinutes"
+        "javascriptTextTransformReloadIntervalMinutes",
+        // This template doesn't use neither firestoreWriteEntityKind/Namespace
+        // nor datastoreWriteEntityKind/Namespace pipeline options.
+        "datastoreWriteEntityKind",
+        "datastoreWriteNamespace"
       },
       documentation =
           "https://cloud.google.com/dataflow/docs/guides/templates/provided/cloud-storage-to-datastore",
@@ -81,7 +85,11 @@ import org.apache.beam.sdk.values.TupleTag;
         "datastoreWriteEntityKind",
         "datastoreWriteNamespace",
         "datastoreHintNumWorkers",
-        "javascriptTextTransformReloadIntervalMinutes"
+        "javascriptTextTransformReloadIntervalMinutes",
+        // This template doesn't use neither firestoreWriteEntityKind/Namespace
+        // nor datastoreWriteEntityKind/Namespace pipeline options.
+        "firestoreWriteEntityKind",
+        "firestoreWriteNamespace"
       },
       documentation =
           "https://cloud.google.com/dataflow/docs/guides/templates/provided/cloud-storage-to-firestore",


### PR DESCRIPTION
There are 2 versions of this template: GCS_Text_to_Datastore and GCS_Text_to_Firestore. The main difference is Datastore/Firestore naming: the template name and parameter names are different. But neither of these 2 templates actually use   **firestore**WriteEntityKind/Namespace or **datastore**WriteEntityKind/Namespace pipeline options. Setting these parameter will cause the pipeline to fail in runtime.