### PR TITLE
Add Kafka To BigQuery Template

### DIFF
--- a/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/options/KafkaReadOptions.java
+++ b/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/options/KafkaReadOptions.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.kafka.options;
 
 import com.google.cloud.teleport.metadata.TemplateParameter;
+import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.PipelineOptions;
 
 /**
@@ -45,4 +46,38 @@ public interface KafkaReadOptions extends PipelineOptions {
   String getKafkaReadTopics();
 
   void setKafkaReadTopics(String inputTopics);
+
+  @TemplateParameter.Text(
+      order = 3,
+      optional = true,
+      description = "The Kafka Offset to read from.",
+      helpText = "The Kafka Offset to read from.")
+  @Default.String("latest")
+  String getKafkaReadOffset();
+
+  void setKafkaReadOffset(String value);
+
+  @TemplateParameter.Text(
+      order = 4,
+      optional = true,
+      description =
+          "Username to be used with SASL_PLAIN mechanism for reading from Kafka, stored in Google Cloud Secret Manager.",
+      helpText =
+          "Secret Manager secret ID for the SASL_PLAIN username. Should be in the format projects/{project}/secrets/{secret}/versions/{secret_version}.",
+      example = "projects/your-project-id/secrets/your-secret/versions/your-secret-version")
+  String getKafkaReadUsernameSecretId();
+
+  void setKafkaReadUsernameSecretId(String value);
+
+  @TemplateParameter.Text(
+      order = 5,
+      optional = true,
+      description =
+          "Password to be used with SASL_PLAIN mechanism for reading from Kafka, stored in Google Cloud Secret Manager.",
+      helpText =
+          "Secret Manager secret ID for the SASL_PLAIN password. Should be in the format projects/{project}/secrets/{secret}/versions/{secret_version}",
+      example = "projects/your-project-id/secrets/your-secret/versions/your-secret-version")
+  String getKafkaReadPasswordSecretId();
+
+  void setKafkaReadPasswordSecretId(String value);
 }

--- a/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/transforms/KafkaTransform.java
+++ b/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/transforms/KafkaTransform.java
@@ -31,6 +31,7 @@ import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
 import org.apache.beam.sdk.io.kafka.DeserializerProvider;
 import org.apache.beam.sdk.io.kafka.KafkaIO;
+import org.apache.beam.sdk.io.kafka.KafkaRecord;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.KV;
@@ -97,6 +98,33 @@ public class KafkaTransform {
       kafkaRecords = kafkaRecords.withConsumerFactoryFn(new SslConsumerFactoryFn(sslConfig));
     }
     return kafkaRecords.withoutMetadata();
+  }
+
+  /**
+   * Configures Kafka consumer that reads bytes.
+   *
+   * @param bootstrapServers Kafka servers to read from
+   * @param topicsList Kafka topics to read from
+   * @param config configuration for the Kafka consumer
+   * @return PCollection of Kafka Key & Value Pair deserialized in string format
+   */
+  public static PTransform<PBegin, PCollection<KafkaRecord<byte[], byte[]>>> readBytesFromKafka(
+      String bootstrapServers,
+      List<String> topicsList,
+      Map<String, Object> config,
+      @Nullable Map<String, String> sslConfig) {
+    KafkaIO.Read<byte[], byte[]> kafkaRecords =
+        KafkaIO.<byte[], byte[]>read()
+            .withBootstrapServers(bootstrapServers)
+            .withTopics(topicsList)
+            .withKeyDeserializerAndCoder(
+                ByteArrayDeserializer.class, NullableCoder.of(ByteArrayCoder.of()))
+            .withValueDeserializerAndCoder(ByteArrayDeserializer.class, ByteArrayCoder.of())
+            .withConsumerConfigUpdates(config);
+    if (sslConfig != null) {
+      kafkaRecords = kafkaRecords.withConsumerFactoryFn(new SslConsumerFactoryFn(sslConfig));
+    }
+    return kafkaRecords;
   }
 
   /**

--- a/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/transforms/NonWireAvroDeserializer.java
+++ b/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/transforms/NonWireAvroDeserializer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.kafka.transforms;
+
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import java.io.IOException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.header.Headers;
+
+public class NonWireAvroDeserializer extends KafkaAvroDeserializer {
+  private Schema schema;
+
+  public NonWireAvroDeserializer() {}
+
+  public NonWireAvroDeserializer(Schema schema) {
+    this.schema = schema;
+  }
+
+  public GenericRecord deserialize(String topic, Headers header, byte[] bytes) {
+    try {
+      Decoder decoder = DecoderFactory.get().binaryDecoder(bytes, null);
+      DatumReader<GenericRecord> reader = new GenericDatumReader<GenericRecord>(this.schema);
+      return reader.read(null, decoder);
+    } catch (IOException e) {
+      throw new SerializationException("Error deserialing avro message", e.getCause());
+    }
+  }
+
+  public void close() {}
+}

--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/options/KafkaToBigQueryFlexOptions.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/options/KafkaToBigQueryFlexOptions.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.options;
+
+import com.google.cloud.teleport.metadata.TemplateParameter;
+import com.google.cloud.teleport.v2.kafka.options.KafkaReadOptions;
+import org.apache.beam.sdk.options.Default;
+
+/**
+ * The {@link KafkaToBigQueryFlexOptions} class provides the custom execution options passed by the
+ * executor at the command-line.
+ */
+public interface KafkaToBigQueryFlexOptions
+    extends KafkaReadOptions, BigQueryStorageApiStreamingOptions {
+
+  @TemplateParameter.BigQueryTable(
+      order = 1,
+      optional = true,
+      description = "BigQuery output table",
+      helpText =
+          "BigQuery table location to write the output to. The name should be in the format "
+              + "`<project>:<dataset>.<table_name>`. The table's schema must match input objects.")
+  String getOutputTableSpec();
+
+  void setOutputTableSpec(String value);
+
+  @TemplateParameter.Enum(
+      order = 2,
+      enumOptions = {
+        @TemplateParameter.TemplateEnumOption("WRITE_APPEND"),
+        @TemplateParameter.TemplateEnumOption("WRITE_EMPTY"),
+        @TemplateParameter.TemplateEnumOption("WRITE_TRUNCATE")
+      },
+      optional = true,
+      description = "Write Disposition to use for BigQuery",
+      helpText =
+          "BigQuery WriteDisposition. For example, WRITE_APPEND, WRITE_EMPTY or WRITE_TRUNCATE.")
+  @Default.String("WRITE_APPEND")
+  String getWriteDisposition();
+
+  void setWriteDisposition(String writeDisposition);
+
+  @TemplateParameter.Enum(
+      order = 3,
+      enumOptions = {
+        @TemplateParameter.TemplateEnumOption("CREATE_IF_NEEDED"),
+        @TemplateParameter.TemplateEnumOption("CREATE_NEVER")
+      },
+      optional = true,
+      description = "Create Disposition to use for BigQuery",
+      helpText = "BigQuery CreateDisposition. For example, CREATE_IF_NEEDED, CREATE_NEVER.")
+  @Default.String("CREATE_IF_NEEDED")
+  String getCreateDisposition();
+
+  void setCreateDisposition(String createDisposition);
+
+  @TemplateParameter.BigQueryTable(
+      order = 4,
+      optional = true,
+      description = "The dead-letter table name to output failed messages to BigQuery",
+      helpText =
+          "BigQuery table for failed messages. Messages failed to reach the output table for different reasons "
+              + "(e.g., mismatched schema, malformed json) are written to this table. If it doesn't exist, it will"
+              + " be created during pipeline execution. If not specified, \"outputTableSpec_error_records\" is used instead.",
+      example = "your-project-id:your-dataset.your-table-name")
+  String getOutputDeadletterTable();
+
+  void setOutputDeadletterTable(String outputDeadletterTable);
+
+  @TemplateParameter.Enum(
+      order = 6,
+      enumOptions = {
+        @TemplateParameter.TemplateEnumOption("AVRO"),
+        @TemplateParameter.TemplateEnumOption("JSON")
+      },
+      optional = true,
+      description = "The message format",
+      helpText = "The message format. Can be AVRO or JSON.")
+  @Default.String("AVRO")
+  String getMessageFormat();
+
+  void setMessageFormat(String value);
+
+  // TODO: Sync the enum options with all the Kafka Templates.
+  @TemplateParameter.Enum(
+      order = 7,
+      enumOptions = {
+        @TemplateParameter.TemplateEnumOption("CONFLUENT_WIRE_FORMAT"),
+        @TemplateParameter.TemplateEnumOption("NON_WIRE_FORMAT")
+      },
+      optional = true,
+      description = "Use the confluent wire format for avro messages.",
+      helpText =
+          "This parameter is used to indicate if the avro messages use confluent wire format. Default is true (Confluent Wire Format)")
+  @Default.String("CONFLUENT_WIRE_FORMAT")
+  String getAvroFormat();
+
+  void setAvroFormat(String value);
+
+  @TemplateParameter.GcsReadFile(
+      order = 8,
+      optional = true,
+      description = "Cloud Storage path to the Avro schema file",
+      helpText = "Cloud Storage path to Avro schema file. For example, gs://MyBucket/file.avsc.")
+  String getAvroSchemaPath();
+
+  void setAvroSchemaPath(String schemaPath);
+
+  @TemplateParameter.Text(
+      order = 9,
+      optional = true,
+      description = "Schema Registry Connection URL.",
+      helpText =
+          "Schema Registry Connection URL for a registry which supports Confluent wire format.")
+  String getSchemaRegistryConnectionUrl();
+
+  void setSchemaRegistryConnectionUrl(String schemaRegistryConnectionUrl);
+
+  @TemplateParameter.Text(
+      order = 11,
+      optional = true,
+      description = "BigQuery output dataset",
+      helpText =
+          "BigQuery output dataset to write the output to."
+              + "Tables will be created dynamically in the dataset.")
+  String getOutputDataset();
+
+  void setOutputDataset(String value);
+
+  @TemplateParameter.Text(
+      order = 12,
+      optional = true,
+      description = "Name prefix to be used while creating BigQuery output tables.",
+      helpText =
+          "Name prefix to be used while creating BigQuery output tables. Only applicable when using schema registry.")
+  @Default.String("")
+  String getBQTableNamePrefix();
+
+  void setBQTableNamePrefix(String value);
+
+  @TemplateParameter.Boolean(
+      order = 13,
+      optional = true,
+      description = "Use at at-least-once semantics in BigQuery Storage Write API",
+      helpText =
+          "This parameter takes effect only if \"Use BigQuery Storage Write API\" is enabled. If"
+              + " enabled the at-least-once semantics will be used for Storage Write API, otherwise"
+              + " exactly-once semantics will be used.",
+      hiddenUi = true)
+  @Default.Boolean(false)
+  @Override
+  Boolean getUseStorageWriteApiAtLeastOnce();
+
+  void setUseStorageWriteApiAtLeastOnce(Boolean value);
+}

