### PR TITLE
Mongo to BigQuery - set schema manually in case js udf is filtering data

### DIFF
--- a/v2/mongodb-to-googlecloud/README_MongoDB_to_BigQuery.md
+++ b/v2/mongodb-to-googlecloud/README_MongoDB_to_BigQuery.md
@@ -18,20 +18,21 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 
 ### Required parameters
 
-* **mongoDbUri** : MongoDB connection URI in the format `mongodb+srv://:@`.
+* **mongoDbUri** : The MongoDB connection URI in the format `mongodb+srv://:@.`.
 * **database** : Database in MongoDB to read the collection from. (Example: my-db).
 * **collection** : Name of the collection inside MongoDB database. (Example: my-collection).
-* **userOption** : User option: `FLATTEN` or `NONE`. `FLATTEN` flattens the documents to the single level. `NONE` stores the whole document as a JSON string. Defaults to: NONE.
-* **outputTableSpec** : BigQuery table location to write the output to. The name should be in the format `<project>:<dataset>.<table_name>`. The table's schema must match input objects.
+* **userOption** : `FLATTEN` or `NONE`. `FLATTEN` flattens the documents to the single level. `NONE` stores the whole document as a JSON string. Defaults to: NONE.
+* **outputTableSpec** : The BigQuery table to write to. For example, `bigquery-project:dataset.output_table`.
 
 ### Optional parameters
 
 * **KMSEncryptionKey** : Cloud KMS Encryption Key to decrypt the mongodb uri connection string. If Cloud KMS key is passed in, the mongodb uri connection string must all be passed in encrypted. (Example: projects/your-project/locations/global/keyRings/your-keyring/cryptoKeys/your-key).
