### PR TITLE
Add CloudSql resource manager

### DIFF
--- a/cicd/cmd/run-it-smoke-tests/main.go
+++ b/cicd/cmd/run-it-smoke-tests/main.go
@@ -65,7 +65,11 @@ func main() {
 		flags.StageBucket(),
 		flags.PrivateConnectivity(),
 		flags.FailureMode(),
-		flags.RetryFailures())
+		flags.RetryFailures(),
+		flags.StaticOracleInstance(),
+		flags.CloudProxyHost(),
+		flags.CloudProxyPort(),
+		flags.CloudProxyPassword())
 	if err != nil {
 		log.Fatalf("%v\n", err)
 	}

--- a/cicd/cmd/run-it-tests/main.go
+++ b/cicd/cmd/run-it-tests/main.go
@@ -66,7 +66,11 @@ func main() {
 		flags.HostIp(),
 		flags.PrivateConnectivity(),
 		flags.FailureMode(),
-		flags.RetryFailures())
+		flags.RetryFailures(),
+		flags.StaticOracleInstance(),
+		flags.CloudProxyHost(),
+		flags.CloudProxyPort(),
+		flags.CloudProxyPassword())
 	if err != nil {
 		log.Fatalf("%v\n", err)
 	}

--- a/cicd/cmd/run-load-tests/main.go
+++ b/cicd/cmd/run-load-tests/main.go
@@ -64,7 +64,11 @@ func main() {
 		flags.PrivateConnectivity(),
 		flags.ExportProject(),
 		flags.ExportDataset(),
-		flags.ExportTable())
+		flags.ExportTable(),
+		flags.StaticOracleInstance(),
+		flags.CloudProxyHost(),
+		flags.CloudProxyPort(),
+		flags.CloudProxyPassword())
 	if err != nil {
 		log.Fatalf("%v\n", err)
 	}

--- a/cicd/internal/flags/it-flags.go
+++ b/cicd/internal/flags/it-flags.go
@@ -32,6 +32,10 @@ var (
 	dPrivateConnectivity string
 	dReleaseMode         bool
 	dRetryFailures       string
+	dCloudProxyHost      string
+	dCloudProxyPort      string
+	dCloudProxyPassword  string
+	dOracleInstance      string
 )
 
 // Registers all common flags. Must be called before flag.Parse().
