### PR TITLE
[Cloud Spanner to BigQuery Template] Fix a NPE when one of the source fields contains a NULL value.

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/utils/SpannerUtils.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/utils/SpannerUtils.java
@@ -55,6 +55,10 @@ public class SpannerUtils {
     List<Type.StructField> structFields = struct.getType().getStructFields();
 
     for (Type.StructField field : structFields) {
+      if (struct.isNull(field.getName())) {
+        continue;
+      }
+
       switch (field.getType().getCode()) {
         case BOOL:
           jsonObject.addProperty(field.getName(), struct.getBoolean(field.getName()));

--- a/v2/common/src/test/java/com/google/cloud/teleport/v2/utils/SpannerUtilsTest.java
+++ b/v2/common/src/test/java/com/google/cloud/teleport/v2/utils/SpannerUtilsTest.java
@@ -351,4 +351,32 @@ public final class SpannerUtilsTest {
     expected.add("col5", innerObject);
     assertThat(actual).isEqualTo(expected);
   }
+
+  @Test
+  public void testMultipleFieldsStructWithNullsToJson() {
+    // arrange
+    // spotless:off
+    Struct testStruct =
+        Struct.newBuilder()
+            .set("boolField").to(bool(true))
+            .set("stringField").to(string("test-string"))
+            .set("floatField").to(float64(1.0))
+            .set("longField").to(int64(123))
+            .set("nullBoolField").to(bool(null))
+            .set("nullStringField").to(string(null))
+            .set("nullFloatField").to(float64(null))
+            .set("nullLongField").to(int64(null))
+            .build();
+    //spotless:on
+
+    // act
+    String actual = convertStructToJson(testStruct).toString();
+
+    // assert
+    // All fields with null values should be omitted in the JSON
+    // that will be sent to BQ, so we expect only non-null fields here:
+    String expected =
+        "{\"boolField\":true,\"stringField\":\"test-string\",\"floatField\":1.0,\"longField\":123}";
+    assertThat(actual).isEqualTo(expected);
+  }
 }

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToBigQueryIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToBigQueryIT.java
@@ -159,13 +159,11 @@ public class SpannerToBigQueryIT extends TemplateTestBase {
     // Arrange
     String createTableStatement =
         String.format(
-            // spotless:off
             "CREATE TABLE `%s` (\n"
                 + "  Id INT64 NOT NULL,\n"
                 + "  FirstName String(1024),\n"
-                + "  LastName String(1024) DEFAULT '" + DEFAULT_STRING_VALUE_IF_NULL + "',\n"
+                + "  LastName String(1024),\n"
                 + ") PRIMARY KEY(Id)",
-            // spotless:on
             testName);
     spannerClient.executeDdlStatement(createTableStatement);
 
@@ -176,7 +174,9 @@ public class SpannerToBigQueryIT extends TemplateTestBase {
         Arrays.asList(
             Field.of("Id", StandardSQLTypeName.INT64),
             Field.of("FirstName", StandardSQLTypeName.STRING),
-            Field.of("LastName", StandardSQLTypeName.STRING));
+            Field.of("LastName", StandardSQLTypeName.STRING).toBuilder()
+                .setDefaultValueExpression("'" + DEFAULT_STRING_VALUE_IF_NULL + "'")
+                .build());
     Schema bqSchema = Schema.of(bqSchemaFields);
 
     TableId table = bigQueryClient.createTable("test-table", bqSchema);

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToBigQueryIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToBigQueryIT.java
@@ -20,20 +20,20 @@ import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipelin
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
 
 import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.Field.Mode;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.spanner.Mutation;
-import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.beam.it.common.PipelineLauncher;
 import org.apache.beam.it.common.PipelineOperator;
 import org.apache.beam.it.common.utils.ResourceManagerUtils;
@@ -54,7 +54,6 @@ import org.junit.runners.JUnit4;
 public class SpannerToBigQueryIT extends TemplateTestBase {
 
   private static final int MESSAGES_COUNT = 20;
-  private static final String DEFAULT_STRING_VALUE_IF_NULL = "empty-string";
 
   private SpannerResourceManager spannerClient;
   private BigQueryResourceManager bigQueryClient;
@@ -106,8 +105,8 @@ public class SpannerToBigQueryIT extends TemplateTestBase {
             testName);
     spannerClient.executeDdlStatement(createTableStatement);
 
-    List<Mutation> expectedData = generateTableRows(testName, false);
-    spannerClient.write(expectedData);
+    List<Mutation> sourceMutations = generateDefaultMutations(testName);
+    spannerClient.write(sourceMutations);
 
     String dataset = bigQueryClient.createDataset(REGION);
     String table = String.format("%s:%s.test-table", PROJECT, dataset);
@@ -135,21 +134,7 @@ public class SpannerToBigQueryIT extends TemplateTestBase {
     TableResult records = bigQueryClient.readTable("test-table");
 
     List<Map<String, Object>> expectedRecords = new ArrayList<>();
-    expectedData.forEach(
-        mutation -> {
-          Map<String, Object> expectedRecord =
-              mutation.asMap().entrySet().stream()
-                  .collect(
-                      Collectors.toMap(
-                          e -> e.getKey(),
-                          // Only checking for int64 and string here. If adding another type, this
-                          // will need to be fixed.
-                          e ->
-                              e.getValue().getType() == Type.int64()
-                                  ? e.getValue().getInt64()
-                                  : e.getValue().getString()));
-          expectedRecords.add(expectedRecord);
-        });
+    sourceMutations.forEach(m -> expectedRecords.add(mutationToMap(m)));
 
     assertThatBigQueryRecords(records).hasRecordsUnordered(expectedRecords);
   }
@@ -167,15 +152,17 @@ public class SpannerToBigQueryIT extends TemplateTestBase {
             testName);
     spannerClient.executeDdlStatement(createTableStatement);
 
-    List<Mutation> expectedData = generateTableRows(testName, true);
-    spannerClient.write(expectedData);
+    List<Mutation> sourceMutations = new ArrayList<>();
+    sourceMutations.add(generateMutationWithNulls(testName));
+    sourceMutations.addAll(generateDefaultMutations(testName));
+    spannerClient.write(sourceMutations);
 
     List<Field> bqSchemaFields =
         Arrays.asList(
             Field.of("Id", StandardSQLTypeName.INT64),
             Field.of("FirstName", StandardSQLTypeName.STRING),
             Field.of("LastName", StandardSQLTypeName.STRING).toBuilder()
-                .setDefaultValueExpression("'" + DEFAULT_STRING_VALUE_IF_NULL + "'")
+                .setMode(Mode.NULLABLE)
                 .build());
     Schema bqSchema = Schema.of(bqSchemaFields);
 
@@ -203,47 +190,41 @@ public class SpannerToBigQueryIT extends TemplateTestBase {
 
     TableResult records = bigQueryClient.readTable(table);
 
-    List<Map<String, Object>> expectedRecords = new ArrayList<>();
-    expectedData.forEach(
-        mutation -> {
-          Map<String, Object> expectedRecord =
-              mutation.asMap().entrySet().stream()
-                  .collect(
-                      Collectors.toMap(
-                          Map.Entry::getKey,
-                          // Only checking for int64 and string here. If adding another type, this
-                          // will need to be fixed.
-                          e -> {
-                            Value v = e.getValue();
-                            switch (v.getType().getCode()) {
-                              case INT64:
-                                return v.getInt64();
-                              case STRING:
-                                return v.isNull() ? DEFAULT_STRING_VALUE_IF_NULL : v.getString();
-                              default:
-                                throw new UnsupportedOperationException(
-                                    "Unsupported type: " + v.getType());
-                            }
-                          }));
-          expectedRecords.add(expectedRecord);
-        });
+    List<Map<String, Object>> expectedRecords = new ArrayList<>(sourceMutations.size());
+    sourceMutations.forEach(m -> expectedRecords.add(mutationToMap(m)));
 
     assertThatBigQueryRecords(records).hasRecordsUnordered(expectedRecords);
   }
 
-  private static List<Mutation> generateTableRows(String tableId, boolean nullLastNames) {
+  private static List<Mutation> generateDefaultMutations(String tableId) {
     List<Mutation> mutations = new ArrayList<>();
-    for (int i = 0; i < MESSAGES_COUNT; i++) {
+    for (int i = 1; i <= MESSAGES_COUNT; i++) {
       Mutation.WriteBuilder mutation = Mutation.newInsertBuilder(tableId);
       mutation.set("Id").to(i);
       mutation.set("FirstName").to(RandomStringUtils.randomAlphanumeric(1, 20));
-      // Make the first record to have a null LastName, to test the null field case:
-      mutation
-          .set("LastName")
-          .to(nullLastNames && i == 0 ? null : RandomStringUtils.randomAlphanumeric(1, 20));
+      mutation.set("LastName").to(RandomStringUtils.randomAlphanumeric(1, 20));
       mutations.add(mutation.build());
     }
 
     return mutations;
+  }
+
+  private static Mutation generateMutationWithNulls(String tableId) {
+    Mutation.WriteBuilder mutation = Mutation.newInsertBuilder(tableId);
+    mutation.set("Id").to(0);
+    mutation.set("FirstName").to(RandomStringUtils.randomAlphanumeric(1, 20));
+    mutation.set("LastName").to((String) null);
+    return mutation.build();
+  }
+
+  private static Map<String, Object> mutationToMap(Mutation mutation) {
+    Map<String, Value> values = mutation.asMap();
+    Map<String, Object> map = new HashMap<>();
+    map.put("Id", values.get("Id").isNull() ? null : values.get("Id").getInt64());
+    map.put(
+        "FirstName", values.get("FirstName").isNull() ? null : values.get("FirstName").getString());
+    map.put(
+        "LastName", values.get("LastName").isNull() ? null : values.get("LastName").getString());
+    return map;
   }
 }


### PR DESCRIPTION
Without this fix, the template expects all the source record fields to have non-NULL values. If there is one, an exception is thrown:

org.apache.beam.sdk.util.UserCodeException:java.lang.NullPointerException: Column field0 contains NULL value.

The reason is that SpannerUtils class tries to call struct.getString/getLong/etc. unconditionally, and these methods throw an exception if the value is null. The fix is to skip such fields and not include them in the JSON object (TableRow) being written to BigQuery. This will also allow a target field in BigQuery to not exist at all if the corresponding source field in Spanner is always null.