### PR TITLE
Fail Spanner CDC to BQ jobs that set BQ changelog table to _metadata_spanner_table_name

### DIFF
--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SpannerChangeStreamsToBigQuery.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SpannerChangeStreamsToBigQuery.java
@@ -202,6 +202,14 @@ public final class SpannerChangeStreamsToBigQuery {
     if (options.getDlqRetryMinutes() <= 0) {
       throw new IllegalArgumentException("dlqRetryMinutes must be positive.");
     }
+    if (options
+        .getBigQueryChangelogTableNameTemplate()
+        .equals(BigQueryUtils.BQ_CHANGELOG_FIELD_NAME_TABLE_NAME)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "bigQueryChangelogTableNameTemplate cannot be set to '{%s}'. This value is reserved for the Cloud Spanner table name.",
+              BigQueryUtils.BQ_CHANGELOG_FIELD_NAME_TABLE_NAME));
+    }
 
     BigQueryIOUtils.validateBQStorageApiOptionsStreaming(options);
   }


### PR DESCRIPTION
Verify that user does not set BigQuery changelog table name template to be '{_metadata_spanner_table_name}' as that will cause a `NullPointerException` when attempting to create the BQ tables.