--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/options/package-info.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/options/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package containing options class for {@link
+ * com.google.cloud.teleport.v2.templates.KafkaToBigQueryFlex} template.
+ */
+package com.google.cloud.teleport.v2.options;

--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlex.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlex.java
@@ -1,0 +1,453 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates;
+
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.cloud.teleport.metadata.Template;
+import com.google.cloud.teleport.metadata.TemplateCategory;
+import com.google.cloud.teleport.v2.coders.FailsafeElementCoder;
+import com.google.cloud.teleport.v2.common.UncaughtExceptionLogger;
+import com.google.cloud.teleport.v2.kafka.transforms.KafkaTransform;
+import com.google.cloud.teleport.v2.options.KafkaToBigQueryFlexOptions;
+import com.google.cloud.teleport.v2.transforms.AvroDynamicTransform;
+import com.google.cloud.teleport.v2.transforms.AvroTransform;
+import com.google.cloud.teleport.v2.transforms.ErrorConverters;
+import com.google.cloud.teleport.v2.transforms.ErrorConverters.WriteKafkaMessageErrors;
+import com.google.cloud.teleport.v2.transforms.StringMessageToTableRow;
+import com.google.cloud.teleport.v2.utils.BigQueryIOUtils;
+import com.google.cloud.teleport.v2.utils.MetadataValidator;
+import com.google.cloud.teleport.v2.utils.SchemaUtils;
+import com.google.cloud.teleport.v2.utils.SecretManagerUtils;
+import com.google.cloud.teleport.v2.values.FailsafeElement;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.NullableCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryInsertError;
+import org.apache.beam.sdk.io.gcp.bigquery.InsertRetryPolicy;
+import org.apache.beam.sdk.io.gcp.bigquery.WriteResult;
+import org.apache.beam.sdk.io.kafka.KafkaRecord;
+import org.apache.beam.sdk.io.kafka.KafkaRecordCoder;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.ProcessElement;
+import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link KafkaToBigQueryFlex} pipeline is a streaming pipeline which ingests text data from
+ * Kafka, executes a UDF, and outputs the resulting records to BigQuery. Any errors which occur in
+ * the transformation of the data, execution of the UDF, or inserting into the output table will be
+ * inserted into a separate errors table in BigQuery. The errors table will be created if it does
+ * not exist prior to execution. Both output and error tables are specified by the user as
+ * parameters.
+ *
+ * <p><b>Pipeline Requirements</b>
+ *
+ * <ul>
+ *   <li>The Kafka topic exists and the message is encoded in a valid JSON format.
+ *   <li>The BigQuery output table exists.
+ *   <li>The Kafka brokers are reachable from the Dataflow worker machines.
+ * </ul>
+ *
+ * <p>Check out <a
+ * href="https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v2/kafka-to-bigquery/README_Kafka_to_BigQuery.md">README</a>
+ * for instructions on how to use or modify this template.
+ */
+@Template(
+    name = "Kafka_to_BigQuery_Flex",
+    category = TemplateCategory.STREAMING,
+    displayName = "Kafka to BigQuery",
+    description =
+        "The Apache Kafka to BigQuery template is a streaming pipeline which ingests text data from Apache Kafka, executes a user-defined function (UDF), and outputs the resulting records to BigQuery. "
+            + "Any errors which occur in the transformation of the data, execution of the UDF, or inserting into the output table are inserted into a separate errors table in BigQuery. "
+            + "If the errors table does not exist prior to execution, then it is created.",
+    optionsClass = KafkaToBigQueryFlexOptions.class,
+    flexContainerName = "kafka-to-bigquery-flex",
+    documentation =
+        "https://cloud.google.com/dataflow/docs/guides/templates/provided/kafka-to-bigquery",
+    contactInformation = "https://cloud.google.com/support",
+    requirements = {
+      "The output BigQuery table must exist.",
+      "The Apache Kafka broker server must be running and be reachable from the Dataflow worker machines.",
+      "The Apache Kafka topics must exist and the messages must be encoded in a valid JSON format."
+    },
+    streaming = true,
+    hidden = true)
+public class KafkaToBigQueryFlex {
+
+  /* Logger for class. */
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaToBigQueryFlex.class);
+
+  /** The tag for the main output of the json transformation. */
+  public static final TupleTag<TableRow> TRANSFORM_OUT = new TupleTag<TableRow>() {};
+
+  /** The tag for the dead-letter output of the json to table row transform. */
+  public static final TupleTag<FailsafeElement<KV<String, String>, String>>
+      TRANSFORM_DEADLETTER_OUT = new TupleTag<FailsafeElement<KV<String, String>, String>>() {};
+
+  /** The default suffix for error tables if dead letter table is not specified. */
+  private static final String DEFAULT_DEADLETTER_TABLE_SUFFIX = "_error_records";
+
+  /** String/String Coder for FailsafeElement. */
+  private static final FailsafeElementCoder<String, String> FAILSAFE_ELEMENT_CODER =
+      FailsafeElementCoder.of(
+          NullableCoder.of(StringUtf8Coder.of()), NullableCoder.of(StringUtf8Coder.of()));
+
+  /**
+   * The main entry-point for pipeline execution. This method will start the pipeline but will not
+   * wait for it's execution to finish. If blocking execution is required, use the {@link
+   * KafkaToBigQueryFlex#run(KafkaToBQFlexOptions)} method to start the pipeline and invoke {@code
+   * result.waitUntilFinish()} on the {@link PipelineResult}.
+   *
+   * @param args The command-line args passed by the executor.
+   */
+  public static void main(String[] args) throws IOException, RestClientException {
+    UncaughtExceptionLogger.register();
+
+    KafkaToBigQueryFlexOptions options =
+        PipelineOptionsFactory.fromArgs(args).withValidation().as(KafkaToBigQueryFlexOptions.class);
+
+    run(options);
+  }
+
+  /**
+   * Runs the pipeline to completion with the specified options. This method does not wait until the
+   * pipeline is finished before returning. Invoke {@code result.waitUntilFinish()} on the result
+   * object to block until the pipeline is finished running if blocking programmatic execution is
+   * required.
+   *
+   * @param options The execution options.
+   * @return The pipeline result.
+   */
+  public static PipelineResult run(KafkaToBigQueryFlexOptions options)
+      throws IOException, RestClientException {
+
+    // Validate BQ STORAGE_WRITE_API options
+    BigQueryIOUtils.validateBQStorageApiOptionsStreaming(options);
+    MetadataValidator.validate(options);
+
+    // Create the pipeline
+    Pipeline pipeline = Pipeline.create(options);
+
+    List<String> topicsList;
+    if (options.getKafkaReadTopics() != null) {
+      topicsList = new ArrayList<>(Arrays.asList(options.getKafkaReadTopics().split(",")));
+    } else {
+      throw new IllegalArgumentException("Please Provide --kafkaReadTopic");
+    }
+    String bootstrapServers;
+    if (options.getReadBootstrapServers() != null) {
+      bootstrapServers = options.getReadBootstrapServers();
+    } else {
+      throw new IllegalArgumentException("Please Provide --bootstrapServers");
+    }
+    /*
+     * Steps:
+     *  1) Read messages in from Kafka
+     *  2) Transform the messages into TableRows
+     *     - Transform message payload via UDF
+     *     - Convert UDF result to TableRow objects
+     *  3) Write successful records out to BigQuery
+     *  4) Write failed records out to BigQuery
+     */
+
+    Map<String, Object> kafkaConfig =
+        ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, options.getKafkaReadOffset());
+
+    String username = SecretManagerUtils.getSecret(options.getKafkaReadUsernameSecretId());
+    String password = SecretManagerUtils.getSecret(options.getKafkaReadPasswordSecretId());
+
+    ImmutableMap<String, Object> finalKafkaConfig =
+        ImmutableMap.<String, Object>builder()
+            .putAll(kafkaConfig)
+            .putAll(setClientAuthConfig(username, password))
+            .build();
+
+    if (options.getMessageFormat() == null || options.getMessageFormat().equals("JSON")) {
+
+      return runJsonPipeline(pipeline, options, topicsList, bootstrapServers, finalKafkaConfig);
+
+    } else if (options.getMessageFormat() == null || options.getMessageFormat().equals("AVRO")) {
+
+      return runAvroPipeline(pipeline, options, topicsList, bootstrapServers, finalKafkaConfig);
+
+    } else {
+      throw new IllegalArgumentException("Invalid format specified: " + options.getMessageFormat());
+    }
+  }
+
+  public static PipelineResult runAvroPipeline(
+      Pipeline pipeline,
+      KafkaToBigQueryFlexOptions options,
+      List<String> topicsList,
+      String bootstrapServers,
+      Map<String, Object> kafkaConfig)
+      throws IOException, RestClientException {
+
+    if (options.getAvroFormat().equals("NON_WIRE_FORMAT") && options.getAvroSchemaPath() == null) {
+      throw new IllegalArgumentException(
+          "Avro schema is needed in order to read non confluent wire format messages.");
+    }
+    if (options.getAvroFormat().equals("CONFLUENT_WIRE_FORMAT")
+        && options.getSchemaRegistryConnectionUrl() == null
+        && options.getAvroSchemaPath() == null) {
+      throw new IllegalArgumentException(
+          "Schema Registry Connection URL OR Avro schema is needed in order to read confluent wire format messages.");
+    }
+
+    PCollection<KafkaRecord<byte[], byte[]>> kafkaRecords;
+
+    kafkaRecords =
+        pipeline
+            /*
+             * Step #1: Read messages in from Kafka and convert to GenericRecords wrap in FailsafeElement
+             */
+            .apply(
+                "ReadBytesFromKafka",
+                KafkaTransform.readBytesFromKafka(bootstrapServers, topicsList, kafkaConfig, null))
+            .setCoder(
+                KafkaRecordCoder.of(NullableCoder.of(ByteArrayCoder.of()), ByteArrayCoder.of()));
+
+    WriteResult writeResult = null;
+
+    if (options.getAvroFormat().equals("NON_WIRE_FORMAT") && options.getAvroSchemaPath() != null) {
+
+      throw new UnsupportedOperationException("Only Confluent Wire Format is supported");
+      // writeResult = kafkaRecords.apply(AvroTransform.of(options));
+
+    } else {
+
+      if (options.getAvroSchemaPath() != null && options.getOutputTableSpec() == null) {
+        throw new IllegalArgumentException("An output BigQuery table is required.");
+      }
+
+      if (options.getAvroSchemaPath() != null && options.getOutputTableSpec() != null) {
+        writeResult = kafkaRecords.apply(AvroTransform.of(options));
+      }
+
+      if (options.getSchemaRegistryConnectionUrl() != null && options.getOutputDataset() == null) {
+        throw new IllegalArgumentException(
+            "An output BigQuery dataset is required. It will be used to create tables per schema.");
+      }
+
+      if (options.getSchemaRegistryConnectionUrl() != null && options.getOutputDataset() != null) {
+        writeResult = kafkaRecords.apply(AvroDynamicTransform.of(options));
+      }
+    }
+
+    /*
+     * Step #2: Elements that failed inserts into BigQuery
+     * are extracted and converted to FailsafeElement.
+     */
+    PCollection<FailsafeElement<String, String>> failedInserts =
+        BigQueryIOUtils.writeResultToBigQueryInsertErrors(writeResult, options)
+            .apply(
+                "WrapInsertionErrors",
+                MapElements.into(FAILSAFE_ELEMENT_CODER.getEncodedTypeDescriptor())
+                    .via(KafkaToBigQueryFlex::wrapBigQueryInsertError))
+            .setCoder(FAILSAFE_ELEMENT_CODER);
+
+    if (options.getOutputDeadletterTable() != null) {
+      /*
+       * Step #3: Insert records that failed BigQuery inserts into a deadletter table.
+       */
+      failedInserts.apply(
+          "WriteInsertionFailedRecords",
+          ErrorConverters.WriteStringMessageErrors.newBuilder()
+              .setErrorRecordsTable(ObjectUtils.firstNonNull(options.getOutputDeadletterTable()))
+              .setErrorRecordsTableSchema(SchemaUtils.DEADLETTER_SCHEMA)
+              .build());
+    } else {
+      failedInserts.apply("PrintInsertionFailedRecords", ParDo.of(new ThrowErrorFn()));
+    }
+
+    return pipeline.run();
+  }
+
+  public static PipelineResult runJsonPipeline(
+      Pipeline pipeline,
+      KafkaToBigQueryFlexOptions options,
+      List<String> topicsList,
+      String bootstrapServers,
+      Map<String, Object> kafkaConfig) {
+
+    PCollectionTuple convertedTableRows;
+    convertedTableRows =
+        pipeline
+            /*
+             * Step #1: Read messages in from Kafka
+             */
+            .apply(
+                "ReadFromKafka",
+                KafkaTransform.readStringFromKafka(bootstrapServers, topicsList, kafkaConfig, null))
+
+            /*
+             * Step #2: Transform the Kafka Messages into TableRows
+             */
+            .apply("ConvertMessageToTableRow", new StringMessageToTableRow());
+    /*
+     * Step #3: Write the successful records out to BigQuery
+     */
+    WriteResult writeResult =
+        convertedTableRows
+            .get(TRANSFORM_OUT)
+            .apply(
+                "WriteSuccessfulRecords",
+                BigQueryIO.writeTableRows()
+                    .withoutValidation()
+                    .withCreateDisposition(CreateDisposition.CREATE_NEVER)
+                    .withWriteDisposition(WriteDisposition.WRITE_APPEND)
+                    .withExtendedErrorInfo()
+                    .withFailedInsertRetryPolicy(InsertRetryPolicy.retryTransientErrors())
+                    .to(options.getOutputTableSpec()));
+
+    /*
+     * Step 3 Contd.
+     * Elements that failed inserts into BigQuery are extracted and converted to FailsafeElement
+     */
+    PCollection<FailsafeElement<String, String>> failedInserts =
+        BigQueryIOUtils.writeResultToBigQueryInsertErrors(writeResult, options)
+            .apply(
+                "WrapInsertionErrors",
+                MapElements.into(FAILSAFE_ELEMENT_CODER.getEncodedTypeDescriptor())
+                    .via(KafkaToBigQueryFlex::wrapBigQueryInsertError))
+            .setCoder(FAILSAFE_ELEMENT_CODER);
+
+    if (options.getOutputDeadletterTable() != null) {
+      /*
+       * Step #4: Write failed records out to BigQuery
+       */
+      PCollectionList.of(convertedTableRows.get(TRANSFORM_DEADLETTER_OUT))
+          .apply("Flatten", Flatten.pCollections())
+          .apply(
+              "WriteTransformationFailedRecords",
+              WriteKafkaMessageErrors.newBuilder()
+                  .setErrorRecordsTable(
+                      ObjectUtils.firstNonNull(options.getOutputDeadletterTable()))
+                  .setErrorRecordsTableSchema(SchemaUtils.DEADLETTER_SCHEMA)
+                  .build());
+    } else {
+      PCollectionList.of(convertedTableRows.get(TRANSFORM_DEADLETTER_OUT))
+          .apply("Flatten", Flatten.pCollections())
+          .apply(
+              "PrintInsertionFailedRecords",
+              ParDo.of(new ThrowErrorFn<KV<String, String>, String>()));
+    }
+
+    if (options.getOutputDeadletterTable() != null) {
+      /*
+       * Step #5: Insert records that failed BigQuery inserts into a deadletter table.
+       */
+      failedInserts.apply(
+          "WriteInsertionFailedRecords",
+          ErrorConverters.WriteStringMessageErrors.newBuilder()
+              .setErrorRecordsTable(
+                  ObjectUtils.firstNonNull(
+                      options.getOutputDeadletterTable(),
+                      options.getOutputTableSpec() + DEFAULT_DEADLETTER_TABLE_SUFFIX))
+              .setErrorRecordsTableSchema(SchemaUtils.DEADLETTER_SCHEMA)
+              .build());
+    } else {
+      failedInserts.apply(
+          "PrintInsertionFailedRecords", ParDo.of(new ThrowErrorFn<String, String>()));
+    }
+
+    return pipeline.run();
+  }
+
+  /**
+   * Method to wrap a {@link BigQueryInsertError} into a {@link FailsafeElement}.
+   *
+   * @param insertError BigQueryInsert error.
+   * @return FailsafeElement object.
+   */
+  protected static FailsafeElement<String, String> wrapBigQueryInsertError(
+      BigQueryInsertError insertError) {
+
+    FailsafeElement<String, String> failsafeElement;
+    try {
+
+      failsafeElement =
+          FailsafeElement.of(
+              insertError.getRow().toPrettyString(), insertError.getRow().toPrettyString());
+      failsafeElement.setErrorMessage(insertError.getError().toPrettyString());
+
+    } catch (IOException e) {
+      LOG.error("Failed to wrap BigQuery insert error.");
+      throw new RuntimeException(e);
+    }
+    return failsafeElement;
+  }
+
+  /**
+   * Method to create Kafka Client Authentication Config with the given username and password.
+   *
+   * @param username Kafka username.
+   * @param password Kafka password.
+   * @return ImmutableMap object.
+   */
+  static ImmutableMap<String, Object> setClientAuthConfig(String username, String password) {
+    ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
+    properties.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+    properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+    properties.put(
+        SaslConfigs.SASL_JAAS_CONFIG,
+        "org.apache.kafka.common.security.plain.PlainLoginModule required"
+            + " username=\'"
+            + username
+            + "\'"
+            + " password=\'"
+            + password
+            + "\';");
+    return properties.buildOrThrow();
+  }
+
+  static class ThrowErrorFn<T, W> extends DoFn<FailsafeElement<T, W>, FailsafeElement<T, W>> {
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      FailsafeElement<T, W> element = context.element();
+      // TODO: Logging every exception might overload Google Cloud Logging API. Find a better way to
+      // log these errors.
+      LOG.error(element.toString() + element.getErrorMessage() + element.getStacktrace());
+      context.output(element);
+    }
+  }
+}

