### PR TITLE
Allows spaces in JDBC URL and PropertyName

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/templates/common/JdbcConverters.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/common/JdbcConverters.java
@@ -68,7 +68,7 @@ public class JdbcConverters {
     @TemplateParameter.Text(
         order = 3,
         regexes = {
-          "(^jdbc:[a-zA-Z0-9/:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
+          "(^jdbc:[a-zA-Z0-9 /:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
         },
         description =
             "JDBC connection URL string. Connection string can be passed in as plaintext or as "
@@ -82,7 +82,7 @@ public class JdbcConverters {
     @TemplateParameter.Text(
         order = 4,
         optional = true,
-        regexes = {"^[a-zA-Z0-9_;!*&=@#-:\\/]+$"},
+        regexes = {"^[a-zA-Z0-9 /:@.?_+!*&=@#-:\\/]+$"},
         description = "JDBC connection property string.",
         helpText =
             "Properties string to use for the JDBC connection. Format of the string must be"

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/auto/options/ReadFromJdbcOptions.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/auto/options/ReadFromJdbcOptions.java
@@ -34,7 +34,7 @@ public interface ReadFromJdbcOptions extends PipelineOptions {
       order = 2,
       optional = false,
       regexes = {
-        "(^jdbc:[a-zA-Z0-9/:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
+        "(^jdbc:[a-zA-Z0-9 /:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
       },
       description = "JDBC connection URL string.",
       helpText =
@@ -82,7 +82,7 @@ public interface ReadFromJdbcOptions extends PipelineOptions {
   @TemplateParameter.Text(
       order = 6,
       optional = true,
-      regexes = {"^[a-zA-Z0-9_;!*&=@#-:\\/]+$"},
+      regexes = {"^[a-zA-Z0-9 /:@.?_+!*&=@#-:\\/]+$"},
       description = "JDBC connection property string.",
       helpText =
           "Properties string to use for the JDBC connection. Format of the string must be [propertyName=property;]*.",

--- a/v2/dataplex/src/main/java/com/google/cloud/teleport/v2/options/DataplexJdbcIngestionOptions.java
+++ b/v2/dataplex/src/main/java/com/google/cloud/teleport/v2/options/DataplexJdbcIngestionOptions.java
@@ -39,7 +39,7 @@ public interface DataplexJdbcIngestionOptions
       order = 1,
       optional = false,
       regexes = {
-        "(^jdbc:[a-zA-Z0-9/:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
+        "(^jdbc:[a-zA-Z0-9 /:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
       },
       description = "JDBC connection URL string.",
       helpText =
@@ -78,7 +78,7 @@ public interface DataplexJdbcIngestionOptions
   @TemplateParameter.Text(
       order = 4,
       optional = true,
-      regexes = {"^[a-zA-Z0-9_;!*&=@#-:\\/]+$"},
+      regexes = {"^[a-zA-Z0-9 /:@.?_+!*&=@#-:\\/]+$"},
       description = "JDBC connection property string.",
       helpText =
           "Properties string to use for the JDBC connection. Format of the string must be"

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/PubsubToJdbcOptions.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/PubsubToJdbcOptions.java
@@ -50,7 +50,7 @@ public interface PubsubToJdbcOptions extends CommonTemplateOptions {
       order = 3,
       optional = false,
       regexes = {
-        "(^jdbc:[a-zA-Z0-9/:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
+        "(^jdbc:[a-zA-Z0-9 /:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
       },
       description = "JDBC connection URL string.",
       helpText =
@@ -98,7 +98,7 @@ public interface PubsubToJdbcOptions extends CommonTemplateOptions {
   @TemplateParameter.Text(
       order = 7,
       optional = true,
-      regexes = {"^[a-zA-Z0-9_;!*&=@#-:\\/]+$"},
+      regexes = {"^[a-zA-Z0-9 /:@.?_+!*&=@#-:\\/]+$"},
       description = "JDBC connection property string.",
       helpText =
           "Properties string to use for the JDBC connection. Format of the string must be [propertyName=property;]*.",

--- a/v2/jdbc-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/JdbcToBigQueryOptions.java
+++ b/v2/jdbc-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/JdbcToBigQueryOptions.java
@@ -50,7 +50,7 @@ public interface JdbcToBigQueryOptions
       order = 3,
       optional = false,
       regexes = {
-        "(^jdbc:[a-zA-Z0-9/:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
+        "(^jdbc:[a-zA-Z0-9 /:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
       },
       groupName = "Source",
       description = "JDBC connection URL string.",
@@ -64,7 +64,7 @@ public interface JdbcToBigQueryOptions
   @TemplateParameter.Text(
       order = 4,
       optional = true,
-      regexes = {"^[a-zA-Z0-9_;!*&=@#-:\\/]+$"},
+      regexes = {"^[a-zA-Z0-9 /:@.?_+!*&=@#-:\\/]+$"},
       groupName = "Source",
       description = "JDBC connection property string.",
       helpText =

--- a/v2/jdbc-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/JdbcToPubsubOptions.java
+++ b/v2/jdbc-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/JdbcToPubsubOptions.java
@@ -38,7 +38,7 @@ public interface JdbcToPubsubOptions extends CommonTemplateOptions {
       order = 2,
       optional = false,
       regexes = {
-        "(^jdbc:[a-zA-Z0-9/:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
+        "(^jdbc:[a-zA-Z0-9 /:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
       },
       description = "JDBC connection URL string.",
       helpText =
@@ -86,7 +86,7 @@ public interface JdbcToPubsubOptions extends CommonTemplateOptions {
   @TemplateParameter.Text(
       order = 6,
       optional = true,
-      regexes = {"^[a-zA-Z0-9_;!*&=@#-:\\/]+$"},
+      regexes = {"^[a-zA-Z0-9 /:@.?_+!*&=@#-:\\/]+$"},
       description = "JDBC connection property string.",
       helpText =
           "Properties string to use for the JDBC connection. Format of the string must be [propertyName=property;]*.",

--- a/v2/mysql-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/MySQLToBigQueryOptions.java
+++ b/v2/mysql-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/MySQLToBigQueryOptions.java
@@ -24,7 +24,7 @@ public interface MySQLToBigQueryOptions extends JdbcToBigQueryOptions {
   @TemplateParameter.Text(
       optional = false,
       regexes = {
-        "(^jdbc:[a-zA-Z0-9/:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
+        "(^jdbc:[a-zA-Z0-9 /:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
       },
       groupName = "Source",
       description = "JDBC connection URL string.",

--- a/v2/oracle-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/OracleToBigQueryOptions.java
+++ b/v2/oracle-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/OracleToBigQueryOptions.java
@@ -24,7 +24,7 @@ public interface OracleToBigQueryOptions extends JdbcToBigQueryOptions {
   @TemplateParameter.Text(
       optional = false,
       regexes = {
-        "(^jdbc:[a-zA-Z0-9/:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
+        "(^jdbc:[a-zA-Z0-9 /:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
       },
       groupName = "Source",
       description = "JDBC connection URL string.",

--- a/v2/postgresql-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/PostgreSQLToBigQueryOptions.java
+++ b/v2/postgresql-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/PostgreSQLToBigQueryOptions.java
@@ -24,7 +24,7 @@ public interface PostgreSQLToBigQueryOptions extends JdbcToBigQueryOptions {
   @TemplateParameter.Text(
       optional = false,
       regexes = {
-        "(^jdbc:[a-zA-Z0-9/:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
+        "(^jdbc:[a-zA-Z0-9 /:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
       },
       groupName = "Source",
       description = "JDBC connection URL string.",

--- a/v2/sqlserver-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SQLServerToBigQueryOptions.java
+++ b/v2/sqlserver-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SQLServerToBigQueryOptions.java
@@ -24,7 +24,7 @@ public interface SQLServerToBigQueryOptions extends JdbcToBigQueryOptions {
   @TemplateParameter.Text(
       optional = false,
       regexes = {
-        "(^jdbc:[a-zA-Z0-9/:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
+        "(^jdbc:[a-zA-Z0-9 /:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
       },
       groupName = "Source",
       description = "JDBC connection URL string.",

--- a/v2/streaming-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/StreamingDataGenerator.java
+++ b/v2/streaming-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/StreamingDataGenerator.java
@@ -292,7 +292,7 @@ public class StreamingDataGenerator {
         order = 17,
         optional = true,
         regexes = {
-          "(^jdbc:[a-zA-Z0-9/:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
+          "(^jdbc:[a-zA-Z0-9 /:@.?_+!*=&-;]+$)|(^([A-Za-z0-9+/]{4}){1,}([A-Za-z0-9+/]{0,3})={0,3})"
         },
         description = "JDBC connection URL string.",
         helpText = "Url connection string to connect to the JDBC source.",
@@ -323,7 +323,7 @@ public class StreamingDataGenerator {
     @TemplateParameter.Text(
         order = 20,
         optional = true,
-        regexes = {"^[a-zA-Z0-9_;!*&=@#-:\\/]+$"},
+        regexes = {"^[a-zA-Z0-9 /:@.?_+!*&=@#-:\\/]+$"},
         description = "JDBC connection property string.",
         helpText =
             "Properties string to use for the JDBC connection. Format of the string must be"


### PR DESCRIPTION
Databases such as IBM AS400 have property strings that require spaces by implementation. 

Example: jdbc:as400://123.123.123.123;block size=512;extended dynamic=true;lazy close=true;query optimization goal=2;data compression=true;

Currently using such strings would lead to a regex match error.

This pull requests fixes such error by allowing spaces in the regular expresion match in both JDBC URL and propertyName string values.