### PR TITLE
Use neo4j version and edition for reset and schema generation

### DIFF
--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/CypherGenerator.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/CypherGenerator.java
@@ -230,7 +230,9 @@ public class CypherGenerator {
 
     if (capabilities.hasNodeKeyConstraints()) {
       cyphers.addAll(getEntityKeyConstraintStatements(labels, keyProperties));
+    }
 
+    if (capabilities.hasNodeUniqueConstraints()) {
       for (String uniqueProperty : uniqueProperties) {
         cyphers.add(
             "CREATE CONSTRAINT IF NOT EXISTS FOR (n:"
@@ -315,7 +317,9 @@ public class CypherGenerator {
                 + ModelUtils.makeSpaceSafeValidNeo4jIdentifier(relKeyProperty)
                 + " IS RELATIONSHIP KEY");
       }
+    }
 
+    if (capabilities.hasRelationshipUniqueConstraints()) {
       for (String uniqueProperty : uniqueProperties) {
         cyphers.add(
             "CREATE CONSTRAINT IF NOT EXISTS FOR ()-[r:"

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/CypherGenerator.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/CypherGenerator.java
@@ -27,6 +27,7 @@ import com.google.cloud.teleport.v2.neo4j.model.job.Target;
 import com.google.cloud.teleport.v2.neo4j.utils.ModelUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -190,19 +191,21 @@ public class CypherGenerator {
    *     com.google.cloud.teleport.v2.neo4j.model.InputRefactoring}
    * @return a list of Cypher schema statements
    */
-  public static Set<String> getIndexAndConstraintsCypherStatements(Target target) {
+  public static Set<String> getIndexAndConstraintsCypherStatements(
+      Target target, Neo4jCapabilities capabilities) {
     TargetType type = target.getType();
     switch (type) {
       case node:
-        return getNodeIndexAndConstraintsCypherStatements(target);
+        return getNodeIndexAndConstraintsCypherStatements(target, capabilities);
       case edge:
-        return getRelationshipIndexAndConstraintsCypherStatements(target);
+        return getRelationshipIndexAndConstraintsCypherStatements(target, capabilities);
       default:
-        throw new IllegalArgumentException(String.format("unexpected target type: %s", type));
+        return Collections.emptySet();
     }
   }
 
-  private static Set<String> getNodeIndexAndConstraintsCypherStatements(Target target) {
+  private static Set<String> getNodeIndexAndConstraintsCypherStatements(
+      Target target, Neo4jCapabilities capabilities) {
     List<String> labels = ModelUtils.getStaticLabels(FragmentType.node, target);
     Set<String> keyProperties =
         filterProperties(
@@ -223,24 +226,32 @@ public class CypherGenerator {
             target,
             (mapping) -> isEntityProperty(mapping, FragmentType.node) && mapping.isIndexed());
 
-    Set<String> cyphers =
-        new LinkedHashSet<>(getEntityKeyConstraintStatements(labels, keyProperties));
-    for (String uniqueProperty : uniqueProperties) {
-      cyphers.add(
-          "CREATE CONSTRAINT IF NOT EXISTS FOR (n:"
-              + StringUtils.join(ModelUtils.makeSpaceSafeValidNeo4jIdentifiers(labels), ":")
-              + ") REQUIRE n."
-              + ModelUtils.makeSpaceSafeValidNeo4jIdentifier(uniqueProperty)
-              + " IS UNIQUE");
+    Set<String> cyphers = new LinkedHashSet<>();
+
+    if (capabilities.hasNodeKeyConstraints()) {
+      cyphers.addAll(getEntityKeyConstraintStatements(labels, keyProperties));
+
+      for (String uniqueProperty : uniqueProperties) {
+        cyphers.add(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:"
+                + StringUtils.join(ModelUtils.makeSpaceSafeValidNeo4jIdentifiers(labels), ":")
+                + ") REQUIRE n."
+                + ModelUtils.makeSpaceSafeValidNeo4jIdentifier(uniqueProperty)
+                + " IS UNIQUE");
+      }
     }
-    for (String mandatoryProperty : mandatoryProperties) {
-      cyphers.add(
-          "CREATE CONSTRAINT IF NOT EXISTS FOR (n:"
-              + StringUtils.join(ModelUtils.makeSpaceSafeValidNeo4jIdentifiers(labels), ":")
-              + ") REQUIRE n."
-              + ModelUtils.makeSpaceSafeValidNeo4jIdentifier(mandatoryProperty)
-              + " IS NOT NULL");
+
+    if (capabilities.hasNodeExistenceConstraints()) {
+      for (String mandatoryProperty : mandatoryProperties) {
+        cyphers.add(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:"
+                + StringUtils.join(ModelUtils.makeSpaceSafeValidNeo4jIdentifiers(labels), ":")
+                + ") REQUIRE n."
+                + ModelUtils.makeSpaceSafeValidNeo4jIdentifier(mandatoryProperty)
+                + " IS NOT NULL");
+      }
     }
+
     for (String indexedProperty : indexedProperties) {
       cyphers.add(
           "CREATE INDEX IF NOT EXISTS FOR (t:"
@@ -253,12 +264,11 @@ public class CypherGenerator {
     return cyphers;
   }
 
-  // TODO: no-op if < 5.7 || not EE for some or all
-
-  private static Set<String> getRelationshipIndexAndConstraintsCypherStatements(Target target) {
-
+  private static Set<String> getRelationshipIndexAndConstraintsCypherStatements(
+      Target target, Neo4jCapabilities capabilities) {
     Set<String> cyphers = new LinkedHashSet<>();
-    if (target.getEdgeNodesMatchMode() == EdgeNodesSaveMode.merge) {
+    if (capabilities.hasNodeKeyConstraints()
+        && target.getEdgeNodesMatchMode() == EdgeNodesSaveMode.merge) {
       cyphers.addAll(
           getEntityKeyConstraintStatements(
               ModelUtils.getStaticLabels(FragmentType.source, target),
@@ -276,6 +286,7 @@ public class CypherGenerator {
                       mapping.getFragmentType() == FragmentType.target
                           && mapping.getRole() == RoleType.key)));
     }
+
     String type = ModelUtils.getStaticType(target);
     Set<String> keyProperties =
         filterProperties(
@@ -295,30 +306,37 @@ public class CypherGenerator {
             (mapping) -> isEntityProperty(mapping, FragmentType.rel) && mapping.isIndexed());
 
     String escapedType = ModelUtils.makeSpaceSafeValidNeo4jIdentifier(type);
-    for (String relKeyProperty : keyProperties) {
-      cyphers.add(
-          "CREATE CONSTRAINT IF NOT EXISTS FOR ()-[r:"
-              + escapedType
-              + "]-() REQUIRE r."
-              + ModelUtils.makeSpaceSafeValidNeo4jIdentifier(relKeyProperty)
-              + " IS RELATIONSHIP KEY");
+    if (capabilities.hasRelationshipKeyConstraints()) {
+      for (String relKeyProperty : keyProperties) {
+        cyphers.add(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR ()-[r:"
+                + escapedType
+                + "]-() REQUIRE r."
+                + ModelUtils.makeSpaceSafeValidNeo4jIdentifier(relKeyProperty)
+                + " IS RELATIONSHIP KEY");
+      }
+
+      for (String uniqueProperty : uniqueProperties) {
+        cyphers.add(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR ()-[r:"
+                + escapedType
+                + "]-() REQUIRE r."
+                + ModelUtils.makeSpaceSafeValidNeo4jIdentifier(uniqueProperty)
+                + " IS UNIQUE");
+      }
     }
-    for (String uniqueProperty : uniqueProperties) {
-      cyphers.add(
-          "CREATE CONSTRAINT IF NOT EXISTS FOR ()-[r:"
-              + escapedType
-              + "]-() REQUIRE r."
-              + ModelUtils.makeSpaceSafeValidNeo4jIdentifier(uniqueProperty)
-              + " IS UNIQUE");
+
+    if (capabilities.hasRelationshipExistenceConstraints()) {
+      for (String mandatoryProperty : mandatoryProperties) {
+        cyphers.add(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR ()-[r:"
+                + escapedType
+                + "]-() REQUIRE r."
+                + ModelUtils.makeSpaceSafeValidNeo4jIdentifier(mandatoryProperty)
+                + " IS NOT NULL");
+      }
     }
-    for (String mandatoryProperty : mandatoryProperties) {
-      cyphers.add(
-          "CREATE CONSTRAINT IF NOT EXISTS FOR ()-[r:"
-              + escapedType
-              + "]-() REQUIRE r."
-              + ModelUtils.makeSpaceSafeValidNeo4jIdentifier(mandatoryProperty)
-              + " IS NOT NULL");
-    }
+
     for (String indexedProperty : indexedProperties) {
       cyphers.add(
           "CREATE INDEX IF NOT EXISTS FOR ()-[r:"

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilities.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilities.java
@@ -24,7 +24,7 @@ public final class Neo4jCapabilities implements Serializable {
   private final Neo4jVersion version;
   private final Neo4jEdition edition;
 
-  Neo4jCapabilities(String version, String edition) {
+  public Neo4jCapabilities(String version, String edition) {
     this.version = Neo4jVersion.of(version);
     this.edition = Neo4jEdition.of(version, edition);
     this.versionString = String.format("Neo4j %s %s", version, edition);

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilities.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilities.java
@@ -38,8 +38,16 @@ public final class Neo4jCapabilities implements Serializable {
     return hasConstraints();
   }
 
+  public boolean hasNodeUniqueConstraints() {
+    return hasConstraints();
+  }
+
   public boolean hasRelationshipKeyConstraints() {
     return hasConstraints() && version == Neo4jVersion.V5;
+  }
+
+  public boolean hasRelationshipUniqueConstraints() {
+    return hasRelationshipKeyConstraints();
   }
 
   public boolean hasNodeExistenceConstraints() {

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilities.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilities.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.neo4j.database;
+
+import java.io.Serializable;
+import java.util.Locale;
+
+public final class Neo4jCapabilities implements Serializable {
+
+  private final String versionString;
+  private final Neo4jVersion version;
+  private final Neo4jEdition edition;
+
+  Neo4jCapabilities(String version, String edition) {
+    this.version = Neo4jVersion.of(version);
+    this.edition = Neo4jEdition.of(version, edition);
+    this.versionString = String.format("Neo4j %s %s", version, edition);
+  }
+
+  public boolean hasConstraints() {
+    return edition != Neo4jEdition.COMMUNITY;
+  }
+
+  public boolean hasNodeKeyConstraints() {
+    return hasConstraints();
+  }
+
+  public boolean hasRelationshipKeyConstraints() {
+    return hasConstraints() && version == Neo4jVersion.V5;
+  }
+
+  public boolean hasNodeExistenceConstraints() {
+    return hasConstraints();
+  }
+
+  public boolean hasRelationshipExistenceConstraints() {
+    return hasConstraints();
+  }
+
+  public boolean hasCreateOrReplaceDatabase() {
+    return edition == Neo4jEdition.ENTERPRISE;
+  }
+
+  @Override
+  public String toString() {
+    return versionString;
+  }
+
+  enum Neo4jEdition {
+    COMMUNITY,
+    ENTERPRISE,
+    AURA;
+
+    public static Neo4jEdition of(String version, String edition) {
+      if (version.toLowerCase(Locale.ROOT).endsWith("-aura")) {
+        return AURA;
+      }
+
+      return Neo4jEdition.valueOf(edition.toUpperCase(Locale.ROOT));
+    }
+  }
+
+  enum Neo4jVersion {
+    UNKNOWN,
+    V4_4,
+    V5;
+
+    public static Neo4jVersion of(String version) {
+      if (version.startsWith("4.4")) {
+        return V4_4;
+      } else if (version.startsWith("5.")) {
+        return V5;
+      } else {
+        return UNKNOWN;
+      }
+    }
+  }
+}

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnection.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnection.java
@@ -154,8 +154,8 @@ public class Neo4jConnection implements AutoCloseable, Serializable {
           LOG.info("Dropping constraint {}", constraint);
 
           executeCypher(
-              "DROP CONSTRAINT $name",
-              Map.of("name", constraint),
+              String.format("DROP CONSTRAINT `%s`", constraint),
+              Map.of(),
               databaseResetMetadata("drop-constraint"));
         }
       }
@@ -172,7 +172,7 @@ public class Neo4jConnection implements AutoCloseable, Serializable {
         LOG.info("Dropping index {}", index);
 
         executeCypher(
-            "DROP INDEX $name", Map.of("name", index), databaseResetMetadata("drop-index"));
+            String.format("DROP INDEX `%s`", index), Map.of(), databaseResetMetadata("drop-index"));
       }
     }
   }

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/CypherGeneratorTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/CypherGeneratorTest.java
@@ -109,19 +109,69 @@ public class CypherGeneratorTest {
   }
 
   @Test
-  public void generatesNodeKeyConstraintsWhenMergingEdgeAndItsNodes() {
+  public void
+      generatesCorrectSchemaStatementsForNodeKeyConstraintsWhenMergingEdgeAndItsNodesOnNeo4j5Enterprise() {
+    assertCorrectSchemaStatementsForNodeKeyConstraintsWhenMergingEdgeAndItsNodes(
+        capabilitiesFor("5.1.0", "enterprise"),
+        Set.of(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source) REQUIRE n.src_id IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target) REQUIRE n.tgt_id IS NODE KEY"));
+  }
+
+  @Test
+  public void
+      generatesCorrectSchemaStatementsForNodeKeyConstraintsWhenMergingEdgeAndItsNodesOnNeo4j5Aura() {
+    assertCorrectSchemaStatementsForNodeKeyConstraintsWhenMergingEdgeAndItsNodes(
+        capabilitiesFor("5.1-aura", "enterprise"),
+        Set.of(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source) REQUIRE n.src_id IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target) REQUIRE n.tgt_id IS NODE KEY"));
+  }
+
+  @Test
+  public void
+      generatesCorrectSchemaStatementsForNodeKeyConstraintsWhenMergingEdgeAndItsNodesOnNeo4j5Community() {
+    assertCorrectSchemaStatementsForNodeKeyConstraintsWhenMergingEdgeAndItsNodes(
+        capabilitiesFor("5.1.5", "community"), Set.of());
+  }
+
+  @Test
+  public void
+      generatesCorrectSchemaStatementsForNodeKeyConstraintsWhenMergingEdgeAndItsNodesOnNeo4j44Enterprise() {
+    assertCorrectSchemaStatementsForNodeKeyConstraintsWhenMergingEdgeAndItsNodes(
+        capabilitiesFor("4.4.2", "enterprise"),
+        Set.of(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source) REQUIRE n.src_id IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target) REQUIRE n.tgt_id IS NODE KEY"));
+  }
+
+  @Test
+  public void
+      generatesCorrectSchemaStatementsForNodeKeyConstraintsWhenMergingEdgeAndItsNodesOnNeo4j44Aura() {
+    assertCorrectSchemaStatementsForNodeKeyConstraintsWhenMergingEdgeAndItsNodes(
+        capabilitiesFor("4.4-aura", "enterprise"),
+        Set.of(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source) REQUIRE n.src_id IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target) REQUIRE n.tgt_id IS NODE KEY"));
+  }
+
+  @Test
+  public void
+      generatesCorrectSchemaStatementsForNodeKeyConstraintsWhenMergingEdgeAndItsNodesOnNeo4j44Community() {
+    assertCorrectSchemaStatementsForNodeKeyConstraintsWhenMergingEdgeAndItsNodes(
+        capabilitiesFor("4.4.25", "community"), Set.of());
+  }
+
+  private void assertCorrectSchemaStatementsForNodeKeyConstraintsWhenMergingEdgeAndItsNodes(
+      Neo4jCapabilities capabilities, Set<String> expectedStatements) {
     JobSpec jobSpec =
         JobSpecMapper.fromUri(SPEC_PATH + "/single-target-relation-import-merge-all.json");
     Target relationshipTarget = jobSpec.getTargets().iterator().next();
 
     Set<String> statements =
-        CypherGenerator.getIndexAndConstraintsCypherStatements(relationshipTarget);
+        CypherGenerator.getIndexAndConstraintsCypherStatements(relationshipTarget, capabilities);
 
-    assertThat(statements)
-        .isEqualTo(
-            Set.of(
-                "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source) REQUIRE n.src_id IS NODE KEY",
-                "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target) REQUIRE n.tgt_id IS NODE KEY"));
+    assertThat(statements).isEqualTo(expectedStatements);
   }
 
   @Test
@@ -132,7 +182,8 @@ public class CypherGeneratorTest {
     Target relationshipTarget = jobSpec.getTargets().iterator().next();
 
     Set<String> statements =
-        CypherGenerator.getIndexAndConstraintsCypherStatements(relationshipTarget);
+        CypherGenerator.getIndexAndConstraintsCypherStatements(
+            relationshipTarget, capabilitiesFor("5.1.0", "enterprise"));
 
     assertThat(statements)
         .isEqualTo(
@@ -142,42 +193,201 @@ public class CypherGeneratorTest {
   }
 
   @Test
-  public void generatesMultiLabelNodeKeyConstraintsWhenMergingEdgeNodes() {
+  public void
+      generatesCorrectSchemaStatementForMultiLabelNodeKeyConstraintsWhenMergingEdgeNodesOnNeo4j5Enterprise() {
+    assertCorrectSchemaStatementForMultiLabelNodeKeyConstraintsWhenMergingEdgeNodes(
+        capabilitiesFor("5.1.0", "enterprise"),
+        Set.of(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source1) REQUIRE n.src_id IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source2) REQUIRE n.src_id IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target1) REQUIRE n.tgt_id IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target2) REQUIRE n.tgt_id IS NODE KEY"));
+  }
+
+  @Test
+  public void
+      generatesCorrectSchemaStatementForMultiLabelNodeKeyConstraintsWhenMergingEdgeNodesOnNeo4j5Aura() {
+    assertCorrectSchemaStatementForMultiLabelNodeKeyConstraintsWhenMergingEdgeNodes(
+        capabilitiesFor("5.1-aura", "enterprise"),
+        Set.of(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source1) REQUIRE n.src_id IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source2) REQUIRE n.src_id IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target1) REQUIRE n.tgt_id IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target2) REQUIRE n.tgt_id IS NODE KEY"));
+  }
+
+  @Test
+  public void
+      generatesCorrectSchemaStatementForMultiLabelNodeKeyConstraintsWhenMergingEdgeNodesOnNeo4j5Community() {
+    assertCorrectSchemaStatementForMultiLabelNodeKeyConstraintsWhenMergingEdgeNodes(
+        capabilitiesFor("5.1.6", "community"), Set.of());
+  }
+
+  @Test
+  public void
+      generatesCorrectSchemaStatementForMultiLabelNodeKeyConstraintsWhenMergingEdgeNodesOnNeo4j44Enterprise() {
+    assertCorrectSchemaStatementForMultiLabelNodeKeyConstraintsWhenMergingEdgeNodes(
+        capabilitiesFor("4.4.25", "enterprise"),
+        Set.of(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source1) REQUIRE n.src_id IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source2) REQUIRE n.src_id IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target1) REQUIRE n.tgt_id IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target2) REQUIRE n.tgt_id IS NODE KEY"));
+  }
+
+  @Test
+  public void
+      generatesCorrectSchemaStatementForMultiLabelNodeKeyConstraintsWhenMergingEdgeNodesOnNeo4j44Aura() {
+    assertCorrectSchemaStatementForMultiLabelNodeKeyConstraintsWhenMergingEdgeNodes(
+        capabilitiesFor("4.4-aura", "enterprise"),
+        Set.of(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source1) REQUIRE n.src_id IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source2) REQUIRE n.src_id IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target1) REQUIRE n.tgt_id IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target2) REQUIRE n.tgt_id IS NODE KEY"));
+  }
+
+  @Test
+  public void
+      generatesCorrectSchemaStatementForMultiLabelNodeKeyConstraintsWhenMergingEdgeNodesOnNeo4j44Community() {
+    assertCorrectSchemaStatementForMultiLabelNodeKeyConstraintsWhenMergingEdgeNodes(
+        capabilitiesFor("4.4.25", "community"), Set.of());
+  }
+
+  private void assertCorrectSchemaStatementForMultiLabelNodeKeyConstraintsWhenMergingEdgeNodes(
+      Neo4jCapabilities capabilities, Set<String> expectedStatements) {
     JobSpec jobSpec = JobSpecMapper.fromUri(SPEC_PATH + "/multi-label-single-pass-import.json");
     Target relationshipTarget = jobSpec.getTargets().iterator().next();
 
     Set<String> statements =
-        CypherGenerator.getIndexAndConstraintsCypherStatements(relationshipTarget);
+        CypherGenerator.getIndexAndConstraintsCypherStatements(relationshipTarget, capabilities);
 
-    assertThat(statements)
-        .isEqualTo(
-            Set.of(
-                "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source1) REQUIRE n.src_id IS NODE KEY",
-                "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source2) REQUIRE n.src_id IS NODE KEY",
-                "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target1) REQUIRE n.tgt_id IS NODE KEY",
-                "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target2) REQUIRE n.tgt_id IS NODE KEY"));
+    assertThat(statements).isEqualTo(expectedStatements);
   }
 
   @Test
-  public void generatesMultiDistinctKeysNodeKeyConstraintsWhenMergingEdgeNodes() {
+  public void
+      generatesCorrectSchemaStatementForMultiDistinctKeysNodeKeyConstraintsWhenMergingEdgeNodesOnNeo4j5Enterprise() {
+    assertCorrectSchemaStatementsForMultiDistinctKeysNodeKeyConstraintsWhenMergingEdgeNodes(
+        capabilitiesFor("5.1.0", "enterprise"),
+        Set.of(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source) REQUIRE n.src_id1 IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source) REQUIRE n.src_id2 IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target) REQUIRE n.tgt_id1 IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target) REQUIRE n.tgt_id2 IS NODE KEY"));
+  }
+
+  @Test
+  public void
+      generatesCorrectSchemaStatementForMultiDistinctKeysNodeKeyConstraintsWhenMergingEdgeNodesOnNeo4j5Aura() {
+    assertCorrectSchemaStatementsForMultiDistinctKeysNodeKeyConstraintsWhenMergingEdgeNodes(
+        capabilitiesFor("5.1-aura", "enterprise"),
+        Set.of(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source) REQUIRE n.src_id1 IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source) REQUIRE n.src_id2 IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target) REQUIRE n.tgt_id1 IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target) REQUIRE n.tgt_id2 IS NODE KEY"));
+  }
+
+  @Test
+  public void
+      generatesCorrectSchemaStatementForMultiDistinctKeysNodeKeyConstraintsWhenMergingEdgeNodesOnNeo4j5Community() {
+    assertCorrectSchemaStatementsForMultiDistinctKeysNodeKeyConstraintsWhenMergingEdgeNodes(
+        capabilitiesFor("5.1.0", "community"), Set.of());
+  }
+
+  @Test
+  public void
+      generatesCorrectSchemaStatementForMultiDistinctKeysNodeKeyConstraintsWhenMergingEdgeNodesOnNeo4j44Enterprise() {
+    assertCorrectSchemaStatementsForMultiDistinctKeysNodeKeyConstraintsWhenMergingEdgeNodes(
+        capabilitiesFor("4.4.25", "enterprise"),
+        Set.of(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source) REQUIRE n.src_id1 IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source) REQUIRE n.src_id2 IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target) REQUIRE n.tgt_id1 IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target) REQUIRE n.tgt_id2 IS NODE KEY"));
+  }
+
+  @Test
+  public void
+      generatesCorrectSchemaStatementForMultiDistinctKeysNodeKeyConstraintsWhenMergingEdgeNodesOnNeo4j44Aura() {
+    assertCorrectSchemaStatementsForMultiDistinctKeysNodeKeyConstraintsWhenMergingEdgeNodes(
+        capabilitiesFor("4.4-aura", "enterprise"),
+        Set.of(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source) REQUIRE n.src_id1 IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source) REQUIRE n.src_id2 IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target) REQUIRE n.tgt_id1 IS NODE KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target) REQUIRE n.tgt_id2 IS NODE KEY"));
+  }
+
+  @Test
+  public void
+      generatesCorrectSchemaStatementForMultiDistinctKeysNodeKeyConstraintsWhenMergingEdgeNodesOnNeo4j44Community() {
+    assertCorrectSchemaStatementsForMultiDistinctKeysNodeKeyConstraintsWhenMergingEdgeNodes(
+        capabilitiesFor("4.4.25", "community"), Set.of());
+  }
+
+  private void
+      assertCorrectSchemaStatementsForMultiDistinctKeysNodeKeyConstraintsWhenMergingEdgeNodes(
+          Neo4jCapabilities capabilities, Set<String> expectedStatements) {
     JobSpec jobSpec =
         JobSpecMapper.fromUri(SPEC_PATH + "/multi-distinct-keys-single-pass-import.json");
     Target relationshipTarget = jobSpec.getTargets().iterator().next();
 
     Set<String> statements =
-        CypherGenerator.getIndexAndConstraintsCypherStatements(relationshipTarget);
+        CypherGenerator.getIndexAndConstraintsCypherStatements(relationshipTarget, capabilities);
 
-    assertThat(statements)
-        .isEqualTo(
-            Set.of(
-                "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source) REQUIRE n.src_id1 IS NODE KEY",
-                "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Source) REQUIRE n.src_id2 IS NODE KEY",
-                "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target) REQUIRE n.tgt_id1 IS NODE KEY",
-                "CREATE CONSTRAINT IF NOT EXISTS FOR (n:Target) REQUIRE n.tgt_id2 IS NODE KEY"));
+    assertThat(statements).isEqualTo(expectedStatements);
   }
 
   @Test
-  public void doesNotGenerateDuplicateStatementForSelfLinkingNodes() {
+  public void generatesCorrectSchemaStatementsForSelfLinkingNodesOnNeo4j5Enterprise() {
+    assertCorrectSchemaStatementsForSelfLinkingNodes(
+        capabilitiesFor("5.1.0", "enterprise"),
+        Set.of(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR ()-[r:SELF_LINKS_TO]-() REQUIRE r.targetRelProperty IS RELATIONSHIP KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:PlaceholderLabel) REQUIRE n.targetNodeProperty IS NODE KEY"));
+  }
+
+  @Test
+  public void generatesCorrectSchemaStatementsForSelfLinkingNodesOnNeo4j5Aura() {
+    assertCorrectSchemaStatementsForSelfLinkingNodes(
+        capabilitiesFor("5.1-aura", "enterprise"),
+        Set.of(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR ()-[r:SELF_LINKS_TO]-() REQUIRE r.targetRelProperty IS RELATIONSHIP KEY",
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:PlaceholderLabel) REQUIRE n.targetNodeProperty IS NODE KEY"));
+  }
+
+  @Test
+  public void generatesCorrectSchemaStatementsForSelfLinkingNodesOnNeo4j5Community() {
+    assertCorrectSchemaStatementsForSelfLinkingNodes(
+        capabilitiesFor("5.1.0", "community"), Set.of());
+  }
+
+  @Test
+  public void generatesCorrectSchemaStatementsForSelfLinkingNodesOnNeo4j44Enterprise() {
+    assertCorrectSchemaStatementsForSelfLinkingNodes(
+        capabilitiesFor("4.4.25", "enterprise"),
+        Set.of(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:PlaceholderLabel) REQUIRE n.targetNodeProperty IS NODE KEY"));
+  }
+
+  @Test
+  public void generatesCorrectSchemaStatementsForSelfLinkingNodesOnNeo4j44Aura() {
+    assertCorrectSchemaStatementsForSelfLinkingNodes(
+        capabilitiesFor("4.4-aura", "enterprise"),
+        Set.of(
+            "CREATE CONSTRAINT IF NOT EXISTS FOR (n:PlaceholderLabel) REQUIRE n.targetNodeProperty IS NODE KEY"));
+  }
+
+  @Test
+  public void generatesCorrectSchemaStatementsForSelfLinkingNodesOnNeo4j44Community() {
+    assertCorrectSchemaStatementsForSelfLinkingNodes(
+        capabilitiesFor("4.4.25", "community"), Set.of());
+  }
+
+  private void assertCorrectSchemaStatementsForSelfLinkingNodes(
+      Neo4jCapabilities capabilities, Set<String> expectedStatements) {
     Target target = new Target();
     target.setSaveMode(SaveMode.merge);
     target.setEdgeNodesMatchMode(EdgeNodesSaveMode.merge);
@@ -212,13 +422,10 @@ public class CypherGeneratorTest {
     targetKey.setField("source_node_field");
     target.setMappings(List.of(type, key, sourceLabel, sourceKey, targetLabel, targetKey));
 
-    Set<String> schemaStatements = CypherGenerator.getIndexAndConstraintsCypherStatements(target);
+    Set<String> schemaStatements =
+        CypherGenerator.getIndexAndConstraintsCypherStatements(target, capabilities);
 
-    assertThat(schemaStatements)
-        .isEqualTo(
-            Set.of(
-                "CREATE CONSTRAINT IF NOT EXISTS FOR ()-[r:SELF_LINKS_TO]-() REQUIRE r.targetRelProperty IS RELATIONSHIP KEY",
-                "CREATE CONSTRAINT IF NOT EXISTS FOR (n:PlaceholderLabel) REQUIRE n.targetNodeProperty IS NODE KEY"));
+    assertThat(schemaStatements).isEqualTo(expectedStatements);
   }
 
   @Test
@@ -262,5 +469,9 @@ public class CypherGeneratorTest {
     assertThat(importStatement)
         .isEqualTo(
             "UNWIND $rows AS row  MATCH (source:StartNode {targetNodeProperty: row.source_node_field}) MATCH (target:EndNode {targetNodeProperty: row.source_node_field}) MERGE (source)-[rel:LINKS_TO {targetRelProperty: row.source_field}]->(target)");
+  }
+
+  private static Neo4jCapabilities capabilitiesFor(String neo4jVersion, String neo4jEdition) {
+    return new Neo4jCapabilities(neo4jVersion, neo4jEdition);
   }
 }

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnectionTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnectionTest.java
@@ -18,12 +18,16 @@ package com.google.cloud.teleport.v2.neo4j.database;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
@@ -37,6 +41,9 @@ import org.mockito.junit.MockitoRule;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.Values;
+import org.neo4j.driver.internal.InternalRecord;
 
 @RunWith(JUnit4.class)
 public class Neo4jConnectionTest {
@@ -57,7 +64,9 @@ public class Neo4jConnectionTest {
   }
 
   @Test
-  public void resetsDatabaseByRecreatingIt() {
+  public void resetsDatabaseByRecreatingItOnEnterprise() {
+    setVersionEdition("5.1.0", "enterprise");
+
     neo4jConnection.resetDatabase();
 
     verify(session)
@@ -71,7 +80,59 @@ public class Neo4jConnectionTest {
   }
 
   @Test
-  public void resetsDatabaseWithDeletionQueriesWhenReplacementFails() {
+  public void resetsDatabaseByRecreatingItOnAura() {
+    setVersionEdition("5.1-aura", "enterprise");
+    setConstraints("a", "b");
+    setIndexes("c", "d");
+
+    neo4jConnection.resetDatabase();
+
+    InOrder inOrder = inOrder(session);
+    inOrder
+        .verify(session)
+        .run(eq("MATCH (n) CALL { WITH n DETACH DELETE n } IN TRANSACTIONS"), eq(Map.of()), any());
+    inOrder.verify(session).run(eq("SHOW CONSTRAINTS YIELD name"), eq(Map.of()), any());
+    inOrder.verify(session).run(eq("DROP CONSTRAINT $name"), eq(Map.of("name", "a")), any());
+    inOrder.verify(session).run(eq("DROP CONSTRAINT $name"), eq(Map.of("name", "b")), any());
+    inOrder
+        .verify(session)
+        .run(
+            eq("SHOW INDEXES YIELD name, type WHERE type <> 'LOOKUP' RETURN name"),
+            eq(Map.of()),
+            any());
+    inOrder.verify(session).run(eq("DROP INDEX $name"), eq(Map.of("name", "c")), any());
+    inOrder.verify(session).run(eq("DROP INDEX $name"), eq(Map.of("name", "d")), any());
+  }
+
+  @Test
+  public void resetsDatabaseByRecreatingItOnCommunity() {
+    setVersionEdition("5.1.0", "community");
+    setIndexes("c", "d");
+
+    neo4jConnection.resetDatabase();
+
+    InOrder inOrder = inOrder(session);
+    inOrder
+        .verify(session)
+        .run(eq("MATCH (n) CALL { WITH n DETACH DELETE n } IN TRANSACTIONS"), eq(Map.of()), any());
+    inOrder
+        .verify(session)
+        .run(
+            eq("SHOW INDEXES YIELD name, type WHERE type <> 'LOOKUP' RETURN name"),
+            eq(Map.of()),
+            any());
+    inOrder.verify(session).run(eq("DROP INDEX $name"), eq(Map.of("name", "c")), any());
+    inOrder.verify(session).run(eq("DROP INDEX $name"), eq(Map.of("name", "d")), any());
+
+    verify(session, never()).run(contains("CONSTRAINT"), anyMap(), any());
+  }
+
+  @Test
+  public void resetsDatabaseWithDeletionQueriesWhenReplacementFailsOnEnterprise() {
+    setVersionEdition("5.1.0", "enterprise");
+    setConstraints("a", "b");
+    setIndexes("c", "d");
+
     when(session.run(
             eq("CREATE OR REPLACE DATABASE $db WAIT 60 SECONDS"),
             eq(Map.of("db", "a-database")),
@@ -83,13 +144,46 @@ public class Neo4jConnectionTest {
     InOrder inOrder = inOrder(session);
     inOrder
         .verify(session)
-        .run(
-            eq("CREATE OR REPLACE DATABASE $db WAIT 60 SECONDS"),
-            eq(Map.of("db", "a-database")),
-            any());
+        .run(eq("MATCH (n) CALL { WITH n DETACH DELETE n } IN TRANSACTIONS"), eq(Map.of()), any());
+    inOrder.verify(session).run(eq("SHOW CONSTRAINTS YIELD name"), eq(Map.of()), any());
+    inOrder.verify(session).run(eq("DROP CONSTRAINT $name"), eq(Map.of("name", "a")), any());
+    inOrder.verify(session).run(eq("DROP CONSTRAINT $name"), eq(Map.of("name", "b")), any());
     inOrder
         .verify(session)
-        .run(eq("MATCH (n) CALL { WITH n DETACH DELETE n } IN TRANSACTIONS"), eq(Map.of()), any());
-    inOrder.verify(session).run(eq("CALL apoc.schema.assert({}, {}, true)"), eq(Map.of()), any());
+        .run(
+            eq("SHOW INDEXES YIELD name, type WHERE type <> 'LOOKUP' RETURN name"),
+            eq(Map.of()),
+            any());
+    inOrder.verify(session).run(eq("DROP INDEX $name"), eq(Map.of("name", "c")), any());
+    inOrder.verify(session).run(eq("DROP INDEX $name"), eq(Map.of("name", "d")), any());
+  }
+
+  private void setVersionEdition(String version, String edition) {
+    var result = mock(Result.class);
+    when(result.single())
+        .thenReturn(
+            new InternalRecord(
+                List.of("version", "edition"),
+                new Value[] {Values.value(version), Values.value(edition)}));
+
+    when(session.run(contains("dbms.components"), anyMap())).thenReturn(result);
+  }
+
+  private void setConstraints(String... names) {
+    var result = mock(Result.class);
+    when(result.list(any())).thenReturn(Arrays.asList(names));
+
+    when(session.run(eq("SHOW CONSTRAINTS YIELD name"), anyMap(), any())).thenReturn(result);
+  }
+
+  private void setIndexes(String... names) {
+    var result = mock(Result.class);
+    when(result.list(any())).thenReturn(Arrays.asList(names));
+
+    when(session.run(
+            eq("SHOW INDEXES YIELD name, type WHERE type <> 'LOOKUP' RETURN name"),
+            anyMap(),
+            any()))
+        .thenReturn(result);
   }
 }

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnectionTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnectionTest.java
@@ -76,7 +76,8 @@ public class Neo4jConnectionTest {
             any());
     verify(session, never())
         .run(eq("MATCH (n) CALL { WITH n DETACH DELETE n } IN TRANSACTIONS"), anyMap(), any());
-    verify(session, never()).run(eq("CALL apoc.schema.assert({}, {}, true)"), anyMap(), any());
+    verify(session, never()).run(contains("CONSTRAINT"), anyMap(), any());
+    verify(session, never()).run(contains("INDEX"), anyMap(), any());
   }
 
   @Test
@@ -92,16 +93,16 @@ public class Neo4jConnectionTest {
         .verify(session)
         .run(eq("MATCH (n) CALL { WITH n DETACH DELETE n } IN TRANSACTIONS"), eq(Map.of()), any());
     inOrder.verify(session).run(eq("SHOW CONSTRAINTS YIELD name"), eq(Map.of()), any());
-    inOrder.verify(session).run(eq("DROP CONSTRAINT $name"), eq(Map.of("name", "a")), any());
-    inOrder.verify(session).run(eq("DROP CONSTRAINT $name"), eq(Map.of("name", "b")), any());
+    inOrder.verify(session).run(eq("DROP CONSTRAINT `a`"), eq(Map.of()), any());
+    inOrder.verify(session).run(eq("DROP CONSTRAINT `b`"), eq(Map.of()), any());
     inOrder
         .verify(session)
         .run(
             eq("SHOW INDEXES YIELD name, type WHERE type <> 'LOOKUP' RETURN name"),
             eq(Map.of()),
             any());
-    inOrder.verify(session).run(eq("DROP INDEX $name"), eq(Map.of("name", "c")), any());
-    inOrder.verify(session).run(eq("DROP INDEX $name"), eq(Map.of("name", "d")), any());
+    inOrder.verify(session).run(eq("DROP INDEX `c`"), eq(Map.of()), any());
+    inOrder.verify(session).run(eq("DROP INDEX `d`"), eq(Map.of()), any());
   }
 
   @Test
@@ -121,8 +122,8 @@ public class Neo4jConnectionTest {
             eq("SHOW INDEXES YIELD name, type WHERE type <> 'LOOKUP' RETURN name"),
             eq(Map.of()),
             any());
-    inOrder.verify(session).run(eq("DROP INDEX $name"), eq(Map.of("name", "c")), any());
-    inOrder.verify(session).run(eq("DROP INDEX $name"), eq(Map.of("name", "d")), any());
+    inOrder.verify(session).run(eq("DROP INDEX `c`"), eq(Map.of()), any());
+    inOrder.verify(session).run(eq("DROP INDEX `d`"), eq(Map.of()), any());
 
     verify(session, never()).run(contains("CONSTRAINT"), anyMap(), any());
   }
@@ -146,16 +147,16 @@ public class Neo4jConnectionTest {
         .verify(session)
         .run(eq("MATCH (n) CALL { WITH n DETACH DELETE n } IN TRANSACTIONS"), eq(Map.of()), any());
     inOrder.verify(session).run(eq("SHOW CONSTRAINTS YIELD name"), eq(Map.of()), any());
-    inOrder.verify(session).run(eq("DROP CONSTRAINT $name"), eq(Map.of("name", "a")), any());
-    inOrder.verify(session).run(eq("DROP CONSTRAINT $name"), eq(Map.of("name", "b")), any());
+    inOrder.verify(session).run(eq("DROP CONSTRAINT `a`"), eq(Map.of()), any());
+    inOrder.verify(session).run(eq("DROP CONSTRAINT `b`"), eq(Map.of()), any());
     inOrder
         .verify(session)
         .run(
             eq("SHOW INDEXES YIELD name, type WHERE type <> 'LOOKUP' RETURN name"),
             eq(Map.of()),
             any());
-    inOrder.verify(session).run(eq("DROP INDEX $name"), eq(Map.of("name", "c")), any());
-    inOrder.verify(session).run(eq("DROP INDEX $name"), eq(Map.of("name", "d")), any());
+    inOrder.verify(session).run(eq("DROP INDEX `c`"), eq(Map.of()), any());
+    inOrder.verify(session).run(eq("DROP INDEX `d`"), eq(Map.of()), any());
   }
 
   private void setVersionEdition(String version, String edition) {

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/templates/ConstraintsIndicesIT.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/templates/ConstraintsIndicesIT.java
@@ -17,12 +17,17 @@ package com.google.cloud.teleport.v2.neo4j.templates;
 
 import static com.google.cloud.teleport.v2.neo4j.templates.Connections.jsonBasicPayload;
 import static com.google.cloud.teleport.v2.neo4j.templates.Resources.contentOf;
+import static com.google.common.truth.Truth.assertThat;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
 
 import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
 import org.apache.beam.it.common.PipelineLauncher.LaunchInfo;
 import org.apache.beam.it.common.PipelineOperator.Result;
@@ -38,18 +43,25 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-@Category(TemplateIntegrationTest.class)
-@TemplateIntegrationTest(GoogleCloudToNeo4j.class)
-@RunWith(JUnit4.class)
-public class ConstraintsIndicesIT extends TemplateTestBase {
+public abstract class ConstraintsIndicesIT extends TemplateTestBase {
   private Neo4jResourceManager neo4jClient;
+
+  protected abstract String neo4jTagName();
+
+  protected abstract boolean dynamicDatabase();
+
+  protected abstract boolean supportsNodeKeyConstraints();
+
+  protected abstract boolean supportsRelationshipKeyConstraints();
 
   @Before
   public void setup() {
     neo4jClient =
         Neo4jResourceManager.builder(testName)
+            .setDatabaseName(dynamicDatabase() ? null : "neo4j")
             .setAdminPassword("letmein!")
             .setHost(TestProperties.hostIp())
+            .setContainerImageTag(neo4jTagName())
             .build();
   }
 
@@ -79,16 +91,19 @@ public class ConstraintsIndicesIT extends TemplateTestBase {
                     .setQuery(
                         "SHOW CONSTRAINTS YIELD * RETURN entityType, labelsOrTypes, properties")
                     .setExpectedResult(
-                        List.of(
-                            Map.of(
-                                "entityType", "NODE",
-                                "labelsOrTypes", List.of("Person"),
-                                "properties", List.of("id"))))
+                        supportsNodeKeyConstraints()
+                            ? List.of(
+                                Map.of(
+                                    "entityType", "NODE",
+                                    "labelsOrTypes", List.of("Person"),
+                                    "properties", List.of("id")))
+                            : Collections.emptyList())
                     .build(),
                 Neo4jQueryCheck.builder(neo4jClient)
                     .setQuery(
-                        "SHOW INDEXES YIELD * WHERE owningConstraint IS NULL AND type <> 'LOOKUP' RETURN count(*) AS count")
-                    .setExpectedResult(List.of(Map.of("count", 0L)))
+                        "SHOW INDEXES YIELD * WHERE type <> 'LOOKUP' RETURN count(*) AS count")
+                    .setExpectedResult(
+                        List.of(Map.of("count", supportsNodeKeyConstraints() ? 1L : 0L)))
                     .build());
     assertThatResult(result).meetsConditions();
   }
@@ -114,21 +129,216 @@ public class ConstraintsIndicesIT extends TemplateTestBase {
                     .setQuery(
                         "SHOW CONSTRAINTS YIELD * RETURN entityType, labelsOrTypes, properties ORDER BY entityType ASC")
                     .setExpectedResult(
-                        List.of(
-                            Map.of(
-                                "entityType", "NODE",
-                                "labelsOrTypes", List.of("Person"),
-                                "properties", List.of("personId")),
-                            Map.of(
-                                "entityType", "RELATIONSHIP",
-                                "labelsOrTypes", List.of("SELF_LINKS_TO"),
-                                "properties", List.of("id"))))
+                        Stream.of(
+                                supportsNodeKeyConstraints()
+                                    ? Map.of(
+                                        "entityType", "NODE",
+                                        "labelsOrTypes", List.of("Person"),
+                                        "properties", List.of("personId"))
+                                    : null,
+                                supportsRelationshipKeyConstraints()
+                                    ? Map.of(
+                                        "entityType", "RELATIONSHIP",
+                                        "labelsOrTypes", List.of("SELF_LINKS_TO"),
+                                        "properties", List.of("id"))
+                                    : null)
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList()))
                     .build(),
                 Neo4jQueryCheck.builder(neo4jClient)
                     .setQuery(
-                        "SHOW INDEXES YIELD * WHERE owningConstraint IS NULL AND type <> 'LOOKUP' RETURN count(*) AS count")
-                    .setExpectedResult(List.of(Map.of("count", 0L)))
+                        "SHOW INDEXES YIELD * WHERE type <> 'LOOKUP' RETURN count(*) AS count")
+                    .setExpectedResult(
+                        List.of(
+                            Map.of(
+                                "count",
+                                (supportsNodeKeyConstraints() ? 1L : 0L)
+                                    + (supportsRelationshipKeyConstraints() ? 1L : 0L))))
                     .build());
     assertThatResult(result).meetsConditions();
+  }
+
+  @Test
+  public void canResetDatabase() throws Exception {
+    assertThat(
+            neo4jClient.run(
+                "UNWIND range(1, 1000) AS id CREATE (n1:From {id: id})-[:CONNECTED_TO {id: id + 1000}]->(n2:To {id: id + 2000}) RETURN id"))
+        .hasSize(1000);
+    if (supportsNodeKeyConstraints()) {
+      assertThat(neo4jClient.run("CREATE CONSTRAINT FOR (n:From) REQUIRE n.id IS NODE KEY"))
+          .isEmpty();
+      assertThat(neo4jClient.run("CREATE CONSTRAINT FOR (n:To) REQUIRE n.id IS NODE KEY"))
+          .isEmpty();
+    }
+    if (supportsRelationshipKeyConstraints()) {
+      assertThat(
+              neo4jClient.run(
+                  "CREATE CONSTRAINT FOR ()-[r:CONNECTED_TO]-() REQUIRE r.id IS RELATIONSHIP KEY"))
+          .isEmpty();
+    }
+    assertThat(neo4jClient.run("CREATE INDEX FOR (n:From) ON n.name")).isEmpty();
+
+    gcsClient.createArtifact(
+        "spec.json", contentOf("/testing-specs/constraints-indices/reset-database.json"));
+    gcsClient.createArtifact("neo4j.json", jsonBasicPayload(neo4jClient));
+
+    LaunchConfig.Builder options =
+        LaunchConfig.builder(testName, specPath)
+            .addParameter("jobSpecUri", getGcsPath("spec.json"))
+            .addParameter("neo4jConnectionUri", getGcsPath("neo4j.json"));
+    LaunchInfo info = launchTemplate(options);
+
+    assertThatPipeline(info).isRunning();
+    Result result =
+        pipelineOperator()
+            .waitForCondition(
+                createConfig(info),
+                Neo4jQueryCheck.builder(neo4jClient)
+                    .setQuery("MATCH (n:From) RETURN count(n) AS count")
+                    .setExpectedResult(List.of(Map.of("count", 0L)))
+                    .build(),
+                Neo4jQueryCheck.builder(neo4jClient)
+                    .setQuery("MATCH (n:To) RETURN count(n) AS count")
+                    .setExpectedResult(List.of(Map.of("count", 0L)))
+                    .build(),
+                Neo4jQueryCheck.builder(neo4jClient)
+                    .setQuery("MATCH ()-[r:CONNECTED_TO]->() RETURN count(r) AS count")
+                    .setExpectedResult(List.of(Map.of("count", 0L)))
+                    .build(),
+                Neo4jQueryCheck.builder(neo4jClient)
+                    .setQuery(
+                        "SHOW CONSTRAINTS YIELD * RETURN entityType, labelsOrTypes, properties ORDER BY entityType ASC")
+                    .setExpectedResult(
+                        Stream.of(
+                                supportsNodeKeyConstraints()
+                                    ? Map.of(
+                                        "entityType", "NODE",
+                                        "labelsOrTypes", List.of("Person"),
+                                        "properties", List.of("personId"))
+                                    : null,
+                                supportsRelationshipKeyConstraints()
+                                    ? Map.of(
+                                        "entityType", "RELATIONSHIP",
+                                        "labelsOrTypes", List.of("SELF_LINKS_TO"),
+                                        "properties", List.of("id"))
+                                    : null)
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList()))
+                    .build(),
+                Neo4jQueryCheck.builder(neo4jClient)
+                    .setQuery(
+                        "SHOW INDEXES YIELD * WHERE type <> 'LOOKUP' RETURN count(*) AS count")
+                    .setExpectedResult(
+                        List.of(
+                            Map.of(
+                                "count",
+                                (supportsNodeKeyConstraints() ? 1L : 0L)
+                                    + (supportsRelationshipKeyConstraints() ? 1L : 0L))))
+                    .build());
+    assertThatResult(result).meetsConditions();
+  }
+
+  @Category(TemplateIntegrationTest.class)
+  @TemplateIntegrationTest(GoogleCloudToNeo4j.class)
+  @RunWith(JUnit4.class)
+  public static class Neo4j5EnterpriseIT extends ConstraintsIndicesIT {
+
+    @Override
+    protected String neo4jTagName() {
+      return "5-enterprise";
+    }
+
+    @Override
+    protected boolean dynamicDatabase() {
+      return true;
+    }
+
+    @Override
+    protected boolean supportsNodeKeyConstraints() {
+      return true;
+    }
+
+    @Override
+    protected boolean supportsRelationshipKeyConstraints() {
+      return true;
+    }
+  }
+
+  @Category(TemplateIntegrationTest.class)
+  @TemplateIntegrationTest(GoogleCloudToNeo4j.class)
+  @RunWith(JUnit4.class)
+  public static class Neo4j5CommunityIT extends ConstraintsIndicesIT {
+
+    @Override
+    protected String neo4jTagName() {
+      return "5";
+    }
+
+    @Override
+    protected boolean dynamicDatabase() {
+      return false;
+    }
+
+    @Override
+    protected boolean supportsNodeKeyConstraints() {
+      return false;
+    }
+
+    @Override
+    protected boolean supportsRelationshipKeyConstraints() {
+      return false;
+    }
+  }
+
+  @Category(TemplateIntegrationTest.class)
+  @TemplateIntegrationTest(GoogleCloudToNeo4j.class)
+  @RunWith(JUnit4.class)
+  public static class Neo4j44EnterpriseIT extends ConstraintsIndicesIT {
+
+    @Override
+    protected String neo4jTagName() {
+      return "4.4-enterprise";
+    }
+
+    @Override
+    protected boolean dynamicDatabase() {
+      return true;
+    }
+
+    @Override
+    protected boolean supportsNodeKeyConstraints() {
+      return true;
+    }
+
+    @Override
+    protected boolean supportsRelationshipKeyConstraints() {
+      return false;
+    }
+  }
+
+  @Category(TemplateIntegrationTest.class)
+  @TemplateIntegrationTest(GoogleCloudToNeo4j.class)
+  @RunWith(JUnit4.class)
+  public static class Neo4j44CommunityIT extends ConstraintsIndicesIT {
+
+    @Override
+    protected String neo4jTagName() {
+      return "4.4";
+    }
+
+    @Override
+    protected boolean dynamicDatabase() {
+      return false;
+    }
+
+    @Override
+    protected boolean supportsNodeKeyConstraints() {
+      return false;
+    }
+
+    @Override
+    protected boolean supportsRelationshipKeyConstraints() {
+      return false;
+    }
   }
 }

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/transforms/Neo4jRowWriterTransformTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/transforms/Neo4jRowWriterTransformTest.java
@@ -19,7 +19,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.google.cloud.teleport.v2.neo4j.database.Neo4jCapabilities;
 import com.google.cloud.teleport.v2.neo4j.database.Neo4jConnection;
 import com.google.cloud.teleport.v2.neo4j.model.enums.FragmentType;
 import com.google.cloud.teleport.v2.neo4j.model.enums.RoleType;
@@ -35,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.neo4j.driver.TransactionConfig;
 
@@ -42,7 +45,8 @@ public class Neo4jRowWriterTransformTest {
 
   @Test
   public void sendsTransactionMetadataForSchemaInit() {
-    Neo4jConnection connection = mock(Neo4jConnection.class);
+    Neo4jConnection connection = createNeo4j5EnterpriseConnection();
+
     JobSpec jobSpec = new JobSpec();
     Source source = new Source();
     source.setSourceType(SourceType.text);
@@ -72,6 +76,13 @@ public class Neo4jRowWriterTransformTest {
             .withMetadata(Map.of("app", "dataflow", "metadata", expectedTxMetadata))
             .build();
     verify(connection).executeCypher(any(), eq(expectedTransactionConfig));
+  }
+
+  @NotNull
+  private static Neo4jConnection createNeo4j5EnterpriseConnection() {
+    Neo4jConnection connection = mock(Neo4jConnection.class);
+    when(connection.capabilities()).thenReturn(new Neo4jCapabilities("5.1.0", "enterprise"));
+    return connection;
   }
 
   private static Mapping aLabelMapping() {

--- a/v2/googlecloud-to-neo4j/src/test/resources/testing-specs/constraints-indices/reset-database.json
+++ b/v2/googlecloud-to-neo4j/src/test/resources/testing-specs/constraints-indices/reset-database.json
@@ -1,0 +1,51 @@
+{
+  "config": {
+    "reset_db": true,
+    "index_all_properties": false
+  },
+  "sources": [
+    {
+      "type": "text",
+      "format": "EXCEL",
+      "name": "persons",
+      "ordered_field_names": "id,person",
+      "data": [
+        ["0","person0"],
+        ["1","person1"],
+        ["2","person2"],
+        ["3","person3"],
+        ["4","person4"]
+      ]
+    }
+  ],
+  "targets": [
+    {
+      "edge": {
+        "source": "persons",
+        "name": "person import",
+        "mode": "merge",
+        "edge_nodes_match_mode": "merge",
+        "mappings": {
+          "type": "\"SELF_LINKS_TO\"",
+          "source": {
+            "label": "\"Person\"",
+            "key": {
+              "person": "personId"
+            }
+          },
+          "target": {
+            "label": "\"Person\"",
+            "key": {
+              "person": "personId"
+            }
+          },
+          "properties": {
+            "keys": [
+              {"id": "id"}
+            ]
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR introduces neo4j version introspection so that we generate version targeted statements during reset database and schema generation.