### PR TITLE
Replace changed-files with modules-to-build

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -46,10 +46,6 @@ inputs:
     description: 'The version of Python to install'
     required: false
     default: '3.11'
-outputs:
-  changed-files:
-    description: 'Comma-separated list of files that were changed'
-    value: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
 
 runs:
   using: 'composite'
@@ -59,11 +55,6 @@ runs:
       with:
         go-version: ${{ inputs.go-version }}
         cache: false
-    - name: Get Changed Files
-      id: changed-files
-      uses: tj-actions/changed-files@4c5f5d698fbf2d763d5f13815ac7c2ccbef1ff7f # v44.2.0
-      with:
-        separator: ','
     # It shouldn't take too long to build all of this, and it will at least
     # make running the target program easier
     - name: Build CI/CD

--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -48,13 +48,11 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
-        with:
-          fetch-depth: 2  # setup-env action assumes fetch depth of at least 2 for https://github.com/tj-actions/changed-files?tab=readme-ov-file#on-push-%EF%B8%8F
       - name: Setup Environment
         id: setup-env
         uses: ./.github/actions/setup-env
       - name: Run Spotless
-        run: ./cicd/run-spotless --changed-files="${{ steps.setup-env.outputs.changed-files }}"
+        run: ./cicd/run-spotless
   checkstyle_check:
     name: Checkstyle
     timeout-minutes: 10
@@ -62,13 +60,11 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
-        with:
-          fetch-depth: 2  # setup-env action assumes fetch depth of at least 2 for https://github.com/tj-actions/changed-files?tab=readme-ov-file#on-push-%EF%B8%8F
       - name: Setup Environment
         id: setup-env
         uses: ./.github/actions/setup-env
       - name: Run Checkstyle
-        run: ./cicd/run-checkstyle --changed-files="${{ steps.setup-env.outputs.changed-files }}"
+        run: ./cicd/run-checkstyle
   java_build:
     name: Build
     timeout-minutes: 60
@@ -76,13 +72,11 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
-        with:
-          fetch-depth: 2  # setup-env action assumes fetch depth of at least 2 for https://github.com/tj-actions/changed-files?tab=readme-ov-file#on-push-%EF%B8%8F
       - name: Setup Environment
         id: setup-env
         uses: ./.github/actions/setup-env
       - name: Run Build
-        run: ./cicd/run-build --changed-files="${{ steps.setup-env.outputs.changed-files }}"
+        run: ./cicd/run-build
       - name: Cleanup Java Environment
         uses: ./.github/actions/cleanup-java-env
   java_unit_tests:
@@ -93,13 +87,11 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
-        with:
-          fetch-depth: 2  # setup-env action assumes fetch depth of at least 2 for https://github.com/tj-actions/changed-files?tab=readme-ov-file#on-push-%EF%B8%8F
       - name: Setup Environment
         id: setup-env
         uses: ./.github/actions/setup-env
       - name: Run Unit Tests
-        run: ./cicd/run-unit-tests --changed-files="${{ steps.setup-env.outputs.changed-files }}"
+        run: ./cicd/run-unit-tests
       - name: Upload Unit Tests Report
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: always() # always run even if the previous step fails
@@ -124,15 +116,12 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
-        with:
-          fetch-depth: 2  # setup-env action assumes fetch depth of at least 2 for https://github.com/tj-actions/changed-files?tab=readme-ov-file#on-push-%EF%B8%8F
       - name: Setup Environment
         id: setup-env
         uses: ./.github/actions/setup-env
       - name: Run Integration Smoke Tests
         run: | 
           ./cicd/run-it-smoke-tests \
-          --changed-files="${{ steps.setup-env.outputs.changed-files }}" \
           --it-region="us-central1" \
           --it-project="cloud-teleport-testing" \
           --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \
@@ -155,15 +144,12 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
-        with:
-          fetch-depth: 2  # setup-env action assumes fetch depth of at least 2 for https://github.com/tj-actions/changed-files?tab=readme-ov-file#on-push-%EF%B8%8F
       - name: Setup Environment
         id: setup-env
         uses: ./.github/actions/setup-env
       - name: Run Integration Tests
         run: | 
           ./cicd/run-it-tests \
-          --changed-files="${{ steps.setup-env.outputs.changed-files }}" \
           --it-region="us-central1" \
           --it-project="cloud-teleport-testing" \
           --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \
@@ -187,15 +173,12 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
-      with:
-        fetch-depth: 2  # setup-env action assumes fetch depth of at least 2 for https://github.com/tj-actions/changed-files?tab=readme-ov-file#on-push-%EF%B8%8F
     - name: Setup Environment
       id: setup-env
       uses: ./.github/actions/setup-env
     - name: Run Load Tests
       run: |
         ./cicd/run-load-tests \
-        --changed-files="${{ steps.setup-env.outputs.changed-files }}" \
         --it-region="us-central1" \
         --it-project="cloud-teleport-testing" \
         --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,13 +68,12 @@ jobs:
       id: setup-env
       uses: ./.github/actions/setup-env
     - name: Run Build
-      run: ./cicd/run-build --changed-files="pom.xml"
+      run: ./cicd/run-build
     - name: Run Unit Tests
-      run: ./cicd/run-unit-tests --changed-files="pom.xml"
+      run: ./cicd/run-unit-tests
     - name: Run Integration Smoke Tests
       run: |
         ./cicd/run-it-smoke-tests \
-        --changed-files="pom.xml" \
         --it-region="us-central1" \
         --it-project="cloud-teleport-testing" \
         --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \
@@ -84,7 +83,6 @@ jobs:
     - name: Run Integration Tests
       run: |
         ./cicd/run-it-tests \
-        --changed-files="pom.xml" \
         --it-region="us-central1" \
         --it-project="cloud-teleport-testing" \
         --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \

--- a/cicd/internal/flags/common-flags.go
+++ b/cicd/internal/flags/common-flags.go
@@ -18,53 +18,25 @@ package flags
 
 import (
 	"flag"
-	"fmt"
-	"log"
-	"regexp"
 	"strings"
+)
+
+const (
+	ALL     = ""
+	SPANNER = "v2/datastream-to-spanner,v2/sourcedb-to-spanner,v2/spanner-change-streams-to-sharded-file-sink"
 )
 
 // Avoid making these vars public.
 var (
-	changedFiles string
+	modulesToBuild string
 )
 
 // Registers all common flags. Must be called before flag.Parse().
 func RegisterCommonFlags() {
-	flag.StringVar(&changedFiles, "changed-files", "", "List of changed files as a comma-separated string")
+	flag.StringVar(&modulesToBuild, "modules-to-build", ALL, "List of modules to build/run commands against")
 }
 
-// Returns all changed files with regexes. If no regexes are passed, all files are returned. If even one
-// is passed, then only file paths with a match anywhere in the file will be returned. If multiple are
-// passed, it is equivalent to (regex1|regex2|...|regexN)
-func ChangedFiles(regexes ...string) []string {
-	if len(changedFiles) == 0 {
-		log.Println("WARNING: No changed files were passed. This could indicate an error.")
-		return make([]string, 0)
-	}
-
-	files := strings.Split(changedFiles, ",")
-	if len(regexes) == 0 {
-		return files
-	}
-
-	var fullRegex string
-	if len(regexes) == 1 {
-		fullRegex = regexes[0]
-	} else {
-		fullRegex = fmt.Sprintf("(%s)", strings.Join(regexes, "|"))
-	}
-	re := regexp.MustCompile(fullRegex)
-
-	results := make([]string, 0)
-	for _, f := range files {
-		if re.MatchString(f) {
-			results = append(results, f)
-		}
-	}
-
-	if len(results) == 0 {
-		log.Println("INFO: All changed files got filtered out.")
-	}
-	return results
+// Returns all modules to build.
+func ModulesToBuild(regexes ...string) []string {
+	return strings.Split(modulesToBuild, ",")
 }

--- a/cicd/internal/flags/common-flags.go
+++ b/cicd/internal/flags/common-flags.go
@@ -29,7 +29,7 @@ const (
 // Avoid making these vars public.
 var (
 	modulesToBuild string
-	moduleMap      = map[string]string{ALL: "", SPANNER: "v2/datastream-to-spanner,v2/sourcedb-to-spanner,v2/spanner-change-streams-to-sharded-file-sink"}
+	moduleMap      = map[string]string{ALL: "", SPANNER: "v2/datastream-to-spanner/,v2/spanner-common/,v2/spanner-change-streams-to-sharded-file-sink/,v2/gcs-to-sourcedb/,v2/spanner-migrations-sdk/,v2/spanner-custom-shard/,v2/sourcedb-to-spanner/,v2/common/,metadata"}
 )
 
 // Registers all common flags. Must be called before flag.Parse().

--- a/cicd/internal/flags/common-flags.go
+++ b/cicd/internal/flags/common-flags.go
@@ -22,13 +22,14 @@ import (
 )
 
 const (
-	ALL     = ""
-	SPANNER = "v2/datastream-to-spanner,v2/sourcedb-to-spanner,v2/spanner-change-streams-to-sharded-file-sink"
+	ALL     = "ALL"
+	SPANNER = "SPANNER"
 )
 
 // Avoid making these vars public.
 var (
 	modulesToBuild string
+	moduleMap      = map[string]string{ALL: "", SPANNER: "v2/datastream-to-spanner,v2/sourcedb-to-spanner,v2/spanner-change-streams-to-sharded-file-sink"}
 )
 
 // Registers all common flags. Must be called before flag.Parse().
@@ -37,6 +38,13 @@ func RegisterCommonFlags() {
 }
 
 // Returns all modules to build.
-func ModulesToBuild(regexes ...string) []string {
-	return strings.Split(modulesToBuild, ",")
+func ModulesToBuild() []string {
+	m := modulesToBuild
+	if val, ok := moduleMap[modulesToBuild]; ok {
+		m = val
+	}
+	if len(m) == 0 {
+		return make([]string, 0)
+	}
+	return strings.Split(m, ",")
 }

--- a/cicd/internal/flags/common-flags.go
+++ b/cicd/internal/flags/common-flags.go
@@ -29,7 +29,7 @@ const (
 // Avoid making these vars public.
 var (
 	modulesToBuild string
-	moduleMap      = map[string]string{ALL: "", SPANNER: "v2/datastream-to-spanner/,v2/spanner-common/,v2/spanner-change-streams-to-sharded-file-sink/,v2/gcs-to-sourcedb/,v2/spanner-migrations-sdk/,v2/spanner-custom-shard/,v2/sourcedb-to-spanner/,v2/common/,metadata"}
+	moduleMap      = map[string]string{ALL: "", SPANNER: "v2/datastream-to-spanner/,v2/spanner-common/,v2/spanner-change-streams-to-sharded-file-sink/,v2/gcs-to-sourcedb/,v2/spanner-migrations-sdk/,v2/spanner-custom-shard/,v2/sourcedb-to-spanner/,v2/common/,metadata,plugins/templates-maven-plugin"}
 )
 
 // Registers all common flags. Must be called before flag.Parse().

--- a/cicd/internal/flags/common-flags_test.go
+++ b/cicd/internal/flags/common-flags_test.go
@@ -40,7 +40,7 @@ func TestModulesToBuild(t *testing.T) {
 		},
 		{
 			input:    "SPANNER",
-			expected: []string{"v2/datastream-to-spanner", "v2/sourcedb-to-spanner", "v2/spanner-change-streams-to-sharded-file-sink"},
+			expected: []string{"v2/datastream-to-spanner/", "v2/spanner-common/", "v2/spanner-change-streams-to-sharded-file-sink/", "v2/gcs-to-sourcedb/", "v2/spanner-migrations-sdk/", "v2/spanner-custom-shard/", "v2/sourcedb-to-spanner/", "v2/common/", "metadata"},
 		},
 	}
 

--- a/cicd/internal/flags/common-flags_test.go
+++ b/cicd/internal/flags/common-flags_test.go
@@ -40,7 +40,7 @@ func TestModulesToBuild(t *testing.T) {
 		},
 		{
 			input:    "SPANNER",
-			expected: []string{"v2/datastream-to-spanner/", "v2/spanner-common/", "v2/spanner-change-streams-to-sharded-file-sink/", "v2/gcs-to-sourcedb/", "v2/spanner-migrations-sdk/", "v2/spanner-custom-shard/", "v2/sourcedb-to-spanner/", "v2/common/", "metadata"},
+			expected: []string{"v2/datastream-to-spanner/", "v2/spanner-common/", "v2/spanner-change-streams-to-sharded-file-sink/", "v2/gcs-to-sourcedb/", "v2/spanner-migrations-sdk/", "v2/spanner-custom-shard/", "v2/sourcedb-to-spanner/", "v2/common/", "metadata", "plugins/templates-maven-plugin"},
 		},
 	}
 

--- a/cicd/internal/flags/common-flags_test.go
+++ b/cicd/internal/flags/common-flags_test.go
@@ -21,79 +21,34 @@ import (
 	"testing"
 )
 
-func TestChangedFilesNoRegex(t *testing.T) {
+func TestModulesToBuild(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected []string
 	}{
 		{
-			input:    "file1,file2",
-			expected: []string{"file1", "file2"},
+			input:    "m1,m2",
+			expected: []string{"m1", "m2"},
 		},
 		{
-			input:    "file1",
-			expected: []string{"file1"},
+			input:    "m1",
+			expected: []string{"m1"},
+		},
+		{
+			input:    "ALL",
+			expected: []string{},
+		},
+		{
+			input:    "SPANNER",
+			expected: []string{"v2/datastream-to-spanner", "v2/sourcedb-to-spanner", "v2/spanner-change-streams-to-sharded-file-sink"},
 		},
 	}
 
 	for _, test := range tests {
-		changedFiles = test.input
-		actual := ChangedFiles()
+		modulesToBuild = test.input
+		actual := ModulesToBuild()
 		if !reflect.DeepEqual(actual, test.expected) {
-			t.Errorf("Returned files are not equal. Expected %v. Got %v.", test.expected, actual)
+			t.Errorf("Returned modules are not equal. Expected %v. Got %v.", test.expected, actual)
 		}
-	}
-}
-
-func TestChangedFilesNoRegexEmpty(t *testing.T) {
-	changedFiles = ""
-	actual := ChangedFiles()
-	if len(actual) != 0 {
-		t.Errorf("Expected empty slice, but got %v of len %v", actual, len(actual))
-	}
-}
-
-func TestChangedFilesRegexes(t *testing.T) {
-	tests := []struct {
-		files    string
-		regexes  []string
-		expected []string
-	}{
-		{
-			files:    "file1,file2,file3",
-			regexes:  []string{"file[1|3]"},
-			expected: []string{"file1", "file3"},
-		},
-		{
-			files:    "file1,file2,file3",
-			regexes:  []string{"f.+1", "fi.+3"},
-			expected: []string{"file1", "file3"},
-		},
-		{
-			files:    "file1,file2,fileN",
-			regexes:  []string{"\\d"},
-			expected: []string{"file1", "file2"},
-		},
-		{
-			files:    "foo.c,bar.cc",
-			regexes:  []string{"\\.c$"},
-			expected: []string{"foo.c"},
-		},
-	}
-
-	for _, test := range tests {
-		changedFiles = test.files
-		actual := ChangedFiles(test.regexes...)
-		if !reflect.DeepEqual(actual, test.expected) {
-			t.Errorf("Returned files are not equal. Expected %v. Got %v.", test.expected, actual)
-		}
-	}
-}
-
-func TestChangedFilesRegexesNoMatch(t *testing.T) {
-	changedFiles = "foo,bar"
-	actual := ChangedFiles("file")
-	if len(actual) != 0 {
-		t.Errorf("Expected empty slice but got %v", actual)
 	}
 }

--- a/cicd/internal/op/maven.go
+++ b/cicd/internal/op/maven.go
@@ -36,8 +36,11 @@ func RunMavenOnPom(pom string, cmd string, args ...string) error {
 // Runs the given Maven command on a specified module. Considering the input, this is equivalent to:
 //
 //	mvn -B {cmd} -f {pom} -pl {module} {args...}
-func RunMavenOnModule(pom string, cmd string, module string, args ...string) error {
-	// fullArgs := []string{"-pl", module}
-	// fullArgs = append(fullArgs, args...)
-	return RunMavenOnPom(pom, cmd, args...)
+func RunMavenOnModule(pom string, cmd string, modules string, args ...string) error {
+	if len(modules) == 0 {
+		return RunMavenOnPom(pom, cmd, args...)
+	}
+	fullArgs := []string{"-pl", modules}
+	fullArgs = append(fullArgs, args...)
+	return RunMavenOnPom(pom, cmd, fullArgs...)
 }

--- a/cicd/internal/workflows/maven-workflows.go
+++ b/cicd/internal/workflows/maven-workflows.go
@@ -33,12 +33,6 @@ const (
 	spotlessCheckCmd   = "spotless:check"
 	checkstyleCheckCmd = "checkstyle:check"
 
-	// regexes
-	javaFileRegex     = "\\.java$"
-	xmlFileRegex      = "\\.xml$"
-	markdownFileRegex = "\\.md$"
-	pomFileRegex      = "pom\\.xml$"
-
 	// notable files
 	unifiedPom = "pom.xml"
 )
@@ -198,7 +192,7 @@ func (*mvnVerifyWorkflow) Run(args ...string) error {
 }
 
 func RunForChangedModules(cmd string, args ...string) error {
-	modules := flags.ModulesToBuild(javaFileRegex, xmlFileRegex)
+	modules := flags.ModulesToBuild()
 
 	parsedArgs := []string{}
 	for _, arg := range args {


### PR DESCRIPTION
Remove the changed-files flag since we end up ignoring it anyways. Replace it with a mechanism for individual workflows to declare their preferred modules to build for arbitrary commands