### PR TITLE
Implement enum based experiment value provider

### DIFF
--- a/metadata/pom.xml
+++ b/metadata/pom.xml
@@ -44,6 +44,11 @@
       <artifactId>beam-sdks-java-core</artifactId>
       <version>${beam.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
 
     <!-- Testing dependencies -->
     <dependency>

--- a/metadata/src/main/java/com/google/cloud/teleport/metadata/util/EnumBasedExperimentValueProvider.java
+++ b/metadata/src/main/java/com/google/cloud/teleport/metadata/util/EnumBasedExperimentValueProvider.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.metadata.util;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.cloud.teleport.metadata.Template;
+import com.google.common.base.CaseFormat;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/** Converts enum types to {@link org.apache.beam.sdk.options.ExperimentalOptions} values. */
+public class EnumBasedExperimentValueProvider<T extends Enum<T>> {
+
+  /**
+   * An {@link EnumBasedExperimentValueProvider for {@link
+   * com.google.cloud.teleport.metadata.Template.StreamingMode}} values.
+   */
+  public static final EnumBasedExperimentValueProvider<Template.StreamingMode>
+      STREAMING_MODE_ENUM_BASED_EXPERIMENT_VALUE_PROVIDER =
+          of(Template.StreamingMode.class, Template.StreamingMode.UNSPECIFIED);
+
+  /**
+   * Instantiate an {@link EnumBasedExperimentValueProvider}. {@param ignored} configures what enum
+   * values are ignored or invalid, typically UNSPECIFIED values.
+   */
+  public static <T extends Enum<T>> EnumBasedExperimentValueProvider<T> of(
+      Class<T> clazz, T... invalid) {
+    return new EnumBasedExperimentValueProvider<>(clazz, invalid);
+  }
+
+  private final Class<T> clazz;
+  private final String prefix;
+  private final Set<T> invalid = new HashSet<>();
+
+  @SafeVarargs
+  private EnumBasedExperimentValueProvider(Class<T> clazz, T... ignored) {
+    this.clazz = clazz;
+    this.prefix = CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, clazz.getSimpleName());
+    invalid.addAll(Arrays.asList(ignored));
+  }
+
+  /**
+   * A getter for the prefix of the experimental value conversion. This is the {@link
+   * Class#getSimpleName()} converted calling {@link CaseFormat#LOWER_CAMEL} {@link CaseFormat#to}
+   * with {@link CaseFormat#LOWER_UNDERSCORE}.
+   */
+  public String getPrefix() {
+    return this.prefix;
+  }
+
+  /**
+   * Convert a {@param value} to String. Concatenates {@link #getPrefix()} with the {@param value}
+   * converted using {@link CaseFormat#UPPER_UNDERSCORE} to {@link CaseFormat#LOWER_UNDERSCORE},
+   * delimited by '_'.
+   */
+  public String convert(T value) {
+    checkArgument(
+        !invalid.contains(value),
+        String.format(
+            "%s is not a valid value for use with %s",
+            value, EnumBasedExperimentValueProvider.class));
+    String suffix = CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.LOWER_UNDERSCORE, value.name());
+    return prefix + "_" + suffix;
+  }
+}

--- a/metadata/src/test/java/com/google/cloud/teleport/metadata/util/EnumBasedExperimentValueProviderTest.java
+++ b/metadata/src/test/java/com/google/cloud/teleport/metadata/util/EnumBasedExperimentValueProviderTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.metadata.util;
+
+import static com.google.cloud.teleport.metadata.util.EnumBasedExperimentValueProvider.STREAMING_MODE_ENUM_BASED_EXPERIMENT_VALUE_PROVIDER;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.teleport.metadata.Template;
+import org.junit.Test;
+
+/** Tests for {@link EnumBasedExperimentValueProvider}. */
+public class EnumBasedExperimentValueProviderTest {
+  @Test
+  public void givenValidValue_converts() {
+    assertThat(
+            STREAMING_MODE_ENUM_BASED_EXPERIMENT_VALUE_PROVIDER.convert(
+                Template.StreamingMode.AT_LEAST_ONCE))
+        .isEqualTo("streaming_mode_at_least_once");
+    assertThat(
+            STREAMING_MODE_ENUM_BASED_EXPERIMENT_VALUE_PROVIDER.convert(
+                Template.StreamingMode.EXACTLY_ONCE))
+        .isEqualTo("streaming_mode_exactly_once");
+  }
+
+  @Test
+  public void givenInvalidValue_throws() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            STREAMING_MODE_ENUM_BASED_EXPERIMENT_VALUE_PROVIDER.convert(
+                Template.StreamingMode.UNSPECIFIED));
+  }
+}


### PR DESCRIPTION
This PR adds a utility class to the metadata module that converts an enum value to a string in the format compatible for Dataflow experiments. The design goals are to prevent misspelling errors when coding applications of enum values to the corresponding experiment value. The immediate application is for StreamingMode. Future PRs will use this class to apply Dataflow experiments to the default environment.