### PR TITLE
Override jacoco coverage

### DIFF
--- a/v2/spanner-common/pom.xml
+++ b/v2/spanner-common/pom.xml
@@ -53,6 +53,73 @@
                     </execution>
                 </executions>
             </plugin>
+		    <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <configuration>
+                    <excludes>
+                        <!-- Excluding exception classes -->
+                        <exclude>**/*Exception.*</exclude>
+                        <!-- Excluding auto-generated classes. -->
+                        <exclude>**/*AutoValue_*</exclude>
+                    </excludes>
+                    <rules>
+                        <rule>
+                            <element>PACKAGE</element>
+                            <includes>
+                                <include>com.google.cloud.teleport.spanner</include>
+                                <include>com.google.cloud.teleport.spanner.**</include>
+                            </includes>
+                            <excludes>
+                                <!-- Excluding classes covered by integration tests. -->
+                                <exclude>com.google.cloud.teleport.spanner.ddl.InformationSchemaScanner</exclude>
+                                <!-- Excluding generated proto java files -->
+                                <exclude>com.google.cloud.teleport.spanner.proto</exclude>
+                            </excludes>
+                        </rule>
+                    </rules>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.5</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.5</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/v2/spanner-common/pom.xml
+++ b/v2/spanner-common/pom.xml
@@ -53,7 +53,7 @@
                     </execution>
                 </executions>
             </plugin>
-		    <plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco.version}</version>
@@ -64,21 +64,6 @@
                         <!-- Excluding auto-generated classes. -->
                         <exclude>**/*AutoValue_*</exclude>
                     </excludes>
-                    <rules>
-                        <rule>
-                            <element>PACKAGE</element>
-                            <includes>
-                                <include>com.google.cloud.teleport.spanner</include>
-                                <include>com.google.cloud.teleport.spanner.**</include>
-                            </includes>
-                            <excludes>
-                                <!-- Excluding classes covered by integration tests. -->
-                                <exclude>com.google.cloud.teleport.spanner.ddl.InformationSchemaScanner</exclude>
-                                <!-- Excluding generated proto java files -->
-                                <exclude>com.google.cloud.teleport.spanner.proto</exclude>
-                            </excludes>
-                        </rule>
-                    </rules>
                 </configuration>
                 <executions>
                     <execution>
@@ -93,30 +78,6 @@
                         <goals>
                             <goal>report</goal>
                         </goals>
-                    </execution>
-                    <execution>
-                        <id>default-check</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <rule>
-                                    <limits>
-                                        <limit>
-                                            <counter>LINE</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.5</minimum>
-                                        </limit>
-                                        <limit>
-                                            <counter>BRANCH</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.5</minimum>
-                                        </limit>
-                                    </limits>
-                                </rule>
-                            </rules>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertorTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertorTest.java
@@ -43,6 +43,7 @@ import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class GenericRecordTypeConvertorTest {
 
@@ -291,7 +292,7 @@ public class GenericRecordTypeConvertorTest {
     genericRecordTypeConvertor.transformChangeEvent(genericRecord, "all_types");
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void transformChangeEventTest_nullDialect() throws IOException {
     ISchemaMapper mockSchemaMapper = mock(ISchemaMapper.class);
     when(mockSchemaMapper.getDialect()).thenReturn(null);
@@ -311,6 +312,10 @@ public class GenericRecordTypeConvertorTest {
     GenericRecordTypeConvertor genericRecordTypeConvertor =
         new GenericRecordTypeConvertor(mockSchemaMapper, "");
 
-    genericRecordTypeConvertor.transformChangeEvent(genericRecord, "all_types");
+    assertThrows(
+        NullPointerException.class,
+        () -> genericRecordTypeConvertor.transformChangeEvent(genericRecord, "all_types"));
+    // Verify that the mock method was called.
+    Mockito.verify(mockSchemaMapper).getDialect();
   }
 }

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertorTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertorTest.java
@@ -290,4 +290,27 @@ public class GenericRecordTypeConvertorTest {
 
     genericRecordTypeConvertor.transformChangeEvent(genericRecord, "all_types");
   }
+
+  @Test(expected = NullPointerException.class)
+  public void transformChangeEventTest_nullDialect() throws IOException {
+    ISchemaMapper mockSchemaMapper = mock(ISchemaMapper.class);
+    when(mockSchemaMapper.getDialect()).thenReturn(null);
+    when(mockSchemaMapper.getSpannerTableName(anyString(), anyString())).thenReturn("test");
+    when(mockSchemaMapper.getSpannerColumns(anyString(), anyString()))
+        .thenReturn(List.of("bool_col"));
+    when(mockSchemaMapper.getSourceColumnName(anyString(), anyString(), anyString()))
+        .thenReturn("bool_col");
+    when(mockSchemaMapper.getSpannerColumnType(anyString(), anyString(), anyString()))
+        .thenReturn(Type.array(Type.bool()));
+
+    GenericRecord genericRecord =
+        new GenericData.Record(
+            SchemaUtils.parseAvroSchema(
+                Files.readString(Paths.get("src/test/resources/avro/all-spanner-types.avsc"))));
+    genericRecord.put("bool_col", true);
+    GenericRecordTypeConvertor genericRecordTypeConvertor =
+        new GenericRecordTypeConvertor(mockSchemaMapper, "");
+
+    genericRecordTypeConvertor.transformChangeEvent(genericRecord, "all_types");
+  }
 }


### PR DESCRIPTION
Configure jacoco for spanner-common to exclude autovalue and exception classes in test coverage.
Also add unit test for null dialect check in avroTransform.