### PR TITLE
auto table inference fix

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
@@ -130,7 +130,7 @@ public final class JdbcIoWrapper implements IoWrapper {
     return sourceSchema.tableSchemas().stream()
         .filter(schema -> schema.tableName().equals(tableConfig.tableName()))
         .findFirst()
-        .orElseGet(null);
+        .orElseThrow();
   }
 
   static SourceSchema getSourceSchema(

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
@@ -31,7 +31,9 @@ import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableSchema;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import org.apache.beam.sdk.io.jdbc.JdbcIO;
 import org.apache.beam.sdk.io.jdbc.JdbcIO.DataSourceConfiguration;
@@ -128,7 +130,7 @@ public final class JdbcIoWrapper implements IoWrapper {
     return sourceSchema.tableSchemas().stream()
         .filter(schema -> schema.tableName().equals(tableConfig.tableName()))
         .findFirst()
-        .orElseThrow();
+        .orElseGet(null);
   }
 
   static SourceSchema getSourceSchema(
@@ -174,10 +176,9 @@ public final class JdbcIoWrapper implements IoWrapper {
    */
   private static ImmutableList<TableConfig> autoInferTableConfigs(
       JdbcIOWrapperConfig config, SchemaDiscovery schemaDiscovery, DataSource dataSource) {
-    ImmutableList<String> tables =
-        (config.tables().isEmpty())
-            ? schemaDiscovery.discoverTables(dataSource, config.sourceSchemaReference())
-            : config.tables();
+    ImmutableList<String> discoveredTables =
+        schemaDiscovery.discoverTables(dataSource, config.sourceSchemaReference());
+    ImmutableList<String> tables = getTablesToMigrate(config.tables(), discoveredTables);
     ImmutableMap<String, ImmutableList<SourceColumnIndexInfo>> indexes =
         schemaDiscovery.discoverTableIndexes(dataSource, config.sourceSchemaReference(), tables);
     ImmutableList.Builder<TableConfig> tableConfigsBuilder = ImmutableList.builder();
@@ -218,6 +219,21 @@ public final class JdbcIoWrapper implements IoWrapper {
       tableConfigsBuilder.add(configBuilder.build());
     }
     return tableConfigsBuilder.build();
+  }
+
+  static ImmutableList<String> getTablesToMigrate(
+      ImmutableList<String> configTables, ImmutableList<String> discoveredTables) {
+    List<String> tables = null;
+    if (configTables.isEmpty()) {
+      tables = discoveredTables;
+    } else {
+      tables =
+          configTables.stream()
+              .filter(t -> discoveredTables.contains(t))
+              .collect(Collectors.toList());
+    }
+    LOG.info("final list of tables to migrate: {}", tables);
+    return ImmutableList.copyOf(tables);
   }
 
   /**

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SourceDbToSpanner.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SourceDbToSpanner.java
@@ -142,6 +142,7 @@ public class SourceDbToSpanner {
                 OptionsToConfigBuilder.MySql.configWithMySqlDefaultsFromOptions(
                     options, tablesToMigrate)));
     SourceSchema srcSchema = reader.getSourceSchema();
+
     ReaderTransform readerTransform = reader.getReaderTransform();
 
     PCollectionTuple rowsAndTables = pipeline.apply("Read rows", readerTransform.readTransform());
@@ -232,24 +233,28 @@ public class SourceDbToSpanner {
     }
 
     List<String> tablesToMigrate = new ArrayList<>();
-    for (String table : sourceTablesConfigured) {
+    for (String srcTable : sourceTablesConfigured) {
       String spannerTable = null;
       try {
-        spannerTable = mapper.getSpannerTableName("", table);
+        spannerTable = mapper.getSpannerTableName("", srcTable);
       } catch (NoSuchElementException e) {
-        LOG.info("could not fetch spanner table from mapper: {}", table);
+        LOG.info("could not fetch spanner table from mapper: {}", srcTable);
+        continue;
       }
-      if (spannerTable != null && ddl.table(spannerTable) != null) {
-        // If spanner table exists against source - mark for migration
-        tablesToMigrate.add(table);
-      } else {
+
+      if (spannerTable == null) {
+        LOG.warn("skipping source table as there is no mapped spanner table: {} ", spannerTable);
+      } else if (ddl.table(spannerTable) == null) {
         LOG.warn(
-            "skipping source table as corresponding spanner table is not present: {} "
-                + "spannerTable: {}",
-            table,
+            "skipping source table: {} as there is no matching spanner table: {} ",
+            srcTable,
             spannerTable);
+      } else {
+        // source table has matching spanner table on current spanner instance
+        tablesToMigrate.add(srcTable);
       }
     }
+
     if (tablesToMigrate.isEmpty()) {
       LOG.error("aborting migration as no tables found to migrate");
       throw new InvalidOptionsException("no configured tables can be migrated");

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
@@ -16,7 +16,9 @@
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -226,5 +228,27 @@ public class JdbcIoWrapperTest {
                     .setJdbcDriverClassName("org.apache.derby.jdbc.EmbeddedDriver")
                     .setDialectAdapter(mockDialectAdapter)
                     .build()));
+  }
+
+  @Test
+  public void testGetTablesToMigrate() {
+    ImmutableList<String> tablesToMigrate =
+        JdbcIoWrapper.getTablesToMigrate(ImmutableList.of("a", "b"), ImmutableList.of("a"));
+    assertEquals(1, tablesToMigrate.size());
+    assertTrue(tablesToMigrate.contains("a"));
+
+    ImmutableList<String> tablesToMigrate2 =
+        JdbcIoWrapper.getTablesToMigrate(ImmutableList.of(), ImmutableList.of("x", "y"));
+    assertEquals(2, tablesToMigrate2.size());
+    assertTrue(tablesToMigrate2.contains("x"));
+    assertTrue(tablesToMigrate2.contains("y"));
+
+    ImmutableList<String> tablesToMigrate3 =
+        JdbcIoWrapper.getTablesToMigrate(
+            ImmutableList.of("p", "q", "r"), ImmutableList.of("p", "q", "r"));
+    assertEquals(3, tablesToMigrate3.size());
+    assertTrue(tablesToMigrate3.contains("p"));
+    assertTrue(tablesToMigrate3.contains("q"));
+    assertTrue(tablesToMigrate3.contains("r"));
   }
 }


### PR DESCRIPTION
Fix to ensure tables not present at source are not picked up during the migration.