### PR TITLE
Jdbc table schema discovery :: Package cleaup

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/exception/RetriableSchemaDiscoveryException.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/exception/RetriableSchemaDiscoveryException.java
@@ -13,14 +13,18 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.dialectadapter.dialectadapter;
-
-import com.google.cloud.teleport.v2.source.reader.io.schema.RetriableSchemaDiscovery;
+package com.google.cloud.teleport.v2.source.reader.io.exception;
 
 /**
- * Interface to support various dialects of JDBC databases.
+ * Schema Discovery Exception that can be retried, for example retriable connection errors.
  *
- * <p><b>Note:</b>As a prt of M2 effort, this interface will expose more mehtods than just extending
- * {@link RetriableSchemaDiscovery}.
+ * <p><b>Note:</b>
+ *
+ * <p>{@link RetriableSchemaDiscoveryException} does not extend SchemaDiscoveryException as it
+ * should not be thrown outside the SchemaDiscovery Interface.
  */
-public interface DialectAdapter extends RetriableSchemaDiscovery {}
+public class RetriableSchemaDiscoveryException extends Exception {
+  public RetriableSchemaDiscoveryException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/exception/SchemaDiscoveryException.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/exception/SchemaDiscoveryException.java
@@ -13,18 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.teleport.v2.source.reader.io.exception.exception;
+package com.google.cloud.teleport.v2.source.reader.io.exception;
 
-/**
- * Schema Discovery Exception that can be retried, for example retriable connection errors.
- *
- * <p><b>Note:</b>
- *
- * <p>{@link RetriableSchemaDiscoveryException} does not extend SchemaDiscoveryException as it
- * should not be thrown outside the SchemaDiscovery Interface.
- */
-public class RetriableSchemaDiscoveryException extends Exception {
-  public RetriableSchemaDiscoveryException(Throwable cause) {
+/** Exceptions During Schema Discovery. */
+public class SchemaDiscoveryException extends RuntimeException {
+  public SchemaDiscoveryException(Throwable cause) {
     super(cause);
   }
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/exception/SchemaDiscoveryRetriesExhaustedException.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/exception/SchemaDiscoveryRetriesExhaustedException.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2024 Google Inc.
+ * Copyright (C) 2024 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -13,6 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+package com.google.cloud.teleport.v2.source.reader.io.exception;
 
-/** Dialect adapter for reader. */
-package com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.dialectadapter.dialectadapter;
+/** Schema Discovery Exception after Failed Retry attempts. */
+public class SchemaDiscoveryRetriesExhaustedException extends RuntimeException {
+  public SchemaDiscoveryRetriesExhaustedException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/exception/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/exception/package-info.java
@@ -14,5 +14,5 @@
  * the License.
  */
 
-/** Mysql dialect adapter. */
-package com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.dialectadapter.dialectadapter.mysql;
+/** Exception Definitions for reader.io classes. */
+package com.google.cloud.teleport.v2.source.reader.io.exception;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/DialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/DialectAdapter.java
@@ -13,11 +13,14 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.teleport.v2.source.reader.io.exception.exception;
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter;
 
-/** Exceptions During Schema Discovery. */
-public class SchemaDiscoveryException extends RuntimeException {
-  public SchemaDiscoveryException(Throwable cause) {
-    super(cause);
-  }
-}
+import com.google.cloud.teleport.v2.source.reader.io.schema.RetriableSchemaDiscovery;
+
+/**
+ * Interface to support various dialects of JDBC databases.
+ *
+ * <p><b>Note:</b>As a prt of M2 effort, this interface will expose more mehtods than just extending
+ * {@link RetriableSchemaDiscovery}.
+ */
+public interface DialectAdapter extends RetriableSchemaDiscovery {}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapter.java
@@ -13,11 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.dialectadapter.dialectadapter.mysql;
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql;
 
-import com.google.cloud.teleport.v2.source.reader.io.exception.exception.RetriableSchemaDiscoveryException;
-import com.google.cloud.teleport.v2.source.reader.io.exception.exception.SchemaDiscoveryException;
-import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.dialectadapter.dialectadapter.DialectAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.exception.RetriableSchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.DialectAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.collect.ImmutableList;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/package-info.java
@@ -14,5 +14,5 @@
  * the License.
  */
 
-/** Exception Definitions for reader.io classes. */
-package com.google.cloud.teleport.v2.source.reader.io.exception.exception;
+/** Mysql dialect adapter. */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/package-info.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2024 Google LLC
+ * Copyright (C) 2024 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -13,11 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.teleport.v2.source.reader.io.exception.exception;
 
-/** Schema Discovery Exception after Failed Retry attempts. */
-public class SchemaDiscoveryRetriesExhaustedException extends RuntimeException {
-  public SchemaDiscoveryRetriesExhaustedException(Throwable cause) {
-    super(cause);
-  }
-}
+/** Dialect adapter for reader. */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/RetriableSchemaDiscovery.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/RetriableSchemaDiscovery.java
@@ -15,8 +15,8 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.schema;
 
-import com.google.cloud.teleport.v2.source.reader.io.exception.exception.RetriableSchemaDiscoveryException;
-import com.google.cloud.teleport.v2.source.reader.io.exception.exception.SchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.exception.RetriableSchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryException;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaDiscovery.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaDiscovery.java
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.schema;
 
-import com.google.cloud.teleport.v2.source.reader.io.exception.exception.SchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryException;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaDiscoveryImpl.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaDiscoveryImpl.java
@@ -15,9 +15,9 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.schema;
 
-import com.google.cloud.teleport.v2.source.reader.io.exception.exception.RetriableSchemaDiscoveryException;
-import com.google.cloud.teleport.v2.source.reader.io.exception.exception.SchemaDiscoveryException;
-import com.google.cloud.teleport.v2.source.reader.io.exception.exception.SchemaDiscoveryRetriesExhaustedException;
+import com.google.cloud.teleport.v2.source.reader.io.exception.RetriableSchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryRetriesExhaustedException;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapterTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapterTest.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.dialectadapter.dialectadapter.mysql;
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -25,10 +25,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.auto.value.AutoValue;
-import com.google.cloud.teleport.v2.source.reader.io.exception.exception.RetriableSchemaDiscoveryException;
-import com.google.cloud.teleport.v2.source.reader.io.exception.exception.SchemaDiscoveryException;
-import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.dialectadapter.dialectadapter.mysql.MysqlDialectAdapter.InformationSchemaCols;
-import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.dialectadapter.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import com.google.cloud.teleport.v2.source.reader.io.exception.RetriableSchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.InformationSchemaCols;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.collect.ImmutableList;

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaDiscoveryImplTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaDiscoveryImplTest.java
@@ -23,8 +23,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.cloud.teleport.v2.source.reader.io.exception.exception.RetriableSchemaDiscoveryException;
-import com.google.cloud.teleport.v2.source.reader.io.exception.exception.SchemaDiscoveryRetriesExhaustedException;
+import com.google.cloud.teleport.v2.source.reader.io.exception.RetriableSchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryRetriesExhaustedException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;


### PR DESCRIPTION
Tiny followup of #1481 
The previous PR#1481 had a slight typo leading to deeper package tree than necessary `dialectadapter.dialectadapter.dialectadapter` instead of `dialectadapter`