--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/transforms/AvroDynamicTransform.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/transforms/AvroDynamicTransform.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.transforms;
+
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.cloud.teleport.v2.coders.FailsafeElementCoder;
+import com.google.cloud.teleport.v2.coders.GenericRecordCoder;
+import com.google.cloud.teleport.v2.options.KafkaToBigQueryFlexOptions;
+import com.google.cloud.teleport.v2.utils.BigQueryAvroUtils;
+import com.google.cloud.teleport.v2.values.FailsafeElement;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import java.io.IOException;
+import java.io.Serializable;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.NullableCoder;
+import org.apache.beam.sdk.extensions.avro.schemas.utils.AvroUtils;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryUtils;
+import org.apache.beam.sdk.io.gcp.bigquery.InsertRetryPolicy;
+import org.apache.beam.sdk.io.gcp.bigquery.TableRowJsonCoder;
+import org.apache.beam.sdk.io.gcp.bigquery.WriteResult;
+import org.apache.beam.sdk.io.kafka.KafkaRecord;
+import org.apache.beam.sdk.io.kafka.KafkaRecordCoder;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+import org.apache.beam.sdk.transforms.DoFn.ProcessElement;
+import org.apache.beam.sdk.transforms.DoFn.Setup;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link AvroDynamicTransform} class is a {@link PTransform} which transforms incoming Kafka
+ * Message objects into {@link TableRow} objects and inserts them into BigQuery using {@link
+ * org.apache.beam.sdk.io.gcp.bigquery.DynamicDestinations} to handle multiple schemas returning the
+ * {@link WriteResult}. The {@link AvroDynamicTransform} transform will output a {@link WriteResult}
+ * which contains the failed BigQuery writes.
+ */
+public class AvroDynamicTransform
+    extends PTransform<PCollection<KafkaRecord<byte[], byte[]>>, WriteResult> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AvroDynamicTransform.class);
+
+  private KafkaToBigQueryFlexOptions options;
+
+  private AvroDynamicTransform(KafkaToBigQueryFlexOptions options) {
+    this.options = options;
+  }
+
+  public static AvroDynamicTransform of(KafkaToBigQueryFlexOptions options) {
+    return new AvroDynamicTransform(options);
+  }
+
+  public WriteResult expand(PCollection<KafkaRecord<byte[], byte[]>> kafkaRecords) {
+    WriteResult writeResult;
+
+    Write<KV<GenericRecord, TableRow>> writeToBQ =
+        BigQueryIO.<KV<GenericRecord, TableRow>>write()
+            .to(
+                BigQueryDynamicDestination.of(
+                    options.getProject(),
+                    options.getOutputDataset(),
+                    options.getBQTableNamePrefix()))
+            .withWriteDisposition(WriteDisposition.valueOf(options.getWriteDisposition()))
+            .withCreateDisposition(CreateDisposition.valueOf(options.getCreateDisposition()))
+            .withFailedInsertRetryPolicy(InsertRetryPolicy.retryTransientErrors())
+            .withFormatFunction(kv -> kv.getValue())
+            .withExtendedErrorInfo();
+
+    writeResult =
+        kafkaRecords
+            .apply(
+                "ConvertKafkaRecordsToGenericRecordsWrappedinFailsafeElement",
+                ParDo.of(
+                    new KafkaRecordToGenericRecordFailsafeElementFn(
+                        options.getSchemaRegistryConnectionUrl())))
+            .setCoder(
+                FailsafeElementCoder.of(
+                    KafkaRecordCoder.of(NullableCoder.of(ByteArrayCoder.of()), ByteArrayCoder.of()),
+                    GenericRecordCoder.of()))
+            .apply("ConvertGenericRecordToTableRow", ParDo.of(new GenericRecordToTableRowFn()))
+            .setCoder(
+                FailsafeElementCoder.of(
+                    KafkaRecordCoder.of(NullableCoder.of(ByteArrayCoder.of()), ByteArrayCoder.of()),
+                    KvCoder.of(GenericRecordCoder.of(), TableRowJsonCoder.of())))
+            .apply(ParDo.of(new FailsafeElementGetPayloadFn()))
+            .apply(writeToBQ);
+
+    return writeResult;
+  }
+
+  private static class KafkaRecordToGenericRecordFailsafeElementFn
+      extends DoFn<
+          KafkaRecord<byte[], byte[]>, FailsafeElement<KafkaRecord<byte[], byte[]>, GenericRecord>>
+      implements Serializable {
+
+    private transient KafkaAvroDeserializer deserializer;
+    private transient SchemaRegistryClient schemaRegistryClient;
+    private String schemaRegistryConnectionUrl = null;
+
+    KafkaRecordToGenericRecordFailsafeElementFn(String schemaRegistryConnectionUrl) {
+      this.schemaRegistryConnectionUrl = schemaRegistryConnectionUrl;
+    }
+
+    @Setup
+    public void setup() throws IOException, RestClientException {
+      if (this.schemaRegistryConnectionUrl != null) {
+        this.schemaRegistryClient =
+            new CachedSchemaRegistryClient(this.schemaRegistryConnectionUrl, 1000);
+        this.deserializer = new KafkaAvroDeserializer(this.schemaRegistryClient);
+      } else {
+        throw new IllegalArgumentException(
+            "Either an Avro schema or Schema Registry URL is needed.");
+      }
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      KafkaRecord<byte[], byte[]> element = context.element();
+      GenericRecord result = null;
+      try {
+        // Serialize to Generic Record
+        result =
+            (GenericRecord)
+                this.deserializer.deserialize(
+                    element.getTopic(), element.getHeaders(), element.getKV().getValue());
+      } catch (Exception e) {
+        LOG.error("Failed during deserialization: " + e.toString());
+      }
+      context.output(FailsafeElement.of(element, result));
+    }
+  }
+
+  private static class GenericRecordToTableRowFn
+      extends DoFn<
+          FailsafeElement<KafkaRecord<byte[], byte[]>, GenericRecord>,
+          FailsafeElement<KafkaRecord<byte[], byte[]>, KV<GenericRecord, TableRow>>>
+      implements Serializable {
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      FailsafeElement<KafkaRecord<byte[], byte[]>, GenericRecord> element = context.element();
+      TableRow row =
+          BigQueryAvroUtils.convertGenericRecordToTableRow(
+              element.getPayload(),
+              BigQueryUtils.toTableSchema(
+                  AvroUtils.toBeamSchema(element.getPayload().getSchema())));
+      context.output(
+          FailsafeElement.of(element.getOriginalPayload(), KV.of(element.getPayload(), row)));
+    }
+  }
+
+  private static class FailsafeElementGetPayloadFn
+      extends DoFn<
+          FailsafeElement<KafkaRecord<byte[], byte[]>, KV<GenericRecord, TableRow>>,
+          KV<GenericRecord, TableRow>> {
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      context.output(context.element().getPayload());
+    }
+  }
+}

