### PR TITLE
Refactor KafkaToBigQueryFlexOptions and choose defaults for the KafkaToBigQueryFlex template

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/utils/BigQueryIOUtils.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/utils/BigQueryIOUtils.java
@@ -44,7 +44,7 @@ public final class BigQueryIOUtils {
     StreamingModeUtils.validateBQOptions(options.as(DataflowPipelineOptions.class));
     if (options.getUseStorageWriteApi()
         && !options.getUseStorageWriteApiAtLeastOnce()
-        && (options.getNumStorageWriteApiStreams() < 1
+        && (options.getNumStorageWriteApiStreams() == null
             || options.getStorageWriteApiTriggeringFrequencySec() == null)) {
       // the number of streams and triggering frequency are only required for exactly-once semantics
       throw new IllegalArgumentException(

--- a/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/options/KafkaReadOptions.java
+++ b/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/options/KafkaReadOptions.java
@@ -27,6 +27,7 @@ public interface KafkaReadOptions extends PipelineOptions {
 
   @TemplateParameter.Text(
       order = 1,
+      groupName = "Source",
       optional = true,
       regexes = {"[,:a-zA-Z0-9._-]+"},
       description = "Kafka Bootstrap Server list",
@@ -38,9 +39,10 @@ public interface KafkaReadOptions extends PipelineOptions {
 
   @TemplateParameter.Text(
       order = 2,
+      groupName = "Source",
       optional = true,
       regexes = {"[,a-zA-Z0-9._-]+"},
-      description = "Kafka topic(s) to read input from.",
+      description = "Kafka Topic(s) to read input from",
       helpText = "Kafka topic(s) to read input from.",
       example = "topic1,topic2")
   String getKafkaReadTopics();
@@ -49,38 +51,61 @@ public interface KafkaReadOptions extends PipelineOptions {
 
   @TemplateParameter.Enum(
       order = 3,
-      description = "The Kafka offset to read from.",
+      groupName = "Source",
       enumOptions = {
-        @TemplateParameter.TemplateEnumOption("latest"),
         @TemplateParameter.TemplateEnumOption("earliest"),
+        @TemplateParameter.TemplateEnumOption("latest"),
       },
-      helpText = "Set the Kafka offset to earliest or latest(default)",
-      optional = true)
+      optional = true,
+      description = "Start Offset",
+      helpText = "The Kafka Offset to read from.")
   @Default.String("latest")
   String getKafkaReadOffset();
 
   void setKafkaReadOffset(String value);
 
+  @TemplateParameter.Enum(
+      order = 4,
+      name = "kafkaReadAuthenticationMode",
+      groupName = "Source",
+      enumOptions = {
+        @TemplateParameter.TemplateEnumOption("NONE"),
+        @TemplateParameter.TemplateEnumOption("SASL_PLAIN"),
+      },
+      optional = false,
+      description = "Authentication Mode",
+      helpText = "Kafka read authentication mode. Can be NONE or SASL_PLAIN")
+  @Default.String("NONE")
+  String getKafkaReadAuthenticationMode();
+
+  void setKafkaReadAuthenticationMode(String value);
+
   @TemplateParameter.Text(
       order = 4,
-      optional = true,
-      description =
-          "Username to be used with SASL_PLAIN mechanism for reading from Kafka, stored in Google Cloud Secret Manager.",
+      groupName = "Source",
+      parentName = "kafkaReadAuthenticationMode",
+      parentTriggerValues = {"SASL_PLAIN"},
+      optional = false,
+      description = "Username",
       helpText =
           "Secret Manager secret ID for the SASL_PLAIN username. Should be in the format projects/{project}/secrets/{secret}/versions/{secret_version}.",
       example = "projects/your-project-id/secrets/your-secret/versions/your-secret-version")
+  @Default.String("")
   String getKafkaReadUsernameSecretId();
 
   void setKafkaReadUsernameSecretId(String value);
 
   @TemplateParameter.Text(
       order = 5,
-      optional = true,
-      description =
-          "Password to be used with SASL_PLAIN mechanism for reading from Kafka, stored in Google Cloud Secret Manager.",
+      groupName = "Source",
+      parentName = "kafkaReadAuthenticationMode",
+      parentTriggerValues = {"SASL_PLAIN"},
+      optional = false,
+      description = "Password",
       helpText =
           "Secret Manager secret ID for the SASL_PLAIN password. Should be in the format projects/{project}/secrets/{secret}/versions/{secret_version}",
       example = "projects/your-project-id/secrets/your-secret/versions/your-secret-version")
+  @Default.String("")
   String getKafkaReadPasswordSecretId();
 
   void setKafkaReadPasswordSecretId(String value);

--- a/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/utils/KafkaTopicUtils.java
+++ b/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/utils/KafkaTopicUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.kafka.utils;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class KafkaTopicUtils {
+
+  private static final Pattern GMK_PATTERN =
+      Pattern.compile("^projects/([^/]+)/locations/([^/]+)/clusters/([^/]+)/topics/([^/]+)$");
+
+  public static List<String> getBootstrapServerAndTopic(String bootstrapServerAndTopicString) {
+    Matcher matcher = GMK_PATTERN.matcher(bootstrapServerAndTopicString);
+    String bootstrapServer = null;
+    String topicName = null;
+    if (matcher.matches()) {
+      bootstrapServer =
+          "bootstrap."
+              + matcher.group(3)
+              + "."
+              + matcher.group(2)
+              + ".managedkafka."
+              + matcher.group(1)
+              + ".cloud.goog:9092";
+      topicName = matcher.group(4);
+    } else {
+      String[] list = bootstrapServerAndTopicString.split(";");
+      bootstrapServer = list[0];
+      topicName = list[1];
+    }
+    return List.of(bootstrapServer, topicName);
+  }
+}

--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlex.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlex.java
@@ -21,6 +21,7 @@ import com.google.cloud.teleport.metadata.TemplateCategory;
 import com.google.cloud.teleport.v2.coders.FailsafeElementCoder;
 import com.google.cloud.teleport.v2.common.UncaughtExceptionLogger;
 import com.google.cloud.teleport.v2.kafka.transforms.KafkaTransform;
+import com.google.cloud.teleport.v2.kafka.utils.KafkaTopicUtils;
 import com.google.cloud.teleport.v2.options.KafkaToBigQueryFlexOptions;
 import com.google.cloud.teleport.v2.transforms.AvroDynamicTransform;
 import com.google.cloud.teleport.v2.transforms.AvroTransform;
@@ -35,8 +36,6 @@ import com.google.cloud.teleport.v2.values.FailsafeElement;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.beam.sdk.Pipeline;
@@ -72,11 +71,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The {@link KafkaToBigQueryFlex} pipeline is a streaming pipeline which ingests text data from
- * Kafka, executes a UDF, and outputs the resulting records to BigQuery. Any errors which occur in
- * the transformation of the data, execution of the UDF, or inserting into the output table will be
- * inserted into a separate errors table in BigQuery. The errors table will be created if it does
- * not exist prior to execution. Both output and error tables are specified by the user as
- * parameters.
+ * Kafka, and outputs the resulting records to BigQuery. Any errors which occur in the
+ * transformation of the data, or inserting into the output table will be inserted into a separate
+ * errors table in BigQuery. Both output and error tables are specified by the user as parameters.
  *
  * <p><b>Pipeline Requirements</b>
  *
@@ -95,9 +92,10 @@ import org.slf4j.LoggerFactory;
     category = TemplateCategory.STREAMING,
     displayName = "Kafka to BigQuery",
     description =
-        "The Apache Kafka to BigQuery template is a streaming pipeline which ingests text data from Apache Kafka, executes a user-defined function (UDF), and outputs the resulting records to BigQuery. "
-            + "Any errors which occur in the transformation of the data, execution of the UDF, or inserting into the output table are inserted into a separate errors table in BigQuery. "
-            + "If the errors table does not exist prior to execution, then it is created.",
+        "The Apache Kafka to BigQuery template is a streaming pipeline which ingests text data from Apache Kafka, and outputs the resulting records to BigQuery. "
+            + "Any errors which occur in the transformation of the data, or inserting into the output table are inserted into a separate errors table in BigQuery. "
+            + "For any errors which occur in the transformation of the data, the original records can be inserted into a seperate Kafka topic. The template supports "
+            + "reading a Kafka topic which contains single/multiple schema(s). It can write to a single or multiple BigQuery tables, depending on the schema of records. ",
     optionsClass = KafkaToBigQueryFlexOptions.class,
     flexContainerName = "kafka-to-bigquery-flex",
     documentation =
@@ -108,7 +106,7 @@ import org.slf4j.LoggerFactory;
       "The Apache Kafka broker server must be running and be reachable from the Dataflow worker machines.",
       "The Apache Kafka topics must exist and the messages must be encoded in a valid JSON format."
     },
-    streaming = true,
+    skipOptions = {"readBootstrapServers", "kafkaReadTopics", "useStorageWriteApi"},
     hidden = true)
 public class KafkaToBigQueryFlex {
 
@@ -156,7 +154,19 @@ public class KafkaToBigQueryFlex {
   public static PipelineResult run(KafkaToBigQueryFlexOptions options)
       throws IOException, RestClientException {
 
+    // Enable Streaming Engine
+    options.setEnableStreamingEngine(true);
+
+    // Enable Resource based billing
+    List<String> dataflowServiceOptions = options.getDataflowServiceOptions();
+    dataflowServiceOptions.add("enable_streaming_engine_resource_based_billing");
+    options.setDataflowServiceOptions(dataflowServiceOptions);
+
     // Validate BQ STORAGE_WRITE_API options
+    options.setUseStorageWriteApi(true);
+    if (options.getStorageWriteApiTriggeringFrequencySec() == null) {
+      options.setStorageWriteApiTriggeringFrequencySec(5);
+    }
     BigQueryIOUtils.validateBQStorageApiOptionsStreaming(options);
     MetadataValidator.validate(options);
 
@@ -164,16 +174,15 @@ public class KafkaToBigQueryFlex {
     Pipeline pipeline = Pipeline.create(options);
 
     List<String> topicsList;
-    if (options.getKafkaReadTopics() != null) {
-      topicsList = new ArrayList<>(Arrays.asList(options.getKafkaReadTopics().split(",")));
-    } else {
-      throw new IllegalArgumentException("Please Provide --kafkaReadTopic");
-    }
     String bootstrapServers;
-    if (options.getReadBootstrapServers() != null) {
-      bootstrapServers = options.getReadBootstrapServers();
+    if (options.getReadBootstrapServerAndTopic() != null) {
+      List<String> bootstrapServerAndTopicList =
+          KafkaTopicUtils.getBootstrapServerAndTopic(options.getReadBootstrapServerAndTopic());
+      topicsList = List.of(bootstrapServerAndTopicList.get(1));
+      bootstrapServers = bootstrapServerAndTopicList.get(0);
     } else {
-      throw new IllegalArgumentException("Please Provide --bootstrapServers");
+      throw new IllegalArgumentException(
+          "Please provide a valid bootstrap server which matches `[,:a-zA-Z0-9._-]+` and a topic which matches `[,a-zA-Z0-9._-]+`");
     }
     /*
      * Steps:
@@ -188,8 +197,7 @@ public class KafkaToBigQueryFlex {
     ImmutableMap<String, Object> kafkaConfig =
         ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, options.getKafkaReadOffset());
 
-    if (options.getKafkaReadUsernameSecretId() != null
-        && options.getKafkaReadPasswordSecretId() != null) {
+    if (options.getKafkaReadAuthenticationMode().equals("SASL_PLAIN")) {
 
       String username = SecretManagerUtils.getSecret(options.getKafkaReadUsernameSecretId());
       String password = SecretManagerUtils.getSecret(options.getKafkaReadPasswordSecretId());
@@ -205,7 +213,8 @@ public class KafkaToBigQueryFlex {
 
       return runJsonPipeline(pipeline, options, topicsList, bootstrapServers, kafkaConfig);
 
-    } else if (options.getMessageFormat() == null || options.getMessageFormat().equals("AVRO")) {
+    } else if (options.getMessageFormat().equals("AVRO_CONFLUENT_WIRE_FORMAT")
+        || options.getMessageFormat().equals("AVRO_BINARY_ENCODING")) {
 
       return runAvroPipeline(pipeline, options, topicsList, bootstrapServers, kafkaConfig);
 
@@ -222,15 +231,16 @@ public class KafkaToBigQueryFlex {
       Map<String, Object> kafkaConfig)
       throws IOException, RestClientException {
 
-    if (options.getAvroFormat().equals("NON_WIRE_FORMAT") && options.getAvroSchemaPath() == null) {
+    if (options.getMessageFormat().equals("AVRO_BINARY_ENCODING")
+        && options.getBinaryAvroSchemaPath() == null) {
       throw new IllegalArgumentException(
           "Avro schema is needed in order to read non confluent wire format messages.");
     }
-    if (options.getAvroFormat().equals("CONFLUENT_WIRE_FORMAT")
+    if (options.getMessageFormat().equals("AVRO_CONFLUENT_WIRE_FORMAT")
         && options.getSchemaRegistryConnectionUrl() == null
-        && options.getAvroSchemaPath() == null) {
+        && options.getConfluentAvroSchemaPath() == null) {
       throw new IllegalArgumentException(
-          "Schema Registry Connection URL OR Avro schema is needed in order to read confluent wire format messages.");
+          "Schema Registry Connection URL or Avro schema is needed in order to read confluent wire format messages.");
     }
 
     PCollection<KafkaRecord<byte[], byte[]>> kafkaRecords;
@@ -248,28 +258,81 @@ public class KafkaToBigQueryFlex {
 
     WriteResult writeResult = null;
 
-    if (options.getAvroFormat().equals("NON_WIRE_FORMAT") && options.getAvroSchemaPath() != null) {
+    if (options.getMessageFormat().equals("AVRO_BINARY_ENCODING")
+        && options.getBinaryAvroSchemaPath() != null) {
+      writeResult =
+          kafkaRecords.apply(
+              AvroTransform.of(
+                  topicsList.get(0),
+                  options.getMessageFormat(),
+                  options.getBinaryAvroSchemaPath(),
+                  options.getConfluentAvroSchemaPath(),
+                  options.getOutputTableSpec(),
+                  options.getWriteDisposition(),
+                  options.getCreateDisposition(),
+                  options.getNumStorageWriteApiStreams(),
+                  options.getStorageWriteApiTriggeringFrequencySec(),
+                  options.getPersistKafkaKey(),
+                  options.getUseAutoSharding()));
 
-      writeResult = kafkaRecords.apply(AvroTransform.of(options));
+    } else if (options.getMessageFormat().equals("AVRO_CONFLUENT_WIRE_FORMAT")
+        && (options.getSchemaRegistryConnectionUrl() != null
+            || options.getConfluentAvroSchemaPath() != null)) {
 
-    } else {
+      if (options.getSchemaFormat().equals("SINGLE_SCHEMA_FILE")) {
 
-      if (options.getAvroSchemaPath() != null && options.getOutputTableSpec() == null) {
-        throw new IllegalArgumentException("An output BigQuery table is required.");
-      }
+        if (options.getConfluentAvroSchemaPath() != null && options.getOutputTableSpec() == null) {
+          throw new IllegalArgumentException(
+              "The outputTableSpec parameter is required when using the SINGLE_SCHEMA_FILE schema format.");
+        }
 
-      if (options.getAvroSchemaPath() != null && options.getOutputTableSpec() != null) {
-        writeResult = kafkaRecords.apply(AvroTransform.of(options));
-      }
+        if (options.getConfluentAvroSchemaPath() != null && options.getOutputTableSpec() != null) {
+          writeResult =
+              kafkaRecords.apply(
+                  AvroTransform.of(
+                      options.getReadBootstrapServerAndTopic().split(":")[2],
+                      options.getMessageFormat(),
+                      options.getBinaryAvroSchemaPath(),
+                      options.getConfluentAvroSchemaPath(),
+                      options.getOutputTableSpec(),
+                      options.getWriteDisposition(),
+                      options.getCreateDisposition(),
+                      options.getNumStorageWriteApiStreams(),
+                      options.getStorageWriteApiTriggeringFrequencySec(),
+                      options.getPersistKafkaKey(),
+                      options.getUseAutoSharding()));
+        }
+      } else if (options.getSchemaFormat().equals("SCHEMA_REGISTRY")) {
 
-      if (options.getSchemaRegistryConnectionUrl() != null && options.getOutputDataset() == null) {
+        if (options.getSchemaRegistryConnectionUrl() != null
+            && options.getOutputDataset() == null) {
+          throw new IllegalArgumentException(
+              "An output BigQuery dataset is required. It will be used to create tables per schema.");
+        }
+
+        if (options.getSchemaRegistryConnectionUrl() != null
+            && options.getOutputDataset() != null) {
+          writeResult =
+              kafkaRecords.apply(
+                  AvroDynamicTransform.of(
+                      options.getSchemaRegistryConnectionUrl(),
+                      options.getOutputProject(),
+                      options.getOutputDataset(),
+                      options.getBqTableNamePrefix(),
+                      options.getWriteDisposition(),
+                      options.getCreateDisposition(),
+                      options.getNumStorageWriteApiStreams(),
+                      options.getStorageWriteApiTriggeringFrequencySec(),
+                      options.getPersistKafkaKey(),
+                      options.getUseAutoSharding()));
+        }
+      } else {
         throw new IllegalArgumentException(
-            "An output BigQuery dataset is required. It will be used to create tables per schema.");
+            "Unsupported schemaFormat parameter value: " + options.getSchemaFormat());
       }
-
-      if (options.getSchemaRegistryConnectionUrl() != null && options.getOutputDataset() != null) {
-        writeResult = kafkaRecords.apply(AvroDynamicTransform.of(options));
-      }
+    } else {
+      throw new IllegalArgumentException(
+          "Message format " + options.getMessageFormat() + " is unsupported.");
     }
 
     /*

--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryDynamicDestination.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryDynamicDestination.java
@@ -58,8 +58,13 @@ public class BigQueryDynamicDestination
 
   @Override
   public TableDestination getTable(GenericRecord element) {
-    // tablename + record name (same across schemas) + schema id?
-    String bqQualifiedFullName = element.getSchema().getFullName().replace(".", "-");
+    String sanitizedNamespace =
+        BigQueryAvroUtils.sanitizeString(element.getSchema().getNamespace());
+    String sanitizedName = BigQueryAvroUtils.sanitizeString(element.getSchema().getName());
+
+    String bqQualifiedFullName =
+        sanitizedNamespace + (sanitizedNamespace.isBlank() ? "" : "-") + sanitizedName;
+
     String tableName =
         this.tableNamePrefix + (this.tableNamePrefix.isBlank() ? "" : "-") + bqQualifiedFullName;
     String tableSpec = this.projectName + ":" + this.datasetName + "." + tableName;

--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/utils/BigQueryAvroUtils.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/utils/BigQueryAvroUtils.java
@@ -37,6 +37,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.avro.Conversions;
@@ -108,7 +109,8 @@ public class BigQueryAvroUtils {
   private static final DateTimeFormatter DATE_AND_SECONDS_FORMATTER =
       DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss").withZoneUTC();
 
-  private static final String kafkaKeyField = "_key";
+  private static final Pattern SANITIZE_PATTERN =
+      Pattern.compile("[^\\w- ]+", Pattern.UNICODE_CHARACTER_CLASS);
 
   static String formatTimestamp(Long timestampMicro) {
     // timestampMicro is in "microseconds since epoch" format,
@@ -536,11 +538,15 @@ public class BigQueryAvroUtils {
     if (persistKafkaKey) {
       List<TableFieldSchema> list = tableSchema.getFields();
       TableFieldSchema field = new TableFieldSchema();
-      field.setName(kafkaKeyField);
+      field.setName(BigQueryConstants.KAFKA_KEY_FIELD);
       field.setType("BYTES");
       list.add(field);
       tableSchema.setFields(list);
     }
     return tableSchema;
+  }
+
+  public static String sanitizeString(String value) {
+    return SANITIZE_PATTERN.matcher(value).replaceAll("-");
   }
 }

--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/utils/BigQueryConstants.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/utils/BigQueryConstants.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.utils;
+
+public class BigQueryConstants {
+
+  private BigQueryConstants() {}
+
+  public static final String KAFKA_KEY_FIELD = "_key";
+}

--- a/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
+++ b/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
@@ -116,9 +116,20 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
     tableId = bigQueryClient.createTable(testName, bqSchema);
     baseKafkaToBigQueryAvro(
         b ->
-            b.addParameter("avroFormat", "CONFLUENT_WIRE_FORMAT")
-                .addParameter("avroSchemaPath", getGcsPath("avro_schema.avsc"))
-                .addParameter("outputTableSpec", toTableSpecLegacy(tableId)));
+            b.addParameter("messageFormat", "AVRO_CONFLUENT_WIRE_FORMAT")
+                .addParameter("schemaFormat", "SINGLE_SCHEMA_FILE")
+                .addParameter("confluentAvroSchemaPath", getGcsPath("avro_schema.avsc"))
+                .addParameter("schemaRegistryConnectionUrl", "")
+                .addParameter("binaryAvroSchemaPath", "gs://FAKE")
+                .addParameter("writeMode", "SINGLE_TABLE_NAME")
+                .addParameter("outputTableSpec", toTableSpecLegacy(tableId))
+                .addParameter("outputProject", "")
+                .addParameter("outputDataset", "")
+                .addParameter("bqTableNamePrefix", "")
+                .addParameter("useBigQueryDLQ", "false")
+                .addParameter("kafkaReadAuthenticationMode", "NONE")
+                .addParameter("kafkaReadUsernameSecretId", "")
+                .addParameter("kafkaReadPasswordSecretId", ""));
   }
 
   @Test
@@ -130,9 +141,20 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
     tableId = bigQueryClient.createTable(testName + "WithKey", bqSchema);
     baseKafkaToBigQueryAvro(
         b ->
-            b.addParameter("avroFormat", "CONFLUENT_WIRE_FORMAT")
-                .addParameter("avroSchemaPath", getGcsPath("avro_schema.avsc"))
+            b.addParameter("messageFormat", "AVRO_CONFLUENT_WIRE_FORMAT")
+                .addParameter("schemaFormat", "SINGLE_SCHEMA_FILE")
+                .addParameter("confluentAvroSchemaPath", getGcsPath("avro_schema.avsc"))
+                .addParameter("schemaRegistryConnectionUrl", "")
+                .addParameter("binaryAvroSchemaPath", "gs://FAKE")
+                .addParameter("writeMode", "SINGLE_TABLE_NAME")
                 .addParameter("outputTableSpec", toTableSpecLegacy(tableId))
+                .addParameter("outputProject", "")
+                .addParameter("outputDataset", "")
+                .addParameter("bqTableNamePrefix", "")
+                .addParameter("useBigQueryDLQ", "false")
+                .addParameter("kafkaReadAuthenticationMode", "NONE")
+                .addParameter("kafkaReadUsernameSecretId", "")
+                .addParameter("kafkaReadPasswordSecretId", "")
                 .addParameter("persistKafkaKey", "true"));
   }
 
@@ -140,9 +162,19 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
   public void testKafkaToBigQueryAvroWithSchemaRegistry() throws IOException, RestClientException {
     baseKafkaToBigQueryAvro(
         b ->
-            b.addParameter("avroFormat", "CONFLUENT_WIRE_FORMAT")
+            b.addParameter("messageFormat", "AVRO_CONFLUENT_WIRE_FORMAT")
+                .addParameter("schemaFormat", "SCHEMA_REGISTRY")
                 .addParameter("schemaRegistryConnectionUrl", "http://10.128.0.60:8081")
-                .addParameter("outputDataset", bqDatasetId));
+                .addParameter("confluentAvroSchemaPath", "gs://FAKE")
+                .addParameter("binaryAvroSchemaPath", "gs://FAKE")
+                .addParameter("writeMode", "DYNAMIC_TABLE_NAMES")
+                .addParameter("outputProject", PROJECT)
+                .addParameter("outputDataset", bqDatasetId)
+                .addParameter("bqTableNamePrefix", "")
+                .addParameter("useBigQueryDLQ", "false")
+                .addParameter("kafkaReadAuthenticationMode", "NONE")
+                .addParameter("kafkaReadUsernameSecretId", "")
+                .addParameter("kafkaReadPasswordSecretId", ""));
   }
 
   @Test
@@ -150,9 +182,19 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
       throws IOException, RestClientException {
     baseKafkaToBigQueryAvro(
         b ->
-            b.addParameter("avroFormat", "CONFLUENT_WIRE_FORMAT")
+            b.addParameter("messageFormat", "AVRO_CONFLUENT_WIRE_FORMAT")
+                .addParameter("schemaFormat", "SCHEMA_REGISTRY")
                 .addParameter("schemaRegistryConnectionUrl", "http://10.128.0.60:8081")
+                .addParameter("confluentAvroSchemaPath", "gs://FAKE")
+                .addParameter("binaryAvroSchemaPath", "gs://FAKE")
+                .addParameter("writeMode", "DYNAMIC_TABLE_NAMES")
+                .addParameter("outputProject", PROJECT)
                 .addParameter("outputDataset", bqDatasetId)
+                .addParameter("bqTableNamePrefix", "")
+                .addParameter("useBigQueryDLQ", "false")
+                .addParameter("kafkaReadAuthenticationMode", "NONE")
+                .addParameter("kafkaReadUsernameSecretId", "")
+                .addParameter("kafkaReadPasswordSecretId", "")
                 .addParameter("persistKafkaKey", "true"));
   }
 
@@ -162,9 +204,20 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
     tableId = bigQueryClient.createTable(testName, bqSchema);
     baseKafkaToBigQueryAvro(
         b ->
-            b.addParameter("avroFormat", "NON_WIRE_FORMAT")
-                .addParameter("avroSchemaPath", getGcsPath("avro_schema.avsc"))
-                .addParameter("outputTableSpec", toTableSpecLegacy(tableId)));
+            b.addParameter("messageFormat", "AVRO_BINARY_ENCODING")
+                .addParameter("schemaFormat", "SINGLE_SCHEMA_FILE")
+                .addParameter("confluentAvroSchemaPath", "gs://FAKE")
+                .addParameter("schemaRegistryConnectionUrl", "")
+                .addParameter("binaryAvroSchemaPath", getGcsPath("avro_schema.avsc"))
+                .addParameter("writeMode", "SINGLE_TABLE_NAME")
+                .addParameter("outputTableSpec", toTableSpecLegacy(tableId))
+                .addParameter("outputProject", "")
+                .addParameter("outputDataset", "")
+                .addParameter("bqTableNamePrefix", "")
+                .addParameter("useBigQueryDLQ", "false")
+                .addParameter("kafkaReadAuthenticationMode", "NONE")
+                .addParameter("kafkaReadUsernameSecretId", "")
+                .addParameter("kafkaReadPasswordSecretId", ""));
   }
 
   @Test
@@ -176,9 +229,20 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
     tableId = bigQueryClient.createTable(testName + "WithKey", bqSchema);
     baseKafkaToBigQueryAvro(
         b ->
-            b.addParameter("avroFormat", "NON_WIRE_FORMAT")
-                .addParameter("avroSchemaPath", getGcsPath("avro_schema.avsc"))
+            b.addParameter("messageFormat", "AVRO_BINARY_ENCODING")
+                .addParameter("schemaFormat", "Schema File - Single Schema")
+                .addParameter("confluentAvroSchemaPath", "gs://FAKE")
+                .addParameter("schemaRegistryConnectionUrl", "")
+                .addParameter("binaryAvroSchemaPath", getGcsPath("avro_schema.avsc"))
+                .addParameter("writeMode", "SINGLE_TABLE_NAME")
                 .addParameter("outputTableSpec", toTableSpecLegacy(tableId))
+                .addParameter("outputProject", "")
+                .addParameter("outputDataset", "")
+                .addParameter("bqTableNamePrefix", "")
+                .addParameter("useBigQueryDLQ", "false")
+                .addParameter("kafkaReadAuthenticationMode", "NONE")
+                .addParameter("kafkaReadUsernameSecretId", "")
+                .addParameter("kafkaReadPasswordSecretId", "")
                 .addParameter("persistKafkaKey", "true"));
   }
 
@@ -189,37 +253,21 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
 
     baseKafkaToBigQueryAvro(
         b ->
-            b.addParameter("outputDeadletterTable", toTableSpecLegacy(deadletterTableId))
-                .addParameter("avroSchemaPath", getGcsPath("avro_schema.avsc"))
-                .addParameter("outputTableSpec", toTableSpecLegacy(tableId)));
-  }
-
-  @Test
-  public void testKafkaToBigQueryAvroWithStorageApi() throws IOException, RestClientException {
-    tableId = bigQueryClient.createTable(testName, bqSchema);
-    baseKafkaToBigQueryAvro(
-        b ->
-            b.addParameter("useStorageWriteApi", "true")
-                .addParameter("numStorageWriteApiStreams", "3")
-                .addParameter("storageWriteApiTriggeringFrequencySec", "3")
-                .addParameter("avroSchemaPath", getGcsPath("avro_schema.avsc"))
-                .addParameter("outputTableSpec", toTableSpecLegacy(tableId)));
-  }
-
-  @Test
-  public void testKafkaToBigQueryAvroWithStorageApiExistingDLQ()
-      throws IOException, RestClientException {
-    tableId = bigQueryClient.createTable(testName, bqSchema);
-    deadletterTableId = bigQueryClient.createTable(testName + "_dlq", getDeadletterSchema());
-
-    baseKafkaToBigQueryAvro(
-        b ->
-            b.addParameter("useStorageWriteApi", "true")
-                .addParameter("numStorageWriteApiStreams", "3")
-                .addParameter("storageWriteApiTriggeringFrequencySec", "3")
+            b.addParameter("messageFormat", "AVRO_CONFLUENT_WIRE_FORMAT")
+                .addParameter("schemaFormat", "Schema File - Single Schema")
+                .addParameter("confluentAvroSchemaPath", getGcsPath("avro_schema.avsc"))
+                .addParameter("schemaRegistryConnectionUrl", "")
+                .addParameter("binaryAvroSchemaPath", "gs://FAKE")
+                .addParameter("writeMode", "SINGLE_TABLE_NAME")
+                .addParameter("outputTableSpec", toTableSpecLegacy(tableId))
+                .addParameter("outputProject", "")
+                .addParameter("outputDataset", "")
+                .addParameter("bqTableNamePrefix", "")
+                .addParameter("useBigQueryDLQ", "true")
                 .addParameter("outputDeadletterTable", toTableSpecLegacy(deadletterTableId))
-                .addParameter("avroSchemaPath", getGcsPath("avro_schema.avsc"))
-                .addParameter("outputTableSpec", toTableSpecLegacy(tableId)));
+                .addParameter("kafkaReadAuthenticationMode", "NONE")
+                .addParameter("kafkaReadUsernameSecretId", "")
+                .addParameter("kafkaReadPasswordSecretId", ""));
   }
 
   private Schema getDeadletterSchema() {
@@ -264,11 +312,11 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
         paramsAdder.apply(
             LaunchConfig.builder(testName, specPath)
                 .addParameter(
-                    "readBootstrapServers",
-                    kafkaResourceManager.getBootstrapServers().replace("PLAINTEXT://", ""))
-                .addParameter("kafkaReadTopics", topicName)
-                .addParameter("kafkaReadOffset", "earliest")
-                .addParameter("messageFormat", "AVRO"));
+                    "readBootstrapServerAndTopic",
+                    kafkaResourceManager.getBootstrapServers().replace("PLAINTEXT://", "")
+                        + ":"
+                        + topicName)
+                .addParameter("kafkaReadOffset", "earliest"));
 
     // Act
     LaunchInfo info = launchTemplate(options);
@@ -276,8 +324,10 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
 
     List<ConditionCheck> conditions = new ArrayList<ConditionCheck>();
 
-    if (options.getParameter("avroFormat") != null
-        && options.getParameter("avroFormat").equals("CONFLUENT_WIRE_FORMAT")
+    if (options.getParameter("messageFormat") != null
+        && options.getParameter("messageFormat").equals("AVRO_CONFLUENT_WIRE_FORMAT")
+        && options.getParameter("schemaFormat") != null
+        && options.getParameter("schemaFormat").equals("SCHEMA_REGISTRY")
         && options.getParameter("schemaRegistryConnectionUrl") != null) {
 
       publishDoubleSchemaMessages(topicName);
@@ -289,9 +339,9 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
       conditions.add(
           BigQueryRowsCheck.builder(bigQueryClient, otherTableId).setMinRows(20).build());
 
-    } else if (options.getParameter("avroFormat") != null
-        && options.getParameter("avroFormat").equals("NON_WIRE_FORMAT")
-        && options.getParameter("avroSchemaPath") != null) {
+    } else if (options.getParameter("messageFormat") != null
+        && options.getParameter("messageFormat").equals("AVRO_BINARY_ENCODING")
+        && options.getParameter("binaryAvroSchemaPath") != null) {
 
       publishBinaryMessages(topicName);
       conditions.add(BigQueryRowsCheck.builder(bigQueryClient, tableId).setMinRows(20).build());


### PR DESCRIPTION
Refactor KafkaToBigQueryFlexOptions and default the KafkaToBigQueryFlex template to Streaming Engine and Resource-based billing, also Storage Write API is required to write to BigQuery.