### PR TITLE
Explicitly enable AutoValue annotation processor

### DIFF
--- a/it/pom.xml
+++ b/it/pom.xml
@@ -124,6 +124,13 @@
           <!-- <compilerArgument>-parameters</compilerArgument> -->
           <parameters>true</parameters>
           <testCompilerArgument>-parameters</testCompilerArgument>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.auto.value</groupId>
+              <artifactId>auto-value</artifactId>
+              <version>${autovalue.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>

--- a/plaintext-logging/pom.xml
+++ b/plaintext-logging/pom.xml
@@ -43,6 +43,13 @@
           <target>${java.version}</target>
           <parameters>true</parameters>
           <testCompilerArgument>-parameters</testCompilerArgument>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.auto.value</groupId>
+              <artifactId>auto-value</artifactId>
+              <version>${autovalue.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>

--- a/structured-logging/pom.xml
+++ b/structured-logging/pom.xml
@@ -74,6 +74,13 @@
           <target>${java.version}</target>
           <parameters>true</parameters>
           <testCompilerArgument>-parameters</testCompilerArgument>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.auto.value</groupId>
+              <artifactId>auto-value</artifactId>
+              <version>${autovalue.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>

--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -736,6 +736,13 @@
           <target>${java.version}</target>
           <parameters>true</parameters>
           <testCompilerArgument>-parameters</testCompilerArgument>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.auto.value</groupId>
+              <artifactId>auto-value</artifactId>
+              <version>${autovalue.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
 

--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -356,6 +356,13 @@
                     <!-- <compilerArgument>-parameters</compilerArgument> -->
                     <parameters>true</parameters>
                     <testCompilerArgument>-parameters</testCompilerArgument>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.auto.value</groupId>
+                            <artifactId>auto-value</artifactId>
+                            <version>${autovalue.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Starting in JDK 23, annotation processors are no longer implicitly enabled from dependencies, this change adds configuration to make AutoValue run on the latest JDK versions.

https://bugs.openjdk.org/browse/JDK-8321314
https://mail.openjdk.org/pipermail/jdk-dev/2024-May/009028.html