--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/transforms/AvroTransform.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/transforms/AvroTransform.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.transforms;
+
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.cloud.teleport.v2.coders.FailsafeElementCoder;
+import com.google.cloud.teleport.v2.coders.GenericRecordCoder;
+import com.google.cloud.teleport.v2.kafka.transforms.NonWireAvroDeserializer;
+import com.google.cloud.teleport.v2.options.KafkaToBigQueryFlexOptions;
+import com.google.cloud.teleport.v2.utils.BigQueryAvroUtils;
+import com.google.cloud.teleport.v2.utils.SchemaUtils;
+import com.google.cloud.teleport.v2.values.FailsafeElement;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import java.io.IOException;
+import java.io.Serializable;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.NullableCoder;
+import org.apache.beam.sdk.extensions.avro.schemas.utils.AvroUtils;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryUtils;
+import org.apache.beam.sdk.io.gcp.bigquery.InsertRetryPolicy;
+import org.apache.beam.sdk.io.gcp.bigquery.TableRowJsonCoder;
+import org.apache.beam.sdk.io.gcp.bigquery.WriteResult;
+import org.apache.beam.sdk.io.kafka.KafkaRecord;
+import org.apache.beam.sdk.io.kafka.KafkaRecordCoder;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+import org.apache.beam.sdk.transforms.DoFn.ProcessElement;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link AvroTransform} class is a {@link PTransform} which transforms incoming Kafka Message
+ * objects into {@link TableRow} objects and inserts them into BigQuery returning the {@link
+ * WriteResult}. The {@link AvroTransform} transform will output a {@link WriteResult} which
+ * contains the failed BigQuery writes.
+ */
+public class AvroTransform
+    extends PTransform<PCollection<KafkaRecord<byte[], byte[]>>, WriteResult> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AvroTransform.class);
+
+  private KafkaToBigQueryFlexOptions options;
+
+  private AvroTransform(KafkaToBigQueryFlexOptions options) {
+    this.options = options;
+  }
+
+  public static AvroTransform of(KafkaToBigQueryFlexOptions options) {
+    return new AvroTransform(options);
+  }
+
+  public WriteResult expand(PCollection<KafkaRecord<byte[], byte[]>> kafkaRecords) {
+    String avroSchema = options.getAvroSchemaPath();
+    Schema schema = SchemaUtils.getAvroSchema(avroSchema);
+    WriteResult writeResult;
+
+    Write<TableRow> writeToBQ =
+        BigQueryIO.<TableRow>write()
+            .withSchema(BigQueryUtils.toTableSchema(AvroUtils.toBeamSchema(schema)))
+            .withWriteDisposition(WriteDisposition.valueOf(options.getWriteDisposition()))
+            .withCreateDisposition(CreateDisposition.valueOf(options.getCreateDisposition()))
+            .withFailedInsertRetryPolicy(InsertRetryPolicy.retryTransientErrors())
+            .withFormatFunction(row -> row)
+            .withExtendedErrorInfo();
+
+    if (options.getOutputTableSpec() != null) {
+      writeToBQ = writeToBQ.to(options.getOutputTableSpec());
+    }
+
+    writeResult =
+        kafkaRecords
+            .apply(
+                "ConvertKafkaRecordsToGenericRecordsWrappedinFailsafeElement",
+                ParDo.of(
+                    new KafkaRecordToGenericRecordFailsafeElementFn(
+                        schema, options.getKafkaReadTopics(), options.getAvroFormat())))
+            .setCoder(
+                FailsafeElementCoder.of(
+                    KafkaRecordCoder.of(NullableCoder.of(ByteArrayCoder.of()), ByteArrayCoder.of()),
+                    GenericRecordCoder.of()))
+            .apply("ConvertGenericRecordToTableRow", ParDo.of(new GenericRecordToTableRowFn()))
+            .setCoder(
+                FailsafeElementCoder.of(
+                    KafkaRecordCoder.of(NullableCoder.of(ByteArrayCoder.of()), ByteArrayCoder.of()),
+                    TableRowJsonCoder.of()))
+            .apply(ParDo.of(new FailsafeElementGetPayloadFn()))
+            .apply(writeToBQ);
+
+    return writeResult;
+  }
+
+  private static class KafkaRecordToGenericRecordFailsafeElementFn
+      extends DoFn<
+          KafkaRecord<byte[], byte[]>, FailsafeElement<KafkaRecord<byte[], byte[]>, GenericRecord>>
+      implements Serializable {
+
+    private transient KafkaAvroDeserializer deserializer;
+    private transient SchemaRegistryClient schemaRegistryClient;
+    private Schema schema = null;
+    private String topicName;
+    private String useConfluentWireFormat;
+
+    KafkaRecordToGenericRecordFailsafeElementFn(
+        Schema schema, String topicName, String useConfluentWireFormat) {
+      this.schema = schema;
+      this.topicName = topicName;
+      this.useConfluentWireFormat = useConfluentWireFormat;
+    }
+
+    @Setup
+    public void setup() throws IOException, RestClientException {
+      if (this.schema != null && this.useConfluentWireFormat.equals("NON_WIRE_FORMAT")) {
+        this.deserializer = new NonWireAvroDeserializer(this.schema);
+      } else if (this.schema != null
+          && this.useConfluentWireFormat.equals("CONFLUENT_WIRE_FORMAT")) {
+        this.schemaRegistryClient = new MockSchemaRegistryClient();
+        this.schemaRegistryClient.register(this.topicName, this.schema, 1, 1);
+        this.deserializer = new KafkaAvroDeserializer(schemaRegistryClient);
+      } else {
+        throw new IllegalArgumentException(
+            "An Avro schema is needed in order to deserialize values.");
+      }
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      KafkaRecord<byte[], byte[]> element = context.element();
+      GenericRecord result = null;
+      try {
+        // Serialize to Generic Record
+        result =
+            (GenericRecord)
+                this.deserializer.deserialize(
+                    element.getTopic(), element.getHeaders(), element.getKV().getValue());
+      } catch (Exception e) {
+        LOG.error("Failed during deserialization: " + e.toString());
+      }
+      context.output(FailsafeElement.of(element, result));
+    }
+  }
+
+  private static class GenericRecordToTableRowFn
+      extends DoFn<
+          FailsafeElement<KafkaRecord<byte[], byte[]>, GenericRecord>,
+          FailsafeElement<KafkaRecord<byte[], byte[]>, TableRow>>
+      implements Serializable {
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      FailsafeElement<KafkaRecord<byte[], byte[]>, GenericRecord> element = context.element();
+      TableRow row =
+          BigQueryAvroUtils.convertGenericRecordToTableRow(
+              element.getPayload(),
+              BigQueryUtils.toTableSchema(
+                  AvroUtils.toBeamSchema(element.getPayload().getSchema())));
+      context.output(FailsafeElement.of(element.getOriginalPayload(), row));
+    }
+  }
+
+  private static class FailsafeElementGetPayloadFn
+      extends DoFn<FailsafeElement<KafkaRecord<byte[], byte[]>, TableRow>, TableRow> {
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      context.output(context.element().getPayload());
+    }
+  }
+}