-* **useStorageWriteApi** : If enabled (set to true) the pipeline will use Storage Write API when writing the data to BigQuery (see https://cloud.google.com/blog/products/data-analytics/streaming-data-into-bigquery-using-storage-write-api). Defaults to: false.
-* **useStorageWriteApiAtLeastOnce** : This parameter takes effect only if "Use BigQuery Storage Write API" is enabled. If enabled the at-least-once semantics will be used for Storage Write API, otherwise exactly-once semantics will be used. Defaults to: false.
-* **javascriptDocumentTransformGcsPath** : The Cloud Storage path pattern for the JavaScript code containing your user-defined functions. (Example: gs://your-bucket/your-transforms/*.js).
-* **javascriptDocumentTransformFunctionName** : The function name should only contain letters, digits and underscores. Example: 'transform' or 'transform_udf1'. (Example: transform).
+* **useStorageWriteApi** : If `true`, the pipeline uses the BigQuery Storage Write API (https://cloud.google.com/bigquery/docs/write-api). The default value is `false`. For more information, see Using the Storage Write API (https://beam.apache.org/documentation/io/built-in/google-bigquery/#storage-write-api).
+* **useStorageWriteApiAtLeastOnce** : When using the Storage Write API, specifies the write semantics. To use at-least-once semantics (https://beam.apache.org/documentation/io/built-in/google-bigquery/#at-least-once-semantics), set this parameter to `true`. To use exactly-once semantics, set the parameter to `false`. This parameter applies only when `useStorageWriteApi` is `true`. The default value is `false`.
+* **javascriptDocumentTransformGcsPath** : The Cloud Storage URI of the `.js` file that defines the JavaScript user-defined function (UDF) to use. (Example: gs://your-bucket/your-transforms/*.js).
+* **javascriptDocumentTransformFunctionName** : The name of the JavaScript user-defined function (UDF) to use. For example, if your JavaScript function code is `myTransform(inJson) { /*...do stuff...*/ }`, then the function name is myTransform. For sample JavaScript UDFs, see UDF Examples (https://github.com/GoogleCloudPlatform/DataflowTemplates#udf-examples). (Example: transform).
 * **bigQuerySchemaPath** : The Cloud Storage path for the BigQuery JSON schema.  (Example: gs://your-bucket/your-schema.json).
+
 
 
 ## Getting Started

--- a/v2/mongodb-to-googlecloud/README_MongoDB_to_BigQuery.md
+++ b/v2/mongodb-to-googlecloud/README_MongoDB_to_BigQuery.md
@@ -18,20 +18,20 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 
 ### Required parameters
 
-* **mongoDbUri** : The MongoDB connection URI in the format `mongodb+srv://:@.`.
+* **mongoDbUri** : MongoDB connection URI in the format `mongodb+srv://:@`.
 * **database** : Database in MongoDB to read the collection from. (Example: my-db).
 * **collection** : Name of the collection inside MongoDB database. (Example: my-collection).
-* **userOption** : `FLATTEN` or `NONE`. `FLATTEN` flattens the documents to the single level. `NONE` stores the whole document as a JSON string. Defaults to: NONE.
-* **outputTableSpec** : The BigQuery table to write to. For example, `bigquery-project:dataset.output_table`.
+* **userOption** : User option: `FLATTEN` or `NONE`. `FLATTEN` flattens the documents to the single level. `NONE` stores the whole document as a JSON string. Defaults to: NONE.
+* **outputTableSpec** : BigQuery table location to write the output to. The name should be in the format `<project>:<dataset>.<table_name>`. The table's schema must match input objects.
 
 ### Optional parameters
 
 * **KMSEncryptionKey** : Cloud KMS Encryption Key to decrypt the mongodb uri connection string. If Cloud KMS key is passed in, the mongodb uri connection string must all be passed in encrypted. (Example: projects/your-project/locations/global/keyRings/your-keyring/cryptoKeys/your-key).
-* **useStorageWriteApi** : If `true`, the pipeline uses the BigQuery Storage Write API (https://cloud.google.com/bigquery/docs/write-api). The default value is `false`. For more information, see Using the Storage Write API (https://beam.apache.org/documentation/io/built-in/google-bigquery/#storage-write-api).
-* **useStorageWriteApiAtLeastOnce** : When using the Storage Write API, specifies the write semantics. To use at-least-once semantics (https://beam.apache.org/documentation/io/built-in/google-bigquery/#at-least-once-semantics), set this parameter to `true`. To use exactly-once semantics, set the parameter to `false`. This parameter applies only when `useStorageWriteApi` is `true`. The default value is `false`.
-* **javascriptDocumentTransformGcsPath** : The Cloud Storage URI of the `.js` file that defines the JavaScript user-defined function (UDF) to use. (Example: gs://your-bucket/your-transforms/*.js).
-* **javascriptDocumentTransformFunctionName** : The name of the JavaScript user-defined function (UDF) to use. For example, if your JavaScript function code is `myTransform(inJson) { /*...do stuff...*/ }`, then the function name is myTransform. For sample JavaScript UDFs, see UDF Examples (https://github.com/GoogleCloudPlatform/DataflowTemplates#udf-examples). (Example: transform).
-
+* **useStorageWriteApi** : If enabled (set to true) the pipeline will use Storage Write API when writing the data to BigQuery (see https://cloud.google.com/blog/products/data-analytics/streaming-data-into-bigquery-using-storage-write-api). Defaults to: false.
+* **useStorageWriteApiAtLeastOnce** : This parameter takes effect only if "Use BigQuery Storage Write API" is enabled. If enabled the at-least-once semantics will be used for Storage Write API, otherwise exactly-once semantics will be used. Defaults to: false.
+* **javascriptDocumentTransformGcsPath** : The Cloud Storage path pattern for the JavaScript code containing your user-defined functions. (Example: gs://your-bucket/your-transforms/*.js).
+* **javascriptDocumentTransformFunctionName** : The function name should only contain letters, digits and underscores. Example: 'transform' or 'transform_udf1'. (Example: transform).
+* **bigQuerySchemaPath** : The Cloud Storage path for the BigQuery JSON schema.  (Example: gs://your-bucket/your-schema.json).
 
 
 ## Getting Started

--- a/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/options/MongoDbToBigQueryOptions.java
+++ b/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/options/MongoDbToBigQueryOptions.java
@@ -108,7 +108,19 @@ public class MongoDbToBigQueryOptions {
     String getOutputTableSpec();
 
     void setOutputTableSpec(String outputTableSpec);
+
+    @TemplateParameter.GcsReadFile(
+        order = 2,
+        optional = true,
+        description = "Cloud Storage path to BigQuery JSON schema",
+        helpText =
+            "The Cloud Storage path for the BigQuery JSON schema.",
+        example = "gs://your-bucket/your-schema.json")
+    String getBigQuerySchemaPath();
+
+    void setBigQuerySchemaPath(String path);
   }
+
 
   /** UDF options. */
   public interface JavascriptDocumentTransformerOptions extends PipelineOptions {

--- a/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/options/MongoDbToBigQueryOptions.java
+++ b/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/options/MongoDbToBigQueryOptions.java
@@ -113,14 +113,12 @@ public class MongoDbToBigQueryOptions {
         order = 2,
         optional = true,
         description = "Cloud Storage path to BigQuery JSON schema",
-        helpText =
-            "The Cloud Storage path for the BigQuery JSON schema.",
+        helpText = "The Cloud Storage path for the BigQuery JSON schema.",
         example = "gs://your-bucket/your-schema.json")
     String getBigQuerySchemaPath();
 
     void setBigQuerySchemaPath(String path);
   }
-
 
   /** UDF options. */
   public interface JavascriptDocumentTransformerOptions extends PipelineOptions {

--- a/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQuery.java
+++ b/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQuery.java
@@ -15,8 +15,10 @@
  */
 package com.google.cloud.teleport.v2.mongodb.templates;
 
+import static com.google.cloud.teleport.v2.utils.GCSUtils.getGcsFileAsString;
 import static com.google.cloud.teleport.v2.utils.KMSUtils.maybeDecrypt;
 
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.cloud.teleport.metadata.Template;
@@ -106,7 +108,12 @@ public class MongoDbToBigQuery {
     // Get MongoDbUri plain text or base64 encrypted with a specific KMS encryption key
     String mongoDbUri = maybeDecrypt(options.getMongoDbUri(), options.getKMSEncryptionKey()).get();
 
-    if (options.getJavascriptDocumentTransformFunctionName() != null
+    if(options.getBigQuerySchemaPath() != null) {
+      String jsonSchema = getGcsFileAsString(options.getBigQuerySchemaPath());
+      GsonFactory gf = new GsonFactory();
+      bigquerySchema = gf.fromString(jsonSchema, TableSchema.class);
+    }
+    else if (options.getJavascriptDocumentTransformFunctionName() != null
         && options.getJavascriptDocumentTransformGcsPath() != null) {
       bigquerySchema =
           MongoDbUtils.getTableFieldSchemaForUDF(

--- a/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQuery.java
+++ b/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQuery.java
@@ -109,14 +109,13 @@ public class MongoDbToBigQuery {
     // Get MongoDbUri plain text or base64 encrypted with a specific KMS encryption key
     String mongoDbUri = maybeDecrypt(options.getMongoDbUri(), options.getKMSEncryptionKey()).get();
 
-    if(options.getBigQuerySchemaPath() != null) {
+    if (options.getBigQuerySchemaPath() != null) {
       // initialize FileSystem to read from GCS
       FileSystems.setDefaultPipelineOptions(options);
       String jsonSchema = getGcsFileAsString(options.getBigQuerySchemaPath());
       GsonFactory gf = new GsonFactory();
       bigquerySchema = gf.fromString(jsonSchema, TableSchema.class);
-    }
-    else if (options.getJavascriptDocumentTransformFunctionName() != null
+    } else if (options.getJavascriptDocumentTransformFunctionName() != null
         && options.getJavascriptDocumentTransformGcsPath() != null) {
       bigquerySchema =
           MongoDbUtils.getTableFieldSchemaForUDF(

--- a/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQuery.java
+++ b/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQuery.java
@@ -34,6 +34,7 @@ import com.google.cloud.teleport.v2.utils.BigQueryIOUtils;
 import java.io.IOException;
 import javax.script.ScriptException;
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
 import org.apache.beam.sdk.io.mongodb.MongoDbIO;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -109,6 +110,8 @@ public class MongoDbToBigQuery {
     String mongoDbUri = maybeDecrypt(options.getMongoDbUri(), options.getKMSEncryptionKey()).get();
 
     if(options.getBigQuerySchemaPath() != null) {
+      // initialize FileSystem to read from GCS
+      FileSystems.setDefaultPipelineOptions(options);
       String jsonSchema = getGcsFileAsString(options.getBigQuerySchemaPath());
       GsonFactory gf = new GsonFactory();
       bigquerySchema = gf.fromString(jsonSchema, TableSchema.class);


### PR DESCRIPTION
MongoDB to JDBC has an issue with schema detection when UDF is used for filtering - #1328 .

Good workaround is providing schema directly, similarly to JDBC, Oracle to BigQuery. 
