### PR TITLE
base64 handling simplified

### DIFF
--- a/v2/gcs-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/processing/dml/DMLGenerator.java
+++ b/v2/gcs-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/processing/dml/DMLGenerator.java
@@ -25,9 +25,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.commons.codec.DecoderException;
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -336,31 +333,19 @@ public class DMLGenerator {
           valuesJson.getJSONArray(colName).toList().stream()
               .map(String::valueOf)
               .collect(Collectors.joining(","));
-    } else if ("STRING".equals(colType)
-        && ("binary".equals(sourceColDef.getType().getName())
-            || "varbinary".equals(sourceColDef.getType().getName()))) {
-
-      // Spanner has the hex string in this case
-      try {
-        colInputValue = new String(Hex.decodeHex(valuesJson.getString(colName)));
-      } catch (DecoderException e) {
-        // return the same string value
-        colInputValue = valuesJson.getString(colName);
-      }
-
     } else if ("BYTES".equals(colType)) {
-      colInputValue = new String(Base64.decodeBase64(valuesJson.getString(colName).getBytes()));
+      colInputValue = "FROM_BASE64('" + valuesJson.getString(colName) + "')";
     } else {
       colInputValue = valuesJson.getString(colName);
     }
     String response =
         getColumnValueByType(
-            sourceColDef.getType().getName(), colInputValue, sourceDbTimezoneOffset);
+            sourceColDef.getType().getName(), colInputValue, sourceDbTimezoneOffset, colType);
     return response;
   }
 
   private static String getColumnValueByType(
-      String columnType, String colValue, String sourceDbTimezoneOffset) {
+      String columnType, String colValue, String sourceDbTimezoneOffset, String spannerColType) {
     String response = "";
     String cleanedNullBytes = "";
     String decodedString = "";
@@ -389,14 +374,14 @@ public class DMLGenerator {
       case "mediumblob":
       case "blob":
       case "longblob":
-        response = getQuotedEscapedString(colValue);
+        response = getQuotedEscapedString(colValue, spannerColType);
         break;
       case "timestamp":
       case "datetime":
         colValue = colValue.substring(0, colValue.length() - 1); // trim the Z for mysql
         response =
             " CONVERT_TZ("
-                + getQuotedEscapedString(colValue)
+                + getQuotedEscapedString(colValue, spannerColType)
                 + ",'+00:00','"
                 + sourceDbTimezoneOffset
                 + "')";
@@ -405,7 +390,7 @@ public class DMLGenerator {
       case "binary":
       case "varbinary":
       case "bit":
-        response = getHexString(colValue);
+        response = getHexString(colValue, spannerColType);
         break;
       default:
         response = colValue;
@@ -420,16 +405,17 @@ public class DMLGenerator {
     return cleanedNullBytes;
   }
 
-  private static String getQuotedEscapedString(String input) {
+  private static String getQuotedEscapedString(String input, String spannerColType) {
+    if ("BYTES".equals(spannerColType)) {
+      return input;
+    }
     String cleanedString = escapeString(input);
     String response = "\'" + cleanedString + "\'";
     return response;
   }
 
-  private static String getHexString(String input) {
-    String cleanedString = escapeString(input);
-    String hexString = Hex.encodeHexString(cleanedString.getBytes());
-    String response = "X\'" + hexString + "\'";
+  private static String getHexString(String input, String spannerColType) {
+    String response = "HEX(" + getQuotedEscapedString(input, spannerColType) + ")";
     return response;
   }
 }

--- a/v2/gcs-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/processing/dml/DMLGeneratorTest.java
+++ b/v2/gcs-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/processing/dml/DMLGeneratorTest.java
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.teleport.v2.templates.processing.dml;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -47,17 +47,15 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO Singers(SingerId,FirstName,LastName) VALUES (999,'kk','ll') ON DUPLICATE KEY"
-            + " UPDATE  FirstName = 'kk', LastName = 'll'";
+    /*The expected sql is:
+    "INSERT INTO Singers(SingerId,FirstName,LastName) VALUES (999,'kk','ll') ON DUPLICATE KEY"
+        + " UPDATE  FirstName = 'kk', LastName = 'll'";*/
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // workaround comparison to bypass TAP flaky behavior
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("FirstName = 'kk'"));
+    assertTrue(sql.contains("LastName = 'll'"));
   }
 
   @Test
@@ -70,17 +68,15 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO Singers(SingerId,FirstName,LastName) VALUES (999,'kk','ll') ON DUPLICATE KEY"
-            + " UPDATE  FirstName = 'kk', LastName = 'll'";
+    /* The expected sql is:
+    "INSERT INTO Singers(SingerId,FirstName,LastName) VALUES (999,'kk','ll') ON DUPLICATE KEY"
+        + " UPDATE  FirstName = 'kk', LastName = 'll'";*/
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // workaround comparison to bypass TAP flaky behavior
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("FirstName = 'kk'"));
+    assertTrue(sql.contains("LastName = 'll'"));
   }
 
   @Test
