### PR TITLE
A small simplification in Bulk Reader tests.

### DIFF
--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/row/SourceRowTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/row/SourceRowTest.java
@@ -29,7 +29,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class SourceRowTest extends TestCase {
   @Test
   public void testSourceRowBuilds() {
-    final String testTableUUID = "fa14a160-2841-42f2-91ee-7929d791f367";
     final String testTable = "testTable";
     final long testReadTime = 1712751118L;
     var schema = SchemaTestUtils.generateTestTableSchema(testTable);
@@ -47,20 +46,17 @@ public class SourceRowTest extends TestCase {
 
   @Test
   public void testSourceRowBuildWithInvalidFieldThrowsNPE() {
-    final String testTableUUID = "fa14a160-2841-42f2-91ee-7929d791f367";
     final String testTable = "testTable";
     final long testReadTime = 1712751118L;
     var schema = SchemaTestUtils.generateTestTableSchema(testTable);
 
     Assert.assertThrows(
         java.lang.NullPointerException.class,
-        () -> {
-          SourceRow sourceRow =
-              SourceRow.builder(schema, testReadTime)
-                  /* Invalid Field */
-                  .setField("middleName", "abc")
-                  .setField("lastName", "def")
-                  .build();
-        });
+        () ->
+            SourceRow.builder(schema, testReadTime)
+                /* Invalid Field */
+                .setField("middleName", "abc")
+                .setField("lastName", "def")
+                .build());
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/transform/AccumulatingTableReaderTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/transform/AccumulatingTableReaderTest.java
@@ -15,26 +15,16 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.transform;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import com.google.cloud.teleport.v2.source.reader.io.row.SourceRow;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableReference;
-import com.google.common.base.Preconditions;
 import java.io.Serializable;
-import java.util.concurrent.atomic.AtomicLong;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
-import org.apache.beam.sdk.transforms.Flatten;
-import org.apache.beam.sdk.transforms.MapElements;
-import org.apache.beam.sdk.transforms.PTransform;
-import org.apache.beam.sdk.transforms.SerializableFunction;
-import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionList;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.TupleTag;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -59,90 +49,13 @@ public class AccumulatingTableReaderTest implements Serializable {
     var accumulatingTableReader =
         readerTransformTestUtils.getTestAccumulatingReader(
             sourceRowTupleTag, sourceTableReferenceTupleTag);
-    PCollection<TestResultType> results =
-        testPipeline
-            .apply("ReaderUnderTest", accumulatingTableReader)
-            .apply(
-                "result mapper",
-                new TestAccumulatorResultTracker(sourceRowTupleTag, sourceTableReferenceTupleTag));
+    PCollectionTuple results = testPipeline.apply("ReaderUnderTest", accumulatingTableReader);
 
-    PAssert.that(results).satisfies(new TestSatisfyFunction(rowCountPerTable, tableCount));
+    PCollection<Long> rowsCount = results.get(sourceRowTupleTag).apply(Count.globally());
+    PAssert.that(rowsCount).containsInAnyOrder(tableCount * rowCountPerTable);
+
+    PAssert.that(results.get(sourceTableReferenceTupleTag))
+        .containsInAnyOrder(readerTransformTestUtils.getSourceTableReferences());
     testPipeline.run();
-  }
-
-  enum TestResultType {
-    SOURCE_ROW,
-    TABLE_COMPLETION
-  }
-
-  static class TestAccumulatorResultTracker
-      extends PTransform<@NonNull PCollectionTuple, @NonNull PCollection<TestResultType>> {
-    private final TupleTag<SourceRow> sourceRowTupleTag;
-    private final TupleTag<SourceTableReference> sourceTableReferenceTupleTag;
-
-    TestAccumulatorResultTracker(
-        TupleTag<SourceRow> sourceRowTupleTag,
-        TupleTag<SourceTableReference> sourceTableReferenceTupleTag) {
-      this.sourceRowTupleTag = sourceRowTupleTag;
-      this.sourceTableReferenceTupleTag = sourceTableReferenceTupleTag;
-    }
-
-    @Override
-    @NonNull
-    public PCollection<TestResultType> expand(@NonNull PCollectionTuple input) {
-      return PCollectionList.of(
-              input
-                  .get(this.sourceTableReferenceTupleTag)
-                  .apply(
-                      "MapTestTableCompletions",
-                      MapElements.via(
-                          new SimpleFunction<SourceTableReference, TestResultType>() {
-                            @Override
-                            public TestResultType apply(SourceTableReference input) {
-                              return TestResultType.TABLE_COMPLETION;
-                            }
-                          })))
-          .and(
-              input
-                  .get(this.sourceRowTupleTag)
-                  .apply(
-                      "MapTestRowOutput",
-                      MapElements.via(
-                          new SimpleFunction<>() {
-                            @Override
-                            public TestResultType apply(SourceRow input) {
-                              return TestResultType.SOURCE_ROW;
-                            }
-                          })))
-          .apply("FlattenMappedTestOutput", Flatten.pCollections());
-    }
-  }
-
-  class TestSatisfyFunction implements SerializableFunction<Iterable<TestResultType>, Void> {
-    private final long rowCountPerTable;
-    private final long tableCount;
-
-    TestSatisfyFunction(long rowCountPerTable, long tableCount) {
-      this.rowCountPerTable = rowCountPerTable;
-      this.tableCount = tableCount;
-    }
-
-    @Override
-    public Void apply(Iterable<TestResultType> input) {
-      Preconditions.checkNotNull(input);
-      AtomicLong resultRowCount = new AtomicLong();
-      AtomicLong resultCompletionCount = new AtomicLong();
-      input.forEach(
-          result -> {
-            if (result.equals(TestResultType.TABLE_COMPLETION)) {
-              resultCompletionCount.getAndIncrement();
-            } else {
-              resultRowCount.getAndIncrement();
-            }
-          });
-      assertThat(resultRowCount.get()).isEqualTo(rowCountPerTable);
-      assertThat(resultCompletionCount.get()).isEqualTo(tableCount);
-      return null;
-    }
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/transform/ReaderTransformTestUtils.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/transform/ReaderTransformTestUtils.java
@@ -50,6 +50,19 @@ public class ReaderTransformTestUtils implements Serializable {
             .collect(ImmutableList.toImmutableList());
   }
 
+  public ImmutableList<SourceTableReference> getSourceTableReferences() {
+    return this.sourceTableSchemas.stream()
+        .map(
+            table ->
+                SourceTableReference.builder()
+                    .setSourceSchemaReference(this.sourceSchemaReference)
+                    .setSourceTableName(table.tableName())
+                    .setSourceTableSchemaUUID(table.tableSchemaUUID())
+                    .setRecordCount(rowCountPerTable)
+                    .build())
+        .collect(ImmutableList.toImmutableList());
+  }
+
   public AccumulatingTableReader getTestAccumulatingReader(
       TupleTag<SourceRow> sourceRowTag, TupleTag<SourceTableReference> sourceTableReferenceTag) {
     AccumulatingTableReader.Builder builder =


### PR DESCRIPTION
This is a quick followup of https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/1439 based on a last minute review with Deep, we figured out an easy simplification of the unit tests.