### PR TITLE
[Neo4j] Allow user to specify only a sub-set of columns.

### DIFF
--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/providers/text/LineToRowFn.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/providers/text/LineToRowFn.java
@@ -50,12 +50,17 @@ public class LineToRowFn extends DoFn<String, Row> {
       // Note: parser must return objects
       List<Object> strCols = TextParserUtils.parseDelimitedLine(csvFormat, line);
       if (!strCols.isEmpty()) {
-        if (this.schema.getFieldCount() != strCols.size()) {
+        // If there are more defined fields than fields to map, error (message) out
+        if (this.schema.getFieldCount() > strCols.size()) {
           LOG.error(
               "Unable to parse line.  Expecting {} fields, found {}",
               this.schema.getFieldCount(),
               strCols.size());
         } else {
+          // truncate input column names to the number of defined field names
+          // this should in the future be moved into a method that
+          // extracts the matching columns from the given header name
+          strCols = strCols.subList(0, this.schema.getFieldCount());
           Row row = Row.withSchema(this.schema).attachValues(strCols);
           processContext.output(row);
         }

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/providers/text/LineToRowFnTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/providers/text/LineToRowFnTest.java
@@ -65,4 +65,26 @@ public class LineToRowFnTest {
 
     pipeline.run();
   }
+
+  @Test
+  public void testNumberOfFieldsTruncated() {
+    // Arrange
+    Source source = new Source();
+    Schema sourceSchema = Schema.of(Field.of("id", FieldType.STRING));
+    CSVFormat csvFormat = CSVFormat.DEFAULT;
+
+    // Act
+    PCollection<Row> convertedRow =
+        pipeline
+            .apply(Create.of("1,Neo4j", "2,MySQL"))
+            .apply(ParDo.of(new LineToRowFn(source, sourceSchema, csvFormat)))
+            .setCoder(RowCoder.of(sourceSchema));
+
+    // Assert
+    Row neo4jRow = Row.withSchema(sourceSchema).withFieldValue("id", "1").build();
+    Row oracleRow = Row.withSchema(sourceSchema).withFieldValue("id", "2").build();
+    PAssert.that(convertedRow).containsInAnyOrder(neo4jRow, oracleRow);
+
+    pipeline.run();
+  }
 }


### PR DESCRIPTION
This will actually truncate the parsed rows to align with the numbers with defined columns/fields.