@@ -92,18 +88,15 @@ public final class DMLGeneratorTest {
     String keyValueString = "{\"SingerId\":\"999\"}";
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
-
-    String expectedSql =
-        "INSERT INTO Singers(SingerId,FirstName,LastName) VALUES ('999',222,'ll') ON DUPLICATE"
-            + " KEY UPDATE  FirstName = 222, LastName = 'll'";
+    /*The expected sql is:
+    "INSERT INTO Singers(SingerId,FirstName,LastName) VALUES ('999',222,'ll') ON DUPLICATE"
+        + " KEY UPDATE  FirstName = 222, LastName = 'll'";*/
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // workaround comparison to bypass TAP flaky behavior
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("FirstName = 222"));
+    assertTrue(sql.contains("LastName = 'll'"));
   }
 
   @Test
@@ -117,17 +110,15 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO Singers(SingerId,FirstName,LastName) VALUES (999,'kk','ll') ON DUPLICATE KEY"
-            + " UPDATE  FirstName = 'kk', LastName = 'll'";
+    /* The expected sql is:
+    "INSERT INTO Singers(SingerId,FirstName,LastName) VALUES (999,'kk','ll') ON DUPLICATE KEY"
+        + " UPDATE  FirstName = 'kk', LastName = 'll'"; */
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // workaround comparison to bypass TAP flaky behavior
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("FirstName = 'kk'"));
+    assertTrue(sql.contains("LastName = 'll'"));
   }
 
   @Test
@@ -142,17 +133,15 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO Singers(SingerId,FirstName,LastName) VALUES (999,'kk','ll') ON DUPLICATE KEY"
-            + " UPDATE  FirstName = 'kk', LastName = 'll'";
+    /* The expected sql is:
+    "INSERT INTO Singers(SingerId,FirstName,LastName) VALUES (999,'kk','ll') ON DUPLICATE KEY"
+        + " UPDATE  FirstName = 'kk', LastName = 'll'";*/
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // workaround comparison to bypass TAP flaky behavior
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("FirstName = 'kk'"));
+    assertTrue(sql.contains("LastName = 'll'"));
   }
 
   @Test
@@ -165,15 +154,12 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql = "";
+    /* The expected sql is: ""*/
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // workaround comparison to bypass TAP flaky behavior
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.isEmpty());
   }
 
   @Test
@@ -186,16 +172,13 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql = "";
+    /* The expected sql is: ""*/
     String sql =
         sql =
             DMLGenerator.getDMLStatement(
                 modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // workaround comparison to bypass TAP flaky behavior
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.isEmpty());
   }
 
   @Test
@@ -208,18 +191,16 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO Singers(SingerId,Bday) VALUES (999,"
-            + " CONVERT_TZ('2023-05-18T12:01:13.088397258','+00:00','+10:00')) ON DUPLICATE KEY"
-            + " UPDATE  Bday =  CONVERT_TZ('2023-05-18T12:01:13.088397258','+00:00','+10:00')";
+    /* The expected sql is:
+    "INSERT INTO Singers(SingerId,Bday) VALUES (999,"
+        + " CONVERT_TZ('2023-05-18T12:01:13.088397258','+00:00','+10:00')) ON DUPLICATE KEY"
+        + " UPDATE  Bday =  CONVERT_TZ('2023-05-18T12:01:13.088397258','+00:00','+10:00')";*/
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+10:00");
 
-    // workaround comparison to bypass TAP flaky behavior
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(
+        sql.contains("Bday =  CONVERT_TZ('2023-05-18T12:01:13.088397258','+00:00','+10:00'"));
   }
 
   @Test
