### PR TITLE
Fix ARRAY<JSON> and ARRAY<NUMERIC> spanner queries to preserve null and empty array correctly

### DIFF
--- a/v1/src/test/java/com/google/cloud/teleport/spanner/BuildReadFromTableOperationsTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/BuildReadFromTableOperationsTest.java
@@ -44,7 +44,8 @@ public class BuildReadFromTableOperationsTest {
         "t.`colName`",
         buildReadFromTableOperations.createColumnExpression(ddl.table("table").column("colName")));
     assertEquals(
-        "(SELECT ARRAY_AGG(CAST(num AS STRING)) FROM UNNEST(t.`colName1`) AS num) AS colName1",
+        "CASE WHEN t.`colName1` IS NULL THEN NULL ELSE IFNULL((SELECT ARRAY_AGG(CASE WHEN num IS NULL THEN NULL ELSE "
+            + "CAST(num AS STRING) END) FROM UNNEST(t.`colName1`) AS num), []) END AS colName1",
         buildReadFromTableOperations.createColumnExpression(ddl.table("table").column("colName1")));
   }
 
@@ -64,11 +65,11 @@ public class BuildReadFromTableOperationsTest {
             .endTable()
             .build();
     assertEquals(
-        "TO_JSON_STRING(t.`colName`) AS colName",
+        "CASE WHEN t.`colName` IS NULL THEN NULL ELSE TO_JSON_STRING(t.`colName`) END AS colName",
         buildReadFromTableOperations.createColumnExpression(ddl.table("table").column("colName")));
     assertEquals(
-        "(SELECT ARRAY_AGG(TO_JSON_STRING(element)) FROM UNNEST(t.`colName1`) AS element) AS"
-            + " colName1",
+        "CASE WHEN t.`colName1` IS NULL THEN NULL ELSE IFNULL((SELECT ARRAY_AGG(CASE WHEN element IS NULL THEN NULL "
+            + "ELSE TO_JSON_STRING(element) END) FROM UNNEST(t.`colName1`) AS element), []) END AS colName1",
         buildReadFromTableOperations.createColumnExpression(ddl.table("table").column("colName1")));
   }
 


### PR DESCRIPTION
## Description:
When a spanner table has either ARRAY\<JSON> or ARRAY\<NUMERIC> columns, the custom select queries were not preserving empty arrays.

## Expected Behaviour:
When a column has type either ARRAY\<JSON> or ARRAY\<NUMERIC> a `null` row entry should export to avro as `null` and an empty array row entry `[]` should export to avro as empty array `[]`

## Actual Behaviour:
`null` entries are exported as `null`, however empty array `[]` entries are converted to `null`. As per spanner documentation, `null` and empty array `[]` are distinct values. https://cloud.google.com/spanner/docs/reference/standard-sql/data-types#array_nulls

When the ARRAY column is also NOT NULL, then the spanner export to Avro fails with the error:
```
Error message from worker: org.apache.beam.sdk.util.UserCodeException: java.lang.IllegalArgumentException: Unexpected null value for field json_array
```
Because it detects that a `null` value was read from a NOT NULL column.

## Testing Notes:
Create the table:
```
CREATE TABLE
  json_array ( id STRING(MAX) NOT NULL,
    json_array ARRAY<JSON> NOT NULL,
    json_array_nullable ARRAY<JSON>,
    )
PRIMARY KEY
  (id);
```

Enter sample data into the table with mix of `null` and empty array `[]`:
```
insert into json_array(id, json_array, json_array_nullable) values ("1", [], null);
insert into json_array(id, json_array, json_array_nullable) values ("2", [null, JSON '{}', JSON '{"key":"value"}'], []);
```

Check Data:
```
# gcloud spanner databases execute-sql json-array-issue --instance=demo-json-array-issue --project=alainbaxter-gke-lab --sql="select * from json_array"
id  json_array                       json_array_nullable
1   []
2   [None, '{}', '{"key":"value"}']  []
```

Run the export to avro job with this fix, it will be successful now:
```
export PROJECT=alainbaxter-gke-lab
export BUCKET_NAME=alainbaxter-testing-bucket
export REGION=northamerica-northeast1
export INSTANCE_ID=demo-json-array-issue
export DATABASE_ID=json-array-issue
export OUTPUT_DIR=gs://$BUCKET_NAME/export
export SPANNER_PROJECT_ID=alainbaxter-gke-lab

gcloud dataflow jobs run "cloud-spanner-to-gcs-avro-job" \
  --project "$PROJECT" \
  --region "$REGION" \
  --gcs-location "gs://$BUCKET_NAME/templates/Cloud_Spanner_to_GCS_Avro" \
  --parameters "instanceId=$INSTANCE_ID" \
  --parameters "databaseId=$DATABASE_ID" \
  --parameters "outputDir=$OUTPUT_DIR" \
  --parameters "spannerProjectId=$SPANNER_PROJECT_ID" \
  --service-account-email=test-sa@alainbaxter-gke-lab.iam.gserviceaccount.com \
  --network=gke-vpc \
  --subnetwork=regions/northamerica-northeast1/subnetworks/na-ne1-subnet \
  --disable-public-ips \
  --worker-machine-type=n2-standard-4
```

Restore from Avro to Spanner into a new instance from the export location:
```
export PROJECT=alainbaxter-gke-lab
export BUCKET_NAME=alainbaxter-testing-bucket
export REGION=northamerica-northeast1
export INSTANCE_ID=demo-json-array-issue-restore
export DATABASE_ID=json-array-issue
export OUTPUT_DIR=gs://$BUCKET_NAME/export
export SPANNER_PROJECT_ID=alainbaxter-gke-lab

gcloud dataflow jobs run "gcs-avro-to-cloud-spanner-job" \
  --project "$PROJECT" \
  --region "$REGION" \
  --gcs-location "gs://$BUCKET_NAME/templates/GCS_Avro_to_Cloud_Spanner" \
  --parameters "instanceId=${INSTANCE_ID}" \
  --parameters "databaseId=$DATABASE_ID" \
  --parameters "inputDir=$OUTPUT_DIR/demo-json-array-issue-json-array-issue-2024-03-26_14_17_03-17351410577973057163" \
  --parameters "spannerProjectId=$SPANNER_PROJECT_ID" \
  --service-account-email=test-sa@alainbaxter-gke-lab.iam.gserviceaccount.com \
  --network=gke-vpc \
  --subnetwork=regions/northamerica-northeast1/subnetworks/na-ne1-subnet \
  --disable-public-ips \
  --worker-machine-type=n2-standard-4
```

Confirm that `null` and empty array `[]` have been preserved:
```
# gcloud spanner databases execute-sql json-array-issue --instance=demo-json-array-issue-restore --project=alainbaxter-gke-lab --sql="select * from json_array"
id  json_array                       json_array_nullable
1   []
2   [None, '{}', '{"key":"value"}']  []
```
