### PR TITLE
Fix example for GcsWriteFolder with trailing slash

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/templates/BulkCompressor.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/BulkCompressor.java
@@ -126,7 +126,7 @@ public class BulkCompressor {
         description = "Output file directory in Cloud Storage",
         helpText =
             "The path and filename prefix for writing output files. Must end with a slash. DateTime formatting is used to parse directory path for date & time formatters.",
-        example = "gs://your-bucket/your-path")
+        example = "gs://your-bucket/your-path/")
     @Required
     ValueProvider<String> getOutputDirectory();
 


### PR DESCRIPTION
> Must end with a slash.

Fix the example to fit the help text.