### PR TITLE
Adding support of uniform partitioning for numeric types and composite keys.

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/DialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/DialectAdapter.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter;
 
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.schema.RetriableSchemaDiscovery;
 
 /**
@@ -23,4 +24,4 @@ import com.google.cloud.teleport.v2.source.reader.io.schema.RetriableSchemaDisco
  * <p><b>Note:</b>As a prt of M2 effort, this interface will expose more mehtods than just extending
  * {@link RetriableSchemaDiscovery}.
  */
-public interface DialectAdapter extends RetriableSchemaDiscovery {}
+public interface DialectAdapter extends RetriableSchemaDiscovery, UniformSplitterDBAdapter {}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapter.java
@@ -406,6 +406,79 @@ public final class MysqlDialectAdapter implements DialectAdapter {
     return mySQlTypeAliases.getOrDefault(normalizedType, normalizedType);
   }
 
+  private String addWhereClause(String query, ImmutableList<String> partitionColumns) {
+
+    // Implementation detail, using StringBuilder since we are generating the query in a loop.
+    StringBuilder queryBuilder = new StringBuilder(query);
+
+    boolean firstDone = false;
+    for (String partitionColumn : partitionColumns) {
+
+      if (firstDone) {
+        // Add AND for iteration after first.
+        queryBuilder.append(" AND ");
+      } else {
+        // add `where` only for first iteration.
+        queryBuilder.append(" where ");
+      }
+
+      // Include the column?
+      queryBuilder.append("((? = FALSE) OR ");
+      // range to define the where clause. `col >= range.start() AND (col < range.end() OR
+      // (range.isLast() = TRUE AND col = range.end()))`
+      queryBuilder.append(
+          String.format("(%1$s >= ? AND (%1$s < ? OR (? = TRUE AND %1$s = ?)))", partitionColumn));
+      queryBuilder.append(")");
+      firstDone = true;
+    }
+    return queryBuilder.toString();
+  }
+
+  /**
+   * Get query for the prepared statement to read columns within a range.
+   *
+   * @param tableName name of the table to read
+   * @param partitionColumns partition columns.
+   * @return Query Statement.
+   */
+  @Override
+  public String getReadQuery(String tableName, ImmutableList<String> partitionColumns) {
+    return addWhereClause("select * from " + tableName, partitionColumns);
+  }
+
+  /**
+   * Get query for the prepared statement to count a given range.
+   *
+   * @param tableName name of the table to read.
+   * @param partitionColumns partition columns.
+   * @param timeoutMillis timeout of the count query in milliseconds. Set to 0 to disable timeout.
+   * @return Query Statement.
+   */
+  @Override
+  public String getCountQuery(
+      String tableName, ImmutableList<String> partitionColumns, long timeoutMillis) {
+    return addWhereClause(
+        String.format(
+            "select /*+ MAX_EXECUTION_TIME(%s) */ COUNT(*) from %s", timeoutMillis, tableName),
+        partitionColumns);
+  }
+
+  /**
+   * Get query for the prepared statement to get min and max of a given column, optionally in the
+   * context of a parent range.
+   *
+   * @param tableName name of the table to read.
+   * @param partitionColumns if not-empty, partition columns. Set empty for first column of
+   *     partitioning.
+   */
+  @Override
+  public String getBoundaryQuery(
+      String tableName, ImmutableList<String> partitionColumns, String colName) {
+    return addWhereClause(
+        String.format("select MIN(%s),MAX(%s) from %s", colName, colName, tableName),
+        partitionColumns);
+  }
+
   /**
    * Version of MySql. As of now the code does not need to distinguish between versions of Mysql.
    * Having the type allows the implementation do finer distinctions if needed in the future.

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapter.java
@@ -419,7 +419,7 @@ public final class MysqlDialectAdapter implements DialectAdapter {
         queryBuilder.append(" AND ");
       } else {
         // add `where` only for first iteration.
-        queryBuilder.append(" where ");
+        queryBuilder.append(" WHERE ");
       }
 
       // Include the column?

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
@@ -17,9 +17,13 @@ package com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper;
 
 import com.google.cloud.teleport.v2.source.reader.io.IoWrapper;
 import com.google.cloud.teleport.v2.source.reader.io.exception.SuitableIndexNotFoundException;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.JdbcIOWrapperConfig;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.TableConfig;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.rowmapper.JdbcSourceRowMapper;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.PartitionColumn;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms.ReadWithUniformPartitions;
 import com.google.cloud.teleport.v2.source.reader.io.row.SourceRow;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SchemaDiscovery;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SchemaDiscoveryImpl;
@@ -50,6 +54,10 @@ import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/*
+ * TODO(vardhanvthigle): Towards M3, make this a reconfigurable class, and expose (if required) the approxRowCounts
+ *  and maxPartitionHints (auto inferred) to the pipeline controller helping a better sequencing of tables.
+ */
 public final class JdbcIoWrapper implements IoWrapper {
   private static final Logger LOG = LoggerFactory.getLogger(JdbcIoWrapper.class);
 
@@ -122,12 +130,19 @@ public final class JdbcIoWrapper implements IoWrapper {
                       .setSourceTableName(sourceTableSchema.tableName())
                       .setSourceTableSchemaUUID(sourceTableSchema.tableSchemaUUID())
                       .build(),
-                  getJdbcIO(
-                      config,
-                      dataSourceConfiguration,
-                      sourceSchema.schemaReference(),
-                      tableConfig,
-                      sourceTableSchema));
+                  (config.readWithUniformPartitionsFeatureEnabled())
+                      ? getReadWithUniformPartitionIO(
+                          config,
+                          dataSourceConfiguration,
+                          sourceSchema.schemaReference(),
+                          tableConfig,
+                          sourceTableSchema)
+                      : getJdbcIO(
+                          config,
+                          dataSourceConfiguration,
+                          sourceSchema.schemaReference(),
+                          tableConfig,
+                          sourceTableSchema));
             })
         .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
   }
@@ -190,42 +205,80 @@ public final class JdbcIoWrapper implements IoWrapper {
         schemaDiscovery.discoverTableIndexes(dataSource, config.sourceSchemaReference(), tables);
     ImmutableList.Builder<TableConfig> tableConfigsBuilder = ImmutableList.builder();
     for (String table : tables) {
-      TableConfig.Builder configBuilder = TableConfig.builder(table);
-      if (config.tableVsPartitionColumns().containsKey(table)) {
-        config.tableVsPartitionColumns().get(table).forEach(configBuilder::withPartitionColum);
-      } else {
-        if (indexes.containsKey(table)) {
-          // As of now only Primary key index with Numeric type is supported.
-          // TODO:
-          //    1. support unique indexes.
-          //    2. support for DateTime type
-          //    3. support for String type.
-          ImmutableList<String> partitionColumns =
-              indexes.get(table).stream()
-                  .filter(
-                      indexInfo ->
-                          (indexInfo.isPrimary()
-                              && indexInfo.ordinalPosition() == 1
-                              && indexInfo.indexType() == IndexType.NUMERIC))
-                  .map(SourceColumnIndexInfo::columnName)
-                  .collect(ImmutableList.toImmutableList());
-          if (partitionColumns.isEmpty()) {
-            throw new SuitableIndexNotFoundException(
-                new Throwable(
-                    "No Suitable Index Found for partition column inference for table " + table));
-          }
-          partitionColumns.forEach(configBuilder::withPartitionColum);
-        } else {
-          throw new SuitableIndexNotFoundException(
-              new Throwable("No Index Found for partition column inference for table " + table));
-        }
-      }
-      if (config.maxPartitions() != null && config.maxPartitions() != 0) {
-        configBuilder.setMaxPartitions(config.maxPartitions());
-      }
-      tableConfigsBuilder.add(configBuilder.build());
+      tableConfigsBuilder.add(getTableConfig(table, config, indexes));
     }
     return tableConfigsBuilder.build();
+  }
+
+  private static TableConfig getTableConfig(
+      String tableName,
+      JdbcIOWrapperConfig config,
+      ImmutableMap<String, ImmutableList<SourceColumnIndexInfo>> indexInfo) {
+    TableConfig.Builder tableConfigBuilder = TableConfig.builder(tableName);
+    if (config.maxPartitions() != null && config.maxPartitions() != 0) {
+      tableConfigBuilder.setMaxPartitions(config.maxPartitions());
+    }
+    /*
+     * TODO(vardhanvthigle): Add optional support for non-primary indexes.
+     * Note: most of the implementation is generic for any unique index.
+     *  Need to benchmark and do the end to end implementation.
+     */
+    if (indexInfo.containsKey(tableName)) {
+      ImmutableList<SourceColumnIndexInfo> tableIndexInfo = indexInfo.get(tableName);
+
+      // TODO(vardhanvthigle): support for non-primary indexes.
+      tableIndexInfo.stream()
+          .filter(info -> info.isPrimary() && info.ordinalPosition() == 1)
+          .map(SourceColumnIndexInfo::cardinality)
+          .forEach(tableConfigBuilder::setApproxRowCount);
+      if (config.tableVsPartitionColumns().containsKey(tableName)) {
+        config.tableVsPartitionColumns().get(tableName).stream()
+            .map(
+                colName ->
+                    tableIndexInfo.stream()
+                        .filter(info -> info.columnName().equals(colName))
+                        .findFirst()
+                        .get())
+            .sorted()
+            .map(
+                idxInfo ->
+                    PartitionColumn.builder()
+                        .setColumnName(idxInfo.columnName())
+                        // TODO(vardhanvthigle): add the class to idxInfo.
+                        .setColumnClass(Integer.class)
+                        .build())
+            .forEach(tableConfigBuilder::withPartitionColum);
+      } else {
+        // As of now only Primary key index with Numeric type is supported.
+        // TODO:
+        //    1. support non-primary unique indexes.
+        //        Note: most of the implementation is generic for any unique index.
+        //        Need to benchmark and do the end to end implementation.
+        //    2. support for DateTime type
+        //    3. support for String type.
+        tableIndexInfo.stream()
+            .filter(idxInfo -> (idxInfo.isPrimary() && idxInfo.indexType() == IndexType.NUMERIC))
+            .sorted()
+            .map(
+                idxInfo ->
+                    PartitionColumn.builder()
+                        .setColumnName(idxInfo.columnName())
+                        // TODO(vardhanvthigle): add the class to idxInfo.
+                        .setColumnClass(Long.class)
+                        .build())
+            .forEach(tableConfigBuilder::withPartitionColum);
+      }
+      TableConfig tableConfig = tableConfigBuilder.build();
+      if (tableConfig.partitionColumns().isEmpty()) {
+        throw new SuitableIndexNotFoundException(
+            new Throwable(
+                "No Suitable Index Found for partition column inference for table " + tableName));
+      }
+      return tableConfig;
+    } else {
+      throw new SuitableIndexNotFoundException(
+          new Throwable("No Index Found for partition column inference for table " + tableName));
+    }
   }
 
   @VisibleForTesting
