### PR TITLE
Fix datetime validation

### DIFF
--- a/metadata/src/main/java/com/google/cloud/teleport/metadata/util/MetadataUtils.java
+++ b/metadata/src/main/java/com/google/cloud/teleport/metadata/util/MetadataUtils.java
@@ -185,7 +185,7 @@ public final class MetadataUtils {
       case "DateTime":
         TemplateParameter.DateTime dateTimeParam = (TemplateParameter.DateTime) parameterAnnotation;
         return List.of(
-            "^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):(([0-9]{2})(\\\\.[0-9]+)?)Z$");
+            "^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):(([0-9]{2})(\\.[0-9]+)?)Z$");
       case "BigQueryTable":
         TemplateParameter.BigQueryTable bigQueryTableParam =
             (TemplateParameter.BigQueryTable) parameterAnnotation;


### PR DESCRIPTION
Today, our datetime validation resolves to `^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):(([0-9]{2})(\\.[0-9]+)?)Z$` after string escaping, but it should resolve to `^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):(([0-9]{2})(\.[0-9]+)?)Z$` (note the single backslash instead of double) so that it can match datetimes like `1970-01-01T00:00:00.00Z`. This fixes that problem.

See https://regex101.com/ to try both patterns. You can also observe this problem in any template where this parameter is used. For example in Datastream to BigQuery, if you change the default value to a valid date you get

<img width="556" alt="image" src="https://github.com/GoogleCloudPlatform/DataflowTemplates/assets/42773683/f005c581-f30a-4d29-8295-d7bb8a4d515d">

if we don't have a `\` in the time, if we add one validation passes:

<img width="563" alt="image" src="https://github.com/GoogleCloudPlatform/DataflowTemplates/assets/42773683/0fc4cfad-7ce6-4c39-9527-0fd201164041">

This relies on DateTime under the covers - https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/3cbe00befcd91dd77fb7d3e4608b033c22ca3fb4/v2/datastream-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToBigQuery.java#L190C6-L190C32
