### PR TITLE
Support FLOAT32 in Spanner Change Streams to BQ

### DIFF
--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SpannerChangeStreamsUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SpannerChangeStreamsUtils.java
@@ -447,6 +447,8 @@ public class SpannerChangeStreamsUtils {
         return Type.bytes();
       case "DATE":
         return Type.date();
+      case "FLOAT32":
+        return Type.float32();
       case "FLOAT64":
         return Type.float64();
       case "INT64":
@@ -487,6 +489,8 @@ public class SpannerChangeStreamsUtils {
         return Type.bool();
       case "BYTEA":
         return Type.bytes();
+      case "REAL":
+        return Type.float32();
       case "DOUBLE PRECISION":
         return Type.float64();
       case "BIGINT":

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SpannerToBigQueryUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SpannerToBigQueryUtils.java
@@ -56,6 +56,9 @@ public class SpannerToBigQueryUtils {
       bigQueryField.setType("BYTES");
     } else if (spannerType.equals(Type.array(Type.date()))) {
       bigQueryField.setType("DATE");
+    } else if (spannerType.equals(Type.array(Type.float32()))) {
+      // BigQuery does not support FLOAT32 type.
+      bigQueryField.setType("FLOAT64");
     } else if (spannerType.equals(Type.array(Type.float64()))) {
       bigQueryField.setType("FLOAT64");
     } else if (spannerType.equals(Type.array(Type.int64()))) {
@@ -89,6 +92,10 @@ public class SpannerToBigQueryUtils {
           break;
         case DATE:
           bigQueryType = StandardSQLTypeName.DATE;
+          break;
+        case FLOAT32:
+          // BigQuery does not support the FLOAT32 type.
+          bigQueryType = StandardSQLTypeName.FLOAT64;
           break;
         case FLOAT64:
           bigQueryType = StandardSQLTypeName.FLOAT64;
@@ -164,6 +171,8 @@ public class SpannerToBigQueryUtils {
       return removeNulls(resultSet.getDateList(columnName)).stream()
           .map(e -> e.toString())
           .collect(Collectors.toList());
+    } else if (columnType.equals(Type.array(Type.float32()))) {
+      return removeNulls(resultSet.getFloatList(columnName));
     } else if (columnType.equals(Type.array(Type.float64()))) {
       return removeNulls(resultSet.getDoubleList(columnName));
     } else if (columnType.equals(Type.array(Type.int64()))) {
@@ -191,6 +200,8 @@ public class SpannerToBigQueryUtils {
           return resultSet.getBytes(columnName).toBase64();
         case DATE:
           return resultSet.getDate(columnName).toString();
+        case FLOAT32:
+          return resultSet.getFloat(columnName);
         case FLOAT64:
           return resultSet.getDouble(columnName);
         case INT64:
@@ -231,6 +242,7 @@ public class SpannerToBigQueryUtils {
       if (columnType.equals(Type.array(Type.bool()))
           || columnType.equals(Type.array(Type.bytes()))
           || columnType.equals(Type.array(Type.date()))
+          || columnType.equals(Type.array(Type.float32()))
           || columnType.equals(Type.array(Type.float64()))
           || columnType.equals(Type.array(Type.int64()))
           || columnType.equals(Type.array(Type.json()))

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToPubSubIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToPubSubIT.java
@@ -20,7 +20,7 @@ import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatRecords
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
 
 import com.google.cloud.spanner.Mutation;
-import com.google.cloud.spanner.Type;
+import com.google.cloud.spanner.Value;
 import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
 import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
 import com.google.gson.Gson;
@@ -87,6 +87,8 @@ public class SpannerChangeStreamsToPubSubIT extends TemplateTestBase {
                 + "  Id INT64 NOT NULL,\n"
                 + "  FirstName String(1024),\n"
                 + "  LastName String(1024),\n"
+                + "  Float32Col FLOAT32,\n"
+                + "  Float64Col FLOAT64,\n"
                 + ") PRIMARY KEY(Id)",
             testName);
     spannerResourceManager.executeDdlStatement(createTableStatement);
@@ -163,18 +165,25 @@ public class SpannerChangeStreamsToPubSubIT extends TemplateTestBase {
         mutation -> {
           Map<String, Object> expectedRecord =
               mutation.asMap().entrySet().stream()
-                  .collect(
-                      Collectors.toMap(
-                          e -> e.getKey(),
-                          // Only checking for int64 and string here. If adding another type, this
-                          // will need to be fixed.
-                          e ->
-                              e.getValue().getType() == Type.int64()
-                                  ? e.getValue().getInt64()
-                                  : e.getValue().getString()));
+                  .collect(Collectors.toMap(e -> e.getKey(), e -> valueToString(e.getValue())));
           expectedRecords.add(expectedRecord);
         });
     assertThatRecords(records).hasRecordsUnorderedCaseInsensitiveColumns(expectedRecords);
+  }
+
+  private static String valueToString(Value val) {
+    switch (val.getType().getCode()) {
+      case INT64:
+        return Long.toString(val.getInt64());
+      case FLOAT32:
+        return Float.toString(val.getFloat32());
+      case FLOAT64:
+        return Double.toString(val.getFloat64());
+      case STRING:
+        return val.getString();
+      default:
+        throw new IllegalArgumentException("Unsupported type: " + val.getType());
+    }
   }
 
   private static List<Mutation> generateTableRows(String tableId) {
@@ -184,6 +193,10 @@ public class SpannerChangeStreamsToPubSubIT extends TemplateTestBase {
       mutation.set("Id").to(i);
       mutation.set("FirstName").to(RandomStringUtils.randomAlphanumeric(1, 20));
       mutation.set("LastName").to(RandomStringUtils.randomAlphanumeric(1, 20));
+      // Avoiding random numbers as asserting their presence via string match is
+      // error-prone for floats.
+      mutation.set("Float32Col").to(i + 0.5);
+      mutation.set("Float64Col").to(i + 1.5);
       mutations.add(mutation.build());
     }
 

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/BigQueryDynamicDestinationsTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/BigQueryDynamicDestinationsTest.java
@@ -29,6 +29,7 @@ import com.google.cloud.teleport.v2.spanner.IntegrationTest;
 import com.google.cloud.teleport.v2.spanner.SpannerServerResource;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.BigQueryDynamicDestinations.BigQueryDynamicDestinationsOptions;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.BigQueryUtils;
+import com.google.common.collect.ImmutableSet;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.values.KV;
@@ -65,6 +66,8 @@ public final class BigQueryDynamicDestinationsTest {
             .setBigQueryProject(TEST_PROJECT)
             .setBigQueryDataset(TEST_BIG_QUERY_DATESET)
             .setBigQueryTableTemplate("{_metadata_spanner_table_name}_changelog")
+            .setUseStorageWriteApi(false)
+            .setIgnoreFields(ImmutableSet.of())
             .build();
     bigQueryDynamicDestinations =
         BigQueryDynamicDestinations.of(bigQueryDynamicDestinationsOptions);
@@ -111,8 +114,7 @@ public final class BigQueryDynamicDestinationsTest {
     String schemaStr = bigQueryDynamicDestinations.getSchema(tableIdToTableRow).toString();
     schemaStr =
         schemaStr.replace(
-            "classInfo=[categories, collationSpec, description, fields, maxLength, mode, name,"
-                + " policyTags, precision, scale, type], ",
+            "classInfo=[categories, collation, defaultValueExpression, description, fields, maxLength, mode, name, policyTags, precision, rangeElementType, roundingMode, scale, type], ",
             "");
     schemaStr = schemaStr.replace("GenericData", "");
     assertThat(schemaStr)
@@ -125,15 +127,17 @@ public final class BigQueryDynamicDestinationsTest {
                 + " name=StringPkCol, type=STRING}}, {{mode=NULLABLE, name=TimestampPkCol,"
                 + " type=TIMESTAMP}}, {{mode=REPEATED, name=BooleanArrayCol, type=BOOL}},"
                 + " {{mode=REPEATED, name=BytesArrayCol, type=BYTES}}, {{mode=REPEATED,"
-                + " name=DateArrayCol, type=DATE}}, {{mode=REPEATED, name=Float64ArrayCol,"
+                + " name=DateArrayCol, type=DATE}}, {{mode=REPEATED, name=Float32ArrayCol,"
+                + " type=FLOAT64}}, {{mode=REPEATED, name=Float64ArrayCol,"
                 + " type=FLOAT64}}, {{mode=REPEATED, name=Int64ArrayCol, type=INT64}},"
-                + " {{mode=REPEATED, name=JsonArrayCol, type=STRING}}, {{mode=REPEATED,"
+                + " {{mode=REPEATED, name=JsonArrayCol, type=JSON}}, {{mode=REPEATED,"
                 + " name=NumericArrayCol, type=NUMERIC}}, {{mode=REPEATED, name=StringArrayCol,"
                 + " type=STRING}}, {{mode=REPEATED, name=TimestampArrayCol, type=TIMESTAMP}},"
                 + " {{mode=NULLABLE, name=BooleanCol, type=BOOL}}, {{mode=NULLABLE, name=BytesCol,"
                 + " type=BYTES}}, {{mode=NULLABLE, name=DateCol, type=DATE}}, {{mode=NULLABLE,"
+                + " name=Float32Col, type=FLOAT64}}, {{mode=NULLABLE,"
                 + " name=Float64Col, type=FLOAT64}}, {{mode=NULLABLE, name=Int64Col, type=INT64}},"
-                + " {{mode=NULLABLE, name=JsonCol, type=STRING}}, {{mode=NULLABLE, name=NumericCol,"
+                + " {{mode=NULLABLE, name=JsonCol, type=JSON}}, {{mode=NULLABLE, name=NumericCol,"
                 + " type=NUMERIC}}, {{mode=NULLABLE, name=StringCol, type=STRING}},"
                 + " {{mode=NULLABLE, name=TimestampCol, type=TIMESTAMP}}, {{mode=REQUIRED,"
                 + " name=_metadata_spanner_mod_type, type=STRING}}, {{mode=REQUIRED,"

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/TestUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/TestUtils.java
@@ -50,6 +50,7 @@ class TestUtils {
   static final String BOOLEAN_ARRAY_COL = "BooleanArrayCol";
   static final String BYTES_ARRAY_COL = "BytesArrayCol";
   static final String DATE_ARRAY_COL = "DateArrayCol";
+  static final String FLOAT32_ARRAY_COL = "Float32ArrayCol";
   static final String FLOAT64_ARRAY_COL = "Float64ArrayCol";
   static final String INT64_ARRAY_COL = "Int64ArrayCol";
   static final String NUMERIC_ARRAY_COL = "NumericArrayCol";
@@ -60,6 +61,7 @@ class TestUtils {
   static final String BOOLEAN_COL = "BooleanCol";
   static final String BYTES_COL = "BytesCol";
   static final String DATE_COL = "DateCol";
+  static final String FLOAT32_COL = "Float32Col";
   static final String FLOAT64_COL = "Float64Col";
   static final String INT64_COL = "Int64Col";
   static final String JSON_COL = "JsonCol";
@@ -70,6 +72,7 @@ class TestUtils {
   static final Boolean BOOLEAN_RAW_VAL = true;
   static final ByteArray BYTES_RAW_VAL = ByteArray.copyFrom("456");
   static final Date DATE_RAW_VAL = Date.fromYearMonthDay(2022, 3, 11);
+  static final Float FLOAT32_RAW_VAL = 1.5f;
   static final Double FLOAT64_RAW_VAL = 2.5;
   static final Long INT64_RAW_VAL = 10L;
   static final String JSON_RAW_VAL = "{\"color\":\"red\"}";
@@ -81,6 +84,7 @@ class TestUtils {
   static final Value BOOLEAN_VAL = Value.bool(BOOLEAN_RAW_VAL);
   static final Value BYTES_VAL = Value.bytes(BYTES_RAW_VAL);
   static final Value DATE_VAL = Value.date(DATE_RAW_VAL);
+  static final Value FLOAT32_VAL = Value.float32(FLOAT32_RAW_VAL);
   static final Value FLOAT64_VAL = Value.float64(FLOAT64_RAW_VAL);
   static final Value INT64_VAL = Value.int64(INT64_RAW_VAL);
   static final Value JSON_VAL = Value.json(JSON_RAW_VAL);
@@ -96,6 +100,8 @@ class TestUtils {
           ByteArray.copyFrom("789").toBase64());
   static final List<Date> DATE_ARRAY_RAW_VAL =
       Arrays.asList(Date.fromYearMonthDay(2022, 1, 22), Date.fromYearMonthDay(2022, 3, 11));
+  static final List<Float> FLOAT32_ARRAY_RAW_VAL =
+      Arrays.asList(Float.MIN_VALUE, Float.MAX_VALUE, 0.0f, 1.0f, -1.0f, 3.14f);
   static final List<Double> FLOAT64_ARRAY_RAW_VAL =
       Arrays.asList(Double.MIN_VALUE, Double.MAX_VALUE, 0.0, 1.0, -1.0, 1.2341);
   static final List<Long> INT64_ARRAY_RAW_VAL =
@@ -114,6 +120,7 @@ class TestUtils {
   static final List<Boolean> BOOLEAN_NULLABLE_ARRAY_RAW_VAL = addNull(BOOLEAN_ARRAY_RAW_VAL);
   static final List<String> BYTES_NULLABLE_ARRAY_RAW_VAL = addNull(BYTES_ARRAY_RAW_VAL);
   static final List<Date> DATE_NULLABLE_ARRAY_RAW_VAL = addNull(DATE_ARRAY_RAW_VAL);
+  static final List<Float> FLOAT32_NULLABLE_ARRAY_RAW_VAL = addNull(FLOAT32_ARRAY_RAW_VAL);
   static final List<Double> FLOAT64_NULLABLE_ARRAY_RAW_VAL = addNull(FLOAT64_ARRAY_RAW_VAL);
   static final List<Long> INT64_NULLABLE_ARRAY_RAW_VAL = addNull(INT64_ARRAY_RAW_VAL);
   static final List<String> JSON_NULLABLE_ARRAY_RAW_VAL = addNull(JSON_ARRAY_RAW_VAL);
@@ -130,6 +137,8 @@ class TestUtils {
               ByteArray.copyFrom("789"),
               null));
   static final Value DATE_NULLABLE_ARRAY_VAL = Value.dateArray(DATE_NULLABLE_ARRAY_RAW_VAL);
+  static final Value FLOAT32_NULLABLE_ARRAY_VAL =
+      Value.float32Array(FLOAT32_NULLABLE_ARRAY_RAW_VAL);
   static final Value FLOAT64_NULLABLE_ARRAY_VAL =
       Value.float64Array(FLOAT64_NULLABLE_ARRAY_RAW_VAL);
   static final Value INT64_NULLABLE_ARRAY_VAL = Value.int64Array(INT64_NULLABLE_ARRAY_RAW_VAL);
@@ -178,6 +187,7 @@ class TestUtils {
         + "BooleanArrayCol ARRAY<BOOL>,"
         + "BytesArrayCol ARRAY<BYTES(1024)>,"
         + "DateArrayCol ARRAY<DATE>,"
+        + "Float32ArrayCol ARRAY<FLOAT32>,"
         + "Float64ArrayCol ARRAY<FLOAT64>,"
         + "Int64ArrayCol ARRAY<INT64>,"
         + "JsonArrayCol ARRAY<JSON>,"
@@ -187,6 +197,7 @@ class TestUtils {
         + "BooleanCol BOOL,"
         + "BytesCol BYTES(1024),"
         + "DateCol DATE,"
+        + "Float32Col FLOAT32,"
         + "Float64Col FLOAT64,"
         + "Int64Col INT64,"
         + "JsonCol JSON,"


### PR DESCRIPTION
Also fixes the BigQueryDynamicDestinationsTest, adds a new float column test in SpannerChangeStreamsToBigQuery and updates SpannerChangeStreamsToGCS and PubSub integration tests.

Verfied that the changes work by running the
BigQueryDynamicDestinationsTest and SpannerChangeStreamsToBigQueryIT tests manually.

Commands for future reference: 

To run BigQueryDynamicDestinationsTest:

```
mvn clean verify -f pom.xml -e -Dcheckstyle.skip -Djib.skip -DskipShade -Dspotless.check.skip -Djacoco.skip -fae -T8 -Dexcluded.spanner.tests="" -DfailIfNoTests=false -pl v2/googlecloud-to-googlecloud,plugins/templates-maven-plugin -am -Dtest=BigQueryDynamicDestinationsTest;
```

To run SpannerChangeStreamsToBigQueryIT:

```
mvn clean verify -f pom.xml -e -Dcheckstyle.skip -Djib.skip -DskipShade -Dspotless.check.skip -Djacoco.skip -fae -T8 -Dexcluded.spanner.tests="" -DfailIfNoTests=false -pl v2/googlecloud-to-googlecloud,plugins/templates-maven-plugin -am -Dproject=span-cloud-testing -DspannerInstanceId=arawind-test -DartifactBucket="gs://arawind-spanner-test/" -Dtest=SpannerChangeStreamsToBigQueryIT;
```