@@ -232,17 +213,15 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO Singers(SingerId,FirstName,LastName) VALUES (999,'kk','ll') ON DUPLICATE KEY"
-            + " UPDATE  FirstName = 'kk', LastName = 'll'";
+    /* The expected sql is:
+    "INSERT INTO Singers(SingerId,FirstName,LastName) VALUES (999,'kk','ll') ON DUPLICATE KEY"
+        + " UPDATE  FirstName = 'kk', LastName = 'll'";*/
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // workaround comparison to bypass TAP flaky behavior
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("FirstName = 'kk'"));
+    assertTrue(sql.contains("LastName = 'll'"));
   }
 
   @Test
@@ -270,33 +249,71 @@ public final class DMLGeneratorTest {
     JSONObject newValuesJson = new JSONObject(newValueJsonStr);
     JSONObject keyValuesJson = new JSONObject(keysJsonStr);
 
-    String expectedSql =
-        "INSERT INTO"
-            + " sample_table(id,mediumint_column,tinyblob_column,datetime_column,enum_column,longtext_column,mediumblob_column,text_column,tinyint_column,timestamp_column,float_column,varbinary_column,binary_column,bigint_column,time_column,tinytext_column,set_column,longblob_column,mediumtext_column,year_column,blob_column,decimal_column,bool_column,char_column,date_column,double_column,smallint_column,varchar_column)"
-            + " VALUES (12,333,'abc',"
-            + " CONVERT_TZ('2023-05-18T12:01:13.088397258','+00:00','+00:00'),'1','<longtext_column>','abclarge','aaaaaddd',1,"
-            + " CONVERT_TZ('2023-05-18T12:01:13.088397258','+00:00','+00:00'),4.2,X'6162636c61726765',X'6162636c61726765',4444,'10:10:10','<tinytext_column>','1,2','ablongblobc','<mediumtext_column>','2023','abbigc',444.222,false,'<char_c','2023-05-18',42.42,22,'abc')"
-            + " ON DUPLICATE KEY UPDATE  mediumint_column = 333, tinyblob_column = 'abc',"
-            + " datetime_column =  CONVERT_TZ('2023-05-18T12:01:13.088397258','+00:00','+00:00'),"
-            + " enum_column = '1', longtext_column = '<longtext_column>', mediumblob_column ="
-            + " 'abclarge', text_column = 'aaaaaddd', tinyint_column = 1, timestamp_column = "
-            + " CONVERT_TZ('2023-05-18T12:01:13.088397258','+00:00','+00:00'), float_column = 4.2,"
-            + " varbinary_column = X'6162636c61726765', binary_column = X'6162636c61726765',"
-            + " bigint_column = 4444, time_column = '10:10:10', tinytext_column ="
-            + " '<tinytext_column>', set_column = '1,2', longblob_column = 'ablongblobc',"
-            + " mediumtext_column = '<mediumtext_column>', year_column = '2023', blob_column ="
-            + " 'abbigc', decimal_column = 444.222, bool_column = false, char_column = '<char_c',"
-            + " date_column = '2023-05-18', double_column = 42.42, smallint_column = 22,"
-            + " varchar_column = 'abc'";
+    /* The expected sql is:
+    "INSERT INTO"
+        + " sample_table(id,mediumint_column,tinyblob_column,datetime_column,enum_column,longtext_column,mediumblob_column,text_column,tinyint_column,timestamp_column,float_column,varbinary_column,binary_column,bigint_column,time_column,tinytext_column,set_column,longblob_column,mediumtext_column,year_column,blob_column,decimal_column,bool_column,char_column,date_column,double_column,smallint_column,varchar_column)"
+        + " VALUES (12,333,FROM_BASE64('YWJj'),"
+        + " CONVERT_TZ('2023-05-18T12:01:13.088397258','+00:00','+00:00'),'1','<longtext_column>',FROM_BASE64('YWJjbGFyZ2U='),'aaaaaddd',1,"
+        + " CONVERT_TZ('2023-05-18T12:01:13.088397258','+00:00','+00:00'),4.2,HEX(FROM_BASE64('YWJjbGFyZ2U=')),HEX(FROM_BASE64('YWJjbGFyZ2U=')),4444,'10:10:10','<tinytext_column>','1,2',FROM_BASE64('YWJsb25nYmxvYmM='),'<mediumtext_column>','2023',FROM_BASE64('YWJiaWdj'),444.222,false,'<char_c','2023-05-18',42.42,22,'abc')"
+        + " ON DUPLICATE KEY UPDATE  mediumint_column = 333, tinyblob_column ="
+        + " FROM_BASE64('YWJj'), datetime_column = "
+        + " CONVERT_TZ('2023-05-18T12:01:13.088397258','+00:00','+00:00'), enum_column = '1',"
+        + " longtext_column = '<longtext_column>', mediumblob_column ="
+        + " FROM_BASE64('YWJjbGFyZ2U='), text_column = 'aaaaaddd', tinyint_column = 1,"
+        + " timestamp_column =  CONVERT_TZ('2023-05-18T12:01:13.088397258','+00:00','+00:00'),"
+        + " float_column = 4.2, varbinary_column = HEX(FROM_BASE64('YWJjbGFyZ2U=')),"
+        + " binary_column = HEX(FROM_BASE64('YWJjbGFyZ2U=')), bigint_column = 4444, time_column"
+        + " = '10:10:10', tinytext_column = '<tinytext_column>', set_column = '1,2',"
+        + " longblob_column = FROM_BASE64('YWJsb25nYmxvYmM='), mediumtext_column ="
+        + " '<mediumtext_column>', year_column = '2023', blob_column = FROM_BASE64('YWJiaWdj'),"
+        + " decimal_column = 444.222, bool_column = false, char_column = '<char_c', date_column"
+        + " = '2023-05-18', double_column = 42.42, smallint_column = 22, varchar_column ="
+        + " 'abc'"; */
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // Note that this fails in critique since the column order is not predictable
-    // But this test case will run locally
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("mediumint_column = 333"));
+    assertTrue(sql.contains("tinyblob_column = FROM_BASE64('YWJj')"));
+    boolean datetimeFlag =
+        sql.contains(
+            "datetime_column =  CONVERT_TZ('2023-05-18T12:01:13.088397258','+00:00','+00:00'");
+    assertTrue(datetimeFlag);
+    // The same assert below fails to run hence as a workaround we are using the above boolean
+    // flag
+    /*  assertTrue(
+    sql.contains(
+        "datetime_column = CONVERT_TZ('2023-05-18T12:01:13.088397258','+00:00','+00:00')"));*/
+    assertTrue(sql.contains("enum_column = '1'"));
+    assertTrue(sql.contains("longtext_column = '<longtext_column>'"));
+    assertTrue(sql.contains("mediumblob_column = FROM_BASE64('YWJjbGFyZ2U=')"));
+    assertTrue(sql.contains("text_column = 'aaaaaddd'"));
+    assertTrue(sql.contains("tinyint_column = 1"));
+    boolean timestampFlag =
+        sql.contains(
+            "timestamp_column =  CONVERT_TZ('2023-05-18T12:01:13.088397258','+00:00','+00:00')");
+    assertTrue(timestampFlag);
+    // The same assert below fails to run hence as a workaround we are using the above boolean
+    // flag
+    /* assertTrue(
+    sql.contains(
+        "timestamp_column = CONVERT_TZ('2023-05-18T12:01:13.088397258','+00:00','+00:00')"));*/
+    assertTrue(sql.contains("float_column = 4.2"));
+    assertTrue(sql.contains("varbinary_column = HEX(FROM_BASE64('YWJjbGFyZ2U='))"));
+    assertTrue(sql.contains("binary_column = HEX(FROM_BASE64('YWJjbGFyZ2U='))"));
+    assertTrue(sql.contains("bigint_column = 4444"));
+    assertTrue(sql.contains("time_column = '10:10:10'"));
+    assertTrue(sql.contains("tinytext_column = '<tinytext_column>'"));
+    assertTrue(sql.contains("set_column = '1,2'"));
+    assertTrue(sql.contains("longblob_column = FROM_BASE64('YWJsb25nYmxvYmM=')"));
+    assertTrue(sql.contains("mediumtext_column = '<mediumtext_column>'"));
+    assertTrue(sql.contains("year_column = '2023'"));
+    assertTrue(sql.contains("blob_column = FROM_BASE64('YWJiaWdj')"));
+    assertTrue(sql.contains("decimal_column = 444.222"));
+    assertTrue(sql.contains("bool_column = false"));
+    assertTrue(sql.contains("char_column = '<char_c'"));
+    assertTrue(sql.contains("date_column = '2023-05-18'"));
+    assertTrue(sql.contains("double_column = 42.42"));
   }
 
   @Test
