### PR TITLE
Fixing timeout handling for uniform partitioning and (temporarily) disabling splitting overhad

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/OptionsToConfigBuilder.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/OptionsToConfigBuilder.java
@@ -104,6 +104,9 @@ public final class OptionsToConfigBuilder {
                     .build())
             .setJdbcDriverClassName(jdbcDriverClassName)
             .setJdbcDriverJars(jdbcDriverJars);
+    if (maxConnections != 0) {
+      builder = builder.setMaxConnections(maxConnections);
+    }
 
     if (sourceDbURL != null) {
       builder.setSourceDbURL(sourceDbURL);

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
@@ -362,10 +362,12 @@ public final class JdbcIoWrapper implements IoWrapper {
                     config.shardID()))
             .setWaitOn(config.waitOn())
             /* The following setting limits number of stages provisioned for the split process.
-             * Currently we mostly deal with auto incrementing keys, so capping it to 4 stages irrespective of table size.
+             * Currently we mostly deal with auto incrementing keys, so we don't need a split depth to make the partition uniform, unless there is a large dataset with a lot of holes.
              * TODO(vardhanvthigle): if index is not of the type of a single auto incrementing key, don't set this.
              */
-            .setSplitStageCountHint(4L)
+            .setSplitStageCountHint(0L)
+            .setDbParallelizationForSplitProcess(config.dbParallelizationForSplitProcess())
+            .setDbParallelizationForReads(config.dbParallelizationForReads())
             .setAdditionalOperationsOnRanges(config.additionalOperationsOnRanges());
 
     if (tableConfig.maxPartitions() != null) {

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/defaults/MySqlConfigDefaults.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/defaults/MySqlConfigDefaults.java
@@ -72,8 +72,10 @@ public class MySqlConfigDefaults {
    *       we are also setting the session timezone to UTC.
    * </ol>
    */
+  // TODO: make the innodb_parallel_read_threads as a config option, no need to set if defaults are
+  // correct.
   public static final ImmutableList<String> DEFAULT_MYSQL_INIT_SEQ =
-      ImmutableList.of("SET TIME_ZONE = 'UTC'");
+      ImmutableList.of("SET TIME_ZONE = 'UTC'", "SET SESSION innodb_parallel_read_threads=32");
 
   private MySqlConfigDefaults() {}
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/UniformSplitterDBAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/UniformSplitterDBAdapter.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter;
 
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
+import java.sql.SQLException;
 
 /** Helper Interface to help uniform splitter adapt to the source database. */
 public interface UniformSplitterDBAdapter extends Serializable {
@@ -49,4 +50,16 @@ public interface UniformSplitterDBAdapter extends Serializable {
    * @param partitionColumns partition columns.
    */
   String getBoundaryQuery(String tableName, ImmutableList<String> partitionColumns, String colName);
+
+  /**
+   * Check if a given {@link SQLException} is a timeout. The implementation needs to check for
+   * dialect specific {@link SQLException#getSQLState() SqlState} and {@link
+   * SQLException#getErrorCode() ErrorCode} to check if the exception indicates a server side
+   * timeout. The client side timeout would be already checked for by handling {@link
+   * java.sql.SQLTimeoutException}, so the implementation does not need to check for the same.
+   *
+   * @param exception
+   * @return
+   */
+  boolean checkForTimeout(SQLException exception);
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/Range.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/Range.java
@@ -222,11 +222,13 @@ public abstract class Range implements Serializable, Comparable<Range> {
     return Pair.of(
         this.toBuilder()
             .setBoundary(boundaries.getLeft())
+            .setCount(INDETERMINATE_COUNT)
             .setIsFirst(isFirst())
             .setIsLast(false)
             .build(),
         this.toBuilder()
             .setBoundary(boundaries.getRight())
+            .setCount(INDETERMINATE_COUNT)
             .setIsFirst(false)
             .setIsLast(isLast())
             .build());

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountTransform.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountTransform.java
@@ -56,8 +56,9 @@ public abstract class RangeCountTransform extends PTransform<PCollection<Range>,
             new RangeCountDoFn(
                 dataSourceProviderFn(),
                 timeoutMillis(),
-                dbAdapter().getCountQuery(tableName(), partitionColumns(), timeoutMillis()),
-                partitionColumns().size())));
+                dbAdapter(),
+                tableName(),
+                partitionColumns())));
   }
 
   public static Builder builder() {

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MergeRangesDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MergeRangesDoFnTest.java
@@ -60,12 +60,10 @@ public class MergeRangesDoFnTest {
                 testRanges.get(0),
                 // Can not merge after 0 into 1 as count exceeds mean.
                 testRanges.get(1),
-                // Can not merge after 1 into 2 as count exceeds adjusted mean.
+                // Can not merge after 1 into 2 as count exceeds mean.
                 testRanges.get(2).mergeRange(testRanges.get(3), mockProcessContext),
                 // Can not merge after 3 into 4 as the ranges are not mergable.
-                testRanges.get(4),
-                // Can not merge after 4 into 5 as count exceeds adjusted mean.
-                testRanges.get(5),
+                testRanges.get(4).mergeRange(testRanges.get(5), mockProcessContext),
                 // can not merge after 5 into 6 as ranges are not mergable.
                 testRanges
                     .get(6)
@@ -147,20 +145,22 @@ public class MergeRangesDoFnTest {
     testRangesBuilder = new ImmutableList.Builder<>();
     for (int i = 0; i < testRanges.size(); i++) {
       if (i == 4) {
-        testRangesBuilder.add(rangeWithChildSplit.getLeft()).add(rangeWithChildSplit.getRight());
+        testRangesBuilder
+            .add(rangeWithChildSplit.getLeft().withCount(1500L, mockProcessContext))
+            .add(rangeWithChildSplit.getRight().withCount(1500L, mockProcessContext));
       } else {
         testRangesBuilder.add(testRanges.get(i));
       }
     }
     /*
      * Ranges we get here are 0-32, 32-48, 48-52, 52-54, 54-55(withChild 0-8), 54-55(withChild 9 - 16), 56-60, 60-62, 62-63
-     * For testing purpose, All ranges have counts equal to 100 * (end - start) (for testing) except for the ones with a child with count 1500.
+     * For testing purpose, All ranges have counts equal to 300 * (end - start) (for testing) except for the ones with a child with count 1500.
      */
     testRanges = testRangesBuilder.build();
     return testRanges;
   }
 
   private static Range dummyCounter(Range range, ProcessContext mockProcessContext) {
-    return range.withCount(100L * ((Long) range.end() - (Long) range.start()), mockProcessContext);
+    return range.withCount(300L * ((Long) range.end() - (Long) range.start()), mockProcessContext);
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountDoFnTest.java
@@ -81,9 +81,9 @@ public class RangeCountDoFnTest {
         new RangeCountDoFn(
             mockDataSourceProviderFn,
             2000L,
-            new MysqlDialectAdapter(MySqlVersion.DEFAULT)
-                .getCountQuery("testTalbe", ImmutableList.of("col1"), 2000L),
-            1);
+            new MysqlDialectAdapter(MySqlVersion.DEFAULT),
+            "testTable",
+            ImmutableList.of("col1"));
     Range input =
         Range.<Integer>builder()
             .setColName("col1")
@@ -112,14 +112,18 @@ public class RangeCountDoFnTest {
         .thenThrow(new SQLTimeoutException("test"))
         .thenReturn(mockResultSet);
     when(mockResultSet.next()).thenReturn(true);
-    when(mockResultSet.getLong(1)).thenThrow(new SQLTimeoutException());
+    when(mockResultSet.getLong(1))
+        .thenThrow(new SQLTimeoutException())
+        .thenThrow(
+            new SQLException(
+                "Query execution was interrupted, maximum statement execution time exceeded"));
     RangeCountDoFn rangeCountDoFn =
         new RangeCountDoFn(
             mockDataSourceProviderFn,
             2000L,
-            new MysqlDialectAdapter(MySqlVersion.DEFAULT)
-                .getCountQuery("testTalbe", ImmutableList.of("col1"), 2000L),
-            1);
+            new MysqlDialectAdapter(MySqlVersion.DEFAULT),
+            "testTable",
+            ImmutableList.of("col1"));
     Range input =
         Range.<Integer>builder()
             .setColName("col1")
@@ -154,9 +158,9 @@ public class RangeCountDoFnTest {
         new RangeCountDoFn(
             mockDataSourceProviderFn,
             2000L,
-            new MysqlDialectAdapter(MySqlVersion.DEFAULT)
-                .getCountQuery("testTalbe", ImmutableList.of("col1"), 2000L),
-            1);
+            new MysqlDialectAdapter(MySqlVersion.DEFAULT),
+            "testTable",
+            ImmutableList.of("col1"));
     Range input =
         Range.<Integer>builder()
             .setColName("col1")
@@ -188,9 +192,9 @@ public class RangeCountDoFnTest {
         new RangeCountDoFn(
             mockDataSourceProviderFn,
             2000L,
-            new MysqlDialectAdapter(MySqlVersion.DEFAULT)
-                .getCountQuery("testTalbe", ImmutableList.of("col1"), 2000L),
-            1);
+            new MysqlDialectAdapter(MySqlVersion.DEFAULT),
+            "testTable",
+            ImmutableList.of("col1"));
     Range input =
         Range.<Integer>builder()
             .setColName("col1")

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitionsTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitionsTest.java
@@ -228,9 +228,9 @@ public class ReadWithUniformPartitionsTest implements Serializable {
         getReadWithUniformPartitionsForTest(64L, null, null, null, null);
     // Large RoCount
     ReadWithUniformPartitions readWithUniformPartitionsLargeRowCount =
-        getReadWithUniformPartitionsForTest(1_000_000_000L /* 1 billion */, null, null, null, null);
+        getReadWithUniformPartitionsForTest(8_000_000_000L /* 1 billion */, null, null, null, null);
     assertThat(readWithUniformPartitionsSmallRowCount.maxPartitionsHint()).isEqualTo(1L);
-    assertThat(readWithUniformPartitionsLargeRowCount.maxPartitionsHint()).isEqualTo(3162L);
+    assertThat(readWithUniformPartitionsLargeRowCount.maxPartitionsHint()).isEqualTo(4472L);
   }
 
   @Test


### PR DESCRIPTION
## Timeout Handling
In Change for splitting a space of single/composite long/integers [PR#165](https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/1657/), timeout is handle via trapping `java.SQL.Timeout`. It turns out that there are situates where the DB is throwing a normal `java.sql.exception` and we will have to look into the error codes to decide whether it was a timeout.

This does not affect tables up to 1 TB size.

## Disabling the overhead of splitting process
While  counting a range completes within 5 seconds if not done in parallel, moment the dataflow job tries to count a lot of ranges in parallel, all of them timeout rendering the process of splitting and uniformizing useless. Although this PR is pushing some of the optimizations done towards better counting, for the main line code, it is also making the stages to 0, essentially removing the overhead entirely.  

The exercise to fine tune the counting process will be continued in the baground and the splits will be enabled again later on.
