### PR TITLE
Increase timeout for Java PRs

### DIFF
--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -146,7 +146,7 @@ jobs:
   java_integration_tests_templates:
     name: Dataflow Templates Integration Tests
     needs: [java_integration_smoke_tests_templates]
-    timeout-minutes: 180
+    timeout-minutes: 240
     # Run on any runner that matches all the specified runs-on values.
     runs-on: [self-hosted, it]
     steps:


### PR DESCRIPTION
The workflow takes just under 180 minutes on average, with some PR runs timing out over that limit - increase to 240 minutes to alleviate.