### PR TITLE
Terraform: Add support for using pre-existing private connectivity configuration

### DIFF
--- a/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/README.md
+++ b/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/README.md
@@ -439,7 +439,7 @@ the service account running the Dataflow job needs to have the
 data to Spanner).
 
 After adding these permissions, configure the
-`var.dataflow_params.template_params.projectId` variable.
+`var.dataflow_params.template_params.spanner_project_id` variable.
 
 ### Adding access to Terraform service account
 

--- a/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/README.md
+++ b/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/README.md
@@ -261,7 +261,7 @@ can exclude it from the state file using `terraform state rm` command.
 
 > **_NOTE:_** By default, **IP Allowlisting** based connectivity is assumed.
 
-There is a variable of the type below in `variables.tf` -
+There are two variables of the type below in `variables.tf` -
 
 ```shell
 private_connectivity = optional(object({
@@ -271,7 +271,19 @@ private_connectivity = optional(object({
     }))
 ```
 
-To enable private connectivity based access for Datastream, specify this
+and 
+
+```shell
+private_connectivity_id = optional(string)
+```
+
+You have the option of either specifying the `id` of an existing private
+connectivity configuration or letting Terraform create one for you.
+
+To re-use an existing private connectivity configuration, specify the `id` in
+the `private_connectivity_id` variable.
+
+Alternatively, to create a private connectivity configuration via Terraform for Datastream, specify this
 configuration in your `*.tfvars`. For example -
 
 ```shell

--- a/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/main.tf
+++ b/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/main.tf
@@ -48,7 +48,7 @@ resource "google_datastream_connection_profile" "source_mysql" {
   }
 
   # If an existing private connectivity configuration is provided, use that.
-  # If nothing is specified on private connectivity, IP whitelisting is
+  # If nothing is specified on private connectivity, IP allowlisting is
   # assumed.
   dynamic "private_connectivity" {
     for_each = var.datastream_params.private_connectivity_id != null ? [1] : []

--- a/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/main.tf
+++ b/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/main.tf
@@ -229,7 +229,7 @@ resource "google_dataflow_flex_template_job" "live_migration_job" {
     sessionFilePath                 = var.dataflow_params.template_params.session_file_path
     instanceId                      = var.dataflow_params.template_params.spanner_instance_id
     databaseId                      = var.dataflow_params.template_params.spanner_database_id
-    projectId                       = var.common_params.project
+    projectId                       = var.dataflow_params.template_params.spanner_project_id ? var.dataflow_params.template_params.spanner_project_id : var.common_params.project
     spannerHost                     = var.dataflow_params.template_params.spanner_host
     gcsPubSubSubscription           = google_pubsub_subscription.datastream_subscription.id
     streamName                      = google_datastream_stream.mysql_to_gcs.id

--- a/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/main.tf
+++ b/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/main.tf
@@ -39,11 +39,21 @@ resource "google_datastream_connection_profile" "source_mysql" {
   }
 
   # Dynamically add private_connectivity block based on private connectivity
-  # resource creation. If resource does not exist, IP whitelisting is assumed.
+  # resource creation.
   dynamic "private_connectivity" {
     for_each = google_datastream_private_connection.datastream_private_connection.*.id
     content {
       private_connection = private_connectivity.value
+    }
+  }
+
+  # If an existing private connectivity configuration is provided, use that.
+  # If nothing is specified on private connectivity, IP whitelisting is
+  # assumed.
+  dynamic "private_connectivity" {
+    for_each = var.datastream_params.private_connectivity_id != null ? [1] : []
+    content {
+      private_connection = "projects/${var.common_params.project}/locations/${var.common_params.region}/privateConnections/${var.datastream_params.private_connectivity_id}"
     }
   }
 

--- a/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/terraform.tfvars
+++ b/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/terraform.tfvars
@@ -22,6 +22,19 @@ datastream_params = {
     }
     # Add more database objects if needed
   ]
+  private_connectivity_id = "<YOUR_PRIVATE_CONNECTIVITY_ID>"
+  # Only one of `private_connectivity_id` or `private_connectivity` block
+  # may exist. Use `private_connectivity_id` to specify an existing
+  # private connectivity configuration, and the `private_connectivity` to
+  # create a new one via Terraform.
+  private_connectivity = {
+    private_connectivity_id = "<YOUR_PRIVATE_CONNECTIVITY_ID>"
+    # ID of the private connection you want to create in Datastream.
+    vpc_name = "<YOUR_VPC_NAME>"
+    # The pre-existing VPC which will be peered to Datastream.
+    range = "<YOUR_RESERVED_RANGE>"
+    # The IP range to be reserved for Datastream.
+  }
 }
 
 # Dataflow Parameters

--- a/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/terraform_simple.tfvars
+++ b/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/terraform_simple.tfvars
@@ -7,7 +7,7 @@ common_params = {
 # Datastream Parameters
 datastream_params = {
   mysql_host = "<YOUR_MYSQL_HOST_IP_ADDRESS>"
-  # Use the Public IP if using IP whitelisting and Private IP if using
+  # Use the Public IP if using IP allowlisting and Private IP if using
   # private connectivity.
   mysql_username = "<YOUR_MYSQL_USERNAME>"
   mysql_password = "<YOUR_MYSQL_PASSWORD>"
@@ -32,8 +32,8 @@ datastream_params = {
     range = "<YOUR_RESERVED_RANGE>"
     # The IP range to be reserved for Datastream.
   }
-  # If the private_connectivity block is not specified, IP whitelisting will be
-  # assumed.
+  # If the private_connectivity block or private_connectivity_id is not specified,
+  # IP allowlisting will be assumed.
 }
 
 # Dataflow Parameters

--- a/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/terraform_simple.tfvars
+++ b/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/terraform_simple.tfvars
@@ -19,6 +19,11 @@ datastream_params = {
       # Optionally list specific tables, or remove "tables" all together for all tables
     }
   ]
+  private_connectivity_id = "<YOUR_PRIVATE_CONNECTIVITY_ID>"
+  # Only one of `private_connectivity_id` or `private_connectivity` block
+  # may exist. Use `private_connectivity_id` to specify an existing
+  # private connectivity configuration, and the `private_connectivity` to
+  # create a new one via Terraform.
   private_connectivity = {
     private_connectivity_id = "<YOUR_PRIVATE_CONNECTIVITY_ID>"
     # ID of the private connection you want to create in Datastream.

--- a/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/variables.tf
+++ b/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/variables.tf
@@ -17,6 +17,7 @@ variable "datastream_params" {
       vpc_name                = string
       range                   = string
     }))
+    private_connectivity_id       = optional(string)
     source_connection_profile_id  = optional(string, "source-mysql")
     mysql_host                    = string
     mysql_username                = string
@@ -35,6 +36,13 @@ variable "datastream_params" {
       tables   = optional(list(string))
     }))
   })
+  validation {
+    condition = (
+      (var.datastream_params.private_connectivity_id == null && var.datastream_params.private_connectivity != null) ||
+      (var.datastream_params.private_connectivity_id != null && var.datastream_params.private_connectivity == null)
+    )
+    error_message = "Exactly one of 'private_connectivity_id' or the 'private_connectivity' block must be provided, not both."
+  }
 }
 
 variable "dataflow_params" {

--- a/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/variables.tf
+++ b/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/variables.tf
@@ -54,6 +54,7 @@ variable "dataflow_params" {
       rfc_start_date_time                 = optional(string)
       file_read_concurrency               = optional(number)
       session_file_path                   = optional(string)
+      spanner_project_id                  = optional(string)
       spanner_instance_id                 = string
       spanner_database_id                 = string
       spanner_host                        = optional(string)

--- a/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/README.md
+++ b/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/README.md
@@ -324,7 +324,7 @@ the service account running the Dataflow job needs to have the
 data to Spanner).
 
 After adding these permissions, configure the
-`var.dataflow_params.template_params.projectId` variable.
+`var.dataflow_params.template_params.spanner_project_id` variable.
 
 ### Adding access to Terraform service account
 

--- a/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/main.tf
+++ b/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/main.tf
@@ -139,7 +139,7 @@ resource "google_dataflow_flex_template_job" "live_migration_job" {
     sessionFilePath                 = var.dataflow_params.template_params.session_file_path
     instanceId                      = var.dataflow_params.template_params.spanner_instance_id
     databaseId                      = var.dataflow_params.template_params.spanner_database_id
-    projectId                       = var.common_params.project
+    projectId                       = var.dataflow_params.template_params.spanner_project_id ? var.dataflow_params.template_params.spanner_project_id : var.common_params.project
     spannerHost                     = var.dataflow_params.template_params.spanner_host
     gcsPubSubSubscription           = google_pubsub_subscription.datastream_subscription.id
     streamName                      = google_datastream_stream.mysql_to_gcs.id

--- a/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/variables.tf
+++ b/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/variables.tf
@@ -40,6 +40,7 @@ variable "dataflow_params" {
       rfc_start_date_time                 = optional(string)
       file_read_concurrency               = optional(number)
       session_file_path                   = optional(string)
+      spanner_project_id                  = optional(string)
       spanner_instance_id                 = string
       spanner_database_id                 = string
       spanner_host                        = optional(string)

--- a/v2/spanner-common/terraform/samples/mysql-vpc-spanner/main.tf
+++ b/v2/spanner-common/terraform/samples/mysql-vpc-spanner/main.tf
@@ -50,7 +50,7 @@ resource "google_compute_instance" "mysql_database_instance" {
     enable-oslogin = "TRUE"
   }
 
-  metadata_startup_script = templatefile("mysql8.4-setup.sh", {
+  metadata_startup_script = templatefile("mysql5.7-setup.sh", {
     root_password        = var.mysql_params.root_password
     custom_user          = var.mysql_params.custom_user
     custom_user_password = var.mysql_params.custom_user_password


### PR DESCRIPTION
1. Adds ability to specify a private connectivity configuration for the end-to-end infrastructure setup Terraform template. Private connectivity requires sensitive permissions hence the users might want to set it up manually instead of relying on automation.
2. Adds ability to configure `spanner_project_id` for cross-project writes.

**Note**: I had spent considerable time setting up MySQL 8.4 VPC setup by self-discovering how to configure a MySQL self-hosted database to work with Datastream. While I made numerous changes as per the official docs of MySQL, I am still running into errors. Current Datastream instructions are for MySQL 5.7 - https://cloud.google.com/datastream/docs/configure-self-managed-mysql. I will ask Datastream to provide documentation on how to configure MySQL 8, in the meantime switching back to MySQL 5.7.