### PR TITLE
Default to THROUGHPUT_BASED autoscaling for classic templates

### DIFF
--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
@@ -259,7 +259,7 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
     arguments.add(element("argument", "--project=" + projectId));
     arguments.add(element("argument", "--region=" + region));
     if (imageSpec.getMetadata().isStreaming()) {
-      // Default autoscaling to THROUGHPUT_BASED for streaming classic templates
+      // Default to THROUGHPUT_BASED autoscaling for streaming classic templates
       arguments.add(element("argument", "--autoscalingAlgorithm=THROUGHPUT_BASED"));
       arguments.add(element("argument", "--maxNumWorkers=5"));
     }

--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
@@ -258,6 +258,11 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
     arguments.add(element("argument", "--templateLocation=" + templatePath));
     arguments.add(element("argument", "--project=" + projectId));
     arguments.add(element("argument", "--region=" + region));
+    if (imageSpec.getMetadata().isStreaming()) {
+      // Default to THROUGHPUT_BASED autoscaling for streaming classic templates
+      arguments.add(element("argument", "--autoscalingAlgorithm=THROUGHPUT_BASED"));
+      arguments.add(element("argument", "--maxNumWorkers=5"));
+    }
 
     if (gcpTempLocation != null) {
       String gcpTempLocationPath = "gs://" + bucketNameOnly(gcpTempLocation) + "/temp/";

--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
@@ -259,7 +259,7 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
     arguments.add(element("argument", "--project=" + projectId));
     arguments.add(element("argument", "--region=" + region));
     if (imageSpec.getMetadata().isStreaming()) {
-      // Default to THROUGHPUT_BASED autoscaling for streaming classic templates
+      // Default autoscaling to THROUGHPUT_BASED for streaming classic templates
       arguments.add(element("argument", "--autoscalingAlgorithm=THROUGHPUT_BASED"));
       arguments.add(element("argument", "--maxNumWorkers=5"));
     }

--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
@@ -229,7 +229,7 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
    *
    * <p>Step 1: Use the Specs generator to create the metadata files.
    *
-   * <p>Step 2: Use the exec:java plugin to execute the Template class, and passing parameters such
+   * <p>Step 2: Use the exec:java plugin to execute the Template class and pass parameters such
    * that the DataflowRunner knows that it is a Template staging (--stagingLocation,
    * --templateLocation). The class itself is responsible for copying all the dependencies to Cloud
    * Storage and saving the Template file.

--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
@@ -229,7 +229,7 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
    *
    * <p>Step 1: Use the Specs generator to create the metadata files.
    *
-   * <p>Step 2: Use the exec:java plugin to execute the Template class and pass parameters such
+   * <p>Step 2: Use the exec:java plugin to execute the Template class, and passing parameters such
    * that the DataflowRunner knows that it is a Template staging (--stagingLocation,
    * --templateLocation). The class itself is responsible for copying all the dependencies to Cloud
    * Storage and saving the Template file.

--- a/v1/src/test/java/com/google/cloud/teleport/templates/PubSubToSplunkIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/PubSubToSplunkIT.java
@@ -254,7 +254,8 @@ public class PubSubToSplunkIT extends TemplateTestBase {
             .addParameter("token", splunkResourceManager.getHecToken())
             .addParameter("batchCount", "1")
             .addEnvironment("additionalExperiments", experiments)
-            .addEnvironment("enableStreamingEngine", true);
+            .addEnvironment("enableStreamingEngine", true)
+            .addEnvironment("maxWorkers", 10);
     testPubSubToSplunkMain(parameters, false);
   }
 }


### PR DESCRIPTION
Before migrating the release process to GitHub, most streaming classic templates had autoscaling enabled by default. This functionality was lost as part of the move over, and this seeks to restore that default.

This has caused user pain because there's not an easy way to enable autoscaling for classic templates if its not on by default.

Note that I chose 10 workers as the default to avoid overwhelming users projects with high scaling (this happened to our templates project with integration tests when I tried 100) and because it seems like a reasonable default. It will cause streaming engine jobs without a default set to change their behavior (currently they default to 100 max workers)