### PR TITLE
[BULK] Remove log param

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/options/CommonTemplateOptions.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/options/CommonTemplateOptions.java
@@ -16,9 +16,7 @@
 package com.google.cloud.teleport.v2.options;
 
 import com.google.cloud.teleport.metadata.TemplateParameter;
-import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.PipelineOptions;
-import org.apache.beam.sdk.options.SdkHarnessOptions;
 
 /** Provides options that are supported by all templates. */
 public interface CommonTemplateOptions extends PipelineOptions {
@@ -51,23 +49,4 @@ public interface CommonTemplateOptions extends PipelineOptions {
   String getExtraFilesToStage();
 
   void setExtraFilesToStage(String extraFilesToStage);
-
-  @TemplateParameter.Enum(
-      order = 33,
-      optional = true,
-      enumOptions = {
-        @TemplateParameter.TemplateEnumOption("OFF"),
-        @TemplateParameter.TemplateEnumOption("ERROR"),
-        @TemplateParameter.TemplateEnumOption("WARN"),
-        @TemplateParameter.TemplateEnumOption("INFO"),
-        @TemplateParameter.TemplateEnumOption("TRACE"),
-        @TemplateParameter.TemplateEnumOption("DEBUG")
-      },
-      description = "Log level in the workers, defaults to INFO",
-      helpText =
-          "Set Log level in the workers. Supported options are OFF, ERROR, WARN, INFO, DEBUG, TRACE. Defaults to INFO")
-  @Default.Enum("INFO")
-  SdkHarnessOptions.LogLevel getDefaultLogLevel();
-
-  void setDefaultLogLevel(SdkHarnessOptions.LogLevel logLevel);
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SourceDbToSpanner.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SourceDbToSpanner.java
@@ -52,7 +52,6 @@ import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.io.gcp.spanner.MutationGroup;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.apache.beam.sdk.options.SdkHarnessOptions;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
@@ -114,7 +113,6 @@ public class SourceDbToSpanner {
     // Parse the user options passed from the command-line
     SourceDbToSpannerOptions options =
         PipelineOptionsFactory.fromArgs(args).withValidation().as(SourceDbToSpannerOptions.class);
-
     run(options);
   }
 
@@ -128,7 +126,6 @@ public class SourceDbToSpanner {
   static PipelineResult run(SourceDbToSpannerOptions options) {
     // TODO - Validate if options are as expected
     Pipeline pipeline = Pipeline.create(options);
-    options.as(SdkHarnessOptions.class).setDefaultSdkHarnessLogLevel(options.getDefaultLogLevel());
 
     SpannerConfig spannerConfig = createSpannerConfig(options);
     Ddl ddl = SpannerSchema.getInformationSchemaAsDdl(spannerConfig);


### PR DESCRIPTION
The existing log setting params already work.
They can be set via `--defaultSdkHarnessLogLevel` and `--defaultWorkerLogLevel` param.

Note: when launching via gcloud, these params need to be passed under the `--parameters` field. These are not independant gcloud flags.