### PR TITLE
support vector_length column annotation in DataFlow Import/Export

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/Column.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/Column.java
@@ -39,6 +39,10 @@ public abstract class Column implements Serializable {
   @Nullable
   public abstract Integer size();
 
+  @Nullable
+  // Used to specify exact length requirements for array type columns.
+  public abstract Integer arrayLength();
+
   public abstract boolean notNull();
 
   public abstract boolean isGenerated();
@@ -121,6 +125,9 @@ public abstract class Column implements Serializable {
   }
 
   public String typeString() {
+    if (arrayLength() != null) {
+      return SizedType.typeString(type(), size(), arrayLength());
+    }
     return SizedType.typeString(type(), size());
   }
 
@@ -140,6 +147,8 @@ public abstract class Column implements Serializable {
     public abstract Builder type(Type type);
 
     public abstract Builder size(Integer size);
+
+    public abstract Builder arrayLength(Integer size);
 
     public abstract Builder notNull(boolean nullable);
 
@@ -255,6 +264,9 @@ public abstract class Column implements Serializable {
 
     public Builder parseType(String spannerType) {
       SizedType sizedType = SizedType.parseSpannerType(spannerType, dialect());
+      if (sizedType.arrayLength != null) {
+        return type(sizedType.type).size(sizedType.size).arrayLength(sizedType.arrayLength);
+      }
       return type(sizedType.type).size(sizedType.size);
     }
 

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/SpannerServerResource.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/SpannerServerResource.java
@@ -41,7 +41,8 @@ public class SpannerServerResource extends ExternalResource {
   private static final String EMULATOR_HOST = System.getenv("SPANNER_EMULATOR_HOST");
   private static final String DEFAULT_PROJECT_ID = "span-cloud-testing";
   private static final String DEFAULT_INSTANCE_ID = "test-instance";
-  private final String host = "https://spanner.googleapis.com";
+  //private final String host = "https://spanner.googleapis.com";
+  private final String host = "https://staging-wrenchworks.sandbox.googleapis.com/";
   private final String projectId;
   private final String instanceId;
 

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/common/SizedTypeTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/common/SizedTypeTest.java
@@ -70,4 +70,25 @@ public class SizedTypeTest {
         SizedType.typeString(complexStruct.type, null),
         "STRUCT<a BOOL, b ARRAY<STRUCT<c STRING(MAX), d ARRAY<FLOAT64>>>, e STRUCT<f STRUCT<g INT64>>>");
   }
+
+  @Test
+  public void testEmbeddingVector() {
+    SizedType embeddingVector =
+        SizedType.parseSpannerType("ARRAY<FLOAT64>(vector_length=>128)",
+            Dialect.GOOGLE_STANDARD_SQL);
+
+    assertEquals(embeddingVector.type, Type.array(Type.float64()));
+    assertEquals(embeddingVector.arrayLength, Integer.valueOf(128));
+
+    assertEquals(SizedType.typeString(embeddingVector.type, null, Integer.valueOf(128)),
+        "ARRAY<FLOAT64>(vector_length=>128)");
+
+    SizedType embeddingVectorPg =
+        SizedType.parseSpannerType("double precision[] vector length 4", Dialect.POSTGRESQL);
+
+    assertEquals(embeddingVectorPg.type, Type.pgArray(Type.pgFloat8()));
+    assertEquals(embeddingVectorPg.arrayLength, Integer.valueOf(4));
+    assertEquals(SizedType.typeString(embeddingVectorPg.type, null, Integer.valueOf(4)),
+        "double precision[] vector length 4");
+  }
 }

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/DdlTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/DdlTest.java
@@ -253,6 +253,67 @@ public class DdlTest {
   }
 
   @Test
+  public void embeddingVector() {
+    Ddl.Builder builder = Ddl.builder();
+    builder
+        .createTable("Users")
+        .column("id")
+        .int64()
+        .notNull()
+        .endColumn()
+        .column("embedding_vector")
+        .type(Type.array(Type.float64()))
+        .arrayLength(Integer.valueOf(128))
+        .endColumn()
+        .primaryKey()
+        .asc("id")
+        .end()
+        .endTable();
+
+    Ddl ddl = builder.build();
+    assertThat(
+        ddl.prettyPrint(),
+        equalToCompressingWhiteSpace("CREATE TABLE `Users` ("
+                + " `id` INT64 NOT NULL,"
+                + " `embedding_vector` ARRAY<FLOAT64>(vector_length=>128),"
+                + " ) PRIMARY KEY (`id` ASC)"
+                ));
+    assertNotNull(ddl.hashCode());
+  }
+
+  @Test
+  public void pgEmbeddingVector() {
+    Ddl.Builder builder = Ddl.builder(Dialect.POSTGRESQL);
+    builder
+        .createTable("Users")
+        .column("id")
+        .pgInt8()
+        .notNull()
+        .endColumn()
+        .column("embedding_vector")
+        .type(Type.pgArray(Type.pgFloat8()))
+        .arrayLength(Integer.valueOf(64))
+        .endColumn()
+        .primaryKey()
+        .asc("id")
+        .end()
+        .endTable();
+
+    Ddl ddl = builder.build();
+
+    assertThat(
+        ddl.prettyPrint(),
+        equalToCompressingWhiteSpace(
+                 " CREATE TABLE \"Users\" ("
+                + " \"id\" bigint NOT NULL,"
+                + " \"embedding_vector\" double precision[] vector length 64,"
+                + " PRIMARY KEY (\"id\")"
+                + " ) "));
+    assertNotNull(ddl.hashCode());
+  }
+
+
+  @Test
   public void interleaves() {
     Ddl ddl =
         Ddl.builder()

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
@@ -116,6 +116,7 @@ public class InformationSchemaScannerIT {
             + " `arr_bytes_field`                       ARRAY<BYTES(MAX)>,"
             + " `arr_timestamp_field`                   ARRAY<TIMESTAMP>,"
             + " `arr_date_field`                        ARRAY<DATE>,"
+            + " `embedding_vector`                      ARRAY<FLOAT64>(vector_length=>16),"
             + " ) PRIMARY KEY (`first_name` ASC, `last_name` DESC, `id` ASC)";
 
     spannerServer.createDatabase(dbId, Collections.singleton(allTypes));
@@ -126,7 +127,7 @@ public class InformationSchemaScannerIT {
     assertThat(ddl.table("aLlTYPeS"), notNullValue());
 
     Table table = ddl.table("alltypes");
-    assertThat(table.columns(), hasSize(17));
+    assertThat(table.columns(), hasSize(18));
 
     // Check case sensitiveness.
     assertThat(table.column("first_name"), notNullValue());
@@ -153,6 +154,8 @@ public class InformationSchemaScannerIT {
     assertThat(table.column("arr_bytes_field").size(), equalTo(-1 /*max*/));
     assertThat(table.column("arr_timestamp_field").type(), equalTo(Type.array(Type.timestamp())));
     assertThat(table.column("arr_date_field").type(), equalTo(Type.array(Type.date())));
+    assertThat(table.column("embedding_vector").type(), equalTo(Type.array(Type.float64())));
+    assertThat(table.column("embedding_vector").arrayLength(), equalTo(16));
 
     // Check not-null.
     assertThat(table.column("first_name").notNull(), is(false));
@@ -196,6 +199,7 @@ public class InformationSchemaScannerIT {
             + " \"arr_timestamp_field\"                   timestamp with time zone[],"
             + " \"arr_date_field\"                        date[],"
             + " \"arr_numeric_field\"                     numeric[],"
+            + " \"embedding_vector\"                      double precision[] vector length 8,"
             + " PRIMARY KEY (\"first_name\", \"last_name\", \"id\")"
             + " )";
 
@@ -207,7 +211,7 @@ public class InformationSchemaScannerIT {
     assertThat(ddl.table("aLlTYPeS"), notNullValue());
 
     Table table = ddl.table("alltypes");
-    assertThat(table.columns(), hasSize(19));
+    assertThat(table.columns(), hasSize(20));
 
     // Check case sensitiveness.
     assertThat(table.column("first_name"), notNullValue());
@@ -235,6 +239,8 @@ public class InformationSchemaScannerIT {
         table.column("arr_timestamp_field").type(), equalTo(Type.pgArray(Type.pgTimestamptz())));
     assertThat(table.column("arr_date_field").type(), equalTo(Type.pgArray(Type.pgDate())));
     assertThat(table.column("arr_numeric_field").type(), equalTo(Type.pgArray(Type.pgNumeric())));
+    assertThat(table.column("embedding_vector").type(), equalTo(Type.pgArray(Type.pgFloat8())));
+    assertThat(table.column("embedding_vector").arrayLength(), equalTo(8));
 
     // Check not-null. Primary keys are implicitly forced to be not-null.
     assertThat(table.column("first_name").notNull(), is(true));

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangelogEntryToBigtableRowFn.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstogcs/BigtableChangelogEntryToBigtableRowFn.java
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.teleport.v2.templates.bigtablechangestreamstogcs;
 
-import com.google.cloud.teleport.bigtable.BigtableRow;
+c
 import com.google.cloud.teleport.bigtable.ChangelogEntry;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.beam.sdk.transforms.SimpleFunction;


### PR DESCRIPTION
- Support for vector_length annotation added for both gsql and spangres.
- vector_length is treated part of the "spanner_type" or "column_type" returned by Spanner's InformationSchema
- SizedType (already existing object) has been updated to support arrayLength which is used to store vector_length param
- Associated tests