### PR TITLE
Update go version in action.yml

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -40,7 +40,7 @@ inputs:
     type: string
     description: 'The version of Go to install'
     required: false
-    default: '1.17'
+    default: '1.21'
 outputs:
   changed-files:
     description: 'Comma-separated list of files that were changed'


### PR DESCRIPTION
This PR updates .github/actions/setup-env/action.yml version of Go to match cicd's go.mod version `1.21`.