### PR TITLE
Allow custom endpoints for Spanner ITs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
         --it-project="cloud-teleport-testing" \
         --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \
         --it-private-connectivity="datastream-private-connect-us-central1" \
+        --it-spanner-host="https://staging-wrenchworks.sandbox.googleapis.com/" \
         --it-release=true \
         --it-retry-failures=2
     - name: Run Integration Tests
@@ -87,6 +88,7 @@ jobs:
         --it-project="cloud-teleport-testing" \
         --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \
         --it-private-connectivity="datastream-private-connect-us-central1" \
+        --it-spanner-host="https://staging-wrenchworks.sandbox.googleapis.com/" \
         --it-release=true \
         --it-retry-failures=2
     - name: Upload Tests Report

--- a/cicd/cmd/run-it-smoke-tests/main.go
+++ b/cicd/cmd/run-it-smoke-tests/main.go
@@ -64,6 +64,7 @@ func main() {
 		flags.ArtifactBucket(),
 		flags.StageBucket(),
 		flags.PrivateConnectivity(),
+		flags.SpannerHost(),
 		flags.FailureMode(),
 		flags.RetryFailures(),
 		flags.StaticOracleInstance(),

--- a/cicd/cmd/run-it-tests/main.go
+++ b/cicd/cmd/run-it-tests/main.go
@@ -65,6 +65,7 @@ func main() {
 		flags.StageBucket(),
 		flags.HostIp(),
 		flags.PrivateConnectivity(),
+		flags.SpannerHost(),
 		flags.FailureMode(),
 		flags.RetryFailures(),
 		flags.StaticOracleInstance(),

--- a/cicd/internal/flags/it-flags.go
+++ b/cicd/internal/flags/it-flags.go
@@ -30,6 +30,7 @@ var (
 	dStageBucket         string
 	dHostIp              string
 	dPrivateConnectivity string
+	dSpannerHost         string
 	dReleaseMode         bool
 	dRetryFailures       string
 	dCloudProxyHost      string
@@ -46,6 +47,7 @@ func RegisterItFlags() {
 	flag.StringVar(&dStageBucket, "it-stage-bucket", "", "(optional) A GCP bucket to stage templates")
 	flag.StringVar(&dHostIp, "it-host-ip", "", "(optional) The ip that the gitactions runner is listening on")
 	flag.StringVar(&dPrivateConnectivity, "it-private-connectivity", "", "(optional) A GCP private connectivity endpoint")
+	flag.StringVar(&dSpannerHost, "it-spanner-host", "", "(optional) A custom endpoint to override Spanner API requests")
 	flag.BoolVar(&dReleaseMode, "it-release", false, "(optional) Set if tests are being executed for a release")
 	flag.StringVar(&dRetryFailures, "it-retry-failures", "0", "Number of retries attempts for failing tests")
 	flag.StringVar(&dCloudProxyHost, "it-cloud-proxy-host", "10.128.0.34", "Hostname or IP address of static Cloud Auth Proxy")
@@ -90,6 +92,13 @@ func PrivateConnectivity() string {
 		return "-DprivateConnectivity=" + dPrivateConnectivity
 	}
 	return ""
+}
+
+func SpannerHost() string {
+	if dSpannerHost == "" {
+		return "-DspannerHost=" + "https://staging-wrenchworks.sandbox.googleapis.com/"
+	}
+	return "-DspannerHost=" + dSpannerHost
 }
 
 func FailureMode() string {

--- a/cicd/internal/workflows/maven-workflows.go
+++ b/cicd/internal/workflows/maven-workflows.go
@@ -56,6 +56,7 @@ type MavenFlags interface {
 	IntegrationTestParallelism(int) string
 	StaticBigtableInstance(string) string
 	StaticSpannerInstance(string) string
+	SpannerHost(string) string
 }
 
 type mvnFlags struct{}
@@ -133,6 +134,10 @@ func (*mvnFlags) StaticBigtableInstance(instanceID string) string {
 
 func (*mvnFlags) StaticSpannerInstance(instanceID string) string {
 	return "-DspannerInstanceId=" + instanceID
+}
+
+func (*mvnFlags) SpannerHost(host string) string {
+	return "-DspannerHost=" + host
 }
 
 func NewMavenFlags() MavenFlags {

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ExportPipelineIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ExportPipelineIT.java
@@ -27,6 +27,7 @@ import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -40,7 +41,6 @@ import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -141,27 +141,38 @@ public class ExportPipelineIT extends TemplateTestBase {
                   + "    }"
                   + "  ]"
                   + "}");
-  private SpannerResourceManager googleSqlResourceManager;
-  private SpannerResourceManager postgresResourceManager;
-
-  @Before
-  public void setup() throws IOException {
-    // Set up resource managers
-    googleSqlResourceManager =
-        SpannerResourceManager.builder(testName, PROJECT, REGION).maybeUseStaticInstance().build();
-    postgresResourceManager =
-        SpannerResourceManager.builder(testName, PROJECT, REGION, Dialect.POSTGRESQL)
-            .maybeUseStaticInstance()
-            .build();
-  }
+  private SpannerResourceManager spannerResourceManager;
 
   @After
   public void teardown() {
-    ResourceManagerUtils.cleanResources(googleSqlResourceManager, postgresResourceManager);
+    ResourceManagerUtils.cleanResources(spannerResourceManager);
   }
 
   @Test
   public void testSpannerToGCSAvro() throws IOException {
+    spannerResourceManager =
+        SpannerResourceManager.builder(testName, PROJECT, REGION, Dialect.GOOGLE_STANDARD_SQL)
+            .maybeUseStaticInstance()
+            .build();
+    testSpannerToGCSAvroBase(Function.identity());
+  }
+
+  @Test
+  public void testSpannerToGCSAvroStaging() throws IOException {
+    spannerResourceManager =
+        SpannerResourceManager.builder(testName, PROJECT, REGION, Dialect.GOOGLE_STANDARD_SQL)
+            .maybeUseStaticInstance()
+            .maybeUseCustomHost()
+            .build();
+    testSpannerToGCSAvroBase(
+        paramAdder ->
+            paramAdder.addParameter("spannerHost", spannerResourceManager.getSpannerHost()));
+  }
+
+  private void testSpannerToGCSAvroBase(
+      Function<PipelineLauncher.LaunchConfig.Builder, PipelineLauncher.LaunchConfig.Builder>
+          paramsAdder)
+      throws IOException {
     // Arrange
     String createEmptyTableStatement =
         String.format(
@@ -184,17 +195,18 @@ public class ExportPipelineIT extends TemplateTestBase {
                 + " REMOTE OPTIONS (endpoint=\"//aiplatform.googleapis.com/projects/span-cloud-testing/locations/us-central1/publishers/google/models/textembedding-gecko\")",
             testName);
 
-    googleSqlResourceManager.executeDdlStatement(createEmptyTableStatement);
-    googleSqlResourceManager.executeDdlStatement(createSingersTableStatement);
-    googleSqlResourceManager.executeDdlStatement(createModelStructStatement);
+    spannerResourceManager.executeDdlStatement(createEmptyTableStatement);
+    spannerResourceManager.executeDdlStatement(createSingersTableStatement);
+    spannerResourceManager.executeDdlStatement(createModelStructStatement);
     List<Mutation> expectedData = generateTableRows(String.format("%s_Singers", testName));
-    googleSqlResourceManager.write(expectedData);
+    spannerResourceManager.write(expectedData);
     PipelineLauncher.LaunchConfig.Builder options =
-        PipelineLauncher.LaunchConfig.builder(testName, specPath)
-            .addParameter("spannerProjectId", PROJECT)
-            .addParameter("instanceId", googleSqlResourceManager.getInstanceId())
-            .addParameter("databaseId", googleSqlResourceManager.getDatabaseId())
-            .addParameter("outputDir", getGcsPath("output/"));
+        paramsAdder.apply(
+            PipelineLauncher.LaunchConfig.builder(testName, specPath)
+                .addParameter("spannerProjectId", PROJECT)
+                .addParameter("instanceId", spannerResourceManager.getInstanceId())
+                .addParameter("databaseId", spannerResourceManager.getDatabaseId())
+                .addParameter("outputDir", getGcsPath("output/")));
 
     // Act
     PipelineLauncher.LaunchInfo info = launchTemplate(options);
@@ -231,6 +243,29 @@ public class ExportPipelineIT extends TemplateTestBase {
 
   @Test
   public void testPostgresSpannerToGCSAvro() throws IOException {
+    spannerResourceManager =
+        SpannerResourceManager.builder(testName, PROJECT, REGION, Dialect.POSTGRESQL)
+            .maybeUseStaticInstance()
+            .build();
+    testPostgresSpannerToGCSAvroBase(Function.identity());
+  }
+
+  @Test
+  public void testPostgresSpannerToGCSAvroStaging() throws IOException {
+    spannerResourceManager =
+        SpannerResourceManager.builder(testName, PROJECT, REGION, Dialect.POSTGRESQL)
+            .maybeUseStaticInstance()
+            .maybeUseCustomHost()
+            .build();
+    testPostgresSpannerToGCSAvroBase(
+        paramAdder ->
+            paramAdder.addParameter("spannerHost", spannerResourceManager.getSpannerHost()));
+  }
+
+  private void testPostgresSpannerToGCSAvroBase(
+      Function<PipelineLauncher.LaunchConfig.Builder, PipelineLauncher.LaunchConfig.Builder>
+          paramsAdder)
+      throws IOException {
     // Arrange
     String createEmptyTableStatement =
         String.format(
@@ -246,16 +281,17 @@ public class ExportPipelineIT extends TemplateTestBase {
                 + "PRIMARY KEY(\"Id\"))",
             testName);
 
-    postgresResourceManager.executeDdlStatement(createEmptyTableStatement);
-    postgresResourceManager.executeDdlStatement(createSingersTableStatement);
+    spannerResourceManager.executeDdlStatement(createEmptyTableStatement);
+    spannerResourceManager.executeDdlStatement(createSingersTableStatement);
     List<Mutation> expectedData = generateTableRows(String.format("%s_Singers", testName));
-    postgresResourceManager.write(expectedData);
+    spannerResourceManager.write(expectedData);
     PipelineLauncher.LaunchConfig.Builder options =
-        PipelineLauncher.LaunchConfig.builder(testName, specPath)
-            .addParameter("spannerProjectId", PROJECT)
-            .addParameter("instanceId", postgresResourceManager.getInstanceId())
-            .addParameter("databaseId", postgresResourceManager.getDatabaseId())
-            .addParameter("outputDir", getGcsPath("output/"));
+        paramsAdder.apply(
+            PipelineLauncher.LaunchConfig.builder(testName, specPath)
+                .addParameter("spannerProjectId", PROJECT)
+                .addParameter("instanceId", spannerResourceManager.getInstanceId())
+                .addParameter("databaseId", spannerResourceManager.getDatabaseId())
+                .addParameter("outputDir", getGcsPath("output/")));
 
     // Act
     PipelineLauncher.LaunchInfo info = launchTemplate(options);


### PR DESCRIPTION
Allows custom endpoints to be specified in Spanner IT's and adds a suite of tests that use a staged spanner instance.