@@ -263,7 +316,7 @@ public final class JdbcIoWrapper implements IoWrapper {
     ReadWithPartitions<SourceRow, @UnknownKeyFor @NonNull @Initialized Long> jdbcIO =
         JdbcIO.<SourceRow>readWithPartitions()
             .withTable(tableConfig.tableName())
-            .withPartitionColumn(tableConfig.partitionColumns().get(0))
+            .withPartitionColumn(tableConfig.partitionColumns().get(0).columnName())
             .withDataSourceProviderFn(JdbcIO.PoolableDataSourceProvider.of(dataSourceConfiguration))
             .withRowMapper(
                 new JdbcSourceRowMapper(
@@ -275,6 +328,49 @@ public final class JdbcIoWrapper implements IoWrapper {
       jdbcIO = jdbcIO.withNumPartitions(tableConfig.maxPartitions());
     }
     return jdbcIO;
+  }
+
+  /**
+   * Private helper to construct {@link ReadWithUniformPartitions} as per the reader configuration.
+   *
+   * @param config Configuration.
+   * @param dataSourceConfiguration dataSourceConfiguration (which is derived earlier from the
+   *     reader configuration)
+   * @param tableConfig discovered table configurations.
+   * @param sourceTableSchema schema of the source table.
+   * @return
+   */
+  private static PTransform<PBegin, PCollection<SourceRow>> getReadWithUniformPartitionIO(
+      JdbcIOWrapperConfig config,
+      DataSourceConfiguration dataSourceConfiguration,
+      SourceSchemaReference sourceSchemaReference,
+      TableConfig tableConfig,
+      SourceTableSchema sourceTableSchema) {
+
+    ReadWithUniformPartitions.Builder<SourceRow> readWithUniformPartitionsBuilder =
+        ReadWithUniformPartitions.<SourceRow>builder()
+            .setTableName(tableConfig.tableName())
+            .setPartitionColumns(tableConfig.partitionColumns())
+            .setDataSourceProviderFn(JdbcIO.PoolableDataSourceProvider.of(dataSourceConfiguration))
+            .setDbAdapter(new MysqlDialectAdapter(MySqlVersion.DEFAULT))
+            .setApproxTotalRowCount(tableConfig.approxRowCount())
+            .setRowMapper(
+                new JdbcSourceRowMapper(
+                    config.valueMappingsProvider(),
+                    sourceSchemaReference,
+                    sourceTableSchema,
+                    config.shardID()))
+            .setWaitOnSignals(config.waitOnSignals())
+            // TODO(vardhanvthigle): if index is not of the type of a single auto incrementing key,
+            // don't set this.
+            .setSplitStageCountHint(4L)
+            .setRangesPeek(config.rangesPeek());
+
+    if (tableConfig.maxPartitions() != null) {
+      readWithUniformPartitionsBuilder =
+          readWithUniformPartitionsBuilder.setMaxPartitionsHint((long) tableConfig.maxPartitions());
+    }
+    return readWithUniformPartitionsBuilder.build();
   }
 
   /**

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
@@ -361,10 +361,12 @@ public final class JdbcIoWrapper implements IoWrapper {
                     sourceTableSchema,
                     config.shardID()))
             .setWaitOnSignals(config.waitOnSignals())
-            // TODO(vardhanvthigle): if index is not of the type of a single auto incrementing key,
-            // don't set this.
+            /* The following setting limits number of stages provisioned for the split process.
+             * Currently we mostly deal with auto incrementing keys, so capping it to 4 stages irrespective of table size.
+             * TODO(vardhanvthigle): if index is not of the type of a single auto incrementing key, don't set this.
+             */
             .setSplitStageCountHint(4L)
-            .setRangesPeek(config.rangesPeek());
+            .setAdditionalOperationsOnRanges(config.additionalOperationsOnRanges());
 
     if (tableConfig.maxPartitions() != null) {
       readWithUniformPartitionsBuilder =

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
@@ -360,7 +360,7 @@ public final class JdbcIoWrapper implements IoWrapper {
                     sourceSchemaReference,
                     sourceTableSchema,
                     config.shardID()))
-            .setWaitOnSignals(config.waitOnSignals())
+            .setWaitOn(config.waitOn())
             /* The following setting limits number of stages provisioned for the split process.
              * Currently we mostly deal with auto incrementing keys, so capping it to 4 stages irrespective of table size.
              * TODO(vardhanvthigle): if index is not of the type of a single auto incrementing key, don't set this.

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/JdbcIOWrapperConfig.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/JdbcIOWrapperConfig.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.Wait.OnSignal;
 import org.apache.beam.sdk.util.FluentBackoff;
 import org.apache.beam.sdk.values.PCollection;
 
@@ -110,7 +111,7 @@ public abstract class JdbcIOWrapperConfig {
    * JdbcIOWrapperConfig#readWithUniformPartitionsFeatureEnabled()} is false. Defaults to null.
    */
   @Nullable
-  public abstract ImmutableList<PCollection<?>> waitOnSignals();
+  public abstract OnSignal<?> waitOn();
 
   /**
    * A transform that can be injected to make use of the discovered splits for additional use case
@@ -133,6 +134,7 @@ public abstract class JdbcIOWrapperConfig {
         .setTables(ImmutableList.of())
         .setTableVsPartitionColumns(ImmutableMap.of())
         .setMaxPartitions(null)
+        .setWaitOn(null)
         .setMaxFetchSize(null)
         .setReadWithUniformPartitionsFeatureEnabled(true);
   }
@@ -173,7 +175,7 @@ public abstract class JdbcIOWrapperConfig {
 
     public abstract Builder setReadWithUniformPartitionsFeatureEnabled(Boolean value);
 
-    public abstract Builder setWaitOnSignals(@Nullable ImmutableList<PCollection<?>> value);
+    public abstract Builder setWaitOn(@Nullable OnSignal<?> value);
 
     public abstract Builder setAdditionalOperationsOnRanges(
         @Nullable PTransform<PCollection<ImmutableList<Range>>, ?> value);

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/JdbcIOWrapperConfig.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/JdbcIOWrapperConfig.java
@@ -118,7 +118,7 @@ public abstract class JdbcIOWrapperConfig {
    * JdbcIOWrapperConfig#readWithUniformPartitionsFeatureEnabled()} is false. Defaults to null.
    */
   @Nullable
-  public abstract PTransform<PCollection<ImmutableList<Range>>, ?> rangesPeek();
+  public abstract PTransform<PCollection<ImmutableList<Range>>, ?> additionalOperationsOnRanges();
 
   public abstract Builder toBuilder();
 
@@ -175,7 +175,7 @@ public abstract class JdbcIOWrapperConfig {
 
     public abstract Builder setWaitOnSignals(@Nullable ImmutableList<PCollection<?>> value);
 
-    public abstract Builder setRangesPeek(
+    public abstract Builder setAdditionalOperationsOnRanges(
         @Nullable PTransform<PCollection<ImmutableList<Range>>, ?> value);
 
     public abstract Builder setMaxConnections(Long value);

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/TableConfig.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/TableConfig.java
@@ -16,7 +16,7 @@
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.base.Preconditions;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.PartitionColumn;
 import com.google.common.collect.ImmutableList;
 import javax.annotation.Nullable;
 
@@ -35,7 +35,10 @@ public abstract class TableConfig {
   public abstract Integer maxPartitions();
 
   /** Partition Column. As of now only a single partition column is supported */
-  public abstract ImmutableList<String> partitionColumns();
+  public abstract ImmutableList<PartitionColumn> partitionColumns();
+
+  /** Approximate count of the rows in the table. */
+  public abstract Long approxRowCount();
 
   public static Builder builder(String tableName) {
     return new AutoValue_TableConfig.Builder().setTableName(tableName).setMaxPartitions(null);
@@ -48,9 +51,11 @@ public abstract class TableConfig {
 
     public abstract Builder setMaxPartitions(Integer value);
 
-    abstract ImmutableList.Builder<String> partitionColumnsBuilder();
+    abstract ImmutableList.Builder<PartitionColumn> partitionColumnsBuilder();
 
-    public Builder withPartitionColum(String column) {
+    public abstract Builder setApproxRowCount(Long value);
+
+    public Builder withPartitionColum(PartitionColumn column) {
       this.partitionColumnsBuilder().add(column);
       return this;
     }
@@ -59,9 +64,6 @@ public abstract class TableConfig {
 
     public TableConfig build() {
       TableConfig tableConfig = this.autoBuild();
-      Preconditions.checkState(
-          tableConfig.partitionColumns().size() == 1,
-          "A single partition column is required. Currently Partition Columns are not auto inferred and composite partition columns are not supported.");
       return tableConfig;
     }
   }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/UniformSplitterDBAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/UniformSplitterDBAdapter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter;
+
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+
+/** Helper Interface to help uniform splitter adapt to the source database. */
+public interface UniformSplitterDBAdapter extends Serializable {
+
+  /**
+   * Get query for the prepared statement to read columns within a range.
+   *
+   * @param tableName name of the table to read
+   * @param partitionColumns partition columns.
+   * @return Query Statement.
+   */
+  String getReadQuery(String tableName, ImmutableList<String> partitionColumns);
+
+  /**
+   * Get query for the prepared statement to count a given range.
+   *
+   * @param tableName name of the table to read.
+   * @param partitionColumns partition columns.
+   * @param timeoutMillis timeout of the count query in milliseconds. Set to 0 to disable timeout.
+   * @return Query Statement.
+   */
+  String getCountQuery(
+      String tableName, ImmutableList<String> partitionColumns, long timeoutMillis);
+
+  /**
+   * Get query for the prepared statement to get min and max of a given column, optionally in the
+   * context of a parent range.
+   *
+   * @param tableName name of the table to read.
+   * @param partitionColumns partition columns.
+   */
+  String getBoundaryQuery(String tableName, ImmutableList<String> partitionColumns, String colName);
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/ColumnForBoundaryQuery.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/ColumnForBoundaryQuery.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.PartitionColumn;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import java.io.Serializable;
+import javax.annotation.Nullable;
+
+/**
+ * Intermediate data structure generated during PTransforms to indicate a column for which a
+ * boundary (min, max) is requested.
+ */
+@AutoValue
+public abstract class ColumnForBoundaryQuery implements Serializable {
+
+  /**
+   * @return column details.
+   */
+  public abstract PartitionColumn partitionColumn();
+
+  /**
+   * @return Parent Range. Null indicates first column for splitting. Defaults to Null.
+   */
+  @Nullable
+  public abstract Range parentRange();
+
+  public static Builder builder() {
+    return new AutoValue_ColumnForBoundaryQuery.Builder().setParentRange(null);
+  }
+
+  /**
+   * @return Name of the column for which a boundary query is needed.
+   */
+  public String columnName() {
+    return partitionColumn().columnName();
+  }
+
+  /**
+   * @return Class of the column for which a boundary query is needed.
+   */
+  public Class columnClass() {
+    return partitionColumn().columnClass();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setPartitionColumn(PartitionColumn value);
+
+    public abstract PartitionColumn.Builder partitionColumnBuilder();
+
+    public Builder setColumnName(String value) {
+      this.partitionColumnBuilder().setColumnName(value);
+      return this;
+    }
+
+    public Builder setColumnClass(Class value) {
+      this.partitionColumnBuilder().setColumnClass(value);
+      return this;
+    }
+
+    public abstract Builder setParentRange(Range value);
+
+    public abstract ColumnForBoundaryQuery build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/ColumnForBoundaryQuery.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/ColumnForBoundaryQuery.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary;
 
 import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.PartitionColumn;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
 import java.io.Serializable;
@@ -34,6 +35,17 @@ public abstract class ColumnForBoundaryQuery implements Serializable {
   public abstract PartitionColumn partitionColumn();
 
   /**
+   * Parent range. There are two kinds of boundary queries that the splitting logic needs to make:
+   *
+   * <ol>
+   *   <li>{@code SELECT MIN(firstCol), MAX(firstCol) from table} for the first column.
+   *   <li>{@code SELECT MIN(col), MAX(col) from table WHERE ...} for subsequent columns.
+   * </ol>
+   *
+   * <p>For the first column, set the parentRange as null. For subsequent columns setting the parent
+   * range helps the {@link UniformSplitterDBAdapter} and {@link
+   * ColumnForBoundaryQueryPreparedStatementSetter} generate a correct query and parameters.
+   *
    * @return Parent Range. Null indicates first column for splitting. Defaults to Null.
    */
   @Nullable

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/ColumnForBoundaryQueryPreparedStatementSetter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/ColumnForBoundaryQueryPreparedStatementSetter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.RangePreparedStatementSetter;
+import com.google.common.collect.ImmutableList;
+import java.sql.PreparedStatement;
+import org.apache.beam.sdk.io.jdbc.JdbcIO.PreparedStatementSetter;
+import org.checkerframework.checker.initialization.qual.Initialized;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
+
+/**
+ * Implement {@link PreparedStatementSetter} to set {@link PreparedStatement} parameters for getting
+ * boundary of a column.
+ */
+public class ColumnForBoundaryQueryPreparedStatementSetter
+    implements PreparedStatementSetter<ColumnForBoundaryQuery> {
+
+  /** List of partition columns. */
+  ImmutableList<String> partitionCols;
+
+  /**
+   * Construct {@link ColumnForBoundaryQuery}.
+   *
+   * @param partitionCols partition columns.
+   */
+  public ColumnForBoundaryQueryPreparedStatementSetter(ImmutableList<String> partitionCols) {
+    this.partitionCols = partitionCols;
+  }
+
+  /**
+   * Set statement parameters.
+   *
+   * @param element details of the colum for which boudnary is to be found.
+   * @param preparedStatement the prepared statement.
+   * @throws Exception coming form jdbc. Since this is in run-time, beam will retry the exception.
+   * @see MysqlDialectAdapter#getBoundaryQuery(String, ImmutableList, String)
+   */
+  @Override
+  public void setParameters(
+      ColumnForBoundaryQuery element,
+      @UnknownKeyFor @NonNull @Initialized PreparedStatement preparedStatement)
+      throws @UnknownKeyFor @NonNull @Initialized Exception {
+    int parameterIdx = 1;
+    new RangePreparedStatementSetter(partitionCols.size())
+        .setRangeParameters(element.parentRange(), preparedStatement, parameterIdx);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/ColumnForBoundaryQueryPreparedStatementSetter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/ColumnForBoundaryQueryPreparedStatementSetter.java
@@ -32,7 +32,7 @@ public class ColumnForBoundaryQueryPreparedStatementSetter
     implements PreparedStatementSetter<ColumnForBoundaryQuery> {
 
   /** List of partition columns. */
-  ImmutableList<String> partitionCols;
+  private ImmutableList<String> partitionCols;
 
   /**
    * Construct {@link ColumnForBoundaryQuery}.

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Helper class to calculate boundary of a {@link
+ * com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range Range} for Uniform
+ * Splitter.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Uniform Splitter for jdbc sources. The {@code uniformsplitter} package implements classes to help
+ * split the range of indexed rows into near uniform partitions.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/Boundary.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/Boundary.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+import java.io.Serializable;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+import org.apache.commons.lang3.tuple.Pair;
+
+@AutoValue
+public abstract class Boundary<T extends Serializable>
+    implements Serializable, Comparable<Boundary> {
+
+  /**
+   * @return column details.
+   */
+  abstract PartitionColumn partitionColumn();
+
+  /**
+   * Helps to reorder the ranges after they are processed in parallel.
+   *
+   * <p>By Design, we don't bound T to extend {@link Comparable}, as types like strings could be
+   * compared in different order syb the DB. Since all ranges are produced out of a process of
+   * splitting, we use a lexicographically sorted splitIndex instead for sorting the ranges such
+   * that ranges of a given column collect as per the `in-order` sorting of their split tree.
+   *
+   * @return the split Index of the boundary
+   */
+  abstract String splitIndex();
+
+  /**
+   * @return start of the range.
+   */
+  @Nullable
+  abstract T start();
+
+  /**
+   * @return end of the range.
+   */
+  @Nullable
+  abstract T end();
+
+  @Nullable T splitPoint = null;
+
+  /**
+   * Splitter to split a given Boundary into 2 halves.
+   *
+   * @return splitter.
+   */
+  abstract BoundarySplitter<T> boundarySplitter();
+
+  /**
+   * Maps a Boundary Type from one to another. This allows the implementation to support splitting
+   * types like strings which can be mapped to BigInteger. Defaults to null.
+   */
+  @Nullable
+  abstract BoundaryTypeMapper boundaryTypeMapper();
+
+  /**
+   * @return column associated with the range.
+   */
+  String colName() {
+    return partitionColumn().columnName();
+  }
+
+  /**
+   * @return column class associated with the range.
+   */
+  Class columnClass() {
+    return partitionColumn().columnClass();
+  }
+
+  @Nullable
+  String stringCollation() {
+    return partitionColumn().stringCollation();
+  }
+
+  @Nullable
+  Integer stringMaxLength() {
+    return partitionColumn().stringMaxLength();
+  }
+
+  /**
+   * @return builder for {@link Boundary}.
+   */
+  public static <T extends Serializable> Builder<T> builder() {
+    return (new AutoValue_Boundary.Builder<T>()).setSplitIndex("1").setBoundaryTypeMapper(null);
+  }
+
+  /**
+   * Checks if two boundaries can be merged with each other.
+   *
+   * @param other other boundary.
+   * @return true if ranges are mergable.
+   */
+  public boolean isMergable(Boundary<?> other) {
+    return Objects.equal(this.end(), other.start()) || Objects.equal(this.start(), other.end());
+  }
+
+  /**
+   * Merge 2 boundaries. The caller must ensure that the boundaries are mergable. The caller should
+   * use {@link Boundary#isMergable(Boundary)} to check if the boundary is mergable before calling
+   * {@link Boundary#merge(Boundary)}.
+   *
+   * @param other Boundary to merge
+   * @return merged Boundary
+   * @throws IllegalArgumentException if boundaries are not mergable. This indicates a programming
+   *     error and should not be seen in production.
+   */
+  public Boundary<T> merge(Boundary<?> other) {
+    Preconditions.checkArgument(
+        this.isMergable(other),
+        "Trying to merge non-mergable boundaries. this: " + this + " other: " + other);
+    String maxSplitIndex =
+        (compareSplitIndex(splitIndex(), other.splitIndex()) < 0)
+            ? other.splitIndex()
+            : splitIndex();
+    if (Objects.equal(this.end(), other.start())) {
+      return this.toBuilder().setEnd((T) other.end()).setSplitIndex(maxSplitIndex).build();
+    } else {
+      return this.toBuilder().setStart((T) other.start()).setSplitIndex(maxSplitIndex).build();
+    }
+  }
+
+  /**
+   * Returns true if a given Boundary can be split.
+   *
+   * @return true if a boundary can be split.
+   */
+  public boolean isSplittable(@Nullable ProcessContext processContext) {
+    T mid = splitPoint(processContext);
+    return !(end().equals(mid)) && !(start().equals(mid));
+  }
+
+  /**
+   * Split a given boundary into 2 boundaries via the {@link Boundary#boundarySplitter()}. The
+   * caller should use {@link Boundary#isSplittable(ProcessContext)} to check if the boundaries is
+   * splittable before calling {@link Boundary#split(ProcessContext)}.
+   *
+   * @return a pair of split boundaries.
+   */
+  public Pair<Boundary<T>, Boundary<T>> split(@Nullable ProcessContext processContext) {
+    T splitPoint = splitPoint(processContext);
+    return Pair.of(
+        toBuilder().setEnd(splitPoint).setSplitIndex(splitIndex() + "-1").build(),
+        toBuilder().setStart(splitPoint).setSplitIndex(splitIndex() + "-2").build());
+  }
+
+  /**
+   * Build a {@link Range} {@link Range#childRange()} from this {@link Boundary}.
+   *
+   * <p>Note: A Range resulting from a boundary query is always first and last within the boundary
+   * until it's split.
+   *
+   * @param parentRange parent range. Pass Null for first column.
+   * @return range from this {@link Boundary}
+   */
+  public Range toRange(@Nullable Range parentRange, @Nullable ProcessContext processContext) {
+    Range thisRange = Range.builder().setBoundary(this).setIsFirst(true).setIsLast(true).build();
+    if (parentRange == null) {
+      return thisRange;
+    } else {
+      return parentRange.withChildRange(thisRange, processContext);
+    }
+  }
+
+  /**
+   * Compares this {@link Boundary} with the specified {@link Boundary} for order. When the
+   * boundaries are sorted, it's desirable that boundaries that have got split from the same parent
+   * range are ordered as per the in-oder traversal of their splitting.
+   *
+   * @param other the object to be compared.
+   * @return a negative integer, zero, or a positive integer as this object is less than, equal to,
+   *     or greater than the specified object.
+   */
+  @Override
+  public int compareTo(Boundary other) {
+    if (this.equals(other)) {
+      return 0;
+    }
+    int colNameComparison = this.colName().compareTo(other.colName());
+    if (colNameComparison != 0) {
+      return colNameComparison; // Different colNames, compare lexicographically
+    }
+
+    // Same colName, compare splitIndex.
+    int splitIndexComparison = compareSplitIndex(this.splitIndex(), other.splitIndex());
+    Preconditions.checkState(
+        splitIndexComparison != 0, "Boundaries with same splitIndex must be equal");
+    return splitIndexComparison;
+  }
+
+  private static int compareSplitIndex(String splitIndex1, String splitIndex2) {
+    return splitIndex1.compareTo(splitIndex2);
+  }
+
+  private T splitPoint(@Nullable ProcessContext processContext) {
+    if (splitPoint == null) {
+      splitPoint =
+          boundarySplitter()
+              .getSplitPoint(
+                  start(), end(), partitionColumn(), boundaryTypeMapper(), processContext);
+    }
+    return splitPoint;
+  }
+
+  public abstract Builder<T> toBuilder();
+
+  @AutoValue.Builder
+  public abstract static class Builder<T extends Serializable> {
+
+    abstract PartitionColumn.Builder partitionColumnBuilder();
+
+    public Builder<T> setColName(String value) {
+      this.partitionColumnBuilder().setColumnName(value);
+      return this;
+    }
+
+    public Builder<T> setColClass(Class value) {
+      this.partitionColumnBuilder().setColumnClass(value);
+      return this;
+    }
+
+    public Builder<T> setStringMaxLength(Integer value) {
+      this.partitionColumnBuilder().setStringMaxLength(value);
+      return this;
+    }
+
+    public Builder<T> setCollation(String value) {
+      this.partitionColumnBuilder().setStringCollation(value);
+      return this;
+    }
+
+    public abstract Builder<T> setPartitionColumn(PartitionColumn value);
+
+    protected abstract Builder<T> setSplitIndex(String value);
+
+    public abstract Builder<T> setStart(@Nullable T value);
+
+    abstract T start();
+
+    public abstract Builder<T> setEnd(@Nullable T value);
+
+    /*
+     * Note currently all boundarySplitters are static classes.
+     * Having a property that can be set allows the possibility of a non-static splitter.
+     */
+    public abstract Builder<T> setBoundarySplitter(BoundarySplitter<T> value);
+
+    public abstract Builder<T> setBoundaryTypeMapper(@Nullable BoundaryTypeMapper value);
+
+    abstract Boundary<T> autoBuild();
+
+    public Boundary<T> build() {
+      Boundary<T> boundary = autoBuild();
+      if (boundary.start() != null) {
+        Preconditions.checkState(
+            boundary.start().getClass().equals(boundary.partitionColumn().columnClass()),
+            String.format(
+                "Creating boundary of mismatched types start-type = %s,  PartitionColumn = %s",
+                boundary.start().getClass(), boundary.columnClass()));
+      }
+      if (boundary.end() != null) {
+        Preconditions.checkState(
+            boundary.end().getClass().equals(boundary.partitionColumn().columnClass()),
+            String.format(
+                "Creating boundary of mismatched types end-type = %s,  PartitionColumn = %s",
+                boundary.end().getClass(), boundary.columnClass()));
+      }
+      return boundary;
+    }
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryExtractor.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryExtractor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
+
+import java.io.Serializable;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Interface to extract Boundary from a given resultSet for the boundary query of the form {@code
+ * SELECT MIN(ColumnName), MAX(ColumnName) from Table}.
+ *
+ * <p>Note:
+ *
+ * <p>Implementations must handle the SQLException thrown.
+ */
+public interface BoundaryExtractor<T extends Serializable> extends Serializable {
+
+  /**
+   * Extract Boundary from a given resultSet for the boundary query of the form {@code SELECT
+   * MIN(columnName), MAX(columnName) from Table}.
+   *
+   * @param partitionColumn details of the partition column.
+   * @param resultSet result set.
+   * @return extracted boundary.
+   * @throws SQLException thrown by the resultSet api.
+   */
+  Boundary<T> getBoundary(
+      PartitionColumn partitionColumn,
+      ResultSet resultSet,
+      @Nullable BoundaryTypeMapper boundaryTypeMapper)
+      throws SQLException;
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryExtractorFactory.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryExtractorFactory.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.Serializable;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/** Factory to construct {@link BoundaryExtractor} for supported {@link class}. */
+public class BoundaryExtractorFactory {
+
+  private static final ImmutableMap<Class, BoundaryExtractor<?>> extractorMap =
+      ImmutableMap.of(
+          Integer.class,
+              (BoundaryExtractor<Integer>)
+                  (partitionColumn, resultSet, boundaryTypeMapper) ->
+                      fromIntegers(partitionColumn, resultSet, boundaryTypeMapper),
+          Long.class,
+              (BoundaryExtractor<Long>)
+                  (partitionColumn, resultSet, boundaryTypeMapper) ->
+                      fromLongs(partitionColumn, resultSet, boundaryTypeMapper),
+          String.class, (BoundaryExtractor<String>) BoundaryExtractorFactory::fromStrings);
+
+  /**
+   * Create a {@link BoundaryExtractor} for the required class.
+   *
+   * @param c class of the column.
+   * @return boundary extractor.
+   */
+  public static <T extends Serializable> BoundaryExtractor<T> create(Class<T> c) {
+    BoundaryExtractor<T> extractor = (BoundaryExtractor<T>) extractorMap.get(c);
+
+    if (extractor == null) {
+      throw new UnsupportedOperationException("Range Extractor not implemented for class " + c);
+    }
+    return extractor;
+  }
+
+  private static Boundary<Integer> fromIntegers(
+      PartitionColumn partitionColumn,
+      ResultSet resultSet,
+      @Nullable BoundaryTypeMapper boundaryTypeMapper)
+      throws SQLException {
+    Preconditions.checkArgument(partitionColumn.columnClass().equals(Integer.class));
+    resultSet.next();
+    return Boundary.<Integer>builder()
+        .setPartitionColumn(partitionColumn)
+        .setStart(resultSet.getInt(1))
+        .setEnd(resultSet.getInt(2))
+        .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+        .setBoundaryTypeMapper(boundaryTypeMapper)
+        .build();
+  }
+
+  private static Boundary<Long> fromLongs(
+      PartitionColumn partitionColumn,
+      ResultSet resultSet,
+      @Nullable BoundaryTypeMapper boundaryTypeMapper)
+      throws SQLException {
+    Preconditions.checkArgument(partitionColumn.columnClass().equals(Long.class));
+    resultSet.next();
+    return Boundary.<Long>builder()
+        .setPartitionColumn(partitionColumn)
+        .setStart(resultSet.getLong(1))
+        .setEnd(resultSet.getLong(2))
+        .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
+        .setBoundaryTypeMapper(boundaryTypeMapper)
+        .build();
+  }
+
+  private static Boundary<String> fromStrings(
+      PartitionColumn partitionColumn,
+      ResultSet resultSet,
+      @Nullable BoundaryTypeMapper boundaryTypeMapper)
+      throws SQLException {
+    Preconditions.checkArgument(partitionColumn.columnClass().equals(String.class));
+    Preconditions.checkArgument(
+        boundaryTypeMapper != null,
+        "String extractor needs boundaryTypeMapper. PartitionColumn = " + partitionColumn);
+    resultSet.next();
+    return Boundary.<String>builder()
+        .setPartitionColumn(partitionColumn)
+        .setStart(resultSet.getString(1))
+        .setEnd(resultSet.getString(2))
+        .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
+        .setBoundaryTypeMapper(boundaryTypeMapper)
+        .build();
+  }
+
+  private BoundaryExtractorFactory() {}
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundarySplitter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundarySplitter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
+
+import java.io.Serializable;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+
+/**
+ * Interface to split point for a boundary to split into half.
+ *
+ * <p>Note:
+ *
+ * <p>
+ *
+ * <ol>
+ *   <li>Implementations must not assume that that start is less than end. It depends on the
+ *       specific ordering used by the database schema.
+ *   <li>Implementations must be overflow safe.
+ *   <li>Implementations must guarantee that the splitter is idempotent. The same boundary must get
+ *       same split point through the lifetime of the migration.
+ *   <li>Implementations must guarantee that the database would teat the splitpoint as being
+ *       in-between the start and end as per the ordering and collation used for the partition
+ *       column.
+ * </ol>
+ */
+public interface BoundarySplitter<T extends Serializable> extends Serializable {
+
+  /**
+   * Get Split point for start and end.
+   *
+   * @param start star of the boundary.
+   * @param end end of the boundary.
+   * @param partitionColumn column being split.
+   * @param boundaryTypeMapper mapper for types like strings. Must not be null if strings are part
+   *     of the partition column list.
+   * @param processContext process context during transforms. Must not be null if strings are part
+   *     of the partition column list.
+   * @return
+   */
+  T getSplitPoint(
+      T start,
+      T end,
+      @Nullable PartitionColumn partitionColumn,
+      @Nullable BoundaryTypeMapper boundaryTypeMapper,
+      @Nullable ProcessContext processContext);
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundarySplitterFactory.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundarySplitterFactory.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import java.io.Serializable;
+import java.math.BigInteger;
+import org.apache.beam.sdk.transforms.DoFn;
+
+/** Factory to construct {@link BoundarySplitter} for supported classes. */
+public class BoundarySplitterFactory {
+  private static final ImmutableMap<Class, BoundarySplitter<?>> splittermap =
+      ImmutableMap.of(
+          Integer.class,
+              (BoundarySplitter<Integer>)
+                  (start, end, partitionColumn, boundaryTypeMapper, processContext) ->
+                      splitIntegers(start, end),
+          Long.class,
+              (BoundarySplitter<Long>)
+                  (start, end, partitionColumn, boundaryTypeMapper, processContext) ->
+                      splitLongs(start, end),
+          BigInteger.class,
+              (BoundarySplitter<BigInteger>)
+                  (start, end, partitionColumn, boundaryTypeMapper, processContext) ->
+                      splitBigIntegers(start, end),
+          String.class, (BoundarySplitter<String>) BoundarySplitterFactory::splitStrings);
+
+  /**
+   * Creates {@link BoundarySplitter BoundarySplitter&lt;T&gt;} for pass class {@code c} such that
+   * {@code T.getClass == c}.
+   *
+   * @param c Class for the type of {@link BoundarySplitter}
+   * @return {@link BoundarySplitter BoundarySplitter&lt;T&gt;}
+   * @throws UnsupportedOperationException if BoundarySplitter is not yet implemented.
+   */
+  public static <T extends Serializable> BoundarySplitter<T> create(Class c) {
+
+    BoundarySplitter<T> splitter = (BoundarySplitter<T>) splittermap.get(c);
+    if (splitter == null) {
+      throw new UnsupportedOperationException("Range Splitter not implemented for class " + c);
+    }
+    return splitter;
+  }
+
+  private BoundarySplitterFactory() {}
+
+  private static Integer splitIntegers(Integer start, Integer end) {
+    if (start == null && end == null) {
+      return null;
+    }
+    if (start == null) {
+      start = Integer.MIN_VALUE;
+    }
+    if (end == null) {
+      end = Integer.MIN_VALUE;
+    }
+
+    /*
+     * We need to find mid point between start and end which is *consistently* rounded down.
+     * There are various ways to do this:
+     * 1. (start + end) /2 - This will overflow if (start + end) overflows.
+     * 2. (start + (end - start)/2) will overflow if (end - start) overflow, this happens if start is closer to Integer.Min and end closer to Integer.Max.
+     * 3. (start + (end/2 - start/2) does not have consistent rounding. For example this will give 11 for 9 and 12 (rounded-up) and give 11 for 10 and 13 too (rounded-down).
+     * 4. The method we have used here is free of overflows. Here is how it works
+     * 4.1 a + b = (a^b) + (a&b) << 1. bit wise addition is xor of individual bits + carry left shifted by 1.
+     * 4.2 therefore, (a+b)/2 = (a&b) + (a^b)>>1. The right side expressions dont have any overflow.
+     */
+    return (start & end) + ((start ^ end) >> 1);
+  }
+
+  private static BigInteger splitBigIntegers(BigInteger start, BigInteger end) {
+    BigInteger low;
+    BigInteger high;
+    if (start == null && end == null) {
+      return null;
+    }
+    if (start == null) {
+      start = BigInteger.ZERO;
+    }
+    if (end == null) {
+      end = BigInteger.ZERO;
+    }
+
+    if (start.compareTo(end) <= 0) {
+      low = start;
+      high = end;
+    } else {
+      high = start;
+      low = end;
+    }
+    return low.add((high.subtract(low)).divide(BigInteger.TWO));
+  }
+
+  private static Long splitLongs(Long start, Long end) {
+    Long low;
+    Long high;
+
+    if (start == null && end == null) {
+      return null;
+    }
+    if (start == null) {
+      start = Long.MIN_VALUE;
+    }
+    if (end == null) {
+      end = Long.MIN_VALUE;
+    }
+
+    /*
+     * We need to find mid point between start and end which is *consistently* rounded down.
+     * There are various ways to do this:
+     * 1. (start + end) /2 - This will overflow if (start + end) overflows.
+     * 2. (start + (end - start)/2) will overflow if (end - start) overflow, this happens if start is closer to Long.Min and end closer to Long.Max.
+     * 3. (start + (end/2 - start/2) does not have consistent rounding. For example this will give 11 for 9 and 12 (rounded-up) and give 11 for 10 and 13 too (rounded-down).
+     * 4. The method we have used here is free of overflows. Here is how it works
+     * 4.1 a + b = (a^b) + (a&b) << 1. bit wise addition is xor of individual bits + carry left shifted by 1.
+     * 4.2 therefore, (a+b)/2 = (a&b) + (a^b)>>1. The right side expressions dont have any overflow.
+     */
+    return (start & end) + ((start ^ end) >> 1);
+  }
+
+  private static String splitStrings(
+      String start,
+      String end,
+      PartitionColumn partitionColumn,
+      BoundaryTypeMapper typeMapper,
+      DoFn.ProcessContext c) {
+    Preconditions.checkArgument(typeMapper != null, "Trying to split strings without type mapper.");
+    Preconditions.checkArgument(
+        partitionColumn != null, "Trying to split strings without partition column information.");
+    Preconditions.checkArgument(
+        partitionColumn.columnClass() == String.class,
+        "Trying to split strings for a non-string class.");
+    if (start == null && end == null) {
+      return null;
+    }
+    if (start == null) {
+      start = "";
+    }
+    if (end == null) {
+      end = "";
+    }
+    // Ideally no string will be longer than the column's max length, unless a table is altered
+    // during a run.
+    // To avoid undefined behaviour in the padding logic, we take the max of the input strings and
+    // the partition column width.
+    int lengthToPad =
+        Math.max(
+            Math.max(start.length(), end.length()), partitionColumn.stringMaxLength().intValue());
+    BigInteger bigIntegerStart =
+        (BigInteger) typeMapper.mapString(start, lengthToPad, partitionColumn, c);
+    BigInteger bigIntegerEnd =
+        (BigInteger) typeMapper.mapString(end, lengthToPad, partitionColumn, c);
+    BigInteger bigIntegerSplit = splitBigIntegers(bigIntegerStart, bigIntegerEnd);
+    return (String) typeMapper.unMapString(bigIntegerSplit, partitionColumn, c);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryTypeMapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryTypeMapper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
+
+import java.io.Serializable;
+import java.math.BigInteger;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+
+/**
+ * Maps a Boundary Type from one to another. This allows the implementation to support splitting
+ * types like strings which can be mapped to BigInteger.
+ */
+public interface BoundaryTypeMapper extends Serializable {
+  BigInteger mapString(
+      String element, int lengthTOPad, PartitionColumn partitionColumn, ProcessContext c);
+
+  String unMapString(BigInteger element, PartitionColumn partitionColumn, ProcessContext c);
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/PartitionColumn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/PartitionColumn.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+import java.io.Serializable;
+import javax.annotation.Nullable;
+
+/** Details about a partition column. */
+@AutoValue
+public abstract class PartitionColumn implements Serializable {
+
+  /**
+   * @return name of the column.
+   */
+  public abstract String columnName();
+
+  /**
+   * @return class of the column.
+   */
+  public abstract Class columnClass();
+
+  /**
+   * String Collation. Must be set for if {@link PartitionColumn#columnClass()} is {@link String}
+   * and must not be set otherwise. Defaults to null.
+   *
+   * @return string collation for this column if it's a string column. Null otherwise.
+   */
+  @Nullable
+  public abstract String stringCollation();
+
+  /** Max Length of a string column. Defaults to null for non-string columns. */
+  @Nullable
+  public abstract Integer stringMaxLength();
+
+  public static Builder builder() {
+    return new AutoValue_PartitionColumn.Builder()
+        .setStringCollation(null)
+        .setStringMaxLength(null);
+  }
+
+  public abstract Builder toBuilder();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setColumnName(String value);
+
+    public abstract Builder setColumnClass(Class value);
+
+    public abstract Builder setStringCollation(String value);
+
+    public abstract Builder setStringMaxLength(Integer value);
+
+    abstract PartitionColumn autoBuild();
+
+    public PartitionColumn build() {
+      PartitionColumn partitionColumn = this.autoBuild();
+      Preconditions.checkState(
+          (partitionColumn.columnClass() == String.class
+                  && partitionColumn.stringCollation() != null
+                  && partitionColumn.stringMaxLength() != null)
+              || (partitionColumn.columnClass() != String.class
+                  && partitionColumn.stringCollation() == null
+                  && partitionColumn.stringMaxLength() == null),
+          "String columns must specify collation, and non string columns must not specify colaltion. PartitionColum = "
+              + partitionColumn);
+      return partitionColumn;
+    }
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/Range.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/Range.java
@@ -1,0 +1,415 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+import java.io.Serializable;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+import org.apache.commons.lang3.tuple.Pair;
+
+/** Represents a range of rows to read from. */
+@AutoValue
+public abstract class Range implements Serializable, Comparable<Range> {
+
+  /** Indicator that a range is not yet counted or that the count has timed out. */
+  public static final long INDETERMINATE_COUNT = Long.MAX_VALUE;
+
+  /**
+   * @return boundary of the range.
+   */
+  abstract Boundary<?> boundary();
+
+  /**
+   * @return child range. null if there's no child range.
+   */
+  @Nullable
+  public abstract Range childRange();
+
+  /**
+   * Count of a given range. Defaults to {@link Range#INDETERMINATE_COUNT}.
+   *
+   * @return count of rows represented by the range.
+   */
+  public abstract long count();
+
+  /**
+   * Height for this range. The leaf child always has a height of 0. Defaults to 0.
+   *
+   * @return split height.
+   */
+  public abstract long height();
+
+  /**
+   * Is this the first range of a given index. Helps to generate inclusive or exclusive bounds on
+   * the range query.
+   *
+   * @return true if this is a first range of a given index.
+   */
+  public abstract boolean isFirst();
+
+  /**
+   * Is this the last range of a given index. Helps to generate inclusive or exclusive bounds on the
+   * range query.
+   *
+   * @return true if this is the last range of a given index.
+   */
+  public abstract boolean isLast();
+
+  /**
+   * Generate a {@link Builder} from a given {@link Range}.
+   *
+   * @return builder.
+   */
+  public abstract Builder toBuilder();
+
+  public String colName() {
+    return this.boundary().colName();
+  }
+
+  @Nullable
+  public Object start() {
+    return this.boundary().start();
+  }
+
+  @Nullable
+  public Object end() {
+    return this.boundary().end();
+  }
+
+  /**
+   * @return builder for {@link Range}.
+   */
+  public static <T extends Serializable> Builder builder() {
+    return new AutoValue_Range.Builder()
+        .setCount(INDETERMINATE_COUNT)
+        .setHeight(0L)
+        .setIsFirst(false)
+        .setIsLast(false);
+  }
+
+  /**
+   * @return true if the range is not yet counted, or if the count query for this range has
+   *     timedout.
+   */
+  public boolean isUncounted() {
+    return count() == INDETERMINATE_COUNT;
+  }
+
+  /**
+   * Return a cloned Range with count parameter set.
+   *
+   * @param count count of the range
+   * @return range with count.
+   */
+  public Range withCount(long count, @Nullable ProcessContext processContext) {
+    if (hasChildRange()) {
+      return withChildRange(childRange().withCount(count, processContext), processContext);
+    }
+    return this.toBuilder().setCount(count).build();
+  }
+
+  /**
+   * Add Counts ensuring that uncounted ranges don't lead to overflow. It is assumed that the total
+   * rows moved by the migration job is less than {@link Long#MAX_VALUE}
+   *
+   * @param left
+   * @param right
+   * @return
+   */
+  private static long addCount(long left, long right) {
+    if (left == INDETERMINATE_COUNT || right == INDETERMINATE_COUNT) {
+      return INDETERMINATE_COUNT;
+    }
+    // Unless the ranges are not counted, we will not have counts overflow as we don't support
+    // tables with (LONG.MAX / 2) rows.
+    return left + right;
+  }
+
+  /**
+   * Acccumulates Counts ensuring that uncounted ranges don't lead to overflow. It is assumed that
+   * the total rows moved by the migration job is less than {@link Long#MAX_VALUE}
+   *
+   * @param accumulator the current value of accumulator
+   * @return new value of accumulator, with the count of this range accumulated.
+   */
+  public long accumulateCount(long accumulator) {
+    return addCount(accumulator, count());
+  }
+
+  /**
+   * Returns given range with child range added to it.
+   *
+   * @param childRange child range.
+   * @param processContext process context.
+   * @return Range with child range appended.
+   * @throws IllegalStateException if parent is splittable. This indicates programming error and
+   *     should not be seen in production.
+   * @throws IllegalArgumentException if child and parent have the same column. This indicates
+   *     programming error and should not be seen in production.
+   */
+  public Range withChildRange(Range childRange, @Nullable ProcessContext processContext) {
+
+    Preconditions.checkState(
+        !this.boundary().isSplittable(processContext),
+        "Only non-splittable Ranges can have a childRange. Range: " + this);
+    Preconditions.checkArgument(
+        this.colName() != childRange.colName(),
+        String.format(
+            "Composite ranges must be on different columns, parent = %s, child = %s",
+            this, childRange));
+    return this.toBuilder()
+        .setChildRange(childRange)
+        .setCount(childRange.count())
+        .setHeight(childRange.height() + 1)
+        .build();
+  }
+
+  /**
+   * @return true if a given range has a child range. False otherwise.
+   */
+  public boolean hasChildRange() {
+    return (this.childRange() != null);
+  }
+
+  /**
+   * Returns true if a given Range can be split. Split always happens at the deepest child range.
+   *
+   * @return true if a range can be split.
+   */
+  public boolean isSplittable(@Nullable ProcessContext processContext) {
+    return (hasChildRange() && childRange().isSplittable(processContext))
+        || boundary().isSplittable(processContext);
+  }
+
+  /**
+   * Split a given range into 2 ranges via the {@link Range#boundary() boundary's} {@link
+   * Boundary#split(ProcessContext) split()}. The caller must ensure that the range is splittable.
+   * The caller should use {@link Range#isSplittable(ProcessContext)} to check if the range is
+   * splittable before calling {@link Range#split(ProcessContext)}.
+   *
+   * @return a pair of split ranges.
+   * @throws IllegalArgumentException if the range is not splittable. this indicates a programming
+   *     error and should not be seen in production.
+   */
+  public Pair<Range, Range> split(@Nullable ProcessContext processContext) {
+    if (!this.isSplittable(processContext)) {
+      throw new IllegalArgumentException("Trying to split non-splittable range: " + this);
+    }
+    if (hasChildRange()) {
+      Pair<Range, Range> splitChild = childRange().split(processContext);
+      return Pair.of(
+          this.withChildRange(splitChild.getLeft(), processContext),
+          this.withChildRange(splitChild.getRight(), processContext));
+    }
+    Pair<? extends Boundary<?>, ? extends Boundary<?>> boundaries =
+        boundary().split(processContext);
+    return Pair.of(
+        this.toBuilder()
+            .setBoundary(boundaries.getLeft())
+            .setIsFirst(isFirst())
+            .setIsLast(false)
+            .build(),
+        this.toBuilder()
+            .setBoundary(boundaries.getRight())
+            .setIsFirst(false)
+            .setIsLast(isLast())
+            .build());
+  }
+
+  /**
+   * Checks if two ranges can be merged with each other.
+   *
+   * @param other other range
+   * @return true if ranges are mergable.
+   */
+  public boolean isMergable(Range other) {
+    if (this.hasChildRange() || other.hasChildRange()) {
+      if (!this.baseEqual(other)) {
+        // For merging children, for parent ranges start, end, columnName and height should be
+        // equal.
+        return false;
+      }
+      return this.childRange().isMergable(other.childRange());
+    } else {
+      return Objects.equal(this.end(), other.start()) || Objects.equal(this.start(), other.end());
+    }
+  }
+
+  /**
+   * Merge 2 ranges. The caller must ensure that the ranges are mergable. The caller should use
+   * {@link Range#isMergable(Range)} to check if the range is mergable before calling {@link
+   * Range#mergeRange(Range)}.
+   *
+   * @param other Range to merge
+   * @return merged range
+   * @throws IllegalArgumentException if ranges are not mergable. This indicates a programming error
+   *     and should not be seen in production.
+   */
+  public Range mergeRange(Range other, @Nullable ProcessContext processContext) {
+    Preconditions.checkArgument(
+        this.isMergable(other),
+        "Trying to merge non-mergable ranges. this: " + this + " other: " + other);
+    if (this.hasChildRange()) {
+      Range mergedChild = this.childRange().mergeRange(other.childRange(), processContext);
+      return this.withChildRange(mergedChild, processContext);
+    } else {
+      if (Objects.equal(this.end(), other.start())) {
+        return this.toBuilder()
+            .setBoundary(this.boundary().merge(other.boundary()))
+            .setCount(addCount(this.count(), other.count()))
+            .setIsLast(other.isLast())
+            .build();
+      } else {
+        return this.toBuilder()
+            .setBoundary(this.boundary().merge(other.boundary()))
+            .setCount(addCount(this.count(), other.count()))
+            .setIsFirst(other.isFirst())
+            .build();
+      }
+    }
+  }
+
+  /**
+   * Check Equality of ranges.
+   *
+   * @param obj to check equality.
+   * @return true if equal.
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (!this.baseEqual(obj)) {
+      return false;
+    }
+    Range that = (Range) obj;
+    if (this.count() != that.count()) {
+      return false;
+    }
+    return Objects.equal(this.childRange(), that.childRange());
+  }
+
+  private boolean baseEqual(Object obj) {
+    if (obj == null) {
+      return false;
+    }
+    if (obj == this) {
+      return true;
+    }
+    if (this.getClass() != obj.getClass()) {
+      return false;
+    }
+    Range that = (Range) obj;
+    return Objects.equal(this.boundary(), that.boundary())
+        && (this.height() == that.height())
+        && this.colName().equals(that.colName());
+  }
+
+  /**
+   * Compares this {@link Range} with the specified {@link Range} for order. When the Ranges are
+   * sorted, it's desirable the Ranges that have got split from the same parent range are ordered as
+   * per the in-oder traversal of their splitting.
+   *
+   * @param other the {@link Range} to be compared.
+   * @return a negative integer, zero, or a positive integer as this {@link Range} is less than,
+   *     equal to, or greater than the specified {@link Range}.
+   */
+  @Override
+  public int compareTo(Range other) {
+
+    if (this.equals(other)) {
+      return 0;
+    }
+    int result = this.boundary().compareTo(other.boundary());
+    if (result != 0) {
+      return result;
+    }
+
+    result = Long.valueOf(height()).compareTo(Long.valueOf(other.height()));
+    if (result != 0) {
+      return result;
+    }
+    if (hasChildRange()) {
+      // Heights are aready compared.
+      result = this.childRange().compareTo(other.childRange());
+      if (result != 0) {
+        return result;
+      }
+    }
+    result = Long.valueOf(this.count()).compareTo(other.count());
+
+    Preconditions.checkState(
+        result != 0,
+        "Ranges that have same boundary, height, children and count must be equal. This = "
+            + this
+            + " other = "
+            + other);
+
+    return result;
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    protected abstract Builder setBoundary(Boundary<?> value);
+
+    abstract Boundary.Builder boundaryBuilder();
+
+    public abstract Builder setCount(long value);
+
+    protected abstract Builder setHeight(long value);
+
+    public abstract Builder setIsFirst(boolean value);
+
+    public abstract Builder setIsLast(boolean value);
+
+    protected abstract Builder setChildRange(Range value);
+
+    public Builder setColName(String colName) {
+      this.boundaryBuilder().setColName(colName);
+      return this;
+    }
+
+    public Builder setColClass(Class value) {
+      this.boundaryBuilder().setColClass(value);
+      return this;
+    }
+
+    public <T extends Serializable> Builder setStart(@Nullable T start) {
+      this.boundaryBuilder().setStart(start);
+      return this;
+    }
+
+    public <T extends Serializable> Builder setEnd(@Nullable T end) {
+      this.boundaryBuilder().setEnd(end);
+      return this;
+    }
+
+    public <T extends Serializable> Builder setBoundarySplitter(
+        BoundarySplitter<T> boundarySplitter) {
+      this.boundaryBuilder().setBoundarySplitter(boundarySplitter);
+      return this;
+    }
+
+    /**
+     * Build {@link Range}.
+     *
+     * @return range.
+     */
+    public abstract Range build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/RangePreparedStatementSetter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/RangePreparedStatementSetter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
+import com.google.common.collect.ImmutableList;
+import java.sql.PreparedStatement;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.io.jdbc.JdbcIO.PreparedStatementSetter;
+import org.checkerframework.checker.initialization.qual.Initialized;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
+
+/**
+ * Implement {@link PreparedStatementSetter} to set {@link PreparedStatement} parameters for getting
+ * a count of, and reading a {@link Range}.
+ */
+public class RangePreparedStatementSetter implements PreparedStatementSetter<Range> {
+
+  private long numColumns;
+
+  public RangePreparedStatementSetter(long numColumns) {
+    this.numColumns = numColumns;
+  }
+
+  /**
+   * Set range parameters for the {@link PreparedStatement}.
+   *
+   * @param element Range for which parameters are set.
+   * @param preparedStatement the prepared statement.
+   * @param startParameterIdx initial parameter index in case of chaining.
+   * @throws Exception coming form jdbc. Since this is in run-time, beam will retry the exception.
+   * @see MysqlDialectAdapter#getReadQuery(String, ImmutableList)
+   * @see MysqlDialectAdapter#getCountQuery(String, ImmutableList, long)
+   */
+  public void setRangeParameters(
+      @Nullable Range element,
+      @UnknownKeyFor @NonNull @Initialized PreparedStatement preparedStatement,
+      int startParameterIdx)
+      throws @UnknownKeyFor @NonNull @Initialized Exception {
+
+    long rangeColumns = (element != null) ? element.height() + 1 : 0;
+    long extraColumns = numColumns - rangeColumns;
+    Range range = element;
+    for (long i = 0; i < rangeColumns; i++) {
+      preparedStatement.setObject(startParameterIdx++, true /* include column */);
+      preparedStatement.setObject(startParameterIdx++, range.start());
+      preparedStatement.setObject(startParameterIdx++, range.end());
+      preparedStatement.setObject(startParameterIdx++, range.isLast());
+      preparedStatement.setObject(startParameterIdx++, range.end());
+      range = range.childRange();
+    }
+    for (long i = 0; i < extraColumns; i++) {
+      preparedStatement.setObject(startParameterIdx++, false /* include column */);
+      preparedStatement.setObject(startParameterIdx++, null);
+      preparedStatement.setObject(startParameterIdx++, null);
+      preparedStatement.setObject(startParameterIdx++, false);
+      preparedStatement.setObject(startParameterIdx++, null);
+    }
+  }
+
+  @Override
+  public void setParameters(
+      Range element, @UnknownKeyFor @NonNull @Initialized PreparedStatement preparedStatement)
+      throws @UnknownKeyFor @NonNull @Initialized Exception {
+    setRangeParameters(element, preparedStatement, 1);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Range for Uniform Splitter. The {@code range} package implements classes to describe and split
+ * the range of indexed rows into near uniform partitions.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/InitialSplitRangeDoFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/InitialSplitRangeDoFn.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collections;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Generates initial splits for the first partition column, upto max partitions, assuming uniform
+ * density to begin with.
+ */
+@AutoValue
+public abstract class InitialSplitRangeDoFn extends DoFn<Range, ImmutableList<Range>> {
+
+  /**
+   * How many iterations of splits to do. For example if you want 1024 ranges to get created
+   * initially, set this to 10.
+   *
+   * @return split height for initial split.
+   */
+  abstract long splitHeight();
+
+  abstract String tableName();
+
+  private static final Logger logger = LoggerFactory.getLogger(InitialSplitRangeDoFn.class);
+
+  /**
+   * @param input Range indicating Min and Max of the first partition column.
+   * @param out output receiver for a list of initial split of ranges. The ranges are not counted as
+   *     yet.
+   * @param c process context
+   */
+  @ProcessElement
+  public void processElement(
+      @Element Range input, OutputReceiver<ImmutableList<Range>> out, ProcessContext c) {
+
+    logger.info(
+        "RWUPT - Began split process for table {} with initia range as {}", tableName(), input);
+
+    ArrayList<Range> ranges = new ArrayList<Range>();
+    ranges.add(input);
+    ArrayList<Range> splitRanges = new ArrayList<>();
+    for (long i = 0; i < splitHeight(); i++) {
+      logger.info(
+          "RWUPT - Creating initial split for table {}. Iteration {} of {}",
+          tableName(),
+          i,
+          splitHeight());
+      for (Range range : ranges) {
+        if (range.isSplittable(c)) {
+          Pair<Range, Range> splitPair = range.split(c);
+          splitRanges.add(splitPair.getLeft());
+          splitRanges.add(splitPair.getRight());
+        } else {
+          splitRanges.add(range);
+        }
+      }
+      ranges = new ArrayList<>(splitRanges);
+      splitRanges.clear();
+    }
+    Collections.sort(ranges);
+    logger.info(
+        "RWUPT - Completed initial split for table {} with initial range as {}, and {} split ranges",
+        tableName(),
+        input,
+        ranges.size());
+    out.output(ImmutableList.copyOf(ranges));
+  }
+
+  public static Builder builder() {
+    return new AutoValue_InitialSplitRangeDoFn.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setSplitHeight(long value);
+
+    public abstract Builder setTableName(String value);
+
+    public abstract InitialSplitRangeDoFn build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/InitialSplitRangeDoFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/InitialSplitRangeDoFn.java
@@ -53,9 +53,10 @@ public abstract class InitialSplitRangeDoFn extends DoFn<Range, ImmutableList<Ra
   @ProcessElement
   public void processElement(
       @Element Range input, OutputReceiver<ImmutableList<Range>> out, ProcessContext c) {
-
+    // Note Searching for "RWUPT -" for ReadWithUniformPartition gives the most import logs for the
+    // splitting process.
     logger.info(
-        "RWUPT - Began split process for table {} with initia range as {}", tableName(), input);
+        "RWUPT - Began split process for table {} with initial range as {}", tableName(), input);
 
     ArrayList<Range> ranges = new ArrayList<Range>();
     ranges.add(input);

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MergeRangesDoFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MergeRangesDoFn.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.common.collect.ImmutableList;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@AutoValue
+public abstract class MergeRangesDoFn extends DoFn<ImmutableList<Range>, ImmutableList<Range>> {
+
+  private static final Logger logger = LoggerFactory.getLogger(MergeRangesDoFn.class);
+
+  /** Approximate row count of the table. */
+  abstract Long approxTotalRowCount();
+
+  /** Max partitions hint as set or auto-inferred by {@link ReadWithUniformPartitions}. */
+  abstract Long maxPartitionHint();
+
+  /**
+   * If true, MaxPartitions will be inferred again after total counts of all ranges is not
+   * in-determinate.
+   */
+  abstract Boolean autoAdjustMaxPartitions();
+
+  /** Name of the table. */
+  abstract String tableName();
+
+  /**
+   * Merge the ranges to get closer to the mean if possible. This DoFn applied at the end of the
+   * split process tries to give number of ranges closer to maxPartitions, to avoid unintented
+   * partitions. Note: In case of composite keys, it is possible to end up with more ranges than the
+   * maxPartitions, for example a range with first column along can not merge with a consecutive
+   * range that spans first and second column both.
+   *
+   * @param input list of ranges to merge.
+   * @param out output receiver for the merged ranges.
+   * @param c process context.
+   */
+  @ProcessElement
+  public void processElement(
+      @Element ImmutableList<Range> input,
+      OutputReceiver<ImmutableList<Range>> out,
+      ProcessContext c) {
+    out.output(mergeRanges(input, c));
+  }
+
+  public static Builder builder() {
+    return new AutoValue_MergeRangesDoFn.Builder();
+  }
+
+  private ImmutableList<Range> mergeRanges(ImmutableList<Range> input, ProcessContext c) {
+
+    long totoalCount = approxTotalRowCount();
+
+    long mean = 0;
+
+    long accumulatedCount = 0;
+
+    logger.info(
+        "RWUPT - Began merging split-ranges for table {} initial split range count as {}",
+        tableName(),
+        input.size());
+
+    // TODO(vardhanvthigle): moving the total count clcuation to combiner will remove code
+    // duplication with {@link RangeClassifierDoFn}.
+    // Refine the Count.
+    for (Range range : input) {
+      accumulatedCount = range.accumulateCount(accumulatedCount);
+    }
+    if (accumulatedCount != Range.INDETERMINATE_COUNT) {
+      totoalCount = accumulatedCount;
+    }
+
+    long maxPartitions = maxPartitionHint();
+    if (autoAdjustMaxPartitions()) {
+      maxPartitions = ReadWithUniformPartitions.inferMaxPartitions(totoalCount);
+    }
+    mean = Math.max(1, totoalCount / maxPartitions);
+
+    ImmutableList.Builder<Range> mergedRanges = ImmutableList.builder();
+    Range lastMergedRange = null; // Store the last merged range
+    for (Range currentRange : input) {
+      if (lastMergedRange == null) {
+        lastMergedRange = currentRange; // First range, no merging yet
+      } else if (lastMergedRange.isMergable(currentRange)
+          && lastMergedRange.accumulateCount(currentRange.count()) <= mean) {
+        // Merge ranges and update lastMergedRange
+        lastMergedRange = lastMergedRange.mergeRange(currentRange, c);
+      } else {
+        // Ranges aren't mergeable, add the lastMergedRange to the result
+        mergedRanges.add(lastMergedRange);
+        lastMergedRange = currentRange; // Update lastMergedRange
+      }
+    }
+    if (lastMergedRange != null) {
+      mergedRanges.add(lastMergedRange); // Add the last merged range
+    }
+
+    ImmutableList<Range> output = mergedRanges.build();
+
+    logger.info(
+        "RWUPT - Completed split process (merging) split-ranges for table {} initial split range {}, final range count as {}",
+        tableName(),
+        input,
+        output.size());
+
+    return output;
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setApproxTotalRowCount(Long value);
+
+    public abstract Builder setMaxPartitionHint(Long value);
+
+    public abstract Builder setAutoAdjustMaxPartitions(Boolean value);
+
+    public abstract Builder setTableName(String value);
+
+    public abstract MergeRangesDoFn build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MergeRangesDoFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MergeRangesDoFn.java
@@ -67,7 +67,7 @@ public abstract class MergeRangesDoFn extends DoFn<ImmutableList<Range>, Immutab
 
   private ImmutableList<Range> mergeRanges(ImmutableList<Range> input, ProcessContext c) {
 
-    long totoalCount = approxTotalRowCount();
+    long totalCount = approxTotalRowCount();
 
     long mean = 0;
 
@@ -85,14 +85,14 @@ public abstract class MergeRangesDoFn extends DoFn<ImmutableList<Range>, Immutab
       accumulatedCount = range.accumulateCount(accumulatedCount);
     }
     if (accumulatedCount != Range.INDETERMINATE_COUNT) {
-      totoalCount = accumulatedCount;
+      totalCount = accumulatedCount;
     }
 
     long maxPartitions = maxPartitionHint();
     if (autoAdjustMaxPartitions()) {
-      maxPartitions = ReadWithUniformPartitions.inferMaxPartitions(totoalCount);
+      maxPartitions = ReadWithUniformPartitions.inferMaxPartitions(totalCount);
     }
-    mean = Math.max(1, totoalCount / maxPartitions);
+    mean = Math.max(1, totalCount / maxPartitions);
 
     ImmutableList.Builder<Range> mergedRanges = ImmutableList.builder();
     Range lastMergedRange = null; // Store the last merged range
@@ -115,10 +115,12 @@ public abstract class MergeRangesDoFn extends DoFn<ImmutableList<Range>, Immutab
 
     ImmutableList<Range> output = mergedRanges.build();
 
+    // Note Searching for "RWUPT -" for ReadWithUniformPartition gives the most import logs for the
+    // splitting process.
     logger.info(
-        "RWUPT - Completed split process (merging) split-ranges for table {} initial split range {}, final range count as {}",
+        "RWUPT - Completed split process (merging) split-ranges for table {} initial split range count {}, final range count as {}",
         tableName(),
-        input,
+        input.size(),
         output.size());
 
     return output;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryDoFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryDoFn.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary.ColumnForBoundaryQuery;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary.ColumnForBoundaryQueryPreparedStatementSetter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundaryExtractorFactory;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundaryTypeMapper;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import javax.annotation.Nullable;
+import javax.sql.DataSource;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** DoFn to find boundary (min, max) for a column (optionally for a given parent range). */
+final class RangeBoundaryDoFn extends DoFn<ColumnForBoundaryQuery, Range> implements Serializable {
+
+  private static final Logger logger = LoggerFactory.getLogger(RangeBoundaryDoFn.class);
+  private final SerializableFunction<Void, DataSource> dataSourceProviderFn;
+
+  private final UniformSplitterDBAdapter dbAdapter;
+
+  private String tableName;
+  private ImmutableList<String> partitionColumns;
+
+  @Nullable private BoundaryTypeMapper boundaryTypeMapper;
+
+  @JsonIgnore private transient @Nullable DataSource dataSource;
+
+  RangeBoundaryDoFn(
+      SerializableFunction<Void, DataSource> dataSourceProviderFn,
+      UniformSplitterDBAdapter dbAdapter,
+      String tableName,
+      ImmutableList<String> partitionColumns,
+      BoundaryTypeMapper boundaryTypeMapper) {
+    this.dataSourceProviderFn = dataSourceProviderFn;
+    this.dbAdapter = dbAdapter;
+    this.tableName = tableName;
+    this.partitionColumns = partitionColumns;
+    this.dataSource = null;
+    this.boundaryTypeMapper = boundaryTypeMapper;
+  }
+
+  @Setup
+  public void setup() throws Exception {
+    dataSource = dataSourceProviderFn.apply(null);
+  }
+
+  private Connection acquireConnection() throws SQLException {
+    return checkStateNotNull(this.dataSource).getConnection();
+  }
+
+  /**
+   * DoFn to find boundary (min, max) for a column (optionally for a given parent range).
+   *
+   * @param input Details for the column and parent range for which a boundary is requested.
+   * @param out new Range with column boundary.
+   * @param c process context.
+   * @throws SQLException - since this is in the run time, beam will auto retry the exception.
+   */
+  @ProcessElement
+  public void processElement(
+      @Element ColumnForBoundaryQuery input, OutputReceiver<Range> out, ProcessContext c)
+      throws SQLException {
+    String boundaryQuery =
+        dbAdapter.getBoundaryQuery(tableName, partitionColumns, input.columnName());
+
+    try (Connection conn = acquireConnection()) {
+      PreparedStatement stmt =
+          conn.prepareStatement(
+              boundaryQuery, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+      new ColumnForBoundaryQueryPreparedStatementSetter(partitionColumns)
+          .setParameters(input, stmt);
+      ResultSet rs = stmt.executeQuery();
+      Range output =
+          BoundaryExtractorFactory.create(input.columnClass())
+              .getBoundary(input.partitionColumn(), rs, boundaryTypeMapper)
+              .toRange(input.parentRange(), c);
+      logger.debug(
+          "Got Boundary, Input = {}, Range = {}, Query = {}, DataSource = {}",
+          input,
+          output,
+          boundaryQuery,
+          dataSource);
+      out.output(output); // Output the counted Range.
+    } catch (SQLException e) {
+      logger.warn(
+          "SQL Exception = {} while getting boundary of columnForRange = {}, Query = {}, DataSource = {}. This will be retried by Beam Runner.",
+          e,
+          input,
+          boundaryQuery,
+          dataSource);
+      throw e;
+    } catch (Exception e) {
+      // This exception is triggered from nullness checks of checker framework for the input to
+      // statement preparator and hence should
+      // indicate a programming error. Any other exception in the code flow returns a SQL Exception.
+      // It's hard to trigger this exception for UT as the checks are not running by default in the
+      // UT.
+      logger.error(
+          "Exception = {}, ColumnForRange = {}, Query = {}, DataSource = {}",
+          e,
+          input,
+          boundaryQuery,
+          dataSource);
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryTransform.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryTransform.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary.ColumnForBoundaryQuery;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundaryTypeMapper;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import javax.annotation.Nullable;
+import javax.sql.DataSource;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.PCollection;
+
+/**
+ * Transform that wraps {@link RangeBoundaryDoFn} to get to find boundary (min, max) for a column
+ * (optionally for a given parent range).
+ */
+@AutoValue
+public abstract class RangeBoundaryTransform
+    extends PTransform<PCollection<ColumnForBoundaryQuery>, PCollection<Range>>
+    implements Serializable {
+
+  /** Provider for {@link DataSource}. */
+  abstract SerializableFunction<Void, DataSource> dataSourceProviderFn();
+
+  /**
+   * Implementations of {@link UniformSplitterDBAdapter} to get queries as per the dialect of the
+   * database.
+   */
+  abstract UniformSplitterDBAdapter dbAdapter();
+
+  /** Name of the table. */
+  abstract String tableName();
+
+  /** Partition Columns. */
+  abstract ImmutableList<String> partitionColumns();
+
+  /** Type mapper to help map types like {@link String String.Class}. */
+  @Nullable
+  abstract BoundaryTypeMapper boundaryTypeMapper();
+
+  @Override
+  public PCollection<Range> expand(PCollection<ColumnForBoundaryQuery> input) {
+    return input.apply(
+        ParDo.of(
+            new RangeBoundaryDoFn(
+                dataSourceProviderFn(),
+                dbAdapter(),
+                tableName(),
+                partitionColumns(),
+                boundaryTypeMapper())));
+  }
+
+  public static Builder builder() {
+    return new AutoValue_RangeBoundaryTransform.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setDataSourceProviderFn(SerializableFunction<Void, DataSource> value);
+
+    public abstract Builder setDbAdapter(UniformSplitterDBAdapter value);
+
+    public abstract Builder setTableName(String value);
+
+    public abstract Builder setPartitionColumns(ImmutableList<String> value);
+
+    public abstract Builder setBoundaryTypeMapper(@Nullable BoundaryTypeMapper value);
+
+    public abstract RangeBoundaryTransform build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeClassifierDoFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeClassifierDoFn.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary.ColumnForBoundaryQuery;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.PartitionColumn;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Classify ranges into ranges to count, split or retain. */
+@AutoValue
+public abstract class RangeClassifierDoFn extends DoFn<ImmutableList<Range>, Range>
+    implements Serializable {
+
+  private static final Logger logger = LoggerFactory.getLogger(RangeCountDoFn.class);
+
+  // Note it is necessary to retain `new TupleTag<Range>() {}`  though editor might point to
+  // dropping `Range` or the `{}`.
+  // It is necessary to retain the type information for the coder inference of beam to work.
+  // Dropping this will make `ReadWithUniformPartitionsTest` fail with coder not found error.
+  public static final TupleTag<Range> TO_COUNT_TAG = new TupleTag<Range>() {};
+
+  // Note it is necessary to retain `new TupleTag<Range>() {}`  though editor might point to
+  // dropping `Range` or the `{}`.
+  // It is necessary to retain the type information for the coder inference of beam to work.
+  // Dropping this will make `ReadWithUniformPartitionsTest` fail with coder not found error.
+  public static final TupleTag<Range> TO_RETAIN_TAG = new TupleTag<Range>() {};
+
+  // Note it is necessary to retain `new TupleTag<ColumnForBoundaryQuery>() {}`  though editor might
+  // point to dropping `ColumnForBoundaryQuery` or the `{}`.
+  // It is necessary to retain the type information for the coder inference of beam to work.
+  // Dropping this will make `ReadWithUniformPartitionsTest` fail with coder not found error.
+  public static final TupleTag<ColumnForBoundaryQuery> TO_ADD_COLUMN_TAG =
+      new TupleTag<ColumnForBoundaryQuery>() {};
+
+  /** Partition Columns. */
+  abstract ImmutableList<PartitionColumn> partitionColumns();
+
+  /** Approximate row count of the table. */
+  abstract Long approxTotalRowCount();
+
+  /** Max partitions hint as set or auto-inferred by {@link ReadWithUniformPartitions}. */
+  abstract Long maxPartitionHint();
+
+  /**
+   * If true, MaxPartitions will be inferred again after total counts of all ranges is not
+   * in-determinate.
+   */
+  abstract Boolean autoAdjustMaxPartitions();
+
+  /** Stage Index. */
+  abstract Long stageIdx();
+
+  @ProcessElement
+  public void processElement(@Element ImmutableList<Range> input, ProcessContext c) {
+
+    logger.debug("Classifying ranges {} for stage {}.", input, stageIdx());
+
+    long totalCount = approxTotalRowCount();
+
+    long mean = 0;
+
+    long accumulatedCount = 0;
+
+    // TODO(vardhanvthigle): moving the total count clcuation to combiner will remove code
+    // duplication with {@link MergeRangeDoFn}.
+    // Refine the Count.
+    // Refine the Count.
+    for (Range range : input) {
+      accumulatedCount = range.accumulateCount(accumulatedCount);
+    }
+    if (accumulatedCount != Range.INDETERMINATE_COUNT) {
+      totalCount = accumulatedCount;
+    }
+
+    long maxPartitions = maxPartitionHint();
+    if (autoAdjustMaxPartitions()) {
+      maxPartitions = ReadWithUniformPartitions.inferMaxPartitions(totalCount);
+    }
+    mean = Math.max(1, totalCount / maxPartitions);
+
+    for (Range range : input) {
+      if (range.isUncounted()
+          || range.count()
+              > ((1 + ReadWithUniformPartitions.SPLITTER_MAX_RELATIVE_DEVIATION) * mean)) {
+        if (stageIdx() == 0) {
+          // For the first stage, we have an initial split without the counts.
+          c.output(TO_COUNT_TAG, range);
+        } else if (range.isSplittable(c)) {
+          Pair<Range, Range> splitPair = range.split(c);
+          logger.debug(
+              "Counting range {} and {} for stage {}.",
+              splitPair.getLeft(),
+              splitPair.getRight(),
+              stageIdx());
+          c.output(TO_COUNT_TAG, splitPair.getLeft());
+          c.output(TO_COUNT_TAG, splitPair.getRight());
+        } else {
+          if (range.height() + 1 < partitionColumns().size()) {
+            PartitionColumn newColumn = partitionColumns().get((int) (range.height() + 1));
+            ColumnForBoundaryQuery columnForBoundaryQuery =
+                ColumnForBoundaryQuery.builder()
+                    .setPartitionColumn(newColumn)
+                    .setParentRange(range)
+                    .build();
+            logger.debug("Adding Column {} for stage {}.", columnForBoundaryQuery, stageIdx());
+            c.output(TO_ADD_COLUMN_TAG, columnForBoundaryQuery);
+          } else {
+            logger.debug("Retaining range {} for stage {}.", range, stageIdx());
+            c.output(TO_RETAIN_TAG, range);
+          }
+        }
+      } else {
+        logger.debug("Retaining range {} for stage {}.", range, stageIdx());
+        c.output(TO_RETAIN_TAG, range);
+      }
+    }
+  }
+
+  public static Builder builder() {
+    return new AutoValue_RangeClassifierDoFn.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setPartitionColumns(ImmutableList<PartitionColumn> value);
+
+    public abstract Builder setApproxTotalRowCount(Long value);
+
+    public abstract Builder setMaxPartitionHint(Long value);
+
+    public abstract Builder setAutoAdjustMaxPartitions(Boolean value);
+
+    public abstract Builder setStageIdx(Long value);
+
+    public abstract RangeClassifierDoFn build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCombiner.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCombiner.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.beam.sdk.transforms.Combine;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PCollection;
+
+/** Combine PCollection&lt;Range&gt; into PCollection&lt;Range&gt;. */
+public class RangeCombiner extends Combine.CombineFn<Range, List<Range>, ImmutableList<Range>> {
+
+  @Override
+  public List<Range> createAccumulator() {
+    return Collections.synchronizedList(new ArrayList<>());
+  }
+
+  @Override
+  public List<Range> addInput(List<Range> accumulator, Range input) {
+    accumulator.add(input);
+    return accumulator;
+  }
+
+  @Override
+  public List<Range> mergeAccumulators(Iterable<List<Range>> accumulators) {
+    List<Range> merged = Collections.synchronizedList(new ArrayList<>());
+    for (List<Range> accumulator : accumulators) {
+      merged.addAll(accumulator);
+    }
+    return merged;
+  }
+
+  @Override
+  public ImmutableList<Range> extractOutput(List<Range> accumulator) {
+    Collections.sort(accumulator); // Sort the list before making it immutable
+    return ImmutableList.copyOf(accumulator);
+  }
+
+  /**
+   * Returns a {@link PTransform} that combines the Range elements in its input {@link PCollection}.
+   */
+  public static PTransform<PCollection<Range>, PCollection<ImmutableList<Range>>> globally() {
+    return Combine.globally(new RangeCombiner());
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountDoFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountDoFn.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.RangePreparedStatementSetter;
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLTimeoutException;
+import javax.annotation.Nullable;
+import javax.sql.DataSource;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** DoFn to count a Range with timeout. */
+final class RangeCountDoFn extends DoFn<Range, Range> implements Serializable {
+
+  /**
+   * We set a millisecond precision timeout for the DB query. Additionally, we also set a timeout at
+   * the level of prepared statement. Setting the timeout at the level of prepared statement covers
+   * for older versions of MySQL that don't honour the magic comment for timeout (note that 5.7.4+
+   * support the select level timeout). Since the timeout at the level of prepared statement is in
+   * seconds, we add 1500 milliseconds to cover for the rounding off error and giving 500
+   * milliseconds for db to vm network latency.
+   */
+  private static final long TIMEOUT_GRACE_MILLIS = 1500;
+
+  private static final Logger logger = LoggerFactory.getLogger(RangeCountDoFn.class);
+  private final SerializableFunction<Void, DataSource> dataSourceProviderFn;
+  private final long timeoutMillis;
+
+  private final String countQuery;
+
+  private final long numColumns;
+
+  @JsonIgnore private transient @Nullable DataSource dataSource;
+
+  RangeCountDoFn(
+      SerializableFunction<Void, DataSource> dataSourceProviderFn,
+      long timeoutMillis,
+      String countQuery,
+      long numColumns) {
+    this.dataSourceProviderFn = dataSourceProviderFn;
+    this.timeoutMillis = timeoutMillis;
+    this.countQuery = countQuery;
+    this.numColumns = numColumns;
+    this.dataSource = null;
+  }
+
+  @Setup
+  public void setup() throws Exception {
+    dataSource = dataSourceProviderFn.apply(null);
+  }
+
+  private Connection acquireConnection() throws SQLException {
+    return checkStateNotNull(this.dataSource).getConnection();
+  }
+
+  /**
+   * Count a Range with timeout. Incase of timeout, the count of range is set as {@link
+   * Range#INDETERMINATE_COUNT}.
+   *
+   * @param input range.
+   * @param out output receiver to get counted range.
+   * @param c process context.
+   * @throws SQLException
+   */
+  @ProcessElement
+  public void processElement(@Element Range input, OutputReceiver<Range> out, ProcessContext c)
+      throws SQLException {
+
+    long count;
+    try (Connection conn = acquireConnection()) {
+      PreparedStatement stmt =
+          conn.prepareStatement(
+              this.countQuery, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+      stmt.setQueryTimeout((int) ((this.timeoutMillis + TIMEOUT_GRACE_MILLIS) / 1000));
+      new RangePreparedStatementSetter(numColumns).setParameters(input, stmt);
+      try {
+        ResultSet rs = stmt.executeQuery();
+        if (rs.next()) {
+          count = rs.getLong(1);
+          if (rs.wasNull()) {
+            logger.error(
+                "Got null for count resultSet. Range = {}, Query = {}, DataSource = {}",
+                input,
+                countQuery,
+                dataSource);
+            count = Range.INDETERMINATE_COUNT;
+          }
+        } else {
+          logger.error(
+              "Got empty count resultSet. Range = {}, Query = {}, DataSource = {}",
+              input,
+              countQuery,
+              dataSource);
+          count = Range.INDETERMINATE_COUNT;
+        }
+      } catch (SQLTimeoutException e) {
+        logger.warn(
+            "Handled timeout while counting Range = {}, Query = {}, DataSource = {}, timeoutMillis = {}",
+            input,
+            countQuery,
+            dataSource,
+            timeoutMillis);
+        count = Range.INDETERMINATE_COUNT;
+      }
+    } catch (SQLException e) {
+      logger.warn(
+          "SQL Exception = {} while counting Range = {}, Query = {}, DataSource = {}. This will be retried by Beam Runner.",
+          e,
+          input,
+          countQuery,
+          dataSource);
+      throw e;
+    } catch (Exception e) {
+      // This exception is triggered from nullness checks of checker framework for the input to
+      // statement preparator and hence should
+      // indicate a programming error. Any other exception in the code flow returns a SQL Exception.
+      // It's hard to trigger this exception for UT as the checks are not running by default in the
+      // UT.
+      logger.error(
+          "Exception = {}, Range = {}, Query = {}, DataSource = {}",
+          e,
+          input,
+          countQuery,
+          dataSource);
+      throw new RuntimeException(e);
+    }
+    Range output = input.withCount(count, c);
+    logger.debug(
+        "Counting Range = {}, Query = {}, DataSource = {}", output, countQuery, dataSource);
+    out.output(output); // Output the counted Range.
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountDoFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountDoFn.java
@@ -78,7 +78,7 @@ final class RangeCountDoFn extends DoFn<Range, Range> implements Serializable {
   }
 
   /**
-   * Count a Range with timeout. Incase of timeout, the count of range is set as {@link
+   * Count a Range with timeout. In case of timeout, the count of range is set as {@link
    * Range#INDETERMINATE_COUNT}.
    *
    * @param input range.

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountTransform.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountTransform.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import javax.sql.DataSource;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.PCollection;
+
+/** PTransform to wrap {@link RangeCountDoFn}. */
+@AutoValue
+public abstract class RangeCountTransform extends PTransform<PCollection<Range>, PCollection<Range>>
+    implements Serializable {
+
+  /** Provider for {@link DataSource}. */
+  abstract SerializableFunction<Void, DataSource> dataSourceProviderFn();
+
+  /**
+   * Implementations of {@link UniformSplitterDBAdapter} to get queries as per the dialect of the
+   * database.
+   */
+  abstract UniformSplitterDBAdapter dbAdapter();
+
+  /** Timeout of the count query in milliseconds. */
+  abstract long timeoutMillis();
+
+  /** Name of the table. */
+  abstract String tableName();
+
+  /** List of partition columns. */
+  abstract ImmutableList<String> partitionColumns();
+
+  @Override
+  public PCollection<Range> expand(PCollection<Range> input) {
+    return input.apply(
+        ParDo.of(
+            new RangeCountDoFn(
+                dataSourceProviderFn(),
+                timeoutMillis(),
+                dbAdapter().getCountQuery(tableName(), partitionColumns(), timeoutMillis()),
+                partitionColumns().size())));
+  }
+
+  public static Builder builder() {
+    return new AutoValue_RangeCountTransform.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setDataSourceProviderFn(SerializableFunction<Void, DataSource> value);
+
+    public abstract Builder setDbAdapter(UniformSplitterDBAdapter value);
+
+    public abstract Builder setTimeoutMillis(long value);
+
+    public abstract Builder setTableName(String value);
+
+    public abstract Builder setPartitionColumns(ImmutableList<String> value);
+
+    public abstract RangeCountTransform build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCounterTransform.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCounterTransform.java
@@ -1,0 +1,5 @@
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+public class RangeCounterTransform {
+
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCounterTransform.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCounterTransform.java
@@ -1,5 +1,0 @@
-package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
-
-public class RangeCounterTransform {
-
-}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitions.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitions.java
@@ -37,6 +37,7 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Reshuffle;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.Wait;
+import org.apache.beam.sdk.transforms.Wait.OnSignal;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
@@ -137,7 +138,7 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
    * applied before the first query is made to the database to detect split points.
    */
   @Nullable
-  abstract ImmutableList<PCollection<?>> waitOnSignals();
+  abstract OnSignal<?> waitOn();
 
   /**
    * An optional, initial range to start with. This can help anywhere from unit testing, to micro
@@ -320,10 +321,10 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
   }
 
   private <V extends PCollection> V wait(V input) {
-    if (waitOnSignals() == null) {
+    if (waitOn() == null) {
       return input;
     } else {
-      return (V) input.apply(Wait.on(waitOnSignals()));
+      return (V) input.apply(waitOn());
     }
   }
 
@@ -378,7 +379,7 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
     public abstract Builder<T> setAdditionalOperationsOnRanges(
         @Nullable PTransform<PCollection<ImmutableList<Range>>, ?> value);
 
-    public abstract Builder<T> setWaitOnSignals(@Nullable ImmutableList<PCollection<?>> value);
+    public abstract Builder<T> setWaitOn(@Nullable OnSignal<?> value);
 
     public abstract Builder<T> setInitialRange(Range value);
 

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitions.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitions.java
@@ -1,0 +1,434 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary.ColumnForBoundaryQuery;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundaryTypeMapper;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.PartitionColumn;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.RangePreparedStatementSetter;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import javax.annotation.Nullable;
+import javax.sql.DataSource;
+import org.apache.beam.sdk.io.jdbc.JdbcIO;
+import org.apache.beam.sdk.io.jdbc.JdbcIO.PreparedStatementSetter;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Reshuffle;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.Wait;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.TupleTagList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@AutoValue
+public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PCollection<T>> {
+
+  private static final Logger logger = LoggerFactory.getLogger(ReadWithUniformPartitions.class);
+
+  /* We try to get Ranges, where a Range is split if it's count is greater than twice the mean */
+  /* TODO(vardhanvthigle): Add this as a configurable parameter */
+  public static final long SPLITTER_MAX_RELATIVE_DEVIATION = 1;
+
+  public static final long SPLITTER_DEFAULT_COUNT_QUERY_TIMEOUT_MILLIS = 30 * 1000;
+
+  /** Provider for {@link DataSource}. Required parameter. */
+  abstract SerializableFunction<Void, DataSource> dataSourceProviderFn();
+
+  /**
+   * Implementations of {@link UniformSplitterDBAdapter} to get queries as per the dialect of the
+   * database. Required parameter.
+   */
+  abstract UniformSplitterDBAdapter dbAdapter();
+
+  /** Name of the table to read. Required parameter. */
+  abstract String tableName();
+
+  /** List of partition columns. Required parameter. */
+  abstract ImmutableList<PartitionColumn> partitionColumns();
+
+  /**
+   * Approximate count of rows in the table. Required parameter. The caller can set this as per the
+   * cardinality of primary key index, or derived from information schema tables. This is used to
+   * auto infer {@link ReadWithUniformPartitions#maxPartitionsHint()} and hence the count for
+   * initial split of ranges. As soon as all the ranges get counts (there is no time out for
+   * counting the size of a range), {@link ReadWithUniformPartitions} is able to get the total count
+   * of rows of the table naturally. If {@link ReadWithUniformPartitions#autoAdjustMaxPartitions()}
+   * is set to true (which is the default), the approximate count can be within half to double of
+   * the actual count still giving the expected split.
+   */
+  // TODO(vardhanvthigle:) make this optional by auto inference.
+  abstract Long approxTotalRowCount();
+
+  /**
+   * Row mapper to map the {@link java.sql.ResultSet}.
+   *
+   * @see org.apache.beam.sdk.io.jdbc.JdbcIO.RowMapper RowMapper.
+   */
+  abstract JdbcIO.RowMapper<T> rowMapper();
+
+  /**
+   * Hint for Maximum number of partitions of the source key space. If not set, it is auto inferred
+   * as 1/10 * sqrt({@link ReadWithUniformPartitions#autoAdjustMaxPartitions()}). Note that if
+   * {@link ReadWithUniformPartitions#autoAdjustMaxPartitions()} is set to true, the aggregated
+   * count of all ranges will auto-adjust this value by replacing the approximate count in above
+   * expression.
+   */
+  abstract Long maxPartitionsHint();
+
+  /**
+   * If set to true, the aggregated count of all ranges will auto-adjust {@link
+   * ReadWithUniformPartitions#maxPartitionsHint()}.
+   */
+  abstract Boolean autoAdjustMaxPartitions();
+
+  /**
+   * Timeout of the count query in milliseconds. Defaults to {@link
+   * ReadWithUniformPartitions#SPLITTER_DEFAULT_COUNT_QUERY_TIMEOUT_MILLIS}
+   */
+  abstract long countQueryTimeoutMillis();
+
+  /**
+   * Hint for number of initial split of ranges. Defaults to {@link
+   * ReadWithUniformPartitions#maxPartitionsHint()}.
+   */
+  abstract Long initialSplitHint();
+
+  /**
+   * Number of stages for the splitting process. This can be set to smaller values like 2/3 for auto
+   * incrementing keys. Defaults to log2({@link ReadWithUniformPartitions#maxPartitionsHint()}).
+   */
+  abstract Long splitStageCountHint();
+
+  /**
+   * An optional transform that can be injected at the end of splitting process to make use of the
+   * ranges. This could range anywhere for logging to gcs, to creating split points on spanner, to
+   * even ease of unit testing.
+   */
+  @Nullable
+  abstract PTransform<PCollection<ImmutableList<Range>>, ?> rangesPeek();
+
+  /**
+   * Wait for completion of dependencies as per the requirements of the pipeline. This wait is
+   * applied before the first query is made to the database to detect split points.
+   */
+  @Nullable
+  abstract ImmutableList<PCollection<?>> waitOnSignals();
+
+  /**
+   * An optional, initial range to start with. This can help anywhere from unit testing, to micro
+   * batching (read only columns after a timestamp), to splitting the whole split detection and read
+   * of a really large table.
+   *
+   * @return
+   */
+  @Nullable
+  abstract Range initialRange();
+
+  @Override
+  public PCollection<T> expand(PBegin input) {
+    // TODO(vardhanvthigle): Implement mapper for strings of various collations as side input.
+    BoundaryTypeMapper typeMapper = null;
+    // Generate Initial Ranges with liner splits (No need to do execute count queries the DB here)
+    PCollection<ImmutableList<Range>> ranges = initialSplit(input, typeMapper);
+    // Classify Ranges to count or get new columns and perform the operations.
+    for (long i = 0; i < splitStageCountHint(); i++) {
+      ranges = addStage(ranges, typeMapper, i);
+    }
+
+    ImmutableList<String> colNames =
+        partitionColumns().stream()
+            .map(PartitionColumn::columnName)
+            .collect(ImmutableList.toImmutableList());
+    PreparedStatementSetter<Range> rangePrepareator =
+        new RangePreparedStatementSetter(colNames.size());
+
+    // Merge the Ranges towards the mean.
+    PCollection<ImmutableList<Range>> mergedRanges =
+        ranges.apply(
+            getTransformName("RangeMerge", null),
+            ParDo.of(
+                MergeRangesDoFn.builder()
+                    .setApproxTotalRowCount(approxTotalRowCount())
+                    .setMaxPartitionHint(maxPartitionsHint())
+                    .setAutoAdjustMaxPartitions(autoAdjustMaxPartitions())
+                    .setTableName(tableName())
+                    .build()));
+    PCollection<Range> rangesToRead =
+        peekRanges(mergedRanges).apply(ParDo.of(new UnflattenRangesDoFn()));
+    return rangesToRead
+        .apply(getTransformName("ReshuffleFinal", null), Reshuffle.viaRandomKey())
+        .apply(
+            getTransformName("RangeRead", null),
+            JdbcIO.<Range, T>readAll()
+                .withOutputParallelization(false)
+                .withQuery(dbAdapter().getReadQuery(tableName(), colNames))
+                .withParameterSetter(rangePrepareator)
+                .withDataSourceProviderFn(dataSourceProviderFn())
+                .withRowMapper(rowMapper()));
+  }
+
+  public static <T> Builder<T> builder() {
+    return new AutoValue_ReadWithUniformPartitions.Builder<T>()
+        .setCountQueryTimeoutMillis(SPLITTER_DEFAULT_COUNT_QUERY_TIMEOUT_MILLIS)
+        .setAutoAdjustMaxPartitions(true);
+  }
+
+  /** Gives log to the base 2 of a given value rounded up. */
+  @VisibleForTesting
+  protected static long logToBaseTwo(long value) {
+    return value == 0L ? 0L : 64L - Long.numberOfLeadingZeros(value - 1);
+  }
+
+  private PCollection<ImmutableList<Range>> initialSplit(
+      PBegin input, @Nullable BoundaryTypeMapper typeMapper) {
+
+    RangeBoundaryTransform rangeBoundaryTransform =
+        RangeBoundaryTransform.builder()
+            .setBoundaryTypeMapper(typeMapper)
+            .setDataSourceProviderFn(dataSourceProviderFn())
+            .setDbAdapter(dbAdapter())
+            .setPartitionColumns(
+                partitionColumns().stream()
+                    .map(c -> c.columnName())
+                    .collect(ImmutableList.toImmutableList()))
+            .setTableName(tableName())
+            .build();
+
+    long splitHeight = logToBaseTwo(initialSplitHint());
+
+    PCollection<Range> initialRange;
+    if (initialRange() == null) {
+      ColumnForBoundaryQuery initialColumn =
+          ColumnForBoundaryQuery.builder()
+              .setPartitionColumn(partitionColumns().get(0))
+              .setParentRange(null)
+              .build();
+      initialRange =
+          wait(input.apply(Create.of(ImmutableList.of(initialColumn))))
+              .apply(rangeBoundaryTransform);
+    } else {
+      initialRange = wait(input.apply(Create.of(ImmutableList.of(initialRange()))));
+    }
+
+    return initialRange.apply(
+        getTransformName("InitialRangeSplit", null),
+        ParDo.of(
+            InitialSplitRangeDoFn.builder()
+                .setSplitHeight(splitHeight)
+                .setTableName(tableName())
+                .build()));
+  }
+
+  private PCollection<ImmutableList<Range>> addStage(
+      PCollection<ImmutableList<Range>> input, BoundaryTypeMapper typeMapper, long stageIdx) {
+
+    RangeClassifierDoFn classifierFn =
+        RangeClassifierDoFn.builder()
+            .setApproxTotalRowCount(approxTotalRowCount())
+            .setMaxPartitionHint(maxPartitionsHint())
+            .setAutoAdjustMaxPartitions(autoAdjustMaxPartitions())
+            .setPartitionColumns(partitionColumns())
+            .setStageIdx(stageIdx)
+            .build();
+
+    RangeCountTransform rangeCountTransform =
+        RangeCountTransform.builder()
+            .setDataSourceProviderFn(dataSourceProviderFn())
+            .setDbAdapter(dbAdapter())
+            .setPartitionColumns(
+                partitionColumns().stream()
+                    .map(c -> c.columnName())
+                    .collect(ImmutableList.toImmutableList()))
+            .setTableName(tableName())
+            .setTimeoutMillis(countQueryTimeoutMillis())
+            .build();
+
+    RangeBoundaryTransform rangeBoundaryTransform =
+        RangeBoundaryTransform.builder()
+            .setDataSourceProviderFn(dataSourceProviderFn())
+            .setBoundaryTypeMapper(typeMapper)
+            .setDbAdapter(dbAdapter())
+            .setPartitionColumns(
+                partitionColumns().stream()
+                    .map(c -> c.columnName())
+                    .collect(ImmutableList.toImmutableList()))
+            .setTableName(tableName())
+            .build();
+    PCollectionTuple classifiedRanges =
+        input.apply(
+            getTransformName("RangeClassifier", stageIdx),
+            ParDo.of(classifierFn)
+                .withOutputTags(
+                    RangeClassifierDoFn.TO_COUNT_TAG,
+                    TupleTagList.of(RangeClassifierDoFn.TO_ADD_COLUMN_TAG)
+                        .and(RangeClassifierDoFn.TO_RETAIN_TAG)));
+    PCollection<Range> countedRanges =
+        classifiedRanges
+            .get(RangeClassifierDoFn.TO_COUNT_TAG)
+            .apply(getTransformName("ReshuffleToCount", stageIdx), Reshuffle.viaRandomKey())
+            .apply(getTransformName("RangeCounter", stageIdx), rangeCountTransform);
+    PCollection<ColumnForBoundaryQuery> rangesToAddColumn =
+        classifiedRanges.get(RangeClassifierDoFn.TO_ADD_COLUMN_TAG);
+    PCollection<Range> rangesWithNewColumns =
+        rangesToAddColumn
+            .apply(getTransformName("ReshuffleToAddColumn", stageIdx), Reshuffle.viaRandomKey())
+            .apply(getTransformName("RangeBoundary", stageIdx), rangeBoundaryTransform)
+            .apply(
+                getTransformName("RangeSplitterAfterColumnAddition", stageIdx),
+                ParDo.of(new SplitRangeDoFn()))
+            .apply(getTransformName("CountAfterColumnAddition", stageIdx), rangeCountTransform);
+    PCollection<Range> retainedRanges = classifiedRanges.get(RangeClassifierDoFn.TO_RETAIN_TAG);
+
+    return PCollectionList.of(retainedRanges)
+        .and(countedRanges)
+        .and(rangesWithNewColumns)
+        .apply(getTransformName("FlattenProcessedRanges", stageIdx), Flatten.pCollections())
+        .apply(getTransformName("RangeCombiner", stageIdx), RangeCombiner.globally());
+  }
+
+  private String getTransformName(String transformType, @Nullable Long stageIdx) {
+    String name = "Table." + tableName() + "." + transformType;
+    if (stageIdx != null) {
+      name = name + "." + stageIdx;
+    }
+    return name;
+  }
+
+  private <V extends PCollection> V wait(V input) {
+    if (waitOnSignals() == null) {
+      return input;
+    } else {
+      return (V) input.apply(Wait.on(waitOnSignals()));
+    }
+  }
+
+  private PCollection<ImmutableList<Range>> peekRanges(
+      PCollection<ImmutableList<Range>> mergedRanges) {
+    if (rangesPeek() == null) {
+      return mergedRanges;
+    } else {
+      return mergedRanges.apply(Wait.on((PCollection<?>) mergedRanges.apply(rangesPeek())));
+    }
+  }
+
+  public static long inferMaxPartitions(long count) {
+    return Math.max(1, Math.round(Math.floor(Math.sqrt(count) / 10)));
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder<T> {
+
+    public abstract Builder<T> setDataSourceProviderFn(
+        SerializableFunction<Void, DataSource> value);
+
+    public abstract Builder<T> setDbAdapter(UniformSplitterDBAdapter value);
+
+    public abstract Builder<T> setCountQueryTimeoutMillis(long value);
+
+    public abstract Builder<T> setTableName(String value);
+
+    public abstract Builder<T> setPartitionColumns(ImmutableList<PartitionColumn> value);
+
+    abstract ImmutableList<PartitionColumn> partitionColumns();
+
+    public abstract Builder<T> setApproxTotalRowCount(Long value);
+
+    abstract Long approxTotalRowCount();
+
+    public abstract Builder<T> setMaxPartitionsHint(Long value);
+
+    public abstract Builder<T> setAutoAdjustMaxPartitions(Boolean value);
+
+    abstract Optional<Long> maxPartitionsHint();
+
+    public abstract Builder<T> setInitialSplitHint(Long value);
+
+    abstract Optional<Long> initialSplitHint();
+
+    public abstract Builder<T> setSplitStageCountHint(Long value);
+
+    public abstract Builder<T> setRowMapper(JdbcIO.RowMapper<T> value);
+
+    public abstract Builder<T> setRangesPeek(
+        @Nullable PTransform<PCollection<ImmutableList<Range>>, ?> value);
+
+    public abstract Builder<T> setWaitOnSignals(@Nullable ImmutableList<PCollection<?>> value);
+
+    public abstract Builder<T> setInitialRange(Range value);
+
+    @Nullable
+    abstract Range initialRange();
+
+    abstract Optional<Long> splitStageCountHint();
+
+    abstract ReadWithUniformPartitions<T> autoBuild();
+
+    public ReadWithUniformPartitions<T> build() {
+      /* TODO(vardhanvthigle): USE `Explain Select *` to auto infer approxCount within the uniform partition splitter itself.
+         Since that will be executed in construction path, it needs to be retried with backoff.
+         For the context of the larger reader, the index cardinality gives a pretty good idea of the approxCount of the table too.
+      */
+      long maxPartitionsHint;
+      if (maxPartitionsHint().isPresent()) {
+        maxPartitionsHint = maxPartitionsHint().get();
+      } else {
+        maxPartitionsHint = inferMaxPartitions(approxTotalRowCount());
+        setMaxPartitionsHint(maxPartitionsHint);
+      }
+      if (!initialSplitHint().isPresent()) {
+        setInitialSplitHint(SPLITTER_MAX_RELATIVE_DEVIATION * maxPartitionsHint);
+      }
+      /* TODO(vardhanvthigle): currently every stage does a single split of a rnage that crosses the 2*Mean mark.
+       * This needed not be the case. Based on the splitStageCount, we could decide how many splits to do in a range.
+       * Current benchmarking suggests that reducing stages is better from overhead pov.
+       */
+      if (!splitStageCountHint().isPresent()) {
+        Long splitHeightHint =
+            logToBaseTwo(maxPartitionsHint)
+                + partitionColumns().size()
+                + 1 /* For initial counts */;
+        setSplitStageCountHint(splitHeightHint);
+      }
+
+      if (initialRange() != null) {
+        Range curRange = initialRange();
+        for (PartitionColumn col : partitionColumns()) {
+          Preconditions.checkState(curRange.colName().equals(col.columnName()));
+          if (curRange.hasChildRange()) {
+            curRange = curRange.childRange();
+          } else {
+            break;
+          }
+        }
+      }
+      ReadWithUniformPartitions readWithUniformPartitions = autoBuild();
+      logger.info("Initialized ReadWithUniformPartitions {}", readWithUniformPartitions);
+      return readWithUniformPartitions;
+    }
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitions.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitions.java
@@ -130,7 +130,7 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
    * even ease of unit testing.
    */
   @Nullable
-  abstract PTransform<PCollection<ImmutableList<Range>>, ?> rangesPeek();
+  abstract PTransform<PCollection<ImmutableList<Range>>, ?> additionalOperationsOnRanges();
 
   /**
    * Wait for completion of dependencies as per the requirements of the pipeline. This wait is
@@ -329,10 +329,11 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
 
   private PCollection<ImmutableList<Range>> peekRanges(
       PCollection<ImmutableList<Range>> mergedRanges) {
-    if (rangesPeek() == null) {
+    if (additionalOperationsOnRanges() == null) {
       return mergedRanges;
     } else {
-      return mergedRanges.apply(Wait.on((PCollection<?>) mergedRanges.apply(rangesPeek())));
+      return mergedRanges.apply(
+          Wait.on((PCollection<?>) mergedRanges.apply(additionalOperationsOnRanges())));
     }
   }
 
@@ -374,7 +375,7 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
 
     public abstract Builder<T> setRowMapper(JdbcIO.RowMapper<T> value);
 
-    public abstract Builder<T> setRangesPeek(
+    public abstract Builder<T> setAdditionalOperationsOnRanges(
         @Nullable PTransform<PCollection<ImmutableList<Range>>, ?> value);
 
     public abstract Builder<T> setWaitOnSignals(@Nullable ImmutableList<PCollection<?>> value);

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/SplitRangeDoFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/SplitRangeDoFn.java
@@ -19,7 +19,10 @@ import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.commons.lang3.tuple.Pair;
 
-/** Split a given range into 2 halves, typically after adding a new column. */
+/**
+ * Split a given range into 2 halves, typically after adding a new column to an existing
+ * unsplittable range.
+ */
 public class SplitRangeDoFn extends DoFn<Range, Range> {
   @ProcessElement
   public void processElement(@Element Range range, OutputReceiver<Range> out, ProcessContext c) {

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/SplitRangeDoFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/SplitRangeDoFn.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.commons.lang3.tuple.Pair;
+
+/** Split a given range into 2 halves, typically after adding a new column. */
+public class SplitRangeDoFn extends DoFn<Range, Range> {
+  @ProcessElement
+  public void processElement(@Element Range range, OutputReceiver<Range> out, ProcessContext c) {
+    if (range.isSplittable(c)) {
+      Pair<Range, Range> splitPair = range.split(c);
+      out.output(splitPair.getLeft());
+      out.output(splitPair.getRight());
+    } else {
+      out.output(range);
+    }
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/UnflattenRangesDoFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/UnflattenRangesDoFn.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import org.apache.beam.sdk.transforms.DoFn;
+
+/** Emit ranges from a collection. */
+public class UnflattenRangesDoFn extends DoFn<ImmutableList<Range>, Range> implements Serializable {
+
+  @ProcessElement
+  public void processElement(@Element ImmutableList<Range> input, OutputReceiver<Range> out) {
+    input.forEach(out::output);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (CountRange) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/** {@link org.apache.beam.sdk.transforms.PTransform PTransforms} for {@code uniform splitter}. */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceColumnIndexInfo.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceColumnIndexInfo.java
@@ -24,7 +24,7 @@ import com.google.common.base.Preconditions;
  * a list of {@llink SourceColumnIndexInfo} is discovered, a composite index will have multiple
  * columns associated with the same indexName with unique ordinal positions.
  */
-public abstract class SourceColumnIndexInfo {
+public abstract class SourceColumnIndexInfo implements Comparable<SourceColumnIndexInfo> {
 
   /**
    * @return name of the column.
@@ -75,6 +75,21 @@ public abstract class SourceColumnIndexInfo {
    */
   public static Builder builder() {
     return new AutoValue_SourceColumnIndexInfo.Builder();
+  }
+
+  @Override
+  public int compareTo(SourceColumnIndexInfo other) {
+    if (this.equals(other)) {
+      return 0;
+    }
+    int nameCompare = this.indexName().compareTo(other.indexName());
+    if (nameCompare != 0) {
+      return nameCompare;
+    }
+    // Within the same index, check the ordinal position comparison.
+    int ordinalCompare =
+        new Long(this.ordinalPosition()).compareTo(new Long(other.ordinalPosition()));
+    return ordinalCompare;
   }
 
   @AutoValue.Builder

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapterTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapterTest.java
@@ -421,7 +421,7 @@ public class MysqlDialectAdapterTest {
     ImmutableList<String> cols = ImmutableList.of("col_1", "col_2");
     assertThat(new MysqlDialectAdapter(MySqlVersion.DEFAULT).getReadQuery(testTable, cols))
         .isEqualTo(
-            "select * from testTable where ((? = FALSE) OR (col_1 >= ? AND (col_1 < ? OR (? = TRUE AND col_1 = ?)))) AND ((? = FALSE) OR (col_2 >= ? AND (col_2 < ? OR (? = TRUE AND col_2 = ?))))");
+            "select * from testTable WHERE ((? = FALSE) OR (col_1 >= ? AND (col_1 < ? OR (? = TRUE AND col_1 = ?)))) AND ((? = FALSE) OR (col_2 >= ? AND (col_2 < ? OR (? = TRUE AND col_2 = ?))))");
   }
 
   @Test
@@ -433,7 +433,7 @@ public class MysqlDialectAdapterTest {
             new MysqlDialectAdapter(MySqlVersion.DEFAULT)
                 .getCountQuery(testTable, cols, timeoutMillis))
         .isEqualTo(
-            "select /*+ MAX_EXECUTION_TIME(42) */ COUNT(*) from testTable where ((? = FALSE) OR (col_1 >= ? AND (col_1 < ? OR (? = TRUE AND col_1 = ?)))) AND ((? = FALSE) OR (col_2 >= ? AND (col_2 < ? OR (? = TRUE AND col_2 = ?))))");
+            "select /*+ MAX_EXECUTION_TIME(42) */ COUNT(*) from testTable WHERE ((? = FALSE) OR (col_1 >= ? AND (col_1 < ? OR (? = TRUE AND col_1 = ?)))) AND ((? = FALSE) OR (col_2 >= ? AND (col_2 < ? OR (? = TRUE AND col_2 = ?))))");
   }
 
   @Test
@@ -443,7 +443,7 @@ public class MysqlDialectAdapterTest {
     assertThat(
             new MysqlDialectAdapter(MySqlVersion.DEFAULT).getBoundaryQuery(testTable, cols, "col3"))
         .isEqualTo(
-            "select MIN(col3),MAX(col3) from testTable where ((? = FALSE) OR (col_1 >= ? AND (col_1 < ? OR (? = TRUE AND col_1 = ?)))) AND ((? = FALSE) OR (col_2 >= ? AND (col_2 < ? OR (? = TRUE AND col_2 = ?))))");
+            "select MIN(col3),MAX(col3) from testTable WHERE ((? = FALSE) OR (col_1 >= ? AND (col_1 < ? OR (? = TRUE AND col_1 = ?)))) AND ((? = FALSE) OR (col_2 >= ? AND (col_2 < ? OR (? = TRUE AND col_2 = ?))))");
   }
 
   private static ResultSet getMockInfoSchemaRs() throws SQLException {

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapterTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapterTest.java
@@ -415,6 +415,37 @@ public class MysqlDialectAdapterTest {
     }
   }
 
+  @Test
+  public void testGetReadQuery() {
+    String testTable = "testTable";
+    ImmutableList<String> cols = ImmutableList.of("col_1", "col_2");
+    assertThat(new MysqlDialectAdapter(MySqlVersion.DEFAULT).getReadQuery(testTable, cols))
+        .isEqualTo(
+            "select * from testTable where ((? = FALSE) OR (col_1 >= ? AND (col_1 < ? OR (? = TRUE AND col_1 = ?)))) AND ((? = FALSE) OR (col_2 >= ? AND (col_2 < ? OR (? = TRUE AND col_2 = ?))))");
+  }
+
+  @Test
+  public void testGetCountQuery() {
+    String testTable = "testTable";
+    ImmutableList<String> cols = ImmutableList.of("col_1", "col_2");
+    Long timeoutMillis = 42L;
+    assertThat(
+            new MysqlDialectAdapter(MySqlVersion.DEFAULT)
+                .getCountQuery(testTable, cols, timeoutMillis))
+        .isEqualTo(
+            "select /*+ MAX_EXECUTION_TIME(42) */ COUNT(*) from testTable where ((? = FALSE) OR (col_1 >= ? AND (col_1 < ? OR (? = TRUE AND col_1 = ?)))) AND ((? = FALSE) OR (col_2 >= ? AND (col_2 < ? OR (? = TRUE AND col_2 = ?))))");
+  }
+
+  @Test
+  public void testGetBoundaryQuery() {
+    String testTable = "testTable";
+    ImmutableList<String> cols = ImmutableList.of("col_1", "col_2");
+    assertThat(
+            new MysqlDialectAdapter(MySqlVersion.DEFAULT).getBoundaryQuery(testTable, cols, "col3"))
+        .isEqualTo(
+            "select MIN(col3),MAX(col3) from testTable where ((? = FALSE) OR (col_1 >= ? AND (col_1 < ? OR (? = TRUE AND col_1 = ?)))) AND ((? = FALSE) OR (col_2 >= ? AND (col_2 < ? OR (? = TRUE AND col_2 = ?))))");
+  }
+
   private static ResultSet getMockInfoSchemaRs() throws SQLException {
     return new MockRSBuilder(
             MockInformationSchema.builder()

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/TableConfigTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/TableConfigTest.java
@@ -16,8 +16,8 @@
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
 
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.PartitionColumn;
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,42 +29,36 @@ public class TableConfigTest {
   @Test
   public void testTableConfigBuildsWithDefaults() {
     final String testTable = "testTable";
-    final String partitionColumn = "col_1";
+    final PartitionColumn partitionColumn =
+        PartitionColumn.builder().setColumnName("col_1").setColumnClass(Integer.class).build();
 
     TableConfig tableConfig =
-        TableConfig.builder(testTable).withPartitionColum(partitionColumn).build();
+        TableConfig.builder(testTable)
+            .withPartitionColum(partitionColumn)
+            .setApproxRowCount(42L)
+            .build();
     assertThat(tableConfig.tableName()).isEqualTo(testTable);
     assertThat(tableConfig.maxPartitions()).isNull();
     assertThat(tableConfig.partitionColumns()).isEqualTo(ImmutableList.of(partitionColumn));
+    assertThat(tableConfig.approxRowCount()).isEqualTo(42L);
   }
 
   @Test
   public void testTableConfigBuilds() {
     final String testTable = "testTable";
-    final String partitionColumn = "col_1";
+    final PartitionColumn partitionColumn =
+        PartitionColumn.builder().setColumnName("col_1").setColumnClass(Integer.class).build();
     final int maxPartitions = 100;
 
     TableConfig tableConfig =
         TableConfig.builder(testTable)
             .withPartitionColum(partitionColumn)
             .setMaxPartitions(maxPartitions)
+            .setApproxRowCount(42L)
             .build();
     assertThat(tableConfig.tableName()).isEqualTo(testTable);
     assertThat(tableConfig.maxPartitions()).isEqualTo(maxPartitions);
     assertThat(tableConfig.partitionColumns()).isEqualTo(ImmutableList.of(partitionColumn));
-  }
-
-  @Test
-  public void testTableConfigPreconditions() {
-    final String testTable = "testTable";
-
-    assertThrows(IllegalStateException.class, () -> TableConfig.builder(testTable).build());
-    assertThrows(
-        IllegalStateException.class,
-        () ->
-            TableConfig.builder(testTable)
-                .withPartitionColum("col_1")
-                .withPartitionColum("col_2")
-                .build());
+    assertThat(tableConfig.approxRowCount()).isEqualTo(42L);
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/ColumnForBoundaryQueryPreparedStatementSetterTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/ColumnForBoundaryQueryPreparedStatementSetterTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundarySplitterFactory;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.common.collect.ImmutableList;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link ColumnForBoundaryQueryPreparedStatementSetter}. */
+@RunWith(MockitoJUnitRunner.class)
+public class ColumnForBoundaryQueryPreparedStatementSetterTest {
+
+  Connection connection;
+
+  @BeforeClass
+  public static void beforeClass() {
+    // by default, derby uses a lock timeout of 60 seconds. In order to speed up the test
+    // and detect the lock faster, we decrease this timeout
+    System.setProperty("derby.locks.waitTimeout", "2");
+    System.setProperty("derby.stream.error.file", "build/derby.log");
+  }
+
+  @Before
+  public void initDerby() throws SQLException, ClassNotFoundException {
+    // Creating testDB database
+    Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+    connection = DriverManager.getConnection("jdbc:derby:memory:TestingDB;create=true");
+    createDerbyTable();
+  }
+
+  private void createDerbyTable() throws SQLException {
+    Statement stmtCreateTable = connection.createStatement();
+    String createTableSQL =
+        "CREATE TABLE test_table_column_boundary ("
+            + "col1 INT,"
+            + "col2 INT,"
+            + "PRIMARY KEY (col1, col2)"
+            + ")";
+    stmtCreateTable.executeUpdate(createTableSQL);
+
+    // 2.2 Insert Data (Using PreparedStatement for Efficiency & Security)
+    String insertSQL = "INSERT INTO test_table_column_boundary (col1, col2) VALUES (?, ?)";
+    PreparedStatement stmtInsert = connection.prepareStatement(insertSQL);
+
+    // Batch the insert operations
+    stmtInsert.setInt(1, 10);
+    stmtInsert.setInt(2, 30);
+    stmtInsert.addBatch();
+
+    stmtInsert.setInt(1, 14);
+    stmtInsert.setInt(2, 140);
+    stmtInsert.addBatch();
+
+    stmtInsert.setInt(1, 15);
+    stmtInsert.setInt(2, 135);
+    stmtInsert.addBatch();
+
+    stmtInsert.setInt(1, 125);
+    stmtInsert.setInt(2, 50);
+    stmtInsert.addBatch();
+
+    stmtInsert.executeBatch();
+  }
+
+  private void dropDerbyTable() throws SQLException {
+    Statement statement = connection.createStatement();
+    statement.executeUpdate("drop table test_table_column_boundary");
+  }
+
+  @Test
+  public void setParameters() throws Exception {
+    ImmutableList<String> partitionCols = ImmutableList.of("col1", "col2");
+    ColumnForBoundaryQueryPreparedStatementSetter columnForBoundaryQueryPreparedStatementSetter =
+        new ColumnForBoundaryQueryPreparedStatementSetter((partitionCols));
+
+    ColumnForBoundaryQuery initialColumn =
+        ColumnForBoundaryQuery.builder()
+            .setColumnName("col1")
+            .setColumnClass(Integer.class)
+            .build();
+    ColumnForBoundaryQuery columnWithinRange =
+        ColumnForBoundaryQuery.builder()
+            .setColumnName("col2")
+            .setColumnClass(Integer.class)
+            .setParentRange(
+                Range.<Integer>builder()
+                    .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+                    .setColName("col1")
+                    .setColClass(Integer.class)
+                    .setStart(14)
+                    .setEnd(15)
+                    .setIsLast(true)
+                    .build())
+            .build();
+
+    String boundaryQuery =
+        new MysqlDialectAdapter(MySqlVersion.DEFAULT)
+            .getBoundaryQuery("test_table_column_boundary", partitionCols);
+    PreparedStatement boundaryStmt = connection.prepareStatement(boundaryQuery);
+
+    /* Min, Max for first column of primary key on entire table */
+    columnForBoundaryQueryPreparedStatementSetter.setParameters(initialColumn, boundaryStmt);
+    ResultSet fullBoundaryResultSet = boundaryStmt.executeQuery();
+    fullBoundaryResultSet.next();
+    Pair<Integer, Integer> initialBoundary =
+        Pair.of(fullBoundaryResultSet.getInt(1), fullBoundaryResultSet.getInt(2));
+
+    /* Min, Max for second column within the range of first column */
+    columnForBoundaryQueryPreparedStatementSetter.setParameters(columnWithinRange, boundaryStmt);
+    ResultSet columnWithinRangeResultSet = boundaryStmt.executeQuery();
+    columnWithinRangeResultSet.next();
+    Pair<Integer, Integer> columnWithinRangeBoundary =
+        Pair.of(columnWithinRangeResultSet.getInt(1), columnWithinRangeResultSet.getInt(2));
+
+    assertThat(initialBoundary).isEqualTo(Pair.of(10, 125));
+    assertThat(columnWithinRangeBoundary).isEqualTo(Pair.of(135, 140));
+  }
+
+  @After
+  public void exitDerby() throws SQLException {
+    dropDerbyTable();
+    connection.close();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/ColumnForBoundaryQueryPreparedStatementSetterTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/ColumnForBoundaryQueryPreparedStatementSetterTest.java
@@ -123,21 +123,27 @@ public class ColumnForBoundaryQueryPreparedStatementSetterTest {
                     .build())
             .build();
 
-    String boundaryQuery =
+    String boundaryQueryCol1 =
         new MysqlDialectAdapter(MySqlVersion.DEFAULT)
-            .getBoundaryQuery("test_table_column_boundary", partitionCols);
-    PreparedStatement boundaryStmt = connection.prepareStatement(boundaryQuery);
+            .getBoundaryQuery("test_table_column_boundary", partitionCols, "col1");
+    PreparedStatement boundaryStmtCol1 = connection.prepareStatement(boundaryQueryCol1);
+
+    String boundaryQueryCol2 =
+        new MysqlDialectAdapter(MySqlVersion.DEFAULT)
+            .getBoundaryQuery("test_table_column_boundary", partitionCols, "col2");
+    PreparedStatement boundaryStmtCol2 = connection.prepareStatement(boundaryQueryCol2);
 
     /* Min, Max for first column of primary key on entire table */
-    columnForBoundaryQueryPreparedStatementSetter.setParameters(initialColumn, boundaryStmt);
-    ResultSet fullBoundaryResultSet = boundaryStmt.executeQuery();
+    columnForBoundaryQueryPreparedStatementSetter.setParameters(initialColumn, boundaryStmtCol1);
+    ResultSet fullBoundaryResultSet = boundaryStmtCol1.executeQuery();
     fullBoundaryResultSet.next();
     Pair<Integer, Integer> initialBoundary =
         Pair.of(fullBoundaryResultSet.getInt(1), fullBoundaryResultSet.getInt(2));
 
     /* Min, Max for second column within the range of first column */
-    columnForBoundaryQueryPreparedStatementSetter.setParameters(columnWithinRange, boundaryStmt);
-    ResultSet columnWithinRangeResultSet = boundaryStmt.executeQuery();
+    columnForBoundaryQueryPreparedStatementSetter.setParameters(
+        columnWithinRange, boundaryStmtCol2);
+    ResultSet columnWithinRangeResultSet = boundaryStmtCol2.executeQuery();
     columnWithinRangeResultSet.next();
     Pair<Integer, Integer> columnWithinRangeBoundary =
         Pair.of(columnWithinRangeResultSet.getInt(1), columnWithinRangeResultSet.getInt(2));

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/ColumnForBoundaryQueryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/ColumnForBoundaryQueryTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundarySplitterFactory;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link ColumnForBoundaryQuery}. */
+@RunWith(MockitoJUnitRunner.class)
+public class ColumnForBoundaryQueryTest {
+  @Test
+  public void testColumnForBoundaryQuery() {
+    Range parentRange =
+        Range.builder()
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setStart(0)
+            .setEnd(42)
+            .build();
+    ColumnForBoundaryQuery columnForBoundaryQueryWithDefaults =
+        ColumnForBoundaryQuery.builder()
+            .setColumnName("col1")
+            .setColumnClass(Integer.class)
+            .build();
+    ColumnForBoundaryQuery columnForBoundaryQueryRange =
+        ColumnForBoundaryQuery.builder()
+            .setColumnName("col2")
+            .setColumnClass(Integer.class)
+            .setParentRange(parentRange)
+            .build();
+    assertThat(columnForBoundaryQueryWithDefaults.columnName()).isEqualTo("col1");
+    assertThat(columnForBoundaryQueryRange.columnClass()).isEqualTo(Integer.class);
+    assertThat(columnForBoundaryQueryWithDefaults.parentRange()).isNull();
+    assertThat(columnForBoundaryQueryRange.columnName()).isEqualTo("col2");
+    assertThat(columnForBoundaryQueryRange.parentRange()).isEqualTo(parentRange);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryExtractorFactoryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryExtractorFactoryTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.math.BigInteger;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.apache.beam.sdk.io.jdbc.JdbcIO.PoolableDataSourceProvider;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link BoundaryExtractorFactory}. */
+@RunWith(MockitoJUnitRunner.class)
+public class BoundaryExtractorFactoryTest {
+
+  @Mock ResultSet mockResultSet;
+
+  @Test
+  public void testFromLongs() throws SQLException {
+    BoundaryExtractor<Long> extractor = BoundaryExtractorFactory.create(Long.class);
+    PartitionColumn partitionColumn =
+        PartitionColumn.builder().setColumnName("col1").setColumnClass(Long.class).build();
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getLong(1)).thenReturn(0L);
+    when(mockResultSet.getLong(2)).thenReturn(42L);
+    Boundary<Long> boundary = extractor.getBoundary(partitionColumn, mockResultSet, null);
+
+    assertThat(boundary.start()).isEqualTo(0L);
+    assertThat(boundary.end()).isEqualTo(42L);
+    assertThat(boundary.split(null).getLeft().end()).isEqualTo(21L);
+    // Mismatched Type
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            extractor.getBoundary(
+                PartitionColumn.builder()
+                    .setColumnName("col1")
+                    .setColumnClass(Integer.class)
+                    .build(),
+                mockResultSet,
+                null));
+  }
+
+  @Test
+  public void testFromIntegers() throws SQLException {
+    PartitionColumn partitionColumn =
+        PartitionColumn.builder().setColumnName("col1").setColumnClass(Integer.class).build();
+    BoundaryExtractor<Integer> extractor = BoundaryExtractorFactory.create(Integer.class);
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getInt(1)).thenReturn(0);
+    when(mockResultSet.getInt(2)).thenReturn(42);
+    Boundary<Integer> boundary = extractor.getBoundary(partitionColumn, mockResultSet, null);
+
+    assertThat(boundary.start()).isEqualTo(0);
+    assertThat(boundary.end()).isEqualTo(42);
+    assertThat(boundary.split(null).getLeft().end()).isEqualTo(21);
+    // Mismatched Type
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            extractor.getBoundary(
+                PartitionColumn.builder().setColumnName("col1").setColumnClass(Long.class).build(),
+                mockResultSet,
+                null));
+  }
+
+  @Test
+  public void testFromStrings() throws SQLException {
+    PartitionColumn partitionColumn =
+        PartitionColumn.builder()
+            .setColumnName("col1")
+            .setColumnClass(String.class)
+            .setStringCollation("latin1_swedish_ci")
+            .setStringMaxLength(255)
+            .build();
+    BoundaryExtractor<String> extractor = BoundaryExtractorFactory.create(String.class);
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getString(1)).thenReturn("cloud");
+    when(mockResultSet.getString(2)).thenReturn("spanner");
+
+    Boundary<String> boundary =
+        extractor.getBoundary(
+            partitionColumn,
+            mockResultSet,
+            new BoundaryTypeMapper() {
+              @Override
+              public BigInteger mapString(
+                  String element,
+                  int lengthTOPad,
+                  PartitionColumn partitionColumn,
+                  ProcessContext c) {
+                return null;
+              }
+
+              @Override
+              public String unMapString(
+                  BigInteger element, PartitionColumn partitionColumn, ProcessContext c) {
+                return null;
+              }
+            });
+
+    assertThat(boundary.start()).isEqualTo("cloud");
+    assertThat(boundary.end()).isEqualTo("spanner");
+    // Null type mapper check
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> extractor.getBoundary(partitionColumn, mockResultSet, null));
+    // Mismatched Type
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            extractor.getBoundary(
+                PartitionColumn.builder()
+                    .setColumnName("col1")
+                    .setColumnClass(Integer.class)
+                    .build(),
+                mockResultSet,
+                null));
+  }
+
+  @Test
+  public void testFromUnsupported() {
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> BoundaryExtractorFactory.create(PoolableDataSourceProvider.class));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundarySplitterFactoryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundarySplitterFactoryTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import java.math.BigInteger;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+import org.apache.commons.pool.impl.GenericObjectPool;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link BoundarySplitterFactory}. */
+@RunWith(MockitoJUnitRunner.class)
+public class BoundarySplitterFactoryTest {
+  @Test
+  public void testLongBoundarySplitter() {
+    BoundarySplitter<Long> splitter = BoundarySplitterFactory.create(Long.class);
+
+    assertThat(splitter.getSplitPoint(Long.MAX_VALUE - 2, Long.MAX_VALUE, null, null, null))
+        .isEqualTo(Long.MAX_VALUE - 1);
+    assertThat(splitter.getSplitPoint(Long.MIN_VALUE, Long.MIN_VALUE + 4, null, null, null))
+        .isEqualTo(Long.MIN_VALUE + 2);
+    assertThat(splitter.getSplitPoint(Long.MIN_VALUE, Long.MAX_VALUE, null, null, null))
+        .isEqualTo(-1L);
+    assertThat(splitter.getSplitPoint(10L, 0L, null, null, null)).isEqualTo(5L);
+    assertThat(splitter.getSplitPoint(null, null, null, null, null)).isNull();
+    assertThat(splitter.getSplitPoint(Long.MIN_VALUE + 2L, null, null, null, null))
+        .isEqualTo(Long.MIN_VALUE + 1);
+    assertThat(splitter.getSplitPoint(null, Long.MIN_VALUE, null, null, null))
+        .isEqualTo(Long.MIN_VALUE);
+  }
+
+  @Test
+  public void testIntegerBoundarySplitter() {
+    BoundarySplitter<Integer> splitter = BoundarySplitterFactory.create(Integer.class);
+
+    assertThat(splitter.getSplitPoint(Integer.MAX_VALUE - 2, Integer.MAX_VALUE, null, null, null))
+        .isEqualTo(Integer.MAX_VALUE - 1);
+    assertThat(splitter.getSplitPoint(Integer.MIN_VALUE, Integer.MIN_VALUE + 4, null, null, null))
+        .isEqualTo(Integer.MIN_VALUE + 2);
+    assertThat(splitter.getSplitPoint(Integer.MIN_VALUE, Integer.MAX_VALUE, null, null, null))
+        .isEqualTo(-1);
+    assertThat(splitter.getSplitPoint(10, 0, null, null, null)).isEqualTo(5);
+    assertThat(splitter.getSplitPoint(null, null, null, null, null)).isNull();
+    assertThat(splitter.getSplitPoint(Integer.MIN_VALUE + 1, null, null, null, null))
+        .isEqualTo(Integer.MIN_VALUE);
+    assertThat(splitter.getSplitPoint(null, Integer.MIN_VALUE + 1, null, null, null))
+        .isEqualTo(Integer.MIN_VALUE);
+  }
+
+  @Test
+  public void testBigIntegerBoundarySplitter() {
+    BoundarySplitter<BigInteger> splitter = BoundarySplitterFactory.create(BigInteger.class);
+    BigInteger start = BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(10L));
+    BigInteger startByTwo = BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(5L));
+    BigInteger end = BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(20L));
+    BigInteger mid = BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(15L));
+
+    assertThat(splitter.getSplitPoint(start, end, null, null, null)).isEqualTo(mid);
+    assertThat(splitter.getSplitPoint(start, BigInteger.valueOf(0L), null, null, null))
+        .isEqualTo(startByTwo);
+    assertThat(
+            splitter.getSplitPoint(
+                BigInteger.valueOf(Long.MIN_VALUE),
+                BigInteger.valueOf(Long.MAX_VALUE),
+                null,
+                null,
+                null))
+        .isEqualTo(BigInteger.valueOf(-1L));
+    assertThat(splitter.getSplitPoint(null, null, null, null, null)).isNull();
+    assertThat(splitter.getSplitPoint(BigInteger.valueOf(42L), null, null, null, null))
+        .isEqualTo(BigInteger.valueOf(21L));
+    assertThat(splitter.getSplitPoint(null, BigInteger.valueOf(42L), null, null, null))
+        .isEqualTo(BigInteger.valueOf(21L));
+  }
+
+  @Test
+  public void testStringBoundarySplitter() {
+
+    BoundaryTypeMapper mapper = new TestBoundaryTypeMapper();
+    BoundarySplitter<String> splitter = BoundarySplitterFactory.create(String.class);
+    StringBuilder repeatedA = new StringBuilder();
+    StringBuilder repeatedAvg = new StringBuilder();
+    StringBuilder longPaddedAvg = new StringBuilder();
+    StringBuilder repeatedZ = new StringBuilder();
+    for (int i = 0; i < 255; i++) {
+      repeatedA.append('a');
+      if (i == 0) {
+        repeatedAvg.append('m');
+        longPaddedAvg.append('m');
+      } else {
+        // The average of zz and aa is mz, just like average of 99 and 00 is 49.
+        repeatedAvg.append('z');
+        longPaddedAvg.append('a');
+      }
+      repeatedZ.append('z');
+    }
+
+    PartitionColumn partitionColumn =
+        PartitionColumn.builder()
+            .setColumnName("col1")
+            .setColumnClass(String.class)
+            .setStringCollation("latin1_general_cs")
+            .setStringMaxLength(255)
+            .build();
+
+    // Same Length
+    assertThat(
+            splitter.getSplitPoint(
+                "Spanner",
+                "branner",
+                partitionColumn.toBuilder().setStringMaxLength(7).build(),
+                mapper,
+                null))
+        .isEqualTo("kdanner");
+    // Variable Length
+    assertThat(
+            splitter.getSplitPoint(
+                "cat",
+                "mouse",
+                partitionColumn.toBuilder().setStringMaxLength(5).build(),
+                mapper,
+                null))
+        .isEqualTo("hhtwc");
+    // Null and empty
+    assertThat(splitter.getSplitPoint(null, null, partitionColumn, mapper, null)).isNull();
+    assertThat(
+            splitter.getSplitPoint(
+                null, "z", partitionColumn.toBuilder().setStringMaxLength(1).build(), mapper, null))
+        .isEqualTo("m");
+    assertThat(
+            splitter.getSplitPoint(
+                "z", null, partitionColumn.toBuilder().setStringMaxLength(1).build(), mapper, null))
+        .isEqualTo("m");
+    assertThat(
+            splitter.getSplitPoint(
+                "z", "", partitionColumn.toBuilder().setStringMaxLength(1).build(), mapper, null))
+        .isEqualTo("m");
+    assertThat(
+            splitter.getSplitPoint(
+                "", "z", partitionColumn.toBuilder().setStringMaxLength(1).build(), mapper, null))
+        .isEqualTo("m");
+
+    // Long string
+    assertThat(
+            splitter.getSplitPoint(
+                repeatedA.toString(),
+                repeatedZ.toString(),
+                partitionColumn.toBuilder().setStringMaxLength(255).build(),
+                mapper,
+                null))
+        .isEqualTo(repeatedAvg.toString());
+    assertThat(
+            splitter.getSplitPoint(
+                "a",
+                "y",
+                partitionColumn.toBuilder().setStringMaxLength(255).build(),
+                mapper,
+                null))
+        .isEqualTo(longPaddedAvg.toString());
+
+    // Null Checks.
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> splitter.getSplitPoint("Spanner", "branner", null, mapper, null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> splitter.getSplitPoint("Spanner", "branner", partitionColumn, null, null));
+    // Mismatched types.
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            splitter.getSplitPoint(
+                "Spanner",
+                "branner",
+                PartitionColumn.builder()
+                    .setColumnName("intcol")
+                    .setColumnClass(Integer.class)
+                    .autoBuild(),
+                mapper,
+                null));
+  }
+
+  @Test
+  public void testBoundarySplitterFactoryExceptions() {
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> BoundarySplitterFactory.create(GenericObjectPool.class));
+  }
+
+  /* Not for production as it does not look at collation ordering */
+  private class TestBoundaryTypeMapper implements BoundaryTypeMapper {
+
+    private static final long CHARACTER_SET_SIZE = 26L;
+
+    private long getOrdinalPosition(char c) {
+      return Character.toLowerCase(c) - 'a';
+    }
+
+    private char getCharacterFromPosition(long position) {
+      return (char) ('a' + position);
+    }
+
+    @Override
+    public BigInteger mapString(
+        String element,
+        int lengthToPad,
+        PartitionColumn partitionColumn,
+        ProcessContext processContext) {
+      BigInteger ret = BigInteger.ZERO;
+      for (char c : element.toCharArray()) {
+        ret =
+            ret.multiply(BigInteger.valueOf(CHARACTER_SET_SIZE))
+                .add(BigInteger.valueOf(getOrdinalPosition(c)));
+      }
+      for (int i = element.length(); i < lengthToPad; i++) {
+        ret = ret.multiply(BigInteger.valueOf(CHARACTER_SET_SIZE));
+      }
+      return ret;
+    }
+
+    @Override
+    public String unMapString(
+        BigInteger element, PartitionColumn partitionColumn, ProcessContext processContext) {
+      StringBuilder word = new StringBuilder();
+      while (element != BigInteger.ZERO) {
+        BigInteger reminder = element.mod(BigInteger.valueOf(CHARACTER_SET_SIZE));
+        char c = getCharacterFromPosition(reminder.longValue());
+        word.append(c);
+        element = element.divide(BigInteger.valueOf(CHARACTER_SET_SIZE));
+      }
+      String ret = word.reverse().toString();
+      return ret;
+    }
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import java.io.Serializable;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link Boundary}. */
+@RunWith(MockitoJUnitRunner.class)
+public class BoundaryTest {
+  @Test
+  public void testBoundaryBasic() {
+    // We are testing capture type on purpose as this is they way it is used by Range class.
+    Boundary<? extends Serializable> boundary =
+        Boundary.builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setStart(0)
+            .setEnd(42)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .build();
+    assertThat(boundary.start()).isEqualTo(0);
+    assertThat(boundary.end()).isEqualTo(42);
+    assertThat(boundary.toBuilder().build()).isEqualTo(boundary);
+    assertThat(boundary.splitIndex().length()).isEqualTo(1);
+  }
+
+  @Test
+  public void testBoundaryWithNulls() {
+
+    Boundary<Integer> boundaryNullStart =
+        Boundary.<Integer>builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setStart(null)
+            .setEnd(42)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .build();
+
+    Boundary<Integer> boundaryNullBoth =
+        Boundary.<Integer>builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setStart(null)
+            .setEnd(null)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .build();
+
+    assertThat(boundaryNullStart.start()).isNull();
+    assertThat(boundaryNullBoth.start()).isNull();
+    assertThat(boundaryNullBoth.end()).isNull();
+  }
+
+  @Test
+  public void testBoundarySplit() {
+
+    Boundary<Integer> integerBoundary =
+        Boundary.<Integer>builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setStart(0)
+            .setEnd(42)
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .build();
+    Boundary stringBoundary =
+        Boundary.<String>builder()
+            .setStart("abc")
+            .setEnd("def")
+            .setColName("col1")
+            .setColClass(String.class)
+            .setBoundarySplitter(
+                (BoundarySplitter<String>)
+                    (start, end, partitionColumn, boundaryTypeMapper, processContext) -> null)
+            .setCollation("latin1_swedish_ci")
+            .setStringMaxLength(255)
+            .build();
+
+    assertThat(integerBoundary.isSplittable(null)).isTrue();
+    assertThat(integerBoundary.toBuilder().setEnd(0).build().isSplittable(null)).isFalse();
+    assertThat(
+            integerBoundary.toBuilder()
+                .setStart(integerBoundary.end() - 1)
+                .build()
+                .isSplittable(null))
+        .isFalse();
+    assertThat(integerBoundary.toBuilder().setStart(42).build().isSplittable(null)).isFalse();
+    Pair<Boundary<Integer>, Boundary<Integer>> splitBoundaries = integerBoundary.split(null);
+    assertThat(splitBoundaries.getLeft().start()).isEqualTo(0);
+    assertThat(splitBoundaries.getLeft().end()).isEqualTo(21);
+
+    assertThat(splitBoundaries.getRight().start()).isEqualTo(21);
+    assertThat(splitBoundaries.getRight().end()).isEqualTo(42);
+    assertThat(splitBoundaries.getLeft().compareTo(splitBoundaries.getRight()) < 0).isTrue();
+    assertThat(splitBoundaries.getRight().compareTo(splitBoundaries.getLeft()) > 0).isTrue();
+    assertThat(splitBoundaries.getLeft().compareTo(splitBoundaries.getLeft())).isEqualTo(0);
+    assertThat(stringBoundary.stringCollation()).isEqualTo("latin1_swedish_ci");
+    assertThat(stringBoundary.stringMaxLength()).isEqualTo(255);
+  }
+
+  @Test
+  public void testBoundaryMerge() {
+
+    Boundary<Integer> firstBoundary =
+        Boundary.<Integer>builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setStart(0)
+            .setEnd(20)
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .build();
+
+    Boundary<Integer> secondBoundary =
+        Boundary.<Integer>builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setStart(20)
+            .setEnd(42)
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .build();
+
+    Boundary<Integer> mergedBoundary =
+        Boundary.<Integer>builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setStart(0)
+            .setEnd(42)
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .build();
+    assertThat(firstBoundary.isMergable(secondBoundary)).isTrue();
+    assertThat(secondBoundary.isMergable(firstBoundary)).isTrue();
+    assertThat(
+            firstBoundary.toBuilder()
+                .setEnd(secondBoundary.start() + 1)
+                .build()
+                .isMergable(secondBoundary))
+        .isFalse();
+    assertThat(
+            secondBoundary.toBuilder()
+                .setStart(firstBoundary.end() + 1)
+                .build()
+                .isMergable(firstBoundary))
+        .isFalse();
+    assertThat(firstBoundary.merge(secondBoundary)).isEqualTo(mergedBoundary);
+    assertThat(secondBoundary.merge(firstBoundary)).isEqualTo(mergedBoundary);
+  }
+
+  @Test
+  public void testBoundaryOrdering() {
+
+    Boundary<Integer> rootBoundary =
+        Boundary.<Integer>builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setStart(0)
+            .setEnd(32)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .build();
+    Pair<Boundary<Integer>, Boundary<Integer>> firstLevelSplit = rootBoundary.split(null);
+    Boundary<Integer> firstLevelFirstBoundary = firstLevelSplit.getLeft();
+    Boundary<Integer> firstLevelSecondBoudnary = firstLevelSplit.getRight();
+
+    Pair<Boundary<Integer>, Boundary<Integer>> secondLevelFirstSplit =
+        firstLevelFirstBoundary.split(null);
+    Boundary<Integer> secondLevelFirstBoudnary = secondLevelFirstSplit.getLeft();
+    Boundary<Integer> secondLevelSecondBoudnary = secondLevelFirstSplit.getRight();
+
+    Pair<Boundary<Integer>, Boundary<Integer>> secondLevelSecondSplit =
+        firstLevelSecondBoudnary.split(null);
+    Boundary<Integer> secondLevelThirdBoudnary = secondLevelSecondSplit.getLeft();
+    Boundary<Integer> secondLevelFourthBoudnary = secondLevelSecondSplit.getRight();
+
+    Boundary<Integer> mergedBoundary = secondLevelSecondBoudnary.merge(secondLevelThirdBoudnary);
+    assertThat(secondLevelFirstBoudnary).isLessThan(mergedBoundary);
+    assertThat(mergedBoundary).isLessThan(secondLevelFourthBoudnary);
+    assertThat(mergedBoundary.splitIndex()).isEqualTo(secondLevelThirdBoudnary.splitIndex());
+
+    assertThat(rootBoundary)
+        .isLessThan(
+            rootBoundary.toBuilder()
+                .setPartitionColumn(
+                    rootBoundary.partitionColumn().toBuilder().setColumnName("col2").build())
+                .build());
+  }
+
+  @Test
+  public void testBoundaryToRange() {
+
+    Boundary<Integer> newBoundary =
+        Boundary.<Integer>builder()
+            .setColName("col2")
+            .setColClass(Integer.class)
+            .setStart(0)
+            .setEnd(42)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .build();
+
+    Range parentRange =
+        Range.builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setStart(42)
+            .setEnd(42)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .build();
+    Range newRangeWithoutParent = newBoundary.toRange(null, null);
+    Range newRangeWithParent = newBoundary.toRange(parentRange, null);
+
+    assertThat(newRangeWithParent.childRange().isFirst()).isTrue();
+    assertThat(newRangeWithParent.childRange().isLast()).isTrue();
+    assertThat(newRangeWithoutParent.isFirst()).isTrue();
+    assertThat(newRangeWithoutParent.isLast()).isTrue();
+    assertThat(newRangeWithoutParent.boundary()).isEqualTo(newBoundary);
+    assertThat(newRangeWithParent.childRange().boundary()).isEqualTo(newBoundary);
+    assertThat(newRangeWithParent.boundary()).isEqualTo(parentRange.boundary());
+  }
+
+  @Test
+  public void testBoundaryTypeSafety() {
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            Boundary.builder()
+                .setColName("col1")
+                .setColClass(Integer.class)
+                .setStart(1)
+                .setEnd(10.30)
+                .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+                .build());
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            Boundary.builder()
+                .setColName("col1")
+                .setColClass(Integer.class)
+                .setStart(null)
+                .setEnd(10.30)
+                .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+                .build());
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            Boundary.builder()
+                .setColName("col1")
+                .setColClass(Integer.class)
+                .setStart(11.3)
+                .setEnd(null)
+                .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+                .build());
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            Boundary.builder()
+                .setPartitionColumn(
+                    PartitionColumn.builder()
+                        .setColumnName("col1")
+                        .setColumnClass(Long.class)
+                        .build())
+                .setStart(1)
+                .setEnd(10.30)
+                .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+                .build());
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/PartitionColumnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/PartitionColumnTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link PartitionColumn}. */
+@RunWith(MockitoJUnitRunner.class)
+public class PartitionColumnTest {
+  @Test
+  public void testPartitionColumnBasic() {
+    PartitionColumn integerPartitionColumn =
+        PartitionColumn.builder().setColumnName("col1").setColumnClass(Integer.class).build();
+
+    PartitionColumn stringPartitionColumn =
+        PartitionColumn.builder()
+            .setColumnName("col1")
+            .setColumnClass(String.class)
+            .setStringCollation("latin1_swedish_ci")
+            .setStringMaxLength(255)
+            .build();
+
+    assertThat(integerPartitionColumn.columnClass()).isEqualTo(Integer.class);
+    assertThat(integerPartitionColumn.columnName()).isEqualTo("col1");
+    assertThat(integerPartitionColumn.stringCollation()).isNull();
+    assertThat(stringPartitionColumn.stringCollation()).isEqualTo("latin1_swedish_ci");
+    assertThat(stringPartitionColumn.stringMaxLength()).isEqualTo(255);
+  }
+
+  @Test
+  public void testPartitionColumnPreconditions() {
+    assertThrows(
+        IllegalStateException.class,
+        () -> PartitionColumn.builder().setColumnName("col1").setColumnClass(String.class).build());
+
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            PartitionColumn.builder()
+                .setColumnName("col1")
+                .setColumnClass(Integer.class)
+                .setStringCollation("latin1_swedish_ci")
+                .build());
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            PartitionColumn.builder()
+                .setColumnName("col1")
+                .setColumnClass(String.class)
+                // NoCollation
+                .setStringMaxLength(255)
+                .build());
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            PartitionColumn.builder()
+                .setColumnName("col1")
+                .setColumnClass(String.class)
+                .setStringCollation("latin1_swedish_ci")
+                // No Max Length.
+                .build());
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/RangePreparedStatementSetterTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/RangePreparedStatementSetterTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import com.google.common.collect.ImmutableList;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link RangePreparedStatementSetter}. */
+@RunWith(MockitoJUnitRunner.class)
+public class RangePreparedStatementSetterTest {
+  Connection connection;
+
+  @BeforeClass
+  public static void beforeClass() {
+    // by default, derby uses a lock timeout of 60 seconds. In order to speed up the test
+    // and detect the lock faster, we decrease this timeout
+    System.setProperty("derby.locks.waitTimeout", "2");
+    System.setProperty("derby.stream.error.file", "build/derby.log");
+  }
+
+  @Before
+  public void initDerby() throws SQLException, ClassNotFoundException {
+    // Creating testDB database
+    Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+    connection = DriverManager.getConnection("jdbc:derby:memory:TestingDB;create=true");
+    createDerbyTable();
+  }
+
+  private void createDerbyTable() throws SQLException {
+    Statement stmtCreateTable = connection.createStatement();
+    String createTableSQL =
+        "CREATE TABLE test_table_range_setter ("
+            + "col1 INT,"
+            + "col2 INT,"
+            + "data CHAR(20),"
+            + "PRIMARY KEY (col1, col2)"
+            + ")";
+    stmtCreateTable.executeUpdate(createTableSQL);
+
+    // 2.2 Insert Data (Using PreparedStatement for Efficiency & Security)
+    String insertSQL = "INSERT INTO test_table_range_setter (col1, col2, data) VALUES (?, ?, ?)";
+    PreparedStatement stmtInsert = connection.prepareStatement(insertSQL);
+
+    // Batch the insert operations
+    stmtInsert.setInt(1, 10);
+    stmtInsert.setInt(2, 30);
+    stmtInsert.setString(3, "Data A");
+    stmtInsert.addBatch();
+
+    stmtInsert.setInt(1, 15);
+    stmtInsert.setInt(2, 35);
+    stmtInsert.setString(3, "Data B");
+    stmtInsert.addBatch();
+
+    stmtInsert.setInt(1, 25);
+    stmtInsert.setInt(2, 50);
+    stmtInsert.setString(3, "Data C");
+    stmtInsert.addBatch();
+
+    stmtInsert.setInt(1, 30);
+    stmtInsert.setInt(2, 60);
+    stmtInsert.setString(3, "Data D");
+    stmtInsert.addBatch();
+
+    stmtInsert.setInt(1, 40);
+    stmtInsert.setInt(2, 70);
+    stmtInsert.setString(3, "Data E");
+    stmtInsert.addBatch();
+
+    stmtInsert.setInt(1, 40);
+    stmtInsert.setInt(2, 80);
+    stmtInsert.setString(3, "Data F");
+    stmtInsert.addBatch();
+
+    stmtInsert.executeBatch();
+  }
+
+  private void dropDerbyTable() throws SQLException {
+    Statement statement = connection.createStatement();
+    statement.executeUpdate("drop table test_table_range_setter");
+  }
+
+  @Test
+  public void testSetParameters() throws Exception {
+
+    ImmutableList<String> partitionCols = ImmutableList.of("col1", "col2");
+    RangePreparedStatementSetter rangePreparedStatementSetter =
+        new RangePreparedStatementSetter(partitionCols.size());
+
+    Range singleColNonLastRange =
+        Range.<Integer>builder()
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setStart(10)
+            .setEnd(25)
+            .setIsLast(false)
+            .build();
+    String readQuery =
+        new MysqlDialectAdapter(MySqlVersion.DEFAULT)
+            .getReadQuery("test_table_range_setter", partitionCols);
+    PreparedStatement readStmtSingleColNonLast = connection.prepareStatement(readQuery);
+    rangePreparedStatementSetter.setParameters(singleColNonLastRange, readStmtSingleColNonLast);
+    ResultSet readStmtSingleColNonLastResultSet = readStmtSingleColNonLast.executeQuery();
+    ImmutableList.Builder<String> readSingleColNonLastRangedataPointsBuilder =
+        ImmutableList.builder();
+    while (readStmtSingleColNonLastResultSet.next()) {
+      readSingleColNonLastRangedataPointsBuilder.add(
+          readStmtSingleColNonLastResultSet.getString("data").trim());
+    }
+
+    String countQuery =
+        new MysqlDialectAdapter(MySqlVersion.DEFAULT)
+            .getCountQuery("test_table_range_setter", partitionCols, 0);
+    PreparedStatement countStmtSingleColNonLast = connection.prepareStatement(countQuery);
+    rangePreparedStatementSetter.setParameters(singleColNonLastRange, countStmtSingleColNonLast);
+    ResultSet countStmtSingleColNonLastResultSet = countStmtSingleColNonLast.executeQuery();
+    countStmtSingleColNonLastResultSet.next();
+    Integer countSingleColNonLast = countStmtSingleColNonLastResultSet.getInt(1);
+
+    Range singleColLastRange = singleColNonLastRange.toBuilder().setIsLast(true).build();
+    rangePreparedStatementSetter.setParameters(singleColLastRange, readStmtSingleColNonLast);
+    ResultSet readStmtSingleColLastResultSet = readStmtSingleColNonLast.executeQuery();
+    ImmutableList.Builder<String> readSingleColLastRangedataPointsBuilder = ImmutableList.builder();
+    while (readStmtSingleColLastResultSet.next()) {
+      readSingleColLastRangedataPointsBuilder.add(
+          readStmtSingleColLastResultSet.getString("data").trim());
+    }
+
+    Range bothColRange =
+        Range.<Integer>builder()
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setStart(10)
+            .setEnd(11)
+            .setIsLast(false)
+            .build()
+            .withChildRange(
+                Range.<Integer>builder()
+                    .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+                    .setColName("col2")
+                    .setColClass(Integer.class)
+                    .setStart(30)
+                    .setEnd(40)
+                    .build(),
+                null);
+    PreparedStatement countStmtBothCol = connection.prepareStatement(countQuery);
+    rangePreparedStatementSetter.setParameters(bothColRange, countStmtBothCol);
+    ResultSet countStmtBothColResultSet = countStmtBothCol.executeQuery();
+    countStmtBothColResultSet.next();
+    Integer countBothCol = countStmtBothColResultSet.getInt(1);
+
+    assertThat(readSingleColNonLastRangedataPointsBuilder.build())
+        .isEqualTo(ImmutableList.of("Data A", "Data B"));
+    assertThat(countSingleColNonLast).isEqualTo(2);
+    assertThat(readSingleColLastRangedataPointsBuilder.build())
+        .isEqualTo(ImmutableList.of("Data A", "Data B", "Data C"));
+    assertThat(countBothCol).isEqualTo(1);
+  }
+
+  @After
+  public void exitDerby() throws SQLException {
+    dropDerbyTable();
+    connection.close();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/RangeTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/RangeTest.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link Range}. */
+@RunWith(MockitoJUnitRunner.class)
+public class RangeTest {
+  @Test
+  public void testRangeBuildBasic() {
+    final String colName = "long_col_1";
+    long start = 0L;
+    long end = 42L;
+    Range range =
+        Range.builder()
+            .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
+            .setColName("long_col_1")
+            .setColClass(Long.class)
+            .setStart(start)
+            .setEnd(end)
+            .build();
+
+    assertThat(range.colName()).isEqualTo(colName);
+    assertThat(range.start()).isEqualTo(start);
+    assertThat(range.end()).isEqualTo(end);
+    assertThat(range.isSplittable(null)).isTrue();
+    /* Check Defaults */
+    assertThat(range.hasChildRange()).isFalse();
+    assertThat(range.height()).isEqualTo(0);
+    assertThat(range.isUncounted()).isTrue();
+    assertThat(range.isFirst()).isFalse();
+    assertThat(range.isLast()).isFalse();
+    assertThat(range.equals(range));
+    assertThat(range.withCount(200L, null).count()).isEqualTo(200L);
+    // Test Split Length.
+    assertThat(
+            range.toBuilder()
+                .setStart(end)
+                .build()
+                .withChildRange(range.toBuilder().setColName("long_col_2").build(), null)
+                .height())
+        .isEqualTo(1);
+    // Test withCount
+    assertThat(range.withCount(10L, null).count()).isEqualTo(10L);
+    assertThat(range.withCount(10L, null).isUncounted()).isFalse();
+  }
+
+  @Test
+  public void testRangeWithChild() {
+    Range basicRange =
+        Range.builder()
+            .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
+            .setColName("long_col_1")
+            .setColClass(Long.class)
+            .setStart(42L)
+            .setEnd(43L)
+            .build();
+    Range rangeWithChild =
+        basicRange.withChildRange(basicRange.toBuilder().setColName("long_col_2").build(), null);
+    Range rangeWithChildCounted = rangeWithChild.withCount(42L, null);
+
+    assertThat(rangeWithChild.hasChildRange()).isTrue();
+    assertThat(rangeWithChildCounted.count()).isEqualTo(42L);
+    assertThat(rangeWithChildCounted.childRange().count()).isEqualTo(42L);
+    assertThat(rangeWithChild.height()).isEqualTo(1L);
+    assertThat(rangeWithChildCounted.height()).isEqualTo(1L);
+    /* Child cant be added on a splitable range */
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            basicRange.toBuilder()
+                .setStart((long) basicRange.end() - 2)
+                .build()
+                .withChildRange(basicRange.toBuilder().setColName("long_col_2").build(), null));
+    /* Child cant be added with same column name */
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> basicRange.withChildRange(basicRange.toBuilder().build(), null));
+  }
+
+  @Test
+  public void testRangeSplit() {
+
+    long startBase = 42L;
+    long endBase = 42L;
+
+    Range rangeBase =
+        Range.builder()
+            .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
+            .setColName("long_col_base")
+            .setColClass(Long.class)
+            .setStart(startBase)
+            .setIsLast(true)
+            .setEnd(endBase)
+            .setIsFirst(true)
+            .setIsLast(true)
+            .build();
+
+    long start = 0L;
+    long end = 42L;
+    long mid = 21L;
+    Range rangeChild =
+        Range.builder()
+            .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
+            .setColName("long_col_child")
+            .setColClass(Long.class)
+            .setStart(start)
+            .setEnd(end)
+            .setIsFirst(true)
+            .setIsLast(true)
+            .build();
+    Range range = rangeBase.withChildRange(rangeChild, null);
+    Pair<Range, Range> splitPair = range.split(null);
+    Range left = splitPair.getLeft();
+    Range right = splitPair.getRight();
+
+    assertThat(range.isSplittable(null)).isTrue();
+    assertThat(rangeChild.isSplittable(null)).isTrue();
+    assertThat(rangeBase.isSplittable(null)).isFalse();
+    assertThat(
+            rangeBase
+                .withChildRange(rangeBase.toBuilder().setColName("long_col_2").build(), null)
+                .isSplittable(null))
+        .isFalse();
+    assertThat(rangeBase.toBuilder().setEnd(startBase + 1).build().isSplittable(null)).isFalse();
+    assertThat(range.isSplittable(null)).isTrue();
+    assertThat(left.start()).isEqualTo(rangeBase.start());
+    assertThat(left.end()).isEqualTo(rangeBase.end());
+    assertThat(left.childRange().start()).isEqualTo(rangeChild.start());
+    assertThat(left.childRange().end()).isEqualTo(mid);
+    assertThat(left.isFirst()).isTrue();
+    assertThat(left.isLast()).isTrue();
+    assertThat(right.start()).isEqualTo(rangeBase.start());
+    assertThat(right.end()).isEqualTo(rangeBase.end());
+    assertThat(right.childRange().start()).isEqualTo(mid);
+    assertThat(right.childRange().end()).isEqualTo(range.end());
+    assertThat(right.isFirst()).isTrue();
+    assertThat(right.isLast()).isTrue();
+    // Comparisons
+    assertThat(left.compareTo(left)).isEqualTo(0);
+    assertThat(left).isLessThan(right);
+    assertThat(rangeBase).isLessThan(range);
+    assertThat(rangeBase.withCount(0L, null)).isLessThan(rangeBase.withCount(42L, null));
+    // Splitting Unsplittable Range.
+    assertThrows(IllegalArgumentException.class, () -> rangeBase.split(null));
+  }
+
+  @Test
+  public void testAccumulateCount() {
+    Range uncountedRange =
+        Range.builder()
+            .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
+            .setColName("long_col_1")
+            .setColClass(Long.class)
+            .setStart(0L)
+            .setEnd(42L)
+            .build();
+
+    Range countedRange = uncountedRange.withCount(20L, null);
+    assertThat(uncountedRange.accumulateCount(countedRange.count()))
+        .isEqualTo(Range.INDETERMINATE_COUNT);
+    assertThat(countedRange.accumulateCount(Range.INDETERMINATE_COUNT))
+        .isEqualTo(Range.INDETERMINATE_COUNT);
+    assertThat(countedRange.accumulateCount(countedRange.count())).isEqualTo(40L);
+  }
+
+  @Test
+  public void testRangeMerge() {
+    long startBase = 42L;
+    long endBase = 42L;
+
+    Range rangeBase =
+        Range.builder()
+            .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
+            .setColName("long_col_base")
+            .setColClass(Long.class)
+            .setStart(startBase)
+            .setIsLast(true)
+            .setEnd(endBase)
+            .setIsFirst(true)
+            .setIsLast(true)
+            .build();
+
+    long start = 0L;
+    long end = 42L;
+    long mid = 21L;
+    Range leftChild =
+        Range.builder()
+            .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
+            .setColName("long_col_child")
+            .setColClass(Long.class)
+            .setStart(start)
+            .setEnd(mid)
+            .setCount(10L)
+            .setIsFirst(true)
+            .setIsLast(false)
+            .build();
+
+    Range rightChild =
+        Range.builder()
+            .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
+            .setColName("long_col_child")
+            .setColClass(Long.class)
+            .setStart(mid)
+            .setEnd(end)
+            .setCount(10L)
+            .setIsFirst(false)
+            .setIsLast(true)
+            .build();
+    Range leftRange = rangeBase.withChildRange(leftChild, null);
+    Range rightRange = rangeBase.withChildRange(rightChild, null);
+    Range mergedRange = leftRange.mergeRange(rightRange, null);
+    Range mergedChild = mergedRange.childRange();
+
+    // Basic Mergability
+    assertThat(leftRange.isMergable(rightRange)).isTrue();
+    assertThat(rightRange.isMergable(leftRange)).isTrue();
+    // Non-Overlapping ranges are not mergable.
+    assertThat(
+            rightRange.isMergable(
+                leftRange.toBuilder()
+                    .setChildRange(rightChild.toBuilder().setStart(mid + 1).build())
+                    .build()))
+        .isFalse();
+    // Ranges with different ColumnNames are not mergable.
+    assertThat(leftRange.isMergable(rightRange.toBuilder().setColName("long_col_2").build()))
+        .isFalse();
+    // With and Without Child.
+    assertThat(rangeBase.isMergable(leftRange)).isFalse();
+    // Validating Merged Range
+    assertThat(mergedRange.count()).isEqualTo(20L);
+    assertThat(mergedRange.start()).isEqualTo(startBase);
+    assertThat(mergedRange.end()).isEqualTo(endBase);
+    assertThat(mergedChild.start()).isEqualTo(start);
+    assertThat(mergedChild.end()).isEqualTo(end);
+    assertThat(mergedChild.count()).isEqualTo(20L);
+    assertThat(mergedRange).isEqualTo(rightRange.mergeRange(leftRange, null));
+
+    assertThat(mergedChild.isFirst()).isTrue();
+    assertThat(mergedChild.isLast()).isTrue();
+    // Merging un-mergable ranges.
+    assertThrows(IllegalArgumentException.class, () -> rangeBase.mergeRange(rightRange, null));
+  }
+
+  @Test
+  public void testRangeEquality() {
+    Range basicRange =
+        Range.builder()
+            .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
+            .setColName("long_col_1")
+            .setColClass(Long.class)
+            .setStart(42L)
+            .setEnd(42L)
+            .build();
+
+    Range rangeWithChild =
+        basicRange.toBuilder()
+            .setChildRange(basicRange.toBuilder().setColName("long_col_2").build())
+            .build();
+
+    // Test Equality
+    assertThat(basicRange).isEqualTo(basicRange.toBuilder().build());
+    // Test Range Comparison
+    assertThat(basicRange).isNotEqualTo(basicRange.toBuilder().setStart(1L).build());
+    assertThat(basicRange).isNotEqualTo(basicRange.toBuilder().setEnd(100L).build());
+    // Test Column Name Comparison
+    assertThat(basicRange).isNotEqualTo(basicRange.toBuilder().setColName("long_col_2"));
+    // Test Class Comparison
+    assertThat(basicRange)
+        .isNotEqualTo(
+            Range.builder()
+                .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+                .setColName(basicRange.colName())
+                .setColClass(Integer.class)
+                .setStart(((Long) basicRange.start()).intValue())
+                .setEnd(((Long) basicRange.end()).intValue())
+                .build());
+    // Child Comparison
+    assertThat(basicRange).isNotEqualTo(rangeWithChild);
+    assertThat(rangeWithChild).isEqualTo(rangeWithChild.toBuilder().build());
+    // Null
+    assertThat(rangeWithChild.equals(null)).isFalse();
+    assertThat((Range) null).isNotEqualTo(rangeWithChild);
+    assertThat(rangeWithChild).isNotEqualTo(null);
+    // Count
+    assertThat(basicRange).isNotEqualTo(basicRange.withCount(100L, null));
+  }
+
+  @Test
+  public void testRangeWithChildPrecondition() {}
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/InitialSplitRangeDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/InitialSplitRangeDoFnTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundarySplitterFactory;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.common.collect.ImmutableList;
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link InitialSplitRangeDoFn}. */
+@RunWith(MockitoJUnitRunner.class)
+public class InitialSplitRangeDoFnTest {
+  @Mock OutputReceiver mockOut;
+  @Captor ArgumentCaptor<ImmutableList<Range>> rangeCaptor;
+  @Mock ProcessContext mockProcessContext;
+
+  @Test
+  public void testInitialSplitRangeBasic() {
+
+    InitialSplitRangeDoFn initialSplitRangeDoFn =
+        InitialSplitRangeDoFn.builder().setSplitHeight(5).setTableName("testTable").build();
+    Range range =
+        Range.builder()
+            .setColName("col1")
+            .setStart(0)
+            .setEnd(5)
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setIsFirst(true)
+            .setIsLast(true)
+            .build();
+    initialSplitRangeDoFn.processElement(range, mockOut, mockProcessContext);
+    verify(mockOut, times(1)).output(rangeCaptor.capture());
+    // We expect these to be 0-1, 1-2, 2-3, 3-4, 4-5
+    ImmutableList<Range> actualRanges = rangeCaptor.getValue();
+    assertThat(actualRanges.size()).isEqualTo(5);
+    for (int i = 0; i < 5; i++) {
+      assertThat(actualRanges.get(i).start()).isEqualTo(i);
+      assertThat(actualRanges.get(i).end()).isEqualTo(i + 1);
+      if (i == 0) {
+        assertThat(actualRanges.get(i).isFirst()).isTrue();
+      }
+      if (i == 4) {
+        assertThat(actualRanges.get(i).isLast()).isTrue();
+      }
+    }
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MergeRangesDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MergeRangesDoFnTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundarySplitterFactory;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.common.collect.ImmutableList;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link MergeRangesDoFn}. */
+@RunWith(MockitoJUnitRunner.class)
+public class MergeRangesDoFnTest {
+
+  @Mock OutputReceiver mockOut;
+  @Captor ArgumentCaptor<ImmutableList<Range>> rangesCaptor;
+  @Mock DoFn.ProcessContext mockProcessContext;
+
+  @Test
+  public void testMergeRangesDoFnWithAutoAdjustment() {
+    ImmutableList<Range> testRanges = getDummyRanges(mockProcessContext);
+    MergeRangesDoFn mergeRangesDoFn =
+        MergeRangesDoFn.builder()
+            .setMaxPartitionHint(2L)
+            .setApproxTotalRowCount(3200L)
+            .setAutoAdjustMaxPartitions(true)
+            .setTableName("testTable")
+            .build();
+    mergeRangesDoFn.processElement(testRanges, mockOut, mockProcessContext);
+
+    verify(mockOut).output(rangesCaptor.capture());
+    ImmutableList<Range> dummy = rangesCaptor.getValue();
+    assertThat(rangesCaptor.getValue())
+        .isEqualTo(
+            ImmutableList.of(
+                testRanges.get(0),
+                // Can not merge after 0 into 1 as count exceeds mean.
+                testRanges.get(1),
+                // Can not merge after 1 into 2 as count exceeds adjusted mean.
+                testRanges.get(2).mergeRange(testRanges.get(3), mockProcessContext),
+                // Can not merge after 3 into 4 as the ranges are not mergable.
+                testRanges.get(4),
+                // Can not merge after 4 into 5 as count exceeds adjusted mean.
+                testRanges.get(5),
+                // can not merge after 5 into 6 as ranges are not mergable.
+                testRanges
+                    .get(6)
+                    .mergeRange(testRanges.get(7), mockProcessContext)
+                    .mergeRange(testRanges.get(8), mockProcessContext)));
+  }
+
+  @Test
+  public void testMergeRangesDoFnNoAutoAdjustment() {
+    ImmutableList<Range> testRanges = getDummyRanges(mockProcessContext);
+    MergeRangesDoFn mergeRangesDoFn =
+        MergeRangesDoFn.builder()
+            .setMaxPartitionHint(2L)
+            .setApproxTotalRowCount(3200L)
+            .setAutoAdjustMaxPartitions(false)
+            .setTableName("testTable")
+            .build();
+    mergeRangesDoFn.processElement(testRanges, mockOut, mockProcessContext);
+
+    verify(mockOut).output(rangesCaptor.capture());
+    assertThat(rangesCaptor.getValue())
+        .isEqualTo(
+            ImmutableList.of(
+                testRanges.get(0),
+                // Can not merge after 0 into 1 as count exceeds mean.
+                testRanges
+                    .get(1)
+                    .mergeRange(testRanges.get(2), mockProcessContext)
+                    .mergeRange(testRanges.get(3), mockProcessContext),
+                // Can not merge after 3 into 4 as the ranges are not mergable.
+                testRanges.get(4).mergeRange(testRanges.get(5), mockProcessContext),
+                // can not merge after 5 into 6 as ranges are not mergable.
+                testRanges
+                    .get(6)
+                    .mergeRange(testRanges.get(7), mockProcessContext)
+                    .mergeRange(testRanges.get(8), mockProcessContext)));
+  }
+
+  private static ImmutableList<Range> getDummyRanges(ProcessContext mockProcessContext) {
+
+    Range testRange =
+        dummyCounter(
+            Range.builder()
+                .setStart(0L)
+                .setEnd(64L)
+                .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
+                .setColName("col1")
+                .setColClass(Long.class)
+                .build(),
+            mockProcessContext);
+    ImmutableList.Builder<Range> testRangesBuilder = ImmutableList.builder();
+    for (int i = 0; i < 6; i++) {
+      Pair<Range, Range> splitRanges = testRange.split(mockProcessContext);
+      if (i == 2) {
+        testRange = dummyCounter(splitRanges.getLeft(), mockProcessContext);
+        for (int j = 0; j < 3; j++) {
+          Pair<Range, Range> splitRangesFine = testRange.split(mockProcessContext);
+          testRangesBuilder.add(dummyCounter(splitRangesFine.getLeft(), mockProcessContext));
+          testRange = dummyCounter(splitRangesFine.getRight(), mockProcessContext);
+        }
+
+      } else {
+        testRangesBuilder.add(dummyCounter(splitRanges.getLeft(), mockProcessContext));
+      }
+      testRange = dummyCounter(splitRanges.getRight(), mockProcessContext);
+    }
+    /*Ranges we get here are 0-32, 32-48, 48-52, 52-54, 54-55, 56-60, 60-62, 62-63*/
+    ImmutableList<Range> testRanges = testRangesBuilder.build();
+    Pair<Range, Range> rangeWithChildSplit =
+        testRanges
+            .get(4)
+            .withChildRange(
+                dummyCounter(
+                    testRange.toBuilder().setColName("col2").setStart(0L).setEnd(15L).build(),
+                    mockProcessContext),
+                mockProcessContext)
+            .split(null);
+
+    testRangesBuilder = new ImmutableList.Builder<>();
+    for (int i = 0; i < testRanges.size(); i++) {
+      if (i == 4) {
+        testRangesBuilder.add(rangeWithChildSplit.getLeft()).add(rangeWithChildSplit.getRight());
+      } else {
+        testRangesBuilder.add(testRanges.get(i));
+      }
+    }
+    /*
+     * Ranges we get here are 0-32, 32-48, 48-52, 52-54, 54-55(withChild 0-8), 54-55(withChild 9 - 16), 56-60, 60-62, 62-63
+     * For testing purpose, All ranges have counts equal to 100 * (end - start) (for testing) except for the ones with a child with count 1500.
+     */
+    testRanges = testRangesBuilder.build();
+    return testRanges;
+  }
+
+  private static Range dummyCounter(Range range, ProcessContext mockProcessContext) {
+    return range.withCount(100L * ((Long) range.end() - (Long) range.start()), mockProcessContext);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryDoFnTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary.ColumnForBoundaryQuery;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundarySplitterFactory;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.common.collect.ImmutableList;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link RangeBoundaryDoFn}. */
+@RunWith(MockitoJUnitRunner.class)
+public class RangeBoundaryDoFnTest {
+  SerializableFunction<Void, DataSource> mockDataSourceProviderFn =
+      Mockito.mock(SerializableFunction.class, withSettings().serializable());
+  DataSource mockDataSource = Mockito.mock(DataSource.class, withSettings().serializable());
+
+  Connection mockConnection = Mockito.mock(Connection.class, withSettings().serializable());
+
+  @Mock PreparedStatement mockPreparedStatemet;
+
+  @Mock ResultSet mockResultSet;
+
+  @Mock OutputReceiver mockOut;
+  @Captor ArgumentCaptor<Range> rangeCaptor;
+  @Mock DoFn.ProcessContext mockProcessContext;
+
+  @Test
+  public void testRangeCountDoFnBasic() throws Exception {
+
+    when(mockDataSourceProviderFn.apply(any())).thenReturn(mockDataSource);
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.prepareStatement(anyString(), anyInt(), anyInt()))
+        .thenReturn(mockPreparedStatemet);
+    doNothing().when(mockPreparedStatemet).setObject(anyInt(), any());
+    when(mockPreparedStatemet.executeQuery()).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getLong(1)).thenReturn(0L);
+    when(mockResultSet.getLong(2)).thenReturn(42L);
+
+    RangeBoundaryDoFn rangeBoundaryDoFn =
+        new RangeBoundaryDoFn(
+            mockDataSourceProviderFn,
+            new MysqlDialectAdapter(MySqlVersion.DEFAULT),
+            "testTable",
+            ImmutableList.of("col1"),
+            null);
+    ColumnForBoundaryQuery input =
+        ColumnForBoundaryQuery.builder()
+            .setColumnClass(Long.class)
+            .setColumnName("col1")
+            .setParentRange(null)
+            .build();
+    rangeBoundaryDoFn.setup();
+    rangeBoundaryDoFn.processElement(input, mockOut, mockProcessContext);
+
+    verify(mockOut).output(rangeCaptor.capture());
+    Range newRange = rangeCaptor.getValue();
+    assertThat(newRange)
+        .isEqualTo(
+            Range.builder()
+                .setStart(0L)
+                .setEnd(42L)
+                .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
+                .setColName("col1")
+                .setColClass(Long.class)
+                .build());
+  }
+
+  @Test
+  public void testRangeCountDoFnSqlException() throws Exception {
+
+    when(mockDataSourceProviderFn.apply(any())).thenReturn(mockDataSource);
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.prepareStatement(anyString(), anyInt(), anyInt()))
+        .thenReturn(mockPreparedStatemet);
+    doNothing().when(mockPreparedStatemet).setObject(anyInt(), any());
+    when(mockPreparedStatemet.executeQuery()).thenThrow(new SQLException("test"));
+
+    RangeBoundaryDoFn rangeBoundaryDoFn =
+        new RangeBoundaryDoFn(
+            mockDataSourceProviderFn,
+            new MysqlDialectAdapter(MySqlVersion.DEFAULT),
+            "testTable",
+            ImmutableList.of("col1"),
+            null);
+    ColumnForBoundaryQuery input =
+        ColumnForBoundaryQuery.builder()
+            .setColumnClass(Long.class)
+            .setColumnName("col1")
+            .setParentRange(null)
+            .build();
+    rangeBoundaryDoFn.setup();
+
+    assertThrows(
+        SQLException.class,
+        () -> rangeBoundaryDoFn.processElement(input, mockOut, mockProcessContext));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryTransformTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryTransformTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary.ColumnForBoundaryQuery;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundarySplitterFactory;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.RangePreparedStatementSetter;
+import com.google.common.collect.ImmutableList;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link RangeBoundaryTransform}. */
+@RunWith(MockitoJUnitRunner.class)
+public class RangeBoundaryTransformTest {
+  private static final String tableName = "test_table_range_boundary";
+
+  SerializableFunction<Void, DataSource> dataSourceProviderFn =
+      ignored -> TransformTestUtils.DATA_SOURCE;
+
+  @Rule public final transient TestPipeline testPipeline = TestPipeline.create();
+
+  @BeforeClass
+  public static void beforeClass() throws SQLException {
+    // by default, derby uses a lock timeout of 60 seconds. In order to speed up the test
+    // and detect the lock faster, we decrease this timeout
+    System.setProperty("derby.locks.waitTimeout", "2");
+    System.setProperty("derby.stream.error.file", "build/derby.log");
+    TransformTestUtils.createDerbyTable(tableName);
+  }
+
+  @Test
+  public void testRangeCountTransform() throws Exception {
+    ImmutableList<String> partitionCols = ImmutableList.of("col1", "col2");
+    RangePreparedStatementSetter rangePreparedStatementSetter =
+        new RangePreparedStatementSetter(partitionCols.size());
+
+    ColumnForBoundaryQuery firstColumnForBoundaryQuery =
+        ColumnForBoundaryQuery.builder()
+            .setColumnName("col1")
+            .setColumnClass(Integer.class)
+            .build();
+    Range fullCol1Range =
+        Range.builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(10)
+            .setEnd(40)
+            .setIsFirst(true)
+            .setIsLast(true)
+            .build();
+
+    Range unSplitableCol1Range =
+        Range.builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(40)
+            .setEnd(40)
+            .setIsFirst(true)
+            .setIsLast(true)
+            .build();
+    ColumnForBoundaryQuery secondColumnForBoundaryQuery =
+        ColumnForBoundaryQuery.builder()
+            .setColumnName("col2")
+            .setColumnClass(Integer.class)
+            .setParentRange(unSplitableCol1Range)
+            .build();
+    Range col2Range =
+        unSplitableCol1Range.withChildRange(
+            Range.builder()
+                .setColName("col2")
+                .setColClass(Integer.class)
+                .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+                .setStart(70)
+                .setEnd(80)
+                .setIsFirst(true)
+                .setIsLast(true)
+                .build(),
+            null);
+
+    // Create a test pipeline.
+    PCollection<ColumnForBoundaryQuery> input =
+        testPipeline.apply(Create.of(firstColumnForBoundaryQuery, secondColumnForBoundaryQuery));
+    RangeBoundaryTransform rangeBoundaryTransform =
+        RangeBoundaryTransform.builder()
+            .setDbAdapter(new MysqlDialectAdapter(MySqlVersion.DEFAULT))
+            .setPartitionColumns(partitionCols)
+            .setDataSourceProviderFn(dataSourceProviderFn)
+            .setTableName(tableName)
+            .build();
+    PCollection<Range> output = input.apply(rangeBoundaryTransform);
+
+    PAssert.that(output).containsInAnyOrder(fullCol1Range, col2Range);
+
+    testPipeline.run().waitUntilFinish();
+  }
+
+  @AfterClass
+  public static void exitDerby() throws SQLException {
+    TransformTestUtils.dropDerbyTable(tableName);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeClassifierDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeClassifierDoFnTest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary.ColumnForBoundaryQuery;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundarySplitterFactory;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.PartitionColumn;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.common.collect.ImmutableList;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link RangeClassifierDoFn}. */
+@RunWith(MockitoJUnitRunner.class)
+public class RangeClassifierDoFnTest {
+
+  @Mock ProcessContext mockProcessContext;
+
+  @Test
+  public void testRangeClassifierNoAutoAdjust() {
+    TaggedOutputCaptor taggedOutputCaptor = new TaggedOutputCaptor();
+    Mockito.doAnswer(
+            invocationOnMock ->
+                taggedOutputCaptor.out(
+                    invocationOnMock.getArgument(0), invocationOnMock.getArgument(1)))
+        .when(mockProcessContext)
+        .output(any(), any());
+    Range rangeToRetainDueToCount =
+        Range.builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(0)
+            .setEnd(1000)
+            .setCount(10L)
+            .build();
+    Range rangeToSplit =
+        Range.builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(1000)
+            .setEnd(2000)
+            .setCount(1000L)
+            .build();
+    Range rangeToAddColumn =
+        Range.builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(2000)
+            .setEnd(2000)
+            .setCount(1000L)
+            .build();
+
+    Range rangeToRetainUnSplitable =
+        Range.builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(2001)
+            .setEnd(2002)
+            .build()
+            .withChildRange(
+                Range.builder()
+                    .setColName("col2")
+                    .setColClass(Integer.class)
+                    .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+                    .setStart(1000)
+                    .setEnd(1001)
+                    .setCount(1000L)
+                    .build(),
+                mockProcessContext);
+    RangeClassifierDoFn rangeClassifierDoFn =
+        RangeClassifierDoFn.builder()
+            .setApproxTotalRowCount(10L)
+            .setStageIdx(1L)
+            .setMaxPartitionHint(10L)
+            .setAutoAdjustMaxPartitions(false)
+            .setPartitionColumns(
+                ImmutableList.of(
+                    PartitionColumn.builder()
+                        .setColumnName("col1")
+                        .setColumnClass(Integer.class)
+                        .build(),
+                    PartitionColumn.builder()
+                        .setColumnName("col2")
+                        .setColumnClass(Integer.class)
+                        .build()))
+            .build();
+
+    Pair<Range, Range> splitRangeToCount = rangeToSplit.split(mockProcessContext);
+
+    rangeClassifierDoFn.processElement(
+        ImmutableList.of(
+            rangeToRetainDueToCount, rangeToSplit, rangeToAddColumn, rangeToRetainUnSplitable),
+        mockProcessContext);
+    assertThat(taggedOutputCaptor.toRetainAccumulator.build())
+        .isEqualTo(ImmutableList.of(rangeToRetainDueToCount, rangeToRetainUnSplitable));
+    assertThat(taggedOutputCaptor.toCountAccumulator.build())
+        .isEqualTo(ImmutableList.of(splitRangeToCount.getLeft(), splitRangeToCount.getRight()));
+    assertThat(taggedOutputCaptor.toAddColumnAccumulator.build())
+        .isEqualTo(
+            ImmutableList.of(
+                ColumnForBoundaryQuery.builder()
+                    .setColumnName("col2")
+                    .setColumnClass(Integer.class)
+                    .setParentRange(rangeToAddColumn)
+                    .build()));
+  }
+
+  @Test
+  public void testRangeClassifierAutoAdjust() {
+    TaggedOutputCaptor taggedOutputCaptor = new TaggedOutputCaptor();
+    Mockito.doAnswer(
+            invocationOnMock ->
+                taggedOutputCaptor.out(
+                    invocationOnMock.getArgument(0), invocationOnMock.getArgument(1)))
+        .when(mockProcessContext)
+        .output(any(), any());
+    Range rangeToRetainDueToCount =
+        Range.builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(0)
+            .setEnd(1000)
+            .setCount(10L)
+            .build();
+    // Here, the code auto-adjusts to 5 partitions
+    Range rangeToRetainAndNotSplit =
+        Range.builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(1000)
+            .setEnd(2000)
+            .setCount(1000L)
+            .build();
+    Range rangeToRetainNotAddColumn =
+        Range.builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(2000)
+            .setEnd(2000)
+            .setCount(1000L)
+            .build();
+
+    Range rangeToRetainUnSplitable =
+        Range.builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(2001)
+            .setEnd(2002)
+            .build()
+            .withChildRange(
+                Range.builder()
+                    .setColName("col2")
+                    .setColClass(Integer.class)
+                    .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+                    .setStart(1000)
+                    .setEnd(1001)
+                    .setCount(1000L)
+                    .build(),
+                mockProcessContext);
+    RangeClassifierDoFn rangeClassifierDoFn =
+        RangeClassifierDoFn.builder()
+            .setApproxTotalRowCount(1L)
+            .setStageIdx(1L)
+            .setMaxPartitionHint(1L)
+            .setAutoAdjustMaxPartitions(true)
+            .setPartitionColumns(
+                ImmutableList.of(
+                    PartitionColumn.builder()
+                        .setColumnName("col1")
+                        .setColumnClass(Integer.class)
+                        .build(),
+                    PartitionColumn.builder()
+                        .setColumnName("col2")
+                        .setColumnClass(Integer.class)
+                        .build()))
+            .build();
+
+    Pair<Range, Range> splitRangeToCount = rangeToRetainAndNotSplit.split(mockProcessContext);
+
+    rangeClassifierDoFn.processElement(
+        ImmutableList.of(
+            rangeToRetainDueToCount,
+            rangeToRetainAndNotSplit,
+            rangeToRetainNotAddColumn,
+            rangeToRetainUnSplitable),
+        mockProcessContext);
+    assertThat(taggedOutputCaptor.toRetainAccumulator.build())
+        .isEqualTo(
+            ImmutableList.of(
+                rangeToRetainDueToCount,
+                rangeToRetainAndNotSplit,
+                rangeToRetainNotAddColumn,
+                rangeToRetainUnSplitable));
+    assertThat(taggedOutputCaptor.toCountAccumulator.build()).isEqualTo(ImmutableList.of());
+    assertThat(taggedOutputCaptor.toAddColumnAccumulator.build()).isEqualTo(ImmutableList.of());
+  }
+
+  @Test
+  public void testRangeClassifierStage0() {
+    TaggedOutputCaptor taggedOutputCaptor = new TaggedOutputCaptor();
+    Mockito.doAnswer(
+            invocationOnMock ->
+                taggedOutputCaptor.out(
+                    invocationOnMock.getArgument(0), invocationOnMock.getArgument(1)))
+        .when(mockProcessContext)
+        .output(any(), any());
+    Range rangeToCount =
+        Range.builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(0)
+            .setEnd(1000)
+            .build();
+    RangeClassifierDoFn rangeClassifierDoFn =
+        RangeClassifierDoFn.builder()
+            .setApproxTotalRowCount(10L)
+            .setStageIdx(0L)
+            .setAutoAdjustMaxPartitions(false)
+            .setMaxPartitionHint(10L)
+            .setPartitionColumns(
+                ImmutableList.of(
+                    PartitionColumn.builder()
+                        .setColumnName("col1")
+                        .setColumnClass(Integer.class)
+                        .build(),
+                    PartitionColumn.builder()
+                        .setColumnName("col2")
+                        .setColumnClass(Integer.class)
+                        .build()))
+            .build();
+
+    ImmutableList<Range> initialSplit =
+        ImmutableList.of(
+            rangeToCount,
+            rangeToCount.toBuilder().setStart(1000).setEnd(2000).build(),
+            rangeToCount.toBuilder().setStart(2000).setEnd(3000).build());
+
+    rangeClassifierDoFn.processElement(initialSplit, mockProcessContext);
+    assertThat(taggedOutputCaptor.toRetainAccumulator.build()).isEmpty();
+    assertThat(taggedOutputCaptor.toCountAccumulator.build()).isEqualTo(initialSplit);
+    assertThat(taggedOutputCaptor.toAddColumnAccumulator.build()).isEmpty();
+  }
+
+  // Traditional Argument Captor gets tricky with multiple tags of multiple types.
+  private class TaggedOutputCaptor {
+    public ImmutableList.Builder toCountAccumulator = ImmutableList.<Range>builder();
+
+    public ImmutableList.Builder toAddColumnAccumulator =
+        ImmutableList.<ColumnForBoundaryQuery>builder();
+    public ImmutableList.Builder toRetainAccumulator = ImmutableList.<Range>builder();
+
+    public Void out(TupleTag tag, Object element) {
+      if (tag.equals(RangeClassifierDoFn.TO_COUNT_TAG)) {
+        toCountAccumulator.add(element);
+      } else if (tag.equals(RangeClassifierDoFn.TO_ADD_COLUMN_TAG)) {
+        toAddColumnAccumulator.add(element);
+      } else if (tag.equals(RangeClassifierDoFn.TO_RETAIN_TAG)) {
+        toRetainAccumulator.add(element);
+      } else {
+        assert (false);
+      }
+      return null;
+    }
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCombinerTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCombinerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundarySplitterFactory;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collections;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link RangeCombiner}. */
+@RunWith(MockitoJUnitRunner.class)
+public class RangeCombinerTest {
+  @Rule public TestPipeline pipeline = TestPipeline.create();
+
+  @Test
+  public void testGloballyCombine() {
+
+    Range rangeBase =
+        Range.builder()
+            .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
+            .setColName("long_col_base")
+            .setColClass(Long.class)
+            .setStart(0L)
+            .setIsLast(true)
+            .setEnd(32L)
+            .setIsFirst(true)
+            .setIsLast(true)
+            .build();
+
+    int splitDepth = 3;
+    ImmutableList<Range> ranges = ImmutableList.of(rangeBase);
+    for (int i = 0; i < splitDepth; i++) {
+      ImmutableList.Builder<Range> curBuilder = ImmutableList.builder();
+      for (Range range : ranges) {
+        if (rangeBase.isSplittable(null)) {
+          var splitRanges = range.split(null);
+          curBuilder.add(splitRanges.getLeft());
+          curBuilder.add(splitRanges.getRight());
+        } else {
+          curBuilder.add(range);
+        }
+      }
+      ranges = curBuilder.build();
+    }
+    var mutableList = new ArrayList<>(ranges);
+    Collections.shuffle(mutableList);
+    ImmutableList<Range> shuffledRanges =
+        mutableList.stream().collect(ImmutableList.toImmutableList());
+
+    // Setup input PCollection
+    PCollection<Range> input = pipeline.apply(Create.of(shuffledRanges));
+
+    // Apply the RangeCombiner
+    PCollection<ImmutableList<Range>> output = input.apply(RangeCombiner.globally());
+
+    // Verify the output
+    PAssert.that(output).containsInAnyOrder(ranges);
+
+    // Run the pipeline
+    pipeline.run();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountDoFnTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundarySplitterFactory;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.common.collect.ImmutableList;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLTimeoutException;
+import javax.sql.DataSource;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link RangeCountDoFn}. */
+@RunWith(MockitoJUnitRunner.class)
+public class RangeCountDoFnTest {
+  SerializableFunction<Void, DataSource> mockDataSourceProviderFn =
+      Mockito.mock(SerializableFunction.class, withSettings().serializable());
+  DataSource mockDataSource = Mockito.mock(DataSource.class, withSettings().serializable());
+
+  Connection mockConnection = Mockito.mock(Connection.class, withSettings().serializable());
+
+  @Mock PreparedStatement mockPreparedStatemet;
+
+  @Mock ResultSet mockResultSet;
+
+  @Mock OutputReceiver mockOut;
+  @Captor ArgumentCaptor<Range> rangeCaptor;
+  @Mock DoFn.ProcessContext mockProcessContext;
+
+  @Test
+  public void testRangeCountDoFnBasic() throws Exception {
+
+    when(mockDataSourceProviderFn.apply(any())).thenReturn(mockDataSource);
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.prepareStatement(anyString(), anyInt(), anyInt()))
+        .thenReturn(mockPreparedStatemet);
+    doNothing().when(mockPreparedStatemet).setQueryTimeout(anyInt());
+    doNothing().when(mockPreparedStatemet).setObject(anyInt(), any());
+    when(mockPreparedStatemet.executeQuery()).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getLong(1)).thenReturn(42L);
+    RangeCountDoFn rangeCountDoFn =
+        new RangeCountDoFn(
+            mockDataSourceProviderFn,
+            2000L,
+            new MysqlDialectAdapter(MySqlVersion.DEFAULT)
+                .getCountQuery("testTalbe", ImmutableList.of("col1"), 2000L),
+            1);
+    Range input =
+        Range.<Integer>builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(0)
+            .setEnd(100)
+            .build();
+    rangeCountDoFn.setup();
+    rangeCountDoFn.processElement(input, mockOut, mockProcessContext);
+
+    verify(mockOut).output(rangeCaptor.capture());
+    assertThat(rangeCaptor.getValue()).isEqualTo(input.withCount(42L, mockProcessContext));
+  }
+
+  @Test
+  public void testRangeCountDoFnTimeoutException() throws Exception {
+
+    when(mockDataSourceProviderFn.apply(any())).thenReturn(mockDataSource);
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.prepareStatement(anyString(), anyInt(), anyInt()))
+        .thenReturn(mockPreparedStatemet);
+    doNothing().when(mockPreparedStatemet).setQueryTimeout(anyInt());
+    doNothing().when(mockPreparedStatemet).setObject(anyInt(), any());
+    when(mockPreparedStatemet.executeQuery())
+        .thenThrow(new SQLTimeoutException("test"))
+        .thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getLong(1)).thenThrow(new SQLTimeoutException());
+    RangeCountDoFn rangeCountDoFn =
+        new RangeCountDoFn(
+            mockDataSourceProviderFn,
+            2000L,
+            new MysqlDialectAdapter(MySqlVersion.DEFAULT)
+                .getCountQuery("testTalbe", ImmutableList.of("col1"), 2000L),
+            1);
+    Range input =
+        Range.<Integer>builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(0)
+            .setEnd(100)
+            .build();
+    rangeCountDoFn.setup();
+    rangeCountDoFn.processElement(input, mockOut, mockProcessContext);
+    rangeCountDoFn.processElement(input, mockOut, mockProcessContext);
+
+    verify(mockOut, times(2)).output(rangeCaptor.capture());
+    ImmutableList<Boolean> outputRangesAreUncounted =
+        rangeCaptor.getAllValues().stream()
+            .map(range -> range.isUncounted())
+            .collect(ImmutableList.toImmutableList());
+    assertThat(outputRangesAreUncounted).isEqualTo(ImmutableList.of(true, true));
+  }
+
+  @Test
+  public void testRangeCountDoFnOtherException() throws Exception {
+
+    when(mockDataSourceProviderFn.apply(any())).thenReturn(mockDataSource);
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.prepareStatement(anyString(), anyInt(), anyInt()))
+        .thenReturn(mockPreparedStatemet);
+    doNothing().when(mockPreparedStatemet).setQueryTimeout(anyInt());
+    doNothing().when(mockPreparedStatemet).setObject(anyInt(), any());
+    when(mockPreparedStatemet.executeQuery()).thenThrow(new SQLException("test"));
+    RangeCountDoFn rangeCountDoFn =
+        new RangeCountDoFn(
+            mockDataSourceProviderFn,
+            2000L,
+            new MysqlDialectAdapter(MySqlVersion.DEFAULT)
+                .getCountQuery("testTalbe", ImmutableList.of("col1"), 2000L),
+            1);
+    Range input =
+        Range.<Integer>builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(0)
+            .setEnd(100)
+            .build();
+    rangeCountDoFn.setup();
+    assertThrows(
+        SQLException.class,
+        () -> rangeCountDoFn.processElement(input, mockOut, mockProcessContext));
+  }
+
+  @Test
+  public void testRangeCountDoFnUnexprectedResultSet() throws Exception {
+
+    when(mockDataSourceProviderFn.apply(any())).thenReturn(mockDataSource);
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.prepareStatement(anyString(), anyInt(), anyInt()))
+        .thenReturn(mockPreparedStatemet);
+    doNothing().when(mockPreparedStatemet).setQueryTimeout(anyInt());
+    doNothing().when(mockPreparedStatemet).setObject(anyInt(), any());
+    when(mockPreparedStatemet.executeQuery()).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(false /* Empty ResultSet */).thenReturn(true);
+    when(mockResultSet.getLong(1)).thenReturn(0L);
+    when(mockResultSet.wasNull()).thenReturn(true) /* Null ResultSet */;
+    RangeCountDoFn rangeCountDoFn =
+        new RangeCountDoFn(
+            mockDataSourceProviderFn,
+            2000L,
+            new MysqlDialectAdapter(MySqlVersion.DEFAULT)
+                .getCountQuery("testTalbe", ImmutableList.of("col1"), 2000L),
+            1);
+    Range input =
+        Range.<Integer>builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(0)
+            .setEnd(100)
+            .build();
+    rangeCountDoFn.setup();
+    rangeCountDoFn.processElement(input, mockOut, mockProcessContext);
+    rangeCountDoFn.processElement(input, mockOut, mockProcessContext);
+    verify(mockOut, times(2)).output(rangeCaptor.capture());
+    // The Range remains uncounted with logs.
+    assertThat(rangeCaptor.getAllValues()).isEqualTo(ImmutableList.of(input, input));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountTransformTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountTransformTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundarySplitterFactory;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.RangePreparedStatementSetter;
+import com.google.common.collect.ImmutableList;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link RangeCountTransform}. */
+@RunWith(MockitoJUnitRunner.class)
+public class RangeCountTransformTest {
+  private static final String tableName = "test_table_range_counter";
+
+  SerializableFunction<Void, DataSource> dataSourceProviderFn =
+      ignored -> TransformTestUtils.DATA_SOURCE;
+
+  @Rule public final transient TestPipeline testPipeline = TestPipeline.create();
+
+  @BeforeClass
+  public static void beforeClass() throws SQLException {
+    // by default, derby uses a lock timeout of 60 seconds. In order to speed up the test
+    // and detect the lock faster, we decrease this timeout
+    System.setProperty("derby.locks.waitTimeout", "2");
+    System.setProperty("derby.stream.error.file", "build/derby.log");
+    TransformTestUtils.createDerbyTable(tableName);
+  }
+
+  @Test
+  public void testRangeCountTransform() throws Exception {
+    ImmutableList<String> partitionCols = ImmutableList.of("col1", "col2");
+    RangePreparedStatementSetter rangePreparedStatementSetter =
+        new RangePreparedStatementSetter(partitionCols.size());
+
+    Range singleColNonLastRange =
+        Range.<Integer>builder()
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setStart(10)
+            .setEnd(25)
+            .setIsLast(false)
+            .build();
+    Range bothColRange =
+        Range.<Integer>builder()
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setStart(10)
+            .setEnd(11)
+            .setIsLast(false)
+            .build()
+            .withChildRange(
+                Range.<Integer>builder()
+                    .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+                    .setColName("col2")
+                    .setColClass(Integer.class)
+                    .setStart(30)
+                    .setEnd(40)
+                    .build(),
+                null);
+    // Create a test pipeline.
+    PCollection<Range> input = testPipeline.apply(Create.of(singleColNonLastRange, bothColRange));
+    RangeCountTransform rangeCountTransform =
+        RangeCountTransform.builder()
+            .setDbAdapter(new MysqlDialectAdapter(MySqlVersion.DEFAULT))
+            .setPartitionColumns(partitionCols)
+            .setDataSourceProviderFn(dataSourceProviderFn)
+            .setTimeoutMillis(42L)
+            .setTableName(tableName)
+            .build();
+    PCollection<Range> output = input.apply(rangeCountTransform);
+
+    PAssert.that(output)
+        .containsInAnyOrder(
+            singleColNonLastRange.withCount(2L, null), bothColRange.withCount(1L, null));
+
+    testPipeline.run().waitUntilFinish();
+  }
+
+  @AfterClass
+  public static void exitDerby() throws SQLException {
+    TransformTestUtils.dropDerbyTable(tableName);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitionsTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitionsTest.java
@@ -52,6 +52,7 @@ import org.apache.beam.sdk.transforms.Flatten;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.Wait;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
 import org.checkerframework.checker.initialization.qual.Initialized;
@@ -183,7 +184,7 @@ public class ReadWithUniformPartitionsTest implements Serializable {
 
     ReadWithUniformPartitions readWithUniformPartitionsSecond =
         getReadWithUniformPartitionsForTest(
-            6L, 2L, null, secondRead, ImmutableList.of(firstReadRows));
+            6L, 2L, null, secondRead, Wait.on(ImmutableList.of(firstReadRows)));
     PCollection<String> secondReadRows =
         (PCollection<String>) testPipeline.apply("secondRead", readWithUniformPartitionsSecond);
 
@@ -271,7 +272,7 @@ public class ReadWithUniformPartitionsTest implements Serializable {
       @Nullable Long maxPartitionHint,
       @Nullable TestRangesPeek testRangesPeek,
       @Nullable Range initialRange,
-      @Nullable ImmutableList<PCollection<?>> waitOnSignals) {
+      Wait.OnSignal<?> waitOnSignal) {
 
     ReadWithUniformPartitions.Builder<String> readWithPartitionBuilder =
         ReadWithUniformPartitions.<String>builder()
@@ -307,8 +308,8 @@ public class ReadWithUniformPartitionsTest implements Serializable {
               .setMaxPartitionsHint(maxPartitionHint)
               .setAutoAdjustMaxPartitions(false);
     }
-    if (waitOnSignals != null) {
-      readWithPartitionBuilder = readWithPartitionBuilder.setWaitOnSignals(waitOnSignals);
+    if (waitOnSignal != null) {
+      readWithPartitionBuilder = readWithPartitionBuilder.setWaitOn(waitOnSignal);
     }
     return readWithPartitionBuilder.build();
   }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitionsTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitionsTest.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundarySplitterFactory;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.PartitionColumn;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Iterator;
+import javax.sql.DataSource;
+import org.apache.beam.sdk.io.jdbc.JdbcIO.RowMapper;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.checkerframework.checker.initialization.qual.Initialized;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link ReadWithUniformPartitions}. */
+@RunWith(MockitoJUnitRunner.class)
+public class ReadWithUniformPartitionsTest implements Serializable {
+  private static final String tableName = "test_table_read_with_uniform_partitions";
+
+  SerializableFunction<Void, DataSource> dataSourceProviderFn =
+      ignored -> TransformTestUtils.DATA_SOURCE;
+
+  @Rule public final transient TestPipeline testPipeline = TestPipeline.create();
+
+  @BeforeClass
+  public static void beforeClass() throws SQLException {
+    // by default, derby uses a lock timeout of 60 seconds. In order to speed up the test
+    // and detect the lock faster, we decrease this timeout
+    System.setProperty("derby.locks.waitTimeout", "2");
+    System.setProperty("derby.stream.error.file", "build/derby.log");
+    TransformTestUtils.createDerbyTable(tableName);
+  }
+
+  @Test
+  public void testReadWithUniformPartitionsPartitionTillSingleRow() throws Exception {
+    // In this test we expect all the entries to split till single row. And hence each range to have
+    // atmost 2 count (mean being 1, there will be atmost 2 rows in the partitions).
+    TestRangesPeekVerification testRangesPeekVerification =
+        (capturedRanges) -> {
+          long totalCount = 0;
+          for (Range range : capturedRanges) {
+            totalCount = range.accumulateCount(totalCount);
+            assertThat(range.count()).isAtMost(2L);
+          }
+          assertThat(totalCount).isEqualTo(6L);
+        };
+    TestRangesPeek testRangesPeek = new TestRangesPeek(testRangesPeekVerification);
+    ReadWithUniformPartitions readWithUniformPartitions =
+        getReadWithUniformPartitionsForTest(100L, 10L, testRangesPeek, null, null);
+
+    PCollection<String> output =
+        (PCollection<String>) testPipeline.apply(readWithUniformPartitions);
+    PAssert.that(output)
+        .containsInAnyOrder("Data A", "Data B", "Data C", "Data D", "Data E", "Data F");
+    testPipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testReadWithUniformPartitionsPartitionSinglePartition() throws Exception {
+    // In this test we expect all the entries to split to a single partition. And hence the range to
+    // have a count of 6 count.
+    TestRangesPeekVerification testRangesPeekVerification =
+        (capturedRanges) -> {
+          long totalCount = 0;
+          assertThat(capturedRanges.size()).isEqualTo(1);
+          for (Range range : capturedRanges) {
+            totalCount = range.accumulateCount(totalCount);
+            assertThat(range.count()).isEqualTo(6L);
+          }
+          assertThat(totalCount).isEqualTo(6L);
+        };
+    TestRangesPeek testRangesPeek = new TestRangesPeek(testRangesPeekVerification);
+
+    ReadWithUniformPartitions readWithUniformPartitions =
+        getReadWithUniformPartitionsForTest(6L, 1L, testRangesPeek, null, null);
+    PCollection<String> output =
+        (PCollection<String>) testPipeline.apply(readWithUniformPartitions);
+
+    PAssert.that(output)
+        .containsInAnyOrder("Data A", "Data B", "Data C", "Data D", "Data E", "Data F");
+    testPipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testReadWithUniformPartitionsPartitionFewPartitions() throws Exception {
+    // Here we expect the table to split int max of 3 partitions and hence each row to have a max of
+    // 4 rows.
+    TestRangesPeekVerification testRangesPeekVerification =
+        (capturedRanges) -> {
+          long totalCount = 0;
+          assertThat(capturedRanges.size()).isEqualTo(3);
+          for (Range range : capturedRanges) {
+            totalCount = range.accumulateCount(totalCount);
+            assertThat(range.count()).isAtMost(4L);
+          }
+          assertThat(totalCount).isEqualTo(6L);
+        };
+    TestRangesPeek testRangesPeek = new TestRangesPeek(testRangesPeekVerification);
+
+    ReadWithUniformPartitions readWithUniformPartitions =
+        getReadWithUniformPartitionsForTest(6L, 3L, testRangesPeek, null, null);
+    PCollection<String> output =
+        (PCollection<String>) testPipeline.apply(readWithUniformPartitions);
+
+    PAssert.that(output)
+        .containsInAnyOrder("Data A", "Data B", "Data C", "Data D", "Data E", "Data F");
+    testPipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testReadWithUniformPartitionsWithWait() throws Exception {
+    // We do two reads with the second-one waiting for first.
+
+    Range firstRead =
+        Range.builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setStart(25)
+            .setEnd(40)
+            .setIsFirst(true)
+            .setIsLast(true)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .build();
+    Range secondRead = firstRead.toBuilder().setStart(10).setEnd(15).build();
+
+    ReadWithUniformPartitions readWithUniformPartitionsFirst =
+        getReadWithUniformPartitionsForTest(6L, 2L, null, firstRead, null);
+    PCollection<String> firstReadRows =
+        (PCollection<String>) testPipeline.apply("firstRead", readWithUniformPartitionsFirst);
+
+    ReadWithUniformPartitions readWithUniformPartitionsSecond =
+        getReadWithUniformPartitionsForTest(
+            6L, 2L, null, secondRead, ImmutableList.of(firstReadRows));
+    PCollection<String> secondReadRows =
+        (PCollection<String>) testPipeline.apply("secondRead", readWithUniformPartitionsSecond);
+
+    var output =
+        PCollectionList.of(secondReadRows).and(firstReadRows).apply(Flatten.pCollections());
+
+    // We check that the rows read in first read appear before the rows in second read.
+    PAssert.that(output)
+        .satisfies(
+            new SerializableFunction<Iterable<String>, Void>() {
+              @Override
+              public Void apply(Iterable<String> input) {
+                ImmutableList.Builder<String> firstFour = ImmutableList.builder();
+                ImmutableList.Builder<String> lastTwo = ImmutableList.builder();
+                Iterator<String> iterator = input.iterator();
+                for (int i = 0; i < 4; i++) {
+                  firstFour.add(iterator.next());
+                }
+                while (iterator.hasNext()) {
+                  lastTwo.add(iterator.next());
+                }
+                assertThat(firstFour.build())
+                    .containsExactlyElementsIn(
+                        ImmutableList.of("Data C", "Data D", "Data E", "Data F"));
+                assertThat(lastTwo.build())
+                    .containsExactlyElementsIn(ImmutableList.of("Data A", "Data B"));
+                return null;
+              }
+            });
+    testPipeline.run().waitUntilFinish();
+  }
+
+  /**
+   * Test Auto-Inference for maxPartition. The AutoInference sets the default to MAx(1,
+   * Floor(sqrt({@link ReadWithUniformPartitions#approxTotalRowCount()})) / 10).
+   */
+  @Test
+  public void testMaxPartitionAutoInference() {
+    // Small Row Count
+    ReadWithUniformPartitions readWithUniformPartitionsSmallRowCount =
+        getReadWithUniformPartitionsForTest(64L, null, null, null, null);
+    // Large RoCount
+    ReadWithUniformPartitions readWithUniformPartitionsLargeRowCount =
+        getReadWithUniformPartitionsForTest(1_000_000_000L /* 1 billion */, null, null, null, null);
+    assertThat(readWithUniformPartitionsSmallRowCount.maxPartitionsHint()).isEqualTo(1L);
+    assertThat(readWithUniformPartitionsLargeRowCount.maxPartitionsHint()).isEqualTo(3162L);
+  }
+
+  @Test
+  public void testMaxPartitionAutoInferencePreConditions() {
+    Range initialRangeWithWrongColumChild =
+        Range.builder()
+            .setColName("wrongCol")
+            .setColClass(Integer.class)
+            .setStart(0)
+            .setEnd(42)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .build();
+    Range initialRange =
+        Range.builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setStart(42)
+            .setEnd(42)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .build()
+            .withChildRange(initialRangeWithWrongColumChild, null);
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> getReadWithUniformPartitionsForTest(100L, null, null, initialRange, null));
+  }
+
+  @Test
+  public void testLogTOBaseTwo() {
+    assertThat(ReadWithUniformPartitions.logToBaseTwo(0L)).isEqualTo(0L);
+    assertThat(ReadWithUniformPartitions.logToBaseTwo(1L)).isEqualTo(0L);
+    assertThat(ReadWithUniformPartitions.logToBaseTwo(2_305_843_009_213_693_851L)).isEqualTo(61L);
+    assertThat(ReadWithUniformPartitions.logToBaseTwo(100L)).isEqualTo(7L);
+    assertThat(ReadWithUniformPartitions.logToBaseTwo(Long.MAX_VALUE)).isEqualTo(63L);
+  }
+
+  private ReadWithUniformPartitions getReadWithUniformPartitionsForTest(
+      long approximateTotalCount,
+      @Nullable Long maxPartitionHint,
+      @Nullable TestRangesPeek testRangesPeek,
+      @Nullable Range initialRange,
+      @Nullable ImmutableList<PCollection<?>> waitOnSignals) {
+
+    ReadWithUniformPartitions.Builder<String> readWithPartitionBuilder =
+        ReadWithUniformPartitions.<String>builder()
+            .setApproxTotalRowCount(approximateTotalCount)
+            .setTableName(tableName)
+            .setInitialRange(initialRange)
+            .setPartitionColumns(
+                ImmutableList.of(
+                    PartitionColumn.builder()
+                        .setColumnName("col1")
+                        .setColumnClass(Integer.class)
+                        .build(),
+                    PartitionColumn.builder()
+                        .setColumnName("col2")
+                        .setColumnClass(Integer.class)
+                        .build()))
+            .setDbAdapter(new MysqlDialectAdapter(MySqlVersion.DEFAULT))
+            .setDataSourceProviderFn(dataSourceProviderFn)
+            .setRangesPeek(testRangesPeek)
+            .setRowMapper(
+                new RowMapper<String>() {
+                  @Override
+                  public String mapRow(@UnknownKeyFor @NonNull @Initialized ResultSet resultSet)
+                      throws @UnknownKeyFor @NonNull @Initialized Exception {
+                    return resultSet.getString(3);
+                  }
+                });
+    if (maxPartitionHint != null) {
+      // For the purpose of this UT we disable auto adjustment as we try to verify the partitioning
+      // logic.
+      readWithPartitionBuilder =
+          readWithPartitionBuilder
+              .setMaxPartitionsHint(maxPartitionHint)
+              .setAutoAdjustMaxPartitions(false);
+    }
+    if (waitOnSignals != null) {
+      readWithPartitionBuilder = readWithPartitionBuilder.setWaitOnSignals(waitOnSignals);
+    }
+    return readWithPartitionBuilder.build();
+  }
+
+  /*
+   * Beam uses reflections to get PTransform Signature forcing us to make this public.
+   */
+  private class TestRangesPeek
+      extends PTransform<PCollection<ImmutableList<Range>>, PCollection<Void>> {
+
+    private TestRangesPeekDoFn peekFn;
+
+    @Override
+    public PCollection<Void> expand(PCollection<ImmutableList<Range>> input) {
+      return input.apply(ParDo.of(peekFn));
+    }
+
+    public TestRangesPeek(TestRangesPeekVerification verification) {
+      this.peekFn = new TestRangesPeekDoFn(verification);
+    }
+  }
+
+  /*
+   * Beam uses reflections to get DoFn signature forcing us to make this public.
+   */
+  public class TestRangesPeekDoFn extends DoFn<ImmutableList<Range>, Void> {
+    TestRangesPeekVerification verification;
+    boolean calledOnce = false;
+
+    @ProcessElement
+    public void processElemnt(@Element ImmutableList<Range> element, OutputReceiver<Void> out) {
+      assertThat(calledOnce).isFalse();
+      calledOnce = true;
+      verification.verifyRanges(element);
+      out.output(null);
+    }
+
+    public TestRangesPeekDoFn(TestRangesPeekVerification verification) {
+      this.verification = verification;
+    }
+  }
+
+  public interface TestRangesPeekVerification extends Serializable {
+    void verifyRanges(ImmutableList<Range> capturedRanges);
+  }
+
+  @AfterClass
+  public static void exitDerby() throws SQLException {
+    TransformTestUtils.dropDerbyTable(tableName);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitionsTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitionsTest.java
@@ -290,7 +290,7 @@ public class ReadWithUniformPartitionsTest implements Serializable {
                         .build()))
             .setDbAdapter(new MysqlDialectAdapter(MySqlVersion.DEFAULT))
             .setDataSourceProviderFn(dataSourceProviderFn)
-            .setRangesPeek(testRangesPeek)
+            .setAdditionalOperationsOnRanges(testRangesPeek)
             .setRowMapper(
                 new RowMapper<String>() {
                   @Override

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/SplitRangeDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/SplitRangeDoFnTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundarySplitterFactory;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link SplitRangeDoFnTest}. */
+@RunWith(MockitoJUnitRunner.class)
+public class SplitRangeDoFnTest {
+
+  @Mock OutputReceiver mockOut;
+  @Captor ArgumentCaptor<Range> rangeCaptor;
+  @Mock ProcessContext mockProcessContext;
+
+  @Test
+  public void testSplitRangeDoFnBasic() {
+    Range splittableRange =
+        Range.builder()
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setStart(0)
+            .setEnd(42)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .build();
+    Range unSplittableRange = splittableRange.toBuilder().setStart(41).build();
+    Pair<Range, Range> splitRanges = splittableRange.split(mockProcessContext);
+
+    SplitRangeDoFn splitRangeDoFn = new SplitRangeDoFn();
+    splitRangeDoFn.processElement(splittableRange, mockOut, mockProcessContext);
+    splitRangeDoFn.processElement(unSplittableRange, mockOut, mockProcessContext);
+
+    verify(mockOut, times(3)).output(rangeCaptor.capture());
+
+    assertThat(rangeCaptor.getAllValues())
+        .containsExactly(unSplittableRange, splitRanges.getLeft(), splitRanges.getRight());
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/TransformTestUtils.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/TransformTestUtils.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.apache.beam.sdk.io.jdbc.JdbcIO.DataSourceConfiguration;
+
+class TransformTestUtils {
+
+  static final DataSourceConfiguration DATA_SOURCE_CONFIGURATION =
+      DataSourceConfiguration.create(
+          "org.apache.derby.jdbc.EmbeddedDriver", "jdbc:derby:memory:testDB;create=true");
+  static final DataSource DATA_SOURCE = DATA_SOURCE_CONFIGURATION.buildDatasource();
+
+  private TransformTestUtils() {}
+
+  static void createDerbyTable(String tableName) throws SQLException {
+    try (java.sql.Connection connection = getConnection()) {
+      Statement stmtCreateTable = connection.createStatement();
+      String createTableSQL =
+          "CREATE TABLE "
+              + tableName
+              + " ("
+              + "col1 INT,"
+              + "col2 INT,"
+              + "data VARCHAR(20),"
+              + "PRIMARY KEY (col1, col2)"
+              + ")";
+      stmtCreateTable.executeUpdate(createTableSQL);
+
+      // 2.2 Insert Data (Using PreparedStatement for Efficiency & Security)
+      String insertSQL = "INSERT INTO " + tableName + " (col1, col2, data) VALUES (?, ?, ?)";
+      PreparedStatement stmtInsert = connection.prepareStatement(insertSQL);
+
+      // Batch the insert operations
+      stmtInsert.setInt(1, 10);
+      stmtInsert.setInt(2, 30);
+      stmtInsert.setString(3, "Data A");
+      stmtInsert.addBatch();
+
+      stmtInsert.setInt(1, 15);
+      stmtInsert.setInt(2, 35);
+      stmtInsert.setString(3, "Data B");
+      stmtInsert.addBatch();
+
+      stmtInsert.setInt(1, 25);
+      stmtInsert.setInt(2, 50);
+      stmtInsert.setString(3, "Data C");
+      stmtInsert.addBatch();
+
+      stmtInsert.setInt(1, 30);
+      stmtInsert.setInt(2, 60);
+      stmtInsert.setString(3, "Data D");
+      stmtInsert.addBatch();
+
+      stmtInsert.setInt(1, 40);
+      stmtInsert.setInt(2, 70);
+      stmtInsert.setString(3, "Data E");
+      stmtInsert.addBatch();
+
+      stmtInsert.setInt(1, 40);
+      stmtInsert.setInt(2, 80);
+      stmtInsert.setString(3, "Data F");
+      stmtInsert.addBatch();
+
+      stmtInsert.executeBatch();
+    }
+  }
+
+  static void dropDerbyTable(String tableName) throws SQLException {
+    try (Connection connection = getConnection()) {
+      Statement statement = connection.createStatement();
+      statement.executeUpdate("drop table " + tableName);
+    }
+  }
+
+  static Connection getConnection() throws SQLException {
+    return DATA_SOURCE.getConnection();
+  }
+}


### PR DESCRIPTION
# Adding support for `ReadWithUniformPartition` for numeric types and composite keys.
## Summary
`ReadWithUniformPartition` is almost equivalent in the basic contract with JDBCIO.readWithPartition.

In addition to `JDBCIO.readWithPartition`, this transforms supports

1. Near uniform splitting of the input key space based on range counts. No partition will have a count greater than twice the expected mean.
2. Uses composite keys for splitting when necessary.
3. Allows injection of type-mapper for making it easier to support strings in future.
## Overview of commits.
This change composes of mainly these parts (in separate commits)
1. Basic Range and boundary classes. This part implements basic classes to represent a splittable boundary and range. An unsplittable range can have child ranges as columns get added to the splitting process.
2. DBAdapter and statement preparator implementation to get count and boundary  (min, max) of a range.
3. Transforms to iteratively split the ranges till a near-uniform split is  achieved.
4. Integration with larger reader under a feature flag.
## Feature Flag.
Currently there is a feature flag in `JdbcIOWrapperConfig` named `readWithUniformPartitionsFeatureEnabled` which controls if the new partitioning logic run in the migration or not.
1. As of now the flag is default to enabled.
2. It's not exposed as a pipeline option (which unfortunately means tooggle need rebuild) so that options don't get added and reverted.

## Performance
1. The splitting takes ~ 2 to 3 mins per table (1 TB table).
2. If the job is running on multiple parallel tables, please consider dding `DATAFLOW_SERVICE_OPTIONS="min_num_workers="` to the dataflow job  as dataflow tends to scale down quickly.

Note - unless we have the entire flow from the basic range class to integration, its hard to test this on a real migration.