### PR TITLE
[PubSubToSplunk Template]: Improve error logging.

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/splunk/SplunkEventWriter.java
+++ b/v1/src/main/java/com/google/cloud/teleport/splunk/SplunkEventWriter.java
@@ -334,8 +334,8 @@ public abstract class SplunkEventWriter extends DoFn<KV<Integer, SplunkEvent>, S
         FAILED_WRITES.inc(countState.read());
         INVALID_REQUESTS.inc();
 
-        logWriteFailures(countState, 0, ioe.getMessage(), null);
-        flushWriteFailures(events, ioe.getMessage(), null, receiver);
+        logWriteFailures(countState, 0, ioe.toString(), null);
+        flushWriteFailures(events, ioe.toString(), null, receiver);
 
       } finally {
         // States are cleared regardless of write success or failure since we


### PR DESCRIPTION
This should make error log less confusing in cases when we get an IOException when writing to Splunk, e.g. instead of this:
"some-domain.com"
it's going to be this:
"java.net.UnknownHostException: some-domain.com"