### PR TITLE
[BULK] Pass through unsupported types as null

### DIFF
--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SourceDbToSpannerITBase.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SourceDbToSpannerITBase.java
@@ -84,6 +84,7 @@ public class SourceDbToSpannerITBase extends JDBCBaseIT {
         if (!stmt.trim().isEmpty()) {
           // Skip SELECT statements
           if (!stmt.trim().toUpperCase().startsWith("SELECT")) {
+            LOG.info("Executing statement: {}", stmt);
             statement.executeUpdate(stmt);
           }
         }

--- a/v2/sourcedb-to-spanner/src/test/resources/DataTypesIt/data-types.sql
+++ b/v2/sourcedb-to-spanner/src/test/resources/DataTypesIt/data-types.sql
@@ -278,5 +278,53 @@ INSERT INTO `year_table` (`year_col`) VALUES (NULL);
 INSERT INTO set_table (set_col) VALUES (NULL);
 
 
+CREATE TABLE IF NOT EXISTS spatial_point (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    location POINT
+);
+
+INSERT INTO spatial_point (location) VALUES (POINT(77.5946, 12.9716));
+
+
+CREATE TABLE IF NOT EXISTS spatial_linestring (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    path LINESTRING
+);
+
+INSERT INTO spatial_linestring (path)
+VALUES (LineString(Point(77.5946, 12.9716), Point(77.6100, 12.9600)));
+
+CREATE TABLE IF NOT EXISTS spatial_polygon (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    area POLYGON
+);
+
+INSERT INTO spatial_polygon (area)
+VALUES (Polygon(LineString(Point(77.5946, 12.9716), Point(77.6100, 12.9600), Point(77.6000, 12.9500), Point(77.5946, 12.9716))));
+
+CREATE TABLE IF NOT EXISTS spatial_multipoint (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    points MULTIPOINT
+);
+
+INSERT INTO spatial_multipoint (points) VALUES (MultiPoint(Point(77.5946, 12.9716), Point(77.6100, 12.9600)));
+
+CREATE TABLE IF NOT EXISTS spatial_multilinestring (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    paths MULTILINESTRING
+);
+
+INSERT INTO spatial_multilinestring (paths)
+VALUES (MultiLineString(LineString(Point(77.5946, 12.9716), Point(77.6100, 12.9600)), LineString(Point(77.6000, 12.9500), Point(77.6200, 12.9400))));
+
+CREATE TABLE IF NOT EXISTS spatial_multipolygon (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    areas MULTIPOLYGON
+);
+
+INSERT INTO spatial_multipolygon (areas)
+VALUES (MultiPolygon(Polygon(LineString(Point(77.5946, 12.9716), Point(77.6100, 12.9600), Point(77.6000, 12.9500), Point(77.5946, 12.9716))),
+                     Polygon(LineString(Point(77.6200, 12.9400), Point(77.6300, 12.9300), Point(77.6400, 12.9450), Point(77.6200, 12.9400)))));
+
 
 

--- a/v2/sourcedb-to-spanner/src/test/resources/DataTypesIt/spanner-schema.sql
+++ b/v2/sourcedb-to-spanner/src/test/resources/DataTypesIt/spanner-schema.sql
@@ -147,3 +147,33 @@ CREATE TABLE year_table (
   id INT64 NOT NULL,
   year_col STRING(MAX),
 ) PRIMARY KEY(id);
+
+CREATE TABLE spatial_linestring (
+  id INT64 NOT NULL,
+  path STRING(MAX),
+) PRIMARY KEY(id);
+
+CREATE TABLE spatial_multilinestring (
+  id INT64 NOT NULL,
+  paths STRING(MAX),
+) PRIMARY KEY(id);
+
+CREATE TABLE spatial_multipoint (
+  id INT64 NOT NULL,
+  points STRING(MAX),
+) PRIMARY KEY(id);
+
+CREATE TABLE spatial_multipolygon (
+  id INT64 NOT NULL,
+  areas STRING(MAX),
+) PRIMARY KEY(id);
+
+CREATE TABLE spatial_point (
+  id INT64 NOT NULL,
+  location STRING(MAX),
+) PRIMARY KEY(id);
+
+CREATE TABLE spatial_polygon (
+  id INT64 NOT NULL,
+  area STRING(MAX),
+) PRIMARY KEY(id);

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertor.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertor.java
@@ -153,6 +153,7 @@ public class GenericRecordTypeConvertor {
     public static final String VARCHAR = "varchar";
     public static final String NUMBER = "number";
     public static final String JSON = "json";
+    public static final String UNSUPPORTED = "unsupported";
   }
 
   /** Avro logical types are converted to an equivalent string type. */
@@ -199,6 +200,9 @@ public class GenericRecordTypeConvertor {
     } else if (fieldSchema.getLogicalType() != null
         && fieldSchema.getLogicalType().getName().equals(CustomAvroTypes.VARCHAR)) {
       return recordValue.toString();
+    } else if (fieldSchema.getLogicalType() != null
+        && fieldSchema.getLogicalType().getName().equals(CustomAvroTypes.UNSUPPORTED)) {
+      return null;
     } else {
       LOG.error("Unknown field type {} for field {} in {}.", fieldSchema, fieldName, recordValue);
       throw new UnsupportedOperationException(

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertorTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertorTest.java
@@ -65,6 +65,9 @@ public class GenericRecordTypeConvertorTest {
     Schema varcharType =
         new LogicalType(GenericRecordTypeConvertor.CustomAvroTypes.VARCHAR)
             .addToSchema(SchemaBuilder.builder().stringType());
+    Schema unsupportedType =
+        new LogicalType(GenericRecordTypeConvertor.CustomAvroTypes.UNSUPPORTED)
+            .addToSchema(SchemaBuilder.builder().nullType());
 
     // Build the schema using the created types
     return SchemaBuilder.record("logicalTypes")
@@ -96,6 +99,9 @@ public class GenericRecordTypeConvertorTest {
         .noDefault()
         .name("varchar_col")
         .type(varcharType)
+        .noDefault()
+        .name("unsupported_col")
+        .type(unsupportedType)
         .noDefault()
         .endRecord();
   }
@@ -156,6 +162,7 @@ public class GenericRecordTypeConvertorTest {
     genericRecord.put("json_col", "{\"k1\":\"v1\"}");
     genericRecord.put("number_col", "289452");
     genericRecord.put("varchar_col", "Hellogcds");
+    genericRecord.put("unsupported_col", null);
 
     String col = "date_col";
     String result =
@@ -210,6 +217,12 @@ public class GenericRecordTypeConvertorTest {
         GenericRecordTypeConvertor.handleLogicalFieldType(
             col, genericRecord.get(col), genericRecord.getSchema().getField(col).schema());
     assertEquals("Test varchar_col conversion: ", "Hellogcds", result);
+
+    col = "unsupported_col";
+    result =
+        GenericRecordTypeConvertor.handleLogicalFieldType(
+            col, genericRecord.get(col), genericRecord.getSchema().getField(col).schema());
+    assertEquals("Test unsupported_col conversion: ", null, result);
   }
 
   @Test


### PR DESCRIPTION
Currently, unsupported types (like spatial types in mysql) throw error and are written to DLQ. This is inconsistent with the live template. This change passes a null values for those types and tries to write the row to Spanner anyways.