### PR TITLE
Add concurrency group to java-pr workflow

### DIFF
--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -32,7 +32,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: java-pr
+  group: java-pr-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -32,7 +32,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: java-pr-${{ github.event.number }}
+  group: java-pr-${{ github.event.issue.number || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -31,6 +31,10 @@ on:
     - cron: "0 */12 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: java-pr
+  cancel-in-progress: true
+
 env:
   MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade=error
 


### PR DESCRIPTION
Added concurrency so that jobs for a PR belonging to the `java-pr-${PR_NUMBER}` concurrency group get cancelled when a new execution is requested.

A new execution would be requested when new commits were added to the PR. 

Adding the `event.number` to the concurrency group name will ensure that resource isolation and in-progress job wounding will happen at a per-PR level, and each PR is treated independently.

Reference - https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-concurrency-and-the-default-behavior