### PR TITLE
Terraform: Improvements to existing Terraform templates for live migrations

### DIFF
--- a/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/README.md
+++ b/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/README.md
@@ -64,7 +64,9 @@ Following permissions are required -
 
 **Note**: Add the `roles/viewer` role as well to the service account.
 
-> **_Note on IAM:_** For ease of use, this sample automatically adds the
+> **_Note on IAM:_** 
+>
+> 1. For ease of use, this sample automatically adds the
 > required
 > roles to the service account used for running the migration. In order to
 > do this, we need the `resourcemanager.projects.setIamPolicy` permission. If
@@ -75,10 +77,17 @@ Following permissions are required -
 > They will have to be added manually. Note that if they are not added, **the
 > migration will fail.**
 > Two service accounts will need to be modified manually -
-> 1. Dataflow service account - The list of roles can be found in the `main.tf`
-     file, in the `live_migration_roles` resource.
-> 2. GCS service account - The list of roles can be found in the `main.tf` file,
-     in the `gcs_publisher_role` resource.
+>    1. Dataflow service account - The list of roles can be found in the `main.tf`
+        file, in the `live_migration_roles` resource.
+>    2. GCS service account - The list of roles can be found in the `main.tf` file,
+        in the `gcs_publisher_role` resource.
+> 
+> 
+> 2. In order to create private connectivity configuration for Datastream, 
+> `compute.*` permissions are required, [as documented here](https://cloud.google.com/datastream/docs/create-a-private-connectivity-configuration#shared-vpc).
+> Private connectivity cannot be created without these permissions. If you don't want to grant these permissions,
+> you can use the [pre-configured connection profiles template](../pre-configured-conn-profiles/README.md). This template
+> assumes you have created connection profiles outside of Terraform.
 
 [This](#adding-access-to-terraform-service-account) section in the FAQ
 provides instructions to add these permissions to an existing service account.
@@ -98,7 +107,9 @@ roles/viewer
 roles/compute.networkAdmin
 ```
 
-> **_Note on IAM:_** For ease of use, this sample automatically adds the
+> **_Note on IAM:_** 
+> 
+> 1. For ease of use, this sample automatically adds the
 > required
 > roles to the service account used for running the migration. In order to
 > do this, we need the `roles/iam.securityAdmin` role. If granting
@@ -108,10 +119,17 @@ roles/compute.networkAdmin
 > They will have to be added manually. Note that if they are not added, **the
 > migration will fail.**
 > Two service accounts will need to be modified manually -
-> 1. Dataflow service account - The list of roles can be found in the `main.tf`
-     file, in the `live_migration_roles` resource.
-> 2. GCS service account - The list of roles can be found in the `main.tf` file,
-     in the `gcs_publisher_role` resource.
+>    1. Dataflow service account - The list of roles can be found in the `main.tf`
+        file, in the `live_migration_roles` resource.
+>    2. GCS service account - The list of roles can be found in the `main.tf` file,
+        in the `gcs_publisher_role` resource.
+>
+>
+>2. In order to create private connectivity configuration for Datastream,
+>`networkAdmin` role is required, [as documented here](https://cloud.google.com/datastream/docs/create-a-private-connectivity-configuration#shared-vpc).
+> Private connectivity cannot be created without these permissions. If you don't want to grant these permissions,
+> you can use the [pre-configured connection profiles template](../pre-configured-conn-profiles/README.md). This template
+> assumes you have created connection profiles outside of Terraform.
 
 [This](#adding-access-to-terraform-service-account) section in the FAQ
 provides instructions to add these roles to an existing service account.
@@ -397,39 +415,36 @@ variable definition -
 In `variables.tf`, following definition exists -
 
 ```shell
-mysql_databases = list(object({
+mysql_database = object({
       database = string
       tables   = optional(list(string))
-    }))
+    })
 ```
 
 To configure, create `*.tfvars` as follows -
 
 ```shell
-mysql_databases = [
-    {
+mysql_database = {
       database = "<YOUR_DATABASE_NAME>"
       tables   = ["TABLE_1", "TABLE_2"]
       # Optionally list specific tables, or remove "tables" all together for all tables
-    },
-    {
-      database = "<YOUR_DATABASE_NAME>"
-      tables   = ["TABLE_1", "TABLE_2"]
-      # Optionally list specific tables, or remove "tables" all together for all tables
-    },
-  ]
+    }
 ```
 
 ### Specifying schema overrides
 
-Any schema changes between source and Spanner can be specified using the
-`session file`. Upload the session file in a GCS bucket and pass the URL
-of the session file to the `var.dataflow_params.template_params.sessionFilePath`
-variable.
+By default, the Dataflow job performs a like-like mapping between
+source and Spanner. Any schema changes between source and Spanner can be
+specified using the `session file`. To specify a session file -
 
-> **_NOTE:_** At the time of generating the session file via SMT, the session
-> file is uploaded to a user-specified (or auto-generated) bucket, so you don't
-> need to upload the session file to GCS manually.
+1. Copy the
+   contents of the SMT generated `session file` to the `session.json` file.
+2. Set
+   the `var.dataflow_params.template_params.local_session_file_path`
+   variable to `"session.json"`.
+
+This will automatically upload the GCS bucket and configure it in the Dataflow
+job.
 
 ### Cross project writes to Spanner
 

--- a/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/main.tf
+++ b/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/main.tf
@@ -155,7 +155,7 @@ resource "google_datastream_stream" "mysql_to_gcs" {
     google_pubsub_subscription.datastream_subscription
   ]
   # Create the stream once the source and target profiles are created along with the subscription.
-  stream_id     = "-${local.migration_id}-${var.datastream_params.stream_id}"
+  stream_id     = "${local.migration_id}-${var.datastream_params.stream_id}"
   location      = var.common_params.region
   display_name  = "${local.migration_id}-${var.datastream_params.stream_id}"
   desired_state = "RUNNING"

--- a/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/main.tf
+++ b/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/main.tf
@@ -186,7 +186,8 @@ resource "google_datastream_stream" "mysql_to_gcs" {
   destination_config {
     destination_connection_profile = google_datastream_connection_profile.target_gcs.id
     gcs_destination_config {
-      path = var.datastream_params.stream_prefix_path
+      path             = var.datastream_params.stream_prefix_path
+      file_rotation_mb = 5
       avro_file_format {
       }
     }

--- a/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/terraform.tfvars
+++ b/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/terraform.tfvars
@@ -48,7 +48,6 @@ dataflow_params = {
     spanner_instance_id                 = "<YOUR_SPANNER_INSTANCE_ID>"
     spanner_database_id                 = "<YOUR_SPANNER_DATABASE_ID>"
     spanner_host                        = "https://<YOUR_REGION>-spanner.googleapis.com" # Replace <YOUR_REGION>
-    dead_letter_queue_directory         = "<YOUR_DLQ_DIRECTORY>"                         # e.g., "gs://<YOUR_BUCKET>/dlq" (optional)
     dlq_retry_minutes                   = 10                                             # Adjust as needed
     dlq_max_retry_count                 = 3                                              # Adjust as needed
     datastream_root_url                 = "<YOUR_DATASTREAM_ROOT_URL>"                   # Base URL of your Datastream API (optional)

--- a/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/variables.tf
+++ b/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/variables.tf
@@ -29,8 +29,8 @@ variable "datastream_params" {
     stream_prefix_path            = optional(string, "data")
     pubsub_topic_name             = optional(string, "live-migration")
     stream_id                     = optional(string, "mysql-stream")
-    max_concurrent_cdc_tasks      = optional(number, 50)
-    max_concurrent_backfill_tasks = optional(number, 50)
+    max_concurrent_cdc_tasks      = optional(number, 5)
+    max_concurrent_backfill_tasks = optional(number, 15)
     mysql_database = object({
       database = string
       tables   = optional(list(string))

--- a/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/variables.tf
+++ b/v2/datastream-to-spanner/terraform/samples/mysql-end-to-end/variables.tf
@@ -31,15 +31,16 @@ variable "datastream_params" {
     stream_id                     = optional(string, "mysql-stream")
     max_concurrent_cdc_tasks      = optional(number, 50)
     max_concurrent_backfill_tasks = optional(number, 50)
-    mysql_databases = list(object({
+    mysql_database = object({
       database = string
       tables   = optional(list(string))
-    }))
+    })
   })
   validation {
     condition = (
       (var.datastream_params.private_connectivity_id == null && var.datastream_params.private_connectivity != null) ||
-      (var.datastream_params.private_connectivity_id != null && var.datastream_params.private_connectivity == null)
+      (var.datastream_params.private_connectivity_id != null && var.datastream_params.private_connectivity == null) ||
+      (var.datastream_params.private_connectivity_id == null && var.datastream_params.private_connectivity == null)
     )
     error_message = "Exactly one of 'private_connectivity_id' or the 'private_connectivity' block must be provided, not both."
   }
@@ -53,19 +54,17 @@ variable "dataflow_params" {
       create_shadow_tables                = optional(bool)
       rfc_start_date_time                 = optional(string)
       file_read_concurrency               = optional(number)
-      session_file_path                   = optional(string)
+      local_session_file_path             = optional(string)
       spanner_project_id                  = optional(string)
       spanner_instance_id                 = string
       spanner_database_id                 = string
       spanner_host                        = optional(string)
-      dead_letter_queue_directory         = optional(string)
       dlq_retry_minutes                   = optional(number)
       dlq_max_retry_count                 = optional(number)
       datastream_root_url                 = optional(string)
       datastream_source_type              = optional(string)
       round_json_decimals                 = optional(bool)
       run_mode                            = optional(string)
-      transformation_context_file_path    = optional(string)
       directory_watch_duration_in_minutes = optional(string)
       spanner_priority                    = optional(string)
       dlq_gcs_pub_sub_subscription        = optional(string)

--- a/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/README.md
+++ b/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/README.md
@@ -282,39 +282,36 @@ variable definition -
 In `variables.tf`, following definition exists -
 
 ```shell
-mysql_databases = list(object({
+mysql_database = object({
       database = string
       tables   = optional(list(string))
-    }))
+    })
 ```
 
 To configure, create `*.tfvars` as follows -
 
 ```shell
-mysql_databases = [
-    {
+mysql_database = {
       database = "<YOUR_DATABASE_NAME>"
       tables   = ["TABLE_1", "TABLE_2"]
       # Optionally list specific tables, or remove "tables" all together for all tables
-    },
-    {
-      database = "<YOUR_DATABASE_NAME>"
-      tables   = ["TABLE_1", "TABLE_2"]
-      # Optionally list specific tables, or remove "tables" all together for all tables
-    },
-  ]
+    }
 ```
 
 ### Specifying schema overrides
 
-Any schema changes between source and Spanner can be specified using the
-`session file`. Upload the session file in a GCS bucket and pass the URL
-of the session file to the `var.dataflow_params.template_params.sessionFilePath`
-variable.
+By default, the Dataflow job performs a like-like mapping between
+source and Spanner. Any schema changes between source and Spanner can be
+specified using the `session file`. To specify a session file -
 
-> **_NOTE:_** At the time of generating the session file via SMT, the session
-> file is uploaded to a user-specified (or auto-generated) bucket, so you don't
-> need to upload the session file to GCS manually.
+1. Copy the
+   contents of the SMT generated `session file` to the `session.json` file.
+2. Set
+   the `var.dataflow_params.template_params.local_session_file_path`
+   variable to `"session.json"`.
+
+This will automatically upload the GCS bucket and configure it in the Dataflow
+job.
 
 ### Cross project writes to Spanner
 

--- a/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/main.tf
+++ b/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/main.tf
@@ -8,30 +8,36 @@ locals {
 
 # Pub/Sub Topic for Datastream
 resource "google_pubsub_topic" "datastream_topic" {
-  name    = "${local.migration_id}-${var.datastream_params.pubsub_topic_name}"
-  project = var.common_params.project
+  depends_on = [google_project_service.enabled_apis]
+  name       = "${local.migration_id}-${var.datastream_params.pubsub_topic_name}"
+  project    = var.common_params.project
   labels = {
-    "migration_id" = random_pet.migration_id.id
+    "migration_id" = local.migration_id
   }
+}
+
+# upload local session file to the created GCS bucket
+resource "google_storage_bucket_object" "session_file_object" {
+  count        = var.dataflow_params.template_params.local_session_file_path != null ? 1 : 0
+  depends_on   = [google_project_service.enabled_apis]
+  name         = "session.json"
+  source       = var.dataflow_params.template_params.local_session_file_path
+  content_type = "application/json"
+  bucket       = var.datastream_params.target_gcs_bucket_name
 }
 
 # Configure permissions to publish Pub/Sub notifications
 resource "google_pubsub_topic_iam_member" "gcs_publisher_role" {
-  count = var.common_params.add_policies_to_service_account ? 1 : 0
-  depends_on = [
-    google_project_service.enabled_apis,
-    google_pubsub_topic.datastream_topic
-  ]
-  topic  = google_pubsub_topic.datastream_topic.name
-  role   = "roles/pubsub.publisher"
-  member = "serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"
+  count      = var.common_params.add_policies_to_service_account ? 1 : 0
+  depends_on = [google_project_service.enabled_apis]
+  topic      = google_pubsub_topic.datastream_topic.name
+  role       = "roles/pubsub.publisher"
+  member     = "serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"
 }
 
 # Pub/Sub Notification on GCS Bucket
 resource "google_storage_notification" "bucket_notification" {
-  depends_on = [
-    google_project_service.enabled_apis, google_pubsub_topic.datastream_topic
-  ] # Create a bucket notification using the created pubsub topic.
+  depends_on         = [google_project_service.enabled_apis] # Create a bucket notification using the created pubsub topic.
   bucket             = var.datastream_params.target_gcs_bucket_name
   object_name_prefix = var.datastream_params.stream_prefix_path
   payload_format     = "JSON_API_V1"
@@ -48,7 +54,7 @@ resource "google_pubsub_subscription" "datastream_subscription" {
   name  = "${google_pubsub_topic.datastream_topic.name}-sub"
   topic = google_pubsub_topic.datastream_topic.id
   labels = {
-    "migration_id" = random_pet.migration_id.id
+    "migration_id" = local.migration_id
   }
 }
 
@@ -73,16 +79,13 @@ resource "google_datastream_stream" "mysql_to_gcs" {
       max_concurrent_cdc_tasks      = var.datastream_params.max_concurrent_cdc_tasks
       max_concurrent_backfill_tasks = var.datastream_params.max_concurrent_backfill_tasks
       include_objects {
-        dynamic "mysql_databases" {
-          for_each = var.datastream_params.mysql_databases
-          content {
-            database = mysql_databases.value.database
-            dynamic "mysql_tables" {
-              for_each = mysql_databases.value.tables != null ? mysql_databases.value.tables : []
-              # Handle optional tables
-              content {
-                table = mysql_tables.value
-              }
+        mysql_databases {
+          database = var.datastream_params.mysql_database.database
+          # Handle optional tables within the single database
+          dynamic "mysql_tables" {
+            for_each = var.datastream_params.mysql_database.tables != null ? var.datastream_params.mysql_database.tables : []
+            content {
+              table = mysql_tables.value
             }
           }
         }
@@ -99,7 +102,7 @@ resource "google_datastream_stream" "mysql_to_gcs" {
     }
   }
   labels = {
-    "migration_id" = random_pet.migration_id.id
+    "migration_id" = local.migration_id
   }
 }
 
@@ -127,7 +130,7 @@ resource "google_project_iam_member" "live_migration_roles" {
 # Dataflow Flex Template Job (for CDC to Spanner)
 resource "google_dataflow_flex_template_job" "live_migration_job" {
   depends_on = [
-    google_project_service.enabled_apis, google_datastream_stream.mysql_to_gcs, google_project_iam_member.live_migration_roles
+    google_project_service.enabled_apis, google_project_iam_member.live_migration_roles
   ] # Launch the template once the stream is created.
   provider                = google-beta
   container_spec_gcs_path = "gs://dataflow-templates-${var.common_params.region}/latest/flex/Cloud_Datastream_to_Spanner"
@@ -136,10 +139,10 @@ resource "google_dataflow_flex_template_job" "live_migration_job" {
   parameters = {
     inputFileFormat                 = "avro"
     inputFilePattern                = "gs://replaced-by-pubsub-notification"
-    sessionFilePath                 = var.dataflow_params.template_params.session_file_path
+    sessionFilePath                 = var.dataflow_params.template_params.local_session_file_path != null ? "gs://${google_storage_bucket_object.session_file_object[0].bucket}/${google_storage_bucket_object.session_file_object[0].name}" : null
     instanceId                      = var.dataflow_params.template_params.spanner_instance_id
     databaseId                      = var.dataflow_params.template_params.spanner_database_id
-    projectId                       = var.dataflow_params.template_params.spanner_project_id ? var.dataflow_params.template_params.spanner_project_id : var.common_params.project
+    projectId                       = var.dataflow_params.template_params.spanner_project_id != null ? var.dataflow_params.template_params.spanner_project_id : var.common_params.project
     spannerHost                     = var.dataflow_params.template_params.spanner_host
     gcsPubSubSubscription           = google_pubsub_subscription.datastream_subscription.id
     streamName                      = google_datastream_stream.mysql_to_gcs.id
@@ -154,7 +157,6 @@ resource "google_dataflow_flex_template_job" "live_migration_job" {
     datastreamSourceType            = var.dataflow_params.template_params.datastream_source_type
     roundJsonDecimals               = tostring(var.dataflow_params.template_params.round_json_decimals)
     runMode                         = var.dataflow_params.template_params.run_mode
-    transformationContextFilePath   = var.dataflow_params.template_params.transformation_context_file_path
     directoryWatchDurationInMinutes = tostring(var.dataflow_params.template_params.directory_watch_duration_in_minutes)
     spannerPriority                 = var.dataflow_params.template_params.spanner_priority
     dlqGcsPubSubSubscription        = var.dataflow_params.template_params.dlq_gcs_pub_sub_subscription
@@ -181,7 +183,7 @@ resource "google_dataflow_flex_template_job" "live_migration_job" {
   region                       = var.common_params.region
   ip_configuration             = var.dataflow_params.runner_params.ip_configuration
   labels = {
-    "migration_id" = random_pet.migration_id.id
+    "migration_id" = local.migration_id
   }
 }
 

--- a/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/main.tf
+++ b/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/main.tf
@@ -96,7 +96,8 @@ resource "google_datastream_stream" "mysql_to_gcs" {
   destination_config {
     destination_connection_profile = "projects/${var.common_params.project}/locations/${var.common_params.region}/connectionProfiles/${var.datastream_params.target_connection_profile_id}"
     gcs_destination_config {
-      path = var.datastream_params.stream_prefix_path
+      path             = var.datastream_params.stream_prefix_path
+      file_rotation_mb = 5
       avro_file_format {
       }
     }

--- a/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/variables.tf
+++ b/v2/datastream-to-spanner/terraform/samples/pre-configured-conn-profiles/variables.tf
@@ -22,12 +22,12 @@ variable "datastream_params" {
     pubsub_topic_name             = optional(string, "live-migration")
     stream_id                     = optional(string, "mysql-stream")
     stream_prefix_path            = optional(string, "data")
-    max_concurrent_cdc_tasks      = optional(number, 50)
-    max_concurrent_backfill_tasks = optional(number, 50)
-    mysql_databases = list(object({
+    max_concurrent_cdc_tasks      = optional(number, 5)
+    max_concurrent_backfill_tasks = optional(number, 15)
+    mysql_database = object({
       database = string
       tables   = optional(list(string))
-    }))
+    })
   })
 }
 
@@ -39,7 +39,7 @@ variable "dataflow_params" {
       create_shadow_tables                = optional(bool)
       rfc_start_date_time                 = optional(string)
       file_read_concurrency               = optional(number)
-      session_file_path                   = optional(string)
+      local_session_file_path             = optional(string)
       spanner_project_id                  = optional(string)
       spanner_instance_id                 = string
       spanner_database_id                 = string
@@ -51,7 +51,6 @@ variable "dataflow_params" {
       datastream_source_type              = optional(string)
       round_json_decimals                 = optional(bool)
       run_mode                            = optional(string)
-      transformation_context_file_path    = optional(string)
       directory_watch_duration_in_minutes = optional(string)
       spanner_priority                    = optional(string)
       dlq_gcs_pub_sub_subscription        = optional(string)


### PR DESCRIPTION
 Made some changes to the single shard templates - 

1. Updated datastream configuration to make it easier to specify the database and tables. 
2. Made it easier to configure session file in the job.
3. Updated `README` with notes about private connectivity related IAM permissions etc.
4. Fixed a bug with label always being auto-generated id.
5. Remove redundant dependencies in `depends_on` and instead rely on Terraform dependency resolution.
