### PR TITLE
Support slash in input topic regex

### DIFF
--- a/v2/mqtt-to-pubsub/src/main/java/com/google/cloud/teleport/v2/templates/MqttToPubsub.java
+++ b/v2/mqtt-to-pubsub/src/main/java/com/google/cloud/teleport/v2/templates/MqttToPubsub.java
@@ -133,7 +133,7 @@ public class MqttToPubsub {
     @TemplateParameter.Text(
         order = 2,
         optional = false,
-        regexes = {"[a-zA-Z0-9._-]+"},
+        regexes = {"[\\/a-zA-Z0-9._-]+"},
         description = "MQTT topic(s) to read the input from",
         helpText = "MQTT topic(s) to read the input from.",
         example = "topic")


### PR DESCRIPTION
This is a feature request from a customer (internal bug id: 326560432). Basically, the customer wanted to use "/" in their input topic name while using MTQQ template, but got an error.

The change is similar to https://github.com/GoogleCloudPlatform/DataflowTemplates/commit/ae0f8201901ba9fb44833f600ba6c8b1a65b3ac7.