### PR TITLE
Update getConnectionUrl documentation with example

### DIFF
--- a/v2/jdbc-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/JdbcToPubsubOptions.java
+++ b/v2/jdbc-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/JdbcToPubsubOptions.java
@@ -44,7 +44,7 @@ public interface JdbcToPubsubOptions extends CommonTemplateOptions {
       description = "JDBC connection URL string.",
       helpText =
           "The JDBC connection URL string. You can pass in this value as a string that's encrypted with a Cloud KMS key and then Base64-encoded. "
-              + "For example: 'echo -n \"my connection string\" | gcloud kms encrypt --location=<location> --keyring=<keyring> --key=<key> --plaintext-file=- --ciphertext-file=- | base64'",
+              + "For example: 'echo -n \"jdbc:mysql://some-host:3306/sampledb\" | gcloud kms encrypt --location=<location> --keyring=<keyring> --key=<key> --plaintext-file=- --ciphertext-file=- | base64'",
       example = "jdbc:mysql://some-host:3306/sampledb")
   String getConnectionUrl();
 

--- a/v2/jdbc-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/JdbcToPubsubOptions.java
+++ b/v2/jdbc-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/JdbcToPubsubOptions.java
@@ -43,7 +43,8 @@ public interface JdbcToPubsubOptions extends CommonTemplateOptions {
       },
       description = "JDBC connection URL string.",
       helpText =
-          "The JDBC connection URL string. You can pass in this value as a string that's encrypted with a Cloud KMS key and then Base64-encoded. Remove whitespace characters from the Base64-encoded string. ",
+          "The JDBC connection URL string. You can pass in this value as a string that's encrypted with a Cloud KMS key and then Base64-encoded. "
+              + "For example: 'echo -n \"my connection string\" | gcloud kms encrypt --location=<location> --keyring=<keyring> --key=<key> --plaintext-file=- --ciphertext-file=- | base64'",
       example = "jdbc:mysql://some-host:3306/sampledb")
   String getConnectionUrl();
 


### PR DESCRIPTION
This PR updates the JdbcToPubsubOptions getConnectionUrl with an example how to use kms to encrypt and base64 encode the connection string.