--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryDynamicDestination.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryDynamicDestination.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.transforms;
+
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.api.services.bigquery.model.TableSchema;
+import com.google.cloud.teleport.v2.coders.GenericRecordCoder;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.extensions.avro.schemas.utils.AvroUtils;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryUtils;
+import org.apache.beam.sdk.io.gcp.bigquery.DynamicDestinations;
+import org.apache.beam.sdk.io.gcp.bigquery.TableDestination;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.ValueInSingleWindow;
+
+public class BigQueryDynamicDestination
+    extends DynamicDestinations<KV<GenericRecord, TableRow>, GenericRecord> {
+
+  private String projectName;
+
+  private String datasetName;
+
+  private String tableNamePrefix;
+
+  public static BigQueryDynamicDestination of(
+      String projectName, String datasetName, String tableNamePrefix) {
+    return new BigQueryDynamicDestination(projectName, datasetName, tableNamePrefix);
+  }
+
+  private BigQueryDynamicDestination(
+      String projectName, String datasetName, String tableNamePrefix) {
+    this.projectName = projectName;
+    this.datasetName = datasetName;
+    this.tableNamePrefix = tableNamePrefix;
+  }
+
+  @Override
+  public GenericRecord getDestination(ValueInSingleWindow<KV<GenericRecord, TableRow>> element) {
+    return element.getValue().getKey();
+  }
+
+  @Override
+  public TableDestination getTable(GenericRecord element) {
+    // tablename + record name (same across schemas) + schema id?
+    String bqQualifiedFullName = element.getSchema().getFullName().replace(".", "-");
+    String tableName =
+        this.tableNamePrefix + (this.tableNamePrefix == "" ? "" : "-") + bqQualifiedFullName;
+    String tableSpec = this.projectName + ":" + this.datasetName + "." + tableName;
+    return new TableDestination(tableSpec, null);
+  }
+
+  @Override
+  public TableSchema getSchema(GenericRecord element) {
+    // TODO: Test if sending null can work here, might be mroe efficient.
+    return BigQueryUtils.toTableSchema(AvroUtils.toBeamSchema(element.getSchema()));
+  }
+
+  @Override
+  public Coder<GenericRecord> getDestinationCoder() {
+    return GenericRecordCoder.of();
+  }
+}

