### PR TITLE
Type mappings for Bulk Reader

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/UnifiedTypeMapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/UnifiedTypeMapper.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping;
+
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.MysqlMappingProvider;
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified.Unsupported;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
+import com.google.common.collect.ImmutableMap;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
+
+/**
+ * Maps the source schema to unified avro type.
+ *
+ * @see <a href = https://cloud.google.com/datastream/docs/unified-types> Mappings of unified types
+ *     to source and destination data types</a>
+ */
+public final class UnifiedTypeMapper {
+
+  /**
+   * A static map of the type mappings for all source database types constructed at class load time.
+   * TODO(vardhanvthigle): Support other mappings beyond Mysql.
+   */
+  private static final ImmutableMap<MapperType, ImmutableMap<String, UnifiedTypeMapping>> mappers =
+      ImmutableMap.of(MapperType.MYSQL, MysqlMappingProvider.getMapping());
+
+  private final MapperType mapperType;
+
+  /**
+   * Constructs the {@link UnifiedTypeMapper}.
+   *
+   * @param mapperType type of the mapping. For example: {@link MapperType#MYSQL}
+   *     <p><b>Note: Currently only {@link MapperType#MYSQL} is supported as {@code mapperType}.</b>
+   */
+  public UnifiedTypeMapper(MapperType mapperType) {
+    Preconditions.checkArgument(
+        mappers.containsKey(mapperType),
+        String.format("Mapper type %s is not supported.", mapperType));
+    this.mapperType = mapperType;
+  }
+
+  /**
+   * Returns the {@link Schema Avro Schema} for the given sourceColumType.
+   *
+   * @param columnType the details of the source column schema as read from information schema.
+   * @return {@link Schema Avro Schema}
+   *     <p><b>Note:</b>
+   *     <p>The Schema returned is always unioned with nullable type irrespective of whether the
+   *     source column has a <code>not null</code> constraint.
+   *     <ol>
+   *       <li>This accommodates cases where a not-null constraint was added by altering a column
+   *           without validation. Refer to <a
+   *           href=https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-DESC-ADD-TABLE-CONSTRAINT>PG
+   *           Alter table documentation</a> for an example.
+   *       <li>Other produces that follow the Unified Mapping, also use nullable union with the
+   *           documented schema
+   *       <li>The <code>reader</code> will not drop null (or any other) values returned by the
+   *           source db that violate the source db's schema constraint. The down stream pipeline
+   *           may choose to transform them, mark them as severe errors, or even write them to
+   *           spanner if spanner schema does not have the same constraint.
+   *     </ol>
+   */
+  public Schema getSchema(SourceColumnType columnType) {
+    Schema schema = getBasicSchema(columnType);
+    return (schema.getType().equals(Schema.Type.NULL))
+        ? schema
+        : SchemaBuilder.builder().unionOf().nullType().and().type(schema).endUnion();
+  }
+
+  private Schema getBasicSchema(SourceColumnType columnType) {
+    return mappers
+        .get(this.mapperType)
+        .getOrDefault(columnType.getName().toUpperCase(), new Unsupported())
+        .getSchema(columnType.getMods(), columnType.getArrayBounds());
+  }
+
+  /** Type of the database for the type mapping. */
+  public enum MapperType {
+    MYSQL,
+    POSTGRESQL,
+    ORACLE,
+    SQLSERVER
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/UnifiedTypeMapping.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/UnifiedTypeMapping.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping;
+
+import javax.annotation.Nullable;
+import org.apache.avro.Schema;
+
+/**
+ * Interface to convert a source schema to {@link Schema Avro Schema} implemented by providers of
+ * various source types, like {@link
+ * com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.MysqlMappingProvider
+ * MysqlMappingProvider}.
+ */
+public interface UnifiedTypeMapping {
+
+  /**
+   * Convert the Source Schema.
+   *
+   * @param mods Parameters like scale, precision are passed through mods. Refer to {@link
+   *     com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType
+   *     SourceColumnType.mods} for more details.
+   * @param arrayBounds Bounds of array types.
+   * @return Schema - {@link Schema Avro Schema}
+   */
+  Schema getSchema(@Nullable Long[] mods, @Nullable Long[] arrayBounds);
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/**
+ * Unified Type mapping for data types supported by various sources.
+ *
+ * @see <a href = https://cloud.google.com/datastream/docs/unified-types> Mappings of unified types
+ *     to source and destination data types</a>
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/MysqlMappingProvider.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/MysqlMappingProvider.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider;
+
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedTypeMapping;
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified.UnifiedMappingProvider;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * Provides a set of {@link org.apache.avro.Schema Avro Schemas} that each of the Mysql database's
+ * type must map into.
+ *
+ * @see <a href = https://cloud.google.com/datastream/docs/unified-types> Mappings of unified types
+ *     to source and destination data types</a>
+ */
+public final class MysqlMappingProvider {
+  // Implementation Detail, ImmutableMap.of(...) supports only upto 10 arguments.
+  private static final ImmutableMap<String, UnifiedTypeMapping> MAPPING =
+      ImmutableMap.<String, UnifiedMappingProvider.Type>builder()
+          .put("BIGINT", UnifiedMappingProvider.Type.LONG)
+          .put("BIGINT UNSIGNED", UnifiedMappingProvider.Type.DECIMAL)
+          .put("BINARY", UnifiedMappingProvider.Type.STRING)
+          .put("BIT", UnifiedMappingProvider.Type.LONG)
+          .put("BLOB", UnifiedMappingProvider.Type.STRING)
+          .put("BOOL", UnifiedMappingProvider.Type.INTEGER)
+          .put("CHAR", UnifiedMappingProvider.Type.STRING)
+          .put("DATE", UnifiedMappingProvider.Type.TIMESTAMP)
+          .put("DateTime", UnifiedMappingProvider.Type.DATETIME)
+          .put("DECIMAL", UnifiedMappingProvider.Type.DECIMAL)
+          .put("DOUBLE", UnifiedMappingProvider.Type.DOUBLE)
+          .put("ENUM", UnifiedMappingProvider.Type.STRING)
+          .put("FLOAT", UnifiedMappingProvider.Type.FLOAT)
+          .put("INTEGER", UnifiedMappingProvider.Type.INTEGER)
+          .put("JSON", UnifiedMappingProvider.Type.JSON)
+          .put("LONGBLOB", UnifiedMappingProvider.Type.STRING)
+          .put("LONGTEXT", UnifiedMappingProvider.Type.STRING)
+          .put("MEDIUMBLOB", UnifiedMappingProvider.Type.STRING)
+          .put("MEDIUMINT", UnifiedMappingProvider.Type.INTEGER)
+          .put("MEDIUMTEXT", UnifiedMappingProvider.Type.STRING)
+          .put("SET", UnifiedMappingProvider.Type.STRING)
+          .put("SMALLINT", UnifiedMappingProvider.Type.INTEGER)
+          .put("TEXT", UnifiedMappingProvider.Type.STRING)
+          .put("TIME", UnifiedMappingProvider.Type.INTERVAL)
+          .put("TIMESTAMP", UnifiedMappingProvider.Type.TIMESTAMP)
+          .put("TINYBLOB", UnifiedMappingProvider.Type.STRING)
+          .put("TINYINT", UnifiedMappingProvider.Type.INTEGER)
+          .put("TINYTEXT", UnifiedMappingProvider.Type.STRING)
+          .put("VARBINARY", UnifiedMappingProvider.Type.STRING)
+          .put("VARCHAR", UnifiedMappingProvider.Type.STRING)
+          .put("YEAR", UnifiedMappingProvider.Type.INTEGER)
+          .put("UNSUPPORTED", UnifiedMappingProvider.Type.UNSUPPORTED)
+          .build()
+          .entrySet()
+          .stream()
+          .map(e -> Map.entry(e.getKey(), UnifiedMappingProvider.getMapping(e.getValue())))
+          .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
+
+  /**
+   * Returns the map of Source Schema to {@link UnifiedTypeMapping} for all supported Mysql types.
+   *
+   * @return Mysql mapping.
+   */
+  public static ImmutableMap<String, UnifiedTypeMapping> getMapping() {
+    return MAPPING;
+  }
+
+  /** Static final class. * */
+  private MysqlMappingProvider() {}
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/**
+ * Unified type mapping for all datasources.
+ *
+ * @see <a href = https://cloud.google.com/datastream/docs/unified-types> Mappings of unified types
+ *     to source and destination data types</a>
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/CustomLogical.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/CustomLogical.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified;
+
+import org.apache.avro.LogicalType;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+
+/**
+ * Wraps Constants for Custom logical types needed by <a
+ * href=https://cloud.google.com/datastream/docs/unified-types>unified types</a>.
+ */
+public final class CustomLogical {
+  public static final class Json {
+    public static final String LOGICAL_TYPE = "json";
+    public static final Schema SCHEMA =
+        new LogicalType(LOGICAL_TYPE).addToSchema(SchemaBuilder.builder().stringType());
+
+    /** Static final class wrapping only constants. * */
+    private Json() {}
+  }
+
+  public static final class Number {
+    public static final String LOGICAL_TYPE = "number";
+    public static final Schema SCHEMA =
+        new LogicalType(LOGICAL_TYPE).addToSchema(SchemaBuilder.builder().stringType());
+
+    /** Static final class wrapping only constants. * */
+    private Number() {}
+  }
+
+  public static class TimeIntervalMicros {
+    public static final String LOGICAL_TYPE = "time-interval-micros";
+    public static final Schema SCHEMA =
+        new LogicalType(LOGICAL_TYPE).addToSchema(SchemaBuilder.builder().longType());
+
+    /** Static final class wrapping only constants. * */
+    private TimeIntervalMicros() {}
+  }
+
+  /** Static final class wrapping only constants. * */
+  private CustomLogical() {}
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/CustomSchema.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/CustomSchema.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified;
+
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+
+/**
+ * Wraps Constants for Custom Schemas needed by <a
+ * href=https://cloud.google.com/datastream/docs/unified-types>unified types</a>.
+ */
+public final class CustomSchema {
+
+  public static final class DateTime {
+    public static final String RECORD_NAME = "datetime";
+    public static final String DATE_FIELD_NAME = "date";
+    public static final String TIME_FIELD_NAME = "time";
+    public static final String TIME_FIELD_LOGICAL_TYPE_NAME = "time-micros";
+    public static final Schema SCHEMA =
+        SchemaBuilder.builder()
+            .record(RECORD_NAME)
+            .fields()
+            .name(DATE_FIELD_NAME)
+            .type(LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT)))
+            .noDefault()
+            .name(TIME_FIELD_NAME)
+            .type(LogicalTypes.timeMicros().addToSchema(Schema.create(Schema.Type.LONG)))
+            .noDefault()
+            .endRecord();
+
+    /** Static final class wrapping only constants. * */
+    private DateTime() {}
+  }
+
+  public static final class Interval {
+    public static final String RECORD_NAME = "interval";
+    public static final String MONTHS_FIELD_NAME = "months";
+    public static final String HOURS_FIELD_NAME = "hours";
+    public static final String MICROS_FIELD_NAME = "micros";
+    public static final Schema SCHEMA =
+        SchemaBuilder.builder()
+            .record(RECORD_NAME)
+            .fields()
+            .name(MONTHS_FIELD_NAME)
+            .type(SchemaBuilder.builder().intType())
+            .noDefault()
+            .name(HOURS_FIELD_NAME)
+            .type(SchemaBuilder.builder().intType())
+            .noDefault()
+            .name(MICROS_FIELD_NAME)
+            .type(SchemaBuilder.builder().longType())
+            .noDefault()
+            .endRecord();
+
+    /** Static final class wrapping only constants. * */
+    private Interval() {}
+  }
+
+  public static final class TimeStampTz {
+    public static final String RECORD_NAME = "timestampTz";
+    public static final String TIMESTAMP_FIELD_NAME = "timestamp";
+    public static final String TIMESTAMP_FIELD_LOGICAL_TYPE_NAME = "timestamp-micros";
+    public static final String OFFSET_FIELD_NAME = "offset";
+    public static final String OFFSET_FIELD_LOGICAL_TYPE_NAME = "time-millis";
+
+    public static final Schema SCHEMA =
+        SchemaBuilder.builder()
+            .record(RECORD_NAME)
+            .fields()
+            .name(TIMESTAMP_FIELD_NAME)
+            .type(LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG)))
+            .noDefault()
+            .name(OFFSET_FIELD_NAME)
+            .type(LogicalTypes.timeMillis().addToSchema(Schema.create(Schema.Type.INT)))
+            .noDefault()
+            .endRecord();
+
+    /** Static final class wrapping only constants. * */
+    private TimeStampTz() {}
+  }
+
+  public static final class TimeTz {
+    public static final String RECORD_NAME = "timeTz";
+    public static final String TIME_FIELD_NAME = "time";
+    public static final String TIME_FIELD_LOGICAL_TYPE_NAME = "time-micros";
+    public static final String OFFSET_FIELD_NAME = "offset";
+    public static final String OFFSET_FIELD_LOGICAL_TYPE_NAME = "time-millis";
+
+    public static final Schema SCHEMA =
+        SchemaBuilder.builder()
+            .record(RECORD_NAME)
+            .fields()
+            .name(TIME_FIELD_NAME)
+            .type(LogicalTypes.timeMicros().addToSchema(Schema.create(Schema.Type.LONG)))
+            .noDefault()
+            .name(OFFSET_FIELD_NAME)
+            .type(LogicalTypes.timeMillis().addToSchema(Schema.create(Schema.Type.INT)))
+            .noDefault()
+            .endRecord();
+
+    /** Static final class wrapping only constants. * */
+    private TimeTz() {}
+  }
+
+  /** Static final class wrapping only constants. * */
+  private CustomSchema() {}
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/Decimal.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/Decimal.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified;
+
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedTypeMapping;
+import com.google.common.base.Preconditions;
+import javax.annotation.Nullable;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.commons.lang3.ArrayUtils;
+
+/**
+ * Generates a <a href=https://avro.apache.org/docs/1.8.2/spec.html#Decimal>Decimal</a> Avro Type.
+ */
+final class Decimal implements UnifiedTypeMapping {
+
+  @Override
+  public Schema getSchema(@Nullable Long[] mods, @Nullable Long[] arrayBounds) {
+    Preconditions.checkArgument(ArrayUtils.isEmpty(arrayBounds), "Arrays are not supported");
+    Preconditions.checkArgument(mods != null, "Decimal type needs precision and scale");
+    Preconditions.checkArgument(mods.length == 2, "Decimal type needs precision and scale");
+    return LogicalTypes.decimal(mods[0].intValue(), mods[1].intValue())
+        .addToSchema(Schema.create(Schema.Type.BYTES));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/SimpleUnifiedTypeMapping.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/SimpleUnifiedTypeMapping.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedTypeMapping;
+import com.google.common.base.Preconditions;
+import javax.annotation.Nullable;
+import org.apache.avro.Schema;
+import org.apache.commons.lang3.ArrayUtils;
+
+/**
+ * Wraps a simple {@link Schema Avro Schema} into the {@link UnifiedTypeMapping} interface. The
+ * {@code SimpleUnifiedTypeMapping} implementation ignores the {@link
+ * com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType mods}. In case you need
+ * to consider the mods in your mapping, you would have to implement the {@link UnifiedTypeMapping}
+ * interface separately, for example {@link Varchar}, or {@link Decimal}.
+ */
+@AutoValue
+abstract class SimpleUnifiedTypeMapping implements UnifiedTypeMapping {
+
+  public static SimpleUnifiedTypeMapping create(Schema schema) {
+    return new AutoValue_SimpleUnifiedTypeMapping(schema);
+  }
+
+  public abstract Schema schema();
+
+  @Override
+  public Schema getSchema(@Nullable Long[] mods, @Nullable Long[] arrayBounds) {
+    Preconditions.checkArgument(ArrayUtils.isEmpty(arrayBounds), "Arrays are not supported");
+    return this.schema();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/UnifiedMappingProvider.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/UnifiedMappingProvider.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified;
+
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedTypeMapping;
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified.CustomLogical.Json;
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified.CustomLogical.Number;
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified.CustomLogical.TimeIntervalMicros;
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified.CustomSchema.DateTime;
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified.CustomSchema.Interval;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+
+/**
+ * Provides a set of {@link Schema Avro Schemas} that each of the source database's type must map
+ * into.
+ *
+ * @see <a href = https://cloud.google.com/datastream/docs/unified-types> Mappings of unified types
+ *     to source and destination data types</a>
+ *     <p><b>Note:</b>
+ *     <p>Most of the type mappings are simple, as in they do not depend on additional parameters
+ *     like length, precision, scale etc. For such mappings, we just wrap the Schema in the {@link
+ *     SimpleUnifiedTypeMapping} imlementation. Types that need to consider length, precision etc
+ *     like {@link Varchar} or {@link Decimal} implement the {@link UnifiedTypeMapping} interface
+ *     separately.
+ */
+public final class UnifiedMappingProvider {
+  public enum Type {
+    BOOLEAN,
+    BYTES,
+    DOUBLE,
+    DATE,
+    DATETIME,
+    DECIMAL,
+    FLOAT,
+    INTEGER,
+    INTERVAL,
+    JSON,
+    LONG,
+    NUMBER,
+    STRING,
+    TIME,
+    TIME_INTERVAL,
+    TIMESTAMP,
+    TIMESTAMP_WITH_TIME_ZONE,
+    TIME_WITH_TIME_ZONE,
+    VARCHAR,
+    UNSUPPORTED,
+  }
+
+  // Implementation Detail, ImmutableMap.of(...) supports only upto 10 arguments.
+  private static final ImmutableMap<Type, UnifiedTypeMapping> MAPPING =
+      ImmutableMap.<Type, UnifiedTypeMapping>builder()
+          .putAll(
+              ImmutableMap.<Type, Schema>builder()
+                  .put(Type.BOOLEAN, SchemaBuilder.builder().booleanType())
+                  .put(Type.BYTES, SchemaBuilder.builder().bytesType())
+                  .put(
+                      Type.DATE, LogicalTypes.date().addToSchema(SchemaBuilder.builder().intType()))
+                  .put(Type.DATETIME, DateTime.SCHEMA)
+                  // Decimal is queued below.
+                  .put(Type.DOUBLE, SchemaBuilder.builder().doubleType())
+                  .put(Type.FLOAT, SchemaBuilder.builder().floatType())
+                  .put(Type.INTEGER, SchemaBuilder.builder().intType())
+                  .put(Type.INTERVAL, Interval.SCHEMA)
+                  .put(Type.JSON, Json.SCHEMA)
+                  .put(Type.LONG, SchemaBuilder.builder().longType())
+                  .put(Type.NUMBER, Number.SCHEMA)
+                  .put(Type.STRING, SchemaBuilder.builder().stringType())
+                  .put(
+                      Type.TIME,
+                      LogicalTypes.timeMicros().addToSchema(SchemaBuilder.builder().longType()))
+                  .put(Type.TIME_INTERVAL, TimeIntervalMicros.SCHEMA)
+                  .put(
+                      Type.TIMESTAMP,
+                      LogicalTypes.timestampMicros()
+                          .addToSchema(SchemaBuilder.builder().longType()))
+                  .put(Type.TIMESTAMP_WITH_TIME_ZONE, CustomSchema.TimeStampTz.SCHEMA)
+                  .put(Type.TIME_WITH_TIME_ZONE, CustomSchema.TimeTz.SCHEMA)
+                  .build()
+                  .entrySet()
+                  .stream()
+                  .map(e -> Map.entry(e.getKey(), SimpleUnifiedTypeMapping.create(e.getValue())))
+                  .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)))
+          .put(Type.DECIMAL, new Decimal())
+          .put(Type.VARCHAR, new Varchar())
+          .put(Type.UNSUPPORTED, new Unsupported())
+          .build();
+
+  /**
+   * Returns the {@link UnifiedTypeMapping} for a unified type mapping.
+   *
+   * @param type reference to the unified type to which an avro schema mapping is requested.
+   * @return mapping implementation. Default is {@link Unsupported} for unrecognized type.
+   */
+  public static UnifiedTypeMapping getMapping(Type type) {
+    return MAPPING.getOrDefault(type, new Unsupported());
+  }
+
+  /** Static final class. * */
+  private UnifiedMappingProvider() {}
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/Unsupported.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/Unsupported.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified;
+
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedTypeMapping;
+import org.apache.avro.LogicalType;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+
+/** Generates a null type for mapping unsupported type. */
+public final class Unsupported implements UnifiedTypeMapping {
+  public static final String UNSUPPORTED_LOGICAL_TYPE_NAME = "unsupported";
+  private static final Schema schema =
+      new LogicalType(UNSUPPORTED_LOGICAL_TYPE_NAME)
+          .addToSchema(SchemaBuilder.builder().nullType());
+
+  @Override
+  public Schema getSchema(Long[] mods, Long[] arrayBounds) {
+    return schema;
+  }
+
+  /**
+   * Tests is a given Schema is of the type Unsupported.
+   *
+   * @param schema Schema to test
+   * @return true if schema is not supported. false otherwise.
+   */
+  public boolean isUnsupported(Schema schema) {
+    return schema.equals(this.schema);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/Varchar.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/Varchar.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified;
+
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedTypeMapping;
+import com.google.common.base.Preconditions;
+import org.apache.avro.LogicalType;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.commons.lang3.ArrayUtils;
+
+/** Generates a Varchar Avro logical type. */
+public final class Varchar implements UnifiedTypeMapping {
+
+  public static final String LENGTH_PROP_NAME = "length";
+  public static final String LOGICAL_TYPE = "varchar";
+
+  @Override
+  public Schema getSchema(Long[] mods, Long[] arrayBounds) {
+    Preconditions.checkArgument(ArrayUtils.isEmpty(arrayBounds), "Arrays are not supported");
+    Preconditions.checkArgument(mods != null, "Varchar type needs length");
+    Preconditions.checkArgument(mods.length == 1, "Varchar type needs length");
+
+    Schema schema = new LogicalType(LOGICAL_TYPE).addToSchema(SchemaBuilder.builder().stringType());
+    schema.addProp(LENGTH_PROP_NAME, mods[0]);
+    return schema;
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+/**
+ * Avro Schemas for Unified types .
+ *
+ * @see <a href = https://cloud.google.com/datastream/docs/unified-types> Mappings of unified types
+ *     to source and destination data types</a>
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified;

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaTestUtils.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaTestUtils.java
@@ -26,19 +26,6 @@ public class SchemaTestUtils {
   public static SourceTableSchema generateTestTableSchema(String tableName) {
     return SourceTableSchema.builder()
         .setTableName(tableName)
-        .setAvroSchema(
-            SourceTableSchema.avroSchemaFieldAssembler()
-                .name(TEST_FIELD_NAME_1)
-                .type()
-                .stringType()
-                .noDefault()
-                .name(TEST_FIELD_NAME_2)
-                .type()
-                .stringType()
-                .noDefault()
-                .endRecord()
-                .noDefault()
-                .endRecord())
         .addSourceColumnNameToSourceColumnType(
             TEST_FIELD_NAME_1, new SourceColumnType("varchar", new Long[] {20L}, null))
         .addSourceColumnNameToSourceColumnType(

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceSchemaTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceSchemaTest.java
@@ -31,8 +31,6 @@ public class SourceSchemaTest extends TestCase {
     final String testDb = "test-db";
     final String testTable = "test-table";
 
-    final String testFieldName = "firstName";
-
     SourceSchema testSchema =
         SourceSchema.builder()
             .setSchemaReference(SourceSchemaReference.builder().setDbName(testDb).build())

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceTableSchemaTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceTableSchemaTest.java
@@ -17,9 +17,8 @@ package com.google.cloud.teleport.v2.source.reader.io.schema;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import junit.framework.TestCase;
-import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,19 +40,11 @@ public class SourceTableSchemaTest extends TestCase {
                 .toString())
         .isEqualTo("{\"type\":\"long\",\"logicalType\":\"time-micros\"}");
     assertThat(
-            sourceTableSchema
-                .getAvroPayload()
-                .getField(SchemaTestUtils.TEST_FIELD_NAME_1)
-                .schema()
-                .getType())
-        .isEqualTo(Schema.Type.STRING);
+            sourceTableSchema.getAvroPayload().getField(SchemaTestUtils.TEST_FIELD_NAME_1).schema())
+        .isEqualTo(SchemaBuilder.unionOf().nullType().and().stringType().endUnion());
     assertThat(
-            sourceTableSchema
-                .getAvroPayload()
-                .getField(SchemaTestUtils.TEST_FIELD_NAME_2)
-                .schema()
-                .getType())
-        .isEqualTo(Schema.Type.STRING);
+            sourceTableSchema.getAvroPayload().getField(SchemaTestUtils.TEST_FIELD_NAME_2).schema())
+        .isEqualTo(SchemaBuilder.unionOf().nullType().and().stringType().endUnion());
     assertThat(sourceTableSchema.tableName()).isEqualTo(testTableName);
   }
 
@@ -68,65 +59,9 @@ public class SourceTableSchemaTest extends TestCase {
   @Test
   public void testTableSchemaPreConditions() {
     String tableName = "testTable";
-    // Missing Source Schema Field.
+    // Miss Adding any fields to schema.
     Assert.assertThrows(
         java.lang.IllegalStateException.class,
-        () ->
-            SourceTableSchema.builder()
-                .setTableName(tableName)
-                .setAvroSchema(
-                    SourceTableSchema.avroSchemaFieldAssembler()
-                        .name(SchemaTestUtils.TEST_FIELD_NAME_1)
-                        .type()
-                        .stringType()
-                        .noDefault()
-                        .name(SchemaTestUtils.TEST_FIELD_NAME_2)
-                        .type()
-                        .stringType()
-                        .noDefault()
-                        .endRecord()
-                        .noDefault()
-                        .endRecord())
-                .addSourceColumnNameToSourceColumnType(
-                    SchemaTestUtils.TEST_FIELD_NAME_2,
-                    new SourceColumnType("varchar", new Long[] {20L}, null))
-                .build());
-
-    /* Missing Avro Schema Field */
-    Assert.assertThrows(
-        java.lang.IllegalStateException.class,
-        () ->
-            SourceTableSchema.builder()
-                .setTableName(tableName)
-                .setAvroSchema(
-                    SourceTableSchema.avroSchemaFieldAssembler()
-                        .name(SchemaTestUtils.TEST_FIELD_NAME_2)
-                        .type()
-                        .stringType()
-                        .noDefault()
-                        .endRecord()
-                        .noDefault()
-                        .endRecord())
-                .addSourceColumnNameToSourceColumnType(
-                    SchemaTestUtils.TEST_FIELD_NAME_1,
-                    new SourceColumnType("varchar", new Long[] {20L}, null))
-                .addSourceColumnNameToSourceColumnType(
-                    SchemaTestUtils.TEST_FIELD_NAME_2,
-                    new SourceColumnType("varchar", new Long[] {20L}, null))
-                .build());
-
-    /* No Avro Schema */
-    Assert.assertThrows(
-        java.lang.IllegalStateException.class,
-        () ->
-            SourceTableSchema.builder()
-                .setTableName(tableName)
-                .addSourceColumnNameToSourceColumnType(
-                    SchemaTestUtils.TEST_FIELD_NAME_1,
-                    new SourceColumnType("varchar", new Long[] {20L}, null))
-                .addSourceColumnNameToSourceColumnType(
-                    SchemaTestUtils.TEST_FIELD_NAME_2,
-                    new SourceColumnType("varchar", new Long[] {20L}, null))
-                .build());
+        () -> SourceTableSchema.builder().setTableName(tableName).build());
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/UnifiedTypeMapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/UnifiedTypeMapperTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedTypeMapper.MapperType;
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified.Unsupported;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link Decimal}. */
+@RunWith(MockitoJUnitRunner.class)
+public class UnifiedTypeMapperTest {
+  @Test
+  public void testUnifiedTypeMapper() {
+    assertThat(
+            new UnifiedTypeMapper(MapperType.MYSQL)
+                .getSchema(new SourceColumnType("bigint", null, null)))
+        .isEqualTo(SchemaBuilder.builder().unionOf().nullType().and().longType().endUnion());
+    Schema unknownType =
+        new UnifiedTypeMapper(MapperType.MYSQL)
+            .getSchema(new SourceColumnType("NewTypeUnknownToTheWorld", null, null));
+    assertThat(new Unsupported().isUnsupported(unknownType)).isTrue();
+  }
+
+  @Test
+  public void testPreconditions() {
+
+    Assert.assertThrows(
+        java.lang.IllegalArgumentException.class,
+        () -> new UnifiedTypeMapper(MapperType.SQLSERVER));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/MysqlMappingProviderTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/MysqlMappingProviderTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link MysqlMappingProvider}. */
+@RunWith(MockitoJUnitRunner.class)
+public class MysqlMappingProviderTest {
+  @Test
+  public void testMySqlMappingProvider() {
+    Long[] testMods = {1L, 1L};
+    // We don't have a use case for arrays yet.
+    Long[] testArrayBounds = {};
+    ImmutableMap<String, String> stringifiedMapping =
+        MysqlMappingProvider.getMapping().entrySet().stream()
+            .map(
+                e ->
+                    Map.entry(
+                        e.getKey(),
+                        e.getValue()
+                            .getSchema(testMods, testArrayBounds)
+                            .toString()
+                            .replaceAll("\\s+", "")))
+            .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
+    assertThat(stringifiedMapping).isEqualTo(expectedMapping());
+  }
+
+  private ImmutableMap<String, String> expectedMapping() {
+    return ImmutableMap.<String, String>builder()
+        .put("BIGINT", "\"long\"")
+        .put(
+            "BIGINT UNSIGNED",
+            "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":1,\"scale\":1}")
+        .put("BINARY", "\"string\"")
+        .put("BIT", "\"long\"")
+        .put("BLOB", "\"string\"")
+        .put("BOOL", "\"int\"")
+        .put("CHAR", "\"string\"")
+        .put("DATE", "{\"type\":\"long\",\"logicalType\":\"timestamp-micros\"}")
+        .put(
+            "DateTime",
+            "{\"type\":\"record\","
+                + "\"name\":\"datetime\","
+                + "\"fields\": ["
+                + "{\"name\":\"date\",\"type\":{\"type\":\"int\",\"logicalType\":\"date\"}},"
+                + "{\"name\":\"time\",\"type\":{\"type\":\"long\",\"logicalType\":\"time-micros\"}}]}")
+        .put(
+            "DECIMAL",
+            "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":1,\"scale\":1}")
+        .put("DOUBLE", "\"double\"")
+        .put("ENUM", "\"string\"")
+        .put("FLOAT", "\"float\"")
+        .put("INTEGER", "\"int\"")
+        .put("JSON", "{\"type\":\"string\",\"logicalType\":\"json\"}")
+        .put("LONGBLOB", "\"string\"")
+        .put("LONGTEXT", "\"string\"")
+        .put("MEDIUMBLOB", "\"string\"")
+        .put("MEDIUMINT", "\"int\"")
+        .put("MEDIUMTEXT", "\"string\"")
+        .put("SET", "\"string\"")
+        .put("SMALLINT", "\"int\"")
+        .put("TEXT", "\"string\"")
+        .put(
+            "TIME",
+            "{\"type\":\"record\","
+                + "\"name\":\"interval\","
+                + "\"fields\":["
+                + "{\"name\":\"months\",\"type\":\"int\"},"
+                + "{\"name\":\"hours\",\"type\":\"int\"},"
+                + "{\"name\":\"micros\",\"type\":\"long\"}]}")
+        .put("TIMESTAMP", "{\"type\":\"long\",\"logicalType\":\"timestamp-micros\"}")
+        .put("TINYBLOB", "\"string\"")
+        .put("TINYINT", "\"int\"")
+        .put("TINYTEXT", "\"string\"")
+        .put("VARBINARY", "\"string\"")
+        .put("VARCHAR", "\"string\"")
+        .put("YEAR", "\"int\"")
+        .put("UNSUPPORTED", "{\"type\":\"null\",\"logicalType\":\"unsupported\"}")
+        .build()
+        .entrySet()
+        .stream()
+        .map(e -> Map.entry(e.getKey(), e.getValue().replaceAll("\\s+", "")))
+        .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/CustomLogicalTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/CustomLogicalTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified.CustomLogical.Json;
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified.CustomLogical.Number;
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified.CustomLogical.TimeIntervalMicros;
+import org.apache.avro.Schema;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link CustomLogical}. */
+@RunWith(MockitoJUnitRunner.class)
+public class CustomLogicalTest {
+  @Test
+  public void testJson() {
+    assertThat(Json.SCHEMA.getLogicalType().getName()).isEqualTo(Json.LOGICAL_TYPE);
+    assertThat(Json.SCHEMA.getType()).isEqualTo(Schema.Type.STRING);
+  }
+
+  @Test
+  public void testNumber() {
+    assertThat(Number.SCHEMA.getLogicalType().getName()).isEqualTo(Number.LOGICAL_TYPE);
+    assertThat(Number.SCHEMA.getType()).isEqualTo(Schema.Type.STRING);
+  }
+
+  @Test
+  public void testTimeIntervalMicros() {
+    assertThat(TimeIntervalMicros.SCHEMA.getLogicalType().getName())
+        .isEqualTo(TimeIntervalMicros.LOGICAL_TYPE);
+    assertThat(TimeIntervalMicros.SCHEMA.getType()).isEqualTo(Schema.Type.LONG);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/CustomSchemaTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/CustomSchemaTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified.CustomSchema.DateTime;
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified.CustomSchema.Interval;
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified.CustomSchema.TimeStampTz;
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified.CustomSchema.TimeTz;
+import org.apache.avro.Schema;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link CustomSchema}. */
+@RunWith(MockitoJUnitRunner.class)
+public class CustomSchemaTest {
+  @Test
+  public void testDateTime() {
+    assertThat(DateTime.SCHEMA.getName()).isEqualTo(DateTime.RECORD_NAME);
+    assertThat(DateTime.SCHEMA.getType()).isEqualTo(Schema.Type.RECORD);
+    assertThat(DateTime.SCHEMA.getField(DateTime.DATE_FIELD_NAME).schema().getType())
+        .isEqualTo(Schema.Type.INT);
+    assertThat(DateTime.SCHEMA.getField(DateTime.TIME_FIELD_NAME).schema().getType())
+        .isEqualTo(Schema.Type.LONG);
+    assertThat(
+            DateTime.SCHEMA.getField(DateTime.TIME_FIELD_NAME).schema().getLogicalType().getName())
+        .isEqualTo(DateTime.TIME_FIELD_LOGICAL_TYPE_NAME);
+  }
+
+  @Test
+  public void testInterval() {
+    assertThat(Interval.SCHEMA.getName()).isEqualTo(Interval.RECORD_NAME);
+    assertThat(Interval.SCHEMA.getType()).isEqualTo(Schema.Type.RECORD);
+    assertThat(Interval.SCHEMA.getField(Interval.MONTHS_FIELD_NAME).schema().getType())
+        .isEqualTo(Schema.Type.INT);
+    assertThat(Interval.SCHEMA.getField(Interval.HOURS_FIELD_NAME).schema().getType())
+        .isEqualTo(Schema.Type.INT);
+    assertThat(Interval.SCHEMA.getField(Interval.MICROS_FIELD_NAME).schema().getType())
+        .isEqualTo(Schema.Type.LONG);
+  }
+
+  @Test
+  public void testTimestampTz() {
+    assertThat(TimeStampTz.SCHEMA.getName()).isEqualTo(TimeStampTz.RECORD_NAME);
+    assertThat(TimeStampTz.SCHEMA.getType()).isEqualTo(Schema.Type.RECORD);
+    assertThat(TimeStampTz.SCHEMA.getField(TimeStampTz.TIMESTAMP_FIELD_NAME).schema().getType())
+        .isEqualTo(Schema.Type.LONG);
+    assertThat(
+            TimeStampTz.SCHEMA
+                .getField(TimeStampTz.TIMESTAMP_FIELD_NAME)
+                .schema()
+                .getLogicalType()
+                .getName())
+        .isEqualTo(TimeStampTz.TIMESTAMP_FIELD_LOGICAL_TYPE_NAME);
+    assertThat(TimeStampTz.SCHEMA.getField(TimeStampTz.OFFSET_FIELD_NAME).schema().getType())
+        .isEqualTo(Schema.Type.INT);
+    assertThat(
+            TimeStampTz.SCHEMA
+                .getField(TimeStampTz.OFFSET_FIELD_NAME)
+                .schema()
+                .getLogicalType()
+                .getName())
+        .isEqualTo(TimeStampTz.OFFSET_FIELD_LOGICAL_TYPE_NAME);
+  }
+
+  @Test
+  public void testTimeTz() {
+    assertThat(TimeTz.SCHEMA.getName()).isEqualTo(TimeTz.RECORD_NAME);
+    assertThat(TimeTz.SCHEMA.getType()).isEqualTo(Schema.Type.RECORD);
+    assertThat(TimeTz.SCHEMA.getField(TimeTz.TIME_FIELD_NAME).schema().getType())
+        .isEqualTo(Schema.Type.LONG);
+    assertThat(TimeTz.SCHEMA.getField(TimeTz.TIME_FIELD_NAME).schema().getLogicalType().getName())
+        .isEqualTo(TimeTz.TIME_FIELD_LOGICAL_TYPE_NAME);
+    assertThat(TimeTz.SCHEMA.getField(TimeTz.OFFSET_FIELD_NAME).schema().getType())
+        .isEqualTo(Schema.Type.INT);
+    assertThat(TimeTz.SCHEMA.getField(TimeTz.OFFSET_FIELD_NAME).schema().getLogicalType().getName())
+        .isEqualTo(TimeTz.OFFSET_FIELD_LOGICAL_TYPE_NAME);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/DecimalTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/DecimalTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link Decimal}. */
+@RunWith(MockitoJUnitRunner.class)
+public class DecimalTest {
+
+  @Test
+  public void testGetSchemaForScaleAndPrecision() {
+    final Long[] mods = {3L, 2L};
+    assertThat(new Decimal().getSchema(mods, null).toString())
+        .isEqualTo("{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":3,\"scale\":2}");
+  }
+
+  @Test
+  public void testGetSchemaPreconditions() {
+
+    final Long[] modsNull = null;
+    final Long[] modsEmpty = {};
+    final Long[] modsNoPrecision = {1L};
+    final Long[] mods = {1L, 1L};
+    final Long[] arrayBounds = {1L};
+
+    Assert.assertThrows(
+        java.lang.IllegalArgumentException.class, () -> new Decimal().getSchema(modsNull, null));
+    Assert.assertThrows(
+        java.lang.IllegalArgumentException.class, () -> new Decimal().getSchema(modsEmpty, null));
+    Assert.assertThrows(
+        java.lang.IllegalArgumentException.class,
+        () -> new Decimal().getSchema(modsNoPrecision, null));
+
+    Assert.assertThrows(
+        java.lang.IllegalArgumentException.class, () -> new Decimal().getSchema(mods, arrayBounds));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/SimpleUnifiedTypeMappingTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/SimpleUnifiedTypeMappingTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.apache.avro.SchemaBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link SimpleUnifiedTypeMapping}. */
+@RunWith(MockitoJUnitRunner.class)
+public class SimpleUnifiedTypeMappingTest {
+  @Test
+  public void testSimpleUnifiedTypeMapping() {
+    assertThat(
+            SimpleUnifiedTypeMapping.create(SchemaBuilder.builder().longType())
+                .getSchema(null, null))
+        .isEqualTo(SchemaBuilder.builder().longType());
+  }
+
+  @Test
+  public void testSimpleUnifiedTypeMappingPreconditions() {
+    final Long[] arrayBounds = {1L};
+    Assert.assertThrows(
+        java.lang.IllegalArgumentException.class,
+        () ->
+            SimpleUnifiedTypeMapping.create(SchemaBuilder.builder().booleanType())
+                .getSchema(null, arrayBounds));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/UnifiedMappingProviderTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/UnifiedMappingProviderTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link UnifiedMappingProvider}. */
+@RunWith(MockitoJUnitRunner.class)
+public class UnifiedMappingProviderTest {
+  @Test
+  public void testUnifiedMappingProvider() {
+    final Long[] decimalMods = {1L, 1L};
+    final Long[] varCharMods = {10L};
+    ImmutableMap<String, String> stringifiedMapping =
+        simpleTypes().stream()
+            .map(
+                t ->
+                    Map.entry(
+                        t.toString(),
+                        UnifiedMappingProvider.getMapping(t)
+                            .getSchema(null, null)
+                            .toString()
+                            .replaceAll("\\s+", "")))
+            .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
+    assertThat(stringifiedMapping).isEqualTo(simpleTypeExpectedMapping());
+    assertThat(
+            UnifiedMappingProvider.getMapping(UnifiedMappingProvider.Type.DECIMAL)
+                .getSchema(decimalMods, null)
+                .toString())
+        .isEqualTo("{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":1,\"scale\":1}");
+
+    assertThat(
+            UnifiedMappingProvider.getMapping(UnifiedMappingProvider.Type.VARCHAR)
+                .getSchema(varCharMods, null)
+                .toString())
+        .isEqualTo("{\"type\":\"string\",\"logicalType\":\"varchar\",\"length\":10}");
+  }
+
+  private ImmutableList<UnifiedMappingProvider.Type> simpleTypes() {
+
+    return ImmutableList.<UnifiedMappingProvider.Type>builder()
+        .add(UnifiedMappingProvider.Type.BOOLEAN)
+        .add(UnifiedMappingProvider.Type.BYTES)
+        .add(UnifiedMappingProvider.Type.DOUBLE)
+        .add(UnifiedMappingProvider.Type.DATE)
+        .add(UnifiedMappingProvider.Type.DATETIME)
+        .add(UnifiedMappingProvider.Type.FLOAT)
+        .add(UnifiedMappingProvider.Type.INTEGER)
+        .add(UnifiedMappingProvider.Type.INTERVAL)
+        .add(UnifiedMappingProvider.Type.JSON)
+        .add(UnifiedMappingProvider.Type.LONG)
+        .add(UnifiedMappingProvider.Type.NUMBER)
+        .add(UnifiedMappingProvider.Type.STRING)
+        .add(UnifiedMappingProvider.Type.TIME)
+        .add(UnifiedMappingProvider.Type.TIME_INTERVAL)
+        .add(UnifiedMappingProvider.Type.TIMESTAMP)
+        .add(UnifiedMappingProvider.Type.TIMESTAMP_WITH_TIME_ZONE)
+        .add(UnifiedMappingProvider.Type.TIME_WITH_TIME_ZONE)
+        .add(UnifiedMappingProvider.Type.UNSUPPORTED)
+        .build();
+  }
+
+  private ImmutableMap<String, String> simpleTypeExpectedMapping() {
+    return ImmutableMap.<String, String>builder()
+        .put("BOOLEAN", "\"boolean\"")
+        .put("BYTES", "\"bytes\"")
+        .put("DOUBLE", "\"double\"")
+        .put("DATE", "{\"type\":\"int\",\"logicalType\":\"date\"}")
+        .put(
+            "DATETIME",
+            "{\"type\":\"record\","
+                + "\"name\":\"datetime\","
+                + "\"fields\": ["
+                + "{\"name\":\"date\",\"type\":{\"type\":\"int\",\"logicalType\":\"date\"}},"
+                + "{\"name\":\"time\",\"type\":{\"type\":\"long\",\"logicalType\":\"time-micros\"}}]}")
+        .put("FLOAT", "\"float\"")
+        .put("INTEGER", "\"int\"")
+        .put(
+            "INTERVAL",
+            "{\"type\":\"record\","
+                + "\"name\":\"interval\","
+                + "\"fields\":["
+                + "{\"name\":\"months\",\"type\":\"int\"},"
+                + "{\"name\":\"hours\",\"type\":\"int\"},"
+                + "{\"name\":\"micros\",\"type\":\"long\"}]}")
+        .put("JSON", "{\"type\":\"string\",\"logicalType\":\"json\"}")
+        .put("LONG", "\"long\"")
+        .put("NUMBER", "{\"type\":\"string\", \"logicalType\":\"number\"}")
+        .put("STRING", "\"string\"")
+        .put("TIME", "{\"type\":\"long\", \"logicalType\":\"time-micros\"}")
+        .put("TIME_INTERVAL", "{\"type\":\"long\", \"logicalType\":\"time-interval-micros\"}")
+        .put("TIMESTAMP", "{\"type\":\"long\", \"logicalType\":\"timestamp-micros\"}")
+        .put(
+            "TIMESTAMP_WITH_TIME_ZONE",
+            "{\"type\":\"record\","
+                + "\"name\":\"timestampTz\","
+                + "\"fields\":[{"
+                + "\"name\":\"timestamp\", \"type\":"
+                + "{\"type\":\"long\",\"logicalType\":\"timestamp-micros\"}},"
+                + "{\"name\":\"offset\",\"type\":"
+                + "{\"type\":\"int\",\"logicalType\":\"time-millis\"}}]}")
+        .put(
+            "TIME_WITH_TIME_ZONE",
+            "{\"type\":\"record\","
+                + "\"name\":\"timeTz\","
+                + "\"fields\":[{"
+                + "\"name\":\"time\","
+                + "\"type\":{\"type\":\"long\",\"logicalType\":\"time-micros\"}},"
+                + "{\"name\":\"offset\", \"type\":"
+                + "{\"type\":\"int\",\"logicalType\":\"time-millis\"}}]}")
+        .put("UNSUPPORTED", "{\"type\":\"null\", \"logicalType\":\"unsupported\"}")
+        .build()
+        .entrySet()
+        .stream()
+        .map(e -> Map.entry(e.getKey(), e.getValue().replaceAll("\\s+", "")))
+        .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/UnsupportedTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/UnsupportedTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link Unsupported}. */
+@RunWith(MockitoJUnitRunner.class)
+public class UnsupportedTest {
+
+  @Test
+  public void getSchema() {
+    assertThat(new Unsupported().getSchema(null, null).getType())
+        .isEqualTo(SchemaBuilder.builder().nullType().getType());
+    assertThat(new Unsupported().getSchema(null, null).getLogicalType().getName())
+        .isEqualTo(Unsupported.UNSUPPORTED_LOGICAL_TYPE_NAME);
+  }
+
+  @Test
+  public void isUnsupported() {
+    Schema unsupportedSchema = new Unsupported().getSchema(null, null);
+    Schema integerSchema = SchemaBuilder.builder().intType();
+    assertThat(new Unsupported().isUnsupported(unsupportedSchema)).isTrue();
+    assertThat(new Unsupported().isUnsupported(integerSchema)).isFalse();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/VarcharTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/VarcharTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link Varchar}. */
+@RunWith(MockitoJUnitRunner.class)
+public class VarcharTest {
+  @Test
+  public void testVarCharWithLength() {
+    final Long[] mods = {3L};
+    assertThat(new Varchar().getSchema(mods, null).toString())
+        .isEqualTo("{\"type\":\"string\",\"logicalType\":\"varchar\",\"length\":3}");
+  }
+
+  @Test
+  public void testGetSchemaPreconditions() {
+
+    final Long[] modsNull = null;
+    final Long[] modsEmpty = {};
+    final Long[] mods = {1L};
+    final Long[] arrayBounds = {1L};
+
+    Assert.assertThrows(
+        java.lang.IllegalArgumentException.class, () -> new Varchar().getSchema(modsNull, null));
+    Assert.assertThrows(
+        java.lang.IllegalArgumentException.class, () -> new Varchar().getSchema(modsEmpty, null));
+    Assert.assertThrows(
+        java.lang.IllegalArgumentException.class, () -> new Varchar().getSchema(mods, arrayBounds));
+  }
+}


### PR DESCRIPTION
Implementing Schema type mappings for Bulk reader.
The Bulk Reader will map various types of source schemas into [Unified types](https://cloud.google.com/datastream/docs/unified-types) .Support for mapping MySQL types to unified types is added in this PR.


The unified type mapping, in general has 2 steps:
Step-1 (inner step) - Generate Avro schemas  for the unified types. For most of the types, this is a pain building of Avro Schema. For a few types like Decimal or Varchar, extra fields like length, precision and scale are needed.
Step-2 (outer step) - Map the source column type name (strings as returned by the scan of information schema table) into the avro schema generators for step-1.


