### PR TITLE
Add terraform validator

### DIFF
--- a/.github/workflows/spanner-terraform-validator.yml
+++ b/.github/workflows/spanner-terraform-validator.yml
@@ -45,15 +45,23 @@ jobs:
           terraform -chdir="$SAMPLE" validate
         
           echo "Verifying sample structure..."
-          for FILE in $FILE_LIST; do
+          MISSING_FILES=() # Initialize empty list for missing files in each sample
+          for FILE in ${FILE_LIST[@]}; do
             if [[ ! -f "$SAMPLE/$FILE" ]]; then
               echo "ERROR: Missing file: $SAMPLE/$FILE"
-              FAILED_SAMPLES+=("$SAMPLE")
-              break
+              MISSING_FILES+=("$FILE") # Add missing file to list
             fi
           done
         
-          if [[ ! " ${FAILED_SAMPLES[*]} " =~ " ${SAMPLE} " ]]; then # Check if sample is in failed list
+          if [[ ${#MISSING_FILES[@]} -gt 0 ]]; then # Check if there are any missing files
+            echo "Sample failed validation: $SAMPLE"
+            echo "Missing files:"
+            for FILE in "${MISSING_FILES[@]}"; do
+              echo "- $FILE"
+              done
+            FAILED_SAMPLES+=("$SAMPLE") # Add the sample to failed list
+            echo "----------------------"
+          else
             echo "Verified sample successfully: $SAMPLE"
             echo "----------------------"
           fi

--- a/.github/workflows/spanner-terraform-validator.yml
+++ b/.github/workflows/spanner-terraform-validator.yml
@@ -1,5 +1,8 @@
 name: Spanner Terraform Validator
 
+#  1. Adds a Terraform Validator for Terraform samples being added to the repo. It verifies the sample structure and the plan generated for it via terraform validate.
+#  2. Checks the formatting of the samples for correctness. Samples need to be formatted with terraform fmt.
+
 on:
   pull_request:
     branches:
@@ -16,7 +19,7 @@ jobs:
     strategy:
       matrix:
         terraform_paths:
-          - v2/sourcedb-to-spanner/terraform/samples
+        - v2/sourcedb-to-spanner/terraform/samples
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
@@ -37,9 +40,9 @@ jobs:
           echo "Skipping non-directory: $SAMPLE"
             continue
           fi
-          
+        
           echo "Verifying sample: $SAMPLE"
-          
+        
           echo "Verifying terraform configuration..."
           terraform -chdir="$SAMPLE" init
           terraform -chdir="$SAMPLE" validate

--- a/.github/workflows/spanner-terraform-validator.yml
+++ b/.github/workflows/spanner-terraform-validator.yml
@@ -16,7 +16,6 @@ jobs:
     strategy:
       matrix:
         terraform_paths:
-          - v2/datastream-to-spanner/terraform/samples
           - v2/sourcedb-to-spanner/terraform/samples
     steps:
     - name: Checkout Code

--- a/.github/workflows/spanner-terraform-validator.yml
+++ b/.github/workflows/spanner-terraform-validator.yml
@@ -1,0 +1,70 @@
+name: Spanner Terraform Validator
+
+on:
+  pull_request:
+    branches:
+    - main  # Adjust the branch if needed
+    paths:
+    # Include spanner terraform sample paths only
+    - '.github/workflows/spanner-terraform-validator.yml'
+    - 'v2/datastream-to-spanner/terraform/samples/**'
+    - 'v2/sourcedb-to-spanner/terraform/samples/**'
+
+jobs:
+  verify-terraform-samples:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        terraform_paths:
+          - v2/datastream-to-spanner/terraform/samples
+          - v2/sourcedb-to-spanner/terraform/samples
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+    - name: Verify Terraform formatting
+      uses: dflook/terraform-fmt-check@v1
+      with:
+        path: ${{ matrix.terraform_paths }}
+    - name: Verify Terraform template and required structure
+      id: find-samples
+      run: |
+        SAMPLES=$(find ${{ matrix.terraform_paths }} -mindepth 1 -maxdepth 1 -type d)
+        echo "Identified sample directories:" $SAMPLES
+        FILE_LIST=(main.tf outputs.tf variables.tf terraform.tf terraform.tfvars terraform_simple.tfvars README.md)
+        FAILED_SAMPLES=()
+        
+        for SAMPLE in $SAMPLES; do
+          if [[ ! -d "$SAMPLE" ]]; then
+          echo "Skipping non-directory: $SAMPLE"
+            continue
+          fi
+          
+          echo "Verifying sample: $SAMPLE"
+          
+          echo "Verifying terraform configuration..."
+          terraform -chdir="$SAMPLE" init
+          terraform -chdir="$SAMPLE" validate
+        
+          echo "Verifying sample structure..."
+          for FILE in $FILE_LIST; do
+            if [[ ! -f "$SAMPLE/$FILE" ]]; then
+              echo "ERROR: Missing file: $SAMPLE/$FILE"
+              FAILED_SAMPLES+=("$SAMPLE")
+              break
+            fi
+          done
+        
+          if [[ ! " ${FAILED_SAMPLES[*]} " =~ " ${SAMPLE} " ]]; then # Check if sample is in failed list
+            echo "Verified sample successfully: $SAMPLE"
+            echo "----------------------"
+          fi
+        done  
+        echo "Verification completed!"
+        if [[ ${#FAILED_SAMPLES[@]} -gt 0 ]]; then
+          echo "The following samples failed validation:"
+          for SAMPLE in "${FAILED_SAMPLES[@]}"; do
+            echo "- $SAMPLE"
+          done
+          exit 1  # Indicate failure if there were any failed samples
+        fi
+        echo "All samples validated successfully!"

--- a/v2/sourcedb-to-spanner/terraform/samples/multiple-jobs/outputs.tf
+++ b/v2/sourcedb-to-spanner/terraform/samples/multiple-jobs/outputs.tf
@@ -4,7 +4,7 @@ output "dataflow_job_ids" {
 }
 
 output "dataflow_job_urls" {
-  value = [for job in google_dataflow_flex_template_job.generated : "https://console.cloud.google.com/dataflow/jobs/${var.common_params.region}/${job.job_id}"]
+  value       = [for job in google_dataflow_flex_template_job.generated : "https://console.cloud.google.com/dataflow/jobs/${var.common_params.region}/${job.job_id}"]
   description = "List of URLs for the created Dataflow Flex Template jobs."
 }
 

--- a/v2/sourcedb-to-spanner/terraform/samples/multiple-jobs/terraform.tf
+++ b/v2/sourcedb-to-spanner/terraform/samples/multiple-jobs/terraform.tf
@@ -6,7 +6,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.0"   # Or the latest compatible version
+      version = "~> 3.0" # Or the latest compatible version
     }
   }
   required_version = "~>1.2"

--- a/v2/sourcedb-to-spanner/terraform/samples/multiple-jobs/terraform.tfvars
+++ b/v2/sourcedb-to-spanner/terraform/samples/multiple-jobs/terraform.tfvars
@@ -1,7 +1,7 @@
 common_params = {
-  on_delete                    = "drain"  # Or "cancel" if you prefer
+  on_delete                    = "drain" # Or "cancel" if you prefer
   project                      = "your-google-cloud-project-id"
-  region                       = "us-central1"  # Or your desired region
+  region                       = "us-central1" # Or your desired region
   jdbcDriverJars               = "gs://your-bucket/driver_jar1.jar,gs://your-bucket/driver_jar2.jar"
   jdbcDriverClassName          = "com.mysql.jdbc.Driver"
   projectId                    = "your-cloud-spanner-project-id"

--- a/v2/sourcedb-to-spanner/terraform/samples/multiple-jobs/terraform_simple.tfvars
+++ b/v2/sourcedb-to-spanner/terraform/samples/multiple-jobs/terraform_simple.tfvars
@@ -3,9 +3,9 @@
 # It creates two bulk migration jobs with public IPs in the default network.
 
 common_params = {
-  on_delete             = "cancel"  # Or "cancel" if you prefer
+  on_delete             = "cancel" # Or "cancel" if you prefer
   project               = "your-google-cloud-project-id"
-  region                = "us-central1"  # Or your desired region
+  region                = "us-central1" # Or your desired region
   projectId             = "your-google-cloud-project-id"
   service_account_email = "your-project-id-compute@developer.gserviceaccount.com"
 }

--- a/v2/sourcedb-to-spanner/terraform/samples/multiple-jobs/variables.tf
+++ b/v2/sourcedb-to-spanner/terraform/samples/multiple-jobs/variables.tf
@@ -1,6 +1,6 @@
 variable "common_params" {
   description = "Parameters which are common across jobs. Please refer to https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v2/sourcedb-to-spanner/README_Sourcedb_to_Spanner_Flex.md for the description of the parameters below."
-  type        = object({
+  type = object({
     on_delete                    = optional(string, "drain")
     project                      = string
     region                       = string
@@ -26,7 +26,7 @@ variable "common_params" {
 
 variable "jobs" {
   description = "List of job configurations. Please refer to https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v2/sourcedb-to-spanner/README_Sourcedb_to_Spanner_Flex.md for the description of the parameters below."
-  type        = list(object({
+  type = list(object({
     instanceId            = string
     databaseId            = string
     sourceDbURL           = string


### PR DESCRIPTION
- Adds a Terraform Validator for Terraform samples being added to the repo. It verifies the sample structure and the `plan` generated for it via `terraform validate`.
- Formats the existing bulk migration example to comply with Terraform validator using `terraform fmt`.