### PR TITLE
Fix BQ deadletter queue for Kafka template

### DIFF
--- a/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/dlq/BigQueryDeadLetterQueueOptions.java
+++ b/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/dlq/BigQueryDeadLetterQueueOptions.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.kafka.dlq;
+
+import com.google.cloud.teleport.metadata.TemplateParameter;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.PipelineOptions;
+
+public interface BigQueryDeadLetterQueueOptions extends PipelineOptions {
+  String GROUP_NAME = "Dead Letter Queue";
+
+  @TemplateParameter.Boolean(
+      name = "useBigQueryDLQ",
+      groupName = GROUP_NAME,
+      optional = false,
+      description = "Write errors to BigQuery",
+      helpText =
+          "If true, failed messages will be written to BigQuery with extra error information.")
+  @Default.Boolean(false)
+  Boolean getUseBigQueryDLQ();
+
+  void setUseBigQueryDLQ(Boolean value);
+
+  @TemplateParameter.Text(
+      groupName = GROUP_NAME,
+      parentName = "useBigQueryDLQ",
+      parentTriggerValues = {"true"},
+      optional = true,
+      description = "Fully Qualified BigQuery table name for Dead Letter Queue.",
+      helpText =
+          "Fully Qualified BigQuery table name for failed messages. Messages failed to reach the "
+              + "output table for different reasons "
+              + "(e.g., mismatched schema, malformed json) are written to this table."
+              + "The table will be created by the template.",
+      example = "your-project-id:your-dataset.your-table-name")
+  String getOutputDeadletterTable();
+
+  void setOutputDeadletterTable(String outputDeadletterTable);
+}

--- a/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/dlq/package-info.java
+++ b/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/dlq/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.teleport.v2.kafka.dlq;

--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/options/KafkaToBigQueryFlexOptions.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/options/KafkaToBigQueryFlexOptions.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.options;
 
 import com.google.cloud.teleport.metadata.TemplateParameter;
+import com.google.cloud.teleport.v2.kafka.dlq.BigQueryDeadLetterQueueOptions;
 import com.google.cloud.teleport.v2.kafka.options.KafkaReadOptions;
 import com.google.cloud.teleport.v2.kafka.options.SchemaRegistryOptions;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
@@ -29,7 +30,8 @@ public interface KafkaToBigQueryFlexOptions
     extends DataflowPipelineOptions,
         KafkaReadOptions,
         BigQueryStorageApiStreamingOptions,
-        SchemaRegistryOptions {
+        SchemaRegistryOptions,
+        BigQueryDeadLetterQueueOptions {
   // This is a duplicate option that already exist in KafkaReadOptions but keeping it here
   // so the KafkaTopic appears above the authentication enum on the Templates UI.
   @TemplateParameter.KafkaReadTopic(
@@ -231,33 +233,4 @@ public interface KafkaToBigQueryFlexOptions
   Boolean getUseStorageWriteApiAtLeastOnce();
 
   void setUseStorageWriteApiAtLeastOnce(Boolean value);
-
-  @TemplateParameter.Boolean(
-      order = 14,
-      name = "useBigQueryDLQ",
-      groupName = "Dead Letter Queue",
-      optional = false,
-      description = "Write errors to BigQuery",
-      helpText =
-          "If true, failed messages will be written to BigQuery with extra error information. "
-              + "The deadletter table should be created with no schema.")
-  @Default.Boolean(false)
-  Boolean getUseBigQueryDLQ();
-
-  void setUseBigQueryDLQ(Boolean value);
-
-  @TemplateParameter.BigQueryTable(
-      order = 15,
-      groupName = "Dead Letter Queue",
-      parentName = "useBigQueryDLQ",
-      parentTriggerValues = {"true"},
-      optional = true,
-      description = "Dead-letter Table",
-      helpText =
-          "BigQuery table for failed messages. Messages failed to reach the output table for different reasons "
-              + "(e.g., mismatched schema, malformed json) are written to this table.",
-      example = "your-project-id:your-dataset.your-table-name")
-  String getOutputDeadletterTable();
-
-  void setOutputDeadletterTable(String outputDeadletterTable);
 }

--- a/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
+++ b/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
@@ -213,7 +213,7 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
   @Test
   public void testKafkaToBigQueryAvroWithExistingDLQ() throws IOException, RestClientException {
     tableId = bigQueryClient.createTable(testName, bqSchema);
-    deadletterTableId = bigQueryClient.createTable(testName + "_dlq", getDeadletterSchema());
+    deadletterTableId = TableId.of(bigQueryClient.getDatasetId(), testName + "_dlq");
 
     baseKafkaToBigQueryAvro(
         b ->


### PR DESCRIPTION
The current BQ dlq fails if the table is already created with empty schema.  Change the BQ dlq pipline option template annotation to Text and ask the user for the fully qualified name of the BQ table.