@@ -309,17 +326,15 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO Singers(SingerId,FirstName,LastName) VALUES (999,'kk',NULL) ON DUPLICATE KEY"
-            + " UPDATE  FirstName = 'kk', LastName = NULL";
+    /* The expected sql is:
+    "INSERT INTO Singers(SingerId,FirstName,LastName) VALUES (999,'kk',NULL) ON DUPLICATE KEY"
+        + " UPDATE  FirstName = 'kk', LastName = NULL";*/
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // workaround comparison to bypass TAP flaky behavior
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("FirstName = 'kk'"));
+    assertTrue(sql.contains("LastName = NULL"));
   }
 
   @Test
@@ -332,15 +347,15 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "DELETE";
 
-    String expectedSql = "DELETE FROM Singers WHERE  FirstName = 'kk' AND  SingerId = 999";
+    /* The expected sql is:
+    "DELETE FROM Singers WHERE  FirstName = 'kk' AND  SingerId = 999";*/
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // workaround comparison to bypass TAP flaky behavior
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("FirstName = 'kk'"));
+    assertTrue(sql.contains("SingerId = 999"));
+    assertTrue(sql.contains("DELETE FROM Singers WHERE"));
   }
 
   @Test
@@ -353,17 +368,15 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO Singers(SingerId,FirstName,LastName) VALUES (999,'k''k','ll') ON DUPLICATE KEY"
-            + " UPDATE  FirstName = 'k''k', LastName = 'll'";
+    /* The expected sql is:
+    "INSERT INTO Singers(SingerId,FirstName,LastName) VALUES (999,'k''k','ll') ON DUPLICATE KEY"
+        + " UPDATE  FirstName = 'k''k', LastName = 'll'"; */
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // workaround comparison to bypass TAP flaky behavior
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("FirstName = 'k''k'"));
+    assertTrue(sql.contains("LastName = 'll'"));
   }
 
   @Test
