### PR TITLE
Fix upgrade bigtable-beam-import to 2.14.2 to support Data Boost (atttempt 2)

### DIFF
--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -39,7 +39,7 @@
     <mock-server-netty.version>5.14.0</mock-server-netty.version>
     <open-census.version>0.24.0</open-census.version>
     <!-- TODO: check if this could be declared on a Beam BOM instead of here -->
-    <bigtable-beam-import.version>2.14.0</bigtable-beam-import.version>
+    <bigtable-beam-import.version>2.14.2</bigtable-beam-import.version>
     <protobuf.version>3.21.7</protobuf.version>
     <nashorn.version>15.4</nashorn.version>
     <junit.jupiter.version>5.5.2</junit.jupiter.version>


### PR DESCRIPTION
I accidentally upgraded only to 2.14.0 in the original PR: https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/1616