### PR TITLE
Add RpcPriority flag to Transaction

### DIFF
--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SpannerTransactionWriterDoFn.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SpannerTransactionWriterDoFn.java
@@ -213,7 +213,9 @@ class SpannerTransactionWriterDoFn extends DoFn<FailsafeElement<String, String>,
       // Start transaction
       spannerAccessor
           .getDatabaseClient()
-          .readWriteTransaction(Options.tag(getTxnTag(c.getPipelineOptions())), Options.priority(spannerConfig.getRpcPriority().get()))
+          .readWriteTransaction(
+              Options.tag(getTxnTag(c.getPipelineOptions())),
+              Options.priority(spannerConfig.getRpcPriority().get()))
           .run(
               (TransactionCallable<Void>)
                   transaction -> {

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SpannerTransactionWriterDoFn.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SpannerTransactionWriterDoFn.java
@@ -213,7 +213,7 @@ class SpannerTransactionWriterDoFn extends DoFn<FailsafeElement<String, String>,
       // Start transaction
       spannerAccessor
           .getDatabaseClient()
-          .readWriteTransaction(Options.tag(getTxnTag(c.getPipelineOptions())))
+          .readWriteTransaction(Options.tag(getTxnTag(c.getPipelineOptions())), Options.priority(spannerConfig.getRpcPriority().get()))
           .run(
               (TransactionCallable<Void>)
                   transaction -> {


### PR DESCRIPTION
Passing the RpcPriority to `spannerConfig` is not sufficient as done in #1305.
It also needs to be set per transaction.