### PR TITLE
Fix logging level from error to info in spanner type into avro type method

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/spanner/DdlToAvroSchemaConverter.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/DdlToAvroSchemaConverter.java
@@ -282,7 +282,7 @@ public class DdlToAvroSchemaConverter {
    */
   private Schema avroType(
       com.google.cloud.teleport.spanner.common.Type spannerType, String structSuffix) {
-    LOG.error("avroType type={} suffix={}", spannerType.toString(), structSuffix);
+    LOG.info("avroType type={} suffix={}", spannerType.toString(), structSuffix);
     switch (spannerType.getCode()) {
       case BOOL:
       case PG_BOOL:


### PR DESCRIPTION
Currently, there is a bug where information that should be logged at the Info level is being output at the Error level in spanner type to avro type method. This PR fixes that inconsistency.
 If there are any concerns or suggestions for improvement regarding my approach or the changes made, please don't hesitate to point them out.
I would appreciate it if you could review this pull request at your earliest convenience. Thank you.