@@ -380,20 +393,16 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO"
-            + " sample_table(id,varchar_column,blob_column)"
-            + " VALUES (12,'''','''')"
-            + " ON DUPLICATE KEY UPDATE  varchar_column = '''', blob_column = ''''";
+    /* The expected sql is:
+    "INSERT INTO"
+        + " sample_table(id,varchar_column,blob_column)"
+        + " VALUES (12,'''',FROM_BASE64('Jw=='))"
+        + " ON DUPLICATE KEY UPDATE  varchar_column = '''', blob_column = FROM_BASE64('Jw==')";*/
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
-
-    // Note that this fails in critique since the column order is not predictable
-    // But this test case will run locally
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("varchar_column = '''"));
+    assertTrue(sql.contains("blob_column = FROM_BASE64('Jw==')"));
   }
 
   @Test
@@ -411,20 +420,16 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO"
-            + " sample_table(id,varchar_column,blob_column)"
-            + " VALUES (12,'''''','''''')"
-            + " ON DUPLICATE KEY UPDATE  varchar_column = '''''', blob_column = ''''''";
+    /* The expected sql is:
+    "INSERT INTO sample_table(id,varchar_column,blob_column) VALUES"
+        + " (12,'''''',FROM_BASE64('Jyc=')) ON DUPLICATE KEY UPDATE  varchar_column = '''''',"
+        + " blob_column = FROM_BASE64('Jyc=')";*/
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // Note that this fails in critique since the column order is not predictable
-    // But this test case will run locally
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("varchar_column = '''''"));
+    assertTrue(sql.contains("blob_column = FROM_BASE64('Jyc=')"));
   }
 
   @Test
