### PR TITLE
Update bigtable-beam-import to 2.14.2 to support Data Boost

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.6.0</maven-dependency-plugin.version>
-    <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
+    <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <maven-javadoc-plugin.version>3.0.0-M1</maven-javadoc-plugin.version>
     <maven-shade-plugin.version>3.0.0</maven-shade-plugin.version>

--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -35,11 +35,11 @@
 
   <properties>
     <autovalue.service.version>1.0.2</autovalue.service.version>
-    <extra.enforcer.rules.version>1.3</extra.enforcer.rules.version>
+    <extra.enforcer.rules.version>1.8.0</extra.enforcer.rules.version>
     <mock-server-netty.version>5.14.0</mock-server-netty.version>
     <open-census.version>0.24.0</open-census.version>
     <!-- TODO: check if this could be declared on a Beam BOM instead of here -->
-    <bigtable-beam-import.version>1.27.1</bigtable-beam-import.version>
+    <bigtable-beam-import.version>2.14.0</bigtable-beam-import.version>
     <protobuf.version>3.21.7</protobuf.version>
     <nashorn.version>15.4</nashorn.version>
     <junit.jupiter.version>5.5.2</junit.jupiter.version>


### PR DESCRIPTION
This is needed to support Data Boost, which checks the feature flags sent by the client.

I also bumped up version for the enforcer and extra enforcer rules, otherwise it would error out with a NullPointerException, due to a bug in the old enforcer logic.