### PR TITLE
Session file support for bulk migration using JSON node

### DIFF
--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/LazyMapper.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/LazyMapper.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.migrations.schema;
+
+import com.google.cloud.teleport.v2.spanner.ddl.Column;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.Table;
+import com.google.cloud.teleport.v2.spanner.type.Type;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+public class LazyMapper implements SchemaMapperIface {
+
+    Ddl ddl;
+
+    public LazyMapper(Ddl ddl) {
+        this.ddl = ddl;
+    }
+
+
+    @Override
+    public String getSpannerTableName(String srcTable) {
+        return srcTable;
+    }
+
+    @Override
+    public String getSpannerColumnName(String srcTable, String srcColumn) {
+        return srcColumn;
+    }
+
+    @Override
+    public String getSourceColumnName(String spannerTable, String spannerColumn) {
+        return spannerColumn;
+    }
+
+    @Override
+    public Type getSpannerColumnType(String spannerTable, String spannerColumn) throws NoSuchElementException {
+        Table spTable = ddl.table(spannerTable);
+        if (spTable == null) {
+            throw new NoSuchElementException(String.format("Spanner table %s not found", spannerTable));
+        }
+        Column col = spTable.column(spannerColumn);
+        if (col == null) {
+            throw new NoSuchElementException(String.format("Spanner column %s not found", spannerColumn));
+        }
+        return col.type();
+    }
+
+    @Override
+    public List<String> getSpannerColumns(String spannerTable) throws NoSuchElementException {
+        Table spTable = ddl.table(spannerTable);
+        if (spTable == null) {
+            throw new NoSuchElementException(String.format("Spanner table %s not found", spannerTable));
+        }
+        return spTable.columns().stream()
+                .map(column -> column.name())
+                .collect(Collectors.toList());
+    }
+}

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/LazyMapper.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/LazyMapper.java
@@ -19,56 +19,53 @@ import com.google.cloud.teleport.v2.spanner.ddl.Column;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.ddl.Table;
 import com.google.cloud.teleport.v2.spanner.type.Type;
-
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 public class LazyMapper implements SchemaMapperIface {
 
-    Ddl ddl;
+  Ddl ddl;
 
-    public LazyMapper(Ddl ddl) {
-        this.ddl = ddl;
+  public LazyMapper(Ddl ddl) {
+    this.ddl = ddl;
+  }
+
+  @Override
+  public String getSpannerTableName(String srcTable) {
+    return srcTable;
+  }
+
+  @Override
+  public String getSpannerColumnName(String srcTable, String srcColumn) {
+    return srcColumn;
+  }
+
+  @Override
+  public String getSourceColumnName(String spannerTable, String spannerColumn) {
+    return spannerColumn;
+  }
+
+  @Override
+  public Type getSpannerColumnType(String spannerTable, String spannerColumn)
+      throws NoSuchElementException {
+    Table spTable = ddl.table(spannerTable);
+    if (spTable == null) {
+      throw new NoSuchElementException(String.format("Spanner table %s not found", spannerTable));
     }
-
-
-    @Override
-    public String getSpannerTableName(String srcTable) {
-        return srcTable;
+    Column col = spTable.column(spannerColumn);
+    if (col == null) {
+      throw new NoSuchElementException(String.format("Spanner column %s not found", spannerColumn));
     }
+    return col.type();
+  }
 
-    @Override
-    public String getSpannerColumnName(String srcTable, String srcColumn) {
-        return srcColumn;
+  @Override
+  public List<String> getSpannerColumns(String spannerTable) throws NoSuchElementException {
+    Table spTable = ddl.table(spannerTable);
+    if (spTable == null) {
+      throw new NoSuchElementException(String.format("Spanner table %s not found", spannerTable));
     }
-
-    @Override
-    public String getSourceColumnName(String spannerTable, String spannerColumn) {
-        return spannerColumn;
-    }
-
-    @Override
-    public Type getSpannerColumnType(String spannerTable, String spannerColumn) throws NoSuchElementException {
-        Table spTable = ddl.table(spannerTable);
-        if (spTable == null) {
-            throw new NoSuchElementException(String.format("Spanner table %s not found", spannerTable));
-        }
-        Column col = spTable.column(spannerColumn);
-        if (col == null) {
-            throw new NoSuchElementException(String.format("Spanner column %s not found", spannerColumn));
-        }
-        return col.type();
-    }
-
-    @Override
-    public List<String> getSpannerColumns(String spannerTable) throws NoSuchElementException {
-        Table spTable = ddl.table(spannerTable);
-        if (spTable == null) {
-            throw new NoSuchElementException(String.format("Spanner table %s not found", spannerTable));
-        }
-        return spTable.columns().stream()
-                .map(column -> column.name())
-                .collect(Collectors.toList());
-    }
+    return spTable.columns().stream().map(column -> column.name()).collect(Collectors.toList());
+  }
 }

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SchemaMapperIface.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SchemaMapperIface.java
@@ -16,33 +16,24 @@
 package com.google.cloud.teleport.v2.spanner.migrations.schema;
 
 import com.google.cloud.teleport.v2.spanner.type.Type;
-
 import java.util.List;
 import java.util.NoSuchElementException;
 
 public interface SchemaMapperIface {
-    /**
-     * Retrieves the corresponding Spanner table name given a source table name.
-     */
-    String getSpannerTableName(String srcTable) throws NoSuchElementException;
+  /** Retrieves the corresponding Spanner table name given a source table name. */
+  String getSpannerTableName(String srcTable) throws NoSuchElementException;
 
-    /**
-     * Retrieves the corresponding Spanner column name given a source table and source column.
-     */
-    String getSpannerColumnName(String srcTable, String srcColumn) throws NoSuchElementException;
+  /** Retrieves the corresponding Spanner column name given a source table and source column. */
+  String getSpannerColumnName(String srcTable, String srcColumn) throws NoSuchElementException;
 
-    /**
-     * Retrieves the corresponding source column name given a Spanner table and Spanner column.
-     */
-    String getSourceColumnName(String spannerTable, String spannerColumn) throws NoSuchElementException;
+  /** Retrieves the corresponding source column name given a Spanner table and Spanner column. */
+  String getSourceColumnName(String spannerTable, String spannerColumn)
+      throws NoSuchElementException;
 
-    /**
-     * Retrieves the Spanner column data type given a spanner table and spanner column.
-     */
-    Type getSpannerColumnType(String spannerTable, String spannerColumn) throws NoSuchElementException;
+  /** Retrieves the Spanner column data type given a spanner table and spanner column. */
+  Type getSpannerColumnType(String spannerTable, String spannerColumn)
+      throws NoSuchElementException;
 
-    /**
-     * Retrieves a list of all column names within a Spanner table.
-     */
-    List<String> getSpannerColumns(String spannerTable) throws NoSuchElementException;
+  /** Retrieves a list of all column names within a Spanner table. */
+  List<String> getSpannerColumns(String spannerTable) throws NoSuchElementException;
 }

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SchemaMapperIface.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SchemaMapperIface.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.migrations.schema;
+
+import com.google.cloud.teleport.v2.spanner.type.Type;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+public interface SchemaMapperIface {
+    /**
+     * Retrieves the corresponding Spanner table name given a source table name.
+     */
+    String getSpannerTableName(String srcTable) throws NoSuchElementException;
+
+    /**
+     * Retrieves the corresponding Spanner column name given a source table and source column.
+     */
+    String getSpannerColumnName(String srcTable, String srcColumn) throws NoSuchElementException;
+
+    /**
+     * Retrieves the corresponding source column name given a Spanner table and Spanner column.
+     */
+    String getSourceColumnName(String spannerTable, String spannerColumn) throws NoSuchElementException;
+
+    /**
+     * Retrieves the Spanner column data type given a spanner table and spanner column.
+     */
+    Type getSpannerColumnType(String spannerTable, String spannerColumn) throws NoSuchElementException;
+
+    /**
+     * Retrieves a list of all column names within a Spanner table.
+     */
+    List<String> getSpannerColumns(String spannerTable) throws NoSuchElementException;
+}

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SessionBasedMapper.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SessionBasedMapper.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.migrations.schema;
+
+import com.google.cloud.teleport.v2.spanner.ddl.Column;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.Table;
+import com.google.cloud.teleport.v2.spanner.type.Type;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+public class SessionBasedMapper implements SchemaMapperIface {
+
+    Ddl ddl;
+
+    Schema schema;
+
+    public SessionBasedMapper(Schema schema, Ddl ddl) {
+        this.schema = schema;
+        this.ddl = ddl;
+    }
+
+
+    @Override
+    public String getSpannerTableName(String srcTable) throws NoSuchElementException {
+        Map<String, NameAndCols> toSpanner = schema.getToSpanner();
+        if (!toSpanner.containsKey(srcTable)) {
+            throw new NoSuchElementException(String.format("Source table %s not found", srcTable));
+        }
+        return toSpanner.get(srcTable).getName();
+    }
+
+    @Override
+    public String getSpannerColumnName(String srcTable, String srcColumn) throws NoSuchElementException {
+        Map<String, NameAndCols> toSpanner = schema.getToSpanner();
+        if (!toSpanner.containsKey(srcTable)) {
+            throw new NoSuchElementException(String.format("Source table %s not found", srcTable));
+        }
+        Map<String, String> cols = toSpanner.get(srcTable).getCols();
+        if (!cols.containsKey(srcColumn)) {
+            throw new NoSuchElementException(String.format("Source column %s not found for table %s", srcColumn, srcTable));
+        }
+        return cols.get(srcColumn);
+    }
+
+    @Override
+    public String getSourceColumnName(String spannerTable, String spannerColumn) throws NoSuchElementException {
+        Map<String, NameAndCols> toSource = schema.getToSource();
+        if (!toSource.containsKey(spannerTable)) {
+            throw new NoSuchElementException(String.format("Spanner table %s not found", spannerTable));
+        }
+        Map<String, String> cols = toSource.get(spannerTable).getCols();
+        if (!cols.containsKey(spannerColumn)) {
+            throw new NoSuchElementException(String.format("Spanner column %s not found for table %s", spannerColumn, spannerTable));
+        }
+        return cols.get(spannerColumn);
+    }
+
+    @Override
+    public Type getSpannerColumnType(String spannerTable, String spannerColumn) throws NoSuchElementException {
+        Table spTable = ddl.table(spannerTable);
+        if (spTable == null) {
+            throw new NoSuchElementException(String.format("Spanner table %s not found", spannerTable));
+        }
+        Column col = spTable.column(spannerColumn);
+        if (col == null) {
+            throw new NoSuchElementException(String.format("Spanner column %s not found", spannerColumn));
+        }
+        return col.type();
+    }
+
+    @Override
+    public List<String> getSpannerColumns(String spannerTable) throws NoSuchElementException {
+        Map<String, NameAndCols> toSource = schema.getToSource();
+        if (!toSource.containsKey(spannerTable)) {
+            throw new NoSuchElementException(String.format("Spanner table %s not found", spannerTable));
+        }
+        Map<String, String> spToSrcCols = toSource.get(spannerTable).getCols();
+        return new ArrayList<>(spToSrcCols.keySet());
+    }
+}

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SessionBasedMapper.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SessionBasedMapper.java
@@ -19,7 +19,6 @@ import com.google.cloud.teleport.v2.spanner.ddl.Column;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.ddl.Table;
 import com.google.cloud.teleport.v2.spanner.type.Type;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -27,71 +26,75 @@ import java.util.NoSuchElementException;
 
 public class SessionBasedMapper implements SchemaMapperIface {
 
-    Ddl ddl;
+  Ddl ddl;
 
-    Schema schema;
+  Schema schema;
 
-    public SessionBasedMapper(Schema schema, Ddl ddl) {
-        this.schema = schema;
-        this.ddl = ddl;
+  public SessionBasedMapper(Schema schema, Ddl ddl) {
+    this.schema = schema;
+    this.ddl = ddl;
+  }
+
+  @Override
+  public String getSpannerTableName(String srcTable) throws NoSuchElementException {
+    Map<String, NameAndCols> toSpanner = schema.getToSpanner();
+    if (!toSpanner.containsKey(srcTable)) {
+      throw new NoSuchElementException(String.format("Source table %s not found", srcTable));
     }
+    return toSpanner.get(srcTable).getName();
+  }
 
-
-    @Override
-    public String getSpannerTableName(String srcTable) throws NoSuchElementException {
-        Map<String, NameAndCols> toSpanner = schema.getToSpanner();
-        if (!toSpanner.containsKey(srcTable)) {
-            throw new NoSuchElementException(String.format("Source table %s not found", srcTable));
-        }
-        return toSpanner.get(srcTable).getName();
+  @Override
+  public String getSpannerColumnName(String srcTable, String srcColumn)
+      throws NoSuchElementException {
+    Map<String, NameAndCols> toSpanner = schema.getToSpanner();
+    if (!toSpanner.containsKey(srcTable)) {
+      throw new NoSuchElementException(String.format("Source table %s not found", srcTable));
     }
-
-    @Override
-    public String getSpannerColumnName(String srcTable, String srcColumn) throws NoSuchElementException {
-        Map<String, NameAndCols> toSpanner = schema.getToSpanner();
-        if (!toSpanner.containsKey(srcTable)) {
-            throw new NoSuchElementException(String.format("Source table %s not found", srcTable));
-        }
-        Map<String, String> cols = toSpanner.get(srcTable).getCols();
-        if (!cols.containsKey(srcColumn)) {
-            throw new NoSuchElementException(String.format("Source column %s not found for table %s", srcColumn, srcTable));
-        }
-        return cols.get(srcColumn);
+    Map<String, String> cols = toSpanner.get(srcTable).getCols();
+    if (!cols.containsKey(srcColumn)) {
+      throw new NoSuchElementException(
+          String.format("Source column %s not found for table %s", srcColumn, srcTable));
     }
+    return cols.get(srcColumn);
+  }
 
-    @Override
-    public String getSourceColumnName(String spannerTable, String spannerColumn) throws NoSuchElementException {
-        Map<String, NameAndCols> toSource = schema.getToSource();
-        if (!toSource.containsKey(spannerTable)) {
-            throw new NoSuchElementException(String.format("Spanner table %s not found", spannerTable));
-        }
-        Map<String, String> cols = toSource.get(spannerTable).getCols();
-        if (!cols.containsKey(spannerColumn)) {
-            throw new NoSuchElementException(String.format("Spanner column %s not found for table %s", spannerColumn, spannerTable));
-        }
-        return cols.get(spannerColumn);
+  @Override
+  public String getSourceColumnName(String spannerTable, String spannerColumn)
+      throws NoSuchElementException {
+    Map<String, NameAndCols> toSource = schema.getToSource();
+    if (!toSource.containsKey(spannerTable)) {
+      throw new NoSuchElementException(String.format("Spanner table %s not found", spannerTable));
     }
+    Map<String, String> cols = toSource.get(spannerTable).getCols();
+    if (!cols.containsKey(spannerColumn)) {
+      throw new NoSuchElementException(
+          String.format("Spanner column %s not found for table %s", spannerColumn, spannerTable));
+    }
+    return cols.get(spannerColumn);
+  }
 
-    @Override
-    public Type getSpannerColumnType(String spannerTable, String spannerColumn) throws NoSuchElementException {
-        Table spTable = ddl.table(spannerTable);
-        if (spTable == null) {
-            throw new NoSuchElementException(String.format("Spanner table %s not found", spannerTable));
-        }
-        Column col = spTable.column(spannerColumn);
-        if (col == null) {
-            throw new NoSuchElementException(String.format("Spanner column %s not found", spannerColumn));
-        }
-        return col.type();
+  @Override
+  public Type getSpannerColumnType(String spannerTable, String spannerColumn)
+      throws NoSuchElementException {
+    Table spTable = ddl.table(spannerTable);
+    if (spTable == null) {
+      throw new NoSuchElementException(String.format("Spanner table %s not found", spannerTable));
     }
+    Column col = spTable.column(spannerColumn);
+    if (col == null) {
+      throw new NoSuchElementException(String.format("Spanner column %s not found", spannerColumn));
+    }
+    return col.type();
+  }
 
-    @Override
-    public List<String> getSpannerColumns(String spannerTable) throws NoSuchElementException {
-        Map<String, NameAndCols> toSource = schema.getToSource();
-        if (!toSource.containsKey(spannerTable)) {
-            throw new NoSuchElementException(String.format("Spanner table %s not found", spannerTable));
-        }
-        Map<String, String> spToSrcCols = toSource.get(spannerTable).getCols();
-        return new ArrayList<>(spToSrcCols.keySet());
+  @Override
+  public List<String> getSpannerColumns(String spannerTable) throws NoSuchElementException {
+    Map<String, NameAndCols> toSource = schema.getToSource();
+    if (!toSource.containsKey(spannerTable)) {
+      throw new NoSuchElementException(String.format("Spanner table %s not found", spannerTable));
     }
+    Map<String, String> spToSrcCols = toSource.get(spannerTable).getCols();
+    return new ArrayList<>(spToSrcCols.keySet());
+  }
 }

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/schema/LazyMapperTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/schema/LazyMapperTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.migrations.schema;
+
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.type.Type;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.assertEquals;
+
+public class LazyMapperTest {
+
+    LazyMapper mapper;
+
+    @Before
+    public void setup() {
+        Ddl ddl =
+                Ddl.builder()
+                        .createTable("Users")
+                        .column("id")
+                        .int64()
+                        .notNull()
+                        .endColumn()
+                        .column("first_name")
+                        .string()
+                        .size(10)
+                        .endColumn()
+                        .column("last_name")
+                        .type(Type.string())
+                        .max()
+                        .endColumn()
+                        .primaryKey()
+                        .asc("id")
+                        .end()
+                        .endTable()
+                        .createTable("Account")
+                        .column("id")
+                        .int64()
+                        .notNull()
+                        .endColumn()
+                        .column("balanceId")
+                        .int64()
+                        .notNull()
+                        .endColumn()
+                        .column("balance")
+                        .float64()
+                        .notNull()
+                        .endColumn()
+                        .primaryKey()
+                        .asc("id")
+                        .end()
+                        .interleaveInParent("Users")
+                        .onDeleteCascade()
+                        .endTable()
+                        .build();
+        this.mapper = new LazyMapper(ddl);
+    }
+
+    @Test
+    public void testGetSpannerTableName() {
+        String srcTableName = "abc";
+        String result = mapper.getSpannerTableName(srcTableName);
+        assertEquals(srcTableName, result);
+    }
+
+    @Test
+    public void testGetSpannerColumnName() {
+        String srcTable = "MySourceTable";
+        String srcColumn = "MySourceColumn";
+        String result = mapper.getSpannerColumnName(srcTable, srcColumn);
+        assertEquals(srcColumn, result);
+    }
+
+    @Test
+    public void testGetSourceColumnName() {
+        String spannerTable = "MySpannerTable";
+        String spannerColumn = "MySpannerColumn";
+        String result = mapper.getSourceColumnName(spannerTable, spannerColumn);
+        assertEquals(spannerColumn, result);
+    }
+
+    @Test
+    public void testGetSpannerColumnType() {
+        String spannerTable = "Users";
+        String spannerColumn = "id";
+        Type expectedType = Type.int64();
+        Type result = mapper.getSpannerColumnType(spannerTable, spannerColumn);
+        assertEquals(expectedType, result);
+
+        spannerColumn = "first_name";
+        expectedType = Type.string();
+        result = mapper.getSpannerColumnType(spannerTable, spannerColumn);
+        assertEquals(expectedType, result);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testGetSpannerColumnTypeMissingTable() {
+        String spannerTable = "wrongTableName";
+        String spannerColumn = "id";
+        mapper.getSpannerColumnType(spannerTable, spannerColumn);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testGetSpannerColumnTypeMissingColumn() {
+        String spannerTable = "Users";
+        String spannerColumn = "wrongColumn";
+        mapper.getSpannerColumnType(spannerTable, spannerColumn);
+    }
+
+    @Test
+    public void testGetSpannerColumns() {
+        String spannerTable = "Users";
+        List<String> expectedColumns = Arrays.asList("id", "first_name", "last_name");
+        List<String> result = mapper.getSpannerColumns(spannerTable);
+        assertEquals(expectedColumns, result);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testGetSpannerColumnsMissingTable() {
+        String spannerTable = "wrongTableName";
+        mapper.getSpannerColumns(spannerTable);
+    }
+}

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/schema/LazyMapperTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/schema/LazyMapperTest.java
@@ -15,127 +15,126 @@
  */
 package com.google.cloud.teleport.v2.spanner.migrations.schema;
 
+import static org.junit.Assert.assertEquals;
+
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.type.Type;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
-
-import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
 
 public class LazyMapperTest {
 
-    LazyMapper mapper;
+  LazyMapper mapper;
 
-    @Before
-    public void setup() {
-        Ddl ddl =
-                Ddl.builder()
-                        .createTable("Users")
-                        .column("id")
-                        .int64()
-                        .notNull()
-                        .endColumn()
-                        .column("first_name")
-                        .string()
-                        .size(10)
-                        .endColumn()
-                        .column("last_name")
-                        .type(Type.string())
-                        .max()
-                        .endColumn()
-                        .primaryKey()
-                        .asc("id")
-                        .end()
-                        .endTable()
-                        .createTable("Account")
-                        .column("id")
-                        .int64()
-                        .notNull()
-                        .endColumn()
-                        .column("balanceId")
-                        .int64()
-                        .notNull()
-                        .endColumn()
-                        .column("balance")
-                        .float64()
-                        .notNull()
-                        .endColumn()
-                        .primaryKey()
-                        .asc("id")
-                        .end()
-                        .interleaveInParent("Users")
-                        .onDeleteCascade()
-                        .endTable()
-                        .build();
-        this.mapper = new LazyMapper(ddl);
-    }
+  @Before
+  public void setup() {
+    Ddl ddl =
+        Ddl.builder()
+            .createTable("Users")
+            .column("id")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("first_name")
+            .string()
+            .size(10)
+            .endColumn()
+            .column("last_name")
+            .type(Type.string())
+            .max()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .createTable("Account")
+            .column("id")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("balanceId")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("balance")
+            .float64()
+            .notNull()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .interleaveInParent("Users")
+            .onDeleteCascade()
+            .endTable()
+            .build();
+    this.mapper = new LazyMapper(ddl);
+  }
 
-    @Test
-    public void testGetSpannerTableName() {
-        String srcTableName = "abc";
-        String result = mapper.getSpannerTableName(srcTableName);
-        assertEquals(srcTableName, result);
-    }
+  @Test
+  public void testGetSpannerTableName() {
+    String srcTableName = "abc";
+    String result = mapper.getSpannerTableName(srcTableName);
+    assertEquals(srcTableName, result);
+  }
 
-    @Test
-    public void testGetSpannerColumnName() {
-        String srcTable = "MySourceTable";
-        String srcColumn = "MySourceColumn";
-        String result = mapper.getSpannerColumnName(srcTable, srcColumn);
-        assertEquals(srcColumn, result);
-    }
+  @Test
+  public void testGetSpannerColumnName() {
+    String srcTable = "MySourceTable";
+    String srcColumn = "MySourceColumn";
+    String result = mapper.getSpannerColumnName(srcTable, srcColumn);
+    assertEquals(srcColumn, result);
+  }
 
-    @Test
-    public void testGetSourceColumnName() {
-        String spannerTable = "MySpannerTable";
-        String spannerColumn = "MySpannerColumn";
-        String result = mapper.getSourceColumnName(spannerTable, spannerColumn);
-        assertEquals(spannerColumn, result);
-    }
+  @Test
+  public void testGetSourceColumnName() {
+    String spannerTable = "MySpannerTable";
+    String spannerColumn = "MySpannerColumn";
+    String result = mapper.getSourceColumnName(spannerTable, spannerColumn);
+    assertEquals(spannerColumn, result);
+  }
 
-    @Test
-    public void testGetSpannerColumnType() {
-        String spannerTable = "Users";
-        String spannerColumn = "id";
-        Type expectedType = Type.int64();
-        Type result = mapper.getSpannerColumnType(spannerTable, spannerColumn);
-        assertEquals(expectedType, result);
+  @Test
+  public void testGetSpannerColumnType() {
+    String spannerTable = "Users";
+    String spannerColumn = "id";
+    Type expectedType = Type.int64();
+    Type result = mapper.getSpannerColumnType(spannerTable, spannerColumn);
+    assertEquals(expectedType, result);
 
-        spannerColumn = "first_name";
-        expectedType = Type.string();
-        result = mapper.getSpannerColumnType(spannerTable, spannerColumn);
-        assertEquals(expectedType, result);
-    }
+    spannerColumn = "first_name";
+    expectedType = Type.string();
+    result = mapper.getSpannerColumnType(spannerTable, spannerColumn);
+    assertEquals(expectedType, result);
+  }
 
-    @Test(expected = NoSuchElementException.class)
-    public void testGetSpannerColumnTypeMissingTable() {
-        String spannerTable = "wrongTableName";
-        String spannerColumn = "id";
-        mapper.getSpannerColumnType(spannerTable, spannerColumn);
-    }
+  @Test(expected = NoSuchElementException.class)
+  public void testGetSpannerColumnTypeMissingTable() {
+    String spannerTable = "wrongTableName";
+    String spannerColumn = "id";
+    mapper.getSpannerColumnType(spannerTable, spannerColumn);
+  }
 
-    @Test(expected = NoSuchElementException.class)
-    public void testGetSpannerColumnTypeMissingColumn() {
-        String spannerTable = "Users";
-        String spannerColumn = "wrongColumn";
-        mapper.getSpannerColumnType(spannerTable, spannerColumn);
-    }
+  @Test(expected = NoSuchElementException.class)
+  public void testGetSpannerColumnTypeMissingColumn() {
+    String spannerTable = "Users";
+    String spannerColumn = "wrongColumn";
+    mapper.getSpannerColumnType(spannerTable, spannerColumn);
+  }
 
-    @Test
-    public void testGetSpannerColumns() {
-        String spannerTable = "Users";
-        List<String> expectedColumns = Arrays.asList("id", "first_name", "last_name");
-        List<String> result = mapper.getSpannerColumns(spannerTable);
-        assertEquals(expectedColumns, result);
-    }
+  @Test
+  public void testGetSpannerColumns() {
+    String spannerTable = "Users";
+    List<String> expectedColumns = Arrays.asList("id", "first_name", "last_name");
+    List<String> result = mapper.getSpannerColumns(spannerTable);
+    assertEquals(expectedColumns, result);
+  }
 
-    @Test(expected = NoSuchElementException.class)
-    public void testGetSpannerColumnsMissingTable() {
-        String spannerTable = "wrongTableName";
-        mapper.getSpannerColumns(spannerTable);
-    }
+  @Test(expected = NoSuchElementException.class)
+  public void testGetSpannerColumnsMissingTable() {
+    String spannerTable = "wrongTableName";
+    mapper.getSpannerColumns(spannerTable);
+  }
 }

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SessionBasedMapperTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SessionBasedMapperTest.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.migrations.schema;
+
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.type.Type;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.assertEquals;
+
+public class SessionBasedMapperTest {
+
+    SessionBasedMapper mapper;
+
+    @Before
+    public void setup() {
+        Ddl ddl =
+                Ddl.builder()
+                        .createTable("new_cart")
+                        .column("new_quantity")
+                        .int64()
+                        .notNull()
+                        .endColumn()
+                        .column("new_user_id")
+                        .string()
+                        .size(10)
+                        .endColumn()
+                        .primaryKey()
+                        .asc("new_user_id")
+                        .asc("new_quantity")
+                        .end()
+                        .endTable()
+                        .createTable("new_people")
+                        .column("synth_id")
+                        .int64()
+                        .notNull()
+                        .endColumn()
+                        .column("new_name")
+                        .string()
+                        .size(10)
+                        .endColumn()
+                        .primaryKey()
+                        .asc("synth_id")
+                        .end()
+                        .endTable()
+                        .build();
+        this.mapper = new SessionBasedMapper(getSchemaObject(), ddl);
+    }
+
+    private static Schema getSchemaObject() {
+        // Add Synthetic PKs.
+        Map<String, SyntheticPKey> syntheticPKeys = getSyntheticPks();
+        // Add SrcSchema.
+        Map<String, SourceTable> srcSchema = getSampleSrcSchema();
+        // Add SpSchema.
+        Map<String, SpannerTable> spSchema = getSampleSpSchema();
+        Schema expectedSchema = new Schema(spSchema, syntheticPKeys, srcSchema);
+        expectedSchema.setToSpanner(new HashMap<String, NameAndCols>());
+        expectedSchema.setToSource(new HashMap<String, NameAndCols>());
+        expectedSchema.setSrcToID(new HashMap<String, NameAndCols>());
+        expectedSchema.setSpannerToID(new HashMap<String, NameAndCols>());
+        expectedSchema.generateMappings();
+        return expectedSchema;
+    }
+
+    private static Map<String, SyntheticPKey> getSyntheticPks() {
+        Map<String, SyntheticPKey> syntheticPKeys = new HashMap<String, SyntheticPKey>();
+        syntheticPKeys.put("t2", new SyntheticPKey("c6", 0));
+        return syntheticPKeys;
+    }
+
+    private static Map<String, SourceTable> getSampleSrcSchema() {
+        Map<String, SourceTable> srcSchema = new HashMap<String, SourceTable>();
+        Map<String, SourceColumnDefinition> t1SrcColDefs =
+                new HashMap<String, SourceColumnDefinition>();
+        t1SrcColDefs.put(
+                "c1",
+                new SourceColumnDefinition(
+                        "product_id", new SourceColumnType("varchar", new Long[]{20L}, null)));
+        t1SrcColDefs.put(
+                "c2", new SourceColumnDefinition("quantity", new SourceColumnType("bigint", null, null)));
+        t1SrcColDefs.put(
+                "c3",
+                new SourceColumnDefinition(
+                        "user_id", new SourceColumnType("varchar", new Long[]{20L}, null)));
+        srcSchema.put(
+                "t1",
+                new SourceTable(
+                        "cart",
+                        "my_schema",
+                        new String[]{"c3", "c1", "c2"},
+                        t1SrcColDefs,
+                        new ColumnPK[]{new ColumnPK("c3", 1), new ColumnPK("c1", 2)}));
+        Map<String, SourceColumnDefinition> t2SrcColDefs =
+                new HashMap<String, SourceColumnDefinition>();
+        t2SrcColDefs.put(
+                "c5",
+                new SourceColumnDefinition(
+                        "name", new SourceColumnType("varchar", new Long[]{20L}, null)));
+        srcSchema.put(
+                "t2", new SourceTable("people", "my_schema", new String[]{"c5"}, t2SrcColDefs, null));
+        return srcSchema;
+    }
+
+    private static Map<String, SpannerTable> getSampleSpSchema() {
+        Map<String, SpannerTable> spSchema = new HashMap<String, SpannerTable>();
+        Map<String, SpannerColumnDefinition> t1SpColDefs =
+                new HashMap<String, SpannerColumnDefinition>();
+        t1SpColDefs.put(
+                "c2", new SpannerColumnDefinition("new_quantity", new SpannerColumnType("INT64", false)));
+        t1SpColDefs.put(
+                "c3", new SpannerColumnDefinition("new_user_id", new SpannerColumnType("STRING", false)));
+        spSchema.put(
+                "t1",
+                new SpannerTable(
+                        "new_cart",
+                        new String[]{"c2", "c3"},
+                        t1SpColDefs,
+                        new ColumnPK[]{new ColumnPK("c3", 1), new ColumnPK("c2", 2)},
+                        ""));
+        Map<String, SpannerColumnDefinition> t2SpColDefs =
+                new HashMap<String, SpannerColumnDefinition>();
+        t2SpColDefs.put(
+                "c5", new SpannerColumnDefinition("new_name", new SpannerColumnType("STRING", false)));
+        t2SpColDefs.put(
+                "c6", new SpannerColumnDefinition("synth_id", new SpannerColumnType("INT64", false)));
+        spSchema.put(
+                "t2",
+                new SpannerTable(
+                        "new_people",
+                        new String[]{"c5", "c6"},
+                        t2SpColDefs,
+                        new ColumnPK[]{new ColumnPK("c6", 1)},
+                        ""));
+        return spSchema;
+    }
+
+    @Test
+    public void testGetSpannerTableName() {
+        String srcTableName = "cart";
+        String result = mapper.getSpannerTableName(srcTableName);
+        String expectedTableName = "new_cart";
+        assertEquals(expectedTableName, result);
+
+        srcTableName = "people";
+        result = mapper.getSpannerTableName(srcTableName);
+        expectedTableName = "new_people";
+        assertEquals(expectedTableName, result);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testGetSpannerTableNameMissingTable() {
+        String srcTable = "wrongTableName";
+        mapper.getSpannerTableName(srcTable);
+    }
+
+    @Test
+    public void testGetSpannerColumnName() {
+        String srcTable = "cart";
+        String srcColumn = "user_id";
+        String result = mapper.getSpannerColumnName(srcTable, srcColumn);
+        String expectedColumn = "new_user_id";
+        assertEquals(expectedColumn, result);
+
+        srcTable = "cart";
+        srcColumn = "quantity";
+        result = mapper.getSpannerColumnName(srcTable, srcColumn);
+        expectedColumn = "new_quantity";
+        assertEquals(expectedColumn, result);
+
+
+        srcTable = "people";
+        srcColumn = "name";
+        result = mapper.getSpannerColumnName(srcTable, srcColumn);
+        expectedColumn = "new_name";
+        assertEquals(expectedColumn, result);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testGetSpannerColumnNameMissingTable() {
+        String srcTable = "wrongTableName";
+        String srcColumn = "user_id";
+        mapper.getSpannerColumnName(srcTable, srcColumn);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testGetSpannerColumnNameMissingColumn() {
+        String srcTable = "cart";
+        String srcColumn = "wrongColumn";
+        mapper.getSpannerColumnName(srcTable, srcColumn);
+    }
+
+    @Test
+    public void testGetSourceColumnName() {
+        String spannerTable = "new_cart";
+        String spannerColumn = "new_quantity";
+        String result = mapper.getSourceColumnName(spannerTable, spannerColumn);
+        String srcColumn = "quantity";
+        assertEquals(srcColumn, result);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testGetSourceColumnNameMissingTable() {
+        String spannerTable = "wrongTableName";
+        String spannerColumn = "new_quantity";
+        mapper.getSourceColumnName(spannerTable, spannerColumn);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testGetSourceColumnNameMissingColumn() {
+        String spannerTable = "new_cart";
+        String spannerColumn = "wrongColumn";
+        mapper.getSourceColumnName(spannerTable, spannerColumn);
+    }
+
+    @Test
+    public void testGetSpannerColumnType() {
+        String spannerTable = "new_cart";
+        String spannerColumn;
+
+        spannerColumn = "new_quantity";
+        Type expectedType = Type.int64();
+        Type result = mapper.getSpannerColumnType(spannerTable, spannerColumn);
+        assertEquals(expectedType, result);
+
+        spannerColumn = "new_user_id";
+        expectedType = Type.string();
+        result = mapper.getSpannerColumnType(spannerTable, spannerColumn);
+        assertEquals(expectedType, result);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testGetSpannerColumnTypeMissingTable() {
+        String spannerTable = "wrongTableName";
+        String spannerColumn = "new_quantity";
+        mapper.getSpannerColumnType(spannerTable, spannerColumn);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testGetSpannerColumnTypeMissingColumn() {
+        String spannerTable = "new_cart";
+        String spannerColumn = "wrongColumn";
+        mapper.getSpannerColumnType(spannerTable, spannerColumn);
+    }
+
+    @Test
+    public void testGetSpannerColumns() {
+        String spannerTable = "new_cart";
+        List<String> expectedColumns = Arrays.asList("new_quantity", "new_user_id");
+        List<String> result = mapper.getSpannerColumns(spannerTable);
+        Collections.sort(result);
+        Collections.sort(expectedColumns);
+        assertEquals(expectedColumns, result);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testGetSpannerColumnsMissingTable() {
+        String spannerTable = "wrongTableName";
+        mapper.getSpannerColumns(spannerTable);
+    }
+}

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SessionBasedMapperTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SessionBasedMapperTest.java
@@ -15,268 +15,266 @@
  */
 package com.google.cloud.teleport.v2.spanner.migrations.schema;
 
+import static org.junit.Assert.assertEquals;
+
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.type.Type;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-
-import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
 
 public class SessionBasedMapperTest {
 
-    SessionBasedMapper mapper;
+  SessionBasedMapper mapper;
 
-    @Before
-    public void setup() {
-        Ddl ddl =
-                Ddl.builder()
-                        .createTable("new_cart")
-                        .column("new_quantity")
-                        .int64()
-                        .notNull()
-                        .endColumn()
-                        .column("new_user_id")
-                        .string()
-                        .size(10)
-                        .endColumn()
-                        .primaryKey()
-                        .asc("new_user_id")
-                        .asc("new_quantity")
-                        .end()
-                        .endTable()
-                        .createTable("new_people")
-                        .column("synth_id")
-                        .int64()
-                        .notNull()
-                        .endColumn()
-                        .column("new_name")
-                        .string()
-                        .size(10)
-                        .endColumn()
-                        .primaryKey()
-                        .asc("synth_id")
-                        .end()
-                        .endTable()
-                        .build();
-        this.mapper = new SessionBasedMapper(getSchemaObject(), ddl);
-    }
+  @Before
+  public void setup() {
+    Ddl ddl =
+        Ddl.builder()
+            .createTable("new_cart")
+            .column("new_quantity")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("new_user_id")
+            .string()
+            .size(10)
+            .endColumn()
+            .primaryKey()
+            .asc("new_user_id")
+            .asc("new_quantity")
+            .end()
+            .endTable()
+            .createTable("new_people")
+            .column("synth_id")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("new_name")
+            .string()
+            .size(10)
+            .endColumn()
+            .primaryKey()
+            .asc("synth_id")
+            .end()
+            .endTable()
+            .build();
+    this.mapper = new SessionBasedMapper(getSchemaObject(), ddl);
+  }
 
-    private static Schema getSchemaObject() {
-        // Add Synthetic PKs.
-        Map<String, SyntheticPKey> syntheticPKeys = getSyntheticPks();
-        // Add SrcSchema.
-        Map<String, SourceTable> srcSchema = getSampleSrcSchema();
-        // Add SpSchema.
-        Map<String, SpannerTable> spSchema = getSampleSpSchema();
-        Schema expectedSchema = new Schema(spSchema, syntheticPKeys, srcSchema);
-        expectedSchema.setToSpanner(new HashMap<String, NameAndCols>());
-        expectedSchema.setToSource(new HashMap<String, NameAndCols>());
-        expectedSchema.setSrcToID(new HashMap<String, NameAndCols>());
-        expectedSchema.setSpannerToID(new HashMap<String, NameAndCols>());
-        expectedSchema.generateMappings();
-        return expectedSchema;
-    }
+  private static Schema getSchemaObject() {
+    // Add Synthetic PKs.
+    Map<String, SyntheticPKey> syntheticPKeys = getSyntheticPks();
+    // Add SrcSchema.
+    Map<String, SourceTable> srcSchema = getSampleSrcSchema();
+    // Add SpSchema.
+    Map<String, SpannerTable> spSchema = getSampleSpSchema();
+    Schema expectedSchema = new Schema(spSchema, syntheticPKeys, srcSchema);
+    expectedSchema.setToSpanner(new HashMap<String, NameAndCols>());
+    expectedSchema.setToSource(new HashMap<String, NameAndCols>());
+    expectedSchema.setSrcToID(new HashMap<String, NameAndCols>());
+    expectedSchema.setSpannerToID(new HashMap<String, NameAndCols>());
+    expectedSchema.generateMappings();
+    return expectedSchema;
+  }
 
-    private static Map<String, SyntheticPKey> getSyntheticPks() {
-        Map<String, SyntheticPKey> syntheticPKeys = new HashMap<String, SyntheticPKey>();
-        syntheticPKeys.put("t2", new SyntheticPKey("c6", 0));
-        return syntheticPKeys;
-    }
+  private static Map<String, SyntheticPKey> getSyntheticPks() {
+    Map<String, SyntheticPKey> syntheticPKeys = new HashMap<String, SyntheticPKey>();
+    syntheticPKeys.put("t2", new SyntheticPKey("c6", 0));
+    return syntheticPKeys;
+  }
 
-    private static Map<String, SourceTable> getSampleSrcSchema() {
-        Map<String, SourceTable> srcSchema = new HashMap<String, SourceTable>();
-        Map<String, SourceColumnDefinition> t1SrcColDefs =
-                new HashMap<String, SourceColumnDefinition>();
-        t1SrcColDefs.put(
-                "c1",
-                new SourceColumnDefinition(
-                        "product_id", new SourceColumnType("varchar", new Long[]{20L}, null)));
-        t1SrcColDefs.put(
-                "c2", new SourceColumnDefinition("quantity", new SourceColumnType("bigint", null, null)));
-        t1SrcColDefs.put(
-                "c3",
-                new SourceColumnDefinition(
-                        "user_id", new SourceColumnType("varchar", new Long[]{20L}, null)));
-        srcSchema.put(
-                "t1",
-                new SourceTable(
-                        "cart",
-                        "my_schema",
-                        new String[]{"c3", "c1", "c2"},
-                        t1SrcColDefs,
-                        new ColumnPK[]{new ColumnPK("c3", 1), new ColumnPK("c1", 2)}));
-        Map<String, SourceColumnDefinition> t2SrcColDefs =
-                new HashMap<String, SourceColumnDefinition>();
-        t2SrcColDefs.put(
-                "c5",
-                new SourceColumnDefinition(
-                        "name", new SourceColumnType("varchar", new Long[]{20L}, null)));
-        srcSchema.put(
-                "t2", new SourceTable("people", "my_schema", new String[]{"c5"}, t2SrcColDefs, null));
-        return srcSchema;
-    }
+  private static Map<String, SourceTable> getSampleSrcSchema() {
+    Map<String, SourceTable> srcSchema = new HashMap<String, SourceTable>();
+    Map<String, SourceColumnDefinition> t1SrcColDefs =
+        new HashMap<String, SourceColumnDefinition>();
+    t1SrcColDefs.put(
+        "c1",
+        new SourceColumnDefinition(
+            "product_id", new SourceColumnType("varchar", new Long[] {20L}, null)));
+    t1SrcColDefs.put(
+        "c2", new SourceColumnDefinition("quantity", new SourceColumnType("bigint", null, null)));
+    t1SrcColDefs.put(
+        "c3",
+        new SourceColumnDefinition(
+            "user_id", new SourceColumnType("varchar", new Long[] {20L}, null)));
+    srcSchema.put(
+        "t1",
+        new SourceTable(
+            "cart",
+            "my_schema",
+            new String[] {"c3", "c1", "c2"},
+            t1SrcColDefs,
+            new ColumnPK[] {new ColumnPK("c3", 1), new ColumnPK("c1", 2)}));
+    Map<String, SourceColumnDefinition> t2SrcColDefs =
+        new HashMap<String, SourceColumnDefinition>();
+    t2SrcColDefs.put(
+        "c5",
+        new SourceColumnDefinition(
+            "name", new SourceColumnType("varchar", new Long[] {20L}, null)));
+    srcSchema.put(
+        "t2", new SourceTable("people", "my_schema", new String[] {"c5"}, t2SrcColDefs, null));
+    return srcSchema;
+  }
 
-    private static Map<String, SpannerTable> getSampleSpSchema() {
-        Map<String, SpannerTable> spSchema = new HashMap<String, SpannerTable>();
-        Map<String, SpannerColumnDefinition> t1SpColDefs =
-                new HashMap<String, SpannerColumnDefinition>();
-        t1SpColDefs.put(
-                "c2", new SpannerColumnDefinition("new_quantity", new SpannerColumnType("INT64", false)));
-        t1SpColDefs.put(
-                "c3", new SpannerColumnDefinition("new_user_id", new SpannerColumnType("STRING", false)));
-        spSchema.put(
-                "t1",
-                new SpannerTable(
-                        "new_cart",
-                        new String[]{"c2", "c3"},
-                        t1SpColDefs,
-                        new ColumnPK[]{new ColumnPK("c3", 1), new ColumnPK("c2", 2)},
-                        ""));
-        Map<String, SpannerColumnDefinition> t2SpColDefs =
-                new HashMap<String, SpannerColumnDefinition>();
-        t2SpColDefs.put(
-                "c5", new SpannerColumnDefinition("new_name", new SpannerColumnType("STRING", false)));
-        t2SpColDefs.put(
-                "c6", new SpannerColumnDefinition("synth_id", new SpannerColumnType("INT64", false)));
-        spSchema.put(
-                "t2",
-                new SpannerTable(
-                        "new_people",
-                        new String[]{"c5", "c6"},
-                        t2SpColDefs,
-                        new ColumnPK[]{new ColumnPK("c6", 1)},
-                        ""));
-        return spSchema;
-    }
+  private static Map<String, SpannerTable> getSampleSpSchema() {
+    Map<String, SpannerTable> spSchema = new HashMap<String, SpannerTable>();
+    Map<String, SpannerColumnDefinition> t1SpColDefs =
+        new HashMap<String, SpannerColumnDefinition>();
+    t1SpColDefs.put(
+        "c2", new SpannerColumnDefinition("new_quantity", new SpannerColumnType("INT64", false)));
+    t1SpColDefs.put(
+        "c3", new SpannerColumnDefinition("new_user_id", new SpannerColumnType("STRING", false)));
+    spSchema.put(
+        "t1",
+        new SpannerTable(
+            "new_cart",
+            new String[] {"c2", "c3"},
+            t1SpColDefs,
+            new ColumnPK[] {new ColumnPK("c3", 1), new ColumnPK("c2", 2)},
+            ""));
+    Map<String, SpannerColumnDefinition> t2SpColDefs =
+        new HashMap<String, SpannerColumnDefinition>();
+    t2SpColDefs.put(
+        "c5", new SpannerColumnDefinition("new_name", new SpannerColumnType("STRING", false)));
+    t2SpColDefs.put(
+        "c6", new SpannerColumnDefinition("synth_id", new SpannerColumnType("INT64", false)));
+    spSchema.put(
+        "t2",
+        new SpannerTable(
+            "new_people",
+            new String[] {"c5", "c6"},
+            t2SpColDefs,
+            new ColumnPK[] {new ColumnPK("c6", 1)},
+            ""));
+    return spSchema;
+  }
 
-    @Test
-    public void testGetSpannerTableName() {
-        String srcTableName = "cart";
-        String result = mapper.getSpannerTableName(srcTableName);
-        String expectedTableName = "new_cart";
-        assertEquals(expectedTableName, result);
+  @Test
+  public void testGetSpannerTableName() {
+    String srcTableName = "cart";
+    String result = mapper.getSpannerTableName(srcTableName);
+    String expectedTableName = "new_cart";
+    assertEquals(expectedTableName, result);
 
-        srcTableName = "people";
-        result = mapper.getSpannerTableName(srcTableName);
-        expectedTableName = "new_people";
-        assertEquals(expectedTableName, result);
-    }
+    srcTableName = "people";
+    result = mapper.getSpannerTableName(srcTableName);
+    expectedTableName = "new_people";
+    assertEquals(expectedTableName, result);
+  }
 
-    @Test(expected = NoSuchElementException.class)
-    public void testGetSpannerTableNameMissingTable() {
-        String srcTable = "wrongTableName";
-        mapper.getSpannerTableName(srcTable);
-    }
+  @Test(expected = NoSuchElementException.class)
+  public void testGetSpannerTableNameMissingTable() {
+    String srcTable = "wrongTableName";
+    mapper.getSpannerTableName(srcTable);
+  }
 
-    @Test
-    public void testGetSpannerColumnName() {
-        String srcTable = "cart";
-        String srcColumn = "user_id";
-        String result = mapper.getSpannerColumnName(srcTable, srcColumn);
-        String expectedColumn = "new_user_id";
-        assertEquals(expectedColumn, result);
+  @Test
+  public void testGetSpannerColumnName() {
+    String srcTable = "cart";
+    String srcColumn = "user_id";
+    String result = mapper.getSpannerColumnName(srcTable, srcColumn);
+    String expectedColumn = "new_user_id";
+    assertEquals(expectedColumn, result);
 
-        srcTable = "cart";
-        srcColumn = "quantity";
-        result = mapper.getSpannerColumnName(srcTable, srcColumn);
-        expectedColumn = "new_quantity";
-        assertEquals(expectedColumn, result);
+    srcTable = "cart";
+    srcColumn = "quantity";
+    result = mapper.getSpannerColumnName(srcTable, srcColumn);
+    expectedColumn = "new_quantity";
+    assertEquals(expectedColumn, result);
 
+    srcTable = "people";
+    srcColumn = "name";
+    result = mapper.getSpannerColumnName(srcTable, srcColumn);
+    expectedColumn = "new_name";
+    assertEquals(expectedColumn, result);
+  }
 
-        srcTable = "people";
-        srcColumn = "name";
-        result = mapper.getSpannerColumnName(srcTable, srcColumn);
-        expectedColumn = "new_name";
-        assertEquals(expectedColumn, result);
-    }
+  @Test(expected = NoSuchElementException.class)
+  public void testGetSpannerColumnNameMissingTable() {
+    String srcTable = "wrongTableName";
+    String srcColumn = "user_id";
+    mapper.getSpannerColumnName(srcTable, srcColumn);
+  }
 
-    @Test(expected = NoSuchElementException.class)
-    public void testGetSpannerColumnNameMissingTable() {
-        String srcTable = "wrongTableName";
-        String srcColumn = "user_id";
-        mapper.getSpannerColumnName(srcTable, srcColumn);
-    }
+  @Test(expected = NoSuchElementException.class)
+  public void testGetSpannerColumnNameMissingColumn() {
+    String srcTable = "cart";
+    String srcColumn = "wrongColumn";
+    mapper.getSpannerColumnName(srcTable, srcColumn);
+  }
 
-    @Test(expected = NoSuchElementException.class)
-    public void testGetSpannerColumnNameMissingColumn() {
-        String srcTable = "cart";
-        String srcColumn = "wrongColumn";
-        mapper.getSpannerColumnName(srcTable, srcColumn);
-    }
+  @Test
+  public void testGetSourceColumnName() {
+    String spannerTable = "new_cart";
+    String spannerColumn = "new_quantity";
+    String result = mapper.getSourceColumnName(spannerTable, spannerColumn);
+    String srcColumn = "quantity";
+    assertEquals(srcColumn, result);
+  }
 
-    @Test
-    public void testGetSourceColumnName() {
-        String spannerTable = "new_cart";
-        String spannerColumn = "new_quantity";
-        String result = mapper.getSourceColumnName(spannerTable, spannerColumn);
-        String srcColumn = "quantity";
-        assertEquals(srcColumn, result);
-    }
+  @Test(expected = NoSuchElementException.class)
+  public void testGetSourceColumnNameMissingTable() {
+    String spannerTable = "wrongTableName";
+    String spannerColumn = "new_quantity";
+    mapper.getSourceColumnName(spannerTable, spannerColumn);
+  }
 
-    @Test(expected = NoSuchElementException.class)
-    public void testGetSourceColumnNameMissingTable() {
-        String spannerTable = "wrongTableName";
-        String spannerColumn = "new_quantity";
-        mapper.getSourceColumnName(spannerTable, spannerColumn);
-    }
+  @Test(expected = NoSuchElementException.class)
+  public void testGetSourceColumnNameMissingColumn() {
+    String spannerTable = "new_cart";
+    String spannerColumn = "wrongColumn";
+    mapper.getSourceColumnName(spannerTable, spannerColumn);
+  }
 
-    @Test(expected = NoSuchElementException.class)
-    public void testGetSourceColumnNameMissingColumn() {
-        String spannerTable = "new_cart";
-        String spannerColumn = "wrongColumn";
-        mapper.getSourceColumnName(spannerTable, spannerColumn);
-    }
+  @Test
+  public void testGetSpannerColumnType() {
+    String spannerTable = "new_cart";
+    String spannerColumn;
 
-    @Test
-    public void testGetSpannerColumnType() {
-        String spannerTable = "new_cart";
-        String spannerColumn;
+    spannerColumn = "new_quantity";
+    Type expectedType = Type.int64();
+    Type result = mapper.getSpannerColumnType(spannerTable, spannerColumn);
+    assertEquals(expectedType, result);
 
-        spannerColumn = "new_quantity";
-        Type expectedType = Type.int64();
-        Type result = mapper.getSpannerColumnType(spannerTable, spannerColumn);
-        assertEquals(expectedType, result);
+    spannerColumn = "new_user_id";
+    expectedType = Type.string();
+    result = mapper.getSpannerColumnType(spannerTable, spannerColumn);
+    assertEquals(expectedType, result);
+  }
 
-        spannerColumn = "new_user_id";
-        expectedType = Type.string();
-        result = mapper.getSpannerColumnType(spannerTable, spannerColumn);
-        assertEquals(expectedType, result);
-    }
+  @Test(expected = NoSuchElementException.class)
+  public void testGetSpannerColumnTypeMissingTable() {
+    String spannerTable = "wrongTableName";
+    String spannerColumn = "new_quantity";
+    mapper.getSpannerColumnType(spannerTable, spannerColumn);
+  }
 
-    @Test(expected = NoSuchElementException.class)
-    public void testGetSpannerColumnTypeMissingTable() {
-        String spannerTable = "wrongTableName";
-        String spannerColumn = "new_quantity";
-        mapper.getSpannerColumnType(spannerTable, spannerColumn);
-    }
+  @Test(expected = NoSuchElementException.class)
+  public void testGetSpannerColumnTypeMissingColumn() {
+    String spannerTable = "new_cart";
+    String spannerColumn = "wrongColumn";
+    mapper.getSpannerColumnType(spannerTable, spannerColumn);
+  }
 
-    @Test(expected = NoSuchElementException.class)
-    public void testGetSpannerColumnTypeMissingColumn() {
-        String spannerTable = "new_cart";
-        String spannerColumn = "wrongColumn";
-        mapper.getSpannerColumnType(spannerTable, spannerColumn);
-    }
+  @Test
+  public void testGetSpannerColumns() {
+    String spannerTable = "new_cart";
+    List<String> expectedColumns = Arrays.asList("new_quantity", "new_user_id");
+    List<String> result = mapper.getSpannerColumns(spannerTable);
+    Collections.sort(result);
+    Collections.sort(expectedColumns);
+    assertEquals(expectedColumns, result);
+  }
 
-    @Test
-    public void testGetSpannerColumns() {
-        String spannerTable = "new_cart";
-        List<String> expectedColumns = Arrays.asList("new_quantity", "new_user_id");
-        List<String> result = mapper.getSpannerColumns(spannerTable);
-        Collections.sort(result);
-        Collections.sort(expectedColumns);
-        assertEquals(expectedColumns, result);
-    }
-
-    @Test(expected = NoSuchElementException.class)
-    public void testGetSpannerColumnsMissingTable() {
-        String spannerTable = "wrongTableName";
-        mapper.getSpannerColumns(spannerTable);
-    }
+  @Test(expected = NoSuchElementException.class)
+  public void testGetSpannerColumnsMissingTable() {
+    String spannerTable = "wrongTableName";
+    mapper.getSpannerColumns(spannerTable);
+  }
 }


### PR DESCRIPTION
Contains the session file support in the bulk template using JSON node as the standard format. If we decide to finalise avro, we will update this PR with avro support.

This PR supports:
- Name transformations, synth PK handling and dropped columns using session file.
- Almost all mysql data types except MySQL YEAR and BIT.

This PR does not support:
- Sharding support (shard id population)
- Transformation context