### PR TITLE
Add IT tests for handling schema update during spanner cdc to big query pipeline running

### DIFF
--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/bigquery/BigQueryResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/bigquery/BigQueryResourceManager.java
@@ -145,7 +145,7 @@ public final class BigQueryResourceManager implements ResourceManager {
    * @return the table, if it exists.
    * @throws IllegalStateException if the given table name does not exist in the dataset.
    */
-  private synchronized Table getTableIfExists(String tableId) throws IllegalStateException {
+  public synchronized Table getTableIfExists(String tableId) throws IllegalStateException {
     checkHasDataset();
     Table table = dataset.get(tableId);
     if (table == null) {

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/BigQueryDynamicDestinations.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/BigQueryDynamicDestinations.java
@@ -24,17 +24,13 @@ import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Dialect;
-import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.TrackedSpannerTable;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.BigQueryUtils;
-import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.SpannerChangeStreamsUtils;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.SpannerToBigQueryUtils;
 import com.google.cloud.teleport.v2.transforms.BigQueryConverters;
 import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import org.apache.beam.sdk.io.gcp.bigquery.DynamicDestinations;
 import org.apache.beam.sdk.io.gcp.bigquery.TableDestination;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
@@ -53,7 +49,6 @@ public final class BigQueryDynamicDestinations
 
   private static final Logger LOG = LoggerFactory.getLogger(BigQueryDynamicDestinations.class);
 
-  private final Map<String, TrackedSpannerTable> spannerTableByName;
   private final String bigQueryProject, bigQueryDataset, bigQueryTableTemplate;
   private final Boolean useStorageWriteApi;
   private final ImmutableSet<String> ignoreFields;
@@ -61,30 +56,11 @@ public final class BigQueryDynamicDestinations
   public static BigQueryDynamicDestinations of(
       BigQueryDynamicDestinationsOptions bigQueryDynamicDestinationsOptions) {
     Dialect dialect = getDialect(bigQueryDynamicDestinationsOptions.getSpannerConfig());
-    try (SpannerAccessor spannerAccessor =
-        SpannerAccessor.getOrCreate(bigQueryDynamicDestinationsOptions.getSpannerConfig())) {
-      Map<String, TrackedSpannerTable> spannerTableByName =
-          new SpannerChangeStreamsUtils(
-                  spannerAccessor.getDatabaseClient(),
-                  bigQueryDynamicDestinationsOptions.getChangeStreamName(),
-                  dialect)
-              .getSpannerTableByName();
-      return new BigQueryDynamicDestinations(
-          bigQueryDynamicDestinationsOptions, spannerTableByName);
-    } catch (RuntimeException e) {
-      String errorMessage =
-          String.format(
-              "Caught exception when getting BigQueryDynamicDestinations, message: %s,"
-                  + " cause: %s",
-              Optional.ofNullable(e.getMessage()), e.getCause());
-      LOG.error(errorMessage);
-      throw new RuntimeException(errorMessage, e);
-    }
+    return new BigQueryDynamicDestinations(bigQueryDynamicDestinationsOptions);
   }
 
   private BigQueryDynamicDestinations(
-      BigQueryDynamicDestinationsOptions bigQueryDynamicDestinationsOptions,
-      Map<String, TrackedSpannerTable> spannerTableByName) {
+      BigQueryDynamicDestinationsOptions bigQueryDynamicDestinationsOptions) {
     this.spannerTableByName = spannerTableByName;
     this.ignoreFields = bigQueryDynamicDestinationsOptions.getIgnoreFields();
     this.bigQueryProject = bigQueryDynamicDestinationsOptions.getBigQueryProject();
@@ -118,10 +94,8 @@ public final class BigQueryDynamicDestinations
   @Override
   public TableSchema getSchema(KV<TableId, TableRow> destination) {
     TableRow tableRow = destination.getValue();
-    String spannerTableName =
-        (String) tableRow.get(BigQueryUtils.BQ_CHANGELOG_FIELD_NAME_TABLE_NAME);
-    TrackedSpannerTable spannerTable = spannerTableByName.get(spannerTableName);
-    List<TableFieldSchema> fields = getFields(spannerTable);
+    // Get List<TableFieldSchema> for both user columns and metadata columns.
+    List<TableFieldSchema> fields = getFields(tableRow);
     List<TableFieldSchema> filteredFields = new ArrayList<>();
     for (TableFieldSchema field : fields) {
       if (!ignoreFields.contains(field.getName())) {
@@ -132,9 +106,12 @@ public final class BigQueryDynamicDestinations
     return new TableSchema().setFields(filteredFields);
   }
 
-  private List<TableFieldSchema> getFields(TrackedSpannerTable spannerTable) {
+  // Returns List<TableFieldSchema> for user columns and metadata columns based on the parameter
+  // TableRow.
+  private List<TableFieldSchema> getFields(TableRow tableRow) {
+    // Add all user data fields (excluding metadata fields stored in metadataColumns).
     List<TableFieldSchema> fields =
-        SpannerToBigQueryUtils.spannerColumnsToBigQueryIOFields(spannerTable.getAllColumns());
+        SpannerToBigQueryUtils.tableRowColumnsToBigQueryIOFields(tableRow, this.useStorageWriteApi);
 
     // Add all metadata fields.
     String requiredMode = Field.Mode.REQUIRED.name();

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/BigQueryDynamicDestinations.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/BigQueryDynamicDestinations.java
@@ -61,7 +61,6 @@ public final class BigQueryDynamicDestinations
 
   private BigQueryDynamicDestinations(
       BigQueryDynamicDestinationsOptions bigQueryDynamicDestinationsOptions) {
-    this.spannerTableByName = spannerTableByName;
     this.ignoreFields = bigQueryDynamicDestinationsOptions.getIgnoreFields();
     this.bigQueryProject = bigQueryDynamicDestinationsOptions.getBigQueryProject();
     this.bigQueryDataset = bigQueryDynamicDestinationsOptions.getBigQueryDataset();

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/FailsafeModJsonToTableRowTransformer.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/FailsafeModJsonToTableRowTransformer.java
@@ -38,6 +38,7 @@ import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.mod
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.TrackedSpannerColumn;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.TrackedSpannerTable;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.BigQueryUtils;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.SchemaUpdateUtils;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.SpannerChangeStreamsUtils;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.SpannerToBigQueryUtils;
 import com.google.cloud.teleport.v2.values.FailsafeElement;
@@ -132,6 +133,7 @@ public final class FailsafeModJsonToTableRowTransformer {
       private transient CallContextConfigurator callContextConfigurator;
       private transient boolean seenException;
       private Boolean useStorageWriteApi;
+      private Dialect dialect;
 
       public FailsafeModJsonToTableRowFn(
           SpannerConfig spannerConfig,
@@ -146,6 +148,7 @@ public final class FailsafeModJsonToTableRowTransformer {
         this.transformDeadLetterOut = transformDeadLetterOut;
         this.ignoreFields = ignoreFields;
         this.useStorageWriteApi = useStorageWriteApi;
+        this.dialect = getDialect(spannerConfig);
       }
 
       private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
@@ -169,7 +172,6 @@ public final class FailsafeModJsonToTableRowTransformer {
       public void setUp() {
         seenException = false;
         try {
-          Dialect dialect = getDialect(spannerConfig);
           spannerAccessor = SpannerAccessor.getOrCreate(spannerConfig);
           spannerTableByName =
               new SpannerChangeStreamsUtils(
@@ -252,19 +254,21 @@ public final class FailsafeModJsonToTableRowTransformer {
         }
         String spannerTableName = mod.getTableName();
         TrackedSpannerTable spannerTable;
-        try {
-          spannerTable = checkStateNotNull(spannerTableByName.get(spannerTableName));
-
-        } catch (IllegalStateException e) {
-          String errorMessage =
-              String.format(
-                  "Can not find spanner table %s in spannerTableByName", spannerTableName);
-          LOG.error(errorMessage);
-          throw new RuntimeException(errorMessage, e);
-        }
         com.google.cloud.Timestamp spannerCommitTimestamp =
             com.google.cloud.Timestamp.ofTimeSecondsAndNanos(
                 mod.getCommitTimestampSeconds(), mod.getCommitTimestampNanos());
+
+        // Detect schema updates (newly added tables/columns) from mod and propagate changes into
+        // spannerTableByName which stores schema information by table name.
+        // Not able to get schema update from DELETE mods as they have empty newValuesJson.
+        if (mod.getModType() != ModType.DELETE) {
+          spannerTableByName =
+              SchemaUpdateUtils.updateStoredSchemaIfNeeded(
+                  spannerAccessor, spannerChangeStream, dialect, mod, spannerTableByName);
+        }
+
+        TrackedSpannerTable spannerTable =
+            checkStateNotNull(spannerTableByName.get(spannerTableName));
 
         // Set metadata fields of the tableRow.
         TableRow tableRow = new TableRow();
@@ -277,20 +281,8 @@ public final class FailsafeModJsonToTableRowTransformer {
             useStorageWriteApi);
         JSONObject keysJsonObject = new JSONObject(mod.getKeysJson());
         // Set Spanner key columns of the tableRow.
-        for (TrackedSpannerColumn spannerColumn : spannerTable.getPkColumns()) {
-          String spannerColumnName = spannerColumn.getName();
-          if (keysJsonObject.has(spannerColumnName)) {
-            tableRow.set(spannerColumnName, keysJsonObject.get(spannerColumnName));
-          } else {
-            String errorMessage =
-                String.format(
-                    "Caught exception when setting key column of the tableRow: Cannot find value"
-                        + " for key column %s",
-                    spannerColumnName);
-            LOG.error(errorMessage);
-            throw new IllegalArgumentException(errorMessage);
-          }
-        }
+        SpannerToBigQueryUtils.addSpannerPkColumnsToTableRow(
+            keysJsonObject, spannerTable.getPkColumns(), tableRow);
 
         // For "DELETE" mod, we only need to set the key columns.
         if (mod.getModType() == ModType.DELETE) {
@@ -383,8 +375,7 @@ public final class FailsafeModJsonToTableRowTransformer {
         return tableRow;
       }
 
-      // Do a Spanner read to retrieve full row. The schema change is currently not supported. so we
-      // assume the schema isn't changed while the pipeline is running,
+      // Do a Spanner read to retrieve full row. Schema can change while the pipeline is running.
       private void readSpannerRow(
           String spannerTableName,
           com.google.cloud.spanner.Key key,

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/FailsafeModJsonToTableRowTransformer.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/FailsafeModJsonToTableRowTransformer.java
@@ -292,17 +292,14 @@ public final class FailsafeModJsonToTableRowTransformer {
         SpannerToBigQueryUtils.addSpannerPkColumnsToTableRow(
             keysJsonObject, spannerTable.getPkColumns(), tableRow);
 
-        // For "DELETE" mod, we only need to set the key columns.
-        if (mod.getModType() == ModType.DELETE) {
-          return tableRow;
-        }
-
         // Set non-key columns of the tableRow.
         SpannerToBigQueryUtils.addSpannerNonPkColumnsToTableRow(
-            mod.getNewValuesJson(), spannerTable.getNonPkColumns(), tableRow);
+            mod.getNewValuesJson(), spannerTable.getNonPkColumns(), tableRow, mod.getModType());
 
         // For "INSERT" mod, we can get all columns from mod.
-        if (mod.getModType() == ModType.INSERT) {
+        // For "DELETE" mod, we only set the key columns. For all non-key columns, we already
+        // populated "null".
+        if (mod.getModType() == ModType.INSERT || mod.getModType() == ModType.DELETE) {
           return tableRow;
         }
 

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SpannerChangeStreamsToBigQuery.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SpannerChangeStreamsToBigQuery.java
@@ -25,6 +25,7 @@ import com.google.cloud.teleport.v2.coders.FailsafeElementCoder;
 import com.google.cloud.teleport.v2.common.UncaughtExceptionLogger;
 import com.google.cloud.teleport.v2.options.SpannerChangeStreamsToBigQueryOptions;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.Mod;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.ModColumnType;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.BigQueryUtils;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.OptionsUtils;
 import com.google.cloud.teleport.v2.transforms.DLQWriteTransform;
@@ -35,6 +36,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
@@ -209,7 +211,8 @@ public final class SpannerChangeStreamsToBigQuery {
         .equals(BigQueryUtils.BQ_CHANGELOG_FIELD_NAME_TABLE_NAME)) {
       throw new IllegalArgumentException(
           String.format(
-              "bigQueryChangelogTableNameTemplate cannot be set to '{%s}'. This value is reserved for the Cloud Spanner table name.",
+              "bigQueryChangelogTableNameTemplate cannot be set to '{%s}'. This value is reserved"
+                  + " for the Cloud Spanner table name.",
               BigQueryUtils.BQ_CHANGELOG_FIELD_NAME_TABLE_NAME));
     }
 
@@ -386,19 +389,39 @@ public final class SpannerChangeStreamsToBigQuery {
                 .setBigQueryTableTemplate(options.getBigQueryChangelogTableNameTemplate())
                 .setUseStorageWriteApi(options.getUseStorageWriteApi())
                 .build();
-    WriteResult writeResult =
-        tableRowTuple
-            .get(failsafeModJsonToTableRow.transformOut)
-            .apply(
-                "Write To BigQuery",
-                BigQueryIO.<TableRow>write()
-                    .to(BigQueryDynamicDestinations.of(bigQueryDynamicDestinationsOptions))
-                    .withFormatFunction(element -> removeIntermediateMetadataFields(element))
-                    .withFormatRecordOnFailureFunction(element -> element)
-                    .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
-                    .withWriteDisposition(Write.WriteDisposition.WRITE_APPEND)
-                    .withExtendedErrorInfo()
-                    .withFailedInsertRetryPolicy(InsertRetryPolicy.retryTransientErrors()));
+    WriteResult writeResult;
+    if (!options.getUseStorageWriteApi()) {
+      writeResult =
+          tableRowTuple
+              .get(failsafeModJsonToTableRow.transformOut)
+              .apply(
+                  "Write To BigQuery",
+                  BigQueryIO.<TableRow>write()
+                      .to(BigQueryDynamicDestinations.of(bigQueryDynamicDestinationsOptions))
+                      .withFormatFunction(element -> removeIntermediateMetadataFields(element))
+                      .withFormatRecordOnFailureFunction(element -> element)
+                      .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
+                      .withWriteDisposition(Write.WriteDisposition.WRITE_APPEND)
+                      .withExtendedErrorInfo()
+                      .withFailedInsertRetryPolicy(InsertRetryPolicy.retryTransientErrors()));
+    } else {
+      writeResult =
+          tableRowTuple
+              .get(failsafeModJsonToTableRow.transformOut)
+              .apply(
+                  "Write To BigQuery",
+                  BigQueryIO.<TableRow>write()
+                      .to(BigQueryDynamicDestinations.of(bigQueryDynamicDestinationsOptions))
+                      .withFormatFunction(element -> removeIntermediateMetadataFields(element))
+                      .withFormatRecordOnFailureFunction(element -> element)
+                      .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
+                      .withWriteDisposition(Write.WriteDisposition.WRITE_APPEND)
+                      .ignoreUnknownValues()
+                      .withAutoSchemaUpdate(true) // only supported when using STORAGE_WRITE_API or
+                      // STORAGE_API_AT_LEAST_ONCE.
+                      .withExtendedErrorInfo()
+                      .withFailedInsertRetryPolicy(InsertRetryPolicy.retryTransientErrors()));
+    }
 
     PCollection<String> transformDlqJson =
         tableRowTuple
@@ -455,7 +478,7 @@ public final class SpannerChangeStreamsToBigQuery {
             ? tempLocation + "dlq/"
             : options.getDeadLetterQueueDirectory();
 
-    LOG.info("Dead letter queue directory: {}", dlqDirectory);
+    LOG.info("Dead letter queue directory: {}" + dlqDirectory);
     return DeadLetterQueueManager.create(dlqDirectory, DLQ_MAX_RETRIES);
   }
 
@@ -471,6 +494,8 @@ public final class SpannerChangeStreamsToBigQuery {
     for (String rowKey : rowKeys) {
       if (metadataFields.contains(rowKey)) {
         cleanTableRow.remove(rowKey);
+      } else if (rowKeys.contains("_type_" + rowKey)) {
+        cleanTableRow.remove("_type_" + rowKey);
       }
     }
 
@@ -496,6 +521,7 @@ public final class SpannerChangeStreamsToBigQuery {
                 input.isLastRecordInTransactionInPartition(),
                 input.getRecordSequence(),
                 input.getTableName(),
+                input.getRowType().stream().map(ModColumnType::new).collect(Collectors.toList()),
                 input.getModType(),
                 input.getValueCaptureType(),
                 input.getNumberOfRecordsInTransaction(),

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SpannerChangeStreamsToBigQuery.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SpannerChangeStreamsToBigQuery.java
@@ -478,7 +478,7 @@ public final class SpannerChangeStreamsToBigQuery {
             ? tempLocation + "dlq/"
             : options.getDeadLetterQueueDirectory();
 
-    LOG.info("Dead letter queue directory: {}" + dlqDirectory);
+    LOG.info("Dead letter queue directory: {}", dlqDirectory);
     return DeadLetterQueueManager.create(dlqDirectory, DLQ_MAX_RETRIES);
   }
 

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/model/ModColumnType.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/model/ModColumnType.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.coders.DefaultCoder;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.ColumnType;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.TypeCode;
+import org.apache.beam.sdk.schemas.SchemaCoder;
+import org.apache.beam.sdk.schemas.annotations.SchemaCreate;
+
+/**
+ * Defines a column type from a Cloud Spanner table with the following information: column name,
+ * column type, flag indicating if column is primary key and column position in the table. These
+ * information are from {@link org.apache.beam.sdk.io.gcp.spanner.changestreams.model.ColumnType}
+ * class, which can't be reused due to JSON parsing error in {@link
+ * FailsafeModJsonToTableRowTransformer}.
+ */
+@SuppressWarnings("initialization.fields.uninitialized") // Avro requires the default constructor
+@DefaultCoder(SchemaCoder.class)
+public class ModColumnType implements Serializable {
+
+  // NOTE: UID not in use, though no specific guide was followed in assigning this value. This is an
+  // arbitrary value.
+  private static final long serialVersionUID = 8703257194338184300L;
+
+  private String name;
+  private TypeCode type;
+  private boolean isPrimaryKey;
+  private long ordinalPosition;
+
+  /** Default constructor for serialization only. */
+  private ModColumnType() {}
+
+  @SchemaCreate
+  public ModColumnType(String name, TypeCode type, boolean primaryKey, long ordinalPosition) {
+    this.name = name;
+    this.type = type;
+    this.isPrimaryKey = primaryKey;
+    this.ordinalPosition = ordinalPosition;
+  }
+
+  public ModColumnType(ColumnType columnType) {
+    this(
+        columnType.getName(),
+        columnType.getType(),
+        columnType.isPrimaryKey(),
+        columnType.getOrdinalPosition());
+  }
+
+  /** The name of the column. */
+  public String getName() {
+    return name;
+  }
+
+  /** The type of the column. */
+  public TypeCode getType() {
+    return type;
+  }
+
+  /** True if the column is part of the primary key, false otherwise. */
+  public boolean getIsPrimaryKey() {
+    return isPrimaryKey;
+  }
+
+  /** The position of the column in the table. */
+  public long getOrdinalPosition() {
+    return ordinalPosition;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ModColumnType)) {
+      return false;
+    }
+    ModColumnType that = (ModColumnType) o;
+    return isPrimaryKey == that.isPrimaryKey
+        && ordinalPosition == that.ordinalPosition
+        && Objects.equals(name, that.name)
+        && Objects.equals(type, that.type);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, type, isPrimaryKey, ordinalPosition);
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "ModColumnType{name='%s', type=%s, isPrimaryKey=%s, ordinalPosition=%s}",
+        name, type, isPrimaryKey, ordinalPosition);
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/OptionsUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/OptionsUtils.java
@@ -29,7 +29,6 @@ public class OptionsUtils {
       SpannerChangeStreamsToBigQueryOptions options) {
     String bigqueryProjectId = options.getBigQueryProjectId();
     String bigqueryDataset = options.getBigQueryDataset();
-    LOG.info("===bigqueryDataset: " + bigqueryDataset);
     int datasetStartPos = bigqueryDataset.indexOf(".");
     if (datasetStartPos != -1) {
       String inferredBigQueryProjectId = bigqueryDataset.substring(0, datasetStartPos);

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SchemaUpdateUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SchemaUpdateUtils.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.Mod;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.ModColumnType;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.TrackedSpannerColumn;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.TrackedSpannerTable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.ValueCaptureType;
+import org.json.JSONObject;
+
+/**
+ * The {@link SchemaUpdateUtils} provides methods that detects schema updates and updates stored
+ * schema information.
+ */
+public class SchemaUpdateUtils {
+
+  // Detect if there's a table/column difference between the mod and the stored map.
+  public static boolean detectDiffColumnInMod(
+      Mod mod, Map<String, TrackedSpannerTable> spannerTableByName) {
+    TrackedSpannerTable spannerTable = spannerTableByName.get(mod.getTableName());
+    Set<String> keySetOfNewValuesJsonObject =
+        mod.getNewValuesJson() == ""
+            ? new JSONObject("{}").keySet()
+            : new JSONObject(mod.getNewValuesJson()).keySet();
+    // At this mod's spannerCommitTimestamp, one column is added/dropped.
+    if (spannerTable.getNonPkColumns().size() != keySetOfNewValuesJsonObject.size()) {
+      return true;
+    }
+    Set<String> nonPkColumnsNamesSet = spannerTable.getNonPkColumnsNamesSet();
+    // Returns true if the stored schema doesn't contain a column in the mod
+    return !nonPkColumnsNamesSet.containsAll(keySetOfNewValuesJsonObject);
+  }
+
+  // Update the stored schema information (spannerTableByName) by fetching from the mod.
+  public static void updateStoredSchemaNewRow(
+      Mod mod, Map<String, TrackedSpannerTable> spannerTableByName, Dialect dialect) {
+    JSONObject keysJsonObject = new JSONObject(mod.getKeysJson());
+    JSONObject newValuesJsonObject =
+        mod.getNewValuesJson() == ""
+            ? new JSONObject("{}")
+            : new JSONObject(mod.getNewValuesJson());
+    String spannerTableName = mod.getTableName();
+    Map<String, ModColumnType> modColumnTypeMap = mod.getRowTypeAsMap();
+    // Create a new table for spannerTableName if it's not in spannerTableByName.
+    if (!spannerTableByName.containsKey(spannerTableName)) {
+      // Create an empty list of pk columns for the new table.
+      List<TrackedSpannerColumn> pkColumns = new ArrayList<>();
+      // Create an empty list of non-pk columns for the new table.
+      List<TrackedSpannerColumn> nonPkColumns = new ArrayList<>();
+      // Introduce the new table into spannerTableByName.
+      TrackedSpannerTable spannerTableObj =
+          new TrackedSpannerTable(spannerTableName, pkColumns, nonPkColumns);
+      spannerTableByName.put(spannerTableName, spannerTableObj);
+      // Populate pk columns from Mod to TrackedSpannerTable.
+      for (String pkColumnName : keysJsonObject.keySet()) {
+        ModColumnType spannerColumn = modColumnTypeMap.get(pkColumnName);
+        String typeStr =
+            TypesUtils.extractTypeFromTypeCode(new JSONObject(spannerColumn.getType().getCode()));
+        spannerTableByName
+            .get(spannerTableName)
+            .addTrackedSpannerColumn(
+                pkColumnName, typeStr, -1, (int) spannerColumn.getOrdinalPosition(), dialect);
+      }
+    }
+
+    // Populate nonPkColumns from Mod to TrackedSpannerTable.
+    Set<String> nonPkColumnsSet =
+        spannerTableByName.get(spannerTableName).getNonPkColumnsNamesSet();
+    for (String nonPkColumnName : newValuesJsonObject.keySet()) {
+      if (!nonPkColumnsSet.contains(nonPkColumnName)) {
+        ModColumnType spannerColumn = modColumnTypeMap.get(nonPkColumnName);
+        String typeStr =
+            TypesUtils.extractTypeFromTypeCode(new JSONObject(spannerColumn.getType().getCode()));
+        spannerTableByName
+            .get(spannerTableName)
+            .addTrackedSpannerColumn(
+                spannerColumn.getName(),
+                typeStr,
+                (int) spannerColumn.getOrdinalPosition(),
+                -1,
+                dialect);
+      }
+    }
+  }
+
+  // For NEW_VALUES and OLD_AND_NEW_VALUES, update the stored schema information by looking up
+  // INFORMATION_SCHEMA at the mod's commit timestamp.
+  // For NEW_ROW, update the stored schema information by fetching from the mod.
+  public static Map<String, TrackedSpannerTable> updateStoredSchemaIfNeeded(
+      SpannerAccessor spannerAccessor,
+      String spannerChangeStream,
+      Dialect dialect,
+      Mod mod,
+      Map<String, TrackedSpannerTable> spannerTableByName) {
+    if (!spannerTableByName.containsKey(mod.getTableName())
+        || SchemaUpdateUtils.detectDiffColumnInMod(mod, spannerTableByName)) {
+      if (mod.getValueCaptureType() != ValueCaptureType.NEW_ROW) {
+        com.google.cloud.Timestamp spannerCommitTimestamp =
+            com.google.cloud.Timestamp.ofTimeSecondsAndNanos(
+                mod.getCommitTimestampSeconds(), mod.getCommitTimestampNanos());
+        // TODO:b/322630434 Consider updating the schema only for one table at a time.
+        spannerTableByName =
+            new SpannerChangeStreamsUtils(
+                    spannerAccessor.getDatabaseClient(),
+                    spannerChangeStream,
+                    dialect,
+                    spannerCommitTimestamp)
+                .getSpannerTableByName();
+      } else {
+        updateStoredSchemaNewRow(mod, spannerTableByName, dialect);
+      }
+    }
+    return spannerTableByName;
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SpannerChangeStreamsUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SpannerChangeStreamsUtils.java
@@ -16,11 +16,13 @@
 package com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils;
 
 import com.google.api.services.bigquery.model.TableRow;
+import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.Mod;
@@ -63,12 +65,19 @@ public class SpannerChangeStreamsUtils {
   private DatabaseClient databaseClient;
   private String changeStreamName;
   private Dialect dialect;
+  private Timestamp bound;
 
   public SpannerChangeStreamsUtils(
-      DatabaseClient databaseClient, String changeStreamName, Dialect dialect) {
+      DatabaseClient databaseClient, String changeStreamName, Dialect dialect, Timestamp bound) {
     this.databaseClient = databaseClient;
     this.changeStreamName = changeStreamName;
     this.dialect = dialect;
+    this.bound = bound;
+  }
+
+  public SpannerChangeStreamsUtils(
+      DatabaseClient databaseClient, String changeStreamName, Dialect dialect) {
+    this(databaseClient, changeStreamName, dialect, null);
   }
 
   /**
@@ -158,7 +167,11 @@ public class SpannerChangeStreamsUtils {
     }
 
     try (ResultSet columnsResultSet =
-        databaseClient.singleUse().executeQuery(statementBuilder.build())) {
+        bound != null
+            ? databaseClient
+                .singleUse(TimestampBound.ofReadTimestamp(bound))
+                .executeQuery(statementBuilder.build())
+            : databaseClient.singleUse().executeQuery(statementBuilder.build())) {
       while (columnsResultSet.next()) {
         String tableName = columnsResultSet.getString(informationSchemaTableName());
         String columnName = columnsResultSet.getString(informationSchemaColumnName());
@@ -257,7 +270,11 @@ public class SpannerChangeStreamsUtils {
     }
 
     try (ResultSet keyColumnsResultSet =
-        databaseClient.singleUse().executeQuery(statementBuilder.build())) {
+        bound != null
+            ? databaseClient
+                .singleUse(TimestampBound.ofReadTimestamp(bound))
+                .executeQuery(statementBuilder.build())
+            : databaseClient.singleUse().executeQuery(statementBuilder.build())) {
       while (keyColumnsResultSet.next()) {
         String tableName = keyColumnsResultSet.getString(informationSchemaTableName());
         String columnName = keyColumnsResultSet.getString(informationSchemaColumnName());
@@ -320,7 +337,12 @@ public class SpannerChangeStreamsUtils {
     }
 
     Set<String> result = new HashSet<>();
-    try (ResultSet resultSet = databaseClient.singleUse().executeQuery(statementBuilder.build())) {
+    try (ResultSet resultSet =
+        bound != null
+            ? databaseClient
+                .singleUse(TimestampBound.ofReadTimestamp(bound))
+                .executeQuery(statementBuilder.build())
+            : databaseClient.singleUse().executeQuery(statementBuilder.build())) {
 
       while (resultSet.next()) {
         result.add(resultSet.getString(informationSchemaTableName()));
@@ -357,7 +379,12 @@ public class SpannerChangeStreamsUtils {
 
       statementBuilder = Statement.newBuilder(sql).bind("changeStreamName").to(changeStreamName);
     }
-    try (ResultSet resultSet = databaseClient.singleUse().executeQuery(statementBuilder.build())) {
+    try (ResultSet resultSet =
+        bound != null
+            ? databaseClient
+                .singleUse(TimestampBound.ofReadTimestamp(bound))
+                .executeQuery(statementBuilder.build())
+            : databaseClient.singleUse().executeQuery(statementBuilder.build())) {
       while (resultSet.next()) {
         if (this.isPostgres()) {
           String resultString = resultSet.getString(informationSchemaAll());
@@ -410,7 +437,12 @@ public class SpannerChangeStreamsUtils {
       statementBuilder = Statement.newBuilder(sql).bind("changeStreamName").to(changeStreamName);
     }
 
-    try (ResultSet resultSet = databaseClient.singleUse().executeQuery(statementBuilder.build())) {
+    try (ResultSet resultSet =
+        bound != null
+            ? databaseClient
+                .singleUse(TimestampBound.ofReadTimestamp(bound))
+                .executeQuery(statementBuilder.build())
+            : databaseClient.singleUse().executeQuery(statementBuilder.build())) {
 
       while (resultSet.next()) {
         String tableName = resultSet.getString(informationSchemaTableName());
@@ -433,107 +465,9 @@ public class SpannerChangeStreamsUtils {
 
   private Type informationSchemaTypeToSpannerType(String type) {
     if (this.isPostgres()) {
-      return informationSchemaPostgreSQLTypeToSpannerType(type);
+      return TypesUtils.informationSchemaPostgreSQLTypeToSpannerType(type);
     }
-    return informationSchemaGoogleSQLTypeToSpannerType(type);
-  }
-
-  private Type informationSchemaGoogleSQLTypeToSpannerType(String type) {
-    type = cleanInformationSchemaType(type);
-    switch (type) {
-      case "BOOL":
-        return Type.bool();
-      case "BYTES":
-        return Type.bytes();
-      case "DATE":
-        return Type.date();
-      case "FLOAT32":
-        return Type.float32();
-      case "FLOAT64":
-        return Type.float64();
-      case "INT64":
-        return Type.int64();
-      case "JSON":
-        return Type.json();
-      case "NUMERIC":
-        return Type.numeric();
-      case "STRING":
-        return Type.string();
-      case "TIMESTAMP":
-        return Type.timestamp();
-      default:
-        if (type.startsWith("ARRAY")) {
-          // Get array type, e.g. "ARRAY<STRING>" -> "STRING".
-          String spannerArrayType = type.substring(6, type.length() - 1);
-          Type itemType = informationSchemaGoogleSQLTypeToSpannerType(spannerArrayType);
-          return Type.array(itemType);
-        }
-
-        throw new IllegalArgumentException(String.format("Unsupported Spanner type: %s", type));
-    }
-  }
-
-  private Type informationSchemaPostgreSQLTypeToSpannerType(String type) {
-    boolean isPostgresArray = isPostgresArray(type);
-    String cleanedType = "";
-    if (isPostgresArray) {
-      cleanedType = type.substring(0, type.length() - 2);
-      Type itemType = informationSchemaPostgreSQLTypeToSpannerType(cleanedType);
-      return Type.array(itemType);
-    } else {
-      cleanedType = cleanInformationSchemaType(type);
-    }
-
-    switch (cleanedType) {
-      case "BOOLEAN":
-        return Type.bool();
-      case "BYTEA":
-        return Type.bytes();
-      case "REAL":
-        return Type.float32();
-      case "DOUBLE PRECISION":
-        return Type.float64();
-      case "BIGINT":
-        return Type.int64();
-      case "DATE":
-        return Type.date();
-      case "JSONB":
-        return Type.pgJsonb();
-      case "NUMERIC":
-        return Type.pgNumeric();
-      case "CHARACTER VARYING":
-        return Type.string();
-      case "TIMESTAMP WITH TIME ZONE":
-        return Type.timestamp();
-      case "SPANNER.COMMIT_TIMESTAMP":
-        return Type.timestamp();
-      default:
-        throw new IllegalArgumentException(
-            String.format("Unsupported Spanner PostgreSQL type: %s", type));
-    }
-  }
-
-  private boolean isPostgresArray(String type) {
-    return type.endsWith("[]");
-  }
-
-  /**
-   * Remove the Spanner type length limit, since Spanner doesn't document clearly on the
-   * parameterized types like BigQuery does, i.e. BigQuery's docmentation on <a
-   * href="https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#parameterized_data_types">Parameterized
-   * data types</a>, but Spanner doesn't have a similar one. We might have problem if we transfer
-   * the length limit into BigQuery. By removing the length limit, we essentially loose the
-   * constraint of data written to BigQuery, and it won't cause errors.
-   */
-  private String cleanInformationSchemaType(String type) {
-    // Remove type size, e.g. STRING(1024) -> STRING.
-    int leftParenthesisIdx = type.indexOf('(');
-    if (leftParenthesisIdx != -1) {
-      type = type.substring(0, leftParenthesisIdx) + type.substring(type.indexOf(')') + 1);
-    }
-
-    // Convert it to upper case.
-    return type.toUpperCase();
+    return TypesUtils.informationSchemaGoogleSQLTypeToSpannerType(type);
   }
 
   public static void appendToSpannerKey(

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SpannerToBigQueryUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SpannerToBigQueryUtils.java
@@ -83,6 +83,7 @@ public class SpannerToBigQueryUtils {
       throw new IllegalArgumentException(String.format("Unsupported Spanner type: %s", type));
     }
   }
+
   private static TableFieldSchema tableRowColumnsToBigQueryIOField(String name, String type) {
     TableFieldSchema bigQueryField =
         new TableFieldSchema().setName(name).setMode(Field.Mode.REPEATED.name());
@@ -92,6 +93,7 @@ public class SpannerToBigQueryUtils {
           "BYTES",
           "DATE",
           "FLOAT64",
+          "FLOAT32",
           "INT64",
           "JSON",
           "NUMERIC",
@@ -108,6 +110,9 @@ public class SpannerToBigQueryUtils {
           bigQueryField.setType("STRING");
         } else if (arrayItemType.equals("PG_JSONB")) {
           bigQueryField.setType("JSON");
+        } else if (arrayItemType.equals("FLOAT32")) {
+          // BigQuery does not support the FLOAT32 type.
+          bigQueryField.setType("FLOAT64");
         } else {
           bigQueryField.setType(arrayItemType);
         }
@@ -127,6 +132,9 @@ public class SpannerToBigQueryUtils {
           bigQueryField.setType("STRING");
         } else if (type.equals("PG_JSONB")) {
           bigQueryField.setType("JSON");
+        } else if (type.equals("FLOAT32")) {
+          // BigQuery does not support the FLOAT32 type.
+          bigQueryField.setType("FLOAT64");
         } else {
           bigQueryField.setType(type);
         }

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SpannerToBigQueryUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SpannerToBigQueryUtils.java
@@ -18,63 +18,103 @@ package com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.sc
 import com.google.api.services.bigquery.model.TableFieldSchema;
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.cloud.bigquery.Field;
-import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.TrackedSpannerColumn;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link SpannerToBigQueryUtils} provides methods that convert Spanner types to BigQuery types.
  */
 public class SpannerToBigQueryUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(SpannerToBigQueryUtils.class);
 
-  public static List<TableFieldSchema> spannerColumnsToBigQueryIOFields(
-      List<TrackedSpannerColumn> spannerColumns) {
-    final List<TableFieldSchema> bigQueryFields = new ArrayList<>(spannerColumns.size());
-    for (TrackedSpannerColumn spannerColumn : spannerColumns) {
-      bigQueryFields.add(spannerColumnToBigQueryIOField(spannerColumn));
+  // Convert user columns in TableRow to BigQueryIO TableFieldSchema.
+  public static List<TableFieldSchema> tableRowColumnsToBigQueryIOFields(
+      TableRow tableRow, boolean useStorageWriteApi) {
+    // Filter out the metadataColumns in building TableFieldSchema for user column tables in
+    // tableRowColumnsToBigQueryIOFields().
+    HashSet<String> metadataColumns =
+        new HashSet<>(
+            Arrays.asList(
+                BigQueryUtils.BQ_CHANGELOG_FIELD_NAME_MOD_TYPE,
+                BigQueryUtils.BQ_CHANGELOG_FIELD_NAME_TABLE_NAME,
+                BigQueryUtils.BQ_CHANGELOG_FIELD_NAME_SPANNER_COMMIT_TIMESTAMP,
+                BigQueryUtils.BQ_CHANGELOG_FIELD_NAME_SERVER_TRANSACTION_ID,
+                BigQueryUtils.BQ_CHANGELOG_FIELD_NAME_RECORD_SEQUENCE,
+                BigQueryUtils.BQ_CHANGELOG_FIELD_NAME_IS_LAST_RECORD_IN_TRANSACTION_IN_PARTITION,
+                BigQueryUtils.BQ_CHANGELOG_FIELD_NAME_NUMBER_OF_RECORDS_IN_TRANSACTION,
+                BigQueryUtils.BQ_CHANGELOG_FIELD_NAME_NUMBER_OF_PARTITIONS_IN_TRANSACTION));
+    if (!useStorageWriteApi) {
+      metadataColumns.add(BigQueryUtils.BQ_CHANGELOG_FIELD_NAME_BIGQUERY_COMMIT_TIMESTAMP);
     }
-
+    List<TableFieldSchema> bigQueryFields = new ArrayList<>();
+    for (String colName : tableRow.keySet()) {
+      // Only create TableFieldSchema for user columns which has type information stored in the
+      // TableRow as well.
+      if (!metadataColumns.contains(colName) && tableRow.containsKey("_type_" + colName)) {
+        bigQueryFields.add(
+            tableRowColumnsToBigQueryIOField(colName, (String) tableRow.get("_type_" + colName)));
+      }
+    }
     return bigQueryFields;
   }
 
-  private static TableFieldSchema spannerColumnToBigQueryIOField(
-      TrackedSpannerColumn spannerColumn) {
+  private static void setBigQueryFieldType(
+      Set<String> supportedTypes, TableFieldSchema bigQueryField, String type) {
+    if (supportedTypes.contains(type)) {
+      bigQueryField.setType(type);
+      if (type.equals("PG_NUMERIC")) {
+        bigQueryField.setType("STRING");
+      } else if (type.equals("PG_JSONB")) {
+        bigQueryField.setType("JSON");
+      }
+    } else {
+      throw new IllegalArgumentException(String.format("Unsupported Spanner type: %s", type));
+    }
+  }
+  private static TableFieldSchema tableRowColumnsToBigQueryIOField(String name, String type) {
     TableFieldSchema bigQueryField =
-        new TableFieldSchema().setName(spannerColumn.getName()).setMode(Field.Mode.REPEATED.name());
-    Type spannerType = spannerColumn.getType();
-
-    if (spannerType.equals(Type.array(Type.bool()))) {
-      bigQueryField.setType("BOOL");
-    } else if (spannerType.equals(Type.array(Type.bytes()))) {
-      bigQueryField.setType("BYTES");
-    } else if (spannerType.equals(Type.array(Type.date()))) {
-      bigQueryField.setType("DATE");
-    } else if (spannerType.equals(Type.array(Type.float32()))) {
-      // BigQuery does not support FLOAT32 type.
-      bigQueryField.setType("FLOAT64");
-    } else if (spannerType.equals(Type.array(Type.float64()))) {
-      bigQueryField.setType("FLOAT64");
-    } else if (spannerType.equals(Type.array(Type.int64()))) {
-      bigQueryField.setType("INT64");
-    } else if (spannerType.equals(Type.array(Type.json()))) {
-      bigQueryField.setType("JSON");
-    } else if (spannerType.equals(Type.array(Type.numeric()))) {
-      bigQueryField.setType("NUMERIC");
-    } else if (spannerType.equals(Type.array(Type.pgNumeric()))) {
-      bigQueryField.setType("STRING");
-    } else if (spannerType.equals(Type.array(Type.pgJsonb()))) {
-      bigQueryField.setType("JSON");
-    } else if (spannerType.equals(Type.array(Type.string()))) {
-      bigQueryField.setType("STRING");
-    } else if (spannerType.equals(Type.array(Type.timestamp()))) {
-      bigQueryField.setType("TIMESTAMP");
+        new TableFieldSchema().setName(name).setMode(Field.Mode.REPEATED.name());
+    String[] supportedTypesArr =
+        new String[] {
+          "BOOL",
+          "BYTES",
+          "DATE",
+          "FLOAT64",
+          "INT64",
+          "JSON",
+          "NUMERIC",
+          "PG_NUMERIC",
+          "PG_JSONB",
+          "STRING",
+          "TIMESTAMP"
+        };
+    Set<String> supportedTypes = Set.of(supportedTypesArr);
+    if (type.startsWith("ARRAY")) {
+      String arrayItemType = type.substring(6, type.length() - 1);
+      if (supportedTypes.contains(arrayItemType)) {
+        if (arrayItemType.equals("PG_NUMERIC")) {
+          bigQueryField.setType("STRING");
+        } else if (arrayItemType.equals("PG_JSONB")) {
+          bigQueryField.setType("JSON");
+        } else {
+          bigQueryField.setType(arrayItemType);
+        }
+      } else {
+        throw new IllegalArgumentException(
+            String.format("Unsupported Spanner type: %s", arrayItemType));
+      }
     } else {
       // Set NULLABLE for all non-array types, since we only insert primary key columns for deleted
       // rows, which leaves non-primary key columns always null.
@@ -82,50 +122,17 @@ public class SpannerToBigQueryUtils {
       // set the same field to NOT NULL in BigQuery, when we delete the Spanner row, we will not
       // populate "FirstName" field in BigQuery, which violates the constraints.
       bigQueryField.setMode(Field.Mode.NULLABLE.name());
-      StandardSQLTypeName bigQueryType;
-      switch (spannerType.getCode()) {
-        case BOOL:
-          bigQueryType = StandardSQLTypeName.BOOL;
-          break;
-        case BYTES:
-          bigQueryType = StandardSQLTypeName.BYTES;
-          break;
-        case DATE:
-          bigQueryType = StandardSQLTypeName.DATE;
-          break;
-        case FLOAT32:
-          // BigQuery does not support the FLOAT32 type.
-          bigQueryType = StandardSQLTypeName.FLOAT64;
-          break;
-        case FLOAT64:
-          bigQueryType = StandardSQLTypeName.FLOAT64;
-          break;
-        case INT64:
-          bigQueryType = StandardSQLTypeName.INT64;
-          break;
-        case JSON:
-          bigQueryType = StandardSQLTypeName.JSON;
-          break;
-        case NUMERIC:
-          bigQueryType = StandardSQLTypeName.NUMERIC;
-          break;
-        case PG_NUMERIC:
-          bigQueryType = StandardSQLTypeName.STRING;
-          break;
-        case PG_JSONB:
-          bigQueryType = StandardSQLTypeName.JSON;
-          break;
-        case STRING:
-          bigQueryType = StandardSQLTypeName.STRING;
-          break;
-        case TIMESTAMP:
-          bigQueryType = StandardSQLTypeName.TIMESTAMP;
-          break;
-        default:
-          throw new IllegalArgumentException(
-              String.format("Unsupported Spanner type: %s", spannerType));
+      if (supportedTypes.contains(type)) {
+        if (type.equals("PG_NUMERIC")) {
+          bigQueryField.setType("STRING");
+        } else if (type.equals("PG_JSONB")) {
+          bigQueryField.setType("JSON");
+        } else {
+          bigQueryField.setType(type);
+        }
+      } else {
+        throw new IllegalArgumentException(String.format("Unsupported Spanner type: %s", type));
       }
-      bigQueryField.setType(bigQueryType.name());
     }
 
     return bigQueryField;
@@ -229,17 +236,46 @@ public class SpannerToBigQueryUtils {
     return list.stream().filter(Objects::nonNull).collect(Collectors.toList());
   }
 
+  public static void addSpannerPkColumnsToTableRow(
+      JSONObject keysJsonObject, List<TrackedSpannerColumn> spannerPkColumns, TableRow tableRow) {
+    for (TrackedSpannerColumn spannerColumn : spannerPkColumns) {
+      String spannerColumnName = spannerColumn.getName();
+      if (keysJsonObject.has(spannerColumnName)) {
+        tableRow.set(spannerColumnName, keysJsonObject.get(spannerColumnName));
+        tableRow.set("_type_" + spannerColumnName, spannerColumn.getType().toString());
+      } else {
+        throw new IllegalArgumentException("Cannot find value for key column " + spannerColumnName);
+      }
+    }
+  }
+
+  public static String cleanSpannerType(String typeStr) {
+    // Remove type annotation, e.g. NUMERIC<PG_NUMERIC> -> NUMERIC; ARRAY<NUMERIC<PG_NUMERIC>> ->
+    // ARRAY<NUMERIC>
+    if (typeStr.startsWith("ARRAY")) {
+      String arrayItemType = typeStr.substring(6, typeStr.length() - 1);
+      return "ARRAY<" + cleanSpannerType(arrayItemType) + ">";
+    } else {
+      int idx = typeStr.indexOf("<");
+      if (idx != -1) {
+        typeStr = typeStr.substring(0, idx);
+      }
+    }
+    return typeStr;
+  }
+
   public static void addSpannerNonPkColumnsToTableRow(
       String newValuesJson, List<TrackedSpannerColumn> spannerNonPkColumns, TableRow tableRow) {
     JSONObject newValuesJsonObject = new JSONObject(newValuesJson);
     for (TrackedSpannerColumn spannerColumn : spannerNonPkColumns) {
       String columnName = spannerColumn.getName();
       Type columnType = spannerColumn.getType();
-      if (!newValuesJsonObject.has(columnName) || newValuesJsonObject.isNull(columnName)) {
+      if (!newValuesJsonObject.has(columnName)) {
         continue;
       }
-
-      if (columnType.equals(Type.array(Type.bool()))
+      if (newValuesJsonObject.isNull(columnName)) {
+        tableRow.set(columnName, null);
+      } else if (columnType.equals(Type.array(Type.bool()))
           || columnType.equals(Type.array(Type.bytes()))
           || columnType.equals(Type.array(Type.date()))
           || columnType.equals(Type.array(Type.float32()))
@@ -263,6 +299,7 @@ public class SpannerToBigQueryUtils {
       } else {
         tableRow.set(columnName, newValuesJsonObject.get(columnName));
       }
+      tableRow.set("_type_" + columnName, cleanSpannerType(columnType.toString()));
     }
   }
 }

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/TypesUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/TypesUtils.java
@@ -33,6 +33,8 @@ public class TypesUtils {
         return Type.bytes();
       case "DATE":
         return Type.date();
+      case "FLOAT32":
+        return Type.float32();
       case "FLOAT64":
         return Type.float64();
       case "INT64":
@@ -73,6 +75,8 @@ public class TypesUtils {
         return Type.bool();
       case "BYTEA":
         return Type.bytes();
+      case "REAL":
+        return Type.float32();
       case "DOUBLE PRECISION":
         return Type.float64();
       case "BIGINT":

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/TypesUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/TypesUtils.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils;
+
+import com.google.cloud.spanner.Type;
+import org.json.JSONObject;
+
+/**
+ * The {@link TypesUtils} provides methods that converts information schema types to spanner types,
+ * extracts data types from Mod, and converts the extracted data types to spanner types.
+ */
+public class TypesUtils {
+
+  public static Type informationSchemaGoogleSQLTypeToSpannerType(String type) {
+    type = cleanInformationSchemaType(type);
+    switch (type) {
+      case "BOOL":
+        return Type.bool();
+      case "BYTES":
+        return Type.bytes();
+      case "DATE":
+        return Type.date();
+      case "FLOAT64":
+        return Type.float64();
+      case "INT64":
+        return Type.int64();
+      case "JSON":
+        return Type.json();
+      case "NUMERIC":
+        return Type.numeric();
+      case "STRING":
+        return Type.string();
+      case "TIMESTAMP":
+        return Type.timestamp();
+      default:
+        if (type.startsWith("ARRAY")) {
+          // Get array type, e.g. "ARRAY<STRING>" -> "STRING".
+          String spannerArrayType = type.substring(6, type.length() - 1);
+          Type itemType = informationSchemaGoogleSQLTypeToSpannerType(spannerArrayType);
+          return Type.array(itemType);
+        }
+
+        throw new IllegalArgumentException(String.format("Unsupported Spanner type: %s", type));
+    }
+  }
+
+  public static Type informationSchemaPostgreSQLTypeToSpannerType(String type) {
+    boolean isPostgresArray = isPostgresArray(type);
+    String cleanedType = "";
+    if (isPostgresArray) {
+      cleanedType = type.substring(0, type.length() - 2);
+      Type itemType = informationSchemaPostgreSQLTypeToSpannerType(cleanedType);
+      return Type.array(itemType);
+    } else {
+      cleanedType = cleanInformationSchemaType(type);
+    }
+
+    switch (cleanedType) {
+      case "BOOLEAN":
+        return Type.bool();
+      case "BYTEA":
+        return Type.bytes();
+      case "DOUBLE PRECISION":
+        return Type.float64();
+      case "BIGINT":
+        return Type.int64();
+      case "DATE":
+        return Type.date();
+      case "JSONB":
+        return Type.pgJsonb();
+      case "NUMERIC":
+        return Type.pgNumeric();
+      case "CHARACTER VARYING":
+        return Type.string();
+      case "TIMESTAMP WITH TIME ZONE":
+        return Type.timestamp();
+      case "SPANNER.COMMIT_TIMESTAMP":
+        return Type.timestamp();
+      default:
+        throw new IllegalArgumentException(
+            String.format("Unsupported Spanner PostgreSQL type: %s", type));
+    }
+  }
+
+  private static boolean isPostgresArray(String type) {
+    return type.endsWith("[]");
+  }
+
+  /**
+   * Remove the Spanner type length limit, since Spanner doesn't document clearly on the
+   * parameterized types like BigQuery does, i.e. BigQuery's docmentation on <a
+   * href="https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#parameterized_data_types">Parameterized
+   * data types</a>, but Spanner doesn't have a similar one. We might have problem if we transfer
+   * the length limit into BigQuery. By removing the length limit, we essentially loose the
+   * constraint of data written to BigQuery, and it won't cause errors.
+   */
+  private static String cleanInformationSchemaType(String type) {
+    // Remove type size, e.g. STRING(1024) -> STRING.
+    int leftParenthesisIdx = type.indexOf('(');
+    if (leftParenthesisIdx != -1) {
+      type = type.substring(0, leftParenthesisIdx) + type.substring(type.indexOf(')') + 1);
+    }
+
+    // Convert it to upper case.
+    return type.toUpperCase();
+  }
+
+  // Eg 1: "{\"array_element_type\":{\"code\":\"STRING\"},\"code\":\"ARRAY\"}" -> ARRAY<STRING>
+  // Eg 2: "{\"code\":\"STRING\"}" -> STRING
+  public static String extractTypeFromTypeCode(JSONObject typeCodeObj) {
+    if (!typeCodeObj.has("array_element_type")) {
+      return typeCodeObj.getString("code");
+    }
+    return "ARRAY<"
+        + extractTypeFromTypeCode(typeCodeObj.getJSONObject("array_element_type"))
+        + ">";
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/BigQueryDynamicDestinationsTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/BigQueryDynamicDestinationsTest.java
@@ -15,15 +15,64 @@
  */
 package com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery;
 
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.BOOLEAN_ARRAY_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.BOOLEAN_ARRAY_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.BOOLEAN_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.BOOLEAN_PK_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.BOOLEAN_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.BYTES_ARRAY_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.BYTES_ARRAY_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.BYTES_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.BYTES_PK_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.BYTES_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.DATE_ARRAY_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.DATE_ARRAY_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.DATE_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.DATE_PK_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.DATE_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.FLOAT32_ARRAY_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.FLOAT32_ARRAY_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.FLOAT32_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.FLOAT32_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.FLOAT64_ARRAY_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.FLOAT64_ARRAY_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.FLOAT64_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.FLOAT64_PK_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.FLOAT64_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.INT64_ARRAY_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.INT64_ARRAY_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.INT64_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.INT64_PK_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.INT64_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.JSON_ARRAY_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.JSON_ARRAY_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.JSON_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.JSON_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.NUMERIC_ARRAY_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.NUMERIC_ARRAY_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.NUMERIC_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.NUMERIC_PK_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.NUMERIC_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.STRING_ARRAY_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.STRING_ARRAY_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.STRING_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.STRING_PK_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.STRING_RAW_VAL;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.TEST_BIG_QUERY_DATESET;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.TEST_PROJECT;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.TEST_SPANNER_CHANGE_STREAM;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.TEST_SPANNER_TABLE;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.TIMESTAMP_ARRAY_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.TIMESTAMP_ARRAY_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.TIMESTAMP_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.TIMESTAMP_PK_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.TIMESTAMP_RAW_VAL;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.createSpannerDatabase;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.dropSpannerDatabase;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.services.bigquery.model.TableRow;
+import com.google.cloud.Timestamp;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.teleport.v2.spanner.IntegrationTest;
 import com.google.cloud.teleport.v2.spanner.SpannerServerResource;
@@ -52,6 +101,8 @@ public final class BigQueryDynamicDestinationsTest {
   private static TableRow tableRow;
   private static KV<TableId, TableRow> tableIdToTableRow;
   private static String spannerDatabaseName;
+
+  private static final String typePrefix = "_type_";
 
   /** Rule for Spanner server resource. */
   @ClassRule public static final SpannerServerResource SPANNER_SERVER = new SpannerServerResource();
@@ -85,6 +136,66 @@ public final class BigQueryDynamicDestinationsTest {
     dropSpannerDatabase(SPANNER_SERVER, spannerDatabaseName);
   }
 
+  public static void fillTableRow() {
+    tableRow = new TableRow();
+    tableRow.set(BOOLEAN_PK_COL, BOOLEAN_RAW_VAL);
+    tableRow.set("_type_" + BOOLEAN_PK_COL, "BOOL");
+    tableRow.set(BYTES_PK_COL, BYTES_RAW_VAL.toBase64());
+    tableRow.set("_type_" + BYTES_PK_COL, "BYTES");
+    tableRow.set(DATE_PK_COL, DATE_RAW_VAL.toString());
+    tableRow.set("_type_" + DATE_PK_COL, "DATE");
+    tableRow.set(FLOAT64_PK_COL, FLOAT64_RAW_VAL);
+    tableRow.set("_type_" + FLOAT64_PK_COL, "FLOAT64");
+    tableRow.set(INT64_PK_COL, INT64_RAW_VAL);
+    tableRow.set("_type_" + INT64_PK_COL, "INT64");
+    tableRow.set(NUMERIC_PK_COL, 10.0);
+    tableRow.set("_type_" + NUMERIC_PK_COL, "NUMERIC");
+    tableRow.set(STRING_PK_COL, STRING_RAW_VAL);
+    tableRow.set("_type_" + STRING_PK_COL, "STRING");
+    tableRow.set(TIMESTAMP_PK_COL, TIMESTAMP_RAW_VAL.toString());
+    tableRow.set("_type_" + TIMESTAMP_PK_COL, "TIMESTAMP");
+    tableRow.set(BOOLEAN_ARRAY_COL, BOOLEAN_ARRAY_RAW_VAL);
+    tableRow.set("_type_" + BOOLEAN_ARRAY_COL, "ARRAY<BOOL>");
+    tableRow.set(BYTES_ARRAY_COL, BYTES_ARRAY_RAW_VAL);
+    tableRow.set("_type_" + BYTES_ARRAY_COL, "ARRAY<BYTES>");
+    tableRow.set(DATE_ARRAY_COL, DATE_ARRAY_RAW_VAL);
+    tableRow.set("_type_" + DATE_ARRAY_COL, "ARRAY<DATE>");
+    tableRow.set(FLOAT32_ARRAY_COL, FLOAT32_ARRAY_RAW_VAL);
+    tableRow.set("_type_" + FLOAT32_ARRAY_COL, "ARRAY<FLOAT32>");
+    tableRow.set(FLOAT64_ARRAY_COL, FLOAT64_ARRAY_RAW_VAL);
+    tableRow.set("_type_" + FLOAT64_ARRAY_COL, "ARRAY<FLOAT64>");
+    tableRow.set(INT64_ARRAY_COL, INT64_ARRAY_RAW_VAL);
+    tableRow.set("_type_" + INT64_ARRAY_COL, "ARRAY<INT64>");
+    tableRow.set(JSON_ARRAY_COL, JSON_ARRAY_RAW_VAL);
+    tableRow.set("_type_" + JSON_ARRAY_COL, "ARRAY<JSON>");
+    tableRow.set(NUMERIC_ARRAY_COL, NUMERIC_ARRAY_RAW_VAL);
+    tableRow.set("_type_" + NUMERIC_ARRAY_COL, "ARRAY<NUMERIC>");
+    tableRow.set(STRING_ARRAY_COL, STRING_ARRAY_RAW_VAL);
+    tableRow.set("_type_" + STRING_ARRAY_COL, "ARRAY<STRING>");
+    tableRow.set(TIMESTAMP_ARRAY_COL, TIMESTAMP_ARRAY_RAW_VAL);
+    tableRow.set("_type_" + TIMESTAMP_ARRAY_COL, "ARRAY<TIMESTAMP>");
+    tableRow.set(BOOLEAN_COL, BOOLEAN_RAW_VAL);
+    tableRow.set("_type_" + BOOLEAN_COL, "BOOL");
+    tableRow.set(BYTES_COL, BYTES_RAW_VAL.toBase64());
+    tableRow.set("_type_" + BYTES_COL, "BYTES");
+    tableRow.set(DATE_COL, DATE_RAW_VAL.toString());
+    tableRow.set("_type_" + DATE_COL, "DATE");
+    tableRow.set(FLOAT32_COL, FLOAT32_RAW_VAL);
+    tableRow.set("_type_" + FLOAT32_COL, "FLOAT32");
+    tableRow.set(FLOAT64_COL, FLOAT64_RAW_VAL);
+    tableRow.set("_type_" + FLOAT64_COL, "FLOAT64");
+    tableRow.set(INT64_COL, INT64_RAW_VAL);
+    tableRow.set("_type_" + INT64_COL, "INT64");
+    tableRow.set(JSON_COL, JSON_RAW_VAL);
+    tableRow.set("_type_" + JSON_COL, "JSON");
+    tableRow.set(NUMERIC_COL, NUMERIC_RAW_VAL);
+    tableRow.set("_type_" + NUMERIC_COL, "NUMERIC");
+    tableRow.set(STRING_COL, STRING_RAW_VAL);
+    tableRow.set("_type_" + STRING_COL, "STRING");
+    tableRow.set(TIMESTAMP_COL, Timestamp.now().toString());
+    tableRow.set("_type_" + TIMESTAMP_COL, "TIMESTAMP");
+  }
+
   @Test
   public void testGetDestination() {
     Instant timestamp = Instant.ofEpochSecond(1649368685L);
@@ -111,6 +222,11 @@ public final class BigQueryDynamicDestinationsTest {
   // INFORMATION_SCHEMA.
   @Test
   public void testGetSchema() {
+    fillTableRow();
+    tableIdToTableRow =
+        KV.of(
+            TableId.of(TEST_PROJECT, TEST_BIG_QUERY_DATESET, TEST_SPANNER_TABLE + "_changelog"),
+            tableRow);
     String schemaStr = bigQueryDynamicDestinations.getSchema(tableIdToTableRow).toString();
     schemaStr =
         schemaStr.replace(

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/FailsafeModJsonToTableRowTransformerTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/FailsafeModJsonToTableRowTransformerTest.java
@@ -96,6 +96,7 @@ import com.google.cloud.teleport.v2.spanner.SpannerServerResource;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.FailsafeModJsonToTableRowTransformer.FailsafeModJsonToTableRow;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.FailsafeModJsonToTableRowTransformer.FailsafeModJsonToTableRowOptions;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.Mod;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.ModColumnType;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.BigQueryUtils;
 import com.google.cloud.teleport.v2.values.FailsafeElement;
 import com.google.common.collect.ImmutableList;
@@ -105,6 +106,7 @@ import java.util.List;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.ModType;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.TypeCode;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.ValueCaptureType;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestStream;
@@ -156,7 +158,8 @@ public final class FailsafeModJsonToTableRowTransformerTest {
         ValueCaptureType.OLD_AND_NEW_VALUES,
         getKeysJson(),
         getNewValuesJson(insertCommitTimestamp),
-        false);
+        false,
+        getRowType(false));
   }
 
   // Test the case where a TableRow can be constructed from an INSERT Mod when storage write API is
@@ -170,7 +173,8 @@ public final class FailsafeModJsonToTableRowTransformerTest {
         ValueCaptureType.OLD_AND_NEW_VALUES,
         getKeysJson(),
         getNewValuesJson(insertCommitTimestamp),
-        true);
+        true,
+        getRowType(false));
   }
 
   // Test the case where a TableRow can be constructed from an INSERT Mod
@@ -184,7 +188,8 @@ public final class FailsafeModJsonToTableRowTransformerTest {
         ValueCaptureType.NEW_ROW_AND_OLD_VALUES,
         getKeysJson(),
         getNewValuesJson(insertCommitTimestamp),
-        false);
+        false,
+        getRowType(false));
   }
 
   // Test the case where a TableRow can be constructed from an INSERT Mod
@@ -198,7 +203,8 @@ public final class FailsafeModJsonToTableRowTransformerTest {
         ValueCaptureType.NEW_ROW,
         getKeysJson(),
         getNewValuesJson(insertCommitTimestamp),
-        false);
+        false,
+        getRowType(false));
   }
 
   // Test the case where a TableRow can be constructed from an INSERT Mod
@@ -213,7 +219,8 @@ public final class FailsafeModJsonToTableRowTransformerTest {
         ValueCaptureType.NEW_ROW_AND_OLD_VALUES,
         getKeysJson(),
         getNewValuesJson(insertCommitTimestamp),
-        true);
+        true,
+        getRowType(true));
   }
 
   // Test the case where a TableRow can be constructed from an INSERT Mod
@@ -227,22 +234,22 @@ public final class FailsafeModJsonToTableRowTransformerTest {
         ValueCaptureType.NEW_ROW,
         getKeysJson(),
         getNewValuesJson(insertCommitTimestamp),
-        true);
+        true,
+        getRowType(false));
   }
 
   // Test the case where a TableRow can be constructed from a UPDATE Mod.
   @Test
   public void testFailsafeModJsonToTableRowUpdate() throws Exception {
-    String updateNewValuesJson =
-        String.format("{\"TimestampCol\":\"%s\"}", updateCommitTimestamp.toString());
     validateBigQueryRow(
         spannerDatabaseName,
         updateCommitTimestamp,
         ModType.UPDATE,
         ValueCaptureType.OLD_AND_NEW_VALUES,
         getKeysJson(),
-        updateNewValuesJson,
-        false);
+        getNewValuesJson(updateCommitTimestamp),
+        false,
+        getRowType(false));
   }
 
   // Test the case where a TableRow can be constructed from a UPDATE Mod
@@ -256,7 +263,8 @@ public final class FailsafeModJsonToTableRowTransformerTest {
         ValueCaptureType.NEW_ROW_AND_OLD_VALUES,
         getKeysJson(),
         getNewValuesJson(updateCommitTimestamp),
-        false);
+        false,
+        getRowType(false));
   }
 
   // Test the case where a TableRow can be constructed from a UPDATE Mod
@@ -270,7 +278,8 @@ public final class FailsafeModJsonToTableRowTransformerTest {
         ValueCaptureType.NEW_ROW,
         getKeysJson(),
         getNewValuesJson(updateCommitTimestamp),
-        false);
+        false,
+        getRowType(false));
   }
 
   // Test the case where a TableRow can be constructed from a DELETE Mod.
@@ -286,7 +295,8 @@ public final class FailsafeModJsonToTableRowTransformerTest {
         ValueCaptureType.OLD_AND_NEW_VALUES,
         getKeysJson(),
         "",
-        false);
+        false,
+        getRowType(true));
   }
 
   // Test the case where a TableRow can be constructed from a DELETE Mod
@@ -303,7 +313,8 @@ public final class FailsafeModJsonToTableRowTransformerTest {
         ValueCaptureType.NEW_ROW_AND_OLD_VALUES,
         getKeysJson(),
         "",
-        false);
+        false,
+        getRowType(false));
   }
 
   // Test the case where a TableRow can be constructed from a DELETE Mod
@@ -320,7 +331,8 @@ public final class FailsafeModJsonToTableRowTransformerTest {
         ValueCaptureType.NEW_ROW,
         getKeysJson(),
         "",
-        false);
+        false,
+        getRowType(true));
   }
 
   // Test the case where the snapshot read to Spanner fails and we can capture the failures from
@@ -331,6 +343,9 @@ public final class FailsafeModJsonToTableRowTransformerTest {
     fakePkColJsonNode.put("fakePkCol", true);
     ObjectNode fakeNonPkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
     fakeNonPkColJsonNode.put("fakeNonPkCol", true);
+    List<ModColumnType> rowTypes = new ArrayList<>();
+    rowTypes.add(new ModColumnType("fakePkCol", new TypeCode("BOOL"), true, 1));
+    rowTypes.add(new ModColumnType("fakeNonPkCol", new TypeCode("BOOL"), false, 2));
     Mod mod =
         new Mod(
             fakePkColJsonNode.toString(),
@@ -340,18 +355,19 @@ public final class FailsafeModJsonToTableRowTransformerTest {
             true,
             "00000001",
             TEST_SPANNER_TABLE,
+            rowTypes,
             ModType.INSERT,
             ValueCaptureType.OLD_AND_NEW_VALUES,
             1L,
             1L);
-    TestStream<String> testStream =
+    TestStream<String> testSream =
         TestStream.create(SerializableCoder.of(String.class))
             .addElements(mod.toJson())
             .advanceWatermarkTo(Instant.now())
             .advanceWatermarkToInfinity();
     Pipeline p = Pipeline.create();
     PCollection<FailsafeElement<String, String>> input =
-        p.apply(testStream)
+        p.apply(testSream)
             .apply(
                 ParDo.of(
                     new DoFn<String, FailsafeElement<String, String>>() {
@@ -371,9 +387,10 @@ public final class FailsafeModJsonToTableRowTransformerTest {
             + "\"newValuesJson\":\"{\\\"fakeNonPkCol\\\":true}\","
             + "\"commitTimestampSeconds\":1650908264,\"commitTimestampNanos\":925679000,"
             + "\"serverTransactionId\":\"1\",\"isLastRecordInTransactionInPartition\":true,"
-            + "\"recordSequence\":\"00000001\",\"tableName\":\"AllTypes\",\"modType\":\"INSERT\","
-            + "\"valueCaptureType\":\"OLD_AND_NEW_VALUES\","
-            + "\"numberOfRecordsInTransaction\":1,\"numberOfPartitionsInTransaction\":1}";
+            + "\"recordSequence\":\"00000001\",\"tableName\":\"AllTypes\","
+            + "\"rowType\":[{\"name\":\"fakePkCol\",\"type\":{\"code\":\"BOOL\"},\"isPrimaryKey\":true,\"ordinalPosition\":1},{\"name\":\"fakeNonPkCol\",\"type\":{\"code\":\"BOOL\"},\"isPrimaryKey\":false,\"ordinalPosition\":2}],"
+            + "\"modType\":\"INSERT\",\"valueCaptureType\":\"OLD_AND_NEW_VALUES\",\"numberOfRecordsInTransaction\":1,\"numberOfPartitionsInTransaction\":1,"
+            + "\"rowTypeAsMap\":{\"fakeNonPkCol\":{\"name\":\"fakeNonPkCol\",\"type\":{\"code\":\"BOOL\"},\"isPrimaryKey\":false,\"ordinalPosition\":2},\"fakePkCol\":{\"name\":\"fakePkCol\",\"type\":{\"code\":\"BOOL\"},\"isPrimaryKey\":true,\"ordinalPosition\":1}}}";
     PAssert.that(
             out.get(failsafeModJsonToTableRow.transformDeadLetterOut)
                 .apply(
@@ -407,7 +424,8 @@ public final class FailsafeModJsonToTableRowTransformerTest {
       ValueCaptureType valueCaptureType,
       String keysJson,
       String newValuesJson,
-      Boolean useStorageWriteApi)
+      Boolean useStorageWriteApi,
+      List<ModColumnType> rowTypes)
       throws Exception {
     Mod mod =
         new Mod(
@@ -418,6 +436,7 @@ public final class FailsafeModJsonToTableRowTransformerTest {
             true,
             "00000001",
             TEST_SPANNER_TABLE,
+            rowTypes,
             modType,
             valueCaptureType,
             1L,
@@ -432,13 +451,23 @@ public final class FailsafeModJsonToTableRowTransformerTest {
         expectedTableRow,
         useStorageWriteApi);
     expectedTableRow.set(BOOLEAN_PK_COL, BOOLEAN_RAW_VAL);
+    expectedTableRow.set("_type_" + BOOLEAN_PK_COL, "BOOL");
     expectedTableRow.set(BYTES_PK_COL, BYTES_RAW_VAL.toBase64());
+    expectedTableRow.set("_type_" + BYTES_PK_COL, "BYTES");
     expectedTableRow.set(DATE_PK_COL, DATE_RAW_VAL.toString());
+    expectedTableRow.set("_type_" + DATE_PK_COL, "DATE");
     expectedTableRow.set(FLOAT64_PK_COL, FLOAT64_RAW_VAL);
+    expectedTableRow.set("_type_" + FLOAT64_PK_COL, "FLOAT64");
     expectedTableRow.set(INT64_PK_COL, INT64_RAW_VAL);
+    expectedTableRow.set("_type_" + INT64_PK_COL, "INT64");
+    // The numeric value seems to be flaky which was introduced by previous cl. The investigation
+    // is tracked by b/305796905.
     expectedTableRow.set(NUMERIC_PK_COL, 10.0);
+    expectedTableRow.set("_type_" + NUMERIC_PK_COL, "NUMERIC");
     expectedTableRow.set(STRING_PK_COL, STRING_RAW_VAL);
+    expectedTableRow.set("_type_" + STRING_PK_COL, "STRING");
     expectedTableRow.set(TIMESTAMP_PK_COL, TIMESTAMP_RAW_VAL.toString());
+    expectedTableRow.set("_type_" + TIMESTAMP_PK_COL, "TIMESTAMP");
     if (modType == modType.INSERT || modType == modType.UPDATE) {
       // The order matters when comparing TableRow, so we need to set different orders for INSERT
       // and UPDATE NEW VALUES.
@@ -446,41 +475,59 @@ public final class FailsafeModJsonToTableRowTransformerTest {
         expectedTableRow.set(TIMESTAMP_COL, commitTimestamp.toString());
       }
       expectedTableRow.set(BOOLEAN_ARRAY_COL, BOOLEAN_ARRAY_RAW_VAL);
+      expectedTableRow.set("_type_" + BOOLEAN_ARRAY_COL, "ARRAY<BOOL>");
       expectedTableRow.set(BYTES_ARRAY_COL, BYTES_ARRAY_RAW_VAL);
+      expectedTableRow.set("_type_" + BYTES_ARRAY_COL, "ARRAY<BYTES>");
       expectedTableRow.set(DATE_ARRAY_COL, DATE_ARRAY_RAW_VAL);
+      expectedTableRow.set("_type_" + DATE_ARRAY_COL, "ARRAY<DATE>");
       expectedTableRow.set(FLOAT64_ARRAY_COL, FLOAT64_ARRAY_RAW_VAL);
+      expectedTableRow.set("_type_" + FLOAT64_ARRAY_COL, "ARRAY<FLOAT64>");
       expectedTableRow.set(INT64_ARRAY_COL, INT64_ARRAY_RAW_VAL);
+      expectedTableRow.set("_type_" + INT64_ARRAY_COL, "ARRAY<INT64>");
       expectedTableRow.set(JSON_ARRAY_COL, JSON_ARRAY_RAW_VAL);
+      expectedTableRow.set("_type_" + JSON_ARRAY_COL, "ARRAY<JSON>");
       expectedTableRow.set(NUMERIC_ARRAY_COL, NUMERIC_ARRAY_RAW_VAL);
+      expectedTableRow.set("_type_" + NUMERIC_ARRAY_COL, "ARRAY<NUMERIC>");
       expectedTableRow.set(STRING_ARRAY_COL, STRING_ARRAY_RAW_VAL);
+      expectedTableRow.set("_type_" + STRING_ARRAY_COL, "ARRAY<STRING>");
       expectedTableRow.set(TIMESTAMP_ARRAY_COL, TIMESTAMP_ARRAY_RAW_VAL);
+      expectedTableRow.set("_type_" + TIMESTAMP_ARRAY_COL, "ARRAY<TIMESTAMP>");
       expectedTableRow.set(BOOLEAN_COL, BOOLEAN_RAW_VAL);
+      expectedTableRow.set("_type_" + BOOLEAN_COL, "BOOL");
       expectedTableRow.set(BYTES_COL, BYTES_RAW_VAL.toBase64());
+      expectedTableRow.set("_type_" + BYTES_COL, "BYTES");
       expectedTableRow.set(DATE_COL, DATE_RAW_VAL.toString());
+      expectedTableRow.set("_type_" + DATE_COL, "DATE");
       expectedTableRow.set(FLOAT64_COL, FLOAT64_RAW_VAL);
+      expectedTableRow.set("_type_" + FLOAT64_COL, "FLOAT64");
       expectedTableRow.set(INT64_COL, INT64_RAW_VAL);
+      expectedTableRow.set("_type_" + INT64_COL, "INT64");
       expectedTableRow.set(JSON_COL, JSON_RAW_VAL);
+      expectedTableRow.set("_type_" + JSON_COL, "JSON");
       // The numeric value seems to be flaky which was introduced by previous cl. The investigation
-      // is tracked by b/305796905. Hardcode it here to pass the test.
+      // is tracked by b/305796905.
       if (valueCaptureType == ValueCaptureType.OLD_AND_NEW_VALUES && modType == ModType.UPDATE) {
         expectedTableRow.set(NUMERIC_COL, NUMERIC_RAW_VAL);
       } else {
         expectedTableRow.set(NUMERIC_COL, 10.0);
       }
+      expectedTableRow.set("_type_" + NUMERIC_COL, "NUMERIC");
       expectedTableRow.set(STRING_COL, STRING_RAW_VAL);
+      expectedTableRow.set("_type_" + STRING_COL, "STRING");
       if (modType != modType.UPDATE || valueCaptureType != ValueCaptureType.OLD_AND_NEW_VALUES) {
         expectedTableRow.set(TIMESTAMP_COL, commitTimestamp.toString());
+        expectedTableRow.set("_type_" + TIMESTAMP_COL, "TIMESTAMP");
       }
     }
 
-    TestStream<String> testStream =
+    TestStream<String> testSream =
         TestStream.create(SerializableCoder.of(String.class))
             .addElements(mod.toJson())
             .advanceWatermarkTo(Instant.now())
             .advanceWatermarkToInfinity();
     Pipeline p = Pipeline.create();
     PCollection<FailsafeElement<String, String>> input =
-        p.apply(testStream)
+        p.apply(testSream)
             .apply(
                 ParDo.of(
                     new DoFn<String, FailsafeElement<String, String>>() {
@@ -532,32 +579,58 @@ public final class FailsafeModJsonToTableRowTransformerTest {
     // spotless:off
     mutations.add(
         Mutation.newInsertBuilder(TEST_SPANNER_TABLE)
-            .set(BOOLEAN_PK_COL).to(BOOLEAN_VAL)
-            .set(BYTES_PK_COL).to(BYTES_VAL)
-            .set(DATE_PK_COL).to(DATE_VAL)
-            .set(FLOAT64_PK_COL).to(FLOAT64_VAL)
-            .set(INT64_PK_COL).to(INT64_VAL)
-            .set(NUMERIC_PK_COL).to(NUMERIC_VAL)
-            .set(STRING_PK_COL).to(STRING_VAL)
-            .set(TIMESTAMP_PK_COL).to(TIMESTAMP_VAL)
-            .set(BOOLEAN_ARRAY_COL).to(BOOLEAN_NULLABLE_ARRAY_VAL)
-            .set(BYTES_ARRAY_COL).to(BYTES_NULLABLE_ARRAY_VAL)
-            .set(DATE_ARRAY_COL).to(DATE_NULLABLE_ARRAY_VAL)
-            .set(FLOAT64_ARRAY_COL).to(FLOAT64_NULLABLE_ARRAY_VAL)
-            .set(INT64_ARRAY_COL).to(INT64_NULLABLE_ARRAY_VAL)
-            .set(NUMERIC_ARRAY_COL).to(NUMERIC_NULLABLE_ARRAY_VAL)
-            .set(JSON_ARRAY_COL).to(JSON_NULLABLE_ARRAY_VAL)
-            .set(STRING_ARRAY_COL).to(STRING_NULLABLE_ARRAY_VAL)
-            .set(TIMESTAMP_ARRAY_COL).to(TIMESTAMP_NULLABLE_ARRAY_VAL)
-            .set(BOOLEAN_COL).to(BOOLEAN_VAL)
-            .set(BYTES_COL).to(BYTES_VAL)
-            .set(DATE_COL).to(DATE_VAL)
-            .set(FLOAT64_COL).to(FLOAT64_VAL)
-            .set(INT64_COL).to(INT64_VAL)
-            .set(JSON_COL).to(JSON_VAL)
-            .set(NUMERIC_COL).to(NUMERIC_VAL)
-            .set(STRING_COL).to(STRING_VAL)
-            .set(TIMESTAMP_COL).to(Value.COMMIT_TIMESTAMP)
+            .set(BOOLEAN_PK_COL)
+            .to(BOOLEAN_VAL)
+            .set(BYTES_PK_COL)
+            .to(BYTES_VAL)
+            .set(DATE_PK_COL)
+            .to(DATE_VAL)
+            .set(FLOAT64_PK_COL)
+            .to(FLOAT64_VAL)
+            .set(INT64_PK_COL)
+            .to(INT64_VAL)
+            .set(NUMERIC_PK_COL)
+            .to(NUMERIC_VAL)
+            .set(STRING_PK_COL)
+            .to(STRING_VAL)
+            .set(TIMESTAMP_PK_COL)
+            .to(TIMESTAMP_VAL)
+            .set(BOOLEAN_ARRAY_COL)
+            .to(BOOLEAN_NULLABLE_ARRAY_VAL)
+            .set(BYTES_ARRAY_COL)
+            .to(BYTES_NULLABLE_ARRAY_VAL)
+            .set(DATE_ARRAY_COL)
+            .to(DATE_NULLABLE_ARRAY_VAL)
+            .set(FLOAT64_ARRAY_COL)
+            .to(FLOAT64_NULLABLE_ARRAY_VAL)
+            .set(INT64_ARRAY_COL)
+            .to(INT64_NULLABLE_ARRAY_VAL)
+            .set(NUMERIC_ARRAY_COL)
+            .to(NUMERIC_NULLABLE_ARRAY_VAL)
+            .set(JSON_ARRAY_COL)
+            .to(JSON_NULLABLE_ARRAY_VAL)
+            .set(STRING_ARRAY_COL)
+            .to(STRING_NULLABLE_ARRAY_VAL)
+            .set(TIMESTAMP_ARRAY_COL)
+            .to(TIMESTAMP_NULLABLE_ARRAY_VAL)
+            .set(BOOLEAN_COL)
+            .to(BOOLEAN_VAL)
+            .set(BYTES_COL)
+            .to(BYTES_VAL)
+            .set(DATE_COL)
+            .to(DATE_VAL)
+            .set(FLOAT64_COL)
+            .to(FLOAT64_VAL)
+            .set(INT64_COL)
+            .to(INT64_VAL)
+            .set(JSON_COL)
+            .to(JSON_VAL)
+            .set(NUMERIC_COL)
+            .to(NUMERIC_VAL)
+            .set(STRING_COL)
+            .to(STRING_VAL)
+            .set(TIMESTAMP_COL)
+            .to(Value.COMMIT_TIMESTAMP)
             .build());
     // spotless:on
     SPANNER_SERVER.getDbClient(spannerDatabaseName).write(mutations);
@@ -657,5 +730,37 @@ public final class FailsafeModJsonToTableRowTransformerTest {
     jsonNode.put(STRING_COL, STRING_RAW_VAL);
     jsonNode.put(TIMESTAMP_COL, commitTimestamp.toString());
     return jsonNode.toString();
+  }
+
+  private List<ModColumnType> getRowType(Boolean deleteModType) {
+    List<ModColumnType> rowTypes = new ArrayList<>();
+    rowTypes.add(new ModColumnType(BOOLEAN_PK_COL, new TypeCode("BOOLEAN"), true, 1));
+    rowTypes.add(new ModColumnType(BYTES_PK_COL, new TypeCode("BYTES"), true, 2));
+    rowTypes.add(new ModColumnType(DATE_PK_COL, new TypeCode("DATE"), true, 3));
+    rowTypes.add(new ModColumnType(FLOAT64_PK_COL, new TypeCode("FLOAT64"), true, 4));
+    rowTypes.add(new ModColumnType(INT64_PK_COL, new TypeCode("INT64"), true, 5));
+    rowTypes.add(new ModColumnType(NUMERIC_PK_COL, new TypeCode("NUMERIC"), true, 6));
+    rowTypes.add(new ModColumnType(STRING_PK_COL, new TypeCode("STRING"), true, 7));
+    rowTypes.add(new ModColumnType(TIMESTAMP_PK_COL, new TypeCode("TIMESTAMP"), true, 8));
+    if (!deleteModType) {
+      rowTypes.add(new ModColumnType(BOOLEAN_ARRAY_COL, new TypeCode("ARRAY"), false, 9));
+      rowTypes.add(new ModColumnType(BYTES_ARRAY_COL, new TypeCode("ARRAY"), false, 10));
+      rowTypes.add(new ModColumnType(DATE_ARRAY_COL, new TypeCode("ARRAY"), false, 11));
+      rowTypes.add(new ModColumnType(FLOAT64_ARRAY_COL, new TypeCode("ARRAY"), false, 12));
+      rowTypes.add(new ModColumnType(INT64_ARRAY_COL, new TypeCode("ARRAY"), false, 13));
+      rowTypes.add(new ModColumnType(JSON_ARRAY_COL, new TypeCode("ARRAY"), false, 14));
+      rowTypes.add(new ModColumnType(NUMERIC_ARRAY_COL, new TypeCode("ARRAY"), false, 15));
+      rowTypes.add(new ModColumnType(STRING_ARRAY_COL, new TypeCode("ARRAY"), false, 16));
+      rowTypes.add(new ModColumnType(TIMESTAMP_ARRAY_COL, new TypeCode("ARRAY"), false, 17));
+      rowTypes.add(new ModColumnType(BOOLEAN_COL, new TypeCode("BOOLEAN"), false, 18));
+      rowTypes.add(new ModColumnType(BYTES_COL, new TypeCode("BYTES"), false, 19));
+      rowTypes.add(new ModColumnType(DATE_COL, new TypeCode("DATE"), false, 20));
+      rowTypes.add(new ModColumnType(FLOAT64_COL, new TypeCode("FLOAT64"), false, 21));
+      rowTypes.add(new ModColumnType(INT64_COL, new TypeCode("INT64"), false, 22));
+      rowTypes.add(new ModColumnType(NUMERIC_COL, new TypeCode("NUMERIC"), false, 23));
+      rowTypes.add(new ModColumnType(STRING_COL, new TypeCode("STRING"), false, 24));
+      rowTypes.add(new ModColumnType(TIMESTAMP_COL, new TypeCode("TIMESTAMP"), false, 25));
+    }
+    return rowTypes;
   }
 }

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/FailsafeModJsonToTableRowTransformerTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/FailsafeModJsonToTableRowTransformerTest.java
@@ -36,6 +36,12 @@ import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigqu
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.DATE_PK_COL;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.DATE_RAW_VAL;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.DATE_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.FLOAT32_ARRAY_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.FLOAT32_ARRAY_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.FLOAT32_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.FLOAT32_NULLABLE_ARRAY_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.FLOAT32_RAW_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.FLOAT32_VAL;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.FLOAT64_ARRAY_COL;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.FLOAT64_ARRAY_RAW_VAL;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.FLOAT64_COL;
@@ -101,6 +107,7 @@ import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.sch
 import com.google.cloud.teleport.v2.values.FailsafeElement;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.Pipeline;
@@ -126,7 +133,7 @@ import org.junit.runners.JUnit4;
 /** Test class for {@link FailsafeModJsonToTableRowTransformerTest}. */
 @RunWith(JUnit4.class)
 @Category(IntegrationTest.class)
-public final class FailsafeModJsonToTableRowTransformerTest {
+public final class FailsafeModJsonToTableRowTransformerTest implements Serializable {
 
   /** Rule for Spanner server resource. */
   @ClassRule public static final SpannerServerResource SPANNER_SERVER = new SpannerServerResource();
@@ -245,7 +252,7 @@ public final class FailsafeModJsonToTableRowTransformerTest {
         spannerDatabaseName,
         updateCommitTimestamp,
         ModType.UPDATE,
-        ValueCaptureType.OLD_AND_NEW_VALUES,
+        ValueCaptureType.NEW_ROW,
         getKeysJson(),
         getNewValuesJson(updateCommitTimestamp),
         false,
@@ -480,6 +487,8 @@ public final class FailsafeModJsonToTableRowTransformerTest {
       expectedTableRow.set("_type_" + BYTES_ARRAY_COL, "ARRAY<BYTES>");
       expectedTableRow.set(DATE_ARRAY_COL, DATE_ARRAY_RAW_VAL);
       expectedTableRow.set("_type_" + DATE_ARRAY_COL, "ARRAY<DATE>");
+      expectedTableRow.set(FLOAT32_ARRAY_COL, FLOAT32_ARRAY_RAW_VAL);
+      expectedTableRow.set("_type_" + FLOAT32_ARRAY_COL, "ARRAY<FLOAT32>");
       expectedTableRow.set(FLOAT64_ARRAY_COL, FLOAT64_ARRAY_RAW_VAL);
       expectedTableRow.set("_type_" + FLOAT64_ARRAY_COL, "ARRAY<FLOAT64>");
       expectedTableRow.set(INT64_ARRAY_COL, INT64_ARRAY_RAW_VAL);
@@ -498,6 +507,8 @@ public final class FailsafeModJsonToTableRowTransformerTest {
       expectedTableRow.set("_type_" + BYTES_COL, "BYTES");
       expectedTableRow.set(DATE_COL, DATE_RAW_VAL.toString());
       expectedTableRow.set("_type_" + DATE_COL, "DATE");
+      expectedTableRow.set(FLOAT32_COL, FLOAT32_RAW_VAL);
+      expectedTableRow.set("_type_" + FLOAT32_COL, "FLOAT32");
       expectedTableRow.set(FLOAT64_COL, FLOAT64_RAW_VAL);
       expectedTableRow.set("_type_" + FLOAT64_COL, "FLOAT64");
       expectedTableRow.set(INT64_COL, INT64_RAW_VAL);
@@ -601,6 +612,8 @@ public final class FailsafeModJsonToTableRowTransformerTest {
             .to(BYTES_NULLABLE_ARRAY_VAL)
             .set(DATE_ARRAY_COL)
             .to(DATE_NULLABLE_ARRAY_VAL)
+            .set(FLOAT32_ARRAY_COL)
+            .to(FLOAT32_NULLABLE_ARRAY_VAL)
             .set(FLOAT64_ARRAY_COL)
             .to(FLOAT64_NULLABLE_ARRAY_VAL)
             .set(INT64_ARRAY_COL)
@@ -619,6 +632,8 @@ public final class FailsafeModJsonToTableRowTransformerTest {
             .to(BYTES_VAL)
             .set(DATE_COL)
             .to(DATE_VAL)
+            .set(FLOAT32_COL)
+            .to(FLOAT32_VAL)
             .set(FLOAT64_COL)
             .to(FLOAT64_VAL)
             .set(INT64_COL)
@@ -691,6 +706,13 @@ public final class FailsafeModJsonToTableRowTransformerTest {
     arrayNode = jsonNode.putArray(DATE_ARRAY_COL);
     arrayNode.add(DATE_ARRAY_RAW_VAL.get(0).toString());
     arrayNode.add(DATE_ARRAY_RAW_VAL.get(1).toString());
+    arrayNode = jsonNode.putArray(FLOAT32_ARRAY_COL);
+    arrayNode.add(FLOAT32_ARRAY_RAW_VAL.get(0));
+    arrayNode.add(FLOAT32_ARRAY_RAW_VAL.get(1));
+    arrayNode.add(FLOAT32_ARRAY_RAW_VAL.get(2));
+    arrayNode.add(FLOAT32_ARRAY_RAW_VAL.get(3));
+    arrayNode.add(FLOAT32_ARRAY_RAW_VAL.get(4));
+    arrayNode.add(FLOAT32_ARRAY_RAW_VAL.get(5));
     arrayNode = jsonNode.putArray(FLOAT64_ARRAY_COL);
     arrayNode.add(FLOAT64_ARRAY_RAW_VAL.get(0));
     arrayNode.add(FLOAT64_ARRAY_RAW_VAL.get(1));
@@ -723,6 +745,7 @@ public final class FailsafeModJsonToTableRowTransformerTest {
     jsonNode.put(BOOLEAN_COL, BOOLEAN_RAW_VAL);
     jsonNode.put(BYTES_COL, BYTES_RAW_VAL.toBase64());
     jsonNode.put(DATE_COL, DATE_RAW_VAL.toString());
+    jsonNode.put(FLOAT32_COL, FLOAT32_RAW_VAL);
     jsonNode.put(FLOAT64_COL, FLOAT64_RAW_VAL);
     jsonNode.put(INT64_COL, INT64_RAW_VAL);
     jsonNode.put(JSON_COL, JSON_RAW_VAL);
@@ -746,20 +769,22 @@ public final class FailsafeModJsonToTableRowTransformerTest {
       rowTypes.add(new ModColumnType(BOOLEAN_ARRAY_COL, new TypeCode("ARRAY"), false, 9));
       rowTypes.add(new ModColumnType(BYTES_ARRAY_COL, new TypeCode("ARRAY"), false, 10));
       rowTypes.add(new ModColumnType(DATE_ARRAY_COL, new TypeCode("ARRAY"), false, 11));
-      rowTypes.add(new ModColumnType(FLOAT64_ARRAY_COL, new TypeCode("ARRAY"), false, 12));
-      rowTypes.add(new ModColumnType(INT64_ARRAY_COL, new TypeCode("ARRAY"), false, 13));
-      rowTypes.add(new ModColumnType(JSON_ARRAY_COL, new TypeCode("ARRAY"), false, 14));
-      rowTypes.add(new ModColumnType(NUMERIC_ARRAY_COL, new TypeCode("ARRAY"), false, 15));
-      rowTypes.add(new ModColumnType(STRING_ARRAY_COL, new TypeCode("ARRAY"), false, 16));
-      rowTypes.add(new ModColumnType(TIMESTAMP_ARRAY_COL, new TypeCode("ARRAY"), false, 17));
-      rowTypes.add(new ModColumnType(BOOLEAN_COL, new TypeCode("BOOLEAN"), false, 18));
-      rowTypes.add(new ModColumnType(BYTES_COL, new TypeCode("BYTES"), false, 19));
-      rowTypes.add(new ModColumnType(DATE_COL, new TypeCode("DATE"), false, 20));
-      rowTypes.add(new ModColumnType(FLOAT64_COL, new TypeCode("FLOAT64"), false, 21));
-      rowTypes.add(new ModColumnType(INT64_COL, new TypeCode("INT64"), false, 22));
-      rowTypes.add(new ModColumnType(NUMERIC_COL, new TypeCode("NUMERIC"), false, 23));
-      rowTypes.add(new ModColumnType(STRING_COL, new TypeCode("STRING"), false, 24));
-      rowTypes.add(new ModColumnType(TIMESTAMP_COL, new TypeCode("TIMESTAMP"), false, 25));
+      rowTypes.add(new ModColumnType(FLOAT32_ARRAY_COL, new TypeCode("ARRAY"), false, 12));
+      rowTypes.add(new ModColumnType(FLOAT64_ARRAY_COL, new TypeCode("ARRAY"), false, 13));
+      rowTypes.add(new ModColumnType(INT64_ARRAY_COL, new TypeCode("ARRAY"), false, 14));
+      rowTypes.add(new ModColumnType(JSON_ARRAY_COL, new TypeCode("ARRAY"), false, 15));
+      rowTypes.add(new ModColumnType(NUMERIC_ARRAY_COL, new TypeCode("ARRAY"), false, 16));
+      rowTypes.add(new ModColumnType(STRING_ARRAY_COL, new TypeCode("ARRAY"), false, 17));
+      rowTypes.add(new ModColumnType(TIMESTAMP_ARRAY_COL, new TypeCode("ARRAY"), false, 18));
+      rowTypes.add(new ModColumnType(BOOLEAN_COL, new TypeCode("BOOLEAN"), false, 19));
+      rowTypes.add(new ModColumnType(BYTES_COL, new TypeCode("BYTES"), false, 20));
+      rowTypes.add(new ModColumnType(DATE_COL, new TypeCode("DATE"), false, 21));
+      rowTypes.add(new ModColumnType(FLOAT64_COL, new TypeCode("FLOAT64"), false, 22));
+      rowTypes.add(new ModColumnType(FLOAT32_COL, new TypeCode("FLOAT32"), false, 23));
+      rowTypes.add(new ModColumnType(INT64_COL, new TypeCode("INT64"), false, 24));
+      rowTypes.add(new ModColumnType(NUMERIC_COL, new TypeCode("NUMERIC"), false, 25));
+      rowTypes.add(new ModColumnType(STRING_COL, new TypeCode("STRING"), false, 26));
+      rowTypes.add(new ModColumnType(TIMESTAMP_COL, new TypeCode("TIMESTAMP"), false, 27));
     }
     return rowTypes;
   }

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/FailsafeModJsonToTableRowTransformerTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/FailsafeModJsonToTableRowTransformerTest.java
@@ -424,6 +424,49 @@ public final class FailsafeModJsonToTableRowTransformerTest implements Serializa
     p.run().waitUntilFinish();
   }
 
+  private void fillNullNonPkColsForDelete(TableRow expectedTableRow) {
+    expectedTableRow.set(BOOLEAN_ARRAY_COL, null);
+    expectedTableRow.set("_type_" + BOOLEAN_ARRAY_COL, "ARRAY<BOOL>");
+    expectedTableRow.set(BYTES_ARRAY_COL, null);
+    expectedTableRow.set("_type_" + BYTES_ARRAY_COL, "ARRAY<BYTES>");
+    expectedTableRow.set(DATE_ARRAY_COL, null);
+    expectedTableRow.set("_type_" + DATE_ARRAY_COL, "ARRAY<DATE>");
+    expectedTableRow.set(FLOAT32_ARRAY_COL, null);
+    expectedTableRow.set("_type_" + FLOAT32_ARRAY_COL, "ARRAY<FLOAT32>");
+    expectedTableRow.set(FLOAT64_ARRAY_COL, null);
+    expectedTableRow.set("_type_" + FLOAT64_ARRAY_COL, "ARRAY<FLOAT64>");
+    expectedTableRow.set(INT64_ARRAY_COL, null);
+    expectedTableRow.set("_type_" + INT64_ARRAY_COL, "ARRAY<INT64>");
+    expectedTableRow.set(JSON_ARRAY_COL, null);
+    expectedTableRow.set("_type_" + JSON_ARRAY_COL, "ARRAY<JSON>");
+    expectedTableRow.set(NUMERIC_ARRAY_COL, null);
+    expectedTableRow.set("_type_" + NUMERIC_ARRAY_COL, "ARRAY<NUMERIC>");
+    expectedTableRow.set(STRING_ARRAY_COL, null);
+    expectedTableRow.set("_type_" + STRING_ARRAY_COL, "ARRAY<STRING>");
+    expectedTableRow.set(TIMESTAMP_ARRAY_COL, null);
+    expectedTableRow.set("_type_" + TIMESTAMP_ARRAY_COL, "ARRAY<TIMESTAMP>");
+    expectedTableRow.set(BOOLEAN_COL, null);
+    expectedTableRow.set("_type_" + BOOLEAN_COL, "BOOL");
+    expectedTableRow.set(BYTES_COL, null);
+    expectedTableRow.set("_type_" + BYTES_COL, "BYTES");
+    expectedTableRow.set(DATE_COL, null);
+    expectedTableRow.set("_type_" + DATE_COL, "DATE");
+    expectedTableRow.set(FLOAT32_COL, null);
+    expectedTableRow.set("_type_" + FLOAT32_COL, "FLOAT32");
+    expectedTableRow.set(FLOAT64_COL, null);
+    expectedTableRow.set("_type_" + FLOAT64_COL, "FLOAT64");
+    expectedTableRow.set(INT64_COL, null);
+    expectedTableRow.set("_type_" + INT64_COL, "INT64");
+    expectedTableRow.set(JSON_COL, null);
+    expectedTableRow.set("_type_" + JSON_COL, "JSON");
+    expectedTableRow.set(NUMERIC_COL, null);
+    expectedTableRow.set("_type_" + NUMERIC_COL, "NUMERIC");
+    expectedTableRow.set(STRING_COL, null);
+    expectedTableRow.set("_type_" + STRING_COL, "STRING");
+    expectedTableRow.set(TIMESTAMP_COL, null);
+    expectedTableRow.set("_type_" + TIMESTAMP_COL, "TIMESTAMP");
+  }
+
   private void validateBigQueryRow(
       String spannerDatabaseName,
       Timestamp commitTimestamp,
@@ -529,6 +572,8 @@ public final class FailsafeModJsonToTableRowTransformerTest implements Serializa
         expectedTableRow.set(TIMESTAMP_COL, commitTimestamp.toString());
         expectedTableRow.set("_type_" + TIMESTAMP_COL, "TIMESTAMP");
       }
+    } else {
+      fillNullNonPkColsForDelete(expectedTableRow);
     }
 
     TestStream<String> testSream =

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SchemaUpdateUtilsTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SchemaUpdateUtilsTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.ReadContext;
+import com.google.cloud.spanner.Type;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.Mod;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.ModColumnType;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.TrackedSpannerColumn;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.TrackedSpannerTable;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.SchemaUpdateUtils;
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.SpannerChangeStreamsUtils;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.ModType;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.TypeCode;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.ValueCaptureType;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class SchemaUpdateUtilsTest {
+  private static final String changeStreamName = "Singers";
+  @Mock private DatabaseClient mockDatabaseClient;
+  @Mock private ReadContext mockReadContext;
+  @Mock private SpannerAccessor mockSpannerAccessor;
+  private Timestamp now = Timestamp.now();
+
+  @Before
+  public void setUp() {
+    when(mockSpannerAccessor.getDatabaseClient()).thenReturn(mockDatabaseClient);
+  }
+
+  public Map<String, TrackedSpannerTable> createSpannerTableByName() {
+    List<TrackedSpannerColumn> singersPkColumns =
+        Collections.singletonList(TrackedSpannerColumn.create("SingerId", Type.int64(), -1, 1));
+    List<TrackedSpannerColumn> singersNonPkColumns =
+        Collections.singletonList(TrackedSpannerColumn.create("FirstName", Type.string(), 2, -1));
+    Map<String, TrackedSpannerTable> spannerTableByName = new HashMap<>();
+    spannerTableByName.put(
+        "Singers", new TrackedSpannerTable("Singers", singersPkColumns, singersNonPkColumns));
+    return spannerTableByName;
+  }
+
+  @Test
+  public void testDetectDiffColumnInModWithoutDiff() {
+    ObjectNode pkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
+    pkColJsonNode.put("SingerId", 1);
+    ObjectNode nonPkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
+    nonPkColJsonNode.put("FirstName", "firstName");
+    List<ModColumnType> rowTypes = new ArrayList<>();
+    rowTypes.add(new ModColumnType("SingerId", new TypeCode("INT64"), true, 1));
+    rowTypes.add(new ModColumnType("FirstName", new TypeCode("STRING"), false, 2));
+    Mod mod =
+        new Mod(
+            pkColJsonNode.toString(),
+            nonPkColJsonNode.toString(),
+            Timestamp.ofTimeSecondsAndNanos(1650908264L, 925679000),
+            "1",
+            true,
+            "00000001",
+            "Singers",
+            rowTypes,
+            ModType.INSERT,
+            ValueCaptureType.OLD_AND_NEW_VALUES,
+            1L,
+            1L);
+    Map<String, TrackedSpannerTable> spannerTableByName = createSpannerTableByName();
+    assertThat(SchemaUpdateUtils.detectDiffColumnInMod(mod, spannerTableByName)).isEqualTo(false);
+  }
+
+  @Test
+  public void testDetectDiffColumnInModWithColDiff() {
+    ObjectNode pkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
+    pkColJsonNode.put("SingerId", 1);
+    ObjectNode nonPkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
+    nonPkColJsonNode.put("FirstName", "firstName");
+    nonPkColJsonNode.put("LastName", "lastName");
+    List<ModColumnType> rowTypes = new ArrayList<>();
+    rowTypes.add(new ModColumnType("SingerId", new TypeCode("{\"code\":\"INT64\"}"), true, 1));
+    rowTypes.add(new ModColumnType("FirstName", new TypeCode("{\"code\":\"STRING\"}"), false, 2));
+    rowTypes.add(new ModColumnType("LastName", new TypeCode("{\"code\":\"STRING\"}"), false, 3));
+    Mod mod =
+        new Mod(
+            pkColJsonNode.toString(),
+            nonPkColJsonNode.toString(),
+            Timestamp.ofTimeSecondsAndNanos(1650908264L, 925679000),
+            "1",
+            true,
+            "00000001",
+            "Singers",
+            rowTypes,
+            ModType.INSERT,
+            ValueCaptureType.OLD_AND_NEW_VALUES,
+            1L,
+            1L);
+    Map<String, TrackedSpannerTable> spannerTableByName = createSpannerTableByName();
+    assertThat(SchemaUpdateUtils.detectDiffColumnInMod(mod, spannerTableByName)).isEqualTo(true);
+  }
+
+  @Test
+  public void testUpdateStoredSchemaNewRow() {
+    ObjectNode pkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
+    pkColJsonNode.put("SingerId", 1);
+    ObjectNode nonPkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
+    nonPkColJsonNode.put("FirstName", "firstName");
+    nonPkColJsonNode.put("LastName", "lastName");
+    List<ModColumnType> rowTypes = new ArrayList<>();
+    rowTypes.add(new ModColumnType("SingerId", new TypeCode("{\"code\":\"INT64\"}"), true, 1));
+    rowTypes.add(new ModColumnType("FirstName", new TypeCode("{\"code\":\"STRING\"}"), false, 2));
+    rowTypes.add(new ModColumnType("LastName", new TypeCode("{\"code\":\"STRING\"}"), false, 3));
+    Mod mod =
+        new Mod(
+            pkColJsonNode.toString(),
+            nonPkColJsonNode.toString(),
+            Timestamp.ofTimeSecondsAndNanos(1650908264L, 925679000),
+            "1",
+            true,
+            "00000001",
+            "Singers",
+            rowTypes,
+            ModType.INSERT,
+            ValueCaptureType.NEW_ROW,
+            1L,
+            1L);
+    Map<String, TrackedSpannerTable> spannerTableByName = createSpannerTableByName();
+    SchemaUpdateUtils.updateStoredSchemaNewRow(
+        mod, spannerTableByName, Dialect.GOOGLE_STANDARD_SQL);
+    assertThat(spannerTableByName.get("Singers").getNonPkColumns().size()).isEqualTo(2);
+  }
+
+  public void testUpdateStoredSchemaInNeeded(ValueCaptureType valueCaptureType, Dialect dialect) {
+    // Construct expectedSpannerTableByName got from INFORMATION_SCHEMA
+    Map<String, TrackedSpannerTable> expectedSpannerTableByName = new HashMap<>();
+    List<TrackedSpannerColumn> singersPkColumns =
+        Collections.singletonList(TrackedSpannerColumn.create("SingerId", Type.int64(), -1, 1));
+    List<TrackedSpannerColumn> singersNonPkColumns =
+        Arrays.asList(
+            TrackedSpannerColumn.create("FirstName", Type.string(), 2, -1),
+            TrackedSpannerColumn.create("LastName", Type.string(), 3, -1));
+    expectedSpannerTableByName.put(
+        "Singers", new TrackedSpannerTable("Singers", singersPkColumns, singersNonPkColumns));
+    // Construct the current mod.
+    ObjectNode pkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
+    pkColJsonNode.put("SingerId", 1);
+    ObjectNode nonPkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
+    nonPkColJsonNode.put("FirstName", "firstName");
+    nonPkColJsonNode.put("LastName", "lastName");
+    List<ModColumnType> rowTypes = new ArrayList<>();
+    rowTypes.add(new ModColumnType("SingerId", new TypeCode("{\"code\":\"INT64\"}"), true, 1));
+    rowTypes.add(new ModColumnType("FirstName", new TypeCode("{\"code\":\"STRING\"}"), false, 2));
+    rowTypes.add(new ModColumnType("LastName", new TypeCode("{\"code\":\"STRING\"}"), false, 3));
+    Mod mod =
+        new Mod(
+            pkColJsonNode.toString(),
+            nonPkColJsonNode.toString(),
+            Timestamp.ofTimeSecondsAndNanos(1650908264L, 925679000),
+            "1",
+            true,
+            "00000001",
+            "Singers",
+            rowTypes,
+            ModType.INSERT,
+            valueCaptureType,
+            1L,
+            1L);
+
+    try (MockedConstruction<SpannerChangeStreamsUtils> mockedSpannerChangeStreamsUtils =
+        Mockito.mockConstruction(
+            SpannerChangeStreamsUtils.class,
+            (mock, context) -> {
+              when(mock.getSpannerTableByName()).thenReturn(expectedSpannerTableByName);
+            })) {
+      // The current stored schema information.
+      Map<String, TrackedSpannerTable> currSpannerTableByName = createSpannerTableByName();
+      currSpannerTableByName =
+          SchemaUpdateUtils.updateStoredSchemaIfNeeded(
+              mockSpannerAccessor, changeStreamName, dialect, mod, currSpannerTableByName);
+      // Ensure the stored schema is updated with the schema from INFORMATION_SCHEMA.
+      assertThat(expectedSpannerTableByName.get("Singers").getNonPkColumns().size()).isEqualTo(2);
+      assertThat(currSpannerTableByName.get("Singers").getNonPkColumns().size()).isEqualTo(2);
+    }
+  }
+
+  @Test
+  public void testUpdateStoredSchemaInNeeded() {
+    testUpdateStoredSchemaInNeeded(
+        ValueCaptureType.OLD_AND_NEW_VALUES, Dialect.GOOGLE_STANDARD_SQL);
+    testUpdateStoredSchemaInNeeded(ValueCaptureType.NEW_ROW, Dialect.GOOGLE_STANDARD_SQL);
+    testUpdateStoredSchemaInNeeded(ValueCaptureType.OLD_AND_NEW_VALUES, Dialect.POSTGRESQL);
+    testUpdateStoredSchemaInNeeded(ValueCaptureType.NEW_ROW, Dialect.POSTGRESQL);
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SchemaUtilsTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SchemaUtilsTest.java
@@ -43,6 +43,8 @@ import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigqu
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.NUMERIC_COL;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.NUMERIC_NULLABLE_ARRAY_VAL;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.NUMERIC_VAL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.PG_JSON_COL;
+import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.PG_NUMERIC_COL;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.STRING_ARRAY_COL;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.STRING_COL;
 import static com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.TestUtils.STRING_NULLABLE_ARRAY_VAL;
@@ -56,6 +58,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.services.bigquery.model.TableFieldSchema;
 import com.google.api.services.bigquery.model.TableRow;
+import com.google.cloud.Timestamp;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Dialect;
@@ -65,6 +68,7 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.ResultSets;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.Type;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.model.TrackedSpannerColumn;
@@ -92,10 +96,13 @@ public class SchemaUtilsTest {
   @Mock private DatabaseClient mockDatabaseClient;
   @Mock private ReadContext mockReadContext;
   private List<TrackedSpannerColumn> spannerColumnsOfAllTypes;
+  private Timestamp now = Timestamp.now();
 
   @Before
   public void setUp() {
     when(mockDatabaseClient.singleUse()).thenReturn(mockReadContext);
+    when(mockDatabaseClient.singleUse(TimestampBound.ofReadTimestamp(now)))
+        .thenReturn(mockReadContext);
     spannerColumnsOfAllTypes =
         ImmutableList.of(
             TrackedSpannerColumn.create(BOOLEAN_COL, Type.bool(), 1, 1),
@@ -138,7 +145,7 @@ public class SchemaUtilsTest {
 
     Map<String, TrackedSpannerTable> actualSpannerTableByName =
         new SpannerChangeStreamsUtils(
-                mockDatabaseClient, changeStreamName, Dialect.GOOGLE_STANDARD_SQL)
+                mockDatabaseClient, changeStreamName, Dialect.GOOGLE_STANDARD_SQL, now)
             .getSpannerTableByName();
 
     List<TrackedSpannerColumn> singersPkColumns =
@@ -172,7 +179,7 @@ public class SchemaUtilsTest {
                 Collections.emptyList()));
 
     Map<String, TrackedSpannerTable> actualSpannerTableByName =
-        new SpannerChangeStreamsUtils(mockDatabaseClient, changeStreamName, Dialect.POSTGRESQL)
+        new SpannerChangeStreamsUtils(mockDatabaseClient, changeStreamName, Dialect.POSTGRESQL, now)
             .getSpannerTableByName();
 
     List<TrackedSpannerColumn> singersPkColumns =
@@ -272,16 +279,24 @@ public class SchemaUtilsTest {
         new ArrayList<>(
             ImmutableList.of(
                 Struct.newBuilder()
-                    .set("TABLE_NAME").to(Value.string("Singers"))
-                    .set("COLUMN_NAME").to(Value.string("SingerId1"))
-                    .set("ORDINAL_POSITION").to(Value.int64(1))
-                    .set("SPANNER_TYPE").to(Value.string("INT64"))
+                    .set("TABLE_NAME")
+                    .to(Value.string("Singers"))
+                    .set("COLUMN_NAME")
+                    .to(Value.string("SingerId1"))
+                    .set("ORDINAL_POSITION")
+                    .to(Value.int64(1))
+                    .set("SPANNER_TYPE")
+                    .to(Value.string("INT64"))
                     .build(),
                 Struct.newBuilder()
-                    .set("TABLE_NAME").to(Value.string("Singers"))
-                    .set("COLUMN_NAME").to(Value.string("SingerId2"))
-                    .set("ORDINAL_POSITION").to(Value.int64(2))
-                    .set("SPANNER_TYPE").to(Value.string("INT64"))
+                    .set("TABLE_NAME")
+                    .to(Value.string("Singers"))
+                    .set("COLUMN_NAME")
+                    .to(Value.string("SingerId2"))
+                    .set("ORDINAL_POSITION")
+                    .to(Value.int64(2))
+                    .set("SPANNER_TYPE")
+                    .to(Value.string("INT64"))
                     .build()));
     // spotless:on
     when(mockReadContext.executeQuery(
@@ -307,16 +322,24 @@ public class SchemaUtilsTest {
         new ArrayList<>(
             ImmutableList.of(
                 Struct.newBuilder()
-                    .set("TABLE_NAME").to(Value.string("Singers"))
-                    .set("COLUMN_NAME").to(Value.string("SingerId2"))
-                    .set("ORDINAL_POSITION").to(Value.int64(1))
-                    .set("CONSTRAINT_NAME").to(Value.string("PK_Singers"))
+                    .set("TABLE_NAME")
+                    .to(Value.string("Singers"))
+                    .set("COLUMN_NAME")
+                    .to(Value.string("SingerId2"))
+                    .set("ORDINAL_POSITION")
+                    .to(Value.int64(1))
+                    .set("CONSTRAINT_NAME")
+                    .to(Value.string("PK_Singers"))
                     .build(),
                 Struct.newBuilder()
-                    .set("TABLE_NAME").to(Value.string("Singers"))
-                    .set("COLUMN_NAME").to(Value.string("SingerId1"))
-                    .set("ORDINAL_POSITION").to(Value.int64(2))
-                    .set("CONSTRAINT_NAME").to(Value.string("PK_Singers"))
+                    .set("TABLE_NAME")
+                    .to(Value.string("Singers"))
+                    .set("COLUMN_NAME")
+                    .to(Value.string("SingerId1"))
+                    .set("ORDINAL_POSITION")
+                    .to(Value.int64(2))
+                    .set("CONSTRAINT_NAME")
+                    .to(Value.string("PK_Singers"))
                     .build()));
     // spotless:on
     when(mockReadContext.executeQuery(
@@ -345,7 +368,7 @@ public class SchemaUtilsTest {
 
     Map<String, TrackedSpannerTable> actualSpannerTableByName =
         new SpannerChangeStreamsUtils(
-                mockDatabaseClient, changeStreamName, Dialect.GOOGLE_STANDARD_SQL)
+                mockDatabaseClient, changeStreamName, Dialect.GOOGLE_STANDARD_SQL, now)
             .getSpannerTableByName();
 
     List<TrackedSpannerColumn> singersPkColumns =
@@ -465,24 +488,42 @@ public class SchemaUtilsTest {
             Type.struct(structFields),
             Collections.singletonList(
                 Struct.newBuilder()
-                    .set(BOOLEAN_COL).to(BOOLEAN_VAL)
-                    .set(BYTES_COL).to(BYTES_VAL)
-                    .set(DATE_COL).to(DATE_VAL)
-                    .set(FLOAT64_COL).to(FLOAT64_VAL)
-                    .set(INT64_COL).to(INT64_VAL)
-                    .set(JSON_COL).to(JSON_VAL)
-                    .set(NUMERIC_COL).to(NUMERIC_VAL)
-                    .set(STRING_COL).to(STRING_VAL)
-                    .set(TIMESTAMP_COL).to(TIMESTAMP_VAL)
-                    .set(BOOLEAN_ARRAY_COL).to(BOOLEAN_NULLABLE_ARRAY_VAL)
-                    .set(BYTES_ARRAY_COL).to(BYTES_NULLABLE_ARRAY_VAL)
-                    .set(DATE_ARRAY_COL).to(DATE_NULLABLE_ARRAY_VAL)
-                    .set(FLOAT64_ARRAY_COL).to(FLOAT64_NULLABLE_ARRAY_VAL)
-                    .set(INT64_ARRAY_COL).to(INT64_NULLABLE_ARRAY_VAL)
-                    .set(JSON_ARRAY_COL).to(JSON_NULLABLE_ARRAY_VAL)
-                    .set(NUMERIC_ARRAY_COL).to(NUMERIC_NULLABLE_ARRAY_VAL)
-                    .set(STRING_ARRAY_COL).to(STRING_NULLABLE_ARRAY_VAL)
-                    .set(TIMESTAMP_ARRAY_COL).to(TIMESTAMP_NULLABLE_ARRAY_VAL)
+                    .set(BOOLEAN_COL)
+                    .to(BOOLEAN_VAL)
+                    .set(BYTES_COL)
+                    .to(BYTES_VAL)
+                    .set(DATE_COL)
+                    .to(DATE_VAL)
+                    .set(FLOAT64_COL)
+                    .to(FLOAT64_VAL)
+                    .set(INT64_COL)
+                    .to(INT64_VAL)
+                    .set(JSON_COL)
+                    .to(JSON_VAL)
+                    .set(NUMERIC_COL)
+                    .to(NUMERIC_VAL)
+                    .set(STRING_COL)
+                    .to(STRING_VAL)
+                    .set(TIMESTAMP_COL)
+                    .to(TIMESTAMP_VAL)
+                    .set(BOOLEAN_ARRAY_COL)
+                    .to(BOOLEAN_NULLABLE_ARRAY_VAL)
+                    .set(BYTES_ARRAY_COL)
+                    .to(BYTES_NULLABLE_ARRAY_VAL)
+                    .set(DATE_ARRAY_COL)
+                    .to(DATE_NULLABLE_ARRAY_VAL)
+                    .set(FLOAT64_ARRAY_COL)
+                    .to(FLOAT64_NULLABLE_ARRAY_VAL)
+                    .set(INT64_ARRAY_COL)
+                    .to(INT64_NULLABLE_ARRAY_VAL)
+                    .set(JSON_ARRAY_COL)
+                    .to(JSON_NULLABLE_ARRAY_VAL)
+                    .set(NUMERIC_ARRAY_COL)
+                    .to(NUMERIC_NULLABLE_ARRAY_VAL)
+                    .set(STRING_ARRAY_COL)
+                    .to(STRING_NULLABLE_ARRAY_VAL)
+                    .set(TIMESTAMP_ARRAY_COL)
+                    .to(TIMESTAMP_NULLABLE_ARRAY_VAL)
                     .build()));
     // spotless:on
     SpannerToBigQueryUtils.spannerSnapshotRowToBigQueryTableRow(
@@ -529,7 +570,49 @@ public class SchemaUtilsTest {
   }
 
   @Test
-  public void testSpannerColumnsToBigQueryIOFields() {
+  public void testTableRowColumnsToBigQueryIOFields() {
+    TableRow tableRow = new TableRow();
+    tableRow.put(BOOLEAN_COL, true);
+    tableRow.put("_type_" + BOOLEAN_COL, "BOOL");
+    tableRow.put(BYTES_COL, "");
+    tableRow.put("_type_" + BYTES_COL, "BYTES");
+    tableRow.put(DATE_COL, "");
+    tableRow.put("_type_" + DATE_COL, "DATE");
+    tableRow.put(FLOAT64_COL, "");
+    tableRow.put("_type_" + FLOAT64_COL, "FLOAT64");
+    tableRow.put(INT64_COL, "");
+    tableRow.put("_type_" + INT64_COL, "INT64");
+    tableRow.put(JSON_COL, "");
+    tableRow.put("_type_" + JSON_COL, "JSON");
+    tableRow.put(PG_JSON_COL, "");
+    tableRow.put("_type_" + PG_JSON_COL, "PG_JSONB");
+    tableRow.put(NUMERIC_COL, "");
+    tableRow.put("_type_" + NUMERIC_COL, "NUMERIC");
+    tableRow.put(PG_NUMERIC_COL, "");
+    tableRow.put("_type_" + PG_NUMERIC_COL, "PG_NUMERIC");
+    tableRow.put(STRING_COL, "");
+    tableRow.put("_type_" + STRING_COL, "STRING");
+    tableRow.put(TIMESTAMP_COL, "");
+    tableRow.put("_type_" + TIMESTAMP_COL, "TIMESTAMP");
+    tableRow.put(BOOLEAN_ARRAY_COL, "");
+    tableRow.put("_type_" + BOOLEAN_ARRAY_COL, "ARRAY<BOOL>");
+    tableRow.put(BYTES_ARRAY_COL, "");
+    tableRow.put("_type_" + BYTES_ARRAY_COL, "ARRAY<BYTES>");
+    tableRow.put(DATE_ARRAY_COL, "");
+    tableRow.put("_type_" + DATE_ARRAY_COL, "ARRAY<DATE>");
+    tableRow.put(FLOAT64_ARRAY_COL, "");
+    tableRow.put("_type_" + FLOAT64_ARRAY_COL, "ARRAY<FLOAT64>");
+    tableRow.put(INT64_ARRAY_COL, "");
+    tableRow.put("_type_" + INT64_ARRAY_COL, "ARRAY<INT64>");
+    tableRow.put(JSON_ARRAY_COL, "");
+    tableRow.put("_type_" + JSON_ARRAY_COL, "ARRAY<JSON>");
+    tableRow.put(NUMERIC_ARRAY_COL, "");
+    tableRow.put("_type_" + NUMERIC_ARRAY_COL, "ARRAY<NUMERIC>");
+    tableRow.put(STRING_ARRAY_COL, "");
+    tableRow.put("_type_" + STRING_ARRAY_COL, "ARRAY<STRING>");
+    tableRow.put(TIMESTAMP_ARRAY_COL, "");
+    tableRow.put("_type_" + TIMESTAMP_ARRAY_COL, "ARRAY<TIMESTAMP>");
+
     List<TableFieldSchema> tableFields =
         ImmutableList.of(
             new TableFieldSchema()
@@ -557,9 +640,17 @@ public class SchemaUtilsTest {
                 .setMode(Field.Mode.NULLABLE.name())
                 .setType("JSON"),
             new TableFieldSchema()
+                .setName(PG_JSON_COL)
+                .setMode(Field.Mode.NULLABLE.name())
+                .setType("JSON"),
+            new TableFieldSchema()
                 .setName(NUMERIC_COL)
                 .setMode(Field.Mode.NULLABLE.name())
                 .setType("NUMERIC"),
+            new TableFieldSchema()
+                .setName(PG_NUMERIC_COL)
+                .setMode(Field.Mode.NULLABLE.name())
+                .setType("STRING"),
             new TableFieldSchema()
                 .setName(STRING_COL)
                 .setMode(Field.Mode.NULLABLE.name())
@@ -604,8 +695,7 @@ public class SchemaUtilsTest {
                 .setName(TIMESTAMP_ARRAY_COL)
                 .setMode(Field.Mode.REPEATED.name())
                 .setType("TIMESTAMP"));
-
-    assertThat(SpannerToBigQueryUtils.spannerColumnsToBigQueryIOFields(spannerColumnsOfAllTypes))
+    assertThat(SpannerToBigQueryUtils.tableRowColumnsToBigQueryIOFields(tableRow, false))
         .isEqualTo(tableFields);
   }
 
@@ -631,14 +721,22 @@ public class SchemaUtilsTest {
 
     assertThat(tableRow.toString())
         .isEqualTo(
-            "GenericData{classInfo=[f], {BytesCol=ZmZm, DateCol=2020-12-12, Float64Col=1.3,"
-                + " Int64Col=5, JsonCol={\"color\":\"red\",\"value\":\"#f00\"}, NumericCol=4.4,"
-                + " StringCol=abc, TimestampCol=2022-03-19T18:51:33.963910279Z,"
-                + " BytesArrayCol=[YWJj, YmNk], DateArrayCol=[2021-01-22, 2022-01-01],"
-                + " Float64ArrayCol=[1.2, 4.4], Int64ArrayCol=[1, 2], JsonArrayCol=[{},"
-                + " {\"color\":\"red\",\"value\":\"#f00\"}, []], NumericArrayCol=[2.2, 3.3],"
-                + " StringArrayCol=[a, b], TimestampArrayCol=[2022-03-19T18:51:33.963910279Z,"
-                + " 2022-03-19T18:51:33.963910279Z]}}");
+            "GenericData{classInfo=[f], {BytesCol=ZmZm, _type_BytesCol=BYTES, DateCol=2020-12-12,"
+                + " _type_DateCol=DATE, Float64Col=1.3, _type_Float64Col=FLOAT64, Int64Col=5,"
+                + " _type_Int64Col=INT64, JsonCol={\"color\":\"red\",\"value\":\"#f00\"},"
+                + " _type_JsonCol=JSON, NumericCol=4.4, _type_NumericCol=NUMERIC, StringCol=abc,"
+                + " _type_StringCol=STRING, TimestampCol=2022-03-19T18:51:33.963910279Z,"
+                + " _type_TimestampCol=TIMESTAMP, BytesArrayCol=[YWJj, YmNk],"
+                + " _type_BytesArrayCol=ARRAY<BYTES>, DateArrayCol=[2021-01-22,"
+                + " 2022-01-01], _type_DateArrayCol=ARRAY<DATE>, Float64ArrayCol=[1.2, 4.4],"
+                + " _type_Float64ArrayCol=ARRAY<FLOAT64>, Int64ArrayCol=[1, 2],"
+                + " _type_Int64ArrayCol=ARRAY<INT64>,"
+                + " JsonArrayCol=[{}, {\"color\":\"red\",\"value\":\"#f00\"}, []],"
+                + " _type_JsonArrayCol=ARRAY<JSON>,"
+                + " NumericArrayCol=[2.2, 3.3], _type_NumericArrayCol=ARRAY<NUMERIC>,"
+                + " StringArrayCol=[a, b], _type_StringArrayCol=ARRAY<STRING>,"
+                + " TimestampArrayCol=[2022-03-19T18:51:33.963910279Z,"
+                + " 2022-03-19T18:51:33.963910279Z], _type_TimestampArrayCol=ARRAY<TIMESTAMP>}}");
   }
 
   private void mockInformationSchemaChangeStreamsQuery(boolean isTrackingAll) {
@@ -705,22 +803,34 @@ public class SchemaUtilsTest {
         new ArrayList<>(
             ImmutableList.of(
                 Struct.newBuilder()
-                    .set("TABLE_NAME").to(Value.string("Singers"))
-                    .set("COLUMN_NAME").to(Value.string("SingerId"))
-                    .set("ORDINAL_POSITION").to(Value.int64(1))
-                    .set("SPANNER_TYPE").to(Value.string("INT64"))
+                    .set("TABLE_NAME")
+                    .to(Value.string("Singers"))
+                    .set("COLUMN_NAME")
+                    .to(Value.string("SingerId"))
+                    .set("ORDINAL_POSITION")
+                    .to(Value.int64(1))
+                    .set("SPANNER_TYPE")
+                    .to(Value.string("INT64"))
                     .build(),
                 Struct.newBuilder()
-                    .set("TABLE_NAME").to(Value.string("Singers"))
-                    .set("COLUMN_NAME").to(Value.string("FirstName"))
-                    .set("ORDINAL_POSITION").to(Value.int64(2))
-                    .set("SPANNER_TYPE").to(Value.string("STRING(1024)"))
+                    .set("TABLE_NAME")
+                    .to(Value.string("Singers"))
+                    .set("COLUMN_NAME")
+                    .to(Value.string("FirstName"))
+                    .set("ORDINAL_POSITION")
+                    .to(Value.int64(2))
+                    .set("SPANNER_TYPE")
+                    .to(Value.string("STRING(1024)"))
                     .build(),
                 Struct.newBuilder()
-                    .set("TABLE_NAME").to(Value.string("Singers"))
-                    .set("COLUMN_NAME").to(Value.string("LastName"))
-                    .set("ORDINAL_POSITION").to(Value.int64(3))
-                    .set("SPANNER_TYPE").to(Value.string("STRING"))
+                    .set("TABLE_NAME")
+                    .to(Value.string("Singers"))
+                    .set("COLUMN_NAME")
+                    .to(Value.string("LastName"))
+                    .set("ORDINAL_POSITION")
+                    .to(Value.int64(3))
+                    .set("SPANNER_TYPE")
+                    .to(Value.string("STRING"))
                     .build()));
     // spotless:on
 
@@ -889,5 +999,16 @@ public class SchemaUtilsTest {
                     Type.StructField.of("ordinal_position", Type.int64()),
                     Type.StructField.of("constraint_name", Type.string())),
                 rows));
+  }
+
+  @Test
+  public void testCleanSpannerType() {
+    // STRING -> STRING
+    assertThat(SpannerToBigQueryUtils.cleanSpannerType("STRING")).isEqualTo("STRING");
+    // NUMERIC<PG_NUMERIC> -> NUMERIC
+    assertThat(SpannerToBigQueryUtils.cleanSpannerType("NUMERIC<PG_NUMERIC>")).isEqualTo("NUMERIC");
+    // ARRAY<NUMERIC<PG_NUMERIC>> -> ARRAY<NUMERIC>
+    assertThat(SpannerToBigQueryUtils.cleanSpannerType("ARRAY<NUMERIC<PG_NUMERIC>>"))
+        .isEqualTo("ARRAY<NUMERIC>");
   }
 }

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SchemaUtilsTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SchemaUtilsTest.java
@@ -81,6 +81,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.ModType;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
@@ -702,11 +703,11 @@ public class SchemaUtilsTest {
   @Test
   public void testAddSpannerNonPkColumnsToTableRow() throws Exception {
     String newValuesJson =
-        "{\"BoolCol\":true,\"BytesCol\":\"ZmZm\",\"DateCol\":\"2020-12-12\",\"Float64Col\":1.3,"
+        "{\"BooleanCol\":true,\"BytesCol\":\"ZmZm\",\"DateCol\":\"2020-12-12\",\"Float64Col\":1.3,"
             + "\"Int64Col\":\"5\","
             + "\"JsonCol\":\"{\\\"color\\\":\\\"red\\\",\\\"value\\\":\\\"#f00\\\"}\","
             + "\"NumericCol\":\"4.4\",\"StringCol\":\"abc\","
-            + "\"TimestampCol\":\"2022-03-19T18:51:33.963910279Z\",\"BoolArrayCol\":[true,false],"
+            + "\"TimestampCol\":\"2022-03-19T18:51:33.963910279Z\",\"BooleanArrayCol\":[true,false],"
             + "\"BytesArrayCol\":[\"YWJj\",\"YmNk\"],"
             + "\"DateArrayCol\":[\"2021-01-22\",\"2022-01-01\"],\"Float64ArrayCol\":[1.2,4.4],"
             + "\"Int64ArrayCol\":[\"1\",\"2\"],"
@@ -717,16 +718,16 @@ public class SchemaUtilsTest {
             + "\"2022-03-19T18:51:33.963910279Z\"]}";
     TableRow tableRow = new TableRow();
     SpannerToBigQueryUtils.addSpannerNonPkColumnsToTableRow(
-        newValuesJson, spannerColumnsOfAllTypes, tableRow);
+        newValuesJson, spannerColumnsOfAllTypes, tableRow, ModType.INSERT);
 
     assertThat(tableRow.toString())
         .isEqualTo(
-            "GenericData{classInfo=[f], {BytesCol=ZmZm, _type_BytesCol=BYTES, DateCol=2020-12-12,"
+            "GenericData{classInfo=[f], {BooleanCol=true, _type_BooleanCol=BOOL, BytesCol=ZmZm, _type_BytesCol=BYTES, DateCol=2020-12-12,"
                 + " _type_DateCol=DATE, Float64Col=1.3, _type_Float64Col=FLOAT64, Int64Col=5,"
                 + " _type_Int64Col=INT64, JsonCol={\"color\":\"red\",\"value\":\"#f00\"},"
                 + " _type_JsonCol=JSON, NumericCol=4.4, _type_NumericCol=NUMERIC, StringCol=abc,"
                 + " _type_StringCol=STRING, TimestampCol=2022-03-19T18:51:33.963910279Z,"
-                + " _type_TimestampCol=TIMESTAMP, BytesArrayCol=[YWJj, YmNk],"
+                + " _type_TimestampCol=TIMESTAMP, BooleanArrayCol=[true, false], _type_BooleanArrayCol=ARRAY<BOOL>, BytesArrayCol=[YWJj, YmNk],"
                 + " _type_BytesArrayCol=ARRAY<BYTES>, DateArrayCol=[2021-01-22,"
                 + " 2022-01-01], _type_DateArrayCol=ARRAY<DATE>, Float64ArrayCol=[1.2, 4.4],"
                 + " _type_Float64ArrayCol=ARRAY<FLOAT64>, Int64ArrayCol=[1, 2],"
@@ -737,6 +738,54 @@ public class SchemaUtilsTest {
                 + " StringArrayCol=[a, b], _type_StringArrayCol=ARRAY<STRING>,"
                 + " TimestampArrayCol=[2022-03-19T18:51:33.963910279Z,"
                 + " 2022-03-19T18:51:33.963910279Z], _type_TimestampArrayCol=ARRAY<TIMESTAMP>}}");
+  }
+
+  @Test
+  public void testAddSpannerNonPkColumnsToTableRowForDelete() throws Exception {
+    String newValuesJson = "";
+    TableRow tableRow = new TableRow();
+    SpannerToBigQueryUtils.addSpannerNonPkColumnsToTableRow(
+        newValuesJson, spannerColumnsOfAllTypes, tableRow, ModType.DELETE);
+
+    assertThat(tableRow.toString())
+        .isEqualTo(
+            "GenericData{classInfo=[f], {BooleanCol=null, _type_BooleanCol=BOOL, BytesCol=null, _type_BytesCol=BYTES, DateCol=null,"
+                + " _type_DateCol=DATE, Float64Col=null, _type_Float64Col=FLOAT64, Int64Col=null,"
+                + " _type_Int64Col=INT64, JsonCol=null,"
+                + " _type_JsonCol=JSON, NumericCol=null, _type_NumericCol=NUMERIC, StringCol=null,"
+                + " _type_StringCol=STRING, TimestampCol=null,"
+                + " _type_TimestampCol=TIMESTAMP, BooleanArrayCol=null, _type_BooleanArrayCol=ARRAY<BOOL>, BytesArrayCol=null,"
+                + " _type_BytesArrayCol=ARRAY<BYTES>, DateArrayCol=null, _type_DateArrayCol=ARRAY<DATE>, Float64ArrayCol=null,"
+                + " _type_Float64ArrayCol=ARRAY<FLOAT64>, Int64ArrayCol=null,"
+                + " _type_Int64ArrayCol=ARRAY<INT64>,"
+                + " JsonArrayCol=null, _type_JsonArrayCol=ARRAY<JSON>,"
+                + " NumericArrayCol=null, _type_NumericArrayCol=ARRAY<NUMERIC>,"
+                + " StringArrayCol=null, _type_StringArrayCol=ARRAY<STRING>,"
+                + " TimestampArrayCol=null, _type_TimestampArrayCol=ARRAY<TIMESTAMP>}}");
+  }
+
+  @Test
+  public void testAddSpannerNonPkColumnsToTableRowForNewRowOldValuesUpdate() throws Exception {
+    String newValuesJson = "{\"BooleanCol\":true,\"BytesCol\":\"ZmZm\"}";
+    TableRow tableRow = new TableRow();
+    SpannerToBigQueryUtils.addSpannerNonPkColumnsToTableRow(
+        newValuesJson, spannerColumnsOfAllTypes, tableRow, ModType.UPDATE);
+
+    assertThat(tableRow.toString())
+        .isEqualTo(
+            "GenericData{classInfo=[f], {BooleanCol=true, _type_BooleanCol=BOOL, BytesCol=ZmZm, _type_BytesCol=BYTES, DateCol=null,"
+                + " _type_DateCol=DATE, Float64Col=null, _type_Float64Col=FLOAT64, Int64Col=null,"
+                + " _type_Int64Col=INT64, JsonCol=null,"
+                + " _type_JsonCol=JSON, NumericCol=null, _type_NumericCol=NUMERIC, StringCol=null,"
+                + " _type_StringCol=STRING, TimestampCol=null,"
+                + " _type_TimestampCol=TIMESTAMP, BooleanArrayCol=null, _type_BooleanArrayCol=ARRAY<BOOL>, BytesArrayCol=null,"
+                + " _type_BytesArrayCol=ARRAY<BYTES>, DateArrayCol=null, _type_DateArrayCol=ARRAY<DATE>, Float64ArrayCol=null,"
+                + " _type_Float64ArrayCol=ARRAY<FLOAT64>, Int64ArrayCol=null,"
+                + " _type_Int64ArrayCol=ARRAY<INT64>,"
+                + " JsonArrayCol=null, _type_JsonArrayCol=ARRAY<JSON>,"
+                + " NumericArrayCol=null, _type_NumericArrayCol=ARRAY<NUMERIC>,"
+                + " StringArrayCol=null, _type_StringArrayCol=ARRAY<STRING>,"
+                + " TimestampArrayCol=null, _type_TimestampArrayCol=ARRAY<TIMESTAMP>}}");
   }
 
   private void mockInformationSchemaChangeStreamsQuery(boolean isTrackingAll) {

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SpannerChangeStreamsToBigQueryIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SpannerChangeStreamsToBigQueryIT.java
@@ -21,16 +21,24 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableResult;
+import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
 import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -47,6 +55,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -99,10 +108,23 @@ public class SpannerChangeStreamsToBigQueryIT extends TemplateTestBase {
 
     String cdcTable = spannerTable + "_changelog";
     spannerResourceManager.executeDdlStatement(createTableStatement);
+
+    int key = nextValue();
+    String firstName = UUID.randomUUID().toString();
+    String lastName = UUID.randomUUID().toString();
+    Mutation insertOneRow =
+        Mutation.newInsertBuilder(spannerTable)
+            .set("Id")
+            .to(key)
+            .set("FirstName")
+            .to(firstName)
+            .set("LastName")
+            .to(lastName)
+            .build();
+    spannerResourceManager.write(Collections.singletonList(insertOneRow));
+
     String createChangeStreamStatement =
-        String.format(
-            "CREATE CHANGE STREAM %s_stream FOR %s OPTIONS (value_capture_type = 'NEW_ROW')",
-            testName, spannerTable);
+        String.format("CREATE CHANGE STREAM %s_stream FOR %s", testName, spannerTable);
     spannerResourceManager.executeDdlStatement(createChangeStreamStatement);
     bigQueryResourceManager.createDataset(REGION);
 
@@ -121,69 +143,28 @@ public class SpannerChangeStreamsToBigQueryIT extends TemplateTestBase {
                     .addParameter("spannerChangeStreamName", testName + "_stream")
                     .addParameter("bigQueryDataset", bigQueryResourceManager.getDatasetId())
                     .addParameter("rpcPriority", "HIGH")
-                    .addParameter("disableDlqRetries", "true")));
+                    .addParameter("dlqRetryMinutes", "3")));
 
     assertThatPipeline(launchInfo).isRunning();
 
-    int key = nextValue();
-    String firstName = UUID.randomUUID().toString();
-    String lastName = UUID.randomUUID().toString();
-    List<Pair> colValPairs =
-        Arrays.asList(new Pair("FirstName", firstName), new Pair("LastName", lastName));
-    Mutation expectedData = generateTableRow(spannerTable, key, colValPairs);
-    spannerResourceManager.write(Collections.singletonList(expectedData));
+    String updatedLastName = UUID.randomUUID().toString();
+    Mutation updateOneRow =
+        Mutation.newUpdateBuilder(spannerTable)
+            .set("Id")
+            .to(key)
+            .set("LastName")
+            .to(updatedLastName)
+            .build();
+    spannerResourceManager.write(Collections.singletonList(updateOneRow));
     String query = queryCdcTable(cdcTable, key);
     waitForQueryToReturnRows(query, 1, true);
 
     TableResult tableResult = bigQueryResourceManager.runQuery(query);
     assertEquals(1, tableResult.getTotalRows());
     for (FieldValueList row : tableResult.iterateAll()) {
-      assertTrue(validateChangeLogTableRow(row, colValPairs));
+      assertEquals(firstName, row.get("FirstName").getStringValue());
+      assertEquals(updatedLastName, row.get("LastName").getStringValue());
     }
-  }
-
-  boolean validateChangeLogTableRow(FieldValueList row, List<Pair> pairs) {
-    for (Pair pair : pairs) {
-      try {
-        if (!row.get(pair.col).getStringValue().equals(pair.val)) {
-          LOG.info(
-              "Changelog table value for col "
-                  + pair.col
-                  + " is: "
-                  + row.get(pair.col).getStringValue()
-                  + ", which is different from spanner table's value: "
-                  + pair.val);
-          return false;
-        }
-      } catch (BigQueryException e) {
-        LOG.info("Error when trying to read the value for column " + pair.col + ": " + e);
-        return false;
-      }
-    }
-    return true;
-  }
-
-  class Pair {
-    String col;
-    String val;
-
-    Pair(String col, String val) {
-      this.col = col;
-      this.val = val;
-    }
-  }
-
-  public static int nextValue() {
-    return counter.getAndIncrement();
-  }
-
-  private static Mutation generateTableRow(String tableId, int key, List<Pair> pairs) {
-    Mutation.WriteBuilder mutation = Mutation.newInsertBuilder(tableId);
-    mutation.set("Id").to(key);
-    for (Pair pair : pairs) {
-      mutation.set(pair.col).to(pair.val);
-    }
-    return mutation.build();
   }
 
   @Test
@@ -222,11 +203,11 @@ public class SpannerChangeStreamsToBigQueryIT extends TemplateTestBase {
                     .addParameter("spannerChangeStreamName", testName + "_stream")
                     .addParameter("bigQueryDataset", bigQueryResourceManager.getDatasetId())
                     .addParameter("rpcPriority", "HIGH")
-                    .addParameter("disableDlqRetries", "true")));
+                    .addParameter("dlqRetryMinutes", "3")));
 
     assertThatPipeline(launchInfo).isRunning();
 
-    int key = 1;
+    int key = nextValue();
     float float32Val = 3.14f;
     double float64Val = 2.71;
 
@@ -251,6 +232,205 @@ public class SpannerChangeStreamsToBigQueryIT extends TemplateTestBase {
       assertEquals(float32Val, (float) (row.get("Float32Col").getDoubleValue()), 1e-6f);
       assertEquals(float64Val, row.get("Float64Col").getDoubleValue(), 1e-15);
     }
+  }
+
+  @Test
+  public void testSpannerChangeStreamsToBigQueryAddTable() throws Exception {
+    String spannerTable = testName + RandomStringUtils.randomAlphanumeric(1, 5);
+    String createTableStatement =
+        String.format(
+            "CREATE TABLE %s (\n"
+                + "  Id INT64 NOT NULL,\n"
+                + "  FirstName String(1024),\n"
+                + "  LastName String(1024),\n"
+                + ") PRIMARY KEY(Id)",
+            spannerTable);
+    String cdcTable = spannerTable + "_changelog";
+    spannerResourceManager.executeDdlStatement(createTableStatement);
+
+    String createChangeStreamStatement =
+        String.format(
+            "CREATE CHANGE STREAM %s_stream FOR ALL OPTIONS (value_capture_type = 'NEW_VALUES')",
+            testName);
+    spannerResourceManager.executeDdlStatement(createChangeStreamStatement);
+    bigQueryResourceManager.createDataset(REGION);
+
+    Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder = Function.identity();
+
+    launchInfo =
+        launchTemplate(
+            paramsAdder.apply(
+                LaunchConfig.builder(testName, specPath)
+                    .addParameter("spannerProjectId", PROJECT)
+                    .addParameter("spannerInstanceId", spannerResourceManager.getInstanceId())
+                    .addParameter("spannerDatabase", spannerResourceManager.getDatabaseId())
+                    .addParameter(
+                        "spannerMetadataInstanceId", spannerResourceManager.getInstanceId())
+                    .addParameter("spannerMetadataDatabase", spannerResourceManager.getDatabaseId())
+                    .addParameter("spannerChangeStreamName", testName + "_stream")
+                    .addParameter("bigQueryDataset", bigQueryResourceManager.getDatasetId())
+                    .addParameter("rpcPriority", "HIGH")
+                    .addParameter("dlqRetryMinutes", "3")));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    int key = nextValue();
+    String firstName = UUID.randomUUID().toString();
+    Mutation insertOneRow =
+        Mutation.newInsertBuilder(spannerTable)
+            .set("Id")
+            .to(key)
+            .set("FirstName")
+            .to(firstName)
+            .build();
+    spannerResourceManager.write(Collections.singletonList(insertOneRow));
+    String query = queryCdcTable(cdcTable, key);
+    waitForQueryToReturnRows(query, 1, false);
+    TableResult tableResult = bigQueryResourceManager.runQuery(query);
+    assertEquals(1, tableResult.getTotalRows());
+    for (FieldValueList row : tableResult.iterateAll()) {
+      assertEquals(firstName, row.get("FirstName").getStringValue());
+      assertTrue(row.get("LastName").isNull());
+    }
+
+    String spannerTable2 = spannerTable + "_new";
+    String cdcTable2 = spannerTable2 + "_changelog";
+    String createTableStatement2 =
+        String.format(
+            "CREATE TABLE %s (\n"
+                + "  Id INT64 NOT NULL,\n"
+                + "  FirstName String(1024),\n"
+                + "  LastName String(1024),\n"
+                + ") PRIMARY KEY(Id)",
+            spannerTable2);
+    spannerResourceManager.executeDdlStatement(createTableStatement2);
+
+    int key2 = nextValue();
+    String lastName2 = UUID.randomUUID().toString();
+    Mutation insertOneRow2 =
+        Mutation.newInsertBuilder(spannerTable2)
+            .set("Id")
+            .to(key2)
+            .set("LastName")
+            .to(lastName2)
+            .build();
+    spannerResourceManager.write(Collections.singletonList(insertOneRow2));
+
+    String query2 = queryCdcTable(cdcTable2, key2);
+    waitForQueryToReturnRows(query2, 1, false);
+    TableResult tableResult2 = bigQueryResourceManager.runQuery(query2);
+    assertEquals(1, tableResult2.getTotalRows());
+    for (FieldValueList row : tableResult2.iterateAll()) {
+      assertTrue(row.get("FirstName").isNull());
+      assertEquals(lastName2, row.get("LastName").getStringValue());
+    }
+  }
+
+  @Test
+  @Ignore("This test requires sleep for >10 mins due to limitation of big query")
+  public void testSpannerChangeStreamsToBigQueryAddColumn() throws Exception {
+    String spannerTable = testName + RandomStringUtils.randomAlphanumeric(1, 5);
+    String createTableStatement =
+        String.format(
+            "CREATE TABLE %s (\n"
+                + "  Id INT64 NOT NULL,\n"
+                + "  FirstName String(1024),\n"
+                + "  LastName String(1024),\n"
+                + ") PRIMARY KEY(Id)",
+            spannerTable);
+    String cdcTable = spannerTable + "_changelog";
+    spannerResourceManager.executeDdlStatement(createTableStatement);
+
+    int key = nextValue();
+    String firstName = UUID.randomUUID().toString();
+    String lastName = UUID.randomUUID().toString();
+    Mutation insertOneRow =
+        Mutation.newInsertBuilder(spannerTable)
+            .set("Id")
+            .to(key)
+            .set("FirstName")
+            .to(firstName)
+            .set("LastName")
+            .to(lastName)
+            .build();
+    spannerResourceManager.write(Collections.singletonList(insertOneRow));
+
+    String createChangeStreamStatement =
+        String.format("CREATE CHANGE STREAM %s_stream FOR %s", testName, spannerTable);
+    spannerResourceManager.executeDdlStatement(createChangeStreamStatement);
+    bigQueryResourceManager.createDataset(REGION);
+
+    Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder = Function.identity();
+
+    launchInfo =
+        launchTemplate(
+            paramsAdder.apply(
+                LaunchConfig.builder(testName, specPath)
+                    .addParameter("spannerProjectId", PROJECT)
+                    .addParameter("spannerInstanceId", spannerResourceManager.getInstanceId())
+                    .addParameter("spannerDatabase", spannerResourceManager.getDatabaseId())
+                    .addParameter(
+                        "spannerMetadataInstanceId", spannerResourceManager.getInstanceId())
+                    .addParameter("spannerMetadataDatabase", spannerResourceManager.getDatabaseId())
+                    .addParameter("spannerChangeStreamName", testName + "_stream")
+                    .addParameter("bigQueryDataset", bigQueryResourceManager.getDatasetId())
+                    .addParameter("rpcPriority", "HIGH")
+                    .addParameter("dlqRetryMinutes", "3")));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    Mutation deleteOneRow = Mutation.delete(spannerTable, Key.of(key));
+    spannerResourceManager.write(Collections.singletonList(deleteOneRow));
+    String query = queryCdcTable(cdcTable, key);
+    waitForQueryToReturnRows(query, 1, false);
+
+    String alterTableStatement =
+        String.format("ALTER TABLE %s ADD Password STRING(MAX)", spannerTable);
+    spannerResourceManager.executeDdlStatement(alterTableStatement);
+    addEmptyColumn("Password", cdcTable);
+
+    // Wait for bq streaming table metadata to notice the updated schema
+    TimeUnit.MINUTES.sleep(15);
+
+    int key2 = nextValue();
+    String firstName2 = UUID.randomUUID().toString();
+    String lastName2 = UUID.randomUUID().toString();
+    String passWord = UUID.randomUUID().toString();
+    Mutation insertOneRow2 =
+        Mutation.newInsertBuilder(spannerTable)
+            .set("Id")
+            .to(key2)
+            .set("FirstName")
+            .to(firstName2)
+            .set("LastName")
+            .to(lastName2)
+            .set("Password")
+            .to(passWord)
+            .build();
+    spannerResourceManager.write(Collections.singletonList(insertOneRow2));
+
+    String query2 = queryCdcTable(cdcTable, key2);
+    waitForQueryToReturnRows(query2, 1, true);
+    TableResult tableResult2 = bigQueryResourceManager.runQuery(query2);
+    assertEquals(1, tableResult2.getTotalRows());
+    for (FieldValueList row : tableResult2.iterateAll()) {
+      assertEquals(firstName2, row.get("FirstName").getStringValue());
+      assertEquals(lastName2, row.get("LastName").getStringValue());
+      assertEquals(passWord, row.get("Password").getStringValue());
+    }
+
+    TableResult tableResult = bigQueryResourceManager.runQuery(query);
+    assertEquals(1, tableResult.getTotalRows());
+    // Verify that the new column "Password" for older row is populated with null
+    for (FieldValueList row : tableResult.iterateAll()) {
+      assertTrue(row.get("FirstName").isNull());
+      assertTrue(row.get("LastName").isNull());
+      assertTrue(row.get("Password").isNull());
+    }
+  }
+
+  public static int nextValue() {
+    return counter.getAndIncrement();
   }
 
   private String queryCdcTable(String cdcTable, int key) {
@@ -286,5 +466,32 @@ public class SpannerChangeStreamsToBigQueryIT extends TemplateTestBase {
                 .waitForConditionAndCancel(config, dataShownUp(query, resultsRequired))
             : pipelineOperator().waitForCondition(config, dataShownUp(query, resultsRequired));
     assertThatResult(result).meetsConditions();
+  }
+
+  public void addEmptyColumn(String newColumnName, String tableId) {
+    try {
+
+      Table table = bigQueryResourceManager.getTableIfExists(tableId);
+      Schema schema = table.getDefinition().getSchema();
+      FieldList fields = schema.getFields();
+
+      // Create the new field/column
+      Field newField = Field.of(newColumnName, LegacySQLTypeName.STRING);
+
+      // Create a new schema adding the current fields, plus the new one
+      List<Field> fieldList = new ArrayList<Field>();
+      fields.forEach(fieldList::add);
+      fieldList.add(newField);
+      Schema newSchema = Schema.of(fieldList);
+
+      // Update the table with the new schema
+      Table updatedTable =
+          table.toBuilder().setDefinition(StandardTableDefinition.of(newSchema)).build();
+      updatedTable.update();
+    } catch (BigQueryException e) {
+      LOG.info(
+          "Caught exception when trying to add a new column to bigquery changelog table. \n"
+              + e.toString());
+    }
   }
 }

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/TestUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/TestUtils.java
@@ -65,7 +65,9 @@ class TestUtils {
   static final String FLOAT64_COL = "Float64Col";
   static final String INT64_COL = "Int64Col";
   static final String JSON_COL = "JsonCol";
+  static final String PG_JSON_COL = "PgJsonCol";
   static final String NUMERIC_COL = "NumericCol";
+  static final String PG_NUMERIC_COL = "PgNumericCol";
   static final String STRING_COL = "StringCol";
   static final String TIMESTAMP_COL = "TimestampCol";
 

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/TypesUtilsTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/TypesUtilsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.TypesUtils;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class TypesUtilsTest {
+
+  @Test
+  public void testExtractTypeFromTypeCode() {
+    // Eg 1: "{\"array_element_type\":{\"code\":\"STRING\"},\"code\":\"ARRAY\"}" -> ARRAY<STRING>
+    JSONObject jsonObject =
+        new JSONObject("{\"array_element_type\":{\"code\":\"STRING\"},\"code\":\"ARRAY\"}");
+    assertThat(TypesUtils.extractTypeFromTypeCode(jsonObject)).isEqualTo("ARRAY<STRING>");
+    // Eg 2: "{\"code\":\"STRING\"}" -> STRING
+    jsonObject = new JSONObject("{\"code\":\"STRING\"}");
+    assertThat(TypesUtils.extractTypeFromTypeCode(jsonObject)).isEqualTo("STRING");
+    final JSONObject invalidJsonObject = new JSONObject("{\"CODE\":\"STRING\"}");
+    assertThrows(JSONException.class, () -> TypesUtils.extractTypeFromTypeCode(invalidJsonObject));
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/TypesUtilsTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/TypesUtilsTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import com.google.cloud.spanner.Type;
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.TypesUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -29,15 +30,65 @@ import org.junit.runners.JUnit4;
 public final class TypesUtilsTest {
 
   @Test
-  public void testExtractTypeFromTypeCode() {
-    // Eg 1: "{\"array_element_type\":{\"code\":\"STRING\"},\"code\":\"ARRAY\"}" -> ARRAY<STRING>
+  public void testExtractArrayTypeFromTypeCode() {
+    // Eg : "{\"array_element_type\":{\"code\":\"STRING\"},\"code\":\"ARRAY\"}" -> ARRAY<STRING>
     JSONObject jsonObject =
         new JSONObject("{\"array_element_type\":{\"code\":\"STRING\"},\"code\":\"ARRAY\"}");
     assertThat(TypesUtils.extractTypeFromTypeCode(jsonObject)).isEqualTo("ARRAY<STRING>");
-    // Eg 2: "{\"code\":\"STRING\"}" -> STRING
-    jsonObject = new JSONObject("{\"code\":\"STRING\"}");
+    jsonObject = new JSONObject("{\"array_element_type\":{\"code\":\"JSON\"},\"code\":\"ARRAY\"}");
+    assertThat(TypesUtils.extractTypeFromTypeCode(jsonObject)).isEqualTo("ARRAY<JSON>");
+    jsonObject = new JSONObject("{\"array_element_type\":{\"code\":\"INT64\"},\"code\":\"ARRAY\"}");
+    assertThat(TypesUtils.extractTypeFromTypeCode(jsonObject)).isEqualTo("ARRAY<INT64>");
+  }
+
+  @Test
+  public void testExtractTypeFromTypeCode() {
+    // Eg : "{\"code\":\"STRING\"}" -> STRING
+    JSONObject jsonObject = new JSONObject("{\"code\":\"STRING\"}");
     assertThat(TypesUtils.extractTypeFromTypeCode(jsonObject)).isEqualTo("STRING");
-    final JSONObject invalidJsonObject = new JSONObject("{\"CODE\":\"STRING\"}");
+    jsonObject = new JSONObject("{\"code\":\"INT64\"}");
+    assertThat(TypesUtils.extractTypeFromTypeCode(jsonObject)).isEqualTo("INT64");
+    jsonObject = new JSONObject("{\"code\":\"BOOL\"}");
+    assertThat(TypesUtils.extractTypeFromTypeCode(jsonObject)).isEqualTo("BOOL");
+    jsonObject = new JSONObject("{\"code\":\"BYTES\"}");
+    assertThat(TypesUtils.extractTypeFromTypeCode(jsonObject)).isEqualTo("BYTES");
+    jsonObject = new JSONObject("{\"code\":\"FLOAT64\"}");
+    assertThat(TypesUtils.extractTypeFromTypeCode(jsonObject)).isEqualTo("FLOAT64");
+    jsonObject = new JSONObject("{\"code\":\"FLOAT32\"}");
+    assertThat(TypesUtils.extractTypeFromTypeCode(jsonObject)).isEqualTo("FLOAT32");
+    jsonObject = new JSONObject("{\"code\":\"DATE\"}");
+    assertThat(TypesUtils.extractTypeFromTypeCode(jsonObject)).isEqualTo("DATE");
+    jsonObject = new JSONObject("{\"code\":\"NUMERIC\"}");
+    assertThat(TypesUtils.extractTypeFromTypeCode(jsonObject)).isEqualTo("NUMERIC");
+    jsonObject = new JSONObject("{\"code\":\"TIMESTAMP\"}");
+    assertThat(TypesUtils.extractTypeFromTypeCode(jsonObject)).isEqualTo("TIMESTAMP");
+    jsonObject = new JSONObject("{\"code\":\"JSON\"}");
+    assertThat(TypesUtils.extractTypeFromTypeCode(jsonObject)).isEqualTo("JSON");
+  }
+
+  @Test
+  public void testInformationSchemaGoogleSQLTypeToSpannerType() {
+    assertThat(TypesUtils.informationSchemaGoogleSQLTypeToSpannerType("ARRAY<STRING(1024)>"))
+        .isEqualTo(Type.array(Type.string()));
+    assertThat(TypesUtils.informationSchemaGoogleSQLTypeToSpannerType("ARRAY<BYTES(MAX)>"))
+        .isEqualTo(Type.array(Type.bytes()));
+    assertThat(TypesUtils.informationSchemaGoogleSQLTypeToSpannerType("DATE"))
+        .isEqualTo(Type.date());
+  }
+
+  @Test
+  public void testInformationSchemaPostgreSQLTypeToSpannerType() {
+    assertThat(TypesUtils.informationSchemaPostgreSQLTypeToSpannerType("CHARACTER VARYING(256)[]"))
+        .isEqualTo(Type.array(Type.string()));
+    assertThat(TypesUtils.informationSchemaPostgreSQLTypeToSpannerType("JSONB[]"))
+        .isEqualTo(Type.array(Type.pgJsonb()));
+    assertThat(TypesUtils.informationSchemaPostgreSQLTypeToSpannerType("real"))
+        .isEqualTo(Type.float32());
+  }
+
+  @Test
+  public void testExtractTypeFromInvalidTypeCode() {
+    final JSONObject invalidJsonObject = new JSONObject("{\"type_code\":\"STRING\"}");
     assertThrows(JSONException.class, () -> TypesUtils.extractTypeFromTypeCode(invalidJsonObject));
   }
 }


### PR DESCRIPTION
Add IT tests for handling schema update during a spanner cdc to bigquery pipeline running.
Previously a base case test that doesn't contain any schema change was added in https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/1705 . This pull request adds two more IT tests following above workflow:

- Add a column(**disabled**): add a column in spanner source table -> add a column in corresponding bq table ->wait for 15mins(this is due to limitation of BigQuery and BQ team recommends wait >10 mins, see more [here](https://github.com/googleapis/google-cloud-python/issues/7433#issuecomment-553145337))->insert a row to source table with new column filled->verify bq table's new column is successfully populated. Due to the above bq limitation, this test requires sleeping at least 10 mins in test body to ensure no flakiness. Thus I disabled this test to avoid just hang the thread and do hardcoded sleep for such a long time.
- Add a table: add a source table in spanner -> insert a new row to new source table -> verify that the new changelog table in created and filled with correct information in bq. Different from updating an existing bq table's schema, add a completely new table does not suffer from the high latency.

I have run all IT tests together in parallel for >15 times locally and no flakiness observed. We can add more test cases later if tests in this pr are running stable.

I also added a 3 minutes dlq retry parameters to all IT tests in case there are any availability/transient errors happening on the spanner side.