### PR TITLE
Create Beam Version Variable for Dockerfile Template

### DIFF
--- a/plugins/core-plugin/src/main/java/com/google/cloud/teleport/plugin/PythonDockerfileGenerator.java
+++ b/plugins/core-plugin/src/main/java/com/google/cloud/teleport/plugin/PythonDockerfileGenerator.java
@@ -73,7 +73,8 @@ public final class PythonDockerfileGenerator {
       String containerName,
       File targetDirectory,
       File artifactFile,
-      String commandSpec)
+      String commandSpec,
+      String beamVersion)
       throws IOException, TemplateException {
     Configuration freemarkerConfig = new Configuration(Configuration.VERSION_2_3_32);
     freemarkerConfig.setDefaultEncoding("UTF-8");
@@ -86,6 +87,7 @@ public final class PythonDockerfileGenerator {
     parameters.put("baseContainerImage", basePythonContainerImage);
     parameters.put("commandSpec", commandSpec);
     parameters.put("containerName", containerName);
+    parameters.put("beamVersion", beamVersion);
 
     Template template = freemarkerConfig.getTemplate("Dockerfile-xlang-template");
 

--- a/plugins/core-plugin/src/main/resources/Dockerfile-xlang-template
+++ b/plugins/core-plugin/src/main/resources/Dockerfile-xlang-template
@@ -26,7 +26,10 @@ WORKDIR $WORKDIR
 ENV DATAFLOW_JAVA_COMMAND_SPEC=${commandSpec}
 ENV FLEX_TEMPLATE_PYTHON_REQUIREMENTS_FILE=requirements.txt
 
-ENV SITE_PACKAGES=/root/.apache_beam/cache/venvs/py-3.11-beam-2.55.1-da39a3ee5e6b4b0d3255bfef95601890afd80709
+# SHA hash here equates to null and is independent of beam version. This hash is generated based on the values of the
+# .withExtraPackages() call made in the PythonExternalTextTransform class. We do not utilize this function meaning that
+# this hash will remain constant.
+ENV SITE_PACKAGES=/root/.apache_beam/cache/venvs/py-3.11-beam-${beamVersion}-da39a3ee5e6b4b0d3255bfef95601890afd80709
 RUN python -m venv $SITE_PACKAGES
 
 # pip install dependencies and cache wheels

--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
@@ -487,7 +487,8 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
             containerName,
             targetDirectory,
             project.getArtifact().getFile(),
-            xlangCommandSpec);
+            xlangCommandSpec,
+            project.getProperties().getProperty("beam.version"));
       }
       LOG.info("Staging XLANG image using Dockerfile");
       stageXlangUsingDockerfile(imagePath, containerName + "/Dockerfile");


### PR DESCRIPTION
Use the beam version stored within the project definition so that we don't have to change the dockerfile with each update to beam.