### PR TITLE
Increase operations and allow manual triggering of stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,7 @@ name: Mark stale issues and pull requests
 on:
   schedule:
   - cron: '23 2 * * *'
+  workflow_dispatch:
 
 jobs:
   stale:
@@ -26,3 +27,4 @@ jobs:
         stale-pr-message: 'This pull request has been marked as stale due to 180 days of inactivity. It will be closed in 1 week if no further activity occurs. If you think that’s incorrect or this pull request requires a review, please simply write any comment. If closed, you can revive the PR at any time. Thank you for your contributions.'
         close-pr-message: 'This pull request has been closed due to lack of activity. If you think that is incorrect, or the pull request requires review, you can revive the PR at any time.'
         days-before-stale: 180
+        operations-per-run: 100


### PR DESCRIPTION
This keeps running out of available operations For example - https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/runs/9152642836/job/25160401225 has this log at the end

```
Warning: No more operations left! Exiting...
Warning: If you think that not enough issues were processed you could try to increase the quantity related to the  operations-per-run (​[https://github.com/actions/stale#operations-per-run​)](https://github.com/actions/stale#operations-per-run%E2%80%8B))  option which is currently set to  30
```

this keeps it from processing all stale issues. Bumping this to 100 worked for the beam project - https://github.com/apache/beam/blob/092f769a4b48740c4e6ab6e1ddc2a060986a645e/.github/workflows/stale.yml#L42 and can probably help here.

Also, we should let this be manually triggered