@@ -44,6 +48,10 @@ func RegisterItFlags() {
 	flag.StringVar(&dPrivateConnectivity, "it-private-connectivity", "", "(optional) A GCP private connectivity endpoint")
 	flag.BoolVar(&dReleaseMode, "it-release", false, "(optional) Set if tests are being executed for a release")
 	flag.StringVar(&dRetryFailures, "it-retry-failures", "0", "Number of retries attempts for failing tests")
+	flag.StringVar(&dCloudProxyHost, "it-cloud-proxy-host", "10.128.0.34", "Hostname or IP address of static Cloud Auth Proxy")
+	flag.StringVar(&dCloudProxyPort, "it-cloud-proxy-port", "33134", "Port number of static Cloud Auth Proxy")
+	flag.StringVar(&dCloudProxyPassword, "it-cloud-proxy-password", "t>5xl%J(&qTK6?FaZ", "Password of static Cloud Auth Proxy")
+	flag.StringVar(&dOracleInstance, "it-oracle-host", "10.128.0.90", "Hostname or IP address of static Oracle DB")
 }
 
 func Region() string {
@@ -96,4 +104,20 @@ func FailureMode() string {
 
 func RetryFailures() string {
 	return "-Dsurefire.rerunFailingTestsCount=" + dRetryFailures
+}
+
+func CloudProxyHost() string {
+	return "-DcloudProxyHost=" + dCloudProxyHost
+}
+
+func CloudProxyPort() string {
+	return "-DcloudProxyPort=" + dCloudProxyPort
+}
+
+func CloudProxyPassword() string {
+	return "-DcloudProxyPassword=" + dCloudProxyPassword
+}
+
+func StaticOracleInstance() string {
+	return "-DcloudOracleHost=" + dOracleInstance
 }

--- a/it/google-cloud-platform/pom.xml
+++ b/it/google-cloud-platform/pom.xml
@@ -65,6 +65,24 @@
             <version>${dataflow-api.version}</version>
         </dependency>
 
+        <!-- JDBC dependencies for CloudSQL -->
+        <dependency>
+            <groupId>org.apache.beam</groupId>
+            <artifactId>beam-it-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>${mysql-connector-java.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <version>${ojdbc8.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Google Cloud -->
         <dependency>
             <groupId>com.google.cloud</groupId>

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/bigquery/BigQueryResourceManagerUtils.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/bigquery/BigQueryResourceManagerUtils.java
@@ -49,7 +49,7 @@ public final class BigQueryResourceManagerUtils {
   static String generateDatasetId(String datasetName) {
 
     // Take substring of datasetName to account for random suffix
-    // TODO(polber) - remove with Beam 2.57.0
+    // TODO(polber) - remove with Beam 2.58.0
     int randomSuffixLength = 6;
     datasetName =
         datasetName.substring(
@@ -63,7 +63,7 @@ public final class BigQueryResourceManagerUtils {
                     - randomSuffixLength));
 
     // Add random suffix to avoid collision
-    // TODO(polber) - remove with Beam 2.57.0
+    // TODO(polber) - remove with Beam 2.58.0
     return generateResourceId(
             datasetName,
             ILLEGAL_DATASET_ID_CHARS,

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/bigtable/BigtableResourceManagerUtils.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/bigtable/BigtableResourceManagerUtils.java
@@ -58,7 +58,7 @@ public final class BigtableResourceManagerUtils {
       String baseString, String zone, int numNodes, StorageType storageType) {
 
     // Take substring of baseString to account for random suffix
-    // TODO(polber) - remove with Beam 2.57.0
+    // TODO(polber) - remove with Beam 2.58.0
     int randomSuffixLength = 6;
     baseString =
         baseString
@@ -82,7 +82,7 @@ public final class BigtableResourceManagerUtils {
             DateTimeFormatter.ofPattern(TIME_FORMAT));
 
     // Add random suffix to avoid collision
-    // TODO(polber) - remove with Beam 2.57.0
+    // TODO(polber) - remove with Beam 2.58.0
     clusterId =
         clusterId + REPLACE_CLUSTER_CHAR + RandomStringUtils.randomAlphanumeric(6).toLowerCase();
 
@@ -101,7 +101,7 @@ public final class BigtableResourceManagerUtils {
   static String generateInstanceId(String baseString) {
 
     // Take substring of baseString to account for random suffix
-    // TODO(polber) - remove with Beam 2.57.0
+    // TODO(polber) - remove with Beam 2.58.0
     int randomSuffixLength = 6;
     baseString =
         baseString.substring(
@@ -115,7 +115,7 @@ public final class BigtableResourceManagerUtils {
                     - randomSuffixLength));
 
     // Add random suffix to avoid collision
-    // TODO(polber) - remove with Beam 2.57.0
+    // TODO(polber) - remove with Beam 2.58.0
     return generateResourceId(
             baseString.toLowerCase(),
             ILLEGAL_INSTANCE_ID_CHARS,
@@ -135,7 +135,7 @@ public final class BigtableResourceManagerUtils {
   public static String generateTableId(String baseString) {
 
     // Take substring of baseString to account for random suffix
-    // TODO(polber) - remove with Beam 2.57.0
+    // TODO(polber) - remove with Beam 2.58.0
     int randomSuffixLength = 6;
     baseString =
         baseString.substring(
@@ -149,7 +149,7 @@ public final class BigtableResourceManagerUtils {
                     - randomSuffixLength));
 
     // Add random suffix to avoid collision
-    // TODO(polber) - remove with Beam 2.57.0
+    // TODO(polber) - remove with Beam 2.58.0
     return generateResourceId(
             baseString.toLowerCase(),
             ILLEGAL_TABLE_CHARS,

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudMySQLResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudMySQLResourceManager.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.it.gcp.cloudsql;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Custom class for the MySQL implementation of {@link CloudSqlResourceManager} abstract class.
+ *
+ * <p>The class supports one database, and multiple tables per database object. A database is *
+ * created when the container first spins up, if one is not given.
+ *
+ * <p>The class is thread-safe.
+ */
+public class CloudMySQLResourceManager extends CloudSqlResourceManager {
+
+  private CloudMySQLResourceManager(Builder builder) {
+    super(builder);
+  }
+
+  public static Builder builder(String testId) {
+    return new Builder(testId);
+  }
+
+  @Override
+  public @NonNull String getJDBCPrefix() {
+    return "mysql";
+  }
+
+  /** Builder for {@link CloudMySQLResourceManager}. */
+  public static final class Builder extends CloudSqlResourceManager.Builder {
+
+    public Builder(String testId) {
+      super(testId);
+    }
+
+    @Override
+    public @NonNull CloudMySQLResourceManager build() {
+      return new CloudMySQLResourceManager(this);
+    }
+  }
+}

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudOracleResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudOracleResourceManager.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.it.gcp.cloudsql;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Custom class for the Oracle implementation of {@link CloudSqlResourceManager} abstract class.
+ *
+ * <p>This class leverages the API in the {@link CloudSqlResourceManager}, but assumes a self-hosted
+ * Oracle instance on GCE or other provider.
+ *
+ * <p>The class supports one database (XE), and multiple tables. The database must already exist to
+ * use this resource manager.
+ *
+ * <p>The class is thread-safe.
+ */
+public class CloudOracleResourceManager extends CloudSqlResourceManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CloudOracleResourceManager.class);
+
+  private static final int DEFAULT_ORACLE_PORT = 1521;
+
+  private CloudOracleResourceManager(Builder builder) {
+    super(builder);
+
+    System.setProperty("oracle.jdbc.timezoneAsRegion", "false");
+  }
+
+  public static Builder builder(String testId) {
+    return new Builder(testId);
+  }
+
+  @Override
+  public @NonNull String getJDBCPrefix() {
+    return "oracle";
+  }
+
+  @Override
+  public synchronized @NonNull String getUri() {
+    return String.format(
+        "jdbc:%s:thin:@%s:%d:%s",
+        getJDBCPrefix(), this.getHost(), this.getPort(getJDBCPort()), this.getDatabaseName());
+  }
+
+  @Override
+  protected @NonNull String getFirstRow(@NonNull String tableName) {
+    return "SELECT * FROM " + tableName + " WHERE ROWNUM <= 1";
+  }
+
+  /** Builder for {@link CloudOracleResourceManager}. */
+  public static final class Builder extends CloudSqlResourceManager.Builder {
+
+    public Builder(String testId) {
+      super(testId);
+
+      this.setDatabaseName("xe");
+      this.setPort(DEFAULT_ORACLE_PORT);
+
+      // Currently only supports static Oracle instance on GCE
+      this.maybeUseStaticInstance();
+    }
+
+    public Builder maybeUseStaticInstance() {
+      if (System.getProperty("cloudOracleHost") != null) {
+        this.setHost(System.getProperty("cloudOracleHost"));
+      } else {
+        LOG.warn("Missing -DcloudOracleHost.");
+      }
+      this.useStaticContainer();
+
+      return this;
+    }
+
+    @Override
+    public @NonNull CloudOracleResourceManager build() {
+      return new CloudOracleResourceManager(this);
+    }
+  }
+}

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlContainer.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlContainer.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.it.gcp.cloudsql;
+
+import org.apache.beam.it.jdbc.AbstractJDBCResourceManager;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Dummy container class so that {@link CloudSqlResourceManager} can leverage {@link
+ * AbstractJDBCResourceManager} framework which leverages Testcontainers, and therefore requires a
+ * container.
+ */
+class CloudSqlContainer<T extends CloudSqlContainer<T>> extends JdbcDatabaseContainer<T> {
+
+  private String username;
+  private String password;
+  private String databaseName;
+
+  CloudSqlContainer(DockerImageName dockerImageName) {
+    super(DockerImageName.parse(""));
+  }
+
+  static CloudSqlContainer<?> of() {
+    return new CloudSqlContainer<>(DockerImageName.parse(""));
+  }
+
+  @Override
+  public String getDriverClassName() {
+    return null;
+  }
+
+  @Override
+  public String getJdbcUrl() {
+    return null;
+  }
+
+  @Override
+  public String getUsername() {
+    return username;
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+  @Override
+  protected String getTestQueryString() {
+    return null;
+  }
+
+  @Override
+  public String getDatabaseName() {
+    return databaseName;
+  }
+
+  public T withUsername(String username) {
+    this.username = username;
+    return this.self();
+  }
+
+  public T withPassword(String password) {
+    this.password = password;
+    return this.self();
+  }
+
+  public T withDatabaseName(String dbName) {
+    this.databaseName = dbName;
+    return this.self();
+  }
+}

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManager.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.it.gcp.cloudsql;
+
+import static org.apache.beam.it.gcp.cloudsql.CloudSqlResourceManagerUtils.generateDatabaseName;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.beam.it.jdbc.AbstractJDBCResourceManager;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Abstract class that extends {@link AbstractJDBCResourceManager} for CloudSQL resource management.
+ *
+ * <p>The class supports one database, and multiple tables per database object. A database is
+ * created when the resource manager first spins up, if one is not specified.
+ *
+ * <p>The database name is formed using testId. The database name will be "{testId}-{ISO8601 time,
+ * microsecond precision}", with additional formatting.
+ *
+ * <p>The class is thread-safe.
+ */
+public abstract class CloudSqlResourceManager
+    extends AbstractJDBCResourceManager<@NonNull CloudSqlContainer<?>> {
+  private static final Logger LOG = LoggerFactory.getLogger(CloudSqlResourceManager.class);
+
+  protected final List<String> createdTables;
+  private boolean createdDatabase;
+  private boolean usingCustomDb;
+
+  protected CloudSqlResourceManager(@NonNull Builder builder) {
+    super(CloudSqlContainer.of(), builder);
+
+    this.createdTables = new ArrayList<>();
+
+    this.createdDatabase = false;
+    this.usingCustomDb = builder.usingCustomDb;
+    if (!usingCustomDb) {
+      createDatabase(builder.dbName);
+    }
+    this.createdDatabase = true;
+  }
+
+  @Override
+  public synchronized @NonNull String getUri() {
+    return String.format(
+        "jdbc:%s://%s:%d/%s",
+        getJDBCPrefix(),
+        this.getHost(),
+        this.getPort(),
+        createdDatabase ? this.getDatabaseName() : "");
+  }
+
+  @Override
+  protected int getJDBCPort() {
+    return this.port;
+  }
+
+  @Override
+  public int getPort() {
+    return this.getPort(getJDBCPort());
+  }
+
+  @Override
+  public boolean createTable(@NonNull String tableName, @NonNull JDBCSchema schema) {
+    boolean status = super.createTable(tableName, schema);
+    this.createdTables.add(tableName);
+    return status;
+  }
+
+  /**
+   * Drops the table with the given name from the current database.
+   *
+   * @param tableName The name of the table.
+   * @return true, if successful.
+   */
+  public void dropTable(@NonNull String tableName) {
+    LOG.info("Dropping table using tableName '{}'.", tableName);
+
+    runSQLUpdate(String.format("DROP TABLE %s", tableName));
+
+    createdTables.remove(tableName);
+    LOG.info("Successfully dropped table {}.{}", databaseName, tableName);
+  }
+
+  /**
+   * Creates a database in the CloudSQL instance.
+   *
+   * @param databaseName name of database to create.
+   */
+  public void createDatabase(@NonNull String databaseName) {
+    LOG.info("Creating database using databaseName '{}'.", databaseName);
+
+    runSQLUpdate(String.format("CREATE DATABASE %s", databaseName));
+
+    LOG.info("Successfully created database {}", databaseName);
+  }
+
+  /**
+   * Drops the given database in the CloudSQL instance.
+   *
+   * @param databaseName name of database to drop.
+   */
+  public void dropDatabase(@NonNull String databaseName) {
+    LOG.info("Dropping database using databaseName '{}'.", databaseName);
+
+    this.createdDatabase = false;
+    runSQLUpdate(String.format("DROP DATABASE %s", databaseName));
+
+    LOG.info("Successfully dropped database {}", databaseName);
+  }
+
+  @Override
+  public void cleanupAll() {
+    LOG.info("Attempting to cleanup CloudSQL manager.");
+    try {
+      if (this.usingCustomDb) {
+        List.copyOf(createdTables).forEach(this::dropTable);
+      } else {
+        dropDatabase(this.databaseName);
+      }
+      LOG.info("CloudSQL manager successfully cleaned up.");
+    } catch (Exception e) {
+      throw new CloudSqlResourceManagerException("Failed to close CloudSQL resources", e);
+    }
+  }
+
+  /**
+   * Builder for {@link CloudSqlResourceManager}.
+   *
+   * <p>A class that extends {@link AbstractJDBCResourceManager.Builder} for specific CloudSQL
+   * implementations.
+   */
+  public abstract static class Builder
+      extends AbstractJDBCResourceManager.Builder<@NonNull CloudSqlContainer<?>> {
+
+    private String dbName;
+    private boolean usingCustomDb;
+
+    public Builder(String testId) {
+      super(testId, "", "");
+
+      this.setDatabaseName(generateDatabaseName(testId));
+      this.usingCustomDb = false;
+
+      // Currently only supports static CloudSQL instance with static Cloud Auth Proxy
+      this.maybeUseStaticCloudProxy();
+    }
+
+    public Builder maybeUseStaticCloudProxy() {
+      if (System.getProperty("cloudProxyHost") != null) {
+        this.setHost(System.getProperty("cloudProxyHost"));
+      } else {
+        LOG.warn("Missing -DcloudProxyHost.");
+      }
+      if (System.getProperty("cloudProxyPort") != null) {
+        this.setPort(Integer.parseInt(System.getProperty("cloudProxyPort")));
+      } else {
+        LOG.warn("Missing -DcloudProxyPort.");
+      }
+      if (System.getProperty("cloudProxyPassword") != null) {
+        this.setPassword(System.getProperty("cloudProxyPassword"));
+      } else {
+        LOG.warn("Missing -DcloudProxyPassword.");
+      }
+      if (System.getProperty("cloudProxyUsername") != null) {
+        this.setUsername(System.getProperty("cloudProxyUsername"));
+      } else {
+        LOG.info("-DcloudProxyUsername not specified, using default: " + DEFAULT_JDBC_USERNAME);
+      }
+      this.useStaticContainer();
+
+      return this;
+    }
+
+    @Override
+    public @NonNull Builder setDatabaseName(@NonNull String databaseName) {
+      super.setDatabaseName(databaseName);
+      this.dbName = databaseName;
+      this.usingCustomDb = true;
+      return this;
+    }
+  }
+}

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManagerException.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManagerException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.it.gcp.cloudsql;
+
+/** Custom exception for {@link TestContainerResourceManager} implementations. */
+public class CloudSqlResourceManagerException extends RuntimeException {
+
+  public CloudSqlResourceManagerException(String errorMessage) {
+    super(errorMessage);
+  }
+
+  public CloudSqlResourceManagerException(String errorMessage, Exception cause) {
+    super(errorMessage, cause);
+  }
+}

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManagerUtils.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManagerUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.it.gcp.cloudsql;
+
+import static org.apache.beam.it.common.utils.ResourceManagerUtils.generateResourceId;
+
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.RandomStringUtils;
+
+/** Utilities for {@link CloudSqlResourceManager} implementations. */
+public final class CloudSqlResourceManagerUtils {
+  // Naming restrictions can be found at:
+  // mySQL -
+  // https://documentation.sas.com/doc/en/pgmsascdc/9.4_3.5/acreldb/n0rfg6x1shw0ppn1cwhco6yn09f7.htm
+  // postgreSQL -
+  // https://documentation.sas.com/doc/en/pgmsascdc/9.4_3.5/acreldb/p1iw263fz6wvnbn1d6nyw71a9sf2.htm
+  // oracle -
+  // https://documentation.sas.com/doc/en/pgmsascdc/9.4_3.5/acreldb/p0t80fm3l1okawn1x3mvo098svir.htm
+  //
+  // The tightest restrictions were used across all flavors of JDBC for simplicity.
+  private static final int MAX_DATABASE_NAME_LENGTH = 30;
+  private static final Pattern ILLEGAL_DATABASE_NAME_CHARS = Pattern.compile("[^a-zA-Z0-9_$#]");
+  private static final String REPLACE_DATABASE_NAME_CHAR = "_";
+  private static final String TIME_FORMAT = "yyyyMMdd_HHmmss";
+
+  private CloudSqlResourceManagerUtils() {}
+
+  /**
+   * Generates a JDBC database name from a given string.
+   *
+   * @param baseString The string to generate the name from.
+   * @return The database name string.
+   */
+  static String generateDatabaseName(String baseString) {
+    baseString = Character.isLetter(baseString.charAt(0)) ? baseString : "d_" + baseString;
+
+    // Take substring of baseString to account for random suffix
+    // TODO(polber) - remove with Beam 2.58.0
+    int randomSuffixLength = 6;
+    baseString =
+        baseString.substring(
+            0,
+            Math.min(
+                baseString.length(),
+                MAX_DATABASE_NAME_LENGTH
+                    - REPLACE_DATABASE_NAME_CHAR.length()
+                    - TIME_FORMAT.length()
+                    - REPLACE_DATABASE_NAME_CHAR.length()
+                    - randomSuffixLength));
+
+    // Add random suffix to avoid collision
+    // TODO(polber) - remove with Beam 2.58.0
+    return generateResourceId(
+            baseString,
+            ILLEGAL_DATABASE_NAME_CHARS,
+            REPLACE_DATABASE_NAME_CHAR,
+            MAX_DATABASE_NAME_LENGTH,
+            DateTimeFormatter.ofPattern(TIME_FORMAT))
+        + REPLACE_DATABASE_NAME_CHAR
+        + RandomStringUtils.randomAlphanumeric(6).toLowerCase();
+  }
+}

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/package-info.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Package for working with test artifacts. */
+package org.apache.beam.it.gcp.cloudsql;

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/datastream/DatastreamResourceManagerUtils.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/datastream/DatastreamResourceManagerUtils.java
@@ -44,7 +44,7 @@ public class DatastreamResourceManagerUtils {
   static String generateDatastreamId(String resourceId) {
 
     // Take substring of baseString to account for random suffix
-    // TODO(polber) - remove with Beam 2.57.0
+    // TODO(polber) - remove with Beam 2.58.0
     int randomSuffixLength = 6;
     resourceId =
         resourceId.substring(
@@ -58,7 +58,7 @@ public class DatastreamResourceManagerUtils {
                     - randomSuffixLength));
 
     // Add random suffix to avoid collision
-    // TODO(polber) - remove with Beam 2.57.0
+    // TODO(polber) - remove with Beam 2.58.0
     return generateResourceId(
             resourceId,
             ILLEGAL_RESOURCE_ID_CHARS,

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/spanner/utils/SpannerResourceManagerUtils.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/spanner/utils/SpannerResourceManagerUtils.java
@@ -50,7 +50,7 @@ public final class SpannerResourceManagerUtils {
     checkArgument(baseString.length() != 0, "baseString cannot be empty!");
 
     // Take substring of baseString to account for random suffix
-    // TODO(polber) - remove with Beam 2.57.0
+    // TODO(polber) - remove with Beam 2.58.0
     int randomSuffixLength = 6;
     baseString =
         baseString.substring(
@@ -86,7 +86,7 @@ public final class SpannerResourceManagerUtils {
     }
 
     // Add random suffix to avoid collision
-    // TODO(polber) - remove with Beam 2.57.0
+    // TODO(polber) - remove with Beam 2.58.0
     trimmed =
         trimmed
             + REPLACE_DATABASE_CHAR
@@ -104,7 +104,7 @@ public final class SpannerResourceManagerUtils {
   public static String generateInstanceId(String baseString) {
 
     // Take substring of baseString to account for random suffix
-    // TODO(polber) - remove with Beam 2.57.0
+    // TODO(polber) - remove with Beam 2.58.0
     int randomSuffixLength = 6;
     baseString =
         baseString.substring(
@@ -133,7 +133,7 @@ public final class SpannerResourceManagerUtils {
     }
 
     // Add random suffix to avoid collision
-    // TODO(polber) - remove with Beam 2.57.0
+    // TODO(polber) - remove with Beam 2.58.0
     instanceId =
         instanceId + REPLACE_INSTANCE_CHAR + RandomStringUtils.randomAlphanumeric(6).toLowerCase();
 

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudMySQLResourceManagerTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudMySQLResourceManagerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.it.gcp.cloudsql;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/** Integration tests for {@link CloudMySQLResourceManager}. */
+@RunWith(JUnit4.class)
+public class CloudMySQLResourceManagerTest {
+
+  @Rule public final MockitoRule mockito = MockitoJUnit.rule();
+
+  private CloudMySQLResourceManager testManager;
+
+  private static final String TEST_ID = "test_id";
+
+  @Before
+  public void setUp() {
+    testManager =
+        (CloudMySQLResourceManager)
+            CloudMySQLResourceManager.builder(TEST_ID)
+                .setDatabaseName("mockDatabase")
+                .setUsername("username")
+                .setPassword("password")
+                .setHost("127.0.0.1")
+                .setPort(1234)
+                .build();
+  }
+
+  @Test
+  public void testGetJDBCPrefixReturnsCorrectValue() {
+    assertThat(testManager.getJDBCPrefix()).isEqualTo("mysql");
+  }
+}

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudOracleResourceManagerTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudOracleResourceManagerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.it.gcp.cloudsql;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/** Integration tests for {@link CloudOracleResourceManager}. */
+@RunWith(JUnit4.class)
+public class CloudOracleResourceManagerTest {
+
+  @Rule public final MockitoRule mockito = MockitoJUnit.rule();
+
+  private CloudOracleResourceManager testManager;
+
+  private static final String TEST_ID = "test_id";
+
+  @Before
+  public void setUp() {
+    testManager =
+        (CloudOracleResourceManager)
+            CloudOracleResourceManager.builder(TEST_ID)
+                .setUsername("username")
+                .setPassword("password")
+                .setHost("127.0.0.1")
+                .build();
+  }
+
+  @Test
+  public void testGetJDBCPrefixReturnsCorrectValue() {
+    assertThat(testManager.getJDBCPrefix()).isEqualTo("oracle");
+  }
+
+  @Test
+  public void testGetDatabaseReturnsCorrectValue() {
+    assertThat(testManager.getDatabaseName()).isEqualTo("xe");
+  }
+
+  @Test
+  public void testGeUriReturnsCorrectValue() {
+    assertThat(testManager.getUri()).isEqualTo("jdbc:oracle:thin:@127.0.0.1:1521:xe");
+  }
+}

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManagerIT.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManagerIT.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.it.gcp.cloudsql;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatRecords;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.beam.it.jdbc.JDBCResourceManager;
+import org.apache.beam.it.testcontainers.TestContainersIntegrationTest;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
+import org.apache.parquet.Strings;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Integration tests for JDBC Resource Managers. */
+@Category(TestContainersIntegrationTest.class)
+@RunWith(JUnit4.class)
+public class CloudSqlResourceManagerIT {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CloudSqlResourceManagerIT.class);
+
+  private static final String TEST_ID = "dummy-test";
+  private static final String TABLE_NAME = "dummy_table";
+
+  @Test
+  public void testDefaultCloudMySQLResourceManagerE2E() {
+    if (missingProperties("cloudProxyHost", "cloudProxyPort")) {
+      return;
+    }
+    CloudMySQLResourceManager mySQL = CloudMySQLResourceManager.builder(TEST_ID).build();
+
+    simpleTest(mySQL);
+  }
+
+  @Test
+  public void testDefaultCloudOracleResourceManagerE2E() {
+    if (missingProperties("cloudOracleHost")) {
+      return;
+    }
+    CloudOracleResourceManager oracle = CloudOracleResourceManager.builder(TEST_ID).build();
+
+    simpleTest(oracle);
+  }
+
+  private <T extends CloudSqlResourceManager> void simpleTest(T rm) {
+    try {
+      Map<String, String> columns = new LinkedHashMap<>();
+      columns.put("id", "INTEGER");
+      columns.put("first", "VARCHAR(32)");
+      columns.put("last", "VARCHAR(32)");
+      columns.put("age", "VARCHAR(32)");
+      JDBCResourceManager.JDBCSchema schema = new JDBCResourceManager.JDBCSchema(columns, "id");
+      rm.createTable(TABLE_NAME, schema);
+
+      List<Map<String, Object>> rows = new ArrayList<>();
+      rows.add(ImmutableMap.of("id", 0, "first", "John", "last", "Doe", "age", 23));
+      rows.add(ImmutableMap.of("id", 1, "first", "Jane", "last", "Doe", "age", 42));
+      rows.add(ImmutableMap.of("id", 2, "first", "A", "last", "B", "age", 1));
+      rm.write(TABLE_NAME, rows);
+
+      List<String> validateSchema = new ArrayList<>(columns.keySet());
+      List<Map<String, Object>> fetchRows = rm.readTable(TABLE_NAME);
+
+      // toUpperCase expected because some databases (Postgres, Oracle) transform column names
+      assertThat(toUpperCase(rm.getTableSchema(TABLE_NAME)))
+          .containsExactlyElementsIn(toUpperCase(validateSchema));
+      assertThat(fetchRows).hasSize(3);
+      assertThatRecords(fetchRows).hasRecordsUnorderedCaseInsensitiveColumns(rows);
+    } finally {
+      rm.cleanupAll();
+    }
+  }
+
+  private List<String> toUpperCase(List<String> list) {
+    return list.stream().map(String::toUpperCase).collect(Collectors.toList());
+  }
+
+  private boolean missingProperties(String... properties) {
+    for (String property : properties) {
+      if (Strings.isNullOrEmpty(System.getProperty(property))) {
+        LOG.info(String.format("-D%s was not specified, skipping...", property));
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManagerTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManagerTest.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.it.gcp.cloudsql;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.checkerframework.checker.initialization.qual.Initialized;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link CloudSqlResourceManager}. */
+@RunWith(JUnit4.class)
+public class CloudSqlResourceManagerTest {
+
+  private static final String TEST_ID = "test_id";
+  private static final String HOST = "127.0.0.1";
+  private static final String PORT = "1234";
+  private static final String USERNAME = "username";
+  private static final String PASSWORD = "password";
+  private static final String JDBC_PREFIX = "fake";
+  private static final String DATABASE = "mockDatabase";
+
+  /**
+   * Helper mock implementation of {@link CloudSqlResourceManager} for testing relevant implemented
+   * methods without exposing underlying {@link org.apache.beam.it.jdbc.AbstractJDBCResourceManager}
+   * or JDBC drivers.
+   */
+  private static class MockCloudSqlResourceManager extends CloudSqlResourceManager {
+
+    private final boolean initialized;
+    private boolean createdDatabase;
+    private String lastRunSqlCommand;
+
+    private MockCloudSqlResourceManager(Builder builder) {
+      super(builder);
+      this.initialized = true;
+    }
+
+    @Override
+    public void createDatabase(@NonNull String databaseName) {
+      // Avoid creating database during initialization of CloudSqlResourceManager
+      if (initialized) {
+        super.createDatabase(databaseName);
+      }
+      createdDatabase = true;
+    }
+
+    @Override
+    public synchronized void runSQLUpdate(@NonNull String sql) {
+      // Keep track of sql statement to ensure caller invoked proper SQL function.
+      this.lastRunSqlCommand = sql;
+    }
+
+    @Override
+    public @UnknownKeyFor @NonNull @Initialized String getJDBCPrefix() {
+      return JDBC_PREFIX;
+    }
+  }
+
+  /**
+   * Helper method for creating a test resource manager either with or without creating a DB.
+   *
+   * @param useCustomDb create a DB.
+   * @return the initialized resource manager.
+   */
+  private MockCloudSqlResourceManager createTestManager(boolean useCustomDb) {
+    CloudSqlResourceManager.Builder testManagerBuilder =
+        new CloudSqlResourceManager.Builder(TEST_ID) {
+          @Override
+          public @NonNull CloudSqlResourceManager build() {
+            return new MockCloudSqlResourceManager(this);
+          }
+        };
+
+    if (useCustomDb) {
+      testManagerBuilder.setDatabaseName(DATABASE);
+    }
+
+    return (MockCloudSqlResourceManager)
+        testManagerBuilder
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .setHost(HOST)
+            .setPort(1234)
+            .build();
+  }
+
+  @Test
+  public void testUsingStaticDBDoesNotCreateDB() {
+    assertThat(createTestManager(false).createdDatabase).isTrue();
+  }
+
+  @Test
+  public void testNotUsingStaticDBDoesCreateDB() {
+    assertThat(createTestManager(true).createdDatabase).isFalse();
+  }
+
+  @Test
+  public void testGetUri() {
+    assertThat(createTestManager(false).getUri())
+        .matches(
+            String.format(
+                "jdbc:%s://%s:%s/%s_" + "\\d{8}_\\d{6}_[a-zA-Z0-9]{6}",
+                JDBC_PREFIX, HOST, PORT, TEST_ID));
+  }
+
+  @Test
+  public void testGetUriUsingStaticDB() {
+    assertThat(createTestManager(true).getUri())
+        .isEqualTo(String.format("jdbc:%s://%s:%s/%s", JDBC_PREFIX, HOST, PORT, DATABASE));
+  }
+
+  @Test
+  public void testDropTable() {
+    MockCloudSqlResourceManager testManager = createTestManager(false);
+
+    testManager.createdTables.add("test_table");
+    testManager.dropTable("test_table");
+
+    assertThat(testManager.lastRunSqlCommand).contains("DROP TABLE");
+    assertThat(testManager.createdTables).isEmpty();
+  }
+
+  @Test
+  public void testCreateDatabase() {
+    MockCloudSqlResourceManager testManager = createTestManager(false);
+
+    testManager.createDatabase("test_db");
+
+    assertThat(testManager.lastRunSqlCommand).contains("CREATE DATABASE");
+  }
+
+  @Test
+  public void testDropDatabase() {
+    MockCloudSqlResourceManager testManager = createTestManager(false);
+
+    testManager.dropDatabase("test_db");
+
+    assertThat(testManager.lastRunSqlCommand).contains("DROP DATABASE test_db");
+  }
+
+  @Test
+  public void testCleanupAllDropsDBWhenCreated() {
+    MockCloudSqlResourceManager testManager = createTestManager(false);
+
+    testManager.cleanupAll();
+    assertThat(testManager.lastRunSqlCommand)
+        .containsMatch(String.format("DROP DATABASE %s_\\d{8}_\\d{6}_[a-zA-Z0-9]{6}", TEST_ID));
+  }
+
+  @Test
+  public void testCleanupAllRemovesAllTablesWhenDBNotCreated() {
+    MockCloudSqlResourceManager testManager = createTestManager(true);
+
+    testManager.createdTables.add("test_table_1");
+    testManager.createdTables.add("test_table_2");
+    testManager.cleanupAll();
+
+    assertThat(testManager.lastRunSqlCommand).contains("DROP TABLE");
+    assertThat(testManager.createdTables).isEmpty();
+  }
+
+  /*
+   * Currently only supports static Cloud SQL instance which means jdbc port uses system property.
+   */
+  @Test
+  public void testGetJDBCPort() {
+    assertThat(String.valueOf(createTestManager(true).getJDBCPort())).isEqualTo(PORT);
+  }
+
+  /*
+   * Currently only supports static Cloud SQL instance which means port uses system property.
+   */
+  @Test
+  public void testGetPort() {
+    assertThat(String.valueOf(createTestManager(true).getPort())).isEqualTo(PORT);
+  }
+}


### PR DESCRIPTION
PR adds the CloudSqlResourceManager to manage SQL resources on GCP.

For MySQL - expects a static CloudSQL instance running MySQL
For Oracle - expects a static GCE VM running Oracle XE 