### PR TITLE
Add user agent back to BQ to ElasticSearch template

### DIFF
--- a/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/BigQueryToElasticsearch.java
+++ b/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/BigQueryToElasticsearch.java
@@ -178,6 +178,7 @@ public class BigQueryToElasticsearch {
     udfOut.apply(
         "WriteToElasticsearch",
         WriteToElasticsearch.newBuilder()
+            .setUserAgent("dataflow-bigquery-to-elasticsearch-template/v2")
             .setOptions(options.as(BigQueryToElasticsearchOptions.class))
             .build());
 

--- a/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/GCSToElasticsearch.java
+++ b/v2/googlecloud-to-elasticsearch/src/main/java/com/google/cloud/teleport/v2/elasticsearch/templates/GCSToElasticsearch.java
@@ -227,8 +227,8 @@ public class GCSToElasticsearch {
           .setPythonUdfFunctionName(options.getPythonExternalTextTransformFunctionName());
     } else {
       lineToFailsafeJsonBuilder
-          .setJavascriptUdfFileSystemPath(options.getPythonExternalTextTransformGcsPath())
-          .setJavascriptUdfFunctionName(options.getPythonExternalTextTransformFunctionName());
+          .setJavascriptUdfFileSystemPath(options.getJavascriptTextTransformGcsPath())
+          .setJavascriptUdfFunctionName(options.getJavascriptTextTransformFunctionName());
     }
     PCollectionTuple convertedCsvLines =
         readCsvLines.apply("ConvertLine", lineToFailsafeJsonBuilder.build());


### PR DESCRIPTION
Should also unblock release which is failing on the `BigQueryToElasticsearchIT` test suite.