@@ -442,20 +447,16 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO"
-            + " sample_table(id,varchar_column,blob_column)"
-            + " VALUES (12,'\\\\''','\\\\''')"
-            + " ON DUPLICATE KEY UPDATE  varchar_column = '\\\\''', blob_column = '\\\\'''";
+    /* The expected sql is:
+    "INSERT INTO sample_table(id,varchar_column,blob_column) VALUES"
+        + " (12,'\\\\''',FROM_BASE64('XCc=')) ON DUPLICATE KEY UPDATE  varchar_column ="
+        + " '\\\\''', blob_column = FROM_BASE64('XCc=')";*/
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // Note that this fails in critique since the column order is not predictable
-    // But this test case will run locally
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("varchar_column = '\\\\'"));
+    assertTrue(sql.contains("blob_column = FROM_BASE64('XCc=')"));
   }
 
   @Test
@@ -474,18 +475,16 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO sample_table(id,varchar_column,blob_column) VALUES (12,'\t','\t'"
-            + ") ON DUPLICATE KEY UPDATE  varchar_column = '\t', blob_column = '\t'";
+    /* The expected sql is:
+    "INSERT INTO sample_table(id,varchar_column,blob_column) VALUES (12,'"
+        + "\t',FROM_BASE64('CQ==')) ON DUPLICATE KEY UPDATE  varchar_column = '\t', blob_column"
+        + " = FROM_BASE64('CQ==')"; */
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // Note that this fails in critique since the column order is not predictable
-    // But this test case will run locally
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("varchar_column = '\t'"));
+    assertTrue(sql.contains("blob_column = FROM_BASE64('CQ==')"));
   }
 
   @Test
@@ -504,18 +503,16 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO sample_table(id,varchar_column,blob_column) VALUES (12,'\b','\b'"
-            + ") ON DUPLICATE KEY UPDATE  varchar_column = '\b', blob_column = '\b'";
+    /* The expected sql is:
+    "INSERT INTO sample_table(id,varchar_column,blob_column) VALUES"
+        + " (12,'\b',FROM_BASE64('CA==')) ON DUPLICATE KEY UPDATE  varchar_column = '\b',"
+        + " blob_column = FROM_BASE64('CA==')";*/
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // Note that this fails in critique since the column order is not predictable
-    // But this test case will run locally
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("varchar_column = '\b'"));
+    assertTrue(sql.contains("blob_column = FROM_BASE64('CA==')"));
   }
 
   @Test
@@ -534,18 +531,16 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO sample_table(id,varchar_column,blob_column) VALUES (12,'\n','\n'"
-            + ") ON DUPLICATE KEY UPDATE  varchar_column = '\n', blob_column = '\n'";
+    /* The expected sql is:
+    "INSERT INTO sample_table(id,varchar_column,blob_column) VALUES (12,'\n"
+        + "',FROM_BASE64('Cg==')) ON DUPLICATE KEY UPDATE  varchar_column = '\n"
+        + "', blob_column = FROM_BASE64('Cg==')";*/
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // Note that this fails in critique since the column order is not predictable
-    // But this test case will run locally
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("varchar_column = '\n'"));
+    assertTrue(sql.contains("blob_column = FROM_BASE64('Cg==')"));
   }
 
   @Test
@@ -564,18 +559,16 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO sample_table(id,varchar_column,blob_column) VALUES (12,'\r','\r'"
-            + ") ON DUPLICATE KEY UPDATE  varchar_column = '\r', blob_column = '\r'";
+    /* The expected sql is:
+    "INSERT INTO sample_table(id,varchar_column,blob_column) VALUES (12,'\r"
+        + "',FROM_BASE64('DQ==')) ON DUPLICATE KEY UPDATE  varchar_column = '\r"
+        + "', blob_column = FROM_BASE64('DQ==')";*/
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // Note that this fails in critique since the column order is not predictable
-    // But this test case will run locally
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("varchar_column = '\r'"));
+    assertTrue(sql.contains("blob_column = FROM_BASE64('DQ==')"));
   }
 
   @Test
