### PR TITLE
Return a bit more accurate count for DataGenerator Template

### DIFF
--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/datagenerator/DataGenerator.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/datagenerator/DataGenerator.java
@@ -86,7 +86,7 @@ public class DataGenerator {
    * @return approximate number of messages generated
    * @throws IOException if any errors are encountered.
    */
-  public Integer execute(Duration timeout) throws IOException {
+  public Long execute(Duration timeout) throws IOException {
     LaunchInfo dataGeneratorLaunchInfo =
         pipelineLauncher.launch(PROJECT, REGION, dataGeneratorOptions);
     assertThatPipeline(dataGeneratorLaunchInfo).isRunning();
@@ -102,11 +102,11 @@ public class DataGenerator {
       assertThatResult(dataGeneratorResult).hasTimedOut();
     }
     @SuppressWarnings("nullness")
-    int generatedMessages =
+    Long generatedMessages =
         pipelineLauncher
             .getMetric(
                 PROJECT, REGION, dataGeneratorLaunchInfo.jobId(), MESSAGES_GENERATED_METRIC_NAME)
-            .intValue();
+            .longValue();
     LOG.info("Data generator finished. Generated {} messages.", generatedMessages);
     return generatedMessages;
   }

--- a/v1/src/test/java/com/google/cloud/teleport/templates/PubsubToPubsubLT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/PubsubToPubsubLT.java
@@ -195,7 +195,7 @@ public class PubsubToPubsubLT extends TemplateLoadTestBase {
     LaunchInfo info = pipelineLauncher.launch(project, region, options);
     assertThatPipeline(info).isRunning();
     // ElementCount metric in dataflow is approximate, allow for 1% difference
-    Integer expectedMessages = (int) (dataGenerator.execute(Duration.ofMinutes(60)) * 0.99);
+    Long expectedMessages = (long) (dataGenerator.execute(Duration.ofMinutes(60)) * 0.99);
     Result result =
         pipelineOperator.waitForConditionAndCancel(
             createConfig(info, Duration.ofMinutes(20)),


### PR DESCRIPTION
Its very easy to exceed the `integer` limit on number of messages, the metric is returned as a `double` so converting to `long` instead of `int`