### PR TITLE
Fix conversion to Long

### DIFF
--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventTypeConvertor.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventTypeConvertor.java
@@ -78,7 +78,7 @@ public class ChangeEventTypeConvertor {
     try {
       JsonNode node = changeEvent.get(key);
       if (node.isTextual()) {
-        return Double.valueOf(node.asText()).longValue();
+        return Long.valueOf(node.asText());
       }
       return node.asLong();
 

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventTypeConvertorTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventTypeConvertorTest.java
@@ -147,13 +147,11 @@ public final class ChangeEventTypeConvertorTest {
     changeEvent.put("field2", -123456789);
     changeEvent.put("field3", 123456.789);
     changeEvent.put("field4", -123456.789);
-    changeEvent.put("field5", "123456789");
-    changeEvent.put("field6", "-123456789");
-    changeEvent.put("field7", "123456.789");
-    changeEvent.put("field8", "-123456.789");
-    changeEvent.put("field9", true); // Interpreted as 1
-    changeEvent.put("field10", false); // Interpreted as 0
-    changeEvent.put("field11", JSONObject.NULL);
+    changeEvent.put("field5", "3123556554908346902");
+    changeEvent.put("field6", "-3123556554908346902");
+    changeEvent.put("field7", true); // Interpreted as 1
+    changeEvent.put("field8", false); // Interpreted as 0
+    changeEvent.put("field9", JSONObject.NULL);
 
     JsonNode ce = getJsonNode(changeEvent.toString());
 
@@ -170,20 +168,23 @@ public final class ChangeEventTypeConvertorTest {
         new Long(-123456));
     assertEquals(
         ChangeEventTypeConvertor.toLong(ce, "field5", /* requiredField= */ true),
-        new Long(123456789));
+        new Long("3123556554908346902"));
     assertEquals(
         ChangeEventTypeConvertor.toLong(ce, "field6", /* requiredField= */ true),
-        new Long(-123456789));
+        new Long("-3123556554908346902"));
     assertEquals(
-        ChangeEventTypeConvertor.toLong(ce, "field7", /* requiredField= */ true), new Long(123456));
+        ChangeEventTypeConvertor.toLong(ce, "field7", /* requiredField= */ true), new Long(1));
     assertEquals(
-        ChangeEventTypeConvertor.toLong(ce, "field8", /* requiredField= */ true),
-        new Long(-123456));
-    assertEquals(
-        ChangeEventTypeConvertor.toLong(ce, "field9", /* requiredField= */ true), new Long(1));
-    assertEquals(
-        ChangeEventTypeConvertor.toLong(ce, "field10", /* requiredField= */ true), new Long(0));
-    assertNull(ChangeEventTypeConvertor.toLong(ce, "field11", /* requiredField= */ false));
+        ChangeEventTypeConvertor.toLong(ce, "field8", /* requiredField= */ true), new Long(0));
+    assertNull(ChangeEventTypeConvertor.toLong(ce, "field9", /* requiredField= */ false));
+  }
+
+  @Test(expected = ChangeEventConvertorException.class)
+  public void cannotConvertFloatingPointWithoutLossOfPrecision() throws Exception {
+    JSONObject changeEvent = new JSONObject();
+    changeEvent.put("field1", "123456.789");
+    JsonNode ce = getJsonNode(changeEvent.toString());
+    ChangeEventTypeConvertor.toLong(ce, "field1", /* requiredField= */ true);
   }
 
   @Test(expected = ChangeEventConvertorException.class)


### PR DESCRIPTION
The [toLong](https://github.com/manitgupta/DataflowTemplates/blob/f44f7ce818882b337b7989b504a7ff1e5a234d2d/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventTypeConvertor.java#L81) method in this class converts an incoming string from JsonNode to Double first and then converts it to a Long.

While both Double and Long are 64 bit, Double reserves extra bits to store the exponent -
![3bM2MXXruW8uM2Q](https://github.com/GoogleCloudPlatform/DataflowTemplates/assets/6614006/5f22a660-e01e-46ac-89b5-e1c32ec6962e)



Therefore, the same range of numbers as Long cannot be represented by Double.
For example, `3123556554908346902` cannot be converted to Long correctly via a Double.

The fix is to directly convert an incoming string to a Long using `Long.valueOf`.