### PR TITLE
Update ImageSpec metadata with streaming mode experiments

### DIFF
--- a/metadata/src/main/java/com/google/cloud/teleport/metadata/util/EnumBasedExperimentValueProvider.java
+++ b/metadata/src/main/java/com/google/cloud/teleport/metadata/util/EnumBasedExperimentValueProvider.java
@@ -22,6 +22,7 @@ import com.google.common.base.CaseFormat;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /** Converts enum types to {@link org.apache.beam.sdk.options.ExperimentalOptions} values. */
 public class EnumBasedExperimentValueProvider<T extends Enum<T>> {
@@ -61,6 +62,11 @@ public class EnumBasedExperimentValueProvider<T extends Enum<T>> {
    */
   public String getPrefix() {
     return this.prefix;
+  }
+
+  /** Returns {@link #getPrefix()} as a {@link Pattern}. */
+  public Pattern getPrefixAsPattern() {
+    return Pattern.compile(String.format("^%s.*$", this.prefix));
   }
 
   /**

--- a/plugins/core-plugin/src/main/java/com/google/cloud/teleport/plugin/model/TemplateDefinitions.java
+++ b/plugins/core-plugin/src/main/java/com/google/cloud/teleport/plugin/model/TemplateDefinitions.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -363,6 +364,12 @@ public class TemplateDefinitions {
     // String element type.
     List<String> additionalExperiments =
         (List<String>) defaultEnvironment.get(ADDITIONAL_EXPERIMENTS);
+
+    // Remove any pre-existing streaming_mode* experiment values.
+    Predicate<String> streamingModePrefix =
+        STREAMING_MODE_ENUM_BASED_EXPERIMENT_VALUE_PROVIDER.getPrefixAsPattern().asMatchPredicate();
+    additionalExperiments.removeIf(streamingModePrefix);
+
     String streamingModeExperiment =
         STREAMING_MODE_ENUM_BASED_EXPERIMENT_VALUE_PROVIDER.convert(
             templateAnnotation.defaultStreamingMode());

--- a/plugins/core-plugin/src/test/java/com/google/cloud/teleport/plugin/model/TemplateDefinitionsTest.java
+++ b/plugins/core-plugin/src/test/java/com/google/cloud/teleport/plugin/model/TemplateDefinitionsTest.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.plugin.model;
 
+import static com.google.cloud.teleport.plugin.model.TemplateDefinitions.ADDITIONAL_EXPERIMENTS;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -25,6 +26,8 @@ import com.google.cloud.teleport.metadata.Template;
 import com.google.cloud.teleport.metadata.TemplateCategory;
 import com.google.cloud.teleport.plugin.sample.AtoBMissingAnnotation;
 import com.google.cloud.teleport.plugin.sample.AtoBOk;
+import java.util.List;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -117,6 +120,37 @@ public class TemplateDefinitionsTest {
     imageSpecWithValidationOf(StreamingALOEOEnabledDefaultNone.class);
     imageSpecWithValidationOf(StreamingALOEOEnabledDefaultALO.class);
     imageSpecWithValidationOf(StreamingALOEOEnabledDefaultEO.class);
+  }
+
+  @Test
+  public void givenStreamingModeNone_noAdditionalExperiments() {
+    ImageSpec imageSpec = imageSpecWithValidationOf(StreamingALOEOEnabledDefaultNone.class);
+    assertThat(imageSpec.getDefaultEnvironment()).isNotNull();
+    assertThat(imageSpec.getDefaultEnvironment()).doesNotContainKey(ADDITIONAL_EXPERIMENTS);
+  }
+
+  @Test
+  public void givenStreamingModeALO_populatesAdditionalExperiments() {
+    ImageSpec imageSpec = imageSpecWithValidationOf(StreamingALOEOEnabledDefaultALO.class);
+    assertThat(imageSpec.getDefaultEnvironment()).isNotNull();
+    Map<String, Object> defaultEnvironment = imageSpec.getDefaultEnvironment();
+    assertThat(defaultEnvironment.size()).isGreaterThan(1);
+    assertThat(defaultEnvironment).containsKey(ADDITIONAL_EXPERIMENTS);
+    List<String> additionalExperiments =
+        (List<String>) defaultEnvironment.get(ADDITIONAL_EXPERIMENTS);
+    assertThat(additionalExperiments).containsExactly("streaming_mode_at_least_once");
+  }
+
+  @Test
+  public void givenStreamingModeEO_populatesAdditionalExperiments() {
+    ImageSpec imageSpec = imageSpecWithValidationOf(StreamingALOEOEnabledDefaultEO.class);
+    assertThat(imageSpec.getDefaultEnvironment()).isNotNull();
+    Map<String, Object> defaultEnvironment = imageSpec.getDefaultEnvironment();
+    assertThat(defaultEnvironment.size()).isGreaterThan(1);
+    assertThat(defaultEnvironment).containsKey(ADDITIONAL_EXPERIMENTS);
+    List<String> additionalExperiments =
+        (List<String>) defaultEnvironment.get(ADDITIONAL_EXPERIMENTS);
+    assertThat(additionalExperiments).containsExactly("streaming_mode_exactly_once");
   }
 
   private static ImageSpec imageSpecWithValidationOf(Class<?> clazz) {


### PR DESCRIPTION
This PR adds `additionalExperiments` with a stringified streaming mode to drive default Dataflow Job streaming mode behavior.