### PR TITLE
Revise datastream to spanner ITs

### DIFF
--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -45,6 +45,9 @@ concurrency:
 
 env:
   MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade=error
+  PROXY_PASSWORD: t>5xl%J(&qTK6?FaZ
+  PROXY_HOST: 10.128.0.34
+  PROXY_PORT: 33134
 
 permissions: read-all
 
@@ -133,7 +136,10 @@ jobs:
           --it-region="us-central1" \
           --it-project="cloud-teleport-testing" \
           --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \
-          --it-private-connectivity="datastream-private-connect-us-central1"
+          --it-private-connectivity="datastream-private-connect-us-central1" \
+          --it-proxy-host="${PROXY_HOST}" \
+          --it-proxy-port="${PROXY_PORT}" \
+          --it-proxy-password="${PROXY_PASSWORD}"
       - name: Upload Smoke Tests Report
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: always() # always run even if the previous step fails
@@ -161,7 +167,10 @@ jobs:
           --it-region="us-central1" \
           --it-project="cloud-teleport-testing" \
           --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \
-          --it-private-connectivity="datastream-private-connect-us-central1"
+          --it-private-connectivity="datastream-private-connect-us-central1" \
+          --it-proxy-host="${PROXY_HOST}" \
+          --it-proxy-port="${PROXY_PORT}" \
+          --it-proxy-password="${PROXY_PASSWORD}"
       - name: Upload Integration Tests Report
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: always() # always run even if the previous step fails
@@ -190,6 +199,9 @@ jobs:
         --it-region="us-central1" \
         --it-project="cloud-teleport-testing" \
         --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \
-        --it-private-connectivity="datastream-private-connect-us-central1"
+        --it-private-connectivity="datastream-private-connect-us-central1" \
+        --it-proxy-host="${PROXY_HOST}" \
+        --it-proxy-port="${PROXY_PORT}" \
+        --it-proxy-password="${PROXY_PASSWORD}"
     - name: Cleanup Java Environment
       uses: ./.github/actions/cleanup-java-env

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -6,6 +6,11 @@ on:
   - cron: '0 0 * * 6'
   workflow_dispatch:
 
+env:
+  PROXY_PASSWORD: t>5xl%J(&qTK6?FaZ
+  PROXY_HOST: 10.128.0.34
+  PROXY_PORT: 33134
+
 permissions: read-all
 
 jobs:
@@ -32,6 +37,9 @@ jobs:
         -DartifactBucket=gs://apache-beam-testing-pranavbhandari \
         -DhostIp=${HOST_IP} \
         -DprivateConnectivity="datastream-private-connect-us-central1" \
+        --it-proxy-host="${PROXY_HOST}" \
+        --it-proxy-port="${PROXY_PORT}" \
+        --it-proxy-password="${PROXY_PASSWORD}" \
         -DexportProject=cloud-teleport-testing \
         -DexportDataset=performance_tests \
         -DexportTable=template_performance_metrics -e -fae

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ on:
         type: string
         required: false
 
+env:
+  PROXY_PASSWORD: t>5xl%J(&qTK6?FaZ
+  PROXY_HOST: 10.128.0.34
+  PROXY_PORT: 33134
+
 permissions:
   contents: write
 
@@ -78,6 +83,9 @@ jobs:
         --it-project="cloud-teleport-testing" \
         --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \
         --it-private-connectivity="datastream-private-connect-us-central1" \
+        --it-proxy-host="${PROXY_HOST}" \
+        --it-proxy-port="${PROXY_PORT}" \
+        --it-proxy-password="${PROXY_PASSWORD}" \
         --it-release=true \
         --it-retry-failures=2
     - name: Run Integration Tests
@@ -87,6 +95,9 @@ jobs:
         --it-project="cloud-teleport-testing" \
         --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \
         --it-private-connectivity="datastream-private-connect-us-central1" \
+        --it-proxy-host="${PROXY_HOST}" \
+        --it-proxy-port="${PROXY_PORT}" \
+        --it-proxy-password="${PROXY_PASSWORD}" \
         --it-release=true \
         --it-retry-failures=2
     - name: Upload Tests Report

--- a/.github/workflows/spanner-pr.yml
+++ b/.github/workflows/spanner-pr.yml
@@ -40,6 +40,9 @@ concurrency:
 
 env:
   MAVEN_OPTS: -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugins.shade=error
+  PROXY_PASSWORD: t>5xl%J(&qTK6?FaZ
+  PROXY_HOST: 10.128.0.34
+  PROXY_PORT: 33134
 
 permissions: read-all
 
@@ -137,7 +140,10 @@ jobs:
         --it-region="us-central1" \
         --it-project="cloud-teleport-testing" \
         --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \
-        --it-private-connectivity="datastream-private-connect-us-central1"
+        --it-private-connectivity="datastream-private-connect-us-central1" \
+        --it-proxy-host="${PROXY_HOST}" \
+        --it-proxy-port="${PROXY_PORT}" \
+        --it-proxy-password="${PROXY_PASSWORD}"
     - name: Upload Smoke Tests Report
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       if: always() # always run even if the previous step fails
@@ -166,7 +172,10 @@ jobs:
         --it-region="us-central1" \
         --it-project="cloud-teleport-testing" \
         --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \
-        --it-private-connectivity="datastream-private-connect-us-central1"
+        --it-private-connectivity="datastream-private-connect-us-central1" \
+        --it-proxy-host="${PROXY_HOST}" \
+        --it-proxy-port="${PROXY_PORT}" \
+        --it-proxy-password="${PROXY_PASSWORD}"
     - name: Upload Integration Tests Report
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       if: always() # always run even if the previous step fails
@@ -196,6 +205,9 @@ jobs:
         --it-region="us-central1" \
         --it-project="cloud-teleport-testing" \
         --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \
-        --it-private-connectivity="datastream-private-connect-us-central1"
+        --it-private-connectivity="datastream-private-connect-us-central1" \
+        --it-proxy-host="${PROXY_HOST}" \
+        --it-proxy-port="${PROXY_PORT}" \
+        --it-proxy-password="${PROXY_PASSWORD}"
     - name: Cleanup Java Environment
       uses: ./.github/actions/cleanup-java-env

--- a/cicd/cmd/run-it-smoke-tests/main.go
+++ b/cicd/cmd/run-it-smoke-tests/main.go
@@ -59,11 +59,15 @@ func main() {
 		mvnFlags.IntegrationTestParallelism(4),
 		mvnFlags.StaticBigtableInstance("teleport"),
 		mvnFlags.StaticSpannerInstance("teleport"),
+		mvnFlags.StaticOracleInstance("10.128.0.90"),
 		flags.Region(),
 		flags.Project(),
 		flags.ArtifactBucket(),
 		flags.StageBucket(),
 		flags.PrivateConnectivity(),
+		flags.CloudProxyHost(),
+		flags.CloudProxyPort(),
+		flags.CloudProxyPassword(),
 		flags.FailureMode(),
 		flags.RetryFailures())
 	if err != nil {

--- a/cicd/cmd/run-it-tests/main.go
+++ b/cicd/cmd/run-it-tests/main.go
@@ -59,12 +59,16 @@ func main() {
 		mvnFlags.IntegrationTestParallelism(3),
 		mvnFlags.StaticBigtableInstance("teleport"),
 		mvnFlags.StaticSpannerInstance("teleport"),
+		mvnFlags.StaticOracleInstance("10.128.0.90"),
 		flags.Region(),
 		flags.Project(),
 		flags.ArtifactBucket(),
 		flags.StageBucket(),
 		flags.HostIp(),
 		flags.PrivateConnectivity(),
+		flags.CloudProxyHost(),
+		flags.CloudProxyPort(),
+		flags.CloudProxyPassword(),
 		flags.FailureMode(),
 		flags.RetryFailures())
 	if err != nil {

--- a/cicd/cmd/run-load-tests/main.go
+++ b/cicd/cmd/run-load-tests/main.go
@@ -62,6 +62,9 @@ func main() {
 		flags.StageBucket(),
 		flags.HostIp(),
 		flags.PrivateConnectivity(),
+		flags.CloudProxyHost(),
+		flags.CloudProxyPort(),
+		flags.CloudProxyPassword(),
 		flags.ExportProject(),
 		flags.ExportDataset(),
 		flags.ExportTable())

--- a/cicd/internal/flags/it-flags.go
+++ b/cicd/internal/flags/it-flags.go
@@ -30,6 +30,10 @@ var (
 	dStageBucket         string
 	dHostIp              string
 	dPrivateConnectivity string
+	dCloudProxyHost      string
+	dCloudProxyPort      string
+	dCloudProxyPassword  string
+	dSpannerHost         string
 	dReleaseMode         bool
 	dRetryFailures       string
 )
@@ -42,6 +46,10 @@ func RegisterItFlags() {
 	flag.StringVar(&dStageBucket, "it-stage-bucket", "", "(optional) A GCP bucket to stage templates")
 	flag.StringVar(&dHostIp, "it-host-ip", "", "(optional) The ip that the gitactions runner is listening on")
 	flag.StringVar(&dPrivateConnectivity, "it-private-connectivity", "", "(optional) A GCP private connectivity endpoint")
+	flag.StringVar(&dCloudProxyHost, "it-proxy-host", "", "(optional) The host for a Cloud Auth Proxy.")
+	flag.StringVar(&dCloudProxyPort, "it-proxy-port", "", "(optional) The port for a Cloud Auth Proxy.")
+	flag.StringVar(&dCloudProxyPassword, "it-proxy-password", "", "(optional) The password for a Cloud Auth Proxy.")
+	flag.StringVar(&dSpannerHost, "it-spanner-host", "", "(optional) A custom endpoint to override Spanner API requests")
 	flag.BoolVar(&dReleaseMode, "it-release", false, "(optional) Set if tests are being executed for a release")
 	flag.StringVar(&dRetryFailures, "it-retry-failures", "0", "Number of retries attempts for failing tests")
 }
@@ -82,6 +90,34 @@ func PrivateConnectivity() string {
 		return "-DprivateConnectivity=" + dPrivateConnectivity
 	}
 	return ""
+}
+
+func CloudProxyHost() string {
+	if dCloudProxyHost != "" {
+		return "-DcloudProxyHost=" + dCloudProxyHost
+	}
+	return ""
+}
+
+func CloudProxyPort() string {
+	if dCloudProxyPort != "" {
+		return "-DcloudProxyPort=" + dCloudProxyPort
+	}
+	return ""
+}
+
+func CloudProxyPassword() string {
+	if dCloudProxyPassword != "" {
+		return "-DcloudProxyPassword=" + dCloudProxyPassword
+	}
+	return ""
+}
+
+func SpannerHost() string {
+	if dSpannerHost == "" {
+		return "-DspannerHost=" + "https://staging-wrenchworks.sandbox.googleapis.com/"
+	}
+	return "-DspannerHost=" + dSpannerHost
 }
 
 func FailureMode() string {

--- a/cicd/internal/workflows/maven-workflows.go
+++ b/cicd/internal/workflows/maven-workflows.go
@@ -56,6 +56,8 @@ type MavenFlags interface {
 	IntegrationTestParallelism(int) string
 	StaticBigtableInstance(string) string
 	StaticSpannerInstance(string) string
+	StaticOracleInstance(string) string
+	SpannerHost(string) string
 }
 
 type mvnFlags struct{}
@@ -133,6 +135,14 @@ func (*mvnFlags) StaticBigtableInstance(instanceID string) string {
 
 func (*mvnFlags) StaticSpannerInstance(instanceID string) string {
 	return "-DspannerInstanceId=" + instanceID
+}
+
+func (*mvnFlags) StaticOracleInstance(host string) string {
+	return "-DcloudOracleHost=" + host
+}
+
+func (*mvnFlags) SpannerHost(host string) string {
+	return "-DspannerHost=" + host
 }
 
 func NewMavenFlags() MavenFlags {

--- a/it/google-cloud-platform/pom.xml
+++ b/it/google-cloud-platform/pom.xml
@@ -65,6 +65,24 @@
             <version>${dataflow-api.version}</version>
         </dependency>
 
+        <!-- JDBC dependencies for CloudSQL -->
+        <dependency>
+            <groupId>org.apache.beam</groupId>
+            <artifactId>beam-it-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>${mysql-connector-java.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <version>${ojdbc8.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Google Cloud -->
         <dependency>
             <groupId>com.google.cloud</groupId>

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudMySQLResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudMySQLResourceManager.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.it.gcp.cloudsql;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Custom class for the MySQL implementation of {@link CloudSqlResourceManager} abstract class.
+ *
+ * <p>The class supports one database, and multiple tables per database object. A database is *
+ * created when the container first spins up, if one is not given.
+ *
+ * <p>The class is thread-safe.
+ */
+public class CloudMySQLResourceManager extends CloudSqlResourceManager {
+
+  private CloudMySQLResourceManager(Builder builder) {
+    super(builder);
+  }
+
+  public static Builder builder(String testId) {
+    return new Builder(testId);
+  }
+
+  @Override
+  public @NotNull String getJDBCPrefix() {
+    return "mysql";
+  }
+
+  /** Builder for {@link CloudMySQLResourceManager}. */
+  public static final class Builder extends CloudSqlResourceManager.Builder {
+
+    public Builder(String testId) {
+      super(testId);
+    }
+
+    @Override
+    public @NotNull CloudMySQLResourceManager build() {
+      return new CloudMySQLResourceManager(this);
+    }
+  }
+}

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudOracleResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudOracleResourceManager.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.it.gcp.cloudsql;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Custom class for the Oracle implementation of {@link CloudSqlResourceManager} abstract class.
+ *
+ * <p>This class leverages the API in the {@link CloudSqlResourceManager}, but assumes a self-hosted
+ * Oracle instance on GCE or other provider.
+ *
+ * <p>The class supports one database (XE), and multiple tables. The database must already exist to
+ * use this resource manager.
+ *
+ * <p>The class is thread-safe.
+ */
+public class CloudOracleResourceManager extends CloudSqlResourceManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CloudOracleResourceManager.class);
+
+  private static final int DEFAULT_ORACLE_PORT = 1521;
+
+  private CloudOracleResourceManager(Builder builder) {
+    super(builder);
+
+    System.setProperty("oracle.jdbc.timezoneAsRegion", "false");
+  }
+
+  public static Builder builder(String testId) {
+    return new Builder(testId);
+  }
+
+  @Override
+  public @NonNull String getJDBCPrefix() {
+    return "oracle";
+  }
+
+  @Override
+  public synchronized @NonNull String getUri() {
+    return String.format(
+        "jdbc:%s:thin:@%s:%d:%s",
+        getJDBCPrefix(), this.getHost(), this.getPort(getJDBCPort()), this.getDatabaseName());
+  }
+
+  @Override
+  protected @NonNull String getFirstRow(@NonNull String tableName) {
+    return "SELECT * FROM " + tableName + " WHERE ROWNUM <= 1";
+  }
+
+  /** Builder for {@link CloudOracleResourceManager}. */
+  public static final class Builder extends CloudSqlResourceManager.Builder {
+
+    public Builder(String testId) {
+      super(testId);
+
+      this.setDatabaseName("xe");
+      this.setPort(DEFAULT_ORACLE_PORT);
+
+      // Currently only supports static Oracle instance on GCE
+      this.maybeUseStaticInstance();
+    }
+
+    public Builder maybeUseStaticInstance() {
+      if (System.getProperty("cloudOracleHost") != null) {
+        this.setHost(System.getProperty("cloudOracleHost"));
+      } else {
+        LOG.warn("Missing -DcloudOracleHost.");
+      }
+      this.useStaticContainer();
+
+      return this;
+    }
+
+    @Override
+    public @NonNull CloudOracleResourceManager build() {
+      return new CloudOracleResourceManager(this);
+    }
+  }
+}

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlContainer.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlContainer.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.it.gcp.cloudsql;
+
+import org.apache.beam.it.jdbc.AbstractJDBCResourceManager;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Dummy container class so that {@link CloudSqlResourceManager} can leverage {@link
+ * AbstractJDBCResourceManager} framework which leverages Testcontainers, and therefore requires a
+ * container.
+ */
+class CloudSqlContainer<T extends CloudSqlContainer<T>> extends JdbcDatabaseContainer<T> {
+
+  private String username;
+  private String password;
+  private String databaseName;
+
+  CloudSqlContainer(DockerImageName dockerImageName) {
+    super(DockerImageName.parse(""));
+  }
+
+  static CloudSqlContainer<?> of() {
+    return new CloudSqlContainer<>(DockerImageName.parse(""));
+  }
+
+  @Override
+  public String getDriverClassName() {
+    return null;
+  }
+
+  @Override
+  public String getJdbcUrl() {
+    return null;
+  }
+
+  @Override
+  public String getUsername() {
+    return username;
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+  @Override
+  protected String getTestQueryString() {
+    return null;
+  }
+
+  @Override
+  public String getDatabaseName() {
+    return databaseName;
+  }
+
+  public T withUsername(String username) {
+    this.username = username;
+    return this.self();
+  }
+
+  public T withPassword(String password) {
+    this.password = password;
+    return this.self();
+  }
+
+  public T withDatabaseName(String dbName) {
+    this.databaseName = dbName;
+    return this.self();
+  }
+}

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManager.java
@@ -1,0 +1,185 @@
+package org.apache.beam.it.gcp.cloudsql;
+
+import static org.apache.beam.it.gcp.cloudsql.CloudSqlResourceManagerUtils.generateDatabaseName;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.beam.it.jdbc.AbstractJDBCResourceManager;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Abstract class that extends {@link AbstractJDBCResourceManager} for CloudSQL resource management.
+ *
+ * <p>The class supports one database, and multiple tables per database object. A database is
+ * created when the resource manager first spins up, if one is not specified.
+ *
+ * <p>The database name is formed using testId. The database name will be "{testId}-{ISO8601 time,
+ * microsecond precision}", with additional formatting.
+ *
+ * <p>The class is thread-safe.
+ */
+public abstract class CloudSqlResourceManager
+    extends AbstractJDBCResourceManager<@NonNull CloudSqlContainer<?>> {
+  private static final Logger LOG = LoggerFactory.getLogger(CloudSqlResourceManager.class);
+
+  protected final List<String> createdTables;
+  private boolean createdDatabase;
+  private boolean usingCustomDb;
+
+  protected CloudSqlResourceManager(@NonNull Builder builder) {
+    super(CloudSqlContainer.of(), builder);
+
+    this.createdTables = new ArrayList<>();
+
+    this.createdDatabase = false;
+    this.usingCustomDb = builder.usingCustomDb;
+    if (!usingCustomDb) {
+      createDatabase(builder.dbName);
+    }
+    this.createdDatabase = true;
+  }
+
+  @Override
+  public synchronized @NonNull String getUri() {
+    return String.format(
+        "jdbc:%s://%s:%d/%s",
+        getJDBCPrefix(),
+        this.getHost(),
+        this.getPort(),
+        createdDatabase ? this.getDatabaseName() : "");
+  }
+
+  @Override
+  protected int getJDBCPort() {
+    return this.port;
+  }
+
+  @Override
+  public int getPort() {
+    return this.getPort(getJDBCPort());
+  }
+
+  @Override
+  public boolean createTable(@NotNull String tableName, @NotNull JDBCSchema schema) {
+    boolean status = super.createTable(tableName, schema);
+    this.createdTables.add(tableName);
+    return status;
+  }
+
+  /**
+   * Drops the table with the given name from the current database.
+   *
+   * @param tableName The name of the table.
+   * @return true, if successful.
+   */
+  public void dropTable(@NotNull String tableName) {
+    LOG.info("Dropping table using tableName '{}'.", tableName);
+
+    runSQLUpdate(String.format("DROP TABLE %s", tableName));
+
+    createdTables.remove(tableName);
+    LOG.info("Successfully dropped table {}.{}", databaseName, tableName);
+  }
+
+  /**
+   * Creates a database in the CloudSQL instance.
+   *
+   * @param databaseName name of database to create.
+   */
+  public void createDatabase(@NotNull String databaseName) {
+    LOG.info("Creating database using databaseName '{}'.", databaseName);
+
+    runSQLUpdate(String.format("CREATE DATABASE %s", databaseName));
+
+    LOG.info("Successfully created database {}", databaseName);
+  }
+
+  /**
+   * Drops the given database in the CloudSQL instance.
+   *
+   * @param databaseName name of database to drop.
+   */
+  public void dropDatabase(@NotNull String databaseName) {
+    LOG.info("Dropping database using databaseName '{}'.", databaseName);
+
+    this.createdDatabase = false;
+    runSQLUpdate(String.format("DROP DATABASE %s", databaseName));
+
+    LOG.info("Successfully dropped database {}", databaseName);
+  }
+
+  @Override
+  public void cleanupAll() {
+    LOG.info("Attempting to cleanup CloudSQL manager.");
+    try {
+      if (this.usingCustomDb) {
+        List.copyOf(createdTables).forEach(this::dropTable);
+      } else {
+        dropDatabase(this.databaseName);
+      }
+      LOG.info("CloudSQL manager successfully cleaned up.");
+    } catch (Exception e) {
+      throw new CloudSqlResourceManagerException("Failed to close CloudSQL resources", e);
+    }
+  }
+
+  /**
+   * Builder for {@link CloudSqlResourceManager}.
+   *
+   * <p>A class that extends {@link AbstractJDBCResourceManager.Builder} for specific CloudSQL
+   * implementations.
+   */
+  public abstract static class Builder
+      extends AbstractJDBCResourceManager.Builder<@NonNull CloudSqlContainer<?>> {
+
+    private String dbName;
+    private boolean usingCustomDb;
+
+    public Builder(String testId) {
+      super(testId, "", "");
+
+      this.setDatabaseName(generateDatabaseName(testId));
+      this.usingCustomDb = false;
+
+      // Currently only supports static CloudSQL instance with static Cloud Auth Proxy
+      this.maybeUseStaticCloudProxy();
+    }
+
+    public Builder maybeUseStaticCloudProxy() {
+      if (System.getProperty("cloudProxyHost") != null) {
+        this.setHost(System.getProperty("cloudProxyHost"));
+      } else {
+        LOG.warn("Missing -DcloudProxyHost.");
+      }
+      if (System.getProperty("cloudProxyPort") != null) {
+        this.setPort(Integer.parseInt(System.getProperty("cloudProxyPort")));
+      } else {
+        LOG.warn("Missing -DcloudProxyPort.");
+      }
+      if (System.getProperty("cloudProxyPassword") != null) {
+        this.setPassword(System.getProperty("cloudProxyPassword"));
+      } else {
+        LOG.warn("Missing -DcloudProxyPassword.");
+      }
+      if (System.getProperty("cloudProxyUsername") != null) {
+        this.setUsername(System.getProperty("cloudProxyUsername"));
+      } else {
+        LOG.info("-DcloudProxyUsername not specified, using default: " + DEFAULT_JDBC_USERNAME);
+      }
+      this.useStaticContainer();
+
+      return this;
+    }
+
+    @Override
+    public @NonNull Builder setDatabaseName(@NonNull String databaseName) {
+      super.setDatabaseName(databaseName);
+      this.dbName = databaseName;
+      this.usingCustomDb = true;
+      return this;
+    }
+  }
+}

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManagerException.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManagerException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.it.gcp.cloudsql;
+
+/** Custom exception for {@link TestContainerResourceManager} implementations. */
+public class CloudSqlResourceManagerException extends RuntimeException {
+
+  public CloudSqlResourceManagerException(String errorMessage) {
+    super(errorMessage);
+  }
+
+  public CloudSqlResourceManagerException(String errorMessage, Exception cause) {
+    super(errorMessage, cause);
+  }
+}

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManagerUtils.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManagerUtils.java
@@ -1,0 +1,61 @@
+package org.apache.beam.it.gcp.cloudsql;
+
+import static org.apache.beam.it.common.utils.ResourceManagerUtils.generateResourceId;
+
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.RandomStringUtils;
+
+/** Utilities for {@link CloudSqlResourceManager} implementations. */
+public final class CloudSqlResourceManagerUtils {
+  // Naming restrictions can be found at:
+  // mySQL -
+  // https://documentation.sas.com/doc/en/pgmsascdc/9.4_3.5/acreldb/n0rfg6x1shw0ppn1cwhco6yn09f7.htm
+  // postgreSQL -
+  // https://documentation.sas.com/doc/en/pgmsascdc/9.4_3.5/acreldb/p1iw263fz6wvnbn1d6nyw71a9sf2.htm
+  // oracle -
+  // https://documentation.sas.com/doc/en/pgmsascdc/9.4_3.5/acreldb/p0t80fm3l1okawn1x3mvo098svir.htm
+  //
+  // The tightest restrictions were used across all flavors of JDBC for simplicity.
+  private static final int MAX_DATABASE_NAME_LENGTH = 30;
+  private static final Pattern ILLEGAL_DATABASE_NAME_CHARS = Pattern.compile("[^a-zA-Z0-9_$#]");
+  private static final String REPLACE_DATABASE_NAME_CHAR = "_";
+  private static final String TIME_FORMAT = "yyyyMMdd_HHmmss";
+
+  private CloudSqlResourceManagerUtils() {}
+
+  /**
+   * Generates a JDBC database name from a given string.
+   *
+   * @param baseString The string to generate the name from.
+   * @return The database name string.
+   */
+  static String generateDatabaseName(String baseString) {
+    baseString = Character.isLetter(baseString.charAt(0)) ? baseString : "d_" + baseString;
+
+    // Take substring of baseString to account for random suffix
+    // TODO(polber) - remove with Beam 2.57.0
+    int randomSuffixLength = 6;
+    baseString =
+        baseString.substring(
+            0,
+            Math.min(
+                baseString.length(),
+                MAX_DATABASE_NAME_LENGTH
+                    - REPLACE_DATABASE_NAME_CHAR.length()
+                    - TIME_FORMAT.length()
+                    - REPLACE_DATABASE_NAME_CHAR.length()
+                    - randomSuffixLength));
+
+    // Add random suffix to avoid collision
+    // TODO(polber) - remove with Beam 2.57.0
+    return generateResourceId(
+            baseString,
+            ILLEGAL_DATABASE_NAME_CHARS,
+            REPLACE_DATABASE_NAME_CHAR,
+            MAX_DATABASE_NAME_LENGTH,
+            DateTimeFormatter.ofPattern(TIME_FORMAT))
+        + REPLACE_DATABASE_NAME_CHAR
+        + RandomStringUtils.randomAlphanumeric(6).toLowerCase();
+  }
+}

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/package-info.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Package for working with test artifacts. */
+package org.apache.beam.it.gcp.cloudsql;

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudMySQLResourceManagerTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudMySQLResourceManagerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.it.gcp.cloudsql;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/** Integration tests for {@link CloudMySQLResourceManager}. */
+@RunWith(JUnit4.class)
+public class CloudMySQLResourceManagerTest {
+
+  @Rule public final MockitoRule mockito = MockitoJUnit.rule();
+
+  private CloudMySQLResourceManager testManager;
+
+  private static final String TEST_ID = "test_id";
+
+  @Before
+  public void setUp() {
+    System.setProperty("cloudProxyHost", "127.0.0.1");
+    System.setProperty("cloudProxyPort", "1234");
+    System.setProperty("cloudProxyUsername", "username");
+    System.setProperty("cloudProxyPassword", "password");
+    testManager =
+        (CloudMySQLResourceManager)
+            CloudMySQLResourceManager.builder(TEST_ID).setDatabaseName("mockDatabase").build();
+  }
+
+  @Test
+  public void testGetJDBCPrefixReturnsCorrectValue() {
+    assertThat(testManager.getJDBCPrefix()).isEqualTo("mysql");
+  }
+}

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudOracleResourceManagerTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudOracleResourceManagerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.it.gcp.cloudsql;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/** Integration tests for {@link CloudOracleResourceManager}. */
+@RunWith(JUnit4.class)
+public class CloudOracleResourceManagerTest {
+
+  @Rule public final MockitoRule mockito = MockitoJUnit.rule();
+
+  private CloudOracleResourceManager testManager;
+
+  private static final String TEST_ID = "test_id";
+
+  @Before
+  public void setUp() {
+    System.setProperty("cloudProxyHost", "127.0.0.1");
+    System.setProperty("cloudOracleHost", "127.0.0.2");
+    System.setProperty("cloudProxyUsername", "username");
+    System.setProperty("cloudProxyPassword", "password");
+    testManager = CloudOracleResourceManager.builder(TEST_ID).build();
+  }
+
+  @Test
+  public void testGetJDBCPrefixReturnsCorrectValue() {
+    assertThat(testManager.getJDBCPrefix()).isEqualTo("oracle");
+  }
+
+  @Test
+  public void testGetDatabaseReturnsCorrectValue() {
+    assertThat(testManager.getDatabaseName()).isEqualTo("xe");
+  }
+
+  @Test
+  public void testGeUriReturnsCorrectValue() {
+    assertThat(testManager.getUri()).isEqualTo("jdbc:oracle:thin:@127.0.0.2:1521:xe");
+  }
+}

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManagerIT.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManagerIT.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.it.gcp.cloudsql;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatRecords;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.beam.it.jdbc.JDBCResourceManager;
+import org.apache.beam.it.testcontainers.TestContainersIntegrationTest;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
+import org.apache.parquet.Strings;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Integration tests for JDBC Resource Managers. */
+@Category(TestContainersIntegrationTest.class)
+@RunWith(JUnit4.class)
+public class CloudSqlResourceManagerIT {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CloudSqlResourceManagerIT.class);
+
+  private static final String TEST_ID = "dummy-test";
+  private static final String TABLE_NAME = "dummy_table";
+
+  @Test
+  public void testDefaultCloudMySQLResourceManagerE2E() {
+    if (missingProperties("cloudProxyHost", "cloudProxyPort")) {
+      return;
+    }
+    CloudMySQLResourceManager mySQL = CloudMySQLResourceManager.builder(TEST_ID).build();
+
+    simpleTest(mySQL);
+  }
+
+  @Test
+  public void testDefaultCloudOracleResourceManagerE2E() {
+    if (missingProperties("cloudOracleHost")) {
+      return;
+    }
+    CloudOracleResourceManager oracle = CloudOracleResourceManager.builder(TEST_ID).build();
+
+    simpleTest(oracle);
+  }
+
+  private <T extends CloudSqlResourceManager> void simpleTest(T rm) {
+    try {
+      Map<String, String> columns = new LinkedHashMap<>();
+      columns.put("id", "INTEGER");
+      columns.put("first", "VARCHAR(32)");
+      columns.put("last", "VARCHAR(32)");
+      columns.put("age", "VARCHAR(32)");
+      JDBCResourceManager.JDBCSchema schema = new JDBCResourceManager.JDBCSchema(columns, "id");
+      rm.createTable(TABLE_NAME, schema);
+
+      List<Map<String, Object>> rows = new ArrayList<>();
+      rows.add(ImmutableMap.of("id", 0, "first", "John", "last", "Doe", "age", 23));
+      rows.add(ImmutableMap.of("id", 1, "first", "Jane", "last", "Doe", "age", 42));
+      rows.add(ImmutableMap.of("id", 2, "first", "A", "last", "B", "age", 1));
+      rm.write(TABLE_NAME, rows);
+
+      List<String> validateSchema = new ArrayList<>(columns.keySet());
+      List<Map<String, Object>> fetchRows = rm.readTable(TABLE_NAME);
+
+      // toUpperCase expected because some databases (Postgres, Oracle) transform column names
+      assertThat(toUpperCase(rm.getTableSchema(TABLE_NAME)))
+          .containsExactlyElementsIn(toUpperCase(validateSchema));
+      assertThat(fetchRows).hasSize(3);
+      assertThatRecords(fetchRows).hasRecordsUnorderedCaseInsensitiveColumns(rows);
+    } finally {
+      rm.cleanupAll();
+    }
+  }
+
+  private List<String> toUpperCase(List<String> list) {
+    return list.stream().map(String::toUpperCase).collect(Collectors.toList());
+  }
+
+  private boolean missingProperties(String... properties) {
+    for (String property : properties) {
+      if (Strings.isNullOrEmpty(System.getProperty(property))) {
+        LOG.info(String.format("-D%s was not specified, skipping...", property));
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManagerTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManagerTest.java
@@ -1,0 +1,196 @@
+package org.apache.beam.it.gcp.cloudsql;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import org.apache.beam.it.testcontainers.TestContainerResourceManagerException;
+import org.checkerframework.checker.initialization.qual.Initialized;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link CloudSqlResourceManager}. */
+@RunWith(JUnit4.class)
+public class CloudSqlResourceManagerTest {
+
+  private static final String TEST_ID = "test_id";
+  private static final String HOST = "127.0.0.1";
+  private static final String PORT = "1234";
+  private static final String USERNAME = "username";
+  private static final String PASSWORD = "password";
+  private static final String JDBC_PREFIX = "fake";
+  private static final String DATABASE = "mockDatabase";
+
+  /**
+   * Helper mock implementation of {@link CloudSqlResourceManager} for testing relevant implemented
+   * methods without exposing underlying {@link org.apache.beam.it.jdbc.AbstractJDBCResourceManager}
+   * or JDBC drivers.
+   */
+  private static class MockCloudSqlResourceManager extends CloudSqlResourceManager {
+
+    private final boolean initialized;
+    private boolean createdDatabase;
+    private String lastRunSqlCommand;
+
+    private MockCloudSqlResourceManager(Builder builder) {
+      super(builder);
+      this.initialized = true;
+    }
+
+    @Override
+    public void createDatabase(@NonNull String databaseName) {
+      // Avoid creating database during initialization of CloudSqlResourceManager
+      if (initialized) {
+        super.createDatabase(databaseName);
+      }
+      createdDatabase = true;
+    }
+
+    @Override
+    public synchronized void runSQLUpdate(@NonNull String sql) {
+      // Keep track of sql statement to ensure caller invoked proper SQL function.
+      this.lastRunSqlCommand = sql;
+    }
+
+    @Override
+    public @UnknownKeyFor @NonNull @Initialized String getJDBCPrefix() {
+      return JDBC_PREFIX;
+    }
+  }
+
+  @Before
+  public void setUp() {
+    // Set necessary system properties
+    System.setProperty("cloudProxyHost", HOST);
+    System.setProperty("cloudProxyPort", PORT);
+    System.setProperty("cloudProxyUsername", USERNAME);
+    System.setProperty("cloudProxyPassword", PASSWORD);
+  }
+
+  /**
+   * Helper method for creating a test resource manager either with or without creating a DB.
+   *
+   * @param useCustomDb create a DB.
+   * @return the initialized resource manager.
+   */
+  private MockCloudSqlResourceManager createTestManager(boolean useCustomDb) {
+    CloudSqlResourceManager.Builder testManagerBuilder =
+        new CloudSqlResourceManager.Builder(TEST_ID) {
+          @Override
+          public @NonNull CloudSqlResourceManager build() {
+            return new MockCloudSqlResourceManager(this);
+          }
+        };
+
+    if (useCustomDb) {
+      testManagerBuilder.setDatabaseName(DATABASE);
+    }
+
+    return (MockCloudSqlResourceManager) testManagerBuilder.build();
+  }
+
+  @Test
+  public void testUsingStaticDBDoesNotCreateDB() {
+    assertThat(createTestManager(false).createdDatabase).isTrue();
+  }
+
+  @Test
+  public void testNotUsingStaticDBDoesCreateDB() {
+    assertThat(createTestManager(true).createdDatabase).isFalse();
+  }
+
+  @Test
+  public void testGetUri() {
+    assertThat(createTestManager(false).getUri())
+        .matches(
+            String.format(
+                "jdbc:%s://%s:%s/%s_" + "\\d{8}_\\d{6}_[a-zA-Z0-9]{6}",
+                JDBC_PREFIX, HOST, PORT, TEST_ID));
+  }
+
+  @Test
+  public void testGetUriUsingStaticDB() {
+    assertThat(createTestManager(true).getUri())
+        .isEqualTo(String.format("jdbc:%s://%s:%s/%s", JDBC_PREFIX, HOST, PORT, DATABASE));
+  }
+
+  @Test
+  public void testDropTable() {
+    MockCloudSqlResourceManager testManager = createTestManager(false);
+
+    testManager.createdTables.add("test_table");
+    testManager.dropTable("test_table");
+
+    assertThat(testManager.lastRunSqlCommand).contains("DROP TABLE");
+    assertThat(testManager.createdTables).isEmpty();
+  }
+
+  @Test
+  public void testCreateDatabase() {
+    MockCloudSqlResourceManager testManager = createTestManager(false);
+
+    testManager.createDatabase("test_db");
+
+    assertThat(testManager.lastRunSqlCommand).contains("CREATE DATABASE");
+  }
+
+  @Test
+  public void testDropDatabase() {
+    MockCloudSqlResourceManager testManager = createTestManager(false);
+
+    testManager.dropDatabase("test_db");
+
+    assertThat(testManager.lastRunSqlCommand).contains("DROP DATABASE test_db");
+  }
+
+  @Test
+  public void testCleanupAllDropsDBWhenCreated() {
+    MockCloudSqlResourceManager testManager = createTestManager(false);
+
+    testManager.cleanupAll();
+    assertThat(testManager.lastRunSqlCommand)
+        .containsMatch(String.format("DROP DATABASE %s_\\d{8}_\\d{6}_[a-zA-Z0-9]{6}", TEST_ID));
+  }
+
+  @Test
+  public void testCleanupAllRemovesAllTablesWhenDBNotCreated() {
+    MockCloudSqlResourceManager testManager = createTestManager(true);
+
+    testManager.createdTables.add("test_table_1");
+    testManager.createdTables.add("test_table_2");
+    testManager.cleanupAll();
+
+    assertThat(testManager.lastRunSqlCommand).contains("DROP TABLE");
+    assertThat(testManager.createdTables).isEmpty();
+  }
+
+  /*
+   * Currently only supports static Cloud SQL instance which means jdbc port uses system property.
+   */
+  @Test
+  public void testGetJDBCPort() {
+    assertThat(String.valueOf(createTestManager(true).getJDBCPort())).isEqualTo(PORT);
+  }
+
+  /*
+   * Currently only supports static Cloud SQL instance which means port uses system property.
+   */
+  @Test
+  public void testGetPort() {
+    assertThat(String.valueOf(createTestManager(true).getPort())).isEqualTo(PORT);
+  }
+
+  /*
+   * Currently only supports static Cloud SQL instance which requires following properties set.
+   */
+  @Test
+  public void testInstantiationFailsWithoutSystemPropertiesSet() {
+    System.clearProperty("cloudProxyHost");
+    System.clearProperty("cloudProxyPort");
+
+    assertThrows(TestContainerResourceManagerException.class, () -> createTestManager(true));
+  }
+}

--- a/v2/datastream-to-spanner/pom.xml
+++ b/v2/datastream-to-spanner/pom.xml
@@ -75,7 +75,13 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.30</version>
+            <version>${mysql-connector-java.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <version>${ojdbc8.version}</version>
             <scope>test</scope>
         </dependency>
 <!--        TODO - Remove when https://github.com/apache/beam/pull/29732 is released. -->

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerIT.java
@@ -21,9 +21,15 @@ import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
 import com.google.cloud.datastream.v1.DestinationConfig;
 import com.google.cloud.datastream.v1.SourceConfig;
 import com.google.cloud.datastream.v1.Stream;
+import com.google.cloud.spanner.Dialect;
 import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
 import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import com.google.common.io.Resources;
+import com.google.pubsub.v1.SubscriptionName;
+import com.google.pubsub.v1.TopicName;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -32,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import org.apache.beam.it.common.PipelineLauncher;
 import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
@@ -42,24 +47,25 @@ import org.apache.beam.it.common.utils.ResourceManagerUtils;
 import org.apache.beam.it.conditions.ChainedConditionCheck;
 import org.apache.beam.it.conditions.ConditionCheck;
 import org.apache.beam.it.gcp.TemplateTestBase;
+import org.apache.beam.it.gcp.cloudsql.CloudMySQLResourceManager;
+import org.apache.beam.it.gcp.cloudsql.CloudOracleResourceManager;
+import org.apache.beam.it.gcp.cloudsql.CloudSqlResourceManager;
 import org.apache.beam.it.gcp.datastream.DatastreamResourceManager;
 import org.apache.beam.it.gcp.datastream.JDBCSource;
 import org.apache.beam.it.gcp.datastream.MySQLSource;
+import org.apache.beam.it.gcp.datastream.OracleSource;
+import org.apache.beam.it.gcp.pubsub.PubsubResourceManager;
 import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
 import org.apache.beam.it.gcp.spanner.conditions.SpannerRowsCheck;
 import org.apache.beam.it.gcp.spanner.matchers.SpannerAsserts;
-import org.apache.beam.it.jdbc.CustomMySQLResourceManager;
 import org.apache.beam.it.jdbc.JDBCResourceManager;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 
 /** Integration test for {@link DataStreamToSpanner} Flex template. */
 @Category({TemplateIntegrationTest.class, SkipDirectRunnerTest.class})
@@ -67,7 +73,10 @@ import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
 @RunWith(JUnit4.class)
 public class DataStreamToSpannerIT extends TemplateTestBase {
 
-  private static final Logger LOG = LoggerFactory.getLogger(DataStreamToSpannerIT.class);
+  enum JDBCType {
+    MYSQL,
+    ORACLE
+  }
 
   private static final Integer NUM_EVENTS = 10;
 
@@ -77,11 +86,18 @@ public class DataStreamToSpannerIT extends TemplateTestBase {
   private static final String MEMBER = "member";
   private static final String ENTRY_ADDED = "entry_added";
 
+  private String gcsPrefix;
+  private String dlqGcsPrefix;
+
+  private SubscriptionName subscription;
+  private SubscriptionName dlqSubscription;
+
   private static final List<String> COLUMNS = List.of(ROW_ID, NAME, AGE, MEMBER, ENTRY_ADDED);
 
-  private CustomMySQLResourceManager jdbcResourceManager;
+  private CloudSqlResourceManager cloudSqlResourceManager;
   private DatastreamResourceManager datastreamResourceManager;
   private SpannerResourceManager spannerResourceManager;
+  private PubsubResourceManager pubsubResourceManager;
 
   @Before
   public void setUp() throws IOException {
@@ -90,148 +106,266 @@ public class DataStreamToSpannerIT extends TemplateTestBase {
             .setCredentialsProvider(credentialsProvider)
             .setPrivateConnectivity("datastream-private-connect-us-central1")
             .build();
+
+    gcsPrefix = getGcsPath(testName + "/cdc/").replace("gs://" + artifactBucketName, "");
+    dlqGcsPrefix = getGcsPath(testName + "/dlq/").replace("gs://" + artifactBucketName, "");
   }
 
   @After
   public void cleanUp() {
     ResourceManagerUtils.cleanResources(
-        jdbcResourceManager, datastreamResourceManager, spannerResourceManager);
+        cloudSqlResourceManager,
+        datastreamResourceManager,
+        spannerResourceManager,
+        pubsubResourceManager);
   }
 
-  @Ignore("Flaky test")
   @Test
   public void testDataStreamMySqlToSpanner() throws IOException {
-    // Create MySQL Resource manager
-    jdbcResourceManager = CustomMySQLResourceManager.builder(testName).build();
-
-    // Arrange MySQL-compatible schema
-    HashMap<String, String> columns = new HashMap<>();
-    columns.put(ROW_ID, "NUMERIC NOT NULL");
-    columns.put(NAME, "VARCHAR(200)");
-    columns.put(AGE, "NUMERIC");
-    columns.put(MEMBER, "VARCHAR(200)");
-    columns.put(ENTRY_ADDED, "VARCHAR(200)");
-    JDBCResourceManager.JDBCSchema schema = new JDBCResourceManager.JDBCSchema(columns, ROW_ID);
-
-    // Create JDBC table
-    String tableName = "MySqlToSpanner";
-    jdbcResourceManager.createTable(tableName, schema);
-
-    MySQLSource mySQLSource =
-        MySQLSource.builder(
-                jdbcResourceManager.getHost(),
-                jdbcResourceManager.getUsername(),
-                jdbcResourceManager.getPassword(),
-                jdbcResourceManager.getPort())
-            .build();
-
-    spannerResourceManager =
-        SpannerResourceManager.builder(tableName, PROJECT, REGION)
-            .setCredentials(credentials)
-            .build();
-
-    // Create Spanner dataset
-    spannerResourceManager.executeDdlStatement(
-        "CREATE TABLE "
-            + tableName
-            + " ("
-            + ROW_ID
-            + " INT64 NOT NULL,"
-            + NAME
-            + " STRING(1024),"
-            + AGE
-            + " INT64,"
-            + MEMBER
-            + " STRING(1024),"
-            + ENTRY_ADDED
-            + " STRING(1024)"
-            + ") PRIMARY KEY ("
-            + ROW_ID
-            + ")");
-
     // Run a simple IT
-    simpleJdbcToSpannerTest(
-        testName,
-        tableName,
-        mySQLSource,
+    simpleMySqlToSpannerTest(
         DatastreamResourceManager.DestinationOutputFormat.AVRO_FILE_FORMAT,
-        b -> b.addParameter("inputFileFormat", "avro"));
+        Dialect.GOOGLE_STANDARD_SQL,
+        false,
+        Function.identity());
   }
 
-  @Ignore("Flaky test")
+  @Test
+  public void testDataStreamOracleToSpanner() throws IOException {
+    // Run a simple IT
+    simpleOracleToSpannerTest(
+        DatastreamResourceManager.DestinationOutputFormat.AVRO_FILE_FORMAT,
+        Dialect.GOOGLE_STANDARD_SQL,
+        false,
+        Function.identity());
+  }
+
+  @Test
+  public void testDataStreamMySqlToSpannerGCSNotifications() throws IOException {
+    createPubSubNotifications();
+
+    // Run a simple IT
+    simpleMySqlToSpannerTest(
+        DatastreamResourceManager.DestinationOutputFormat.AVRO_FILE_FORMAT,
+        Dialect.GOOGLE_STANDARD_SQL,
+        false,
+        config ->
+            config
+                .addParameter("gcsPubSubSubscription", subscription.toString())
+                .addParameter("dlqGcsPubSubSubscription", dlqSubscription.toString()));
+  }
+
+  @Test
+  public void testDataStreamOracleToSpannerGCSNotifications() throws IOException {
+    createPubSubNotifications();
+
+    // Run a simple IT
+    simpleOracleToSpannerTest(
+        DatastreamResourceManager.DestinationOutputFormat.AVRO_FILE_FORMAT,
+        Dialect.GOOGLE_STANDARD_SQL,
+        false,
+        config ->
+            config
+                .addParameter("gcsPubSubSubscription", subscription.toString())
+                .addParameter("dlqGcsPubSubSubscription", dlqSubscription.toString()));
+  }
+
+  @Test
+  public void testDataStreamMySqlToSpannerStaging() throws IOException {
+    // Run a simple IT
+    simpleMySqlToSpannerTest(
+        DatastreamResourceManager.DestinationOutputFormat.AVRO_FILE_FORMAT,
+        Dialect.GOOGLE_STANDARD_SQL,
+        true,
+        Function.identity());
+  }
+
+  @Test
+  public void testDataStreamOracleToSpannerStaging() throws IOException {
+    // Run a simple IT
+    simpleOracleToSpannerTest(
+        DatastreamResourceManager.DestinationOutputFormat.AVRO_FILE_FORMAT,
+        Dialect.GOOGLE_STANDARD_SQL,
+        true,
+        Function.identity());
+  }
+
+  @Test
+  public void testDataStreamMySqlToPostgresSpanner() throws IOException {
+    // Run a simple IT
+    simpleMySqlToSpannerTest(
+        DatastreamResourceManager.DestinationOutputFormat.AVRO_FILE_FORMAT,
+        Dialect.POSTGRESQL,
+        false,
+        Function.identity());
+  }
+
+  @Test
+  public void testDataStreamMySqlToPostgresSpannerStaging() throws IOException {
+    // Run a simple IT
+    simpleMySqlToSpannerTest(
+        DatastreamResourceManager.DestinationOutputFormat.AVRO_FILE_FORMAT,
+        Dialect.POSTGRESQL,
+        true,
+        Function.identity());
+  }
+
+  @Test
+  public void testDataStreamMySqlToSpannerStreamingEngine() throws IOException {
+    // Run a simple IT
+    simpleMySqlToSpannerTest(
+        DatastreamResourceManager.DestinationOutputFormat.AVRO_FILE_FORMAT,
+        Dialect.GOOGLE_STANDARD_SQL,
+        false,
+        config -> config.addEnvironment("enableStreamingEngine", true));
+  }
+
   @Test
   public void testDataStreamMySqlToSpannerJson() throws IOException {
-    // Create MySQL Resource manager
-    jdbcResourceManager = CustomMySQLResourceManager.builder(testName).build();
-
-    // Arrange MySQL-compatible schema
-    HashMap<String, String> columns = new HashMap<>();
-    columns.put(ROW_ID, "NUMERIC NOT NULL");
-    columns.put(NAME, "VARCHAR(200)");
-    columns.put(AGE, "NUMERIC");
-    columns.put(MEMBER, "VARCHAR(200)");
-    columns.put(ENTRY_ADDED, "VARCHAR(200)");
-    JDBCResourceManager.JDBCSchema schema = new JDBCResourceManager.JDBCSchema(columns, ROW_ID);
-
-    // Create JDBC table
-    String tableName = "MySqlToSpannerJson";
-    jdbcResourceManager.createTable(tableName, schema);
-
-    MySQLSource mySQLSource =
-        MySQLSource.builder(
-                jdbcResourceManager.getHost(),
-                jdbcResourceManager.getUsername(),
-                jdbcResourceManager.getPassword(),
-                jdbcResourceManager.getPort())
-            .build();
-
-    spannerResourceManager =
-        SpannerResourceManager.builder(testName, PROJECT, REGION)
-            .setCredentials(credentials)
-            .build();
-
-    // Create Spanner dataset
-    spannerResourceManager.executeDdlStatement(
-        "CREATE TABLE "
-            + tableName
-            + " ("
-            + ROW_ID
-            + " INT64 NOT NULL,"
-            + NAME
-            + " STRING(1024),"
-            + AGE
-            + " INT64,"
-            + MEMBER
-            + " STRING(1024),"
-            + ENTRY_ADDED
-            + " STRING(1024)"
-            + ") PRIMARY KEY ("
-            + ROW_ID
-            + ")");
-
     // Run a simple IT
-    simpleJdbcToSpannerTest(
-        testName,
-        tableName,
-        mySQLSource,
+    simpleMySqlToSpannerTest(
         DatastreamResourceManager.DestinationOutputFormat.JSON_FILE_FORMAT,
-        b -> b.addParameter("inputFileFormat", "json"));
+        Dialect.GOOGLE_STANDARD_SQL,
+        false,
+        Function.identity());
   }
 
-  private void simpleJdbcToSpannerTest(
-      String testName,
-      String tableName,
-      JDBCSource jdbcSource,
+  @Test
+  public void testDataStreamOracleToSpannerJson() throws IOException {
+    // Run a simple IT
+    simpleOracleToSpannerTest(
+        DatastreamResourceManager.DestinationOutputFormat.JSON_FILE_FORMAT,
+        Dialect.GOOGLE_STANDARD_SQL,
+        false,
+        Function.identity());
+  }
+
+  @Test
+  public void testDataStreamMySqlToSpannerJsonStaging() throws IOException {
+    // Run a simple IT
+    simpleMySqlToSpannerTest(
+        DatastreamResourceManager.DestinationOutputFormat.JSON_FILE_FORMAT,
+        Dialect.GOOGLE_STANDARD_SQL,
+        true,
+        Function.identity());
+  }
+
+  @Test
+  public void testDataStreamOracleToSpannerJsonStaging() throws IOException {
+    // Run a simple IT
+    simpleOracleToSpannerTest(
+        DatastreamResourceManager.DestinationOutputFormat.JSON_FILE_FORMAT,
+        Dialect.GOOGLE_STANDARD_SQL,
+        true,
+        Function.identity());
+  }
+
+  private void simpleMySqlToSpannerTest(
       DatastreamResourceManager.DestinationOutputFormat fileFormat,
+      Dialect spannerDialect,
+      boolean isStaging,
       Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder)
       throws IOException {
 
+    simpleJdbcToSpannerTest(
+        JDBCType.MYSQL,
+        fileFormat,
+        spannerDialect,
+        isStaging,
+        config ->
+            paramsAdder.apply(
+                config.addParameter("sessionFilePath", getGcsPath("input/mysql-session.json"))));
+  }
+
+  private void simpleOracleToSpannerTest(
+      DatastreamResourceManager.DestinationOutputFormat fileFormat,
+      Dialect spannerDialect,
+      boolean isStaging,
+      Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder)
+      throws IOException {
+
+    simpleJdbcToSpannerTest(
+        JDBCType.ORACLE,
+        fileFormat,
+        spannerDialect,
+        isStaging,
+        config -> paramsAdder.apply(config));
+  }
+
+  private void simpleJdbcToSpannerTest(
+      JDBCType jdbcType,
+      DatastreamResourceManager.DestinationOutputFormat fileFormat,
+      Dialect spannerDialect,
+      boolean isStaging,
+      Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder)
+      throws IOException {
+
+    // Create JDBC Resource manager
+    cloudSqlResourceManager =
+        jdbcType.equals(JDBCType.MYSQL)
+            ? CloudMySQLResourceManager.builder(testName).build()
+            : CloudOracleResourceManager.builder(testName).build();
+
+    // Create Spanner Resource Manager
+    SpannerResourceManager.Builder spannerResourceManagerBuilder =
+        SpannerResourceManager.builder(testName, PROJECT, REGION, spannerDialect)
+            .maybeUseStaticInstance()
+            .setCredentials(credentials);
+    if (isStaging) {
+      spannerResourceManagerBuilder.maybeUseCustomHost();
+    }
+    spannerResourceManager = spannerResourceManagerBuilder.build();
+
+    // Generate table names
+    List<String> tableNames =
+        List.of(
+            "DatastreamToSpanner_1_" + RandomStringUtils.randomAlphanumeric(5),
+            "DatastreamToSpanner_2_" + RandomStringUtils.randomAlphanumeric(5));
+
+    // Generate session file
+    if (jdbcType.equals(JDBCType.MYSQL)) {
+      gcsClient.createArtifact(
+          "input/mysql-session.json",
+          generateSessionFile(
+              cloudSqlResourceManager.getDatabaseName(),
+              spannerResourceManager.getDatabaseId(),
+              tableNames));
+    }
+
+    // Create JDBC tables
+    tableNames.forEach(
+        tableName ->
+            cloudSqlResourceManager.createTable(
+                tableName, createJdbcSchema(jdbcType.equals(JDBCType.ORACLE))));
+
+    JDBCSource jdbcSource;
+    if (jdbcType.equals(JDBCType.MYSQL)) {
+      jdbcSource =
+          MySQLSource.builder(
+                  cloudSqlResourceManager.getHost(),
+                  cloudSqlResourceManager.getUsername(),
+                  cloudSqlResourceManager.getPassword(),
+                  cloudSqlResourceManager.getPort())
+              .build();
+    } else {
+      jdbcSource =
+          OracleSource.builder(
+                  cloudSqlResourceManager.getHost(),
+                  cloudSqlResourceManager.getUsername(),
+                  cloudSqlResourceManager.getPassword(),
+                  cloudSqlResourceManager.getPort(),
+                  cloudSqlResourceManager.getDatabaseName())
+              .build();
+    }
+
+    // Create Spanner tables
+    createSpannerTables(tableNames, spannerDialect);
+
     // Create Datastream JDBC Source Connection profile and config
     SourceConfig sourceConfig =
-        datastreamResourceManager.buildJDBCSourceConfig("mysql-profile", jdbcSource);
+        datastreamResourceManager.buildJDBCSourceConfig("jdbc-profile", jdbcSource);
 
     // Create Datastream GCS Destination Connection profile and config
-    String gcsPrefix = getGcsPath(testName).replace("gs://" + artifactBucketName, "") + "/cdc/";
     DestinationConfig destinationConfig =
         datastreamResourceManager.buildGCSDestinationConfig(
             "gcs-profile", artifactBucketName, gcsPrefix, fileFormat);
@@ -251,51 +385,157 @@ public class DataStreamToSpannerIT extends TemplateTestBase {
                 .addParameter("instanceId", spannerResourceManager.getInstanceId())
                 .addParameter("databaseId", spannerResourceManager.getDatabaseId())
                 .addParameter("projectId", PROJECT)
-                .addParameter("deadLetterQueueDirectory", getGcsPath(testName) + "/dlq/"));
+                .addParameter("deadLetterQueueDirectory", getGcsPath(testName) + "/dlq/")
+                .addParameter(
+                    "inputFileFormat",
+                    fileFormat.equals(
+                            DatastreamResourceManager.DestinationOutputFormat.AVRO_FILE_FORMAT)
+                        ? "avro"
+                        : "json"));
 
     // Act
     PipelineLauncher.LaunchInfo info = launchTemplate(options);
     assertThatPipeline(info).isRunning();
-
-    // Increase timeout to reduce flakiness caused by multi-stage ConditionCheck
-    PipelineOperator.Config config =
-        PipelineOperator.Config.builder()
-            .setJobId(info.jobId())
-            .setProject(PROJECT)
-            .setRegion(REGION)
-            .setTimeoutAfter(Duration.ofMinutes(20))
-            .build();
-
-    AtomicReference<List<Map<String, Object>>> cdcEvents = new AtomicReference<>(new ArrayList<>());
 
     // Construct a ChainedConditionCheck with 4 stages.
     // 1. Send initial wave of events to JDBC
     // 2. Wait on Spanner to merge events from staging to destination
     // 3. Send wave of mutations to JDBC
     // 4. Wait on Spanner to merge second wave of events
+    Map<String, List<Map<String, Object>>> cdcEvents = new HashMap<>();
     ChainedConditionCheck conditionCheck =
         ChainedConditionCheck.builder(
                 List.of(
-                    writeJdbcData(tableName, cdcEvents),
-                    SpannerRowsCheck.builder(spannerResourceManager, tableName)
+                    writeJdbcData(tableNames, cdcEvents, jdbcType.equals(JDBCType.ORACLE)),
+                    SpannerRowsCheck.builder(spannerResourceManager, tableNames.get(0))
                         .setMinRows(NUM_EVENTS)
                         .build(),
-                    changeJdbcData(tableName, cdcEvents),
-                    SpannerRowsCheck.builder(spannerResourceManager, tableName)
-                        .setMinRows(1)
-                        .setMaxRows(NUM_EVENTS / 2)
-                        .build()))
+                    SpannerRowsCheck.builder(spannerResourceManager, tableNames.get(1))
+                        .setMinRows(NUM_EVENTS)
+                        .build(),
+                    changeJdbcData(tableNames, cdcEvents, jdbcType.equals(JDBCType.ORACLE)),
+                    checkDestinationRows(tableNames, cdcEvents)))
             .build();
 
     // Job needs to be cancelled as draining will time out
     PipelineOperator.Result result =
-        pipelineOperator().waitForConditionAndCancel(config, conditionCheck);
+        pipelineOperator()
+            .waitForConditionAndCancel(createConfig(info, Duration.ofMinutes(20)), conditionCheck);
 
     // Assert
+    checkSpannerTables(tableNames, cdcEvents);
     assertThatResult(result).meetsConditions();
+  }
 
-    SpannerAsserts.assertThatStructs(spannerResourceManager.readTableRecords(tableName, COLUMNS))
-        .hasRecordsUnorderedCaseInsensitiveColumns(cdcEvents.get());
+  private String generateSessionFile(String srcDb, String spannerDb, List<String> tableNames)
+      throws IOException {
+    String sessionFile =
+        Files.readString(
+            Paths.get(Resources.getResource("DataStreamToSpannerIT/mysql-session.json").getPath()));
+    return sessionFile
+        .replaceAll("SRC_DATABASE", srcDb)
+        .replaceAll("SP_DATABASE", spannerDb)
+        .replaceAll("TABLE1", tableNames.get(0))
+        .replaceAll("TABLE2", tableNames.get(1));
+  }
+
+  private JDBCResourceManager.JDBCSchema createJdbcSchema(boolean isOracle) {
+    // Arrange MySQL-compatible schema
+    HashMap<String, String> columns = new HashMap<>();
+    columns.put(ROW_ID, (isOracle ? "NUMBER" : "NUMERIC") + " NOT NULL");
+    columns.put(NAME, "VARCHAR(200)");
+    columns.put(AGE, isOracle ? "NUMBER" : "NUMERIC");
+    columns.put(MEMBER, "VARCHAR(200)");
+    columns.put(ENTRY_ADDED, "VARCHAR(200)");
+    return new JDBCResourceManager.JDBCSchema(columns, ROW_ID);
+  }
+
+  private void createPubSubNotifications() throws IOException {
+    // Instantiate pubsub resource manager for notifications
+    pubsubResourceManager =
+        PubsubResourceManager.builder(testName, PROJECT, credentialsProvider).build();
+
+    // Create pubsub notifications
+    TopicName topic = pubsubResourceManager.createTopic("it");
+    TopicName dlqTopic = pubsubResourceManager.createTopic("dlq");
+    subscription = pubsubResourceManager.createSubscription(topic, "it-sub");
+    dlqSubscription = pubsubResourceManager.createSubscription(dlqTopic, "dlq-sub");
+    gcsClient.createNotification(topic.toString(), gcsPrefix.substring(1));
+    gcsClient.createNotification(dlqTopic.toString(), dlqGcsPrefix.substring(1));
+  }
+
+  private void createSpannerTables(List<String> tableNames, Dialect spannerDialect) {
+    boolean usingPg = Dialect.POSTGRESQL.equals(spannerDialect);
+    // Create Spanner dataset
+    tableNames.forEach(
+        tableName ->
+            spannerResourceManager.executeDdlStatement(
+                "CREATE TABLE "
+                    + tableName
+                    + " ("
+                    + ROW_ID
+                    + (usingPg ? " bigint " : " INT64 ")
+                    + "NOT NULL, "
+                    + NAME
+                    + (usingPg ? " character varying(50), " : " STRING(1024), ")
+                    + AGE
+                    + (usingPg ? " bigint, " : " INT64, ")
+                    + MEMBER
+                    + (usingPg ? " character varying(50), " : " STRING(1024), ")
+                    + ENTRY_ADDED
+                    + (usingPg ? " character varying(50)" : " STRING(1024)")
+                    + (usingPg ? ", " : ") ")
+                    + "PRIMARY KEY ("
+                    + ROW_ID
+                    + ")"
+                    + (usingPg ? ")" : "")));
+  }
+
+  /**
+   * Helper function for constructing a ConditionCheck whose check() method checks the rows in the
+   * destination Spanner database for specific rows.
+   *
+   * @return A ConditionCheck containing the check operation.
+   */
+  private ConditionCheck checkDestinationRows(
+      List<String> tableNames, Map<String, List<Map<String, Object>>> cdcEvents) {
+    return new ConditionCheck() {
+      @Override
+      protected String getDescription() {
+        return "Check Spanner rows.";
+      }
+
+      @Override
+      protected CheckResult check() {
+        // First, check that correct number of rows were deleted.
+        for (String tableName : tableNames) {
+          long totalRows = spannerResourceManager.getRowCount(tableName);
+          long maxRows = cdcEvents.get(tableName).size();
+          if (totalRows > maxRows) {
+            return new CheckResult(
+                false, String.format("Expected up to %d rows but found %d", maxRows, totalRows));
+          }
+        }
+
+        // Next, make sure in-place mutations were applied.
+        try {
+          checkSpannerTables(tableNames, cdcEvents);
+          return new CheckResult(true, "Spanner tables contain expected rows.");
+        } catch (AssertionError error) {
+          return new CheckResult(false, "Spanner tables do not contain expected rows.");
+        }
+      }
+    };
+  }
+
+  /** Helper function for checking the rows of the destination Spanner tables. */
+  private void checkSpannerTables(
+      List<String> tableNames, Map<String, List<Map<String, Object>>> cdcEvents) {
+    tableNames.forEach(
+        tableName ->
+            SpannerAsserts.assertThatStructs(
+                    spannerResourceManager.readTableRecords(tableName, COLUMNS))
+                .hasRecordsUnorderedCaseInsensitiveColumns(cdcEvents.get(tableName)));
   }
 
   /**
@@ -305,7 +545,7 @@ public class DataStreamToSpannerIT extends TemplateTestBase {
    * @return A ConditionCheck containing the JDBC write operation.
    */
   private ConditionCheck writeJdbcData(
-      String tableName, AtomicReference<List<Map<String, Object>>> cdcEvents) {
+      List<String> tableNames, Map<String, List<Map<String, Object>>> cdcEvents, boolean isOracle) {
     return new ConditionCheck() {
       @Override
       protected String getDescription() {
@@ -314,21 +554,31 @@ public class DataStreamToSpannerIT extends TemplateTestBase {
 
       @Override
       protected CheckResult check() {
-        List<Map<String, Object>> rows = new ArrayList<>();
-        for (int i = 0; i < NUM_EVENTS; i++) {
-          Map<String, Object> values = new HashMap<>();
-          values.put(COLUMNS.get(0), i);
-          values.put(COLUMNS.get(1), RandomStringUtils.randomAlphabetic(10));
-          values.put(COLUMNS.get(2), new Random().nextInt(100));
-          values.put(COLUMNS.get(3), new Random().nextInt() % 2 == 0 ? "Y" : "N");
-          values.put(COLUMNS.get(4), Instant.now().toString());
-          rows.add(values);
-        }
-        cdcEvents.set(rows);
+        boolean success = true;
+        List<String> messages = new ArrayList<>();
+        for (String tableName : tableNames) {
 
-        return new CheckResult(
-            jdbcResourceManager.write(tableName, rows),
-            String.format("Sent %d rows to %s.", rows.size(), tableName));
+          List<Map<String, Object>> rows = new ArrayList<>();
+          for (int i = 0; i < NUM_EVENTS; i++) {
+            Map<String, Object> values = new HashMap<>();
+            values.put(COLUMNS.get(0), i);
+            values.put(COLUMNS.get(1), RandomStringUtils.randomAlphabetic(10));
+            values.put(COLUMNS.get(2), new Random().nextInt(100));
+            values.put(COLUMNS.get(3), new Random().nextInt() % 2 == 0 ? "Y" : "N");
+            values.put(COLUMNS.get(4), Instant.now().toString());
+            rows.add(values);
+          }
+          cdcEvents.put(tableName, rows);
+          success &= cloudSqlResourceManager.write(tableName, rows);
+          messages.add(String.format("%d rows to %s", rows.size(), tableName));
+        }
+
+        // Force log file archive - needed so Datastream can see changes which are read from
+        // archived log files.
+        if (isOracle) {
+          cloudSqlResourceManager.runSQLUpdate("ALTER SYSTEM SWITCH LOGFILE");
+        }
+        return new CheckResult(success, "Sent " + String.join(", ", messages) + ".");
       }
     };
   }
@@ -341,56 +591,69 @@ public class DataStreamToSpannerIT extends TemplateTestBase {
    * @return A ConditionCheck containing the JDBC mutate operation.
    */
   private ConditionCheck changeJdbcData(
-      String tableName, AtomicReference<List<Map<String, Object>>> cdcEvents) {
+      List<String> tableNames, Map<String, List<Map<String, Object>>> cdcEvents, boolean isOracle) {
     return new ConditionCheck() {
       @Override
       protected String getDescription() {
-        return "Send initial JDBC events.";
+        return "Send JDBC changes.";
       }
 
       @Override
       protected CheckResult check() {
-        List<Map<String, Object>> newCdcEvents = new ArrayList<>();
-        for (int i = 0; i < NUM_EVENTS; i++) {
-          if (i % 2 == 0) {
-            Map<String, Object> values = cdcEvents.get().get(i);
-            values.put(COLUMNS.get(1), values.get(COLUMNS.get(1)).toString().toUpperCase());
-            values.put(COLUMNS.get(2), new Random().nextInt(100));
-            values.put(
-                COLUMNS.get(3),
-                (Objects.equals(values.get(COLUMNS.get(3)).toString(), "Y") ? "N" : "Y"));
+        List<String> messages = new ArrayList<>();
+        for (String tableName : tableNames) {
 
-            String updateSql =
-                "UPDATE "
-                    + tableName
-                    + " SET "
-                    + COLUMNS.get(1)
-                    + " = '"
-                    + values.get(COLUMNS.get(1))
-                    + "',"
-                    + COLUMNS.get(2)
-                    + " = "
-                    + values.get(COLUMNS.get(2))
-                    + ","
-                    + COLUMNS.get(3)
-                    + " = '"
-                    + values.get(COLUMNS.get(3))
-                    + "'"
-                    + " WHERE "
-                    + COLUMNS.get(0)
-                    + " = "
-                    + i;
-            jdbcResourceManager.runSQLUpdate(updateSql);
-            newCdcEvents.add(values);
-          } else {
-            jdbcResourceManager.runSQLUpdate(
-                "DELETE FROM " + tableName + " WHERE " + COLUMNS.get(0) + "=" + i);
+          List<Map<String, Object>> newCdcEvents = new ArrayList<>();
+          for (int i = 0; i < NUM_EVENTS; i++) {
+            if (i % 2 == 0) {
+              Map<String, Object> values = cdcEvents.get(tableName).get(i);
+              values.put(COLUMNS.get(1), values.get(COLUMNS.get(1)).toString().toUpperCase());
+              values.put(COLUMNS.get(2), new Random().nextInt(100));
+              values.put(
+                  COLUMNS.get(3),
+                  (Objects.equals(values.get(COLUMNS.get(3)).toString(), "Y") ? "N" : "Y"));
+
+              String updateSql =
+                  "UPDATE "
+                      + tableName
+                      + " SET "
+                      + COLUMNS.get(1)
+                      + " = '"
+                      + values.get(COLUMNS.get(1))
+                      + "',"
+                      + COLUMNS.get(2)
+                      + " = "
+                      + values.get(COLUMNS.get(2))
+                      + ","
+                      + COLUMNS.get(3)
+                      + " = '"
+                      + values.get(COLUMNS.get(3))
+                      + "'"
+                      + " WHERE "
+                      + COLUMNS.get(0)
+                      + " = "
+                      + i;
+              cloudSqlResourceManager.runSQLUpdate(updateSql);
+              newCdcEvents.add(values);
+            } else {
+              cloudSqlResourceManager.runSQLUpdate(
+                  "DELETE FROM " + tableName + " WHERE " + COLUMNS.get(0) + "=" + i);
+            }
           }
+          cdcEvents.put(tableName, newCdcEvents);
+          messages.add(String.format("%d changes to %s", newCdcEvents.size(), tableName));
         }
-        cdcEvents.set(newCdcEvents);
 
-        return new CheckResult(
-            true, String.format("Sent %d rows to %s.", newCdcEvents.size(), tableName));
+        if (isOracle) {
+          cloudSqlResourceManager.runSQLUpdate("ALTER SYSTEM SWITCH LOGFILE");
+        }
+
+        // Force log file archive - needed so Datastream can see changes which are read from
+        // archived log files.
+        if (isOracle) {
+          cloudSqlResourceManager.runSQLUpdate("ALTER SYSTEM SWITCH LOGFILE");
+        }
+        return new CheckResult(true, "Sent " + String.join(", ", messages) + ".");
       }
     };
   }

--- a/v2/datastream-to-spanner/src/test/resources/DataStreamToSpannerIT/mysql-session.json
+++ b/v2/datastream-to-spanner/src/test/resources/DataStreamToSpannerIT/mysql-session.json
@@ -1,0 +1,439 @@
+{
+  "SessionName": "NewSession",
+  "EditorName": "",
+  "DatabaseType": "mysql",
+  "DatabaseName": "SP_DATABASE",
+  "Dialect": "google_standard_sql",
+  "Notes": null,
+  "Tags": null,
+  "SpSchema": {
+    "t1": {
+      "Name": "TABLE1",
+      "ColIds": [
+        "c3",
+        "c4",
+        "c5",
+        "c6",
+        "c7"
+      ],
+      "ShardIdColumn": "",
+      "ColDefs": {
+        "c3": {
+          "Name": "row_id",
+          "T": {
+            "Name": "NUMERIC",
+            "Len": 0,
+            "IsArray": false
+          },
+          "NotNull": true,
+          "Comment": "From: row_id decimal(10)",
+          "Id": "c3"
+        },
+        "c4": {
+          "Name": "entry_added",
+          "T": {
+            "Name": "STRING",
+            "Len": 200,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: entry_added varchar(200)",
+          "Id": "c4"
+        },
+        "c5": {
+          "Name": "name",
+          "T": {
+            "Name": "STRING",
+            "Len": 200,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: name varchar(200)",
+          "Id": "c5"
+        },
+        "c6": {
+          "Name": "member",
+          "T": {
+            "Name": "STRING",
+            "Len": 200,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: member varchar(200)",
+          "Id": "c6"
+        },
+        "c7": {
+          "Name": "age",
+          "T": {
+            "Name": "NUMERIC",
+            "Len": 0,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: age decimal(10)",
+          "Id": "c7"
+        }
+      },
+      "PrimaryKeys": [
+        {
+          "ColId": "c3",
+          "Desc": false,
+          "Order": 1
+        }
+      ],
+      "ForeignKeys": null,
+      "Indexes": null,
+      "ParentId": "",
+      "Comment": "Spanner schema for source table TABLE1",
+      "Id": "t1"
+    },
+    "t2": {
+      "Name": "TABLE2",
+      "ColIds": [
+        "c8",
+        "c9",
+        "c10",
+        "c11",
+        "c12"
+      ],
+      "ShardIdColumn": "",
+      "ColDefs": {
+        "c10": {
+          "Name": "name",
+          "T": {
+            "Name": "STRING",
+            "Len": 200,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: name varchar(200)",
+          "Id": "c10"
+        },
+        "c11": {
+          "Name": "member",
+          "T": {
+            "Name": "STRING",
+            "Len": 200,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: member varchar(200)",
+          "Id": "c11"
+        },
+        "c12": {
+          "Name": "age",
+          "T": {
+            "Name": "NUMERIC",
+            "Len": 0,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: age decimal(10)",
+          "Id": "c12"
+        },
+        "c8": {
+          "Name": "row_id",
+          "T": {
+            "Name": "NUMERIC",
+            "Len": 0,
+            "IsArray": false
+          },
+          "NotNull": true,
+          "Comment": "From: row_id decimal(10)",
+          "Id": "c8"
+        },
+        "c9": {
+          "Name": "entry_added",
+          "T": {
+            "Name": "STRING",
+            "Len": 200,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: entry_added varchar(200)",
+          "Id": "c9"
+        }
+      },
+      "PrimaryKeys": [
+        {
+          "ColId": "c8",
+          "Desc": false,
+          "Order": 1
+        }
+      ],
+      "ForeignKeys": null,
+      "Indexes": null,
+      "ParentId": "",
+      "Comment": "Spanner schema for source table TABLE2",
+      "Id": "t2"
+    }
+  },
+  "SyntheticPKeys": {},
+  "SrcSchema": {
+    "t1": {
+      "Name": "TABLE1",
+      "Schema": "SRC_DATABASE",
+      "ColIds": [
+        "c3",
+        "c4",
+        "c5",
+        "c6",
+        "c7"
+      ],
+      "ColDefs": {
+        "c3": {
+          "Name": "row_id",
+          "Type": {
+            "Name": "decimal",
+            "Mods": [
+              10
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": true,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c3"
+        },
+        "c4": {
+          "Name": "entry_added",
+          "Type": {
+            "Name": "varchar",
+            "Mods": [
+              200
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c4"
+        },
+        "c5": {
+          "Name": "name",
+          "Type": {
+            "Name": "varchar",
+            "Mods": [
+              200
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c5"
+        },
+        "c6": {
+          "Name": "member",
+          "Type": {
+            "Name": "varchar",
+            "Mods": [
+              200
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c6"
+        },
+        "c7": {
+          "Name": "age",
+          "Type": {
+            "Name": "decimal",
+            "Mods": [
+              10
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c7"
+        }
+      },
+      "PrimaryKeys": [
+        {
+          "ColId": "c3",
+          "Desc": false,
+          "Order": 1
+        }
+      ],
+      "ForeignKeys": null,
+      "Indexes": null,
+      "Id": "t1"
+    },
+    "t2": {
+      "Name": "TABLE2",
+      "Schema": "SRC_DATABASE",
+      "ColIds": [
+        "c8",
+        "c9",
+        "c10",
+        "c11",
+        "c12"
+      ],
+      "ColDefs": {
+        "c10": {
+          "Name": "name",
+          "Type": {
+            "Name": "varchar",
+            "Mods": [
+              200
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c10"
+        },
+        "c11": {
+          "Name": "member",
+          "Type": {
+            "Name": "varchar",
+            "Mods": [
+              200
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c11"
+        },
+        "c12": {
+          "Name": "age",
+          "Type": {
+            "Name": "decimal",
+            "Mods": [
+              10
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c12"
+        },
+        "c8": {
+          "Name": "row_id",
+          "Type": {
+            "Name": "decimal",
+            "Mods": [
+              10
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": true,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c8"
+        },
+        "c9": {
+          "Name": "entry_added",
+          "Type": {
+            "Name": "varchar",
+            "Mods": [
+              200
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c9"
+        }
+      },
+      "PrimaryKeys": [
+        {
+          "ColId": "c8",
+          "Desc": false,
+          "Order": 1
+        }
+      ],
+      "ForeignKeys": null,
+      "Indexes": null,
+      "Id": "t2"
+    }
+  },
+  "SchemaIssues": {
+    "t1": {
+      "ColumnLevelIssues": {},
+      "TableLevelIssues": null
+    },
+    "t2": {
+      "ColumnLevelIssues": {},
+      "TableLevelIssues": null
+    }
+  },
+  "Location": {},
+  "TimezoneOffset": "+00:00",
+  "SpDialect": "google_standard_sql",
+  "UniquePKey": {},
+  "Rules": [],
+  "IsSharded": false,
+  "SpRegion": "",
+  "ResourceValidation": false,
+  "UI": false
+}


### PR DESCRIPTION
De-flakes the previously ignored Datastream to Spanner IT's and adds several variations to test various configurations of the template.

Also adds a CloudSQLResource manager for creating and operating on CloudSQL resources. The MySQL variants of these tests (oracle on the way) use a static CloudSQL instance and connect using a static Cloud Auth Proxy server (see #1591). This should help alleviate flakes related to Datastream being unable to connect to certain ports on the runners which was seemingly non-deterministic and difficult to debug.

---

Depends on #1465.