@@ -594,18 +587,16 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO sample_table(id,varchar_column,blob_column) VALUES (12,'\f','\f'"
-            + ") ON DUPLICATE KEY UPDATE  varchar_column = '\f', blob_column = '\f'";
+    /* The expected sql is:
+    "INSERT INTO sample_table(id,varchar_column,blob_column) VALUES"
+        + " (12,'\f',FROM_BASE64('DA==')) ON DUPLICATE KEY UPDATE  varchar_column = '\f',"
+        + " blob_column = FROM_BASE64('DA==')";*/
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // Note that this fails in critique since the column order is not predictable
-    // But this test case will run locally
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("varchar_column = '\f'"));
+    assertTrue(sql.contains("blob_column = FROM_BASE64('DA==')"));
   }
 
   @Test
@@ -624,18 +615,16 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO sample_table(id,varchar_column,blob_column) VALUES (12,'\"','\"'"
-            + ") ON DUPLICATE KEY UPDATE  varchar_column = '\"', blob_column = '\"'";
+    /* The expected sql is:
+    "INSERT INTO sample_table(id,varchar_column,blob_column) VALUES"
+        + " (12,'\"',FROM_BASE64('Ig==')) ON DUPLICATE KEY UPDATE  varchar_column = '\"',"
+        + " blob_column = FROM_BASE64('Ig==')";*/
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // Note that this fails in critique since the column order is not predictable
-    // But this test case will run locally
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("varchar_column = '\"'"));
+    assertTrue(sql.contains("blob_column = FROM_BASE64('Ig==')"));
   }
 
   @Test
@@ -654,18 +643,16 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO sample_table(id,varchar_column,blob_column) VALUES (12,'\\\\','\\\\'"
-            + ") ON DUPLICATE KEY UPDATE  varchar_column = '\\\\', blob_column = '\\\\'";
+    /*The expected sql is:
+    "INSERT INTO sample_table(id,varchar_column,blob_column) VALUES"
+        + " (12,'\\\\',FROM_BASE64('XA==')) ON DUPLICATE KEY UPDATE  varchar_column = '\\\\',"
+        + " blob_column = FROM_BASE64('XA==')";*/
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // Note that this fails in critique since the column order is not predictable
-    // But this test case will run locally
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("varchar_column = '\\\\'"));
+    assertTrue(sql.contains("blob_column = FROM_BASE64('XA==')"));
   }
 
   @Test
@@ -678,16 +665,14 @@ public final class DMLGeneratorTest {
     JSONObject keyValuesJson = new JSONObject(keyValueString);
     String modType = "INSERT";
 
-    String expectedSql =
-        "INSERT INTO Singers(SingerId,FirstName,LastName) VALUES (999,'kk',X'62696c5f636f6c') ON"
-            + " DUPLICATE KEY UPDATE  FirstName = 'kk', LastName = X'62696c5f636f6c'";
+    /*The expected sql is:
+    "INSERT INTO Singers(SingerId,FirstName,LastName) VALUES"
+        + " (999,'kk',HEX(FROM_BASE64('YmlsX2NvbA=='))) ON DUPLICATE KEY UPDATE  FirstName ="
+        + " 'kk', LastName = HEX(FROM_BASE64('YmlsX2NvbA=='))"; */
     String sql =
         DMLGenerator.getDMLStatement(
             modType, tableName, schema, newValuesJson, keyValuesJson, "+00:00");
 
-    // workaround comparison to bypass TAP flaky behavior
-    // TODO: Parse the returned SQL to create map of column names and values and compare with
-    // expected map of column names and values
-    assertEquals(sql, sql);
+    assertTrue(sql.contains("LastName = HEX(FROM_BASE64('YmlsX2NvbA=='))"));
   }
 }


### PR DESCRIPTION
For BYTES when Spanner stores it as base64 encoded, no need to decode it and escape - rather use the built in constructs to handle base64. Similar use of built in constructs to handle hex.