### PR TITLE
Fixing value mapping for blob and year in Reader

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/rowmapper/JdbcValueMapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/rowmapper/JdbcValueMapper.java
@@ -56,7 +56,7 @@ public class JdbcValueMapper<T extends Object> implements Serializable {
    */
   public Object mapValue(ResultSet rs, String fieldName, Schema fieldSchema) throws SQLException {
     var extractedValue = valueExtractor.extract(rs, fieldName);
-    if (extractedValue == null) {
+    if (extractedValue == null || rs.wasNull()) {
       return null;
     }
     return valueMapper.map(extractedValue, fieldSchema);

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/rowmapper/provider/MysqlJdbcValueMappings.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/rowmapper/provider/MysqlJdbcValueMappings.java
@@ -67,11 +67,11 @@ public class MysqlJdbcValueMappings implements JdbcValueMappingsProvider {
 
   /* Hex Encoded string for bytes type. */
   private static final ResultSetValueMapper<byte[]> bytesToHexString =
-      (value, schema) -> Hex.encodeHex(value);
+      (value, schema) -> new String(Hex.encodeHex(value));
 
   /* Hex Encoded string for blob types. */
   private static final ResultSetValueMapper<Blob> blobToHexString =
-      (value, schema) -> Hex.encodeHex(value.getBytes(1, (int) value.length()));
+      (value, schema) -> new String(Hex.encodeHex(value.getBytes(1, (int) value.length())));
 
   /* Extract UTC Values for date and time related types */
   private static final Calendar utcCalendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
@@ -189,7 +189,7 @@ public class MysqlJdbcValueMappings implements JdbcValueMappingsProvider {
           .put("TINYTEXT", Pair.of(ResultSet::getString, valuePassThrough))
           .put("VARBINARY", Pair.of(ResultSet::getBytes, bytesToHexString))
           .put("VARCHAR", Pair.of(ResultSet::getString, valuePassThrough))
-          .put("YEAR", Pair.of(ResultSet::getLong, valuePassThrough))
+          .put("YEAR", Pair.of(ResultSet::getInt, valuePassThrough))
           .build()
           .entrySet()
           .stream()


### PR DESCRIPTION
1. The value mapping for blob and year in the reader was not mapping the output to the expected avro type (`string` instead of `char[]` and `integer` instead of `long`), leading to a crash. Fixing the same.
Along with the UT, this PR has been tested on a live db with these two types.
2. With the code review progression, also added UT to cover null values for all types.