--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/transforms/StringMessageToTableRow.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/transforms/StringMessageToTableRow.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.transforms;
+
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.cloud.teleport.v2.templates.KafkaToBigQueryFlex;
+import com.google.cloud.teleport.v2.transforms.BigQueryConverters.FailsafeJsonToTableRow;
+import com.google.cloud.teleport.v2.values.FailsafeElement;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+
+/**
+ * The {@link StringMessageToTableRow} class is a {@link PTransform} which transforms incoming Kafka
+ * Message objects into {@link TableRow} objects for insertion into BigQuery while applying a UDF to
+ * the input. The executions of the UDF and transformation to {@link TableRow} objects is done in a
+ * fail-safe way by wrapping the element with it's original payload inside the {@link
+ * FailsafeElement} class. The {@link StringMessageToTableRow} transform will output a {@link
+ * PCollectionTuple} which contains all output and dead-letter {@link PCollection}.
+ *
+ * <p>The {@link PCollectionTuple} output will contain the following {@link PCollection}:
+ *
+ * <ul>
+ *   <li>{@link KafkaToBigQuery#TRANSFORM_OUT} - Contains all records successfully converted from
+ *       JSON to {@link TableRow} objects.
+ *   <li>{@link KafkaToBigQuery#TRANSFORM_DEADLETTER_OUT} - Contains all {@link FailsafeElement}
+ *       records which couldn't be converted to table rows.
+ * </ul>
+ */
+public class StringMessageToTableRow
+    extends PTransform<PCollection<KV<String, String>>, PCollectionTuple> {
+
+  @Override
+  public PCollectionTuple expand(PCollection<KV<String, String>> input) {
+
+    PCollectionTuple jsonToTableRowOut =
+        input
+            // Map the incoming messages into FailsafeElements so we can recover from failures
+            // across multiple transforms.
+            .apply("MapToRecord", ParDo.of(new StringMessageToFailsafeElementFn()))
+            .apply(
+                "JsonToTableRow",
+                FailsafeJsonToTableRow.<KV<String, String>>newBuilder()
+                    .setSuccessTag(KafkaToBigQueryFlex.TRANSFORM_OUT)
+                    .setFailureTag(KafkaToBigQueryFlex.TRANSFORM_DEADLETTER_OUT)
+                    .build());
+
+    // Re-wrap the PCollections so we can return a single PCollectionTuple
+    return PCollectionTuple.of(
+            KafkaToBigQueryFlex.TRANSFORM_OUT,
+            jsonToTableRowOut.get(KafkaToBigQueryFlex.TRANSFORM_OUT))
+        .and(
+            KafkaToBigQueryFlex.TRANSFORM_DEADLETTER_OUT,
+            jsonToTableRowOut.get(KafkaToBigQueryFlex.TRANSFORM_DEADLETTER_OUT));
+  }
+
+  /**
+   * The {@link StringMessageToFailsafeElementFn} wraps an Kafka Message with the {@link
+   * FailsafeElement} class so errors can be recovered from and the original message can be output
+   * to an error records table.
+   */
+  static class StringMessageToFailsafeElementFn
+      extends DoFn<KV<String, String>, FailsafeElement<KV<String, String>, String>> {
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      KV<String, String> message = context.element();
+      context.output(FailsafeElement.of(message, message.getValue()));
+    }
+  }
+}

--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/transforms/package-info.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/transforms/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Provides {@link org.apache.beam.sdk.transforms.PTransform}s for read/write and transforming data
+ * in a pipeline.
+ */
+package com.google.cloud.teleport.v2.transforms;

