### PR TITLE
Mongo to BQ - advanced filters

### DIFF
--- a/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/options/MongoDbToBigQueryOptions.java
+++ b/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/options/MongoDbToBigQueryOptions.java
@@ -89,7 +89,6 @@ public class MongoDbToBigQueryOptions {
         optional = true,
         helpText = "Bson filter in json format.",
         example = "{ \"val\": { $gt: 0, $lt: 9 }}")
-    @Default.String("{}")
     String getFilter();
 
     void setFilter(String jsonFilter);

--- a/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/options/MongoDbToBigQueryOptions.java
+++ b/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/options/MongoDbToBigQueryOptions.java
@@ -81,6 +81,18 @@ public class MongoDbToBigQueryOptions {
     String getKMSEncryptionKey();
 
     void setKMSEncryptionKey(String keyName);
+
+    @TemplateParameter.Text(
+        order = 6,
+        groupName = "Source",
+        description = "Bson filter",
+        optional = true,
+        helpText = "Bson filter in json format.",
+        example = "{ \"val\": { $gt: 0, $lt: 9 }}")
+    @Default.String("{}")
+    String getFilter();
+
+    void setFilter(String jsonFilter);
   }
 
   /** Options for reading from PubSub. */

--- a/v2/mongodb-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQueryIT.java
+++ b/v2/mongodb-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQueryIT.java
@@ -183,6 +183,84 @@ public final class MongoDbToBigQueryIT extends TemplateTestBase {
                       JSONObject bigQueryJson = new JSONObject(val.getStringValue());
                       assertTrue(bigQueryJson.has("timestamp"));
 
+                      assertTrue(bigQueryJson.getInt("filter_test")<10);
+
+                      bigQueryJson.remove("timestamp");
+                      String bigQueryId = bigQueryJson.getString(MONGO_DB_ID);
+                      assertTrue(mongoMap.get(bigQueryId).similar(bigQueryJson));
+                    }));
+  }
+
+  @Test
+  public void testMongoDbToBigQueryWithFilters() throws IOException {
+    // Arrange
+    String collectionName = testName;
+    List<Document> mongoDocuments = generateDocuments();
+    mongoDbClient.insertDocuments(collectionName, mongoDocuments);
+
+    String bqTable = testName;
+    String udfFileName = "transform.js";
+    gcsClient.createArtifact(
+        "input/" + udfFileName,
+        "function transform(inJson) {\n"
+            + "    var outJson = JSON.parse(inJson);\n"
+            + "    outJson.udf = \"out\";\n"
+            + "    return JSON.stringify(outJson);\n"
+            + "}");
+    List<Field> bqSchemaFields = new ArrayList<>();
+    bqSchemaFields.add(Field.of("timestamp", StandardSQLTypeName.TIMESTAMP));
+    mongoDocuments
+        .get(0)
+        .forEach((key, val) -> bqSchemaFields.add(Field.of(key, StandardSQLTypeName.STRING)));
+    Schema bqSchema = Schema.of(bqSchemaFields);
+
+    bigQueryClient.createDataset(REGION);
+    TableId table = bigQueryClient.createTable(bqTable, bqSchema);
+
+    LaunchConfig.Builder options =
+        LaunchConfig.builder(testName, specPath)
+            .addParameter(MONGO_URI, mongoDbClient.getUri())
+            .addParameter(MONGO_DB, mongoDbClient.getDatabaseName())
+            .addParameter(MONGO_COLLECTION, collectionName)
+            .addParameter(BIGQUERY_TABLE, toTableSpecLegacy(table))
+            .addParameter(USER_OPTION, "FLATTEN")
+            .addParameter()
+            .addParameter("filter", "{ \"filter_test\": { $gt: 0, $lt: 10 }}")
+            .addParameter("javascriptDocumentTransformFunctionName", "transform");
+
+    // Act
+    LaunchInfo info = launchTemplate(options);
+    assertThatPipeline(info).isRunning();
+
+    Result result =
+        pipelineOperator()
+            .waitForCondition(
+                createConfig(info),
+                BigQueryRowsCheck.builder(bigQueryClient, table).setMinRows(1).build());
+
+    // Assert
+    assertThatResult(result).meetsConditions();
+
+    Map<String, JSONObject> mongoMap = new HashMap<>();
+    mongoDocuments.forEach(
+        mongoDocument -> {
+          JSONObject mongoDbJson = new JSONObject(mongoDocument.toJson());
+          String mongoId = mongoDbJson.getJSONObject(MONGO_DB_ID).getString("$oid");
+          mongoDbJson.put("udf", "out");
+          mongoDbJson.put(MONGO_DB_ID, mongoId);
+          mongoMap.put(mongoId, mongoDbJson);
+        });
+
+    TableResult tableRows = bigQueryClient.readTable(bqTable);
+    tableRows
+        .getValues()
+        .forEach(
+            row ->
+                row.forEach(
+                    val -> {
+                      JSONObject bigQueryJson = new JSONObject(val.getStringValue());
+                      assertTrue(bigQueryJson.has("timestamp"));
+
                       bigQueryJson.remove("timestamp");
                       String bigQueryId = bigQueryJson.getString(MONGO_DB_ID);
                       assertTrue(mongoMap.get(bigQueryId).similar(bigQueryJson));
@@ -225,6 +303,7 @@ public final class MongoDbToBigQueryIT extends TemplateTestBase {
       }
       randomDocument.append("udf", "in");
       randomDocument.append("nullonly", null);
+      randomDocument.append("filter_test", i);
 
       mongoDocuments.add(randomDocument);
     }

--- a/v2/mongodb-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQueryIT.java
+++ b/v2/mongodb-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQueryIT.java
@@ -183,7 +183,7 @@ public final class MongoDbToBigQueryIT extends TemplateTestBase {
                       JSONObject bigQueryJson = new JSONObject(val.getStringValue());
                       assertTrue(bigQueryJson.has("timestamp"));
 
-                      assertTrue(bigQueryJson.getInt("filter_test")<10);
+                      assertTrue(bigQueryJson.getInt("filter_test") < 10);
 
                       bigQueryJson.remove("timestamp");
                       String bigQueryId = bigQueryJson.getString(MONGO_DB_ID);


### PR DESCRIPTION
Mongo to BQ has poor support for filters - they are on dataflow side with help of UDFs. This makes it expensive to run for Mongo Database and is expensive to filter on dataflow side. 

BSON filters are pushed to MongoDB which allows easy filtering, especially for daily ETLs. 