### PR TITLE
Live migration pre-configured profiles terraform sample

### DIFF
--- a/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/README.md
+++ b/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/README.md
@@ -1,0 +1,223 @@
+## Sample Scenario: MySQL to Spanner using pre-configured connection profiles
+
+> **_SCENARIO:_** This Terraform example illustrates launching a live migration
+> job
+> for a MySQL
+> source, **given pre-created Datastream source and target connection profiles
+**.
+> As a
+> result, it does not create any new buckets in the GCP account.
+
+It takes the following assumptions -
+
+1. `Service account`/`User account` being used to run Terraform
+   has [permissions](https://cloud.google.com/iam/docs/manage-access-service-accounts#multiple-roles-console)
+   to create and destroy -
+    1. Datastream streams
+    2. Pubsub topics
+    3. Pubsub subscriptions
+    4. Dataflow jobs
+2. A Spanner instance with database containing the data-migration compatible
+   schema is created.
+
+> **_NOTE:_**
+[SMT](https://googlecloudplatform.github.io/spanner-migration-tool/quickstart.html)
+> can be used for converting a MySQL schema to a Spanner compatible schema.
+
+Given these assumptions, it uses a supplied source database connection
+configuration and creates the following resources -
+
+1. **Pubsub topic and subscription** - This contains GCS object notifications as
+   files are written to GCS for consumption by the Dataflow job.
+2. **Datastream stream** - A datastream stream which reads from the source
+   specified in the source connection profile and writes the data to the bucket
+   specified in the target connection profile. Note that it uses a mandatory
+   prefix path inside the bucket where it will write the data to. The default
+   prefix path is `data` (can be overridden).
+3. **Bucket notification** - Creates the GCS bucket notification which publish
+   to the pubsub topic created. Note that the bucket notification is created on
+   the mandatory prefix path specified for the stream above.
+4. **Dataflow job** - The Dataflow job which reads from GCS and writes to
+   Spanner.
+5. **Permissions** - It adds the required roles to the specified (or the
+   default) service accounts for the live migration to work.
+
+> **_NOTE:_** A label is attached to all the resources created via Terraform.
+> The key is `migration_id` and the value is auto-generated. The auto-generated
+> value is used as a global identifier for a migration job across resources. The
+> auto-generated value is always pre-fixed with a `smt-`.
+
+## Description
+
+This sample contains the following files -
+
+1. `main.tf` - This contains the Terraform resources which will be created.
+2. `outputs.tf` - This declares the outputs that will be output as part of
+   running this terraform example.
+3. `variables.tf` - This declares the input variables that are required to
+   configure the resources.
+4. `terraform.tf` - This contains the required providers and APIs/project
+   configurations for this sample.
+5. `terraform.tfvars` - This contains the dummy inputs that need to be populated
+   to run this example.
+6. `terraform_simple.tfvars` - This contains the minimal list of dummy inputs
+   that need to be populated to run this example.
+
+## How to run
+
+1. Clone this repository or the sample locally.
+2. Edit the `terraform.tfvars` or `terraform_simple.tfvars` file and replace the
+   dummy variables with real values. Extend the configuration to meet your
+   needs. It is recommended to get started with `terraform_simple.tfvars`.
+3. Run the following commands -
+
+### Initialise Terraform
+
+```shell
+# Initialise terraform - You only need to do this once for a directory.
+terraform init
+```
+
+### Run `plan` and `apply`
+
+Validate the terraform files with -
+
+```shell
+terraform plan --var-file=terraform_simple.tfvars
+```
+
+Run the terraform script with -
+
+```shell
+terraform apply --var-file=terraform_simple.tfvars
+```
+
+This will launch the configured jobs and produce an output like below -
+
+```shell
+Outputs:
+
+resource_ids = {
+  "dataflow_job" = "2024-06-14_03_01_00-3421054840094926119"
+  "datastream_source_connection_profile" = "your-source-connection-profile-here"
+  "datastream_stream" = "mysql-stream-thorough-wombat"
+  "datastream_target_connection_profile" = "your-target-connection-profile-here"
+  "gcs_bucket" = "your-target-gcs-bucket-here"
+  "pubsub_subscription" = "live-migration-thorough-wombat-sub"
+  "pubsub_topic" = "live-migration-thorough-wombat"
+}
+resource_urls = {
+  "dataflow_job" = "https://console.cloud.google.com/dataflow/jobs/us-central1/2024-06-14_03_01_00-3421054840094926119?project=your-project-here"
+  "datastream_source_connection_profile" = "https://console.cloud.google.com/datastream/connection-profiles/locations/us-central1/instances/source-mysql-thorough-wombat?project=your-project-here"
+  "datastream_stream" = "https://console.cloud.google.com/datastream/streams/locations/us-central1/instances/mysql-stream-thorough-wombat?project=your-project-here"
+  "datastream_target_connection_profile" = "https://console.cloud.google.com/datastream/connection-profiles/locations/us-central1/instances/target-gcs-thorough-wombat?project=your-project-here"
+  "gcs_bucket" = "https://console.cloud.google.com/storage/browser/live-migration-thorough-wombat?project=your-project-here"
+  "pubsub_subscription" = "https://console.cloud.google.com/cloudpubsub/subscription/detail/live-migration-thorough-wombat-sub?project=your-project-here"
+  "pubsub_topic" = "https://console.cloud.google.com/cloudpubsub/topic/detail/live-migration-thorough-wombat?project=your-project-here"
+}
+```
+
+**Note:** Each of the jobs will have a random suffix added to it to prevent name
+collisions.
+
+### Cleanup
+
+Once the jobs have finished running, you can clean up by running -
+
+```shell
+terraform destroy
+```
+
+## FAQ
+
+### Configuring to run using a VPC
+
+#### Datastream
+
+This should already be pre-configured in the source connection profile you are using.
+
+#### Dataflow
+
+1. Set the `network` and the `subnetwork` parameters to run the Dataflow job
+   inside a VPC.
+   Specify [network](https://cloud.google.com/dataflow/docs/guides/specifying-networks#network_parameter)
+   and [subnetwork](https://cloud.google.com/dataflow/docs/guides/specifying-networks#subnetwork_parameter)
+   according to the
+   linked guidelines.
+2. Set the `ip_configuration` to `WORKER_IP_PRIVATE` to disable public IP
+   addresses for the worker VMs.
+
+Note that the VPC should already exist. This template does not create a VPC.
+
+### Updating template parameters for an existing job
+
+Template parameters can be updated in place. Terraform and Dataflow will take
+care of `UPDATING` a Dataflow job. This works internally by terminating the
+existing job with an `UPDATED` state and creating a new job in its place. All 
+of this is done seamlessly by Dataflow and there is no risk to the fidelity of
+an already executing job.
+
+Example update: Changing `round_json_decimals` to `true` from `false`.
+
+Look for the following log during `terraform apply` - 
+
+```shell
+  # google_dataflow_flex_template_job.live_migration_job will be updated in-place
+```
+
+### Updating workers of a Dataflow job
+
+Currently, the Terraform `google_dataflow_flex_template_job` resource does not
+support updating the workers of a Dataflow job.
+If the worker counts are changed in `tfvars` and a Terraform apply is run,
+Terraform will attempt to cancel/drain the existing Dataflow job and replace it
+with a new one.
+**This is not recommended**. Instead use the `gcloud` CLI to update the worker
+counts of a launched Dataflow job.
+
+```shell
+gcloud dataflow jobs update-options \                                                                                                                                                                                                                                                                                                                      (base) 
+        --region=us-central1 \
+        --min-num-workers=5 \
+        --max-num-workers=20 \
+      2024-06-17_01_21_44-12198433486526363702
+```
+
+### Dumped data in the GCS bucket
+
+Because this template assumes you provide your own bucket, it does not manage
+the lifecycle of the bucket or its contents. You will have to manually clean up
+the data dumped to the bucket. One way of doing this is to set up
+[lifecycle policies](https://cloud.google.com/storage/docs/lifecycle)
+on the bucket.
+
+### Configuring Databases and Tables in Datastream
+
+Which databases and tables to replicate can be configured via the following
+variable definition - 
+
+In `variables.tf`, following definition exists - 
+
+```shell
+mysql_databases = list(object({
+      database = string
+      tables   = optional(list(string))
+    }))
+```
+
+To configure, create `*.tfvars` as follows - 
+
+```shell
+mysql_databases = [
+    {
+      database = "<YOUR_DATABASE_NAME>"
+      tables   = ["TABLE_1", "TABLE_2"]
+      # Optionally list specific tables, or remove "tables" all together for all tables
+    },
+    {
+      database = "<YOUR_DATABASE_NAME>"
+      tables   = ["TABLE_1", "TABLE_2"]
+      # Optionally list specific tables, or remove "tables" all together for all tables
+    },
+  ]
+```

--- a/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/main.tf
+++ b/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/main.tf
@@ -1,0 +1,180 @@
+resource "random_pet" "migration_id" {
+  prefix = "smt"
+}
+
+# Pub/Sub Topic for Datastream
+resource "google_pubsub_topic" "datastream_topic" {
+  name    = "${random_pet.migration_id.id}-${var.datastream_params.pubsub_topic_name}"
+  project = var.common_params.project
+  labels = {
+    "migration_id" = random_pet.migration_id.id
+  }
+}
+
+# Configure permissions to publish Pub/Sub notifications
+resource "google_pubsub_topic_iam_member" "gcs_publisher_role" {
+  depends_on = [
+    google_project_service.enabled_apis,
+    google_pubsub_topic.datastream_topic
+  ]
+  topic  = google_pubsub_topic.datastream_topic.name
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"
+}
+
+# Pub/Sub Notification on GCS Bucket
+resource "google_storage_notification" "bucket_notification" {
+  depends_on = [
+    google_project_service.enabled_apis, google_pubsub_topic.datastream_topic
+  ] # Create a bucket notification using the created pubsub topic.
+  bucket             = var.datastream_params.target_gcs_bucket_name
+  object_name_prefix = var.datastream_params.stream_prefix_path
+  payload_format     = "JSON_API_V1"
+  topic              = google_pubsub_topic.datastream_topic.id
+  event_types        = ["OBJECT_FINALIZE"]
+}
+
+# Pub/Sub Subscription for the created notification
+resource "google_pubsub_subscription" "datastream_subscription" {
+  depends_on = [
+    google_project_service.enabled_apis,
+    google_storage_notification.bucket_notification
+  ] # Create the subscription once the notification is created.
+  name  = "${google_pubsub_topic.datastream_topic.name}-sub"
+  topic = google_pubsub_topic.datastream_topic.id
+  labels = {
+    "migration_id" = random_pet.migration_id.id
+  }
+}
+
+# Datastream Stream (MySQL to GCS)
+resource "google_datastream_stream" "mysql_to_gcs" {
+  depends_on = [
+    google_project_service.enabled_apis,
+    google_pubsub_subscription.datastream_subscription
+  ]
+  # Create the stream once the source and target profiles are created along with the subscription.
+  stream_id     = "${random_pet.migration_id.id}-${var.datastream_params.stream_id}"
+  location      = var.common_params.region
+  display_name  = "${random_pet.migration_id.id}-${var.datastream_params.stream_id}"
+  desired_state = "RUNNING"
+  backfill_all {
+  }
+
+  source_config {
+    source_connection_profile = "projects/${var.common_params.project}/locations/${var.common_params.region}/connectionProfiles/${var.datastream_params.source_connection_profile_id}"
+
+    mysql_source_config {
+      max_concurrent_cdc_tasks      = var.datastream_params.max_concurrent_cdc_tasks
+      max_concurrent_backfill_tasks = var.datastream_params.max_concurrent_backfill_tasks
+      include_objects {
+        dynamic "mysql_databases" {
+          for_each = var.datastream_params.mysql_databases
+          content {
+            database = mysql_databases.value.database
+            dynamic "mysql_tables" {
+              for_each = mysql_databases.value.tables != null ? mysql_databases.value.tables : []
+              # Handle optional tables
+              content {
+                table = mysql_tables.value
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  destination_config {
+    destination_connection_profile = "projects/${var.common_params.project}/locations/${var.common_params.region}/connectionProfiles/${var.datastream_params.target_connection_profile_id}"
+    gcs_destination_config {
+      path = var.datastream_params.stream_prefix_path
+      avro_file_format {
+      }
+    }
+  }
+  labels = {
+    "migration_id" = random_pet.migration_id.id
+  }
+}
+
+# Add roles to the service account that will run Dataflow for live migration
+resource "google_project_iam_member" "live_migration_roles" {
+  for_each = toset([
+    "roles/viewer",
+    "roles/storage.objectAdmin",
+    "roles/datastream.viewer",
+    "roles/dataflow.worker",
+    "roles/dataflow.admin",
+    "roles/pubsub.subscriber",
+    "roles/pubsub.viewer",
+    "roles/spanner.databaseAdmin",
+    "roles/monitoring.metricWriter",
+    "roles/cloudprofiler.agent"
+  ])
+  project = data.google_project.project.id
+  role    = each.key
+  member  = var.dataflow_params.runner_params.service_account_email != null ? "serviceAccount:${var.dataflow_params.runner_params.service_account_email}" : "serviceAccount:${data.google_compute_default_service_account.gce_account.email}"
+}
+
+# Dataflow Flex Template Job (for CDC to Spanner)
+resource "google_dataflow_flex_template_job" "live_migration_job" {
+  depends_on = [
+    google_project_service.enabled_apis, google_datastream_stream.mysql_to_gcs, google_project_iam_member.live_migration_roles
+  ] # Launch the template once the stream is created.
+  provider                = google-beta
+  container_spec_gcs_path = "gs://dataflow-templates-${var.common_params.region}/latest/flex/Cloud_Datastream_to_Spanner"
+
+  # Parameters from Dataflow Template
+  parameters = {
+    inputFileFormat                 = "avro"
+    inputFilePattern                = "gs://replaced-by-pubsub-notification"
+    sessionFilePath                 = var.dataflow_params.template_params.session_file_path
+    instanceId                      = var.dataflow_params.template_params.spanner_instance_id
+    databaseId                      = var.dataflow_params.template_params.spanner_database_id
+    projectId                       = var.common_params.project
+    spannerHost                     = var.dataflow_params.template_params.spanner_host
+    gcsPubSubSubscription           = google_pubsub_subscription.datastream_subscription.id
+    streamName                      = google_datastream_stream.mysql_to_gcs.id
+    shadowTablePrefix               = var.dataflow_params.template_params.shadow_table_prefix
+    shouldCreateShadowTables        = tostring(var.dataflow_params.template_params.create_shadow_tables)
+    rfcStartDateTime                = var.dataflow_params.template_params.rfc_start_date_time
+    fileReadConcurrency             = tostring(var.dataflow_params.template_params.file_read_concurrency)
+    deadLetterQueueDirectory        = "gs://${var.datastream_params.target_gcs_bucket_name}/dlq"
+    dlqRetryMinutes                 = tostring(var.dataflow_params.template_params.dlq_retry_minutes)
+    dlqMaxRetryCount                = tostring(var.dataflow_params.template_params.dlq_max_retry_count)
+    dataStreamRootUrl               = var.dataflow_params.template_params.datastream_root_url
+    datastreamSourceType            = var.dataflow_params.template_params.datastream_source_type
+    roundJsonDecimals               = tostring(var.dataflow_params.template_params.round_json_decimals)
+    runMode                         = var.dataflow_params.template_params.run_mode
+    transformationContextFilePath   = var.dataflow_params.template_params.transformation_context_file_path
+    directoryWatchDurationInMinutes = tostring(var.dataflow_params.template_params.directory_watch_duration_in_minutes)
+    spannerPriority                 = var.dataflow_params.template_params.spanner_priority
+    dlqGcsPubSubSubscription        = var.dataflow_params.template_params.dlq_gcs_pub_sub_subscription
+  }
+
+  # Additional Job Configurations
+  additional_experiments       = var.dataflow_params.runner_params.additional_experiments
+  autoscaling_algorithm        = var.dataflow_params.runner_params.autoscaling_algorithm
+  enable_streaming_engine      = var.dataflow_params.runner_params.enable_streaming_engine
+  kms_key_name                 = var.dataflow_params.runner_params.kms_key_name
+  launcher_machine_type        = var.dataflow_params.runner_params.launcher_machine_type
+  machine_type                 = var.dataflow_params.runner_params.machine_type
+  max_workers                  = var.dataflow_params.runner_params.max_workers
+  name                         = "${random_pet.migration_id.id}-${var.dataflow_params.runner_params.job_name}"
+  network                      = var.dataflow_params.runner_params.network
+  num_workers                  = var.dataflow_params.runner_params.num_workers
+  sdk_container_image          = var.dataflow_params.runner_params.sdk_container_image
+  service_account_email        = var.dataflow_params.runner_params.service_account_email
+  skip_wait_on_job_termination = var.dataflow_params.runner_params.skip_wait_on_job_termination
+  staging_location             = var.dataflow_params.runner_params.staging_location
+  subnetwork                   = var.dataflow_params.runner_params.subnetwork
+  temp_location                = var.dataflow_params.runner_params.temp_location
+  on_delete                    = var.dataflow_params.runner_params.on_delete
+  region                       = var.common_params.region
+  ip_configuration             = var.dataflow_params.runner_params.ip_configuration
+  labels = {
+    "migration_id" = random_pet.migration_id.id
+  }
+}
+

--- a/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/outputs.tf
+++ b/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/outputs.tf
@@ -1,0 +1,27 @@
+# Resource IDs
+output "resource_ids" {
+  description = "IDs of resources created during migration setup."
+  value = {
+    datastream_source_connection_profile = var.datastream_params.source_connection_profile_id
+    datastream_target_connection_profile = var.datastream_params.target_connection_profile_id
+    datastream_stream                    = google_datastream_stream.mysql_to_gcs.stream_id
+    gcs_bucket                           = var.datastream_params.target_gcs_bucket_name
+    pubsub_topic                         = google_pubsub_topic.datastream_topic.name
+    pubsub_subscription                  = google_pubsub_subscription.datastream_subscription.name
+    dataflow_job                         = google_dataflow_flex_template_job.live_migration_job.job_id
+  }
+}
+
+# Resource URLs (for easy access in Google Cloud Console)
+output "resource_urls" {
+  description = "URLs to access resources in the Google Cloud Console."
+  value = {
+    datastream_source_connection_profile = "https://console.cloud.google.com/datastream/connection-profiles/locations/${var.common_params.region}/instances/${var.datastream_params.source_connection_profile_id}?project=${var.common_params.project}"
+    datastream_target_connection_profile = "https://console.cloud.google.com/datastream/connection-profiles/locations/${var.common_params.region}/instances/${var.datastream_params.target_connection_profile_id}?project=${var.common_params.project}"
+    datastream_stream                    = "https://console.cloud.google.com/datastream/streams/locations/${var.common_params.region}/instances/${google_datastream_stream.mysql_to_gcs.stream_id}?project=${var.common_params.project}"
+    gcs_bucket                           = "https://console.cloud.google.com/storage/browser/${var.datastream_params.target_gcs_bucket_name}?project=${var.common_params.project}"
+    pubsub_topic                         = "https://console.cloud.google.com/cloudpubsub/topic/detail/${google_pubsub_topic.datastream_topic.name}?project=${var.common_params.project}"
+    pubsub_subscription                  = "https://console.cloud.google.com/cloudpubsub/subscription/detail/${google_pubsub_subscription.datastream_subscription.name}?project=${var.common_params.project}"
+    dataflow_job                         = "https://console.cloud.google.com/dataflow/jobs/${var.common_params.region}/${google_dataflow_flex_template_job.live_migration_job.job_id}?project=${var.common_params.project}"
+  }
+}

--- a/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/terraform.tf
+++ b/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/terraform.tf
@@ -1,0 +1,52 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0" # Or the latest compatible version
+    }
+  }
+  required_version = "~>1.5"
+}
+
+#Set the project
+provider "google-beta" {
+  project = var.common_params.project
+  region  = var.common_params.region
+}
+
+provider "google" {
+  project = var.common_params.project
+  region  = var.common_params.region
+}
+
+#Enable the APIs
+resource "google_project_service" "enabled_apis" {
+  for_each = toset([
+    "dataflow.googleapis.com",
+    "datastream.googleapis.com",
+    "storage.googleapis.com",
+    "pubsub.googleapis.com",
+    "cloudprofiler.googleapis.com"
+  ])
+  service            = each.key
+  project            = var.common_params.project
+  disable_on_destroy = false
+}
+
+# To fetch project number
+data "google_project" "project" {
+}
+
+# Fetch the service account for GCS
+data "google_storage_project_service_account" "gcs_account" {
+  depends_on = [google_project_service.enabled_apis]
+}
+
+# Fetch the default service account for Compute Engine (used by Dataflow)
+data "google_compute_default_service_account" "gce_account" {
+  depends_on = [google_project_service.enabled_apis]
+}

--- a/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/variables.tf
+++ b/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/variables.tf
@@ -1,0 +1,80 @@
+variable "common_params" {
+  description = "Parameters that are common to multiple resources"
+  type = object({
+    project = string
+    region  = string
+  })
+}
+
+variable "datastream_params" {
+  description = "Parameters to setup Datastream"
+  type = object({
+    source_connection_profile_id = string
+    target_connection_profile_id = string
+    # Datastream does not expose a data source to read connection profile information
+    # so the bucket has to be explicitly added. This will be simplified in the
+    # future to only require the target_connection_profile_id.
+    # Specify the bucket name without gs:// prefix.
+    target_gcs_bucket_name        = string
+    pubsub_topic_name             = optional(string, "live-migration")
+    stream_id                     = optional(string, "mysql-stream")
+    stream_prefix_path            = optional(string, "data")
+    max_concurrent_cdc_tasks      = optional(number, 50)
+    max_concurrent_backfill_tasks = optional(number, 50)
+    mysql_databases = list(object({
+      database = string
+      tables   = optional(list(string))
+    }))
+  })
+}
+
+variable "dataflow_params" {
+  description = "Parameters for the Dataflow job. Please refer to https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v2/sourcedb-to-spanner/README_Sourcedb_to_Spanner_Flex.md for the description of the parameters below."
+  type = object({
+    template_params = object({
+      shadow_table_prefix                 = optional(string)
+      create_shadow_tables                = optional(bool)
+      rfc_start_date_time                 = optional(string)
+      file_read_concurrency               = optional(number)
+      session_file_path                   = optional(string)
+      spanner_instance_id                 = string
+      spanner_database_id                 = string
+      spanner_host                        = optional(string)
+      dead_letter_queue_directory         = optional(string)
+      dlq_retry_minutes                   = optional(number)
+      dlq_max_retry_count                 = optional(number)
+      datastream_root_url                 = optional(string)
+      datastream_source_type              = optional(string)
+      round_json_decimals                 = optional(bool)
+      run_mode                            = optional(string)
+      transformation_context_file_path    = optional(string)
+      directory_watch_duration_in_minutes = optional(string)
+      spanner_priority                    = optional(string)
+      dlq_gcs_pub_sub_subscription        = optional(string)
+    })
+    runner_params = object({
+      additional_experiments = optional(set(string), [
+        "enable_google_cloud_profiler", "enable_stackdriver_agent_metrics",
+        "disable_runner_v2", "enable_google_cloud_heap_sampling"
+      ])
+      autoscaling_algorithm        = optional(string)
+      enable_streaming_engine      = optional(bool, true)
+      kms_key_name                 = optional(string)
+      labels                       = optional(map(string))
+      launcher_machine_type        = optional(string)
+      machine_type                 = optional(string, "n2-standard-2")
+      max_workers                  = number
+      job_name                     = optional(string, "live-migration-job")
+      network                      = optional(string)
+      num_workers                  = number
+      sdk_container_image          = optional(string)
+      service_account_email        = optional(string)
+      skip_wait_on_job_termination = optional(bool, false)
+      staging_location             = optional(string)
+      subnetwork                   = optional(string)
+      temp_location                = optional(string)
+      on_delete                    = optional(string, "drain")
+      ip_configuration             = optional(string)
+    })
+  })
+}


### PR DESCRIPTION
This PR adds samples for common scenarios users might have while trying to run a live migration to Spanner.

Each sample contains the following (and potentially more) files - 

1. `main.tf` - This contains the Terraform resources which will be created.
2. `outputs.tf` - This declares the outputs that will be output as part of
   running the terraform example.
3. `variables.tf` - This declares the input variables that are required to
   configure the resources.
4. `terraform.tf` - This contains the required providers and APIs/project
   configurations for the sample.
5. `terraform.tfvars` - This contains the dummy inputs that need to be populated
   to run the example.
6. `terraform_simple.tfvars` - This contains the minimal list of dummy inputs
   that need to be populated to run the example.

**_SCENARIO:_** This Terraform example illustrates launching a live migration job for a MySQL source, **given pre-created Datastream source and target connection profiles**. As a result, it does not create any new buckets in the GCP account.

Creates the following resources -

1. **Pubsub topic and subscription** - This contains GCS object notifications as files are written to GCS for consumption by the Dataflow job.
2. **Datastream stream** - A datastream stream which reads from the source specified in the source connection profile and writes the data to the bucket specified in the target connection profile. Note that it uses a mandatory
   prefix path inside the bucket where it will write the data to. The default
   prefix path is `data` (can be overridden).
3. **Bucket notification** - Creates the GCS bucket notification which publish
   to the pubsub topic created. Note that the bucket notification is created on
   the mandatory prefix path specified for the stream above.
4. **Dataflow job** - The Dataflow job which reads from GCS and writes to
   Spanner.
5. **Permissions** - It adds the required roles to the specified (or the
   default) service accounts for the live migration to work.