### PR TITLE
Get consistent java-pr signal on main

### DIFF
--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        with:
+          fetch-depth: 2  # setup-env action assumes fetch depth of at least 2 for https://github.com/tj-actions/changed-files?tab=readme-ov-file#on-push-%EF%B8%8F
       - name: Setup Environment
         id: setup-env
         uses: ./.github/actions/setup-env
@@ -55,6 +57,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        with:
+          fetch-depth: 2  # setup-env action assumes fetch depth of at least 2 for https://github.com/tj-actions/changed-files?tab=readme-ov-file#on-push-%EF%B8%8F
       - name: Setup Environment
         id: setup-env
         uses: ./.github/actions/setup-env
@@ -67,6 +71,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        with:
+          fetch-depth: 2  # setup-env action assumes fetch depth of at least 2 for https://github.com/tj-actions/changed-files?tab=readme-ov-file#on-push-%EF%B8%8F
       - name: Setup Environment
         id: setup-env
         uses: ./.github/actions/setup-env
@@ -82,6 +88,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        with:
+          fetch-depth: 2  # setup-env action assumes fetch depth of at least 2 for https://github.com/tj-actions/changed-files?tab=readme-ov-file#on-push-%EF%B8%8F
       - name: Setup Environment
         id: setup-env
         uses: ./.github/actions/setup-env
@@ -111,6 +119,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        with:
+          fetch-depth: 2  # setup-env action assumes fetch depth of at least 2 for https://github.com/tj-actions/changed-files?tab=readme-ov-file#on-push-%EF%B8%8F
       - name: Setup Environment
         id: setup-env
         uses: ./.github/actions/setup-env
@@ -140,6 +150,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        with:
+          fetch-depth: 2  # setup-env action assumes fetch depth of at least 2 for https://github.com/tj-actions/changed-files?tab=readme-ov-file#on-push-%EF%B8%8F
       - name: Setup Environment
         id: setup-env
         uses: ./.github/actions/setup-env
@@ -170,6 +182,8 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      with:
+        fetch-depth: 2  # setup-env action assumes fetch depth of at least 2 for https://github.com/tj-actions/changed-files?tab=readme-ov-file#on-push-%EF%B8%8F
     - name: Setup Environment
       id: setup-env
       uses: ./.github/actions/setup-env


### PR DESCRIPTION
Right now, https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/workflows/java-pr.yml?query=branch%3Amain is perma-red on main. This is because one of the underlying actions in setup-env assumes a checkout depth of 2 or greater - https://github.com/tj-actions/changed-files?tab=readme-ov-file#on-push-%EF%B8%8F - this should fix the problem