### PR TITLE
Fix BigQueryDynamicDestination to properly fetch TableRow field names

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/templates/common/BigQueryDynamicConverters.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/common/BigQueryDynamicConverters.java
@@ -15,15 +15,12 @@
  */
 package com.google.cloud.teleport.templates.common;
 
-// import com.google.cloud.teleport.templates.common.BigQueryConverters;
-import com.google.api.services.bigquery.model.TableCell;
 import com.google.api.services.bigquery.model.TableFieldSchema;
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.cloud.bigquery.TableId;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import org.apache.beam.sdk.io.gcp.bigquery.DynamicDestinations;
 import org.apache.beam.sdk.io.gcp.bigquery.TableDestination;
 import org.apache.beam.sdk.options.ValueProvider;
@@ -161,14 +158,11 @@ public class BigQueryDynamicConverters {
       TableRow bqRow = destination.getValue();
       TableSchema schema = new TableSchema();
       List<TableFieldSchema> fields = new ArrayList<TableFieldSchema>();
-      List<TableCell> cells = bqRow.getF();
-      for (int i = 0; i < cells.size(); i++) {
-        Map<String, Object> object = cells.get(i);
-        String header = object.keySet().iterator().next();
+      for (String field : bqRow.keySet()) {
         /** currently all BQ data types are set to String */
         // Why do we use checkHeaderName here and not elsewhere, TODO if we add this back in
         // fields.add(new TableFieldSchema().setName(checkHeaderName(header)).setType("STRING"));
-        fields.add(new TableFieldSchema().setName(header).setType("STRING"));
+        fields.add(new TableFieldSchema().setName(field).setType("STRING"));
       }
 
       schema.setFields(fields);

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryDynamicConverters.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryDynamicConverters.java
@@ -15,14 +15,12 @@
  */
 package com.google.cloud.teleport.v2.transforms;
 
-import com.google.api.services.bigquery.model.TableCell;
 import com.google.api.services.bigquery.model.TableFieldSchema;
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.cloud.bigquery.TableId;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import org.apache.beam.sdk.io.gcp.bigquery.DynamicDestinations;
 import org.apache.beam.sdk.io.gcp.bigquery.TableDestination;
 import org.apache.beam.sdk.transforms.MapElements;
@@ -146,14 +144,11 @@ public class BigQueryDynamicConverters {
       TableRow bqRow = destination.getValue();
       TableSchema schema = new TableSchema();
       List<TableFieldSchema> fields = new ArrayList<TableFieldSchema>();
-      List<TableCell> cells = bqRow.getF();
-      for (int i = 0; i < cells.size(); i++) {
-        Map<String, Object> object = cells.get(i);
-        String header = object.keySet().iterator().next();
+      for (String field : bqRow.keySet()) {
         /** currently all BQ data types are set to String */
         // Why do we use checkHeaderName here and not elsewhere, TODO if we add this back in
         // fields.add(new TableFieldSchema().setName(checkHeaderName(header)).setType("STRING"));
-        fields.add(new TableFieldSchema().setName(header).setType("STRING"));
+        fields.add(new TableFieldSchema().setName(field).setType("STRING"));
       }
 
       schema.setFields(fields);

--- a/v2/datastream-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/BigQueryDynamicConverters.java
+++ b/v2/datastream-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/BigQueryDynamicConverters.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.teleport.v2.templates;
 
-import com.google.api.services.bigquery.model.TableCell;
 import com.google.api.services.bigquery.model.TableFieldSchema;
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.api.services.bigquery.model.TableSchema;
@@ -23,7 +22,6 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.teleport.v2.transforms.BigQueryConverters;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import org.apache.beam.sdk.io.gcp.bigquery.DynamicDestinations;
 import org.apache.beam.sdk.io.gcp.bigquery.TableDestination;
 import org.apache.beam.sdk.transforms.MapElements;

--- a/v2/datastream-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/BigQueryDynamicConverters.java
+++ b/v2/datastream-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/BigQueryDynamicConverters.java
@@ -147,14 +147,11 @@ public class BigQueryDynamicConverters {
       TableRow bqRow = destination.getValue();
       TableSchema schema = new TableSchema();
       List<TableFieldSchema> fields = new ArrayList<TableFieldSchema>();
-      List<TableCell> cells = bqRow.getF();
-      /** currently all BQ data types are set to String */
-      for (Map<String, Object> object : cells) {
-        String header = object.keySet().iterator().next();
+      for (String field : bqRow.keySet()) {
         /** currently all BQ data types are set to String */
         // Why do we use checkHeaderName here and not elsewhere, TODO if we add this back in
         // fields.add(new TableFieldSchema().setName(checkHeaderName(header)).setType("STRING"));
-        fields.add(new TableFieldSchema().setName(header).setType("STRING"));
+        fields.add(new TableFieldSchema().setName(field).setType("STRING"));
       }
 
       schema.setFields(fields);


### PR DESCRIPTION
Copied from #1304 because that CL got stale

In our BigQueryDynamicDestination classes, we fetch a TableRow's field names to dynamically create a TableSchema. We do this by calling TableRow::getF(), but this is an unreliable method that can return null and causing this error:

Caused by: java.lang.NullPointerException
	at com.google.cloud.teleport.v2.templates.BigQueryDynamicConverters$BigQueryDynamicDestination.getSchema(BigQueryDynamicConverters.java:152)
	at com.google.cloud.teleport.v2.templates.BigQueryDynamicConverters$BigQueryDynamicDestination.getSchema(BigQueryDynamicConverters.java:120)
	at org.apache.beam.sdk.io.gcp.bigquery.DynamicDestinationsHelpers$DelegatingDynamicDestinations.getSchema(DynamicDestinationsHelpers.java:178)
	at org.apache.beam.sdk.io.gcp.bigquery.StorageApiDynamicDestinationsTableRow.getSchema(StorageApiDynamicDestinationsTableRow.java:36)
	at org.apache.beam.sdk.io.gcp.bigquery.StorageApiDynamicDestinationsTableRow$TableRowConverter.<init>(StorageApiDynamicDestinationsTableRow.java:95)
	at org.apache.beam.sdk.io.gcp.bigquery.StorageApiDynamicDestinationsTableRow.getMessageConverter(StorageApiDynamicDestinationsTableRow.java:73)
	at org.apache.beam.sdk.io.gcp.bigquery.TwoLevelMessageConverterCache.lambda$get$0(TwoLevelMessageConverterCache.java:72)
This especially affects writing with Storage API because getSchema() is called to encode TableRows before sending to BQ.

TableRow is ultimately a map, so we can look at the keySet instead.

Internal bugs: 321906363 and 319648178