### PR TITLE
Adding init seq to set session timezone.

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
@@ -280,6 +280,10 @@ public final class JdbcIoWrapper implements IoWrapper {
                 StaticValueProvider.of(config.sourceDbURL()))
             .withMaxConnections(Math.toIntExact(config.maxConnections()));
 
+    if (!config.sqlInitSeq().isEmpty()) {
+      dataSourceConfig = dataSourceConfig.withConnectionInitSqls(config.sqlInitSeq());
+    }
+
     if (config.jdbcDriverJars() != null && !config.jdbcDriverJars().isEmpty()) {
       dataSourceConfig = dataSourceConfig.withDriverJars(config.jdbcDriverJars());
     }
@@ -289,6 +293,8 @@ public final class JdbcIoWrapper implements IoWrapper {
     if (!config.dbAuth().getPassword().get().isBlank()) {
       dataSourceConfig = dataSourceConfig.withPassword(config.dbAuth().getPassword().get());
     }
+
+    LOG.info("Final DatasourceConfiguration: {}", dataSourceConfig);
     return dataSourceConfig;
   }
 

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/JdbcIOWrapperConfig.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/JdbcIOWrapperConfig.java
@@ -91,12 +91,16 @@ public abstract class JdbcIOWrapperConfig {
   @Nullable
   public abstract Integer maxFetchSize();
 
+  /** Sequence of Sql Init statements for the connection. */
+  public abstract ImmutableList<String> sqlInitSeq();
+
   public static Builder builderWithMySqlDefaults() {
     return new AutoValue_JdbcIOWrapperConfig.Builder()
         .setSchemaMapperType(MySqlConfigDefaults.DEFAULT_MYSQL_SCHEMA_MAPPER_TYPE)
         .setDialectAdapter(MySqlConfigDefaults.DEFAULT_MYSQL_DIALECT_ADAPTER)
         .setValueMappingsProvider(MySqlConfigDefaults.DEFAULT_MYSQL_VALUE_MAPPING_PROVIDER)
         .setMaxConnections(MySqlConfigDefaults.DEFAULT_MYSQL_MAX_CONNECTIONS)
+        .setSqlInitSeq(MySqlConfigDefaults.DEFAULT_MYSQL_INIT_SEQ)
         .setSchemaDiscoveryBackOff(MySqlConfigDefaults.DEFAULT_MYSQL_SCHEMA_DISCOVERY_BACKOFF)
         .setTables(ImmutableList.of())
         .setTableVsPartitionColumns(ImmutableMap.of())
@@ -135,6 +139,8 @@ public abstract class JdbcIOWrapperConfig {
     public abstract Builder setMaxPartitions(Integer value);
 
     public abstract Builder setMaxFetchSize(Integer value);
+
+    public abstract Builder setSqlInitSeq(ImmutableList<String> value);
 
     public abstract Builder setMaxConnections(Long value);
 

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/defaults/MySqlConfigDefaults.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/defaults/MySqlConfigDefaults.java
@@ -21,6 +21,8 @@ import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.M
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.rowmapper.JdbcValueMappingsProvider;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.rowmapper.provider.MysqlJdbcValueMappings;
 import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedTypeMapper.MapperType;
+import com.google.common.collect.ImmutableList;
+import java.util.Calendar;
 import org.apache.beam.sdk.util.FluentBackoff;
 
 // TODO: Fine-tune the defaults based on benchmarking.
@@ -53,6 +55,25 @@ public class MySqlConfigDefaults {
 
   public static final long DEFAULT_MYSQL_RECONNECT_ATTEMPTS = 10L;
   public static final FluentBackoff DEFAULT_MYSQL_SCHEMA_DISCOVERY_BACKOFF = FluentBackoff.DEFAULT;
+
+  /**
+   * Default Initialization Sequence for the JDBC connection.
+   *
+   * <p>
+   *
+   * <ol>
+   *   <li>Session Timezone: session time zone is set to UTC to always retrieve timestamp in UTC.
+   *       The most idomatic way to achieve this via jdbc would be to pass a {@link Calendar} object
+   *       initialized to UTC to {@link java.sql.ResultSet#getTimestamp(String, Calendar)} api
+   *       (which is what we do in {@link MysqlJdbcValueMappings}), but due to bugs like <a
+   *       href="https://bugs.mysql.com/bug.php?id=95644">Bug#95644</a>, <a
+   *       href="https://bugs.mysql.com/bug.php?id=96276">Bug#96276</a>, <a
+   *       href="https://bugs.mysql.com/bug.php?id=93444">Bug#93444</a>, etc. in the older drivers,
+   *       we are also setting the session timezone to UTC.
+   * </ol>
+   */
+  public static final ImmutableList<String> DEFAULT_MYSQL_INIT_SEQ =
+      ImmutableList.of("SET TIME_ZONE = 'UTC'");
 
   private MySqlConfigDefaults() {}
 }


### PR DESCRIPTION
Adding Initialization Sequence for the JDBC connection.
## Summary of Changes
Session Timezone: The PR sets the session time zone to UTC by default to retrieve timestamp in UTC. This is asper the contract exposed by the Reader to always output timestamp in UTC (irrespective of the source settings).The most idomatic way to achieve this via jdbc would be to pass a Calendar object initialized to UTC to [java.sql.ResultSet.getTimestamp(String, Calendar)](https://docs.oracle.com/javase%2F8%2Fdocs%2Fapi%2F%2F/java/sql/ResultSet.html#getTimestamp-java.lang.String-java.util.Calendar-) api (which is what we do in [MysqlJdbcValueMappings](https://github.com/VardhanThigle/DataflowTemplates/blob/main/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/rowmapper/provider/MysqlJdbcValueMappings.java#L80)), but due to bugs like [Bug#95644](https://bugs.mysql.com/bug.php?id=95644) , [Bug#96276](https://bugs.mysql.com/bug.php?id=96276), [Bug#93444](https://bugs.mysql.com/bug.php?id=93444), etc. in the older drivers, we are also setting the session timezone to UTC.
## Testing
This change has been tested on an end to end migration setup where MySQL server was in IST timezone and the timestamp was migrated to spanner by verifying that the migrated timestamp obtained from Spanner was as per the correct timezone offsets applied.