--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/utils/BigQueryAvroUtils.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/utils/BigQueryAvroUtils.java
@@ -1,0 +1,529 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.utils;
+
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.MoreObjects.firstNonNull;
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Verify.verify;
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Verify.verifyNotNull;
+
+import com.google.api.services.bigquery.model.TableFieldSchema;
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.api.services.bigquery.model.TableSchema;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.avro.Conversions;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.Schema.Type;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableCollection;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMultimap;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.io.BaseEncoding;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+/**
+ * A set of utilities for working with Avro files.
+ *
+ * <p>These utilities are based on the <a href="https://avro.apache.org/docs/1.8.1/spec.html">Avro
+ * 1.8.1</a> specification.
+ *
+ * <p>This utility class has been imported temporarily from the Beam repository {@link
+ * org.apache.beam.sdk.io.gcp.bigquery.BigQueryAvroUtils}. It will be removed once the upstream
+ * class has been updated.
+ */
+public class BigQueryAvroUtils {
+
+  /**
+   * Defines the valid mapping between BigQuery types and native Avro types.
+   *
+   * <p>Some BigQuery types are duplicated here since slightly different Avro records are produced
+   * when exporting data in Avro format and when reading data directly using the read API.
+   */
+  static final ImmutableMultimap<String, Type> BIG_QUERY_TO_AVRO_TYPES =
+      ImmutableMultimap.<String, Type>builder()
+          .put("STRING", Type.STRING)
+          .put("GEOGRAPHY", Type.STRING)
+          .put("BYTES", Type.BYTES)
+          .put("INTEGER", Type.LONG)
+          .put("INTEGER", Type.INT)
+          .put("INT64", Type.LONG)
+          .put("INT64", Type.INT)
+          .put("FLOAT", Type.DOUBLE)
+          .put("FLOAT", Type.INT)
+          .put("FLOAT64", Type.DOUBLE)
+          .put("FLOAT64", Type.INT)
+          .put("NUMERIC", Type.BYTES)
+          .put("BIGNUMERIC", Type.BYTES)
+          .put("BOOLEAN", Type.BOOLEAN)
+          .put("BOOL", Type.BOOLEAN)
+          .put("TIMESTAMP", Type.LONG)
+          .put("RECORD", Type.RECORD)
+          .put("STRUCT", Type.RECORD)
+          .put("DATE", Type.STRING)
+          .put("DATE", Type.INT)
+          .put("DATETIME", Type.STRING)
+          .put("TIME", Type.STRING)
+          .put("TIME", Type.LONG)
+          .put("JSON", Type.STRING)
+          .build();
+
+  /**
+   * Formats BigQuery seconds-since-epoch into String matching JSON export. Thread-safe and
+   * immutable.
+   */
+  private static final DateTimeFormatter DATE_AND_SECONDS_FORMATTER =
+      DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss").withZoneUTC();
+
+  static String formatTimestamp(Long timestampMicro) {
+    // timestampMicro is in "microseconds since epoch" format,
+    // e.g., 1452062291123456L means "2016-01-06 06:38:11.123456 UTC".
+    // Separate into seconds and microseconds.
+    long timestampSec = timestampMicro / 1_000_000;
+    long micros = timestampMicro % 1_000_000;
+    if (micros < 0) {
+      micros += 1_000_000;
+      timestampSec -= 1;
+    }
+    String dayAndTime = DATE_AND_SECONDS_FORMATTER.print(timestampSec * 1000);
+
+    if (micros == 0) {
+      return String.format("%s UTC", dayAndTime);
+    }
+    return String.format("%s.%06d UTC", dayAndTime, micros);
+  }
+
+  /**
+   * This method formats a BigQuery DATE value into a String matching the format used by JSON
+   * export. Date records are stored in "days since epoch" format, and BigQuery uses the proleptic
+   * Gregorian calendar.
+   */
+  private static String formatDate(int date) {
+    return LocalDate.ofEpochDay(date).format(java.time.format.DateTimeFormatter.ISO_LOCAL_DATE);
+  }
+
+  private static final java.time.format.DateTimeFormatter ISO_LOCAL_TIME_FORMATTER_MICROS =
+      new DateTimeFormatterBuilder()
+          .appendValue(HOUR_OF_DAY, 2)
+          .appendLiteral(':')
+          .appendValue(MINUTE_OF_HOUR, 2)
+          .appendLiteral(':')
+          .appendValue(SECOND_OF_MINUTE, 2)
+          .appendLiteral('.')
+          .appendFraction(NANO_OF_SECOND, 6, 6, false)
+          .toFormatter();
+
+  private static final java.time.format.DateTimeFormatter ISO_LOCAL_TIME_FORMATTER_MILLIS =
+      new DateTimeFormatterBuilder()
+          .appendValue(HOUR_OF_DAY, 2)
+          .appendLiteral(':')
+          .appendValue(MINUTE_OF_HOUR, 2)
+          .appendLiteral(':')
+          .appendValue(SECOND_OF_MINUTE, 2)
+          .appendLiteral('.')
+          .appendFraction(NANO_OF_SECOND, 3, 3, false)
+          .toFormatter();
+
+  private static final java.time.format.DateTimeFormatter ISO_LOCAL_TIME_FORMATTER_SECONDS =
+      new DateTimeFormatterBuilder()
+          .appendValue(HOUR_OF_DAY, 2)
+          .appendLiteral(':')
+          .appendValue(MINUTE_OF_HOUR, 2)
+          .appendLiteral(':')
+          .appendValue(SECOND_OF_MINUTE, 2)
+          .toFormatter();
+
+  /**
+   * This method formats a BigQuery TIME value into a String matching the format used by JSON
+   * export. Time records are stored in "microseconds since midnight" format.
+   */
+  private static String formatTime(long timeMicros) {
+    java.time.format.DateTimeFormatter formatter;
+    if (timeMicros % 1000000 == 0) {
+      formatter = ISO_LOCAL_TIME_FORMATTER_SECONDS;
+    } else if (timeMicros % 1000 == 0) {
+      formatter = ISO_LOCAL_TIME_FORMATTER_MILLIS;
+    } else {
+      formatter = ISO_LOCAL_TIME_FORMATTER_MICROS;
+    }
+    return LocalTime.ofNanoOfDay(timeMicros * 1000).format(formatter);
+  }
+
+  static TableSchema trimBigQueryTableSchema(TableSchema inputSchema, Schema avroSchema) {
+    List<TableFieldSchema> subSchemas =
+        inputSchema.getFields().stream()
+            .flatMap(fieldSchema -> mapTableFieldSchema(fieldSchema, avroSchema))
+            .collect(Collectors.toList());
+
+    return new TableSchema().setFields(subSchemas);
+  }
+
+  private static Stream<TableFieldSchema> mapTableFieldSchema(
+      TableFieldSchema fieldSchema, Schema avroSchema) {
+    Field avroFieldSchema = avroSchema.getField(fieldSchema.getName());
+    if (avroFieldSchema == null) {
+      return Stream.empty();
+    } else if (avroFieldSchema.schema().getType() != Type.RECORD) {
+      return Stream.of(fieldSchema);
+    }
+
+    List<TableFieldSchema> subSchemas =
+        fieldSchema.getFields().stream()
+            .flatMap(subSchema -> mapTableFieldSchema(subSchema, avroFieldSchema.schema()))
+            .collect(Collectors.toList());
+
+    TableFieldSchema output =
+        new TableFieldSchema()
+            .setCategories(fieldSchema.getCategories())
+            .setDescription(fieldSchema.getDescription())
+            .setFields(subSchemas)
+            .setMode(fieldSchema.getMode())
+            .setName(fieldSchema.getName())
+            .setType(fieldSchema.getType());
+
+    return Stream.of(output);
+  }
+
+  /**
+   * Utility function to convert from an Avro {@link GenericRecord} to a BigQuery {@link TableRow}.
+   *
+   * <p>See <a href="https://cloud.google.com/bigquery/exporting-data-from-bigquery#config">"Avro
+   * format"</a> for more information.
+   */
+  public static TableRow convertGenericRecordToTableRow(GenericRecord record, TableSchema schema) {
+    return convertGenericRecordToTableRow(record, schema.getFields());
+  }
+
+  private static TableRow convertGenericRecordToTableRow(
+      GenericRecord record, List<TableFieldSchema> fields) {
+    TableRow row = new TableRow();
+    for (TableFieldSchema subSchema : fields) {
+      // Per https://cloud.google.com/bigquery/docs/reference/v2/tables#schema, the name field
+      // is required, so it may not be null.
+      Field field = record.getSchema().getField(subSchema.getName());
+      Object convertedValue =
+          getTypedCellValue(field.schema(), subSchema, record.get(field.name()));
+      if (convertedValue != null) {
+        // To match the JSON files exported by BigQuery, do not include null values in the output.
+        row.set(field.name(), convertedValue);
+      }
+    }
+
+    return row;
+  }
+
+  private static @Nullable Object getTypedCellValue(
+      Schema schema, TableFieldSchema fieldSchema, Object v) {
+    // Per https://cloud.google.com/bigquery/docs/reference/v2/tables#schema, the mode field
+    // is optional (and so it may be null), but defaults to "NULLABLE".
+    String mode = firstNonNull(fieldSchema.getMode(), "NULLABLE");
+    switch (mode) {
+      case "REQUIRED":
+        return convertRequiredField(schema.getType(), schema.getLogicalType(), fieldSchema, v);
+      case "REPEATED":
+        return convertRepeatedField(schema, fieldSchema, v);
+      case "NULLABLE":
+        return convertNullableField(schema, fieldSchema, v);
+      default:
+        throw new UnsupportedOperationException(
+            "Parsing a field with BigQuery field schema mode " + fieldSchema.getMode());
+    }
+  }
+
+  private static List<Object> convertRepeatedField(
+      Schema schema, TableFieldSchema fieldSchema, Object v) {
+    Type arrayType = schema.getType();
+    verify(
+        arrayType == Type.ARRAY,
+        "BigQuery REPEATED field %s should be Avro ARRAY, not %s",
+        fieldSchema.getName(),
+        arrayType);
+    // REPEATED fields are represented as Avro arrays.
+    if (v == null) {
+      // Handle the case of an empty repeated field.
+      return new ArrayList<>();
+    }
+    @SuppressWarnings("unchecked")
+    List<Object> elements = (List<Object>) v;
+    ArrayList<Object> values = new ArrayList<>();
+    Type elementType = schema.getElementType().getType();
+    LogicalType elementLogicalType = schema.getElementType().getLogicalType();
+    for (Object element : elements) {
+      values.add(convertRequiredField(elementType, elementLogicalType, fieldSchema, element));
+    }
+    return values;
+  }
+
+  private static Object convertRequiredField(
+      Type avroType, LogicalType avroLogicalType, TableFieldSchema fieldSchema, Object v) {
+    // REQUIRED fields are represented as the corresponding Avro types. For example, a BigQuery
+    // INTEGER type maps to an Avro LONG type.
+    checkNotNull(v, "REQUIRED field %s should not be null", fieldSchema.getName());
+    // Per https://cloud.google.com/bigquery/docs/reference/v2/tables#schema, the type field
+    // is required, so it may not be null.
+    String bqType = fieldSchema.getType();
+    ImmutableCollection<Type> expectedAvroTypes = BIG_QUERY_TO_AVRO_TYPES.get(bqType);
+    verifyNotNull(expectedAvroTypes, "Unsupported BigQuery type: %s", bqType);
+    verify(
+        expectedAvroTypes.contains(avroType),
+        "Expected Avro schema types %s for BigQuery %s field %s, but received %s",
+        expectedAvroTypes,
+        bqType,
+        fieldSchema.getName(),
+        avroType);
+    // For historical reasons, don't validate avroLogicalType except for with NUMERIC.
+    // BigQuery represents NUMERIC in Avro format as BYTES with a DECIMAL logical type.
+    switch (bqType) {
+      case "STRING":
+      case "DATETIME":
+      case "GEOGRAPHY":
+      case "JSON":
+        // Avro will use a CharSequence to represent String objects, but it may not always use
+        // java.lang.String; for example, it may prefer org.apache.avro.util.Utf8.
+        verify(v instanceof CharSequence, "Expected CharSequence (String), got %s", v.getClass());
+        return v.toString();
+      case "DATE":
+        if (avroType == Type.INT) {
+          verify(v instanceof Integer, "Expected Integer, got %s", v.getClass());
+          verifyNotNull(avroLogicalType, "Expected Date logical type");
+          verify(avroLogicalType instanceof LogicalTypes.Date, "Expected Date logical type");
+          return formatDate((Integer) v);
+        } else {
+          verify(v instanceof CharSequence, "Expected CharSequence (String), got %s", v.getClass());
+          return v.toString();
+        }
+      case "TIME":
+        if (avroType == Type.LONG) {
+          verify(v instanceof Long, "Expected Long, got %s", v.getClass());
+          verifyNotNull(avroLogicalType, "Expected TimeMicros logical type");
+          verify(
+              avroLogicalType instanceof LogicalTypes.TimeMicros,
+              "Expected TimeMicros logical type");
+          return formatTime((Long) v);
+        } else {
+          verify(v instanceof CharSequence, "Expected CharSequence (String), got %s", v.getClass());
+          return v.toString();
+        }
+      case "INTEGER":
+      case "INT64":
+        if (avroType == Type.INT) {
+          verify(v instanceof Integer, "Expected Integer, got %s", v.getClass());
+          return ((Long) ((Integer) v).longValue()).toString();
+        } else {
+          verify(v instanceof Long, "Expected Long, got %s", v.getClass());
+          return ((Long) v).toString();
+        }
+      case "FLOAT":
+      case "FLOAT64":
+        if (avroType == Type.INT) {
+          verify(v instanceof Integer, "Expected Integer, got %s", v.getClass());
+          return (Double) ((Integer) v).doubleValue();
+        } else {
+          verify(v instanceof Double, "Expected Double, got %s", v.getClass());
+          return v;
+        }
+      case "NUMERIC":
+      case "BIGNUMERIC":
+        // NUMERIC data types are represented as BYTES with the DECIMAL logical type. They are
+        // converted back to Strings with precision and scale determined by the logical type.
+        verify(v instanceof ByteBuffer, "Expected ByteBuffer, got %s", v.getClass());
+        verifyNotNull(avroLogicalType, "Expected Decimal logical type");
+        verify(avroLogicalType instanceof LogicalTypes.Decimal, "Expected Decimal logical type");
+        BigDecimal numericValue =
+            new Conversions.DecimalConversion()
+                .fromBytes((ByteBuffer) v, Schema.create(avroType), avroLogicalType);
+        return numericValue.toString();
+      case "BOOL":
+      case "BOOLEAN":
+        verify(v instanceof Boolean, "Expected Boolean, got %s", v.getClass());
+        return v;
+      case "TIMESTAMP":
+        // TIMESTAMP data types are represented as Avro LONG types, microseconds since the epoch.
+        // Values may be negative since BigQuery timestamps start at 0001-01-01 00:00:00 UTC.
+        verify(v instanceof Long, "Expected Long, got %s", v.getClass());
+        return formatTimestamp((Long) v);
+      case "RECORD":
+      case "STRUCT":
+        verify(v instanceof GenericRecord, "Expected GenericRecord, got %s", v.getClass());
+        return convertGenericRecordToTableRow((GenericRecord) v, fieldSchema.getFields());
+      case "BYTES":
+        verify(v instanceof ByteBuffer, "Expected ByteBuffer, got %s", v.getClass());
+        ByteBuffer byteBuffer = (ByteBuffer) v;
+        byte[] bytes = new byte[byteBuffer.limit()];
+        byteBuffer.get(bytes);
+        return BaseEncoding.base64().encode(bytes);
+      default:
+        throw new UnsupportedOperationException(
+            String.format(
+                "Unexpected BigQuery field schema type %s for field named %s",
+                fieldSchema.getType(), fieldSchema.getName()));
+    }
+  }
+
+  private static @Nullable Object convertNullableField(
+      Schema avroSchema, TableFieldSchema fieldSchema, Object v) {
+    // NULLABLE fields are represented as an Avro Union of the corresponding type and "null".
+    verify(
+        avroSchema.getType() == Type.UNION,
+        "Expected Avro schema type UNION, not %s, for BigQuery NULLABLE field %s",
+        avroSchema.getType(),
+        fieldSchema.getName());
+    List<Schema> unionTypes = avroSchema.getTypes();
+    verify(
+        unionTypes.size() == 2,
+        "BigQuery NULLABLE field %s should be an Avro UNION of NULL and another type, not %s",
+        fieldSchema.getName(),
+        unionTypes);
+
+    if (v == null) {
+      return null;
+    }
+
+    Type firstType = unionTypes.get(0).getType();
+    if (!firstType.equals(Type.NULL)) {
+      return convertRequiredField(firstType, unionTypes.get(0).getLogicalType(), fieldSchema, v);
+    }
+    return convertRequiredField(
+        unionTypes.get(1).getType(), unionTypes.get(1).getLogicalType(), fieldSchema, v);
+  }
+
+  static Schema toGenericAvroSchema(
+      String schemaName, List<TableFieldSchema> fieldSchemas, @Nullable String namespace) {
+
+    String nextNamespace = namespace == null ? null : String.format("%s.%s", namespace, schemaName);
+
+    List<Field> avroFields = new ArrayList<>();
+    for (TableFieldSchema bigQueryField : fieldSchemas) {
+      avroFields.add(convertField(bigQueryField, nextNamespace));
+    }
+    return Schema.createRecord(
+        schemaName,
+        "Translated Avro Schema for " + schemaName,
+        namespace == null ? "org.apache.beam.sdk.io.gcp.bigquery" : namespace,
+        false,
+        avroFields);
+  }
+
+  static Schema toGenericAvroSchema(String schemaName, List<TableFieldSchema> fieldSchemas) {
+    return toGenericAvroSchema(
+        schemaName,
+        fieldSchemas,
+        hasNamespaceCollision(fieldSchemas) ? "org.apache.beam.sdk.io.gcp.bigquery" : null);
+  }
+
+  // To maintain backwards compatibility we only disambiguate collisions in the field namespaces as
+  // these never worked with this piece of code.
+  private static boolean hasNamespaceCollision(List<TableFieldSchema> fieldSchemas) {
+    Set<String> recordTypeFieldNames = new HashSet<>();
+
+    List<TableFieldSchema> fieldsToCheck = new ArrayList<>();
+    for (fieldsToCheck.addAll(fieldSchemas); !fieldsToCheck.isEmpty(); ) {
+      TableFieldSchema field = fieldsToCheck.remove(0);
+      if ("STRUCT".equals(field.getType()) || "RECORD".equals(field.getType())) {
+        if (recordTypeFieldNames.contains(field.getName())) {
+          return true;
+        }
+        recordTypeFieldNames.add(field.getName());
+        fieldsToCheck.addAll(field.getFields());
+      }
+    }
+
+    // No collisions present
+    return false;
+  }
+
+  @SuppressWarnings({
+    "nullness" // Avro library not annotated
+  })
+  private static Field convertField(TableFieldSchema bigQueryField, @Nullable String namespace) {
+    ImmutableCollection<Type> avroTypes = BIG_QUERY_TO_AVRO_TYPES.get(bigQueryField.getType());
+    if (avroTypes.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Unable to map BigQuery field type " + bigQueryField.getType() + " to avro type.");
+    }
+
+    Type avroType = avroTypes.iterator().next();
+    Schema elementSchema;
+    if (avroType == Type.RECORD) {
+      elementSchema =
+          toGenericAvroSchema(bigQueryField.getName(), bigQueryField.getFields(), namespace);
+    } else {
+      elementSchema = handleAvroLogicalTypes(bigQueryField, avroType);
+    }
+    Schema fieldSchema;
+    if (bigQueryField.getMode() == null || "NULLABLE".equals(bigQueryField.getMode())) {
+      fieldSchema = Schema.createUnion(Schema.create(Type.NULL), elementSchema);
+    } else if ("REQUIRED".equals(bigQueryField.getMode())) {
+      fieldSchema = elementSchema;
+    } else if ("REPEATED".equals(bigQueryField.getMode())) {
+      fieldSchema = Schema.createArray(elementSchema);
+    } else {
+      throw new IllegalArgumentException(
+          String.format("Unknown BigQuery Field Mode: %s", bigQueryField.getMode()));
+    }
+    return new Field(
+        bigQueryField.getName(),
+        fieldSchema,
+        bigQueryField.getDescription(),
+        (Object) null /* Cast to avoid deprecated JsonNode constructor. */);
+  }
+
+  private static Schema handleAvroLogicalTypes(TableFieldSchema bigQueryField, Type avroType) {
+    String bqType = bigQueryField.getType();
+    switch (bqType) {
+      case "NUMERIC":
+        // Default value based on
+        // https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#decimal_types
+        int precision = Optional.ofNullable(bigQueryField.getPrecision()).orElse(38L).intValue();
+        int scale = Optional.ofNullable(bigQueryField.getScale()).orElse(9L).intValue();
+        return LogicalTypes.decimal(precision, scale).addToSchema(Schema.create(Type.BYTES));
+      case "BIGNUMERIC":
+        // Default value based on
+        // https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#decimal_types
+        int precisionBigNumeric =
+            Optional.ofNullable(bigQueryField.getPrecision()).orElse(77L).intValue();
+        int scaleBigNumeric = Optional.ofNullable(bigQueryField.getScale()).orElse(38L).intValue();
+        return LogicalTypes.decimal(precisionBigNumeric, scaleBigNumeric)
+            .addToSchema(Schema.create(Type.BYTES));
+      case "TIMESTAMP":
+        return LogicalTypes.timestampMicros().addToSchema(Schema.create(Type.LONG));
+      case "GEOGRAPHY":
+        Schema geoSchema = Schema.create(Type.STRING);
+        geoSchema.addProp(LogicalType.LOGICAL_TYPE_PROP, "geography_wkt");
+        return geoSchema;
+      default:
+        return Schema.create(avroType);
+    }
+  }
+}

--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/utils/package-info.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/utils/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package containing utility classes for {@link
+ * com.google.cloud.teleport.v2.templates.KafkaToBigQueryFlex} template.
+ */
+package com.google.cloud.teleport.v2.utils;


### PR DESCRIPTION
Kafka to BigQuery template

Authentication

1. Only support SASL_PLAIN and read the username/password from the Google Cloud Secret Manager.

Input

1. Reading Kafka Avro messages (Confluent wire format) using schema registry. Supports multiple schemas in a single topic.
2. Reading Kafka Avro messages (Confluent wire format) when a static schema is provided. Schema ID is hard coded to 1.
3. Reading JSON messages.

Output

1. Writing AVRO messages to the BigQuery. If using schema registry and Confluent wire format, it can write to multiple or single BQ table/s. 
2. Writing JSON message to the BigQuery.

TODO - will be in the future PRs

1. DLQ for Kafka Sink.
2. IT and load tests for the template.
3. Reading Kafka Avro messages encoded in Single-object encoding etc mentioned at https://gist.github.com/davideicardi/e8c5a69b98e2a0f18867b637069d03a9#avro-serialization
4. Other authentication protocols such as SSL and secret managers such as HashiCorp for retrieving credentials for Kafka auth.
5. Add README