### PR TITLE
Add python version to setup-env actions

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -41,6 +41,11 @@ inputs:
     description: 'The version of Go to install'
     required: false
     default: '1.21'
+  python-version:
+    type: string
+    description: 'The version of Python to install'
+    required: false
+    default: '3.11'
 outputs:
   changed-files:
     description: 'Comma-separated list of files that were changed'
@@ -73,3 +78,7 @@ runs:
       with:
         cache-key: ${{ inputs.java-cache-key }}
         java-version: ${{ inputs.java-version }}
+    - name: Setup Python
+      uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d
+      with:
+          python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
Add python version to the setup-env actions for cross-language unit tests