### PR TITLE
Support schema updates after pipeline starts running

### DIFF
--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/BigQueryDynamicDestinations.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/BigQueryDynamicDestinations.java
@@ -24,16 +24,13 @@ import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Dialect;
-import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.TrackedSpannerTable;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.BigQueryUtils;
-import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.SpannerChangeStreamsUtils;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.SpannerToBigQueryUtils;
 import com.google.cloud.teleport.v2.transforms.BigQueryConverters;
 import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import org.apache.beam.sdk.io.gcp.bigquery.DynamicDestinations;
 import org.apache.beam.sdk.io.gcp.bigquery.TableDestination;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
@@ -47,32 +44,17 @@ import org.apache.beam.sdk.values.ValueInSingleWindow;
  */
 public final class BigQueryDynamicDestinations
     extends DynamicDestinations<TableRow, KV<TableId, TableRow>> {
-
-  private final Map<String, TrackedSpannerTable> spannerTableByName;
   private final String bigQueryProject, bigQueryDataset, bigQueryTableTemplate;
   private final Boolean useStorageWriteApi;
   private final ImmutableSet<String> ignoreFields;
 
   public static BigQueryDynamicDestinations of(
       BigQueryDynamicDestinationsOptions bigQueryDynamicDestinationsOptions) {
-    Dialect dialect = getDialect(bigQueryDynamicDestinationsOptions.getSpannerConfig());
-    try (SpannerAccessor spannerAccessor =
-        SpannerAccessor.getOrCreate(bigQueryDynamicDestinationsOptions.getSpannerConfig())) {
-      Map<String, TrackedSpannerTable> spannerTableByName =
-          new SpannerChangeStreamsUtils(
-                  spannerAccessor.getDatabaseClient(),
-                  bigQueryDynamicDestinationsOptions.getChangeStreamName(),
-                  dialect)
-              .getSpannerTableByName();
-      return new BigQueryDynamicDestinations(
-          bigQueryDynamicDestinationsOptions, spannerTableByName);
-    }
+    return new BigQueryDynamicDestinations(bigQueryDynamicDestinationsOptions);
   }
 
   private BigQueryDynamicDestinations(
-      BigQueryDynamicDestinationsOptions bigQueryDynamicDestinationsOptions,
-      Map<String, TrackedSpannerTable> spannerTableByName) {
-    this.spannerTableByName = spannerTableByName;
+      BigQueryDynamicDestinationsOptions bigQueryDynamicDestinationsOptions) {
     this.ignoreFields = bigQueryDynamicDestinationsOptions.getIgnoreFields();
     this.bigQueryProject = bigQueryDynamicDestinationsOptions.getBigQueryProject();
     this.bigQueryDataset = bigQueryDynamicDestinationsOptions.getBigQueryDataset();
@@ -105,10 +87,8 @@ public final class BigQueryDynamicDestinations
   @Override
   public TableSchema getSchema(KV<TableId, TableRow> destination) {
     TableRow tableRow = destination.getValue();
-    String spannerTableName =
-        (String) tableRow.get(BigQueryUtils.BQ_CHANGELOG_FIELD_NAME_TABLE_NAME);
-    TrackedSpannerTable spannerTable = spannerTableByName.get(spannerTableName);
-    List<TableFieldSchema> fields = getFields(spannerTable);
+    // Get List<TableFieldSchema> for both user columns and metadata columns.
+    List<TableFieldSchema> fields = getFields(tableRow);
     List<TableFieldSchema> filteredFields = new ArrayList<>();
     for (TableFieldSchema field : fields) {
       if (!ignoreFields.contains(field.getName())) {
@@ -119,9 +99,12 @@ public final class BigQueryDynamicDestinations
     return new TableSchema().setFields(filteredFields);
   }
 
-  private List<TableFieldSchema> getFields(TrackedSpannerTable spannerTable) {
+  // Returns List<TableFieldSchema> for user columns and metadata columns based on the parameter
+  // TableRow.
+  private List<TableFieldSchema> getFields(TableRow tableRow) {
+    // Add all user data fields (excluding metadata fields stored in metadataColumns).
     List<TableFieldSchema> fields =
-        SpannerToBigQueryUtils.spannerColumnsToBigQueryIOFields(spannerTable.getAllColumns());
+        SpannerToBigQueryUtils.tableRowColumnsToBigQueryIOFields(tableRow, this.useStorageWriteApi);
 
     // Add all metadata fields.
     String requiredMode = Field.Mode.REQUIRED.name();

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/FailsafeModJsonToTableRowTransformer.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/FailsafeModJsonToTableRowTransformer.java
@@ -35,6 +35,7 @@ import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.mod
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.TrackedSpannerColumn;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.TrackedSpannerTable;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.BigQueryUtils;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.SchemaUpdateUtils;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.SpannerChangeStreamsUtils;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.SpannerToBigQueryUtils;
 import com.google.cloud.teleport.v2.values.FailsafeElement;
@@ -128,6 +129,7 @@ public final class FailsafeModJsonToTableRowTransformer {
       private transient CallContextConfigurator callContextConfigurator;
       private transient boolean seenException;
       private Boolean useStorageWriteApi;
+      private Dialect dialect;
 
       public FailsafeModJsonToTableRowFn(
           SpannerConfig spannerConfig,
@@ -142,6 +144,7 @@ public final class FailsafeModJsonToTableRowTransformer {
         this.transformDeadLetterOut = transformDeadLetterOut;
         this.ignoreFields = ignoreFields;
         this.useStorageWriteApi = useStorageWriteApi;
+        this.dialect = getDialect(spannerConfig);
       }
 
       private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
@@ -163,7 +166,6 @@ public final class FailsafeModJsonToTableRowTransformer {
 
       @Setup
       public void setUp() {
-        Dialect dialect = getDialect(spannerConfig);
         spannerAccessor = SpannerAccessor.getOrCreate(spannerConfig);
         spannerTableByName =
             new SpannerChangeStreamsUtils(
@@ -194,7 +196,7 @@ public final class FailsafeModJsonToTableRowTransformer {
           if (!seenException) {
             LOG.error(
                 "Caught exception when processing element , storing into dead letter queue. "
-                    + e.getMessage());
+                    + Throwables.getStackTraceAsString(e));
             seenException = true;
           }
           context.output(
@@ -212,13 +214,21 @@ public final class FailsafeModJsonToTableRowTransformer {
             modObjectNode.remove(excludeFieldName);
           }
         }
-
         Mod mod = Mod.fromJson(modObjectNode.toString());
         String spannerTableName = mod.getTableName();
-        TrackedSpannerTable spannerTable = spannerTableByName.get(spannerTableName);
         com.google.cloud.Timestamp spannerCommitTimestamp =
             com.google.cloud.Timestamp.ofTimeSecondsAndNanos(
                 mod.getCommitTimestampSeconds(), mod.getCommitTimestampNanos());
+        // Detect schema updates (newly added tables/columns) from mod and propagate changes into
+        // spannerTableByName which stores schema information by table name.
+        // Not able to get schema update from DELETE mods as they have empty newValuesJson.
+        if (mod.getModType() != ModType.DELETE) {
+          spannerTableByName =
+              SchemaUpdateUtils.updateStoredSchemaIfNeeded(
+                  spannerAccessor, spannerChangeStream, dialect, mod, spannerTableByName);
+        }
+
+        TrackedSpannerTable spannerTable = spannerTableByName.get(spannerTableName);
 
         // Set metadata fields of the tableRow.
         TableRow tableRow = new TableRow();
@@ -231,15 +241,8 @@ public final class FailsafeModJsonToTableRowTransformer {
             useStorageWriteApi);
         JSONObject keysJsonObject = new JSONObject(mod.getKeysJson());
         // Set Spanner key columns of the tableRow.
-        for (TrackedSpannerColumn spannerColumn : spannerTable.getPkColumns()) {
-          String spannerColumnName = spannerColumn.getName();
-          if (keysJsonObject.has(spannerColumnName)) {
-            tableRow.set(spannerColumnName, keysJsonObject.get(spannerColumnName));
-          } else {
-            throw new IllegalArgumentException(
-                "Cannot find value for key column " + spannerColumnName);
-          }
-        }
+        SpannerToBigQueryUtils.addSpannerPkColumnsToTableRow(
+            keysJsonObject, spannerTable.getPkColumns(), tableRow);
 
         // For "DELETE" mod, we only need to set the key columns.
         if (mod.getModType() == ModType.DELETE) {
@@ -320,8 +323,7 @@ public final class FailsafeModJsonToTableRowTransformer {
         return tableRow;
       }
 
-      // Do a Spanner read to retrieve full row. The schema change is currently not supported. so we
-      // assume the schema isn't changed while the pipeline is running,
+      // Do a Spanner read to retrieve full row. Schema can change while the pipeline is running.
       private void readSpannerRow(
           String spannerTableName,
           com.google.cloud.spanner.Key key,

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/model/ModColumnType.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/model/ModColumnType.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.coders.DefaultCoder;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.ColumnType;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.TypeCode;
+import org.apache.beam.sdk.schemas.SchemaCoder;
+import org.apache.beam.sdk.schemas.annotations.SchemaCreate;
+
+/**
+ * Defines a column type from a Cloud Spanner table with the following information: column name,
+ * column type, flag indicating if column is primary key and column position in the table. These
+ * information are from {@link org.apache.beam.sdk.io.gcp.spanner.changestreams.model.ColumnType}
+ * class, which can't be reused due to JSON parsing error in {@link
+ * FailsafeModJsonToTableRowTransformer}.
+ */
+@SuppressWarnings("initialization.fields.uninitialized") // Avro requires the default constructor
+@DefaultCoder(SchemaCoder.class)
+public class ModColumnType implements Serializable {
+
+  // NOTE: UID not in use, though no specific guide was followed in assigning this value. This is an
+  // arbitrary value.
+  private static final long serialVersionUID = 8703257194338184300L;
+
+  private String name;
+  private TypeCode type;
+  private boolean isPrimaryKey;
+  private long ordinalPosition;
+
+  /** Default constructor for serialization only. */
+  private ModColumnType() {}
+
+  @SchemaCreate
+  public ModColumnType(String name, TypeCode type, boolean primaryKey, long ordinalPosition) {
+    this.name = name;
+    this.type = type;
+    this.isPrimaryKey = primaryKey;
+    this.ordinalPosition = ordinalPosition;
+  }
+
+  public ModColumnType(ColumnType columnType) {
+    this(
+        columnType.getName(),
+        columnType.getType(),
+        columnType.isPrimaryKey(),
+        columnType.getOrdinalPosition());
+  }
+
+  /** The name of the column. */
+  public String getName() {
+    return name;
+  }
+
+  /** The type of the column. */
+  public TypeCode getType() {
+    return type;
+  }
+
+  /** True if the column is part of the primary key, false otherwise. */
+  public boolean getIsPrimaryKey() {
+    return isPrimaryKey;
+  }
+
+  /** The position of the column in the table. */
+  public long getOrdinalPosition() {
+    return ordinalPosition;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ModColumnType)) {
+      return false;
+    }
+    ModColumnType that = (ModColumnType) o;
+    return isPrimaryKey == that.isPrimaryKey
+        && ordinalPosition == that.ordinalPosition
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, type, isPrimaryKey, ordinalPosition);
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "ModColumnType{name='%s', type=%s, isPrimaryKey=%s, ordinalPosition=%s}",
+        name, type, isPrimaryKey, ordinalPosition);
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/OptionsUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/OptionsUtils.java
@@ -29,7 +29,6 @@ public class OptionsUtils {
       SpannerChangeStreamsToBigQueryOptions options) {
     String bigqueryProjectId = options.getBigQueryProjectId();
     String bigqueryDataset = options.getBigQueryDataset();
-    LOG.info("===bigqueryDataset: " + bigqueryDataset);
     int datasetStartPos = bigqueryDataset.indexOf(".");
     if (datasetStartPos != -1) {
       String inferredBigQueryProjectId = bigqueryDataset.substring(0, datasetStartPos);

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SchemaUpdateUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SchemaUpdateUtils.java
@@ -1,0 +1,120 @@
+package com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.Mod;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.ModColumnType;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.TrackedSpannerColumn;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.TrackedSpannerTable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.ValueCaptureType;
+import org.json.JSONObject;
+
+/**
+ * The {@link SchemaUpdateUtils} provides methods that detects schema updates and updates stored
+ * schema information.
+ */
+public class SchemaUpdateUtils {
+
+  // Detect if there's a table/column difference between the mod and the stored map.
+  public static boolean detectDiffColumnInMod(
+      Mod mod, Map<String, TrackedSpannerTable> spannerTableByName) {
+    TrackedSpannerTable spannerTable = spannerTableByName.get(mod.getTableName());
+    Set<String> keySetOfNewValuesJsonObject =
+        mod.getNewValuesJson() == ""
+            ? new JSONObject("{}").keySet()
+            : new JSONObject(mod.getNewValuesJson()).keySet();
+    // At this mod's spannerCommitTimestamp, one column is added/dropped.
+    if (spannerTable.getNonPkColumns().size() != keySetOfNewValuesJsonObject.size()) {
+      return true;
+    }
+    Set<String> nonPkColumnsNamesSet = spannerTable.getNonPkColumnsNamesSet();
+    // Returns true if the stored schema doesn't contain a column in the mod
+    return !nonPkColumnsNamesSet.containsAll(keySetOfNewValuesJsonObject);
+  }
+
+  // Update the stored schema information (spannerTableByName) by fetching from the mod.
+  public static void updateStoredSchemaNewRow(
+      Mod mod, Map<String, TrackedSpannerTable> spannerTableByName, Dialect dialect) {
+    JSONObject keysJsonObject = new JSONObject(mod.getKeysJson());
+    JSONObject newValuesJsonObject =
+        mod.getNewValuesJson() == ""
+            ? new JSONObject("{}")
+            : new JSONObject(mod.getNewValuesJson());
+    String spannerTableName = mod.getTableName();
+    Map<String, ModColumnType> modColumnTypeMap = mod.getRowTypeAsMap();
+    // Create a new table for spannerTableName if it's not in spannerTableByName.
+    if (!spannerTableByName.containsKey(spannerTableName)) {
+      // Create an empty list of pk columns for the new table.
+      List<TrackedSpannerColumn> pkColumns = new ArrayList<>();
+      // Create an empty list of non-pk columns for the new table.
+      List<TrackedSpannerColumn> nonPkColumns = new ArrayList<>();
+      // Introduce the new table into spannerTableByName.
+      TrackedSpannerTable spannerTableObj =
+          new TrackedSpannerTable(spannerTableName, pkColumns, nonPkColumns);
+      spannerTableByName.put(spannerTableName, spannerTableObj);
+      // Populate pk columns from Mod to TrackedSpannerTable.
+      for (String pkColumnName : keysJsonObject.keySet()) {
+        ModColumnType spannerColumn = modColumnTypeMap.get(pkColumnName);
+        String typeStr =
+            TypesUtils.extractTypeFromTypeCode(new JSONObject(spannerColumn.getType().getCode()));
+        spannerTableByName
+            .get(spannerTableName)
+            .addTrackedSpannerColumn(
+                pkColumnName, typeStr, -1, (int) spannerColumn.getOrdinalPosition(), dialect);
+      }
+    }
+
+    // Populate nonPkColumns from Mod to TrackedSpannerTable.
+    Set<String> nonPkColumnsSet =
+        spannerTableByName.get(spannerTableName).getNonPkColumnsNamesSet();
+    for (String nonPkColumnName : newValuesJsonObject.keySet()) {
+      if (!nonPkColumnsSet.contains(nonPkColumnName)) {
+        ModColumnType spannerColumn = modColumnTypeMap.get(nonPkColumnName);
+        String typeStr =
+            TypesUtils.extractTypeFromTypeCode(new JSONObject(spannerColumn.getType().getCode()));
+        spannerTableByName
+            .get(spannerTableName)
+            .addTrackedSpannerColumn(
+                spannerColumn.getName(),
+                typeStr,
+                (int) spannerColumn.getOrdinalPosition(),
+                -1,
+                dialect);
+      }
+    }
+  }
+
+  // For NEW_VALUES and OLD_AND_NEW_VALUES, update the stored schema information by looking up
+  // INFORMATION_SCHEMA at the mod's commit timestamp.
+  // For NEW_ROW, update the stored schema information by fetching from the mod.
+  public static Map<String, TrackedSpannerTable> updateStoredSchemaIfNeeded(
+      SpannerAccessor spannerAccessor,
+      String spannerChangeStream,
+      Dialect dialect,
+      Mod mod,
+      Map<String, TrackedSpannerTable> spannerTableByName) {
+    if (!spannerTableByName.containsKey(mod.getTableName())
+        || SchemaUpdateUtils.detectDiffColumnInMod(mod, spannerTableByName)) {
+      if (mod.getValueCaptureType() != ValueCaptureType.NEW_ROW) {
+        com.google.cloud.Timestamp spannerCommitTimestamp =
+            com.google.cloud.Timestamp.ofTimeSecondsAndNanos(
+                mod.getCommitTimestampSeconds(), mod.getCommitTimestampNanos());
+        // TODO:b/322630434 Consider updating the schema only for one table at a time.
+        spannerTableByName =
+            new SpannerChangeStreamsUtils(
+                    spannerAccessor.getDatabaseClient(),
+                    spannerChangeStream,
+                    dialect,
+                    spannerCommitTimestamp)
+                .getSpannerTableByName();
+      } else {
+        updateStoredSchemaNewRow(mod, spannerTableByName, dialect);
+      }
+    }
+    return spannerTableByName;
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/TypesUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/TypesUtils.java
@@ -1,0 +1,116 @@
+package com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils;
+
+import com.google.cloud.spanner.Type;
+import org.json.JSONObject;
+
+/**
+ * The {@link TypesUtils} provides methods that converts information schema types to spanner types,
+ * extracts data types from Mod, and converts the extracted data types to spanner types.
+ */
+public class TypesUtils {
+
+  public static Type informationSchemaGoogleSQLTypeToSpannerType(String type) {
+    type = cleanInformationSchemaType(type);
+    switch (type) {
+      case "BOOL":
+        return Type.bool();
+      case "BYTES":
+        return Type.bytes();
+      case "DATE":
+        return Type.date();
+      case "FLOAT64":
+        return Type.float64();
+      case "INT64":
+        return Type.int64();
+      case "JSON":
+        return Type.json();
+      case "NUMERIC":
+        return Type.numeric();
+      case "STRING":
+        return Type.string();
+      case "TIMESTAMP":
+        return Type.timestamp();
+      default:
+        if (type.startsWith("ARRAY")) {
+          // Get array type, e.g. "ARRAY<STRING>" -> "STRING".
+          String spannerArrayType = type.substring(6, type.length() - 1);
+          Type itemType = informationSchemaGoogleSQLTypeToSpannerType(spannerArrayType);
+          return Type.array(itemType);
+        }
+
+        throw new IllegalArgumentException(String.format("Unsupported Spanner type: %s", type));
+    }
+  }
+
+  public static Type informationSchemaPostgreSQLTypeToSpannerType(String type) {
+    boolean isPostgresArray = isPostgresArray(type);
+    String cleanedType = "";
+    if (isPostgresArray) {
+      cleanedType = type.substring(0, type.length() - 2);
+      Type itemType = informationSchemaPostgreSQLTypeToSpannerType(cleanedType);
+      return Type.array(itemType);
+    } else {
+      cleanedType = cleanInformationSchemaType(type);
+    }
+
+    switch (cleanedType) {
+      case "BOOLEAN":
+        return Type.bool();
+      case "BYTEA":
+        return Type.bytes();
+      case "DOUBLE PRECISION":
+        return Type.float64();
+      case "BIGINT":
+        return Type.int64();
+      case "DATE":
+        return Type.date();
+      case "JSONB":
+        return Type.pgJsonb();
+      case "NUMERIC":
+        return Type.pgNumeric();
+      case "CHARACTER VARYING":
+        return Type.string();
+      case "TIMESTAMP WITH TIME ZONE":
+        return Type.timestamp();
+      case "SPANNER.COMMIT_TIMESTAMP":
+        return Type.timestamp();
+      default:
+        throw new IllegalArgumentException(
+            String.format("Unsupported Spanner PostgreSQL type: %s", type));
+    }
+  }
+
+  private static boolean isPostgresArray(String type) {
+    return type.endsWith("[]");
+  }
+
+  /**
+   * Remove the Spanner type length limit, since Spanner doesn't document clearly on the
+   * parameterized types like BigQuery does, i.e. BigQuery's docmentation on <a
+   * href="https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#parameterized_data_types">Parameterized
+   * data types</a>, but Spanner doesn't have a similar one. We might have problem if we transfer
+   * the length limit into BigQuery. By removing the length limit, we essentially loose the
+   * constraint of data written to BigQuery, and it won't cause errors.
+   */
+  private static String cleanInformationSchemaType(String type) {
+    // Remove type size, e.g. STRING(1024) -> STRING.
+    int leftParenthesisIdx = type.indexOf('(');
+    if (leftParenthesisIdx != -1) {
+      type = type.substring(0, leftParenthesisIdx) + type.substring(type.indexOf(')') + 1);
+    }
+
+    // Convert it to upper case.
+    return type.toUpperCase();
+  }
+
+  // Eg 1: "{\"array_element_type\":{\"code\":\"STRING\"},\"code\":\"ARRAY\"}" -> ARRAY<STRING>
+  // Eg 2: "{\"code\":\"STRING\"}" -> STRING
+  public static String extractTypeFromTypeCode(JSONObject typeCodeObj) {
+    if (!typeCodeObj.has("array_element_type")) {
+      return typeCodeObj.getString("code");
+    }
+    return "ARRAY<"
+        + extractTypeFromTypeCode(typeCodeObj.getJSONObject("array_element_type"))
+        + ">";
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SchemaUpdateUtilsTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SchemaUpdateUtilsTest.java
@@ -1,0 +1,209 @@
+package com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.ReadContext;
+import com.google.cloud.spanner.Type;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.Mod;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.ModColumnType;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.TrackedSpannerColumn;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.TrackedSpannerTable;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.SchemaUpdateUtils;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.SpannerChangeStreamsUtils;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.ModType;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.TypeCode;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.ValueCaptureType;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class SchemaUpdateUtilsTest {
+  private static final String changeStreamName = "Singers";
+  @Mock private DatabaseClient mockDatabaseClient;
+  @Mock private ReadContext mockReadContext;
+  @Mock private SpannerAccessor mockSpannerAccessor;
+  private Timestamp now = Timestamp.now();
+
+  @Before
+  public void setUp() {
+    when(mockSpannerAccessor.getDatabaseClient()).thenReturn(mockDatabaseClient);
+  }
+
+  public Map<String, TrackedSpannerTable> createSpannerTableByName() {
+    List<TrackedSpannerColumn> singersPkColumns =
+        Collections.singletonList(TrackedSpannerColumn.create("SingerId", Type.int64(), -1, 1));
+    List<TrackedSpannerColumn> singersNonPkColumns =
+        Collections.singletonList(TrackedSpannerColumn.create("FirstName", Type.string(), 2, -1));
+    Map<String, TrackedSpannerTable> spannerTableByName = new HashMap<>();
+    spannerTableByName.put(
+        "Singers", new TrackedSpannerTable("Singers", singersPkColumns, singersNonPkColumns));
+    return spannerTableByName;
+  }
+
+  @Test
+  public void testDetectDiffColumnInModWithoutDiff() {
+    ObjectNode pkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
+    pkColJsonNode.put("SingerId", 1);
+    ObjectNode nonPkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
+    nonPkColJsonNode.put("FirstName", "firstName");
+    List<ModColumnType> rowTypes = new ArrayList<>();
+    rowTypes.add(new ModColumnType("SingerId", new TypeCode("INT64"), true, 1));
+    rowTypes.add(new ModColumnType("FirstName", new TypeCode("STRING"), false, 2));
+    Mod mod =
+        new Mod(
+            pkColJsonNode.toString(),
+            nonPkColJsonNode.toString(),
+            Timestamp.ofTimeSecondsAndNanos(1650908264L, 925679000),
+            "1",
+            true,
+            "00000001",
+            "Singers",
+            rowTypes,
+            ModType.INSERT,
+            ValueCaptureType.OLD_AND_NEW_VALUES,
+            1L,
+            1L);
+    Map<String, TrackedSpannerTable> spannerTableByName = createSpannerTableByName();
+    assertThat(SchemaUpdateUtils.detectDiffColumnInMod(mod, spannerTableByName)).isEqualTo(false);
+  }
+
+  @Test
+  public void testDetectDiffColumnInModWithColDiff() {
+    ObjectNode pkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
+    pkColJsonNode.put("SingerId", 1);
+    ObjectNode nonPkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
+    nonPkColJsonNode.put("FirstName", "firstName");
+    nonPkColJsonNode.put("LastName", "lastName");
+    List<ModColumnType> rowTypes = new ArrayList<>();
+    rowTypes.add(new ModColumnType("SingerId", new TypeCode("{\"code\":\"INT64\"}"), true, 1));
+    rowTypes.add(new ModColumnType("FirstName", new TypeCode("{\"code\":\"STRING\"}"), false, 2));
+    rowTypes.add(new ModColumnType("LastName", new TypeCode("{\"code\":\"STRING\"}"), false, 3));
+    Mod mod =
+        new Mod(
+            pkColJsonNode.toString(),
+            nonPkColJsonNode.toString(),
+            Timestamp.ofTimeSecondsAndNanos(1650908264L, 925679000),
+            "1",
+            true,
+            "00000001",
+            "Singers",
+            rowTypes,
+            ModType.INSERT,
+            ValueCaptureType.OLD_AND_NEW_VALUES,
+            1L,
+            1L);
+    Map<String, TrackedSpannerTable> spannerTableByName = createSpannerTableByName();
+    assertThat(SchemaUpdateUtils.detectDiffColumnInMod(mod, spannerTableByName)).isEqualTo(true);
+  }
+
+  @Test
+  public void testUpdateStoredSchemaNewRow() {
+    ObjectNode pkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
+    pkColJsonNode.put("SingerId", 1);
+    ObjectNode nonPkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
+    nonPkColJsonNode.put("FirstName", "firstName");
+    nonPkColJsonNode.put("LastName", "lastName");
+    List<ModColumnType> rowTypes = new ArrayList<>();
+    rowTypes.add(new ModColumnType("SingerId", new TypeCode("{\"code\":\"INT64\"}"), true, 1));
+    rowTypes.add(new ModColumnType("FirstName", new TypeCode("{\"code\":\"STRING\"}"), false, 2));
+    rowTypes.add(new ModColumnType("LastName", new TypeCode("{\"code\":\"STRING\"}"), false, 3));
+    Mod mod =
+        new Mod(
+            pkColJsonNode.toString(),
+            nonPkColJsonNode.toString(),
+            Timestamp.ofTimeSecondsAndNanos(1650908264L, 925679000),
+            "1",
+            true,
+            "00000001",
+            "Singers",
+            rowTypes,
+            ModType.INSERT,
+            ValueCaptureType.NEW_ROW,
+            1L,
+            1L);
+    Map<String, TrackedSpannerTable> spannerTableByName = createSpannerTableByName();
+    SchemaUpdateUtils.updateStoredSchemaNewRow(
+        mod, spannerTableByName, Dialect.GOOGLE_STANDARD_SQL);
+    assertThat(spannerTableByName.get("Singers").getNonPkColumns().size()).isEqualTo(2);
+  }
+
+  public void testUpdateStoredSchemaInNeeded(ValueCaptureType valueCaptureType, Dialect dialect) {
+    // Construct expectedSpannerTableByName got from INFORMATION_SCHEMA
+    Map<String, TrackedSpannerTable> expectedSpannerTableByName = new HashMap<>();
+    List<TrackedSpannerColumn> singersPkColumns =
+        Collections.singletonList(TrackedSpannerColumn.create("SingerId", Type.int64(), -1, 1));
+    List<TrackedSpannerColumn> singersNonPkColumns =
+        Arrays.asList(
+            TrackedSpannerColumn.create("FirstName", Type.string(), 2, -1),
+            TrackedSpannerColumn.create("LastName", Type.string(), 3, -1));
+    expectedSpannerTableByName.put(
+        "Singers", new TrackedSpannerTable("Singers", singersPkColumns, singersNonPkColumns));
+    // Construct the current mod.
+    ObjectNode pkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
+    pkColJsonNode.put("SingerId", 1);
+    ObjectNode nonPkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
+    nonPkColJsonNode.put("FirstName", "firstName");
+    nonPkColJsonNode.put("LastName", "lastName");
+    List<ModColumnType> rowTypes = new ArrayList<>();
+    rowTypes.add(new ModColumnType("SingerId", new TypeCode("{\"code\":\"INT64\"}"), true, 1));
+    rowTypes.add(new ModColumnType("FirstName", new TypeCode("{\"code\":\"STRING\"}"), false, 2));
+    rowTypes.add(new ModColumnType("LastName", new TypeCode("{\"code\":\"STRING\"}"), false, 3));
+    Mod mod =
+        new Mod(
+            pkColJsonNode.toString(),
+            nonPkColJsonNode.toString(),
+            Timestamp.ofTimeSecondsAndNanos(1650908264L, 925679000),
+            "1",
+            true,
+            "00000001",
+            "Singers",
+            rowTypes,
+            ModType.INSERT,
+            valueCaptureType,
+            1L,
+            1L);
+
+    try (MockedConstruction<SpannerChangeStreamsUtils> mockedSpannerChangeStreamsUtils =
+        Mockito.mockConstruction(
+            SpannerChangeStreamsUtils.class,
+            (mock, context) -> {
+              when(mock.getSpannerTableByName()).thenReturn(expectedSpannerTableByName);
+            })) {
+      // The current stored schema information.
+      Map<String, TrackedSpannerTable> currSpannerTableByName = createSpannerTableByName();
+      currSpannerTableByName =
+          SchemaUpdateUtils.updateStoredSchemaIfNeeded(
+              mockSpannerAccessor, changeStreamName, dialect, mod, currSpannerTableByName);
+      // Ensure the stored schema is updated with the schema from INFORMATION_SCHEMA.
+      assertThat(expectedSpannerTableByName.get("Singers").getNonPkColumns().size()).isEqualTo(2);
+      assertThat(currSpannerTableByName.get("Singers").getNonPkColumns().size()).isEqualTo(2);
+    }
+  }
+
+  @Test
+  public void testUpdateStoredSchemaInNeeded() {
+    testUpdateStoredSchemaInNeeded(
+        ValueCaptureType.OLD_AND_NEW_VALUES, Dialect.GOOGLE_STANDARD_SQL);
+    testUpdateStoredSchemaInNeeded(ValueCaptureType.NEW_ROW, Dialect.GOOGLE_STANDARD_SQL);
+    testUpdateStoredSchemaInNeeded(ValueCaptureType.OLD_AND_NEW_VALUES, Dialect.POSTGRESQL);
+    testUpdateStoredSchemaInNeeded(ValueCaptureType.NEW_ROW, Dialect.POSTGRESQL);
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SchemaUtilsTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SchemaUtilsTest.java
@@ -43,6 +43,8 @@ import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigqu
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.NUMERIC_COL;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.NUMERIC_NULLABLE_ARRAY_VAL;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.NUMERIC_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.PG_JSON_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.PG_NUMERIC_COL;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.STRING_ARRAY_COL;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.STRING_COL;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.STRING_NULLABLE_ARRAY_VAL;
@@ -56,6 +58,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.services.bigquery.model.TableFieldSchema;
 import com.google.api.services.bigquery.model.TableRow;
+import com.google.cloud.Timestamp;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Dialect;
@@ -65,6 +68,7 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.ResultSets;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.TrackedSpannerColumn;
@@ -92,10 +96,13 @@ public class SchemaUtilsTest {
   @Mock private DatabaseClient mockDatabaseClient;
   @Mock private ReadContext mockReadContext;
   private List<TrackedSpannerColumn> spannerColumnsOfAllTypes;
+  private Timestamp now = Timestamp.now();
 
   @Before
   public void setUp() {
     when(mockDatabaseClient.singleUse()).thenReturn(mockReadContext);
+    when(mockDatabaseClient.singleUse(TimestampBound.ofReadTimestamp(now)))
+        .thenReturn(mockReadContext);
     spannerColumnsOfAllTypes =
         ImmutableList.of(
             TrackedSpannerColumn.create(BOOLEAN_COL, Type.bool(), 1, 1),
@@ -138,7 +145,7 @@ public class SchemaUtilsTest {
 
     Map<String, TrackedSpannerTable> actualSpannerTableByName =
         new SpannerChangeStreamsUtils(
-                mockDatabaseClient, changeStreamName, Dialect.GOOGLE_STANDARD_SQL)
+                mockDatabaseClient, changeStreamName, Dialect.GOOGLE_STANDARD_SQL, now)
             .getSpannerTableByName();
 
     List<TrackedSpannerColumn> singersPkColumns =
@@ -172,7 +179,7 @@ public class SchemaUtilsTest {
                 Collections.emptyList()));
 
     Map<String, TrackedSpannerTable> actualSpannerTableByName =
-        new SpannerChangeStreamsUtils(mockDatabaseClient, changeStreamName, Dialect.POSTGRESQL)
+        new SpannerChangeStreamsUtils(mockDatabaseClient, changeStreamName, Dialect.POSTGRESQL, now)
             .getSpannerTableByName();
 
     List<TrackedSpannerColumn> singersPkColumns =
@@ -272,16 +279,24 @@ public class SchemaUtilsTest {
         new ArrayList<>(
             ImmutableList.of(
                 Struct.newBuilder()
-                    .set("TABLE_NAME").to(Value.string("Singers"))
-                    .set("COLUMN_NAME").to(Value.string("SingerId1"))
-                    .set("ORDINAL_POSITION").to(Value.int64(1))
-                    .set("SPANNER_TYPE").to(Value.string("INT64"))
+                    .set("TABLE_NAME")
+                    .to(Value.string("Singers"))
+                    .set("COLUMN_NAME")
+                    .to(Value.string("SingerId1"))
+                    .set("ORDINAL_POSITION")
+                    .to(Value.int64(1))
+                    .set("SPANNER_TYPE")
+                    .to(Value.string("INT64"))
                     .build(),
                 Struct.newBuilder()
-                    .set("TABLE_NAME").to(Value.string("Singers"))
-                    .set("COLUMN_NAME").to(Value.string("SingerId2"))
-                    .set("ORDINAL_POSITION").to(Value.int64(2))
-                    .set("SPANNER_TYPE").to(Value.string("INT64"))
+                    .set("TABLE_NAME")
+                    .to(Value.string("Singers"))
+                    .set("COLUMN_NAME")
+                    .to(Value.string("SingerId2"))
+                    .set("ORDINAL_POSITION")
+                    .to(Value.int64(2))
+                    .set("SPANNER_TYPE")
+                    .to(Value.string("INT64"))
                     .build()));
     // spotless:on
     when(mockReadContext.executeQuery(
@@ -307,16 +322,24 @@ public class SchemaUtilsTest {
         new ArrayList<>(
             ImmutableList.of(
                 Struct.newBuilder()
-                    .set("TABLE_NAME").to(Value.string("Singers"))
-                    .set("COLUMN_NAME").to(Value.string("SingerId2"))
-                    .set("ORDINAL_POSITION").to(Value.int64(1))
-                    .set("CONSTRAINT_NAME").to(Value.string("PK_Singers"))
+                    .set("TABLE_NAME")
+                    .to(Value.string("Singers"))
+                    .set("COLUMN_NAME")
+                    .to(Value.string("SingerId2"))
+                    .set("ORDINAL_POSITION")
+                    .to(Value.int64(1))
+                    .set("CONSTRAINT_NAME")
+                    .to(Value.string("PK_Singers"))
                     .build(),
                 Struct.newBuilder()
-                    .set("TABLE_NAME").to(Value.string("Singers"))
-                    .set("COLUMN_NAME").to(Value.string("SingerId1"))
-                    .set("ORDINAL_POSITION").to(Value.int64(2))
-                    .set("CONSTRAINT_NAME").to(Value.string("PK_Singers"))
+                    .set("TABLE_NAME")
+                    .to(Value.string("Singers"))
+                    .set("COLUMN_NAME")
+                    .to(Value.string("SingerId1"))
+                    .set("ORDINAL_POSITION")
+                    .to(Value.int64(2))
+                    .set("CONSTRAINT_NAME")
+                    .to(Value.string("PK_Singers"))
                     .build()));
     // spotless:on
     when(mockReadContext.executeQuery(
@@ -345,7 +368,7 @@ public class SchemaUtilsTest {
 
     Map<String, TrackedSpannerTable> actualSpannerTableByName =
         new SpannerChangeStreamsUtils(
-                mockDatabaseClient, changeStreamName, Dialect.GOOGLE_STANDARD_SQL)
+                mockDatabaseClient, changeStreamName, Dialect.GOOGLE_STANDARD_SQL, now)
             .getSpannerTableByName();
 
     List<TrackedSpannerColumn> singersPkColumns =
@@ -465,24 +488,42 @@ public class SchemaUtilsTest {
             Type.struct(structFields),
             Collections.singletonList(
                 Struct.newBuilder()
-                    .set(BOOLEAN_COL).to(BOOLEAN_VAL)
-                    .set(BYTES_COL).to(BYTES_VAL)
-                    .set(DATE_COL).to(DATE_VAL)
-                    .set(FLOAT64_COL).to(FLOAT64_VAL)
-                    .set(INT64_COL).to(INT64_VAL)
-                    .set(JSON_COL).to(JSON_VAL)
-                    .set(NUMERIC_COL).to(NUMERIC_VAL)
-                    .set(STRING_COL).to(STRING_VAL)
-                    .set(TIMESTAMP_COL).to(TIMESTAMP_VAL)
-                    .set(BOOLEAN_ARRAY_COL).to(BOOLEAN_NULLABLE_ARRAY_VAL)
-                    .set(BYTES_ARRAY_COL).to(BYTES_NULLABLE_ARRAY_VAL)
-                    .set(DATE_ARRAY_COL).to(DATE_NULLABLE_ARRAY_VAL)
-                    .set(FLOAT64_ARRAY_COL).to(FLOAT64_NULLABLE_ARRAY_VAL)
-                    .set(INT64_ARRAY_COL).to(INT64_NULLABLE_ARRAY_VAL)
-                    .set(JSON_ARRAY_COL).to(JSON_NULLABLE_ARRAY_VAL)
-                    .set(NUMERIC_ARRAY_COL).to(NUMERIC_NULLABLE_ARRAY_VAL)
-                    .set(STRING_ARRAY_COL).to(STRING_NULLABLE_ARRAY_VAL)
-                    .set(TIMESTAMP_ARRAY_COL).to(TIMESTAMP_NULLABLE_ARRAY_VAL)
+                    .set(BOOLEAN_COL)
+                    .to(BOOLEAN_VAL)
+                    .set(BYTES_COL)
+                    .to(BYTES_VAL)
+                    .set(DATE_COL)
+                    .to(DATE_VAL)
+                    .set(FLOAT64_COL)
+                    .to(FLOAT64_VAL)
+                    .set(INT64_COL)
+                    .to(INT64_VAL)
+                    .set(JSON_COL)
+                    .to(JSON_VAL)
+                    .set(NUMERIC_COL)
+                    .to(NUMERIC_VAL)
+                    .set(STRING_COL)
+                    .to(STRING_VAL)
+                    .set(TIMESTAMP_COL)
+                    .to(TIMESTAMP_VAL)
+                    .set(BOOLEAN_ARRAY_COL)
+                    .to(BOOLEAN_NULLABLE_ARRAY_VAL)
+                    .set(BYTES_ARRAY_COL)
+                    .to(BYTES_NULLABLE_ARRAY_VAL)
+                    .set(DATE_ARRAY_COL)
+                    .to(DATE_NULLABLE_ARRAY_VAL)
+                    .set(FLOAT64_ARRAY_COL)
+                    .to(FLOAT64_NULLABLE_ARRAY_VAL)
+                    .set(INT64_ARRAY_COL)
+                    .to(INT64_NULLABLE_ARRAY_VAL)
+                    .set(JSON_ARRAY_COL)
+                    .to(JSON_NULLABLE_ARRAY_VAL)
+                    .set(NUMERIC_ARRAY_COL)
+                    .to(NUMERIC_NULLABLE_ARRAY_VAL)
+                    .set(STRING_ARRAY_COL)
+                    .to(STRING_NULLABLE_ARRAY_VAL)
+                    .set(TIMESTAMP_ARRAY_COL)
+                    .to(TIMESTAMP_NULLABLE_ARRAY_VAL)
                     .build()));
     // spotless:on
     SpannerToBigQueryUtils.spannerSnapshotRowToBigQueryTableRow(
@@ -529,7 +570,49 @@ public class SchemaUtilsTest {
   }
 
   @Test
-  public void testSpannerColumnsToBigQueryIOFields() {
+  public void testTableRowColumnsToBigQueryIOFields() {
+    TableRow tableRow = new TableRow();
+    tableRow.put(BOOLEAN_COL, true);
+    tableRow.put("_type_" + BOOLEAN_COL, "BOOL");
+    tableRow.put(BYTES_COL, "");
+    tableRow.put("_type_" + BYTES_COL, "BYTES");
+    tableRow.put(DATE_COL, "");
+    tableRow.put("_type_" + DATE_COL, "DATE");
+    tableRow.put(FLOAT64_COL, "");
+    tableRow.put("_type_" + FLOAT64_COL, "FLOAT64");
+    tableRow.put(INT64_COL, "");
+    tableRow.put("_type_" + INT64_COL, "INT64");
+    tableRow.put(JSON_COL, "");
+    tableRow.put("_type_" + JSON_COL, "JSON");
+    tableRow.put(PG_JSON_COL, "");
+    tableRow.put("_type_" + PG_JSON_COL, "PG_JSONB");
+    tableRow.put(NUMERIC_COL, "");
+    tableRow.put("_type_" + NUMERIC_COL, "NUMERIC");
+    tableRow.put(PG_NUMERIC_COL, "");
+    tableRow.put("_type_" + PG_NUMERIC_COL, "PG_NUMERIC");
+    tableRow.put(STRING_COL, "");
+    tableRow.put("_type_" + STRING_COL, "STRING");
+    tableRow.put(TIMESTAMP_COL, "");
+    tableRow.put("_type_" + TIMESTAMP_COL, "TIMESTAMP");
+    tableRow.put(BOOLEAN_ARRAY_COL, "");
+    tableRow.put("_type_" + BOOLEAN_ARRAY_COL, "ARRAY<BOOL>");
+    tableRow.put(BYTES_ARRAY_COL, "");
+    tableRow.put("_type_" + BYTES_ARRAY_COL, "ARRAY<BYTES>");
+    tableRow.put(DATE_ARRAY_COL, "");
+    tableRow.put("_type_" + DATE_ARRAY_COL, "ARRAY<DATE>");
+    tableRow.put(FLOAT64_ARRAY_COL, "");
+    tableRow.put("_type_" + FLOAT64_ARRAY_COL, "ARRAY<FLOAT64>");
+    tableRow.put(INT64_ARRAY_COL, "");
+    tableRow.put("_type_" + INT64_ARRAY_COL, "ARRAY<INT64>");
+    tableRow.put(JSON_ARRAY_COL, "");
+    tableRow.put("_type_" + JSON_ARRAY_COL, "ARRAY<JSON>");
+    tableRow.put(NUMERIC_ARRAY_COL, "");
+    tableRow.put("_type_" + NUMERIC_ARRAY_COL, "ARRAY<NUMERIC>");
+    tableRow.put(STRING_ARRAY_COL, "");
+    tableRow.put("_type_" + STRING_ARRAY_COL, "ARRAY<STRING>");
+    tableRow.put(TIMESTAMP_ARRAY_COL, "");
+    tableRow.put("_type_" + TIMESTAMP_ARRAY_COL, "ARRAY<TIMESTAMP>");
+
     List<TableFieldSchema> tableFields =
         ImmutableList.of(
             new TableFieldSchema()
@@ -557,9 +640,17 @@ public class SchemaUtilsTest {
                 .setMode(Field.Mode.NULLABLE.name())
                 .setType("JSON"),
             new TableFieldSchema()
+                .setName(PG_JSON_COL)
+                .setMode(Field.Mode.NULLABLE.name())
+                .setType("JSON"),
+            new TableFieldSchema()
                 .setName(NUMERIC_COL)
                 .setMode(Field.Mode.NULLABLE.name())
                 .setType("NUMERIC"),
+            new TableFieldSchema()
+                .setName(PG_NUMERIC_COL)
+                .setMode(Field.Mode.NULLABLE.name())
+                .setType("STRING"),
             new TableFieldSchema()
                 .setName(STRING_COL)
                 .setMode(Field.Mode.NULLABLE.name())
@@ -604,8 +695,7 @@ public class SchemaUtilsTest {
                 .setName(TIMESTAMP_ARRAY_COL)
                 .setMode(Field.Mode.REPEATED.name())
                 .setType("TIMESTAMP"));
-
-    assertThat(SpannerToBigQueryUtils.spannerColumnsToBigQueryIOFields(spannerColumnsOfAllTypes))
+    assertThat(SpannerToBigQueryUtils.tableRowColumnsToBigQueryIOFields(tableRow, false))
         .isEqualTo(tableFields);
   }
 
@@ -631,14 +721,22 @@ public class SchemaUtilsTest {
 
     assertThat(tableRow.toString())
         .isEqualTo(
-            "GenericData{classInfo=[f], {BytesCol=ZmZm, DateCol=2020-12-12, Float64Col=1.3,"
-                + " Int64Col=5, JsonCol={\"color\":\"red\",\"value\":\"#f00\"}, NumericCol=4.4,"
-                + " StringCol=abc, TimestampCol=2022-03-19T18:51:33.963910279Z,"
-                + " BytesArrayCol=[YWJj, YmNk], DateArrayCol=[2021-01-22, 2022-01-01],"
-                + " Float64ArrayCol=[1.2, 4.4], Int64ArrayCol=[1, 2], JsonArrayCol=[{},"
-                + " {\"color\":\"red\",\"value\":\"#f00\"}, []], NumericArrayCol=[2.2, 3.3],"
-                + " StringArrayCol=[a, b], TimestampArrayCol=[2022-03-19T18:51:33.963910279Z,"
-                + " 2022-03-19T18:51:33.963910279Z]}}");
+            "GenericData{classInfo=[f], {BytesCol=ZmZm, _type_BytesCol=BYTES, DateCol=2020-12-12,"
+                + " _type_DateCol=DATE, Float64Col=1.3, _type_Float64Col=FLOAT64, Int64Col=5,"
+                + " _type_Int64Col=INT64, JsonCol={\"color\":\"red\",\"value\":\"#f00\"},"
+                + " _type_JsonCol=JSON, NumericCol=4.4, _type_NumericCol=NUMERIC, StringCol=abc,"
+                + " _type_StringCol=STRING, TimestampCol=2022-03-19T18:51:33.963910279Z,"
+                + " _type_TimestampCol=TIMESTAMP, BytesArrayCol=[YWJj, YmNk],"
+                + " _type_BytesArrayCol=ARRAY<BYTES>, DateArrayCol=[2021-01-22,"
+                + " 2022-01-01], _type_DateArrayCol=ARRAY<DATE>, Float64ArrayCol=[1.2, 4.4],"
+                + " _type_Float64ArrayCol=ARRAY<FLOAT64>, Int64ArrayCol=[1, 2],"
+                + " _type_Int64ArrayCol=ARRAY<INT64>,"
+                + " JsonArrayCol=[{}, {\"color\":\"red\",\"value\":\"#f00\"}, []],"
+                + " _type_JsonArrayCol=ARRAY<JSON>,"
+                + " NumericArrayCol=[2.2, 3.3], _type_NumericArrayCol=ARRAY<NUMERIC>,"
+                + " StringArrayCol=[a, b], _type_StringArrayCol=ARRAY<STRING>,"
+                + " TimestampArrayCol=[2022-03-19T18:51:33.963910279Z,"
+                + " 2022-03-19T18:51:33.963910279Z], _type_TimestampArrayCol=ARRAY<TIMESTAMP>}}");
   }
 
   private void mockInformationSchemaChangeStreamsQuery(boolean isTrackingAll) {
@@ -705,22 +803,34 @@ public class SchemaUtilsTest {
         new ArrayList<>(
             ImmutableList.of(
                 Struct.newBuilder()
-                    .set("TABLE_NAME").to(Value.string("Singers"))
-                    .set("COLUMN_NAME").to(Value.string("SingerId"))
-                    .set("ORDINAL_POSITION").to(Value.int64(1))
-                    .set("SPANNER_TYPE").to(Value.string("INT64"))
+                    .set("TABLE_NAME")
+                    .to(Value.string("Singers"))
+                    .set("COLUMN_NAME")
+                    .to(Value.string("SingerId"))
+                    .set("ORDINAL_POSITION")
+                    .to(Value.int64(1))
+                    .set("SPANNER_TYPE")
+                    .to(Value.string("INT64"))
                     .build(),
                 Struct.newBuilder()
-                    .set("TABLE_NAME").to(Value.string("Singers"))
-                    .set("COLUMN_NAME").to(Value.string("FirstName"))
-                    .set("ORDINAL_POSITION").to(Value.int64(2))
-                    .set("SPANNER_TYPE").to(Value.string("STRING(1024)"))
+                    .set("TABLE_NAME")
+                    .to(Value.string("Singers"))
+                    .set("COLUMN_NAME")
+                    .to(Value.string("FirstName"))
+                    .set("ORDINAL_POSITION")
+                    .to(Value.int64(2))
+                    .set("SPANNER_TYPE")
+                    .to(Value.string("STRING(1024)"))
                     .build(),
                 Struct.newBuilder()
-                    .set("TABLE_NAME").to(Value.string("Singers"))
-                    .set("COLUMN_NAME").to(Value.string("LastName"))
-                    .set("ORDINAL_POSITION").to(Value.int64(3))
-                    .set("SPANNER_TYPE").to(Value.string("STRING"))
+                    .set("TABLE_NAME")
+                    .to(Value.string("Singers"))
+                    .set("COLUMN_NAME")
+                    .to(Value.string("LastName"))
+                    .set("ORDINAL_POSITION")
+                    .to(Value.int64(3))
+                    .set("SPANNER_TYPE")
+                    .to(Value.string("STRING"))
                     .build()));
     // spotless:on
 
@@ -889,5 +999,16 @@ public class SchemaUtilsTest {
                     Type.StructField.of("ordinal_position", Type.int64()),
                     Type.StructField.of("constraint_name", Type.string())),
                 rows));
+  }
+
+  @Test
+  public void testCleanSpannerType() {
+    // STRING -> STRING
+    assertThat(SpannerToBigQueryUtils.cleanSpannerType("STRING")).isEqualTo("STRING");
+    // NUMERIC<PG_NUMERIC> -> NUMERIC
+    assertThat(SpannerToBigQueryUtils.cleanSpannerType("NUMERIC<PG_NUMERIC>")).isEqualTo("NUMERIC");
+    // ARRAY<NUMERIC<PG_NUMERIC>> -> ARRAY<NUMERIC>
+    assertThat(SpannerToBigQueryUtils.cleanSpannerType("ARRAY<NUMERIC<PG_NUMERIC>>"))
+        .isEqualTo("ARRAY<NUMERIC>");
   }
 }

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/TestUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/TestUtils.java
@@ -63,7 +63,9 @@ class TestUtils {
   static final String FLOAT64_COL = "Float64Col";
   static final String INT64_COL = "Int64Col";
   static final String JSON_COL = "JsonCol";
+  static final String PG_JSON_COL = "PgJsonCol";
   static final String NUMERIC_COL = "NumericCol";
+  static final String PG_NUMERIC_COL = "PgNumericCol";
   static final String STRING_COL = "StringCol";
   static final String TIMESTAMP_COL = "TimestampCol";
 
@@ -165,36 +167,36 @@ class TestUtils {
     // spotless:off
     String createTableDdl =
         "CREATE TABLE "
-        + TEST_SPANNER_TABLE
-        + " ("
-        + "BooleanPkCol BOOL,"
-        + "BytesPkCol BYTES(1024),"
-        + "DatePkCol DATE,"
-        + "Float64PkCol FLOAT64,"
-        + "Int64PkCol INT64,"
-        + "NumericPkCol NUMERIC,"
-        + "StringPkCol STRING(MAX),"
-        + "TimestampPkCol TIMESTAMP OPTIONS (allow_commit_timestamp=true),"
-        + "BooleanArrayCol ARRAY<BOOL>,"
-        + "BytesArrayCol ARRAY<BYTES(1024)>,"
-        + "DateArrayCol ARRAY<DATE>,"
-        + "Float64ArrayCol ARRAY<FLOAT64>,"
-        + "Int64ArrayCol ARRAY<INT64>,"
-        + "JsonArrayCol ARRAY<JSON>,"
-        + "NumericArrayCol ARRAY<NUMERIC>,"
-        + "StringArrayCol ARRAY<STRING(1024)>,"
-        + "TimestampArrayCol ARRAY<TIMESTAMP>,"
-        + "BooleanCol BOOL,"
-        + "BytesCol BYTES(1024),"
-        + "DateCol DATE,"
-        + "Float64Col FLOAT64,"
-        + "Int64Col INT64,"
-        + "JsonCol JSON,"
-        + "NumericCol NUMERIC,"
-        + "StringCol STRING(1024),"
-        + "TimestampCol TIMESTAMP OPTIONS (allow_commit_timestamp=true)"
-        + ") PRIMARY KEY(BooleanPkCol, BytesPkCol, DatePkCol, Float64PkCol, Int64PkCol,"
-        + " NumericPkCol, StringPkCol, TimestampPkCol)";
+            + TEST_SPANNER_TABLE
+            + " ("
+            + "BooleanPkCol BOOL,"
+            + "BytesPkCol BYTES(1024),"
+            + "DatePkCol DATE,"
+            + "Float64PkCol FLOAT64,"
+            + "Int64PkCol INT64,"
+            + "NumericPkCol NUMERIC,"
+            + "StringPkCol STRING(MAX),"
+            + "TimestampPkCol TIMESTAMP OPTIONS (allow_commit_timestamp=true),"
+            + "BooleanArrayCol ARRAY<BOOL>,"
+            + "BytesArrayCol ARRAY<BYTES(1024)>,"
+            + "DateArrayCol ARRAY<DATE>,"
+            + "Float64ArrayCol ARRAY<FLOAT64>,"
+            + "Int64ArrayCol ARRAY<INT64>,"
+            + "JsonArrayCol ARRAY<JSON>,"
+            + "NumericArrayCol ARRAY<NUMERIC>,"
+            + "StringArrayCol ARRAY<STRING(1024)>,"
+            + "TimestampArrayCol ARRAY<TIMESTAMP>,"
+            + "BooleanCol BOOL,"
+            + "BytesCol BYTES(1024),"
+            + "DateCol DATE,"
+            + "Float64Col FLOAT64,"
+            + "Int64Col INT64,"
+            + "JsonCol JSON,"
+            + "NumericCol NUMERIC,"
+            + "StringCol STRING(1024),"
+            + "TimestampCol TIMESTAMP OPTIONS (allow_commit_timestamp=true)"
+            + ") PRIMARY KEY(BooleanPkCol, BytesPkCol, DatePkCol, Float64PkCol, Int64PkCol,"
+            + " NumericPkCol, StringPkCol, TimestampPkCol)";
     // spotless:on
     String createChangeStreamDdl =
         "CREATE CHANGE STREAM " + TEST_SPANNER_CHANGE_STREAM + " FOR " + TEST_SPANNER_TABLE;

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/TypesUtilsTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/TypesUtilsTest.java
@@ -1,0 +1,28 @@
+package com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.TypesUtils;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class TypesUtilsTest {
+
+  @Test
+  public void testExtractTypeFromTypeCode() {
+    // Eg 1: "{\"array_element_type\":{\"code\":\"STRING\"},\"code\":\"ARRAY\"}" -> ARRAY<STRING>
+    JSONObject jsonObject =
+        new JSONObject("{\"array_element_type\":{\"code\":\"STRING\"},\"code\":\"ARRAY\"}");
+    assertThat(TypesUtils.extractTypeFromTypeCode(jsonObject)).isEqualTo("ARRAY<STRING>");
+    // Eg 2: "{\"code\":\"STRING\"}" -> STRING
+    jsonObject = new JSONObject("{\"code\":\"STRING\"}");
+    assertThat(TypesUtils.extractTypeFromTypeCode(jsonObject)).isEqualTo("STRING");
+    final JSONObject invalidJsonObject = new JSONObject("{\"CODE\":\"STRING\"}");
+    assertThrows(JSONException.class, () -> TypesUtils.extractTypeFromTypeCode(invalidJsonObject));
+  }
+}


### PR DESCRIPTION
1. Supports schema changes (1) add a new table, and (2) add a new column for all value capture types and for both streaming inserts and storage write apis.
2. Detects schema changes by comparing the mod and the stored schema map.
3. For NEW_ROW, update the stored schema map with new table / columns included in mod.
4. For OLD_AND_NEW_VALUES and NEW_ROW, read from INFORMATION_SCHEMA to get the schema at the mod's commit timestamp, and update the stored schema map.
5. Store column type information in TableRow to avoid reading from INFORMATION_SCHEMA at a timestamp past version GC limit.
6. Update unit tests to reflect changes.
7. This change hasn't been verified in integration tests yet.