### PR TITLE
Add user-agent string to Elasticsearch templates

### DIFF
--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
@@ -100,6 +100,8 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
 
   public abstract ElasticsearchWriteOptions options();
 
+  abstract String templateName();
+
   /**
    * Types have been removed in ES 7.0. Default will be _doc. See
    * https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html"
@@ -115,7 +117,8 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
         ElasticsearchIO.ConnectionConfiguration.create(
             new String[] {connectionInformation.getElasticsearchURL().toString()},
             options().getIndex(),
-            DOCUMENT_TYPE);
+            DOCUMENT_TYPE,
+            templateName());
 
     // If username and password are not blank, use them instead of ApiKey
     if (StringUtils.isNotBlank(options().getElasticsearchUsername())
@@ -241,6 +244,9 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
     public abstract Builder setOptions(ElasticsearchWriteOptions options);
 
     abstract ElasticsearchWriteOptions options();
+
+    public abstract Builder setTemplateName(String name);
+    abstract String templateName();
 
     abstract WriteToElasticsearch autoBuild();
 

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
@@ -100,7 +100,7 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
 
   public abstract ElasticsearchWriteOptions options();
 
-  abstract String templateName();
+  abstract String userAgent();
 
   /**
    * Types have been removed in ES 7.0. Default will be _doc. See
@@ -118,7 +118,7 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
             new String[] {connectionInformation.getElasticsearchURL().toString()},
             options().getIndex(),
             DOCUMENT_TYPE,
-            templateName());
+            userAgent());
 
     // If username and password are not blank, use them instead of ApiKey
     if (StringUtils.isNotBlank(options().getElasticsearchUsername())
@@ -245,8 +245,8 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
 
     abstract ElasticsearchWriteOptions options();
 
-    public abstract Builder setTemplateName(String name);
-    abstract String templateName();
+    public abstract Builder setUserAgent(String name);
+    abstract String userAgent();
 
     abstract WriteToElasticsearch autoBuild();
 

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearch.java
@@ -246,6 +246,7 @@ public abstract class WriteToElasticsearch extends PTransform<PCollection<String
     abstract ElasticsearchWriteOptions options();
 
     public abstract Builder setUserAgent(String name);
+
     abstract String userAgent();
 
     abstract WriteToElasticsearch autoBuild();

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
@@ -316,7 +316,8 @@ public class ElasticsearchIO {
      * @param userAgent identifies the template user-agent string
      * @return the connection configuration object
      */
-    public static ConnectionConfiguration create(String[] addresses, String index, String type, String userAgent) {
+    public static ConnectionConfiguration create(
+        String[] addresses, String index, String type, String userAgent) {
       checkArgument(addresses != null, "addresses can not be null");
       checkArgument(addresses.length > 0, "addresses can not be empty");
       checkArgument(index != null, "index can not be null");
@@ -424,8 +425,9 @@ public class ElasticsearchIO {
     /**
      * Sets User-Agent headers.
      *
-     * Sets Authorization: ApiKey if ApiKey is present
-     * Sets Authorization: Bearer if BearerToken is present
+     * <p>Sets Authorization: ApiKey if ApiKey is present Sets Authorization: Bearer if BearerToken
+     * is present
+     *
      * @return an array of {@link Header} that apply to all HTTP requests
      */
     protected Header[] configureDefaultHeaders() {

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
@@ -430,7 +430,7 @@ public class ElasticsearchIO {
      */
     protected Header[] configureDefaultHeaders() {
       final ArrayList<Header> headerList = new ArrayList<Header>();
-      
+
       headerList.add(new BasicHeader("user-agent", getUserAgent()));
 
       if (getApiKey() != null) {
@@ -504,7 +504,6 @@ public class ElasticsearchIO {
         i++;
       }
       RestClientBuilder restClientBuilder = RestClient.builder(hosts);
-
       if (getUsername() != null) {
         final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(

--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
@@ -433,7 +433,7 @@ public class ElasticsearchIO {
     protected Header[] configureDefaultHeaders() {
       final ArrayList<Header> headerList = new ArrayList<Header>();
 
-      headerList.add(new BasicHeader("user-agent", getUserAgent()));
+      headerList.add(new BasicHeader("User-Agent", getUserAgent()));
 
       if (getApiKey() != null) {
         headerList.add(new BasicHeader("Authorization", "ApiKey " + getApiKey()));

--- a/v2/elasticsearch-common/src/test/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearchTest.java
+++ b/v2/elasticsearch-common/src/test/java/com/google/cloud/teleport/v2/elasticsearch/transforms/WriteToElasticsearchTest.java
@@ -15,7 +15,11 @@
  */
 package com.google.cloud.teleport.v2.elasticsearch.transforms;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.teleport.v2.elasticsearch.options.ElasticsearchWriteOptions;
 import com.google.cloud.teleport.v2.elasticsearch.utils.ElasticsearchIO;

--- a/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/BigQueryToElasticsearch.java
+++ b/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/BigQueryToElasticsearch.java
@@ -115,7 +115,7 @@ public class BigQueryToElasticsearch {
         .apply(
             "WriteToElasticsearch",
             WriteToElasticsearch.newBuilder()
-                .setTemplateName("dataflow-bigquery-to-elasticsearch-template/v2")
+                .setUserAgent("dataflow-bigquery-to-elasticsearch-template/v2")
                 .setOptions(options.as(BigQueryToElasticsearchOptions.class))
                 .build());
 

--- a/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/BigQueryToElasticsearch.java
+++ b/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/BigQueryToElasticsearch.java
@@ -115,6 +115,7 @@ public class BigQueryToElasticsearch {
         .apply(
             "WriteToElasticsearch",
             WriteToElasticsearch.newBuilder()
+                .setTemplateName("dataflow-bigquery-to-elasticsearch-template/v2")
                 .setOptions(options.as(BigQueryToElasticsearchOptions.class))
                 .build());
 

--- a/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/GCSToElasticsearch.java
+++ b/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/GCSToElasticsearch.java
@@ -189,7 +189,7 @@ public class GCSToElasticsearch {
         .apply(
             "WriteToElasticsearch",
             WriteToElasticsearch.newBuilder()
-                .setTemplateName("dataflow-gcs-to-elasticsearch-template/v2")
+                .setUserAgent("dataflow-gcs-to-elasticsearch-template/v2")
                 .setOptions(options.as(GCSToElasticsearchOptions.class))
                 .build());
 

--- a/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/GCSToElasticsearch.java
+++ b/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/GCSToElasticsearch.java
@@ -189,6 +189,7 @@ public class GCSToElasticsearch {
         .apply(
             "WriteToElasticsearch",
             WriteToElasticsearch.newBuilder()
+                .setTemplateName("dataflow-gcs-to-elasticsearch-template/v2")
                 .setOptions(options.as(GCSToElasticsearchOptions.class))
                 .build());
 

--- a/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/PubSubToElasticsearch.java
+++ b/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/PubSubToElasticsearch.java
@@ -203,7 +203,7 @@ public class PubSubToElasticsearch {
         .apply(
             "WriteToElasticsearch",
             WriteToElasticsearch.newBuilder()
-                .setTemplateName("dataflow-pubsub-to-elasticsearch-template/v2")
+                .setUserAgent("dataflow-pubsub-to-elasticsearch-template/v2")
                 .setOptions(options.as(PubSubToElasticsearchOptions.class))
                 .build());
 

--- a/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/PubSubToElasticsearch.java
+++ b/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/PubSubToElasticsearch.java
@@ -203,6 +203,7 @@ public class PubSubToElasticsearch {
         .apply(
             "WriteToElasticsearch",
             WriteToElasticsearch.newBuilder()
+                .setTemplateName("dataflow-pubsub-to-elasticsearch-template/v2")
                 .setOptions(options.as(PubSubToElasticsearchOptions.class))
                 .build());
 


### PR DESCRIPTION
Our team at Elastic is interested to have metrics to understand how popular the templates are. With that data we might justify investing to help to maintain them. 

This PR just adds a user-agent string to BigQuery/GCS/PubSub to Elasticsearch templates.

The changes are tested in GCP