### PR TITLE
fix concurrency on Java PR's

### DIFF
--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -40,7 +40,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: java-pr-${{ github.event.issue.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
#1526 was merged in an attempt to cancel duplicate runs of the same workflow when the same PR is updated. However, upon looking at the backlog of Java PR actions, this is clearly not WAI.

I tested this change on my personal fork, and can confirm that runs already running are cancelled when the same PR is updated.

This works by instead looking at the current workflow (in this case, it is always Java PR) and cancels existing runs of the workflow that are running on the same ref (branch), since each PR will have a unique branch that it is running on.

Using example from GitHub actions docs: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow