### PR TITLE
Fix Neo4j query parameter creation

### DIFF
--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/utils/DataCastingUtils.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/utils/DataCastingUtils.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.neo4j.utils;
 
 import com.google.cloud.teleport.v2.neo4j.logicaltypes.IsoDateTime;
+import com.google.cloud.teleport.v2.neo4j.model.enums.RoleType;
 import com.google.cloud.teleport.v2.neo4j.model.job.Mapping;
 import com.google.cloud.teleport.v2.neo4j.model.job.Target;
 import java.math.BigDecimal;
@@ -222,17 +223,20 @@ public class DataCastingUtils {
       map.put(fieldName, fromBeamType(fieldName, field.getType(), row.getValue(fieldName)));
     }
 
-    for (Mapping m : target.getMappings()) {
+    for (Mapping mapping : target.getMappings()) {
       // if row is empty continue
       if (listFullOfNulls(row.getValues())) {
         continue;
       }
-      // lookup data type
-      if (StringUtils.isNotEmpty(m.getConstant())) {
-        if (StringUtils.isNotEmpty(m.getName())) {
-          map.put(m.getName(), m.getConstant());
+      var role = mapping.getRole();
+      if (role == RoleType.label || role == RoleType.type) {
+        continue;
+      }
+      if (StringUtils.isNotEmpty(mapping.getConstant())) {
+        if (StringUtils.isNotEmpty(mapping.getName())) {
+          map.put(mapping.getName(), mapping.getConstant());
         } else {
-          map.put(m.getConstant(), m.getConstant());
+          map.put(mapping.getConstant(), mapping.getConstant());
         }
       }
     }

--- a/v2/googlecloud-to-neo4j/src/test/resources/testing-specs/property-mappings/mapping-clash-bq-spec.json
+++ b/v2/googlecloud-to-neo4j/src/test/resources/testing-specs/property-mappings/mapping-clash-bq-spec.json
@@ -1,0 +1,35 @@
+{
+  "source": {
+    "type": "bigquery",
+    "name": "stations",
+    "query": "SELECT Station, Latitude, Longitude, Zone FROM $bqtable"
+  },
+  "targets": [
+    {
+      "node": {
+        "source": "stations",
+        "name": "Station",
+        "mode": "merge",
+        "transform": {
+          "group": true
+        },
+        "mappings": {
+          "labels": [
+            "\"Station\""
+          ],
+          "properties": {
+            "keys": [
+              {"Station": "name"}
+            ],
+            "strings": [
+              {"Zone": "zone"}
+            ],
+            "floats": [
+              {"Longitude": "longitude"},
+              {"Latitude": "latitude"}
+            ]
+          }
+        }
+      }
+    }
+  ]}


### PR DESCRIPTION
In cases where node label or relationship type mappings were colliding with source field names, the constant value of the label or type would overwrite the source field value.