### PR TITLE
Support float32 type in datastream

### DIFF
--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventConvertorTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventConvertorTest.java
@@ -81,6 +81,9 @@ public class ChangeEventConvertorTest {
             .column("int64_field")
             .int64()
             .endColumn()
+            .column("float32_field")
+            .float32()
+            .endColumn()
             .column("float64_field")
             .float64()
             .endColumn()
@@ -150,6 +153,9 @@ public class ChangeEventConvertorTest {
             .column("int64_field")
             .int64()
             .endColumn()
+            .column("float32_field")
+            .float32()
+            .endColumn()
             .column("float64_field")
             .float64()
             .endColumn()
@@ -213,6 +219,9 @@ public class ChangeEventConvertorTest {
             .column("int64_field")
             .int64()
             .endColumn()
+            .column("float32_field")
+            .float32()
+            .endColumn()
             .column("float64_field")
             .float64()
             .endColumn()
@@ -268,6 +277,7 @@ public class ChangeEventConvertorTest {
     changeEvent.put("bool_field", "true");
     changeEvent.put("bool_field2", true);
     changeEvent.put("int64_field", "2344");
+    changeEvent.put("float32_field", "-137.81");
     changeEvent.put("float64_field", "2344.34");
     changeEvent.put("string_field", "testtest");
     changeEvent.put("json_field", "{\"key1\": \"value1\", \"key2\": \"value2\"}");
@@ -293,6 +303,7 @@ public class ChangeEventConvertorTest {
             put("bool_field", Value.bool(true));
             put("bool_field2", Value.bool(true));
             put("int64_field", Value.int64(2344));
+            put("float32_field", Value.float32(-137.81f));
             put("float64_field", Value.float64(2344.34));
             put("string_field", Value.string("testtest"));
             put("json_field", Value.string("{\"key1\": \"value1\", \"key2\": \"value2\"}"));
@@ -420,6 +431,15 @@ public class ChangeEventConvertorTest {
     Ddl ddl = getTestDdl();
     JSONObject changeEvent = getTestChangeEvent("Users");
     changeEvent.put("int64_field", "asdfas");
+    JsonNode ce = parseChangeEvent(changeEvent.toString());
+    Mutation mutation = ChangeEventConvertor.changeEventToMutation(ddl, ce);
+  }
+
+  @Test(expected = ChangeEventConvertorException.class)
+  public void cannotConvertChangeEventWithInvalidFloat32ToMutation() throws Exception {
+    Ddl ddl = getTestDdl();
+    JSONObject changeEvent = getTestChangeEvent("Users");
+    changeEvent.put("float32_field", "asdfasdf");
     JsonNode ce = parseChangeEvent(changeEvent.toString());
     Mutation mutation = ChangeEventConvertor.changeEventToMutation(ddl, ce);
   }

--- a/v2/datastream-to-spanner/src/test/resources/DataStreamToSpannerDDLIT/spanner-schema.sql
+++ b/v2/datastream-to-spanner/src/test/resources/DataStreamToSpannerDDLIT/spanner-schema.sql
@@ -39,7 +39,7 @@ CREATE TABLE IF NOT EXISTS AllDatatypeColumns2 (
   mediumint_column INT64,
   int_column INT64,
   bigint_column INT64,
-  float_column FLOAT64,
+  float_column FLOAT32,
   double_column FLOAT64,
   decimal_column NUMERIC,
   datetime_column TIMESTAMP,
@@ -63,7 +63,7 @@ CREATE TABLE IF NOT EXISTS AllDatatypeColumns2 (
 
 CREATE TABLE IF NOT EXISTS DatatypeColumnsWithSizes (
    varchar_column STRING(30) NOT NULL,
-   float_column FLOAT64,
+   float_column FLOAT32,
    decimal_column NUMERIC,
    char_column STRING(50),
    bool_column BOOL,
@@ -74,7 +74,7 @@ CREATE TABLE IF NOT EXISTS DatatypeColumnsWithSizes (
 
 CREATE TABLE IF NOT EXISTS DatatypeColumnsReducedSizes (
     varchar_column STRING(10) NOT NULL,
-    float_column FLOAT64,
+    float_column FLOAT32,
     decimal_column NUMERIC,
     char_column STRING(20),
     bool_column BOOL,
@@ -103,7 +103,7 @@ CREATE TABLE AllDatatypeTransformation (
 	date_column DATE,
 	int_column INT64,
 	bigint_column INT64,
-	float_column FLOAT64,
+	float_column FLOAT32,
 	double_column FLOAT64,
 	decimal_column NUMERIC,
 	datetime_column TIMESTAMP,

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/Column.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/Column.java
@@ -126,6 +126,10 @@ public abstract class Column implements Serializable {
         return Type.Code.FLOAT64.getName();
       case PG_FLOAT8:
         return Type.Code.PG_FLOAT8.getName();
+      case FLOAT32:
+        return Type.Code.FLOAT32.getName();
+      case PG_FLOAT4:
+        return Type.Code.PG_FLOAT4.getName();
       case STRING:
         return Type.Code.STRING + "(" + (size == -1 ? "MAX" : Integer.toString(size)) + ")";
       case PG_VARCHAR:
@@ -218,8 +222,11 @@ public abstract class Column implements Serializable {
     }
 
     public Builder float64() {
-
       return type(Type.float64());
+    }
+
+    public Builder float32() {
+      return type(Type.float32());
     }
 
     public Builder bool() {
@@ -335,6 +342,9 @@ public abstract class Column implements Serializable {
           if (spannerType.equals(Type.Code.FLOAT64.getName())) {
             return t(Type.float64(), null);
           }
+          if (spannerType.equals(Type.Code.FLOAT32.getName())) {
+            return t(Type.float32(), null);
+          }
           if (spannerType.startsWith(Type.Code.STRING.getName())) {
             String sizeStr = spannerType.substring(7, spannerType.length() - 1);
             int size = sizeStr.equals("MAX") ? -1 : Integer.parseInt(sizeStr);
@@ -382,6 +392,9 @@ public abstract class Column implements Serializable {
           }
           if (spannerType.equals(Type.Code.PG_FLOAT8.getName())) {
             return t(Type.pgFloat8(), null);
+          }
+          if (spannerType.equals(Type.Code.PG_FLOAT4.getName())) {
+            return t(Type.pgFloat4(), null);
           }
           if (spannerType.equals(Type.Code.PG_TEXT.getName())) {
             return t(Type.pgText(), -1);

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/convertors/ChangeEventSpannerConvertor.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/convertors/ChangeEventSpannerConvertor.java
@@ -68,6 +68,11 @@ public class ChangeEventSpannerConvertor {
           columnValue =
               Value.float64(ChangeEventTypeConvertor.toDouble(changeEvent, colName, requiredField));
           break;
+        case FLOAT32:
+        case PG_FLOAT4:
+          columnValue =
+              Value.float32(ChangeEventTypeConvertor.toFloat(changeEvent, colName, requiredField));
+          break;
         case STRING:
         case PG_VARCHAR:
         case PG_TEXT:

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/convertors/ChangeEventTypeConvertor.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/convertors/ChangeEventTypeConvertor.java
@@ -105,6 +105,23 @@ public class ChangeEventTypeConvertor {
     }
   }
 
+  public static Float toFloat(JsonNode changeEvent, String key, boolean requiredField)
+      throws ChangeEventConvertorException {
+
+    if (!containsValue(changeEvent, key, requiredField)) {
+      return null;
+    }
+    try {
+      JsonNode node = changeEvent.get(key);
+      if (node.isTextual()) {
+        return Float.valueOf(node.asText());
+      }
+      return new Float(node.asDouble());
+    } catch (Exception e) {
+      throw new ChangeEventConvertorException("Unable to convert field " + key + " to float ", e);
+    }
+  }
+
   public static String toString(JsonNode changeEvent, String key, boolean requiredField)
       throws ChangeEventConvertorException {
 

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/type/Type.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/type/Type.java
@@ -38,6 +38,7 @@ import javax.annotation.concurrent.Immutable;
 public final class Type implements Serializable {
   private static final Type TYPE_BOOL = new Type(Type.Code.BOOL, null, null);
   private static final Type TYPE_INT64 = new Type(Type.Code.INT64, null, null);
+  private static final Type TYPE_FLOAT32 = new Type(Type.Code.FLOAT32, null, null);
   private static final Type TYPE_FLOAT64 = new Type(Type.Code.FLOAT64, null, null);
   private static final Type TYPE_NUMERIC = new Type(Type.Code.NUMERIC, null, null);
   private static final Type TYPE_STRING = new Type(Type.Code.STRING, null, null);
@@ -47,6 +48,7 @@ public final class Type implements Serializable {
   private static final Type TYPE_DATE = new Type(Type.Code.DATE, null, null);
   private static final Type TYPE_ARRAY_BOOL = new Type(Type.Code.ARRAY, TYPE_BOOL, null);
   private static final Type TYPE_ARRAY_INT64 = new Type(Type.Code.ARRAY, TYPE_INT64, null);
+  private static final Type TYPE_ARRAY_FLOAT32 = new Type(Type.Code.ARRAY, TYPE_FLOAT32, null);
   private static final Type TYPE_ARRAY_FLOAT64 = new Type(Type.Code.ARRAY, TYPE_FLOAT64, null);
   private static final Type TYPE_ARRAY_NUMERIC = new Type(Type.Code.ARRAY, TYPE_NUMERIC, null);
   private static final Type TYPE_ARRAY_STRING = new Type(Type.Code.ARRAY, TYPE_STRING, null);
@@ -57,6 +59,7 @@ public final class Type implements Serializable {
 
   private static final Type TYPE_PG_BOOL = new Type(Type.Code.PG_BOOL, null, null);
   private static final Type TYPE_PG_INT8 = new Type(Type.Code.PG_INT8, null, null);
+  private static final Type TYPE_PG_FLOAT4 = new Type(Type.Code.PG_FLOAT4, null, null);
   private static final Type TYPE_PG_FLOAT8 = new Type(Type.Code.PG_FLOAT8, null, null);
   private static final Type TYPE_PG_VARCHAR = new Type(Type.Code.PG_VARCHAR, null, null);
   private static final Type TYPE_PG_TEXT = new Type(Type.Code.PG_TEXT, null, null);
@@ -67,6 +70,8 @@ public final class Type implements Serializable {
   private static final Type TYPE_PG_DATE = new Type(Type.Code.PG_DATE, null, null);
   private static final Type TYPE_PG_ARRAY_BOOL = new Type(Type.Code.PG_ARRAY, TYPE_PG_BOOL, null);
   private static final Type TYPE_PG_ARRAY_INT8 = new Type(Type.Code.PG_ARRAY, TYPE_PG_INT8, null);
+  private static final Type TYPE_PG_ARRAY_FLOAT4 =
+      new Type(Type.Code.PG_ARRAY, TYPE_PG_FLOAT4, null);
   private static final Type TYPE_PG_ARRAY_FLOAT8 =
       new Type(Type.Code.PG_ARRAY, TYPE_PG_FLOAT8, null);
   private static final Type TYPE_PG_ARRAY_VARCHAR =
@@ -96,6 +101,14 @@ public final class Type implements Serializable {
    */
   public static Type int64() {
     return TYPE_INT64;
+  }
+
+  /**
+   * Returns the descriptor for the {@code FLOAT32} type: a floating point type with the same value
+   * domain as a Java {code float}.
+   */
+  public static Type float32() {
+    return TYPE_FLOAT32;
   }
 
   /**
@@ -152,6 +165,10 @@ public final class Type implements Serializable {
     return TYPE_PG_INT8;
   }
 
+  public static Type pgFloat4() {
+    return TYPE_PG_FLOAT4;
+  }
+
   public static Type pgFloat8() {
     return TYPE_PG_FLOAT8;
   }
@@ -196,6 +213,8 @@ public final class Type implements Serializable {
         return TYPE_ARRAY_BOOL;
       case INT64:
         return TYPE_ARRAY_INT64;
+      case FLOAT32:
+        return TYPE_ARRAY_FLOAT32;
       case FLOAT64:
         return TYPE_ARRAY_FLOAT64;
       case NUMERIC:
@@ -223,6 +242,8 @@ public final class Type implements Serializable {
         return TYPE_PG_ARRAY_BOOL;
       case PG_INT8:
         return TYPE_PG_ARRAY_INT8;
+      case PG_FLOAT4:
+        return TYPE_PG_ARRAY_FLOAT4;
       case PG_FLOAT8:
         return TYPE_PG_ARRAY_FLOAT8;
       case PG_NUMERIC:
@@ -284,6 +305,7 @@ public final class Type implements Serializable {
     BOOL("BOOL", Dialect.GOOGLE_STANDARD_SQL),
     INT64("INT64", Dialect.GOOGLE_STANDARD_SQL),
     NUMERIC("NUMERIC", Dialect.GOOGLE_STANDARD_SQL),
+    FLOAT32("FLOAT32", Dialect.GOOGLE_STANDARD_SQL),
     FLOAT64("FLOAT64", Dialect.GOOGLE_STANDARD_SQL),
     STRING("STRING", Dialect.GOOGLE_STANDARD_SQL),
     JSON("JSON", Dialect.GOOGLE_STANDARD_SQL),
@@ -294,6 +316,7 @@ public final class Type implements Serializable {
     STRUCT("STRUCT", Dialect.GOOGLE_STANDARD_SQL),
     PG_BOOL("boolean", Dialect.POSTGRESQL),
     PG_INT8("bigint", Dialect.POSTGRESQL),
+    PG_FLOAT4("real", Dialect.POSTGRESQL),
     PG_FLOAT8("double precision", Dialect.POSTGRESQL),
     PG_TEXT("text", Dialect.POSTGRESQL),
     PG_VARCHAR("character varying", Dialect.POSTGRESQL),

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/ddl/DdlTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/ddl/DdlTest.java
@@ -88,6 +88,9 @@ public class DdlTest {
         .generatedAs("CONCAT(first_name, ' ', last_name)")
         .stored()
         .endColumn()
+        .column("balance")
+        .type(Type.float32())
+        .endColumn()
         .primaryKey()
         .asc("id")
         .end()
@@ -104,6 +107,7 @@ public class DdlTest {
                 + " `first_name` STRING(10),"
                 + " `last_name` STRING(MAX),"
                 + " `full_name` STRING(MAX) AS (CONCAT(first_name, ' ', last_name)) STORED,"
+                + " `balance` FLOAT32,"
                 + " CONSTRAINT `ck` CHECK (`first_name` != `last_name`),"
                 + " ) PRIMARY KEY (`id` ASC)"
                 + " CREATE INDEX `UsersByFirstName` ON `Users` (`first_name`)"
@@ -119,6 +123,7 @@ public class DdlTest {
                 + " `first_name` STRING(10),"
                 + " `last_name` STRING(MAX),"
                 + " `full_name` STRING(MAX) AS (CONCAT(first_name, ' ', last_name)) STORED,"
+                + " `balance` FLOAT32,"
                 + " CONSTRAINT `ck` CHECK (`first_name` != `last_name`),"
                 + " ) PRIMARY KEY (`id` ASC)"));
     assertThat(
@@ -164,6 +169,9 @@ public class DdlTest {
         .generatedAs("CONCAT(first_name, ' ', last_name)")
         .stored()
         .endColumn()
+        .column("balance")
+        .type(Type.pgFloat4())
+        .endColumn()
         .primaryKey()
         .asc("id")
         .end()
@@ -183,6 +191,7 @@ public class DdlTest {
                 + " \"last_name\" character varying,"
                 + " \"full_name\" character varying GENERATED ALWAYS AS"
                 + " (CONCAT(first_name, ' ', last_name)) STORED,"
+                + " \"balance\" real,"
                 + " CONSTRAINT \"ck\" CHECK (\"first_name\" != \"last_name\"),"
                 + " PRIMARY KEY (\"id\")"
                 + " ) "

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/ddl/InformationSchemaScannerTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/ddl/InformationSchemaScannerTest.java
@@ -169,12 +169,15 @@ public class InformationSchemaScannerTest {
     ResultSet listColumnsResultSet = mock(ResultSet.class);
 
     when(context.executeQuery(listColumns)).thenReturn(listColumnsResultSet);
-    when(listColumnsResultSet.next()).thenReturn(true, true, true, true, true, false);
+    when(listColumnsResultSet.next()).thenReturn(true, true, true, true, true, true, true, false);
     when(listColumnsResultSet.getString(0))
-        .thenReturn("singer", "singer", "album", "album", "album");
+        .thenReturn("singer", "singer", "album", "album", "album", "album", "album");
     when(listColumnsResultSet.getString(1))
-        .thenReturn("singerId", "singerName", "singerId", "albumId", "albumName");
-    when(listColumnsResultSet.getString(3)).thenReturn("STRING(50)");
+        .thenReturn(
+            "singerId", "singerName", "singerId", "albumId", "albumName", "rating", "ratings");
+    when(listColumnsResultSet.getString(3))
+        .thenReturn(
+            "INT64", "STRING(50)", "INT64", "INT64", "STRING(50)", "FLOAT32", "ARRAY<FLOAT32>");
     when(listColumnsResultSet.getString(4)).thenReturn("NO");
     when(listColumnsResultSet.getString(5)).thenReturn("NO");
     when(listColumnsResultSet.isNull(6)).thenReturn(true);
@@ -327,12 +330,21 @@ public class InformationSchemaScannerTest {
     ResultSet listColumnsResultSet = mock(ResultSet.class);
 
     when(context.executeQuery(listColumns)).thenReturn(listColumnsResultSet);
-    when(listColumnsResultSet.next()).thenReturn(true, true, true, true, true, false);
+    when(listColumnsResultSet.next()).thenReturn(true, true, true, true, true, true, true, false);
     when(listColumnsResultSet.getString(0))
-        .thenReturn("singer", "singer", "album", "album", "album");
+        .thenReturn("singer", "singer", "album", "album", "album", "album", "album");
     when(listColumnsResultSet.getString(1))
-        .thenReturn("singerId", "singerName", "singerId", "albumId", "albumName");
-    when(listColumnsResultSet.getString(3)).thenReturn("character varying(50)");
+        .thenReturn(
+            "singerId", "singerName", "singerId", "albumId", "albumName", "rating", "ratings");
+    when(listColumnsResultSet.getString(3))
+        .thenReturn(
+            "bigint",
+            "character varying(50)",
+            "bigint",
+            "bigint",
+            "character varying(50)",
+            "real",
+            "real[]");
     when(listColumnsResultSet.getString(4)).thenReturn("NO");
     when(listColumnsResultSet.getString(5)).thenReturn("NO");
     when(listColumnsResultSet.isNull(6)).thenReturn(true);
@@ -355,16 +367,18 @@ public class InformationSchemaScannerTest {
     Ddl ddl = informationSchemaScanner.scan();
     String expectedDdl =
         "CREATE TABLE `singer` (\n"
-            + "\t`singerId`                              STRING(50) NOT NULL,\n"
+            + "\t`singerId`                              INT64 NOT NULL,\n"
             + "\t`singerName`                            STRING(50) NOT NULL OPTIONS (option1=\"SomeName\"),\n"
             + ") PRIMARY KEY (`singerId` ASC)\n"
             + "CREATE INDEX `PRIMARY_KEY` ON `singer`()\n"
             + "CREATE INDEX `index1` ON `singer`() STORING (`singerName`)\n"
             + "\n"
             + "CREATE TABLE `album` (\n"
-            + "\t`singerId`                              STRING(50) NOT NULL,\n"
-            + "\t`albumId`                               STRING(50) NOT NULL,\n"
+            + "\t`singerId`                              INT64 NOT NULL,\n"
+            + "\t`albumId`                               INT64 NOT NULL,\n"
             + "\t`albumName`                             STRING(50) NOT NULL,\n"
+            + "\t`rating`                                FLOAT32 NOT NULL,\n"
+            + "\t`ratings`                               ARRAY<FLOAT32> NOT NULL,\n"
             + "\tCONSTRAINT `check1` CHECK (albumName!=NULL),\n"
             + ") PRIMARY KEY (`albumId` DESC),\n"
             + "INTERLEAVE IN PARENT `singer` ON DELETE CASCADE\n"
@@ -389,16 +403,18 @@ public class InformationSchemaScannerTest {
     Ddl ddl = informationSchemaScanner.scan();
     String expectedDdl =
         "CREATE TABLE \"singer\" (\n"
-            + "\t\"singerId\"                              character varying(50) NOT NULL,\n"
+            + "\t\"singerId\"                              bigint NOT NULL,\n"
             + "\t\"singerName\"                            character varying(50) NOT NULL OPTIONS (option1='SomeName'),\n"
             + "\tPRIMARY KEY ()\n"
             + ")\n"
             + "CREATE UNIQUE INDEX \"index1\" ON \"singer\"() INCLUDE (\"singerName\")\n"
             + "\n"
             + "CREATE TABLE \"album\" (\n"
-            + "\t\"singerId\"                              character varying(50) NOT NULL,\n"
-            + "\t\"albumId\"                               character varying(50) NOT NULL,\n"
+            + "\t\"singerId\"                              bigint NOT NULL,\n"
+            + "\t\"albumId\"                               bigint NOT NULL,\n"
             + "\t\"albumName\"                             character varying(50) NOT NULL,\n"
+            + "\t\"rating\"                                real NOT NULL,\n"
+            + "\t\"ratings\"                               real[] NOT NULL,\n"
             + "\tCONSTRAINT \"check1\" CHECK (albumName!=NULL),\n"
             + "\tPRIMARY KEY ()\n"
             + ") \n"

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/convertors/ChangeEventTypeConvertorTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/convertors/ChangeEventTypeConvertorTest.java
@@ -206,6 +206,79 @@ public final class ChangeEventTypeConvertorTest {
   }
 
   /*
+   * Tests for float conversion.
+   */
+  @Test
+  public void canConvertToFloat() throws Exception {
+
+    // Change Event with all valid forms of float values
+    JSONObject changeEvent = new JSONObject();
+    changeEvent.put("field1", Float.MAX_VALUE);
+    changeEvent.put("field2", -Float.MAX_VALUE);
+    changeEvent.put("field3", Float.MIN_VALUE);
+    changeEvent.put("field4", -Float.MIN_VALUE);
+    changeEvent.put("field5", "123456789");
+    changeEvent.put("field6", "-123456789");
+    changeEvent.put("field7", "123456.789");
+    changeEvent.put("field8", "-123456.789");
+    changeEvent.put("field9", 123456789.012345678912f);
+    changeEvent.put("field10", true);
+    changeEvent.put("field11", false);
+    changeEvent.put("field12", JSONObject.NULL);
+    JsonNode ce = getJsonNode(changeEvent.toString());
+
+    assertEquals(
+        ChangeEventTypeConvertor.toFloat(ce, "field1", /* requiredField= */ true),
+        new Float(Float.MAX_VALUE));
+    assertEquals(
+        ChangeEventTypeConvertor.toFloat(ce, "field2", /* requiredField= */ true),
+        new Float(-Float.MAX_VALUE));
+    assertEquals(
+        ChangeEventTypeConvertor.toFloat(ce, "field3", /* requiredField= */ true),
+        new Float(Float.MIN_VALUE));
+    assertEquals(
+        ChangeEventTypeConvertor.toFloat(ce, "field4", /* requiredField= */ true),
+        new Float(-Float.MIN_VALUE));
+    assertEquals(
+        ChangeEventTypeConvertor.toFloat(ce, "field5", /* requiredField= */ true),
+        new Float(123456789));
+    assertEquals(
+        ChangeEventTypeConvertor.toFloat(ce, "field6", /* requiredField= */ true),
+        new Float(-123456789));
+    assertEquals(
+        ChangeEventTypeConvertor.toFloat(ce, "field7", /* requiredField= */ true),
+        new Float(123456.789));
+    assertEquals(
+        ChangeEventTypeConvertor.toFloat(ce, "field8", /* requiredField= */ true),
+        new Float(-123456.789));
+    assertEquals(
+        ChangeEventTypeConvertor.toFloat(ce, "field9", /* requiredField= */ true),
+        new Float(123456789.012345678912));
+    assertEquals(
+        ChangeEventTypeConvertor.toFloat(ce, "field10", /* requiredField= */ true), new Float(1));
+    assertEquals(
+        ChangeEventTypeConvertor.toFloat(ce, "field11", /* requiredField= */ true), new Float(0));
+    assertNull(ChangeEventTypeConvertor.toFloat(ce, "field12", /* requiredField= */ false));
+  }
+
+  @Test(expected = ChangeEventConvertorException.class)
+  public void cannotConvertRandomStringToFloat() throws Exception {
+    JSONObject changeEvent = new JSONObject();
+    changeEvent.put("field1", "asd123456.789");
+    JsonNode ce = getJsonNode(changeEvent.toString());
+    assertEquals(
+        ChangeEventTypeConvertor.toFloat(ce, "field1", /* requiredField= */ true),
+        new Long(123457));
+  }
+
+  @Test(expected = ChangeEventConvertorException.class)
+  public void cannotConvertNonExistentRequiredFieldToFloat() throws Exception {
+    JSONObject changeEvent = new JSONObject();
+    JsonNode ce = getJsonNode(changeEvent.toString());
+    ChangeEventTypeConvertor.toFloat(ce, "field1", /* requiredField= */ true);
+  }
+
+  /*
    * Tests for double conversion.
    */
   @Test


### PR DESCRIPTION
This is a patch of https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/1375.

Successfully ran the dataflow template:

MySQL source, stored to GCS via datastream:
![Screenshot from 2024-07-10 01-12-34](https://github.com/GoogleCloudPlatform/DataflowTemplates/assets/1905114/5c4284e7-e703-4a00-881b-ad3388273d4f)

Spanner destination from datastream:
![Screenshot from 2024-07-10 01-12-52](https://github.com/GoogleCloudPlatform/DataflowTemplates/assets/1905114/5c53a569-f45e-4445-89c4-e77887096fa3)

```
export PROJECT=span-cloud-testing
export IMAGE_NAME=datastream-to-spanner
export BUCKET_NAME=gs://shubhamswe-test
export TARGET_GCR_IMAGE=gcr.io/${PROJECT}/templates/${IMAGE_NAME}
export BASE_CONTAINER_IMAGE=gcr.io/dataflow-templates-base/java11-template-launcher-base
export BASE_CONTAINER_IMAGE_VERSION=latest
export APP_ROOT=/template/${IMAGE_NAME}
export DATAFLOW_JAVA_COMMAND_SPEC=${APP_ROOT}/resources/${IMAGE_NAME}-command-spec.json
#export SPANNER_HOST="https://staging-wrenchworks.sandbox.googleapis.com/"
export INSTANCE_ID="arawind-test"
export DATABASE_ID="float32-test"
export GCS_LOCATION="gs://shubhamswe-test/float32-mysql-out"
export STREAM_NAME="projects/span-cloud-testing/locations/us-central1/streams/arawind-mysql-datastream"
export TEMPLATE_IMAGE_SPEC="gs://shubhamswe-test/images/2024_07_09_01/flex/Cloud_Datastream_to_Spanner"
export JOB_NAME="${IMAGE_NAME}-`date +%Y%m%d-%H%M%S-%N`"

gcloud dataflow flex-template run ${JOB_NAME} \
        --project=${PROJECT} --region=us-central1 \
        --template-file-gcs-location=${TEMPLATE_IMAGE_SPEC} \
        --parameters instanceId=${INSTANCE_ID},databaseId=${DATABASE_ID},inputFilePattern=${GCS_LOCATION},streamName=${STREAM_NAME}
```

