### PR TITLE
Upgrade jackson version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <hbase.client.version>2.5.3-hadoop3</hbase.client.version>
     <mockito.version>4.11.0</mockito.version>
     <log4j-2.version>2.17.2</log4j-2.version>
-    <jackson.version>2.14.1</jackson.version>
+    <jackson.version>2.15.4</jackson.version>
     <jettison.version>1.5.4</jettison.version>
     <json.version>20231013</json.version>
     <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
Apache Beam depends on Jackson 2.15.4 as of https://github.com/apache/beam/pull/31473 which is breaking at least the JMS To PubSub template when deserializing pipeline options due to 
```
java.lang.NoSuchFieldError: READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE
  at com.fasterxml.jackson.databind.deser.std.EnumDeserializer.createContextual(EnumDeserializer.java:211)
  ...
  at org.apache.beam.sdk.options.PipelineOptionsFactory.computeDeserializerForMethod(PipelineOptionsFactory.java:1739)
  ...
```
which was a field added in 2.15.4