### PR TITLE
String splitter

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapter.java
@@ -22,13 +22,20 @@ import com.google.cloud.teleport.v2.source.reader.io.exception.RetriableSchemaDi
 import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryException;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.DialectAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.rowmapper.JdbcSourceRowMapper;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceColumnIndexInfo;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceColumnIndexInfo.IndexType;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.re2j.Matcher;
 import com.google.re2j.Pattern;
+import java.net.URL;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -37,6 +44,7 @@ import java.sql.SQLTimeoutException;
 import java.sql.SQLTransientConnectionException;
 import java.sql.Statement;
 import java.util.HashSet;
+import javax.annotation.Nullable;
 import javax.sql.DataSource;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
@@ -45,6 +53,11 @@ import org.slf4j.LoggerFactory;
 
 /** Adapter for MySql dialect of JDBC databases. */
 public final class MysqlDialectAdapter implements DialectAdapter {
+
+  public static final String PAD_SPACE = "PAD SPACE";
+  public static final String NO_PAD = "NO PAD";
+  public static final String BINARY_CHARACTER_SET = "binary";
+  public static final String BINARY_COLLATION = "binary";
   private final MySqlVersion mySqlVersion;
 
   private static final Logger logger = LoggerFactory.getLogger(MysqlDialectAdapter.class);
@@ -81,6 +94,8 @@ public final class MysqlDialectAdapter implements DialectAdapter {
 
   private final Counter schemaDiscoveryErrors =
       Metrics.counter(JdbcSourceRowMapper.class, MetricCounters.READER_SCHEMA_DISCOVERY_ERRORS);
+
+  private static final String COLLATIONS_QUERY_RESOURCE_PATH = "sql/mysql_collation_oder_query.sql";
 
   public MysqlDialectAdapter(MySqlVersion mySqlVersion) {
     this.mySqlVersion = mySqlVersion;
@@ -287,6 +302,13 @@ public final class MysqlDialectAdapter implements DialectAdapter {
         + " TABLE_NAME = ?";
   }
 
+  /**
+   * Discover Indexed columns and their Collations(if applicable). You could try this on <a href =
+   * https://www.db-fiddle.com/f/kRVPA5jDwZYNj2rsdtif4K/2>db-fiddle</a>
+   *
+   * @param sourceSchemaReference
+   * @return
+   */
   protected static String getIndexDiscoveryQuery(SourceSchemaReference sourceSchemaReference) {
     return "SELECT "
         + String.join(",", InformationSchemaStatsCols.colList())
@@ -297,6 +319,10 @@ public final class MysqlDialectAdapter implements DialectAdapter {
         + "stats.table_schema = cols.table_schema"
         + " AND stats.table_name = cols.table_name"
         + " AND stats.column_name = cols.column_name"
+        + " LEFT JOIN "
+        + "INFORMATION_SCHEMA.COLLATIONS collations"
+        + " ON "
+        + "cols.COLLATION_NAME = collations.COLLATION_NAME"
         + " WHERE stats.TABLE_SCHEMA = "
         + "'"
         + sourceSchemaReference.dbName()
@@ -335,7 +361,18 @@ public final class MysqlDialectAdapter implements DialectAdapter {
           .put("MEDIUMINT", IndexType.NUMERIC)
           .put("SMALLINT", IndexType.NUMERIC)
           .put("TINYINT", IndexType.NUMERIC)
+          // String types: Ref https://dev.mysql.com/doc/refman/8.4/en/string-type-syntax.html
+          .put("CHAR", IndexType.STRING)
+          .put("VARCHAR", IndexType.STRING)
+          .put("BINARY", IndexType.STRING)
+          .put("VARBINARY", IndexType.STRING)
+          .put("BLOB", IndexType.STRING)
+          .put("TEXT", IndexType.STRING)
+          .put("ENUM", IndexType.STRING)
+          .put("SET", IndexType.STRING)
           .build();
+
+  private ImmutableSet<String> binaryColumnTypes = ImmutableSet.of("BINARY", "VARBINARY", "BLOB");
 
   private ImmutableList<SourceColumnIndexInfo> getTableIndexes(
       String table, PreparedStatement statement) throws SchemaDiscoveryException {
@@ -352,8 +389,50 @@ public final class MysqlDialectAdapter implements DialectAdapter {
         boolean isPrimary = indexName.trim().toUpperCase().equals("PRIMARY");
         long cardinality = rs.getLong(InformationSchemaStatsCols.CARDINALITY_COL);
         long ordinalPosition = rs.getLong(InformationSchemaStatsCols.ORDINAL_POS_COL);
+        @Nullable
+        Integer stringMaxLength = rs.getInt(InformationSchemaStatsCols.CHAR_MAX_LENGTH_COL);
+        if (rs.wasNull()) {
+          stringMaxLength = null;
+        }
+        @Nullable String characterSet = rs.getString(InformationSchemaStatsCols.CHARACTER_SET_COL);
+        @Nullable String collation = rs.getString(InformationSchemaStatsCols.COLLATION_COL);
+        @Nullable String padSpace = rs.getString(InformationSchemaStatsCols.PAD_SPACE_COL);
+        logger.debug(
+            "Discovered column {} from index {}, isUnique {}, isPrimary {}, cardinality {}, ordinalPosition {}, character-set {}, collation {}, pad-space {}",
+            colName,
+            indexName,
+            isUnique,
+            isPrimary,
+            cardinality,
+            ordinalPosition,
+            characterSet,
+            collation,
+            padSpace);
+        // TODO(vardhanvthigle): MySql 5.7 is always PAD space and does not have PAD_ATTRIBUTE
+        // Column.
         String columType = normalizeColumnType(rs.getString(InformationSchemaStatsCols.TYPE_COL));
         IndexType indexType = INDEX_TYPE_MAPPING.getOrDefault(columType, IndexType.OTHER);
+
+        CollationReference collationReference = null;
+        // Binary (and similar columns like VarBinary, Blob etc) columns have a fixed character-set
+        // and collation called "binary".
+        // Ref https://dev.mysql.com/doc/refman/8.4/en/charset-binary-collations.html
+        // In information_schema.columns query, these column types show null as character set.
+        // Ref: https://www.db-fiddle.com/f/kRVPA5jDwZYNj2rsdtif4K/2
+        if (binaryColumnTypes.contains(columType) && characterSet == null) {
+          characterSet = BINARY_CHARACTER_SET;
+          collation = BINARY_COLLATION;
+          padSpace = NO_PAD;
+        }
+        if (characterSet != null) {
+          collationReference =
+              CollationReference.builder()
+                  .setDbCharacterSet(characterSet)
+                  .setDbCollation(collation)
+                  .setPadSpace(
+                      (padSpace == null) ? false : padSpace.trim().toUpperCase().equals(PAD_SPACE))
+                  .build();
+        }
 
         indexesBuilder.add(
             SourceColumnIndexInfo.builder()
@@ -364,6 +443,8 @@ public final class MysqlDialectAdapter implements DialectAdapter {
                 .setCardinality(cardinality)
                 .setOrdinalPosition(ordinalPosition)
                 .setIndexType(indexType)
+                .setCollationReference(collationReference)
+                .setStringMaxLength(stringMaxLength)
                 .build());
       }
     } catch (java.sql.SQLException e) {
@@ -534,6 +615,77 @@ public final class MysqlDialectAdapter implements DialectAdapter {
   }
 
   /**
+   * Replace tags for collations and character set as needed in run-time, and, Remove blank lines
+   * and comments from the collations query. Queries with size > max_allowed_packet get rejected by
+   * the db. max_allowed_packet is generally around 16Mb which is a lot for our use case.
+   *
+   * @param query query to prepare.
+   * @param dbCharset character set used by the database for which collation ordering has to be
+   *     found.
+   * @param dbCollation collation set used by the database for which collation ordering has to be
+   *     found.
+   * @return
+   */
+  @VisibleForTesting
+  protected String prepareCollationsOrderQuery(String query, String dbCharset, String dbCollation) {
+    // Replace tags
+    String processedQuery =
+        query
+            .replace("'charset_replacement_tag'", "'" + dbCharset + "'")
+            .replace("'collation_replacement_tag'", "'" + dbCollation + "'");
+
+    // Remove MySQL comments and blank lines.
+
+    // Remove MySql Comments.
+    // Note we don't remove block comments for sake of simplicity.
+    Pattern commentPattern = Pattern.compile("(?m)^[ \\t]?--.*$");
+    Matcher matcher = commentPattern.matcher(processedQuery);
+    processedQuery = matcher.replaceAll("");
+
+    // Remove blank lines
+    processedQuery = processedQuery.replaceAll("(?m)^\\s*\\r?\\n", "");
+    return processedQuery;
+  }
+
+  /**
+   * Load a resource file as string.
+   *
+   * @param resource path of the resource file.
+   * @return resource file as string.
+   */
+  @VisibleForTesting
+  protected static String resourceAsString(String resource) {
+    try {
+      URL url = com.google.common.io.Resources.getResource(resource);
+      return com.google.common.io.Resources.toString(url, Charsets.UTF_8);
+    } catch (Exception e) {
+      // This exception should not happen in production as it really means we don't have the
+      // expected resource
+      // file in bundled in the build or a fatal IO failure in reading one.
+      logger.error(
+          "Exception {} while trying to load the SQL file {} for collation discovery.",
+          e,
+          resource);
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Get Query that returns order of collation. The query must return all the characters in the
+   * character set with the columns listed in {@link CollationsOrderQueryColumns}.
+   *
+   * @param dbCharset character set used by the database for which collation ordering has to be
+   *     found.
+   * @param dbCollation collation set used by the database for which collation ordering has to be
+   *     found.
+   */
+  @Override
+  public String getCollationsOrderQuery(String dbCharset, String dbCollation) {
+    return prepareCollationsOrderQuery(
+        resourceAsString(COLLATIONS_QUERY_RESOURCE_PATH), dbCharset, dbCollation);
+  }
+
+  /**
    * Version of MySql. As of now the code does not need to distinguish between versions of Mysql.
    * Having the type allows the implementation do finer distinctions if needed in the future.
    */
@@ -564,10 +716,25 @@ public final class MysqlDialectAdapter implements DialectAdapter {
     public static final String CARDINALITY_COL = "stats.CARDINALITY";
 
     public static final String TYPE_COL = "cols.DATA_TYPE";
+    public static final String CHAR_MAX_LENGTH_COL = "cols.CHARACTER_MAXIMUM_LENGTH";
+    public static final String CHARACTER_SET_COL = "cols.CHARACTER_SET_NAME";
+    public static final String COLLATION_COL = "cols.COLLATION_NAME";
+
+    // TODO(vardhanvthigle): MySql 5.7 is always PAD space and does not have PAD_ATTRIBUTE Column.
+    public static final String PAD_SPACE_COL = "collations.PAD_ATTRIBUTE";
 
     public static ImmutableList<String> colList() {
       return ImmutableList.of(
-          COL_NAME_COL, INDEX_NAME_COL, ORDINAL_POS_COL, NON_UNIQ_COL, CARDINALITY_COL, TYPE_COL);
+          COL_NAME_COL,
+          INDEX_NAME_COL,
+          ORDINAL_POS_COL,
+          NON_UNIQ_COL,
+          CARDINALITY_COL,
+          TYPE_COL,
+          CHAR_MAX_LENGTH_COL,
+          CHARACTER_SET_COL,
+          COLLATION_COL,
+          PAD_SPACE_COL);
     }
 
     private InformationSchemaStatsCols() {}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/UniformSplitterDBAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/UniformSplitterDBAdapter.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter;
 
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.sql.SQLException;
@@ -62,4 +63,16 @@ public interface UniformSplitterDBAdapter extends Serializable {
    * @return
    */
   boolean checkForTimeout(SQLException exception);
+
+  /**
+   * Get a query that returns order of collation. The query must return all the characters in the
+   * character set with the columns listed in {@link CollationsOrderQueryColumns}.
+   *
+   * @param dbCharset character set used by the database for which collation ordering has to be
+   *     found.
+   * @param dbCollation collation set used by the database for which collation ordering has to be
+   *     found.
+   * @return Query to get the order of collation.
+   */
+  String getCollationsOrderQuery(String dbCharset, String dbCollation);
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/Boundary.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/Boundary.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
 
 import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import java.io.Serializable;
@@ -87,7 +88,7 @@ public abstract class Boundary<T extends Serializable>
   }
 
   @Nullable
-  String stringCollation() {
+  CollationReference stringCollation() {
     return partitionColumn().stringCollation();
   }
 
@@ -242,7 +243,7 @@ public abstract class Boundary<T extends Serializable>
       return this;
     }
 
-    public Builder<T> setCollation(String value) {
+    public Builder<T> setCollation(CollationReference value) {
       this.partitionColumnBuilder().setStringCollation(value);
       return this;
     }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundarySplitterFactory.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundarySplitterFactory.java
@@ -161,10 +161,10 @@ public class BoundarySplitterFactory {
         Math.max(
             Math.max(start.length(), end.length()), partitionColumn.stringMaxLength().intValue());
     BigInteger bigIntegerStart =
-        (BigInteger) typeMapper.mapString(start, lengthToPad, partitionColumn, c);
+        (BigInteger) typeMapper.mapStringToBigInteger(start, lengthToPad, partitionColumn, c);
     BigInteger bigIntegerEnd =
-        (BigInteger) typeMapper.mapString(end, lengthToPad, partitionColumn, c);
+        (BigInteger) typeMapper.mapStringToBigInteger(end, lengthToPad, partitionColumn, c);
     BigInteger bigIntegerSplit = splitBigIntegers(bigIntegerStart, bigIntegerEnd);
-    return (String) typeMapper.unMapString(bigIntegerSplit, partitionColumn, c);
+    return (String) typeMapper.unMapStringFromBigInteger(bigIntegerSplit, partitionColumn, c);
   }
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryTypeMapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryTypeMapper.java
@@ -15,17 +15,46 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
 
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationMapper;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
 import java.io.Serializable;
 import java.math.BigInteger;
+import java.util.Map;
 import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+import org.apache.beam.sdk.values.PCollectionView;
 
 /**
  * Maps a Boundary Type from one to another. This allows the implementation to support splitting
  * types like strings which can be mapped to BigInteger.
  */
 public interface BoundaryTypeMapper extends Serializable {
-  BigInteger mapString(
+  /**
+   * Map String to BigInteger.
+   *
+   * @param element String
+   * @param lengthTOPad Length to pad the string, generally same as width of the column.
+   * @param partitionColumn partition column details with {@link CollationReference} set.
+   * @param c ProcessContext.
+   * @return mapped BigInteger.
+   */
+  BigInteger mapStringToBigInteger(
       String element, int lengthTOPad, PartitionColumn partitionColumn, ProcessContext c);
 
-  String unMapString(BigInteger element, PartitionColumn partitionColumn, ProcessContext c);
+  /**
+   * Unmap BigInteger into String.
+   *
+   * @param element BigInteger
+   * @param partitionColumn partition column details with {@link CollationReference} set.
+   * @param c ProcessContext.
+   * @return unmapped string.
+   */
+  String unMapStringFromBigInteger(
+      BigInteger element, PartitionColumn partitionColumn, ProcessContext c);
+
+  /**
+   * Relay the pCollectionView for mapped Collations mapping ease of chaining transforms.
+   *
+   * @return pCollationView
+   */
+  PCollectionView<Map<CollationReference, CollationMapper>> getCollationMapperView();
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/PartitionColumn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/PartitionColumn.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
 
 import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
 import com.google.common.base.Preconditions;
 import java.io.Serializable;
 import javax.annotation.Nullable;
@@ -41,7 +42,7 @@ public abstract class PartitionColumn implements Serializable {
    * @return string collation for this column if it's a string column. Null otherwise.
    */
   @Nullable
-  public abstract String stringCollation();
+  public abstract CollationReference stringCollation();
 
   /** Max Length of a string column. Defaults to null for non-string columns. */
   @Nullable
@@ -62,7 +63,7 @@ public abstract class PartitionColumn implements Serializable {
 
     public abstract Builder setColumnClass(Class value);
 
-    public abstract Builder setStringCollation(String value);
+    public abstract Builder setStringCollation(CollationReference value);
 
     public abstract Builder setStringMaxLength(Integer value);
 

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/BoundaryTypeMapperImpl.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/BoundaryTypeMapperImpl.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundaryTypeMapper;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.PartitionColumn;
+import java.io.Serializable;
+import java.math.BigInteger;
+import java.util.Map;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Maps a Boundary Type from one to another. This allows the implementation to support splitting
+ * types like strings which can be mapped to BigInteger. For Mapping strings, {@link
+ * BoundaryTypeMapperImpl} gets the {@link CollationMapper} from the {@link
+ * ProcessContext#sideInput(PCollectionView)}. While using {@link BoundaryTypeMapperImpl} it must be
+ * ensured that the {@link CollationMapper} is available in the side input.
+ */
+@AutoValue
+public abstract class BoundaryTypeMapperImpl implements BoundaryTypeMapper, Serializable {
+
+  abstract PCollectionView<Map<CollationReference, CollationMapper>> collationMapperView();
+
+  private static final Logger logger = LoggerFactory.getLogger(BoundaryTypeMapperImpl.class);
+
+  /**
+   * Map String to BigInteger.
+   *
+   * @param element String
+   * @param lengthTOPad Length to pad the string, generally same as width of the column.
+   * @param partitionColumn partition column details with {@link CollationReference} set.
+   * @param c ProcessContext.
+   * @return mapped BigInteger.
+   * @throws RuntimeException if {@link CollationMapper} is not found in the process context.
+   */
+  @Override
+  public BigInteger mapStringToBigInteger(
+      String element, int lengthTOPad, PartitionColumn partitionColumn, ProcessContext c) {
+    Map<CollationReference, CollationMapper> collationMap =
+        (Map<CollationReference, CollationMapper>) c.sideInput(collationMapperView());
+    if (!collationMap.containsKey(partitionColumn.stringCollation())) {
+      logger.error(
+          "No CollationMapper found for {}. Discovered collations are {}",
+          partitionColumn,
+          collationMap);
+      throw new RuntimeException(
+          String.format(
+              "No CollationMapper found for %s. Discovered collations are %s",
+              partitionColumn, collationMap));
+    }
+    CollationMapper mapper = collationMap.get(partitionColumn.stringCollation());
+    return mapper.mapString(element, lengthTOPad);
+  }
+
+  /**
+   * Unmap BigInteger into String.
+   *
+   * @param element BigInteger
+   * @param partitionColumn partition column details with {@link CollationReference} set.
+   * @param c ProcessContext.
+   * @return unmapped string.
+   * @throws RuntimeException if {@link CollationMapper} is not found in the process context.
+   */
+  @Override
+  public String unMapStringFromBigInteger(
+      BigInteger element, PartitionColumn partitionColumn, ProcessContext c) {
+    Map<CollationReference, CollationMapper> collationMap =
+        (Map<CollationReference, CollationMapper>) c.sideInput(collationMapperView());
+    if (!collationMap.containsKey(partitionColumn.stringCollation())) {
+      logger.error(
+          "No CollationMapper found for {}. Discovered collations are {}",
+          partitionColumn,
+          collationMap);
+      throw new RuntimeException(
+          String.format(
+              "No CollationMapper found for %s. Discovered collations are %s",
+              partitionColumn, collationMap));
+    }
+    CollationMapper mapper = collationMap.get(partitionColumn.stringCollation());
+    return mapper.unMapString(element);
+  }
+
+  /**
+   * Relay the pCollectionView for mapped Collations mapping ease of chaining transforms.
+   *
+   * @return pCollationView
+   */
+  @Override
+  public PCollectionView<Map<CollationReference, CollationMapper>> getCollationMapperView() {
+    return collationMapperView();
+  }
+
+  public static Builder builder() {
+    return new AutoValue_BoundaryTypeMapperImpl.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setCollationMapperView(
+        PCollectionView<Map<CollationReference, CollationMapper>> value);
+
+    public abstract BoundaryTypeMapperImpl build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/CollationIndex.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/CollationIndex.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Maintains maps from characters to their positions as per the collation order and a reverse map to
+ * map a position to back to a character.
+ */
+@AutoValue
+public abstract class CollationIndex implements Serializable {
+
+  private static final Logger logger = LoggerFactory.getLogger(CollationIndex.class);
+
+  /** Details about the collation. */
+  public abstract CollationReference collationReference();
+
+  /** Index type. */
+  public abstract CollationIndexType indexType();
+
+  /**
+   * Map of character to it's index position based on collation order. Helps us map a string to big
+   * integer.
+   */
+  public abstract ImmutableMap<Character, Long> characterToIndex();
+
+  /**
+   * Map if Index back to character based on collation order. Helps us unmap a big integer to
+   * string. Note this maps the index back to a minimum set of characters. For example in
+   * case-insensitive collations, 'a' and 'A' will have the same index in {@link
+   * #characterToIndex()} and {@link #indexToCharacter()} will map the index to 'A'.
+   */
+  public abstract ImmutableMap<Long, Character> indexToCharacter();
+
+  public static CollationIndex.Builder builder() {
+    return new AutoValue_CollationIndex.Builder();
+  }
+
+  public long getCharsetSize() {
+    return indexToCharacter().size();
+  }
+
+  public long getOrdinalPosition(Character c) {
+    return characterToIndex().get(c);
+  }
+
+  public Character getCharacterFromPosition(Long position) {
+    return indexToCharacter().get(position);
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setCollationReference(CollationReference value);
+
+    abstract CollationReference collationReference();
+
+    public abstract Builder setIndexType(CollationIndexType value);
+
+    abstract CollationIndexType indexType();
+
+    private Map<Character, Long> charToIndexCache = new HashMap<>();
+    private Map<Long, Character> indexToCharacterCache = new HashMap<>();
+    private Map<Character, Long> indexToCharacterReverseCache = new HashMap<>();
+
+    abstract Builder setIndexToCharacter(ImmutableMap<Long, Character> value);
+
+    abstract Builder setCharacterToIndex(ImmutableMap<Character, Long> value);
+
+    public Builder addCharacter(Character charsetChar, Character equivalentChar, Long index) {
+      logger.debug(
+          "Registering character order for {}, index-type = {}, character = {}, equivalentCharacter = {}, index = {}, isBlank = {}",
+          collationReference(),
+          indexType(),
+          charsetChar,
+          equivalentChar,
+          index);
+
+      if (this.indexToCharacterCache.containsKey(index)
+          || this.indexToCharacterReverseCache.containsKey(equivalentChar)) {
+        if (!(this.indexToCharacterCache.containsKey(index)
+                && this.indexToCharacterCache.get(index).equals(equivalentChar))
+            || !(this.indexToCharacterReverseCache.containsKey(equivalentChar)
+                && this.indexToCharacterReverseCache.get(equivalentChar).equals(index))) {
+          throw new IllegalStateException(
+              "Duplicate Equivalent characters share same index. Please check the collation order query. "
+                  + "passed index: "
+                  + index
+                  + " passed equivalent char: "
+                  + equivalentChar
+                  + " existing equivalent char: "
+                  + (this.indexToCharacterCache.containsKey(index)
+                      ? this.indexToCharacterCache.get(index)
+                      : "not-present")
+                  + " existing index: "
+                  + (this.indexToCharacterReverseCache.containsKey(equivalentChar)
+                      ? this.indexToCharacterReverseCache.get(equivalentChar)
+                      : "not-present")
+                  + " passed charsetChar: "
+                  + charsetChar
+                  + " for "
+                  + collationReference()
+                  + "index-type = "
+                  + indexType());
+        }
+      } else {
+        this.indexToCharacterCache.put(index, equivalentChar);
+        this.indexToCharacterReverseCache.put(equivalentChar, index);
+      }
+      if (this.charToIndexCache.containsKey(charsetChar)) {
+        throw new IllegalStateException(
+            "Duplicate Charset characters added. Please check the collation order query. "
+                + "new index: "
+                + index
+                + " existing idx: "
+                + this.charToIndexCache.get(charsetChar)
+                + " equivalent char: "
+                + equivalentChar
+                + " charsetChar: "
+                + charsetChar
+                + " for "
+                + collationReference()
+                + "index-type = "
+                + indexType());
+      }
+      this.charToIndexCache.put(charsetChar, index);
+      return this;
+    }
+
+    abstract CollationIndex autoBuild();
+
+    public CollationIndex build() {
+      this.setIndexToCharacter(ImmutableMap.copyOf(this.indexToCharacterCache));
+      this.setCharacterToIndex(ImmutableMap.copyOf(this.charToIndexCache));
+
+      ImmutableList<Long> indexes =
+          this.indexToCharacterCache.keySet().stream()
+              .sorted()
+              .collect(ImmutableList.toImmutableList());
+      for (int i = 0; i < indexes.size(); i++) {
+        if (indexes.get(i) != i) {
+          throw new IllegalStateException(
+              "Discontinuous index found at position "
+                  + i
+                  + " please check the collation order query"
+                  + " for "
+                  + collationReference()
+                  + " for character set = "
+                  + "index-type = "
+                  + indexType());
+        }
+        if (!charToIndexCache.containsKey(indexToCharacterCache.get(indexes.get(i)))) {
+          throw new IllegalStateException(
+              "index which is not part of the character set found at position "
+                  + i
+                  + " index is "
+                  + indexes.get(i)
+                  + " index character is "
+                  + indexToCharacterCache.get(indexes.get(i))
+                  + " please check the collation order query"
+                  + " for "
+                  + collationReference()
+                  + " for character set = "
+                  + "index-type = "
+                  + indexType());
+        }
+        if (charToIndexCache.get(indexToCharacterCache.get(indexes.get(i))) != indexes.get(i)) {
+          throw new IllegalStateException(
+              "index not mapping onto itself found at position "
+                  + i
+                  + " index is "
+                  + indexes.get(i)
+                  + " index character is "
+                  + indexToCharacterCache.get(indexes.get(i))
+                  + " index character is mapped to "
+                  + charToIndexCache.get(indexToCharacterCache.get(indexes.get(i)))
+                  + " please check the collation order query"
+                  + " for "
+                  + collationReference()
+                  + " for character set = "
+                  + "index-type = "
+                  + indexType());
+        }
+      }
+      CollationIndex index = autoBuild();
+      logger.info(
+          "Initialized Index {} for {}, with {} characters, {} unique characters, and {} empty characters",
+          index.indexType(),
+          index.collationReference(),
+          index.characterToIndex().size(),
+          index.indexToCharacter().size());
+      return index;
+    }
+  }
+
+  public enum CollationIndexType {
+    /**
+     * An index that tracks the collation ordering for all positions, except for the trailing
+     * position for the specific case of a PAD SPACE comparison.
+     */
+    ALL_POSITIONS,
+    /**
+     * An index that tracks the collation ordering for trailing position in case of a PAD SPACE
+     * comparison.
+     */
+    TRAILING_POSITION_PAD_SPACE
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/CollationMapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/CollationMapper.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper;
+
+import com.google.auto.value.AutoValue;
+import com.google.auto.value.extension.memoized.Memoized;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationIndex.CollationIndexType;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import java.io.Serializable;
+import java.math.BigInteger;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Map characters of a string read from the database to a {@link BigInteger} based on the collation
+ * ordering.
+ *
+ * <p><b>Basic Requirement for mapping</b>
+ *
+ * <p>Consider two strings read from the database - stringLeft and stringRight, and say {@link
+ * CollationMapper#mapString(String, int)} maps them to bigIntLeft and bigIntRight. Consider
+ * BigIntMean as the mean of BigIntLeft and BitIntRight, and stringSplit as the output of {@link
+ * CollationMapper#unMapString(BigInteger)} for BigIntMean, then,
+ *
+ * <p>{@code SELECT StringLeft <= StringSplit} and {@code SELECT StringRight >= StringSplit} must
+ * always hold true. Also split points of ranges of same column should never compare equal.
+ */
+@AutoValue
+public abstract class CollationMapper implements Serializable {
+
+  private static final Logger logger = LoggerFactory.getLogger(CollationMapper.class);
+
+  /** Details about the collation. */
+  public abstract CollationReference collationReference();
+
+  /**
+   * Map of character to it's index position based on collation order. Helps us map a string to big
+   * integer for all positions. {@link #allPositionsIndex()} is the primarily referred index except
+   * for the case of trailing position in a non-pad comparison.
+   */
+  public abstract CollationIndex allPositionsIndex();
+
+  /**
+   * Map of character to it's index position based on collation order. Helps us map a string to big
+   * integer for trailing position in case a pad-space comparison is needed. Pad Space comparison is
+   * needed in case of a PAD Space collation in MYSQL, or a CHAR column in PG.
+   *
+   * <p>{@link #trailingPositionsPadSpace()} is referred only for trailing position in a non-pad
+   * comparison.
+   *
+   * @return
+   */
+  public abstract CollationIndex trailingPositionsPadSpace();
+
+  /**
+   * Empty Characters. MySQL ignores empty characters in comparisons. For example consider the below
+   * query that adds a control-z between a and b. {@code SELECT CONCAT('a', CONVERT(UNHEX('001A')
+   * using utf8mb4), 'b') = 'ab' COLLATE <collation>;} returns 1. TODO(vardhanvthigle): Check this
+   * behavior for PG and other databases.
+   */
+  public abstract ImmutableSet<Character> emptyCharacters();
+
+  /**
+   * Space Characters. MySQL ignores trailing space characters in comparisons for PAD space
+   * collations and PG has the same behavior for CHAR columns. Note that there are various
+   * codepoints that can potentially represent a space, like the ascii space or non-breaking space
+   * (UNHEX(C2H0)) when the collation is Pad Space. These have same behavior to ascii space as far
+   * as trailing or non-trailing comparison is concerned.
+   */
+  public abstract ImmutableSet<Character> spaceCharacters();
+
+  @Memoized
+  String allSpaceCharacters() {
+    return this.spaceCharacters().stream().map(String::valueOf).collect(Collectors.joining(""));
+  }
+
+  @Memoized
+  String emptyReplacePattern() {
+    if (this.emptyCharacters().isEmpty()) {
+      return "";
+    }
+    return "["
+        + Pattern.quote(
+            this.emptyCharacters().stream().map(String::valueOf).collect(Collectors.joining("")))
+        + "]";
+  }
+
+  /**
+   * Map a {@link String} to {@link BigInteger}.
+   *
+   * @param element String.
+   * @param lengthToPad maximum length of the string as per the column width.
+   * @return mapped big integer.
+   *     <p><b>Note:</b>
+   *     <p>The logic for mapping th string has to take care of various database nuances like:
+   *     <ul>
+   *       <li>Control Characters like control-z are ignored for comparisons at all positions.
+   *       <li>Space is ignored for comparison at trailing positions. Depending on the
+   *           character-set, there could be more than one character that represents a space like <a
+   *           href=https://www.compart.com/en/unicode/U+2001>EM quad</a>, <a
+   *           href=https://www.compart.com/en/unicode/U+00A0#>non-breaking space</a>.
+   *       <li>Space is not ignored at non-trailing positions in the comparison and characters like
+   *           tab or new-line could compare less then space at non-trailing positions.
+   *     </ul>
+   */
+  public BigInteger mapString(@Nullable String element, int lengthToPad) {
+
+    if (element == null) {
+      return BigInteger.valueOf(-1);
+    }
+    BigInteger ret = BigInteger.ZERO;
+
+    // MySQL ignores empty character in string comparisons.
+    // For example (adding control-z between a and b):
+    // SELECT CONCAT('a', CONVERT(UNHEX('001A') using utf8mb4), 'b') = 'ab' COLLATE
+    // utf8mb4_0900_ai_ci;
+    // returns 1.
+    // Remove all the empty characters.
+    element = element.replaceAll(emptyReplacePattern(), "");
+
+    // Remove trailing spaces for padSpace comparison.
+    if (this.collationReference().padSpace()) {
+      element = StringUtils.stripEnd(element, allSpaceCharacters());
+    }
+    if (element.isEmpty()) {
+      return BigInteger.valueOf(-1);
+    }
+
+    // Convert the string to BigInteger.
+    for (int index = 0; index < element.length(); index++) {
+      Character c = element.charAt(index);
+      ret =
+          ret.multiply(BigInteger.valueOf(getCharsetSize(index == (element.length() - 1))))
+              .add(BigInteger.valueOf(getOrdinalPosition(c, index == (element.length() - 1))));
+    }
+    for (int index = element.length(); index < lengthToPad; index++) {
+      ret = ret.multiply(BigInteger.valueOf(getCharsetSize(index == (element.length() - 1))));
+    }
+    return ret;
+  }
+
+  /**
+   * Unmap a {@link BigInteger} back to {@link String}.
+   *
+   * @param element BigInteger to unmap.
+   * @return mapped String.
+   *     <p><b>Note:</b>
+   *     <p>The logic for mapping th string has to take care of various database nuances like:
+   *     <ul>
+   *       <li>Control Characters like control-z are ignored for comparisons at all positions.
+   *       <li>Space is ignored for comparison at trailing positions. Depending on the
+   *           character-set, there could be more than one character that represents a space like <a
+   *           href=https://www.compart.com/en/unicode/U+2001>EM quad</a>, <a
+   *           href=https://www.compart.com/en/unicode/U+00A0#>non-breaking space</a>.
+   *       <li>Space is not ignored at non-trailing positions in the comparison and characters like
+   *           tab or new-line could compare less then space at non-trailing positions.
+   *     </ul>
+   */
+  public String unMapString(BigInteger element) {
+    StringBuilder word = new StringBuilder();
+    int index = 0;
+
+    if (element.equals(BigInteger.valueOf(-1))) {
+      return "";
+    }
+
+    // Base Case that the string just represents single character
+    if (element == BigInteger.ZERO) {
+      char c = getCharacterFromPosition(element.longValue(), true);
+      return String.valueOf(c);
+    }
+
+    while (element != BigInteger.ZERO) {
+      long charsetSize = getCharsetSize(index == 0);
+
+      BigInteger reminder = element.mod(BigInteger.valueOf(charsetSize));
+      char c = getCharacterFromPosition(reminder.longValue(), (index == 0));
+      word.append(c);
+
+      element = element.divide(BigInteger.valueOf(charsetSize));
+      index++;
+    }
+    String ret = word.reverse().toString();
+    return ret;
+  }
+
+  public static Builder builder(CollationReference collationReference) {
+    Builder builder =
+        new AutoValue_CollationMapper.Builder().setCollationReference(collationReference);
+
+    builder
+        .allPositionsIndexBuilder()
+        .setIndexType(CollationIndexType.ALL_POSITIONS)
+        .setCollationReference(collationReference);
+    builder
+        .trailingPositionsPadSpaceBuilder()
+        .setIndexType(CollationIndexType.TRAILING_POSITION_PAD_SPACE)
+        .setCollationReference(collationReference);
+    return builder;
+  }
+
+  public static CollationMapper fromDB(
+      Connection connection,
+      UniformSplitterDBAdapter dbAdapter,
+      CollationReference collationReference)
+      throws SQLException {
+    String query =
+        dbAdapter.getCollationsOrderQuery(
+            collationReference.dbCharacterSet(), collationReference.dbCollation());
+    CollationMapper mapper = null;
+    try (Statement statement = connection.createStatement()) {
+      statement.setEscapeProcessing(false);
+      // Due to https://bugs.mysql.com/bug.php?id=108195 affecting the version of connector,
+      // we can't use executeQuery for a multi line complex query.
+      boolean foundResultSet = statement.execute(query);
+      // The recommended workaround is a while(true) loop, we limit the iterations to number of
+      // lines in the query (as it's impossible to have more resultsets than that as hangs are not
+      // easy to debug in dataflow)
+      for (int i = 0; i < query.lines().count() + 1; i++) {
+        if (foundResultSet) {
+          ResultSet rs = statement.getResultSet();
+          mapper = fromResultSet(rs, collationReference);
+          break;
+        }
+        foundResultSet = statement.getMoreResults();
+        if (!foundResultSet && statement.getUpdateCount() == -1) {
+          Preconditions.checkState(
+              false, "No result sets found while querying collation for " + collationReference);
+        }
+      }
+    } catch (SQLException e) {
+      // Beam will auto retry the exceptions in run time.
+      logger.error(
+          "Exception while getting collation order for {}, exception = {}, query = {}",
+          collationReference,
+          e,
+          query);
+      throw e;
+    }
+    if (mapper == null) {
+      Preconditions.checkState(
+          false, "No result sets found while querying collation for " + collationReference);
+    }
+    return mapper;
+  }
+
+  private long getCharsetSize(boolean lastCharacter) {
+    return (lastCharacter && collationReference().padSpace())
+        ? this.trailingPositionsPadSpace().getCharsetSize()
+        : this.allPositionsIndex().getCharsetSize();
+  }
+
+  private long getOrdinalPosition(Character c, boolean lastCharacter) {
+    return (lastCharacter && collationReference().padSpace())
+        ? this.trailingPositionsPadSpace().getOrdinalPosition(c)
+        : this.allPositionsIndex().getOrdinalPosition(c);
+  }
+
+  private Character getCharacterFromPosition(long ordinalPosition, boolean firstIteration) {
+    return (firstIteration && collationReference().padSpace())
+        ? this.trailingPositionsPadSpace().getCharacterFromPosition(ordinalPosition)
+        : this.allPositionsIndex().getCharacterFromPosition(ordinalPosition);
+  }
+
+  private static CollationMapper fromResultSet(ResultSet rs, CollationReference collationReference)
+      throws SQLException {
+    Builder builder = builder(collationReference);
+    while (rs.next()) {
+      builder.addCharacter(CollationOrderRow.fromRS(rs));
+    }
+    return builder.build();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    abstract Builder setCollationReference(CollationReference collationReference);
+
+    abstract CollationReference collationReference();
+
+    abstract CollationIndex.Builder allPositionsIndexBuilder();
+
+    abstract CollationIndex.Builder trailingPositionsPadSpaceBuilder();
+
+    abstract ImmutableSet.Builder<Character> emptyCharactersBuilder();
+
+    abstract ImmutableSet.Builder<Character> spaceCharactersBuilder();
+
+    public Builder addCharacter(CollationOrderRow collationOrderRow) {
+
+      logger.debug(
+          "Registering character order for {}, character-details = {}",
+          collationReference(),
+          collationOrderRow);
+      if (collationOrderRow.isEmpty()) {
+        emptyCharactersBuilder().add(collationOrderRow.charsetChar());
+        return this;
+      }
+      if (collationOrderRow.isSpace()) {
+        spaceCharactersBuilder().add(collationOrderRow.charsetChar());
+      }
+      allPositionsIndexBuilder()
+          .addCharacter(
+              collationOrderRow.charsetChar(),
+              collationOrderRow.equivalentChar(),
+              collationOrderRow.codepointRank());
+      if (!collationOrderRow.isSpace()) {
+        trailingPositionsPadSpaceBuilder()
+            .addCharacter(
+                collationOrderRow.charsetChar(),
+                collationOrderRow.equivalentCharPadSpace(),
+                collationOrderRow.codepointRankPadSpace());
+      }
+      return this;
+    }
+
+    abstract CollationMapper autoBuild();
+
+    public CollationMapper build() {
+      return autoBuild();
+    }
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/CollationOrderRow.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/CollationOrderRow.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper;
+
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.CHARSET_CHAR_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.CODEPOINT_RANK_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.CODEPOINT_RANK_PAD_SPACE_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.EQUIVALENT_CHARSET_CHAR_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.EQUIVALENT_CHARSET_CHAR_PAD_SPACE_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.IS_EMPTY_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.IS_SPACE_COL;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Represents a row of the minimum required columns from the collations output query. You can refer
+ * to src/test/resources/TestCollations/collation-output-mysql-utf8mb4-0900-ai-ci.tsv for example of
+ * the columns.
+ */
+@AutoValue
+public abstract class CollationOrderRow {
+
+  private static final Logger logger = LoggerFactory.getLogger(CollationOrderRow.class);
+
+  /** Character in the character set. */
+  public abstract Character charsetChar();
+
+  /** A character with lowest rank charset_char character is equal to as per the collation. */
+  public abstract Character equivalentChar();
+
+  /** 0 offset rank of this character as per the collation sort ordering at all positions. */
+  public abstract Long codepointRank();
+
+  /**
+   * A character with lowest rank charset_char character is equal to as per the collation at
+   * trailing position, in case a PAD SPACE comparison is needed. Unless you are looking at space
+   * like characters, this will be exactly same as equivalent_character.
+   */
+  public abstract Character equivalentCharPadSpace();
+
+  /**
+   * A character with lowest rank charset_char character is equal to as per the collation at
+   * trailing position, in case a PAD SPACE comparison is needed. Unless you are looking at space
+   * like characters, this will be exactly same as equivalent_character.
+   */
+  public abstract Long codepointRankPadSpace();
+
+  /**
+   * A boolean columns, true if the character is equal to '\0' at all positions of comparison. False
+   * otherwise.
+   */
+  public abstract Boolean isEmpty();
+
+  /**
+   * A boolean columns, true if the character is equal to ' ' at all positions of comparison. False
+   * otherwise.
+   */
+  public abstract Boolean isSpace();
+
+  public static Builder builder() {
+    return new AutoValue_CollationOrderRow.Builder();
+  }
+
+  public abstract Builder toBuilder();
+
+  /**
+   * Construct a {@link CollationOrderRow} from a result set for the collation order query. It is
+   * expected that the caller handlers iteration of resultSet via {@link ResultSet#next()} and
+   * exceptions if any.
+   *
+   * @param rs
+   * @return fields of the output enclosed in {@link CollationOrderRow}.
+   * @throws SQLException if thrown by the {@link ResultSet ResultSet api}.
+   */
+  public static CollationOrderRow fromRS(ResultSet rs) throws SQLException {
+
+    String charSetChar = rs.getString(CHARSET_CHAR_COL);
+    String equivalentCharsetChar = rs.getString(EQUIVALENT_CHARSET_CHAR_COL);
+    Long codePointRank = rs.getLong(CODEPOINT_RANK_COL);
+    Boolean isEmpty = rs.getBoolean(IS_EMPTY_COL);
+    Boolean isSpace = rs.getBoolean(IS_SPACE_COL);
+    String equivalentCharsetCharPadSpace = rs.getString(EQUIVALENT_CHARSET_CHAR_PAD_SPACE_COL);
+    Long codePointRankPadSpace = rs.getLong(CODEPOINT_RANK_PAD_SPACE_COL);
+
+    logger.debug(
+        "Going to register collation query row charSetChar = {} with length = {}, equivalentCharSetChar = {} with length - {}, codePointRank = {}, isEmpty = {} isSpace = {}",
+        charSetChar,
+        charSetChar.length(),
+        equivalentCharsetChar,
+        equivalentCharsetChar.length(),
+        codePointRank,
+        isEmpty,
+        isSpace);
+
+    Preconditions.checkArgument(
+        charSetChar.length() <= 1, "Found a long character in collation output " + charSetChar);
+    Preconditions.checkArgument(
+        equivalentCharsetChar.length() <= 1,
+        "Found a long equivalent character in collation output " + equivalentCharsetChar);
+    Preconditions.checkArgument(
+        equivalentCharsetCharPadSpace.length() <= 1,
+        "Found a long equivalent character for pad space in collation output "
+            + equivalentCharsetChar);
+
+    return CollationOrderRow.builder()
+        .setCharsetChar(charSetChar.charAt(0))
+        .setEquivalentChar(equivalentCharsetChar.charAt(0))
+        .setCodepointRank(codePointRank)
+        .setEquivalentCharPadSpace(equivalentCharsetCharPadSpace.charAt(0))
+        .setCodepointRankPadSpace(codePointRankPadSpace)
+        .setIsEmpty(isEmpty)
+        .setIsSpace(isSpace)
+        .build();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setCharsetChar(Character value);
+
+    public abstract Builder setEquivalentChar(Character value);
+
+    public abstract Builder setCodepointRank(Long value);
+
+    public abstract Builder setEquivalentCharPadSpace(Character value);
+
+    public abstract Builder setCodepointRankPadSpace(Long value);
+
+    public abstract Builder setIsEmpty(Boolean value);
+
+    public abstract Builder setIsSpace(Boolean value);
+
+    public abstract CollationOrderRow build();
+  }
+
+  /** Column names that must be returned by the collations order query. */
+  public static class CollationsOrderQueryColumns {
+
+    /** Character in the character set. */
+    public static final String CHARSET_CHAR_COL = "charset_char";
+
+    /** A character with lowest rank charset_char character is equal to as per the collation. */
+    public static final String EQUIVALENT_CHARSET_CHAR_COL = "equivalent_charset_char";
+
+    /**
+     * A boolean columns, true if the character is equal to '\0' at all positions of comparison.
+     * False otherwise.
+     */
+    public static final String IS_EMPTY_COL = "is_empty";
+
+    /**
+     * A boolean columns, true if the character is equal to ' ' at all positions of comparison.
+     * False otherwise.
+     */
+    public static final String IS_SPACE_COL = "is_space";
+
+    /** 0 offset rank of this character as per the collation sort ordering at all positions. */
+    public static final String CODEPOINT_RANK_COL = "codepoint_rank";
+
+    /**
+     * A character with lowest rank charset_char character is equal to as per the collation at
+     * trailing position, in case a PAD SPACE comparison is needed. Unless you are looking at space
+     * like characters, this will be exactly same as equivalent_character.
+     */
+    public static final String EQUIVALENT_CHARSET_CHAR_PAD_SPACE_COL =
+        "equivalent_charset_char_pad_space";
+
+    /**
+     * 0 offset rank of this character as per the collation sort ordering at trailing position in
+     * case a PAD SPACE comparison is needed.
+     */
+    public static final String CODEPOINT_RANK_PAD_SPACE_COL = "codepoint_rank_pad_space";
+
+    private CollationsOrderQueryColumns() {}
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/CollationReference.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/CollationReference.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper;
+
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+
+/** Reference to a collation. */
+@AutoValue
+public abstract class CollationReference implements Serializable {
+
+  /** Character set of the column. */
+  public abstract String dbCharacterSet();
+
+  /** Collation of the column. */
+  public abstract String dbCollation();
+
+  /**
+   * For MySql, set to true if collation is of the type PAD SPACE. For PG, set to true if column is
+   * of CHAR type.
+   */
+  public abstract Boolean padSpace();
+
+  public static Builder builder() {
+    return new AutoValue_CollationReference.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setDbCharacterSet(String value);
+
+    public abstract Builder setDbCollation(String value);
+
+    public abstract Builder setPadSpace(Boolean value);
+
+    public abstract CollationReference build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/package-info.java
@@ -1,0 +1,1 @@
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/CollationMapperDoFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/CollationMapperDoFn.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationMapper;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.annotation.Nullable;
+import javax.sql.DataSource;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.KV;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Discover the Collation Mapping information for a given {@link CollationReference}. */
+public class CollationMapperDoFn
+    extends DoFn<CollationReference, KV<CollationReference, CollationMapper>>
+    implements Serializable {
+
+  private static final Logger logger = LoggerFactory.getLogger(CollationMapper.class);
+  private final SerializableFunction<Void, DataSource> dataSourceProviderFn;
+  private final UniformSplitterDBAdapter dbAdapter;
+
+  @JsonIgnore private transient @Nullable DataSource dataSource;
+
+  public CollationMapperDoFn(
+      SerializableFunction<Void, DataSource> dataSourceProviderFn,
+      UniformSplitterDBAdapter dbAdapter) {
+    this.dataSourceProviderFn = dataSourceProviderFn;
+    this.dbAdapter = dbAdapter;
+    this.dataSource = null;
+  }
+
+  @Setup
+  public void setup() throws Exception {
+    dataSource = dataSourceProviderFn.apply(null);
+  }
+
+  private Connection acquireConnection() throws SQLException {
+    return checkStateNotNull(this.dataSource).getConnection();
+  }
+
+  @ProcessElement
+  public void processElement(
+      @Element CollationReference input,
+      OutputReceiver<KV<CollationReference, CollationMapper>> out)
+      throws SQLException {
+
+    try (Connection conn = acquireConnection()) {
+      CollationMapper mapper = CollationMapper.fromDB(conn, dbAdapter, input);
+      out.output(KV.of(input, mapper));
+    } catch (Exception e) {
+      logger.error(
+          "Exception: {} while generating collationMapper for dataSource: {}, collationReference: {}",
+          e,
+          dataSource,
+          input);
+      // Beam will re-try exceptions generation during pipeline-run phase.
+      throw e;
+    }
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/CollationMapperTransform.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/CollationMapperTransform.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationMapper;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.sql.DataSource;
+import org.apache.beam.sdk.coders.CannotProvideCoderException;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.View;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollectionView;
+
+/**
+ * Generate the Side-Input that encodes the Collation Mapping information for given instance of
+ * {@link ReadWithUniformPartitions}.
+ */
+@AutoValue
+public abstract class CollationMapperTransform
+    extends PTransform<PBegin, PCollectionView<Map<CollationReference, CollationMapper>>>
+    implements Serializable {
+
+  /** List of {@link CollationReference} to discover the mapping for. */
+  public abstract ImmutableList<CollationReference> collationReferences();
+
+  /** Provider for connection pool. */
+  public abstract SerializableFunction<Void, DataSource> dataSourceProviderFn();
+
+  /** Provider to dialect specific Collation mapping query. */
+  public abstract UniformSplitterDBAdapter dbAdapter();
+
+  /**
+   * Generate the Side-Input that encodes the Collation Mapping information for given instance of
+   * {@link ReadWithUniformPartitions}.
+   *
+   * @param input PBegin
+   * @return {@link PCollectionView} for discovered {@link CollationReference}, {@link
+   *     CollationMapper} pairs.
+   */
+  @Override
+  public PCollectionView<Map<CollationReference, CollationMapper>> expand(PBegin input) {
+    try {
+      if (collationReferences().isEmpty()) {
+        return input
+            .apply(
+                Create.empty(
+                    KvCoder.of(
+                        input.getPipeline().getCoderRegistry().getCoder(CollationReference.class),
+                        input.getPipeline().getCoderRegistry().getCoder(CollationMapper.class))))
+            .apply("To Empty Map View", View.asMap());
+      }
+      return input
+          .apply(
+              "Create-Collation-References",
+              Create.of(collationReferences().stream().distinct().collect(Collectors.toList())))
+          .apply(
+              "Generate-Mappers",
+              ParDo.of(new CollationMapperDoFn(dataSourceProviderFn(), dbAdapter())))
+          .setCoder(
+              KvCoder.of(
+                  input.getPipeline().getCoderRegistry().getCoder(CollationReference.class),
+                  input.getPipeline().getCoderRegistry().getCoder(CollationMapper.class)))
+          .apply("CollationMapperView", View.asMap());
+    } catch (CannotProvideCoderException e) {
+      // This line is hard to unit test as the coders for serializable classes will be available.
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static Builder builder() {
+    return new AutoValue_CollationMapperTransform.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setCollationReferences(ImmutableList<CollationReference> value);
+
+    public abstract Builder setDataSourceProviderFn(SerializableFunction<Void, DataSource> value);
+
+    public abstract Builder setDbAdapter(UniformSplitterDBAdapter value);
+
+    public abstract CollationMapperTransform build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/InitialSplitRangeDoFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/InitialSplitRangeDoFn.java
@@ -59,7 +59,7 @@ public abstract class InitialSplitRangeDoFn extends DoFn<Range, ImmutableList<Ra
         "RWUPT - Began split process for table {} with initial range as {}", tableName(), input);
 
     ArrayList<Range> ranges = new ArrayList<Range>();
-    ranges.add(input);
+    ranges.add(input.toBuilder().build());
     ArrayList<Range> splitRanges = new ArrayList<>();
     for (long i = 0; i < splitHeight(); i++) {
       logger.info(

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceColumnIndexInfo.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceColumnIndexInfo.java
@@ -16,7 +16,9 @@
 package com.google.cloud.teleport.v2.source.reader.io.schema;
 
 import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
 import com.google.common.base.Preconditions;
+import javax.annotation.Nullable;
 
 @AutoValue
 /**
@@ -68,6 +70,14 @@ public abstract class SourceColumnIndexInfo implements Comparable<SourceColumnIn
    */
   public abstract IndexType indexType();
 
+  /** Collation details for string columns. Null if the column is not of string type. */
+  @Nullable
+  public abstract CollationReference collationReference();
+
+  /** Maximum Length for String Columns. Null for other types. */
+  @Nullable
+  public abstract Integer stringMaxLength();
+
   /**
    * Builder for {@link SourceColumnIndexInfo}.
    *
@@ -109,6 +119,10 @@ public abstract class SourceColumnIndexInfo implements Comparable<SourceColumnIn
 
     public abstract Builder setIndexType(IndexType value);
 
+    public abstract Builder setCollationReference(CollationReference value);
+
+    public abstract Builder setStringMaxLength(@Nullable Integer value);
+
     abstract SourceColumnIndexInfo autoBuild();
 
     public SourceColumnIndexInfo build() {
@@ -121,6 +135,7 @@ public abstract class SourceColumnIndexInfo implements Comparable<SourceColumnIn
 
   public enum IndexType {
     NUMERIC,
+    STRING,
     DATE_TIME,
     OTHER
   };

--- a/v2/sourcedb-to-spanner/src/main/resources/sql/mysql_collation_oder_query.sql
+++ b/v2/sourcedb-to-spanner/src/main/resources/sql/mysql_collation_oder_query.sql
@@ -1,0 +1,144 @@
+-- In this query, at a high level we sort a sequence of variable length code points as per the collation order of the database to understand how the code points for characters compare for the given collation.
+-- We start with all possible variable length code points which represent a single characters, sort them by the collation order and condense the output to groups.
+-- More details are explained in the query that follows.
+-- Note that although the query appears big it completes in a time < 60 seconds as the db just has to do in-memory sorting of literals.
+-- TODO(vardhanvthigle): Currently this query might not be compatible with MySQl 5.7. Change window functions with inner joins.
+
+-- Unfortunately we can't use prepared statement to set variable values via jdbc.
+-- The dataflow code will replace the below tags with the actual db charset and collation.
+SET @db_charset = 'charset_replacement_tag';
+SET @db_collation = 'collation_replacement_tag';
+
+
+
+-- A union of single byte literals from 0x00 to 0xff.
+SET @byte_literals = CONCAT(
+      'SELECT ''00'' AS h UNION ALL SELECT ''01'' UNION ALL SELECT ''02'' UNION ALL SELECT ''03'' UNION ALL SELECT ''04'' UNION ALL SELECT ''05'' UNION ALL SELECT ''06'' UNION ALL SELECT ''07'' UNION ALL SELECT ''08'' UNION ALL SELECT ''09'' UNION ALL SELECT ''0a'' UNION ALL SELECT ''0b'' UNION ALL SELECT ''0c'' UNION ALL SELECT ''0d'' UNION ALL SELECT ''0e'' UNION ALL SELECT ''0f''',
+'UNION ALL SELECT ''10'' AS h UNION ALL SELECT ''11'' UNION ALL SELECT ''12'' UNION ALL SELECT ''13'' UNION ALL SELECT ''14'' UNION ALL SELECT ''15'' UNION ALL SELECT ''16'' UNION ALL SELECT ''17'' UNION ALL SELECT ''18'' UNION ALL SELECT ''19'' UNION ALL SELECT ''1a'' UNION ALL SELECT ''1b'' UNION ALL SELECT ''1c'' UNION ALL SELECT ''1d'' UNION ALL SELECT ''1e'' UNION ALL SELECT ''1f''',
+'UNION ALL SELECT ''20'' AS h UNION ALL SELECT ''21'' UNION ALL SELECT ''22'' UNION ALL SELECT ''23'' UNION ALL SELECT ''24'' UNION ALL SELECT ''25'' UNION ALL SELECT ''26'' UNION ALL SELECT ''27'' UNION ALL SELECT ''28'' UNION ALL SELECT ''29'' UNION ALL SELECT ''2a'' UNION ALL SELECT ''2b'' UNION ALL SELECT ''2c'' UNION ALL SELECT ''2d'' UNION ALL SELECT ''2e'' UNION ALL SELECT ''2f''',
+'UNION ALL SELECT ''30'' AS h UNION ALL SELECT ''31'' UNION ALL SELECT ''32'' UNION ALL SELECT ''33'' UNION ALL SELECT ''34'' UNION ALL SELECT ''35'' UNION ALL SELECT ''36'' UNION ALL SELECT ''37'' UNION ALL SELECT ''38'' UNION ALL SELECT ''39'' UNION ALL SELECT ''3a'' UNION ALL SELECT ''3b'' UNION ALL SELECT ''3c'' UNION ALL SELECT ''3d'' UNION ALL SELECT ''3e'' UNION ALL SELECT ''3f''',
+'UNION ALL SELECT ''40'' AS h UNION ALL SELECT ''41'' UNION ALL SELECT ''42'' UNION ALL SELECT ''43'' UNION ALL SELECT ''44'' UNION ALL SELECT ''45'' UNION ALL SELECT ''46'' UNION ALL SELECT ''47'' UNION ALL SELECT ''48'' UNION ALL SELECT ''49'' UNION ALL SELECT ''4a'' UNION ALL SELECT ''4b'' UNION ALL SELECT ''4c'' UNION ALL SELECT ''4d'' UNION ALL SELECT ''4e'' UNION ALL SELECT ''4f''',
+'UNION ALL SELECT ''50'' AS h UNION ALL SELECT ''51'' UNION ALL SELECT ''52'' UNION ALL SELECT ''53'' UNION ALL SELECT ''54'' UNION ALL SELECT ''55'' UNION ALL SELECT ''56'' UNION ALL SELECT ''57'' UNION ALL SELECT ''58'' UNION ALL SELECT ''59'' UNION ALL SELECT ''5a'' UNION ALL SELECT ''5b'' UNION ALL SELECT ''5c'' UNION ALL SELECT ''5d'' UNION ALL SELECT ''5e'' UNION ALL SELECT ''5f''',
+'UNION ALL SELECT ''60'' AS h UNION ALL SELECT ''61'' UNION ALL SELECT ''62'' UNION ALL SELECT ''63'' UNION ALL SELECT ''64'' UNION ALL SELECT ''65'' UNION ALL SELECT ''66'' UNION ALL SELECT ''67'' UNION ALL SELECT ''68'' UNION ALL SELECT ''69'' UNION ALL SELECT ''6a'' UNION ALL SELECT ''6b'' UNION ALL SELECT ''6c'' UNION ALL SELECT ''6d'' UNION ALL SELECT ''6e'' UNION ALL SELECT ''6f''',
+'UNION ALL SELECT ''70'' AS h UNION ALL SELECT ''71'' UNION ALL SELECT ''72'' UNION ALL SELECT ''73'' UNION ALL SELECT ''74'' UNION ALL SELECT ''75'' UNION ALL SELECT ''76'' UNION ALL SELECT ''77'' UNION ALL SELECT ''78'' UNION ALL SELECT ''79'' UNION ALL SELECT ''7a'' UNION ALL SELECT ''7b'' UNION ALL SELECT ''7c'' UNION ALL SELECT ''7d'' UNION ALL SELECT ''7e'' UNION ALL SELECT ''7f''',
+'UNION ALL SELECT ''80'' AS h UNION ALL SELECT ''81'' UNION ALL SELECT ''82'' UNION ALL SELECT ''83'' UNION ALL SELECT ''84'' UNION ALL SELECT ''85'' UNION ALL SELECT ''86'' UNION ALL SELECT ''87'' UNION ALL SELECT ''88'' UNION ALL SELECT ''89'' UNION ALL SELECT ''8a'' UNION ALL SELECT ''8b'' UNION ALL SELECT ''8c'' UNION ALL SELECT ''8d'' UNION ALL SELECT ''8e'' UNION ALL SELECT ''8f''',
+'UNION ALL SELECT ''90'' AS h UNION ALL SELECT ''91'' UNION ALL SELECT ''92'' UNION ALL SELECT ''93'' UNION ALL SELECT ''94'' UNION ALL SELECT ''95'' UNION ALL SELECT ''96'' UNION ALL SELECT ''97'' UNION ALL SELECT ''98'' UNION ALL SELECT ''99'' UNION ALL SELECT ''9a'' UNION ALL SELECT ''9b'' UNION ALL SELECT ''9c'' UNION ALL SELECT ''9d'' UNION ALL SELECT ''9e'' UNION ALL SELECT ''9f''',
+'UNION ALL SELECT ''a0'' AS h UNION ALL SELECT ''a1'' UNION ALL SELECT ''a2'' UNION ALL SELECT ''a3'' UNION ALL SELECT ''a4'' UNION ALL SELECT ''a5'' UNION ALL SELECT ''a6'' UNION ALL SELECT ''a7'' UNION ALL SELECT ''a8'' UNION ALL SELECT ''a9'' UNION ALL SELECT ''aa'' UNION ALL SELECT ''ab'' UNION ALL SELECT ''ac'' UNION ALL SELECT ''ad'' UNION ALL SELECT ''ae'' UNION ALL SELECT ''af''',
+'UNION ALL SELECT ''b0'' AS h UNION ALL SELECT ''b1'' UNION ALL SELECT ''b2'' UNION ALL SELECT ''b3'' UNION ALL SELECT ''b4'' UNION ALL SELECT ''b5'' UNION ALL SELECT ''b6'' UNION ALL SELECT ''b7'' UNION ALL SELECT ''b8'' UNION ALL SELECT ''b9'' UNION ALL SELECT ''ba'' UNION ALL SELECT ''bb'' UNION ALL SELECT ''bc'' UNION ALL SELECT ''bd'' UNION ALL SELECT ''be'' UNION ALL SELECT ''bf''',
+'UNION ALL SELECT ''c0'' AS h UNION ALL SELECT ''c1'' UNION ALL SELECT ''c2'' UNION ALL SELECT ''c3'' UNION ALL SELECT ''c4'' UNION ALL SELECT ''c5'' UNION ALL SELECT ''c6'' UNION ALL SELECT ''c7'' UNION ALL SELECT ''c8'' UNION ALL SELECT ''c9'' UNION ALL SELECT ''ca'' UNION ALL SELECT ''cb'' UNION ALL SELECT ''cc'' UNION ALL SELECT ''cd'' UNION ALL SELECT ''ce'' UNION ALL SELECT ''cf''',
+'UNION ALL SELECT ''d0'' AS h UNION ALL SELECT ''d1'' UNION ALL SELECT ''d2'' UNION ALL SELECT ''d3'' UNION ALL SELECT ''d4'' UNION ALL SELECT ''d5'' UNION ALL SELECT ''d6'' UNION ALL SELECT ''d7'' UNION ALL SELECT ''d8'' UNION ALL SELECT ''d9'' UNION ALL SELECT ''da'' UNION ALL SELECT ''db'' UNION ALL SELECT ''dc'' UNION ALL SELECT ''dd'' UNION ALL SELECT ''de'' UNION ALL SELECT ''df''',
+'UNION ALL SELECT ''e0'' AS h UNION ALL SELECT ''e1'' UNION ALL SELECT ''e2'' UNION ALL SELECT ''e3'' UNION ALL SELECT ''e4'' UNION ALL SELECT ''e5'' UNION ALL SELECT ''e6'' UNION ALL SELECT ''e7'' UNION ALL SELECT ''e8'' UNION ALL SELECT ''e9'' UNION ALL SELECT ''ea'' UNION ALL SELECT ''eb'' UNION ALL SELECT ''ec'' UNION ALL SELECT ''ed'' UNION ALL SELECT ''ee'' UNION ALL SELECT ''ef''',
+'UNION ALL SELECT ''f0'' AS h UNION ALL SELECT ''f1'' UNION ALL SELECT ''f2'' UNION ALL SELECT ''f3'' UNION ALL SELECT ''f4'' UNION ALL SELECT ''f5'' UNION ALL SELECT ''f6'' UNION ALL SELECT ''f7'' UNION ALL SELECT ''f8'' UNION ALL SELECT ''f9'' UNION ALL SELECT ''fa'' UNION ALL SELECT ''fb'' UNION ALL SELECT ''fc'' UNION ALL SELECT ''fd'' UNION ALL SELECT ''fe'' UNION ALL SELECT ''ff'''
+);
+
+-- Four byte code points.
+SET @four_byte_codepoints = CONCAT(
+  '(SELECT * FROM (SELECT ',
+    'CONVERT(UNHEX(CONCAT(t1.h, t2.h, t3.h, t4.h)) USING ', @db_charset, ') AS charset_char ',
+    'FROM (', @byte_literals, ') AS t1 ',
+    'LEFT JOIN (', @byte_literals, ') AS t2 ON 1=1 ',
+    'LEFT JOIN (', @byte_literals, ') AS t3 ON 1=1 ',
+    'LEFT JOIN (', @byte_literals, ') AS t4 ON 1=1 ',
+    ') AS dt ',
+    'WHERE CHAR_LENGTH(charset_char) <= 1 AND charset_char IS NOT NULL'
+  ')'
+);
+
+-- Three byte code points.
+SET @three_byte_codepoints = CONCAT(
+  '(SELECT * FROM (SELECT ',
+    'CONVERT(UNHEX(CONCAT(t1.h, t2.h, t3.h)) USING ', @db_charset, ') AS charset_char ',
+    'FROM (', @byte_literals, ') AS t1 ',
+    'LEFT JOIN (', @byte_literals, ') AS t2 ON 1=1 ',
+    'LEFT JOIN (', @byte_literals, ') AS t3 ON 1=1 ',
+    ') AS dt ',
+    'WHERE CHAR_LENGTH(charset_char) <= 1 AND charset_char IS NOT NULL'
+  ')'
+);
+
+-- Two byte code points.
+SET @two_byte_codepoints = CONCAT(
+  '(SELECT * FROM (SELECT ',
+    'CONVERT(UNHEX(CONCAT(t1.h, t2.h)) USING ', @db_charset, ') AS charset_char ',
+    'FROM (', @byte_literals, ') AS t1 ',
+    'LEFT JOIN (', @byte_literals, ') AS t2 ON 1=1 ',
+    ') AS dt ',
+    'WHERE CHAR_LENGTH(charset_char) <= 1 AND charset_char IS NOT NULL'
+  ')'
+);
+
+-- Single byte code points.
+SET @one_byte_codepoints = CONCAT(
+  '(SELECT * FROM (SELECT ',
+    'CONVERT(UNHEX(t1.h) USING ', @db_charset, ') AS charset_char ',
+    'FROM (', @byte_literals, ') AS t1',
+    ') AS dt ', -- derived table
+    'WHERE CHAR_LENGTH(charset_char) <= 1 AND charset_char IS NOT NULL'
+  ')'
+);
+
+-- all variable length code points representing a single character within the @db_charset from length 0 till 4.
+SET @charset_chars = CONCAT(@three_byte_codepoints, ' UNION ALL ', @two_byte_codepoints, ' UNION ALL ', @one_byte_codepoints);
+
+SET @SPACE=CONCAT('CONVERT('' '' USING ', @db_charset,')');
+SET @ALPHABET=CONCAT('CONVERT(''a'' USING ', @db_charset,')');
+SET @ALPHABET_PAIR=CONCAT('CONCAT(', @ALPHABET, ',', @ALPHABET, ')');
+SET @SPACE_BETWEEN_ALPHABET=CONCAT('CONCAT(',@ALPHABET,',',@SPACE,',',@ALPHABET, ')');
+SET @CHAR_BETWEEN_ALPHABET=CONCAT('CONCAT(', @ALPHABET , ',', 'charset_char,', @ALPHABET, ')');
+SET @CHECK_SPACE=CONCAT(@CHAR_BETWEEN_ALPHABET, ' = ', @SPACE_BETWEEN_ALPHABET, ' COLLATE ', @db_collation);
+SET @CHECK_EMPTY=CONCAT(@CHAR_BETWEEN_ALPHABET, ' = ', @ALPHABET_PAIR, ' COLLATE ', @db_collation);
+
+
+-- Get the characters with their codepoints.
+SET @charset_chars_with_codepoints = CONCAT(
+    'SELECT ',
+    '  CONV(HEX(CONVERT(charset_char using ', @db_charset ,' )), 16, 10) AS codepoint, charset_char, ',
+    @CHAR_BETWEEN_ALPHABET, ' AS charset_char_non_trailing,',
+     @CHECK_EMPTY,' AS is_empty,',
+     @CHECK_SPACE, ' AS is_space ',
+    '  FROM (', @charset_chars, ') AS charset_with_codepoints_query '
+);
+
+
+
+-- We use codepoint to map character of the string to a java code-point.
+-- equivalent_codepoint is the minimum code point which is equal to a given character for the given @db_collation.
+-- For example in any case insensitive collation, the equivalent_codepoint for 'a' will be the codepoint for 'A'
+-- Mysql ignores empty characters coming in between a string for comparison. For example _utf8mb4`ab` will compare equal to CONCAT(_utf8mb4'a', CONVERT(UNHEX('001A') using utf8mb4), _utf8mb4'b')
+-- Trailing spaces are ignored depending on whether a collation is PAD SPACE or not.
+-- Note that there are various codepoints that can potentially represent a space, like the ascii space or non-breaking space (UNHEX(C2H0)) when the collation is Pad Space. These have same behavior to ascii space as far as trailing or non-trailing comparison is concerned.
+SET @find_equivalents_query = CONCAT(
+    ' SELECT *, ',
+    ' FIRST_VALUE(CAST(codepoint AS SIGNED)) OVER (PARTITION BY charset_char COLLATE ', @db_collation, ', is_empty ORDER BY charset_char COLLATE ', @db_collation, ',CAST(codepoint AS SIGNED) ) AS equivalent_codepoint, ',
+    ' FIRST_VALUE(charset_char) OVER (PARTITION BY charset_char COLLATE ', @db_collation, ', is_empty ORDER BY charset_char COLLATE ', @db_collation, ',CAST(codepoint AS SIGNED) ) AS equivalent_charset_char, ',
+    ' FIRST_VALUE(CAST(codepoint AS SIGNED)) OVER (PARTITION BY charset_char_non_trailing COLLATE ', @db_collation, ', is_empty ORDER BY charset_char COLLATE ', @db_collation, ',CAST(codepoint AS SIGNED) ) AS equivalent_codepoint_non_trailing, ',
+    ' FIRST_VALUE(charset_char) OVER (PARTITION BY charset_char_non_trailing COLLATE ', @db_collation, ', is_empty ORDER BY charset_char COLLATE ', @db_collation, ',CAST(codepoint AS SIGNED) ) AS equivalent_charset_char_non_trailing, ',
+    ' FIRST_VALUE(CAST(codepoint AS SIGNED)) OVER (PARTITION BY charset_char COLLATE ', @db_collation, ', is_empty, is_space ORDER BY charset_char COLLATE ', @db_collation, ',CAST(codepoint AS SIGNED) ) AS equivalent_codepoint_pad_space, ',
+    ' FIRST_VALUE(charset_char) OVER (PARTITION BY charset_char COLLATE ', @db_collation, ', is_empty, is_space ORDER BY charset_char COLLATE ', @db_collation, ',CAST(codepoint AS SIGNED) ) AS equivalent_charset_char_pad_space ',
+    ' FROM ( ', @charset_chars_with_codepoints, ' ) AS find_equivalents',
+    ' ORDER BY codepoint'
+);
+
+-- Find the rank of a code_point as per the collation ordering.
+-- The `_pad_space` rank is the rank of the code_point at trailing position if pad-space comparison is enforced.
+SET @find_rank_query = CONCAT(
+    'SELECT *, ',
+    ' DENSE_RANK() OVER (PARTITION BY is_empty ORDER BY equivalent_charset_char_non_trailing COLLATE ', @db_collation, ') - 1 AS codepoint_rank, ',
+    ' DENSE_RANK() OVER (PARTITION BY is_empty, is_space ORDER BY equivalent_charset_char_pad_space COLLATE ', @db_collation, ') - 1 AS codepoint_rank_pad_space ',
+    ' FROM ( ',
+    @find_equivalents_query,
+    ' ) AS find_rank ',
+    ' ORDER BY CAST(codepoint AS SIGNED) ASC '
+);
+
+SET @output_query = CONCAT(
+  ' SELECT * ',
+  ' FROM (',
+    @find_rank_query,
+  ' ) AS output_query ',
+  ' ORDER BY CAST(codepoint AS SIGNED) '
+);
+
+PREPARE stmt FROM @output_query;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/options/OptionsToConfigBuilderTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/options/OptionsToConfigBuilderTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.JdbcIOWrapperConfig;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -57,7 +58,7 @@ public class OptionsToConfigBuilderTest {
         OptionsToConfigBuilder.MySql.configWithMySqlDefaultsFromOptions(
             sourceDbToSpannerOptions, List.of("table1", "table2"), null, Wait.on(dummyPCollection));
     assertThat(config.jdbcDriverClassName()).isEqualTo(testdriverClassName);
-    assertThat(config.sourceDbURL()).isEqualTo(testUrl);
+    assertThat(config.sourceDbURL()).isEqualTo(testUrl + "?allowMultiQueries=true");
     assertThat(config.tables()).containsExactlyElementsIn(new String[] {"table1", "table2"});
     assertThat(config.dbAuth().getUserName().get()).isEqualTo(testuser);
     assertThat(config.dbAuth().getPassword().get()).isEqualTo(testpassword);
@@ -75,5 +76,41 @@ public class OptionsToConfigBuilderTest {
         () ->
             OptionsToConfigBuilder.MySql.configWithMySqlDefaultsFromOptions(
                 sourceDbToSpannerOptions, new ArrayList<>(), null, null));
+  }
+
+  @Test
+  public void testaddParamToJdbcUrl() throws URISyntaxException {
+    // No Parameters initially.
+    assertThat(
+            OptionsToConfigBuilder.addParamToJdbcUrl(
+                "jdbc:mysql://localhost:3306/testDB", "allowMultiQueries", "true"))
+        .isEqualTo("jdbc:mysql://localhost:3306/testDB?allowMultiQueries=true");
+    assertThat(
+            OptionsToConfigBuilder.addParamToJdbcUrl(
+                "jdbc:mysql://localhost:3306/testDB?", "allowMultiQueries", "true"))
+        .isEqualTo("jdbc:mysql://localhost:3306/testDB?allowMultiQueries=true");
+    // Other Parameters present.
+    assertThat(
+            OptionsToConfigBuilder.addParamToJdbcUrl(
+                "jdbc:mysql://localhost:3306/testDB?useSSL=true&autoReconnect=true",
+                "allowMultiQueries",
+                "true"))
+        .isEqualTo(
+            "jdbc:mysql://localhost:3306/testDB?useSSL=true&autoReconnect=true&allowMultiQueries=true");
+    // Parameter present with same value.
+    assertThat(
+            OptionsToConfigBuilder.addParamToJdbcUrl(
+                "jdbc:mysql://localhost:3306/testDB?useSSL=true&autoReconnect=true&allowMultiQueries=true",
+                "allowMultiQueries",
+                "true"))
+        .isEqualTo(
+            "jdbc:mysql://localhost:3306/testDB?useSSL=true&autoReconnect=true&allowMultiQueries=true");
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            OptionsToConfigBuilder.addParamToJdbcUrl(
+                "jdbc:mysql://localhost:3306/testDB?useSSL=true&autoReconnect=true&allowMultiQueries=false",
+                "allowMultiQueries",
+                "true"));
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryExtractorFactoryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryExtractorFactoryTest.java
@@ -19,11 +19,15 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationMapper;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
 import java.math.BigInteger;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Map;
 import org.apache.beam.sdk.io.jdbc.JdbcIO.PoolableDataSourceProvider;
 import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+import org.apache.beam.sdk.values.PCollectionView;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -90,7 +94,12 @@ public class BoundaryExtractorFactoryTest {
         PartitionColumn.builder()
             .setColumnName("col1")
             .setColumnClass(String.class)
-            .setStringCollation("latin1_swedish_ci")
+            .setStringCollation(
+                CollationReference.builder()
+                    .setDbCharacterSet("latin1")
+                    .setDbCollation("latin1_swedish_ci")
+                    .setPadSpace(true)
+                    .build())
             .setStringMaxLength(255)
             .build();
     BoundaryExtractor<String> extractor = BoundaryExtractorFactory.create(String.class);
@@ -104,7 +113,7 @@ public class BoundaryExtractorFactoryTest {
             mockResultSet,
             new BoundaryTypeMapper() {
               @Override
-              public BigInteger mapString(
+              public BigInteger mapStringToBigInteger(
                   String element,
                   int lengthTOPad,
                   PartitionColumn partitionColumn,
@@ -113,8 +122,14 @@ public class BoundaryExtractorFactoryTest {
               }
 
               @Override
-              public String unMapString(
+              public String unMapStringFromBigInteger(
                   BigInteger element, PartitionColumn partitionColumn, ProcessContext c) {
+                return null;
+              }
+
+              @Override
+              public PCollectionView<Map<CollationReference, CollationMapper>>
+                  getCollationMapperView() {
                 return null;
               }
             });

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundarySplitterFactoryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundarySplitterFactoryTest.java
@@ -18,8 +18,12 @@ package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationMapper;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
 import java.math.BigInteger;
+import java.util.Map;
 import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.commons.pool.impl.GenericObjectPool;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -116,7 +120,12 @@ public class BoundarySplitterFactoryTest {
         PartitionColumn.builder()
             .setColumnName("col1")
             .setColumnClass(String.class)
-            .setStringCollation("latin1_general_cs")
+            .setStringCollation(
+                CollationReference.builder()
+                    .setDbCharacterSet("latin1")
+                    .setDbCollation("latin1_general_cs")
+                    .setPadSpace(true)
+                    .build())
             .setStringMaxLength(255)
             .build();
 
@@ -218,7 +227,7 @@ public class BoundarySplitterFactoryTest {
     }
 
     @Override
-    public BigInteger mapString(
+    public BigInteger mapStringToBigInteger(
         String element,
         int lengthToPad,
         PartitionColumn partitionColumn,
@@ -236,7 +245,7 @@ public class BoundarySplitterFactoryTest {
     }
 
     @Override
-    public String unMapString(
+    public String unMapStringFromBigInteger(
         BigInteger element, PartitionColumn partitionColumn, ProcessContext processContext) {
       StringBuilder word = new StringBuilder();
       while (element != BigInteger.ZERO) {
@@ -247,6 +256,11 @@ public class BoundarySplitterFactoryTest {
       }
       String ret = word.reverse().toString();
       return ret;
+    }
+
+    @Override
+    public PCollectionView<Map<CollationReference, CollationMapper>> getCollationMapperView() {
+      return null;
     }
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
 import java.io.Serializable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
@@ -91,7 +92,12 @@ public class BoundaryTest {
             .setBoundarySplitter(
                 (BoundarySplitter<String>)
                     (start, end, partitionColumn, boundaryTypeMapper, processContext) -> null)
-            .setCollation("latin1_swedish_ci")
+            .setCollation(
+                CollationReference.builder()
+                    .setDbCharacterSet("latin1")
+                    .setDbCollation("latin1_swedish_ci")
+                    .setPadSpace(true)
+                    .build())
             .setStringMaxLength(255)
             .build();
 
@@ -113,7 +119,7 @@ public class BoundaryTest {
     assertThat(splitBoundaries.getLeft().compareTo(splitBoundaries.getRight()) < 0).isTrue();
     assertThat(splitBoundaries.getRight().compareTo(splitBoundaries.getLeft()) > 0).isTrue();
     assertThat(splitBoundaries.getLeft().compareTo(splitBoundaries.getLeft())).isEqualTo(0);
-    assertThat(stringBoundary.stringCollation()).isEqualTo("latin1_swedish_ci");
+    assertThat(stringBoundary.stringCollation().dbCollation()).isEqualTo("latin1_swedish_ci");
     assertThat(stringBoundary.stringMaxLength()).isEqualTo(255);
   }
 

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/PartitionColumnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/PartitionColumnTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -34,14 +35,20 @@ public class PartitionColumnTest {
         PartitionColumn.builder()
             .setColumnName("col1")
             .setColumnClass(String.class)
-            .setStringCollation("latin1_swedish_ci")
+            .setStringCollation(
+                CollationReference.builder()
+                    .setDbCharacterSet("latin1")
+                    .setDbCollation("latin1_swedish_ci")
+                    .setPadSpace(true)
+                    .build())
             .setStringMaxLength(255)
             .build();
 
     assertThat(integerPartitionColumn.columnClass()).isEqualTo(Integer.class);
     assertThat(integerPartitionColumn.columnName()).isEqualTo("col1");
     assertThat(integerPartitionColumn.stringCollation()).isNull();
-    assertThat(stringPartitionColumn.stringCollation()).isEqualTo("latin1_swedish_ci");
+    assertThat(stringPartitionColumn.stringCollation().dbCollation())
+        .isEqualTo("latin1_swedish_ci");
     assertThat(stringPartitionColumn.stringMaxLength()).isEqualTo(255);
   }
 
@@ -57,7 +64,12 @@ public class PartitionColumnTest {
             PartitionColumn.builder()
                 .setColumnName("col1")
                 .setColumnClass(Integer.class)
-                .setStringCollation("latin1_swedish_ci")
+                .setStringCollation(
+                    CollationReference.builder()
+                        .setDbCharacterSet("latin1")
+                        .setDbCollation("latin1_general_cs")
+                        .setPadSpace(true)
+                        .build())
                 .build());
     assertThrows(
         IllegalStateException.class,
@@ -74,7 +86,12 @@ public class PartitionColumnTest {
             PartitionColumn.builder()
                 .setColumnName("col1")
                 .setColumnClass(String.class)
-                .setStringCollation("latin1_swedish_ci")
+                .setStringCollation(
+                    CollationReference.builder()
+                        .setDbCharacterSet("latin1")
+                        .setDbCollation("latin1_swedish_ci")
+                        .setPadSpace(true)
+                        .build())
                 // No Max Length.
                 .build());
   }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/BoundaryTypeMapperImplTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/BoundaryTypeMapperImplTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.PartitionColumn;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link BoundaryTypeMapperImpl}. */
+@RunWith(MockitoJUnitRunner.class)
+public class BoundaryTypeMapperImplTest {
+  @Mock PCollectionView<Map<CollationReference, CollationMapper>> mockCollationMapperView;
+  @Mock ProcessContext mockProcessContext;
+
+  @Test
+  public void testBoundaryTypeMappingImpl() {
+
+    CollationReference testCollationReference =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharSet")
+            .setDbCollation("testCollation")
+            .setPadSpace(true)
+            .build();
+    CollationMapper.Builder collationMapperBuilder =
+        CollationMapper.builder(testCollationReference);
+
+    CollationReference testCollationReferenceUndiscovered =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharSetUndiscovered")
+            .setDbCollation("testCollation")
+            .setPadSpace(true)
+            .build();
+
+    /* Add Single Character */
+    collationMapperBuilder
+        .addCharacter(
+            CollationOrderRow.builder()
+                .setCharsetChar('a')
+                .setEquivalentChar('A')
+                .setEquivalentCharPadSpace('A')
+                .setCodepointRank(0L)
+                .setCodepointRankPadSpace(0L)
+                .setIsEmpty(false)
+                .setIsSpace(false)
+                .build())
+        .addCharacter(
+            CollationOrderRow.builder()
+                .setCharsetChar('A')
+                .setEquivalentChar('A')
+                .setEquivalentCharPadSpace('A')
+                .setCodepointRank(0L)
+                .setCodepointRankPadSpace(0L)
+                .setIsEmpty(false)
+                .setIsSpace(false)
+                .build());
+    CollationMapper testCollationMapper = collationMapperBuilder.build();
+    when(mockProcessContext.sideInput(mockCollationMapperView))
+        .thenReturn(ImmutableMap.of(testCollationReference, testCollationMapper));
+
+    PartitionColumn testPartitionColumn =
+        PartitionColumn.builder()
+            .setColumnName("strCol")
+            .setColumnClass(String.class)
+            .setStringMaxLength(1)
+            .setStringCollation(testCollationReference)
+            .build();
+
+    BoundaryTypeMapperImpl boundaryTypeMapper =
+        BoundaryTypeMapperImpl.builder().setCollationMapperView(mockCollationMapperView).build();
+    assertThat(
+            boundaryTypeMapper.unMapStringFromBigInteger(
+                boundaryTypeMapper.mapStringToBigInteger(
+                    "a", 1, testPartitionColumn, mockProcessContext),
+                testPartitionColumn,
+                mockProcessContext))
+        .isEqualTo("A");
+    assertThat(boundaryTypeMapper.getCollationMapperView()).isEqualTo(mockCollationMapperView);
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            boundaryTypeMapper.unMapStringFromBigInteger(
+                boundaryTypeMapper.mapStringToBigInteger(
+                    "a",
+                    1,
+                    testPartitionColumn.toBuilder()
+                        .setStringCollation(testCollationReferenceUndiscovered)
+                        .build(),
+                    mockProcessContext),
+                testPartitionColumn,
+                mockProcessContext));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/CollationIndexTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/CollationIndexTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationIndex.CollationIndexType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link CollationIndex}. */
+@RunWith(MockitoJUnitRunner.class)
+public class CollationIndexTest {
+  @Test
+  public void testCollationIndexBasic() {
+    CollationReference testCollationReference =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharSet")
+            .setDbCollation("testCollation")
+            .setPadSpace(true)
+            .build();
+    CollationIndex collationIndex =
+        CollationIndex.builder()
+            .setCollationReference(testCollationReference)
+            .setIndexType(CollationIndexType.TRAILING_POSITION_PAD_SPACE)
+            .addCharacter('a', 'A', 0L)
+            .addCharacter('A', 'A', 0L)
+            .build();
+
+    assertThat(collationIndex.indexType())
+        .isEqualTo(CollationIndexType.TRAILING_POSITION_PAD_SPACE);
+    assertThat(collationIndex.collationReference()).isEqualTo(testCollationReference);
+    assertThat(collationIndex.getCharsetSize()).isEqualTo(1);
+    assertThat(collationIndex.characterToIndex().size()).isEqualTo(2);
+    assertThat(collationIndex.getCharacterFromPosition(0L)).isEqualTo('A');
+    assertThat(collationIndex.getOrdinalPosition('a')).isEqualTo(0L);
+  }
+
+  @Test
+  public void testCollationIndexPreConditions() {
+    CollationReference testCollationReference =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharSet")
+            .setDbCollation("testCollation")
+            .setPadSpace(true)
+            .build();
+
+    // Duplicate Characters
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            CollationIndex.builder()
+                .setIndexType(CollationIndexType.ALL_POSITIONS)
+                .setCollationReference(testCollationReference)
+                .addCharacter('a', 'A', 0L)
+                .addCharacter('a', 'A', 0L)
+                .build());
+    // Duplicate Index
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            CollationIndex.builder()
+                .setIndexType(CollationIndexType.ALL_POSITIONS)
+                .setCollationReference(testCollationReference)
+                .addCharacter('a', 'A', 0L)
+                .addCharacter('A', 'A', 2L));
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            CollationIndex.builder()
+                .setIndexType(CollationIndexType.ALL_POSITIONS)
+                .setCollationReference(testCollationReference)
+                .addCharacter('a', 'A', 0L)
+                .addCharacter('z', 'Z', 0L));
+    // Index with Holes.
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            CollationIndex.builder()
+                .setIndexType(CollationIndexType.ALL_POSITIONS)
+                .setCollationReference(testCollationReference)
+                .addCharacter('a', 'A', 0L)
+                .addCharacter('A', 'A', 0L)
+                .addCharacter('z', 'Z', 10L)
+                .addCharacter('Z', 'Z', 10L)
+                .build());
+    // Index Character not part of basic character set.
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            CollationIndex.builder()
+                .setIndexType(CollationIndexType.ALL_POSITIONS)
+                .setCollationReference(testCollationReference)
+                .addCharacter('a', 'M', 0L)
+                .addCharacter('A', 'A', 5L)
+                .addCharacter('z', 'Z', 10L)
+                .addCharacter('Z', 'Z', 10L)
+                .build());
+    // Index Character does not map to itself
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            CollationIndex.builder()
+                .setIndexType(CollationIndexType.ALL_POSITIONS)
+                .setCollationReference(testCollationReference)
+                .addCharacter('a', 'A', 0L)
+                .addCharacter('A', 'M', 5L)
+                .addCharacter('M', 'M', 5L)
+                .addCharacter('z', 'Z', 10L)
+                .addCharacter('Z', 'Z', 10L)
+                .build());
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/CollationMapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/CollationMapperTest.java
@@ -1,0 +1,477 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper;
+
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.CHARSET_CHAR_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.CODEPOINT_RANK_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.CODEPOINT_RANK_PAD_SPACE_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.EQUIVALENT_CHARSET_CHAR_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.EQUIVALENT_CHARSET_CHAR_PAD_SPACE_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.IS_EMPTY_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.IS_SPACE_COL;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+/** Test class for {@link CollationMapper}. */
+@RunWith(MockitoJUnitRunner.class)
+public class CollationMapperTest {
+  @Mock Connection mockConnection;
+
+  @Mock Statement mockStatement;
+
+  @Mock ResultSet mockResultSet;
+
+  @Test
+  public void testCollationMapperBasic() {
+    CollationReference testCollationReference =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharSet")
+            .setDbCollation("testCollation")
+            .setPadSpace(false)
+            .build();
+    /* Initialize a basic case insensitive collation of english alphabet. Lower case characters map to upper case ones. */
+    CollationMapper.Builder collationMapperBuilder =
+        CollationMapper.builder(testCollationReference);
+    ImmutableList.Builder<Character> enAlphabetsBuilder = ImmutableList.builder();
+    for (Character c = 'a'; c <= 'z'; c++) {
+      enAlphabetsBuilder.add(c);
+    }
+    for (Character c = 'A'; c <= 'Z'; c++) {
+      enAlphabetsBuilder.add(c);
+    }
+    for (Character c : enAlphabetsBuilder.build()) {
+      CollationOrderRow collationOrderRow =
+          CollationOrderRow.builder()
+              .setCharsetChar(c)
+              .setEquivalentChar(Character.toUpperCase(c))
+              .setEquivalentCharPadSpace(Character.toUpperCase(c))
+              .setCodepointRank((long) (Character.toUpperCase(c) - 'A'))
+              .setCodepointRankPadSpace((long) (Character.toUpperCase(c) - 'A'))
+              .setIsEmpty(false)
+              .setIsSpace(false)
+              .build();
+      collationMapperBuilder.addCharacter(collationOrderRow);
+    }
+    /** Add blank character */
+    collationMapperBuilder.addCharacter(
+        CollationOrderRow.builder()
+            .setCharsetChar('\0')
+            .setEquivalentChar('\0')
+            .setEquivalentCharPadSpace('\0')
+            .setCodepointRank(0L)
+            .setCodepointRankPadSpace(0L)
+            .setIsEmpty(true)
+            .setIsSpace(false)
+            .build());
+    CollationMapper collationMapper = collationMapperBuilder.build();
+
+    assertThat(collationMapper.emptyCharacters().size()).isEqualTo(1);
+    assertThat(collationMapper.allPositionsIndex().characterToIndex().size()).isEqualTo(52);
+    assertThat(collationMapper.allPositionsIndex().indexToCharacter().size()).isEqualTo(26);
+    assertThat(collationMapper.collationReference().dbCollation()).isEqualTo("testCollation");
+    assertThat(collationMapper.collationReference().dbCharacterSet()).isEqualTo("testCharSet");
+    assertThat(collationMapper.unMapString(collationMapper.mapString("google", 6)))
+        .isEqualTo("GOOGLE");
+    // midpoint of cat and mat is HAT.
+    BigInteger catAsBigInt = collationMapper.mapString("cat", 3);
+    BigInteger matAsBigInt = collationMapper.mapString("mat", 3);
+    BigInteger average = (catAsBigInt.add(matAsBigInt)).divide(BigInteger.valueOf(2));
+    String averageString = collationMapper.unMapString(average);
+    assertThat(averageString).isEqualTo("HAT");
+    // Test Blank Characters.
+    assertThat(collationMapper.unMapString(collationMapper.mapString("goo" + '\0' + "gle", 6)))
+        .isEqualTo("GOOGLE");
+    // Test Padding.
+    assertThat(collationMapper.unMapString(collationMapper.mapString("google", 7)))
+        .isEqualTo("GOOGLEA");
+  }
+
+  @Test
+  public void testCollationMapperPadSpace() {
+    CollationReference testCollationReference =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharSet")
+            .setDbCollation("testCollation")
+            .setPadSpace(true)
+            .build();
+    /* Initialize a basic case insensitive collation of english alphabet. Lower case characters map to upper case ones. */
+    CollationMapper.Builder collationMapperBuilder =
+        CollationMapper.builder(testCollationReference);
+    ImmutableList.Builder<Character> enAlphabetsBuilder = ImmutableList.builder();
+    for (Character c = 'a'; c <= 'z'; c++) {
+      enAlphabetsBuilder.add(c);
+    }
+    for (Character c = 'A'; c <= 'Z'; c++) {
+      enAlphabetsBuilder.add(c);
+    }
+    for (Character c : enAlphabetsBuilder.build()) {
+      CollationOrderRow collationOrderRow =
+          CollationOrderRow.builder()
+              .setCharsetChar(c)
+              .setEquivalentChar(Character.toUpperCase(c))
+              .setEquivalentCharPadSpace(Character.toUpperCase(c))
+              .setCodepointRank((long) (Character.toUpperCase(c) - 'A' + 1))
+              .setCodepointRankPadSpace((long) (Character.toUpperCase(c) - 'A'))
+              .setIsEmpty(false)
+              .setIsSpace(false)
+              .build();
+      collationMapperBuilder.addCharacter(collationOrderRow);
+    }
+    /** Add Space Character */
+    collationMapperBuilder.addCharacter(
+        CollationOrderRow.builder()
+            .setCharsetChar(' ')
+            .setEquivalentChar(' ')
+            .setEquivalentCharPadSpace('\0')
+            .setCodepointRank(0L)
+            .setCodepointRankPadSpace(0L)
+            .setIsEmpty(false)
+            .setIsSpace(true)
+            .build());
+
+    CollationMapper collationMapper = collationMapperBuilder.build();
+    assertThat(collationMapper.unMapString(collationMapper.mapString("google ", 6)))
+        .isEqualTo("GOOGLE");
+    // midpoint of cat and mat is HAT.
+    BigInteger catAsBigInt = collationMapper.mapString("cat", 3);
+    BigInteger matAsBigInt = collationMapper.mapString("mat", 3);
+    BigInteger average = (catAsBigInt.add(matAsBigInt)).divide(BigInteger.valueOf(2));
+    String averageString = collationMapper.unMapString(average);
+    assertThat(averageString).isEqualTo("HAT");
+  }
+
+  @Test
+  public void testCollationMapperEmptyStrings() {
+    CollationReference testCollationReference =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharSet")
+            .setDbCollation("testCollation")
+            .setPadSpace(true)
+            .build();
+    CollationMapper.Builder collationMapperBuilder =
+        CollationMapper.builder(testCollationReference);
+
+    /* Add space character */
+    collationMapperBuilder.addCharacter(
+        CollationOrderRow.builder()
+            .setCharsetChar(' ')
+            .setEquivalentChar(' ')
+            .setEquivalentCharPadSpace('\0')
+            .setCodepointRank(0L)
+            .setCodepointRankPadSpace(0L)
+            .setIsEmpty(false)
+            .setIsSpace(true)
+            .build());
+    /* Add empty Character */
+    collationMapperBuilder.addCharacter(
+        CollationOrderRow.builder()
+            .setCharsetChar('\0')
+            .setEquivalentChar('\0')
+            .setEquivalentCharPadSpace('\0')
+            .setCodepointRank(0L)
+            .setCodepointRankPadSpace(0L)
+            .setIsEmpty(true)
+            .setIsSpace(true)
+            .build());
+    CollationMapper collationMapper = collationMapperBuilder.build();
+    assertThat(collationMapper.unMapString(collationMapper.mapString("", 0))).isEqualTo("");
+    assertThat(collationMapper.unMapString(collationMapper.mapString("\0", 0))).isEqualTo("");
+    assertThat(collationMapper.unMapString(collationMapper.mapString(null, 0))).isEqualTo("");
+    assertThat(collationMapper.unMapString(collationMapper.mapString("    ", 0))).isEqualTo("");
+  }
+
+  @Test
+  public void testCollationMapperSingleCharacterString() {
+
+    CollationReference testCollationReference =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharSet")
+            .setDbCollation("testCollation")
+            .setPadSpace(true)
+            .build();
+    CollationMapper.Builder collationMapperBuilder =
+        CollationMapper.builder(testCollationReference);
+
+    /* Add Single Character */
+    collationMapperBuilder.addCharacter(
+        CollationOrderRow.builder()
+            .setCharsetChar('a')
+            .setEquivalentChar('a')
+            .setEquivalentCharPadSpace('a')
+            .setCodepointRank(0L)
+            .setCodepointRankPadSpace(0L)
+            .setIsEmpty(false)
+            .setIsSpace(false)
+            .build());
+    CollationMapper collationMapper = collationMapperBuilder.build();
+    assertThat(collationMapper.unMapString(collationMapper.mapString("a", 1))).isEqualTo("a");
+  }
+
+  @Test
+  public void testCollationFromDbBasic() throws SQLException {
+
+    CollationReference testCollationReference =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharSet")
+            .setDbCollation("testCollation")
+            .setPadSpace(false)
+            .build();
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+    when(mockStatement.execute(any())).thenReturn(false);
+    when(mockStatement.getMoreResults()).thenReturn(false).thenReturn(false).thenReturn(true);
+    when(mockStatement.getUpdateCount()).thenReturn(0);
+    when(mockStatement.getResultSet()).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true).thenReturn(false);
+    when(mockResultSet.getString(CHARSET_CHAR_COL)).thenReturn("a");
+    when(mockResultSet.getString(EQUIVALENT_CHARSET_CHAR_COL)).thenReturn("a");
+    when(mockResultSet.getLong(CODEPOINT_RANK_COL)).thenReturn(0L);
+    when(mockResultSet.getString(EQUIVALENT_CHARSET_CHAR_PAD_SPACE_COL)).thenReturn("a");
+    when(mockResultSet.getLong(CODEPOINT_RANK_PAD_SPACE_COL)).thenReturn(0L);
+    when(mockResultSet.getBoolean(IS_EMPTY_COL)).thenReturn(false);
+    when(mockResultSet.getBoolean(IS_SPACE_COL)).thenReturn(false);
+
+    CollationMapper collationMapper =
+        CollationMapper.fromDB(
+            mockConnection, new MysqlDialectAdapter(MySqlVersion.DEFAULT), testCollationReference);
+
+    assertThat(collationMapper.allPositionsIndex().characterToIndex().size()).isEqualTo(1);
+    assertThat(collationMapper.collationReference().dbCollation()).isEqualTo("testCollation");
+    assertThat(collationMapper.collationReference().dbCharacterSet()).isEqualTo("testCharSet");
+  }
+
+  @Test
+  public void testCollationFromDbSqlException() throws SQLException {
+    CollationReference testCollationReference =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharset")
+            .setDbCollation("testCollation")
+            .setPadSpace(false)
+            .build();
+    int expectedSqlExceptionsCount = 0;
+    when(mockConnection.createStatement())
+        .thenThrow(new SQLException("test"))
+        .thenReturn(mockStatement);
+    expectedSqlExceptionsCount++;
+    when(mockStatement.execute(any())).thenReturn(false);
+    when(mockStatement.getMoreResults()).thenReturn(false).thenReturn(false).thenReturn(true);
+    when(mockStatement.getUpdateCount()).thenReturn(0);
+    when(mockStatement.getResultSet()).thenThrow(new SQLException()).thenReturn(mockResultSet);
+    expectedSqlExceptionsCount++;
+    when(mockResultSet.next()).thenThrow(new SQLException("test"));
+    expectedSqlExceptionsCount++;
+    for (int i = 0; i < expectedSqlExceptionsCount; i++) {
+      assertThrows(
+          SQLException.class,
+          () ->
+              CollationMapper.fromDB(
+                  mockConnection,
+                  new MysqlDialectAdapter(MySqlVersion.DEFAULT),
+                  testCollationReference));
+    }
+  }
+
+  @Test
+  public void testCollationFromDbNoResultSetExceptionBasic() throws SQLException {
+    CollationReference testCollationReference =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharset")
+            .setDbCollation("testCollation")
+            .setPadSpace(false)
+            .build();
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+    when(mockStatement.execute(any())).thenReturn(false);
+    when(mockStatement.getMoreResults()).thenReturn(false).thenReturn(false);
+    when(mockStatement.getUpdateCount()).thenReturn(-1);
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            CollationMapper.fromDB(
+                mockConnection,
+                new MysqlDialectAdapter(MySqlVersion.DEFAULT),
+                testCollationReference));
+  }
+
+  @Test
+  public void testCollationFromDbNoResultSetExceptionAfterExhaustedLoop() throws SQLException {
+    CollationReference testCollationReference =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharset")
+            .setDbCollation("testCollation")
+            .setPadSpace(false)
+            .build();
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+    when(mockStatement.execute(any())).thenReturn(false);
+    when(mockStatement.getMoreResults()).thenReturn(false);
+    when(mockStatement.getUpdateCount()).thenReturn(0);
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            CollationMapper.fromDB(
+                mockConnection,
+                new MysqlDialectAdapter(MySqlVersion.DEFAULT),
+                testCollationReference));
+  }
+
+  @Test
+  public void testUtf8Mb40900AiCi() throws SQLException, IOException {
+
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+    when(mockStatement.execute(any())).thenReturn(false);
+    when(mockStatement.getMoreResults()).thenReturn(false).thenReturn(false).thenReturn(true);
+    when(mockStatement.getUpdateCount()).thenReturn(0);
+    when(mockStatement.getResultSet()).thenReturn(mockResultSet);
+    CollationReference collationReference =
+        CollationReference.builder()
+            .setDbCharacterSet("utf8mb4")
+            .setDbCollation("utf8mb4_0900_ai_ci")
+            .setPadSpace(false)
+            .build();
+    int numRows =
+        TestUtils.wireMockResultSet(
+            "TestCollations/collation-output-mysql-utf8mb4-0900-ai-ci.tsv", mockResultSet);
+    CollationMapper collationMapper =
+        CollationMapper.fromDB(
+            mockConnection, new MysqlDialectAdapter(MySqlVersion.DEFAULT), collationReference);
+    // All characters are mapped.
+    assertThat(
+            collationMapper.allPositionsIndex().characterToIndex().size()
+                + collationMapper.emptyCharacters().size())
+        .isEqualTo(numRows);
+    assertThat(
+            collationMapper.trailingPositionsPadSpace().characterToIndex().size()
+                + collationMapper.emptyCharacters().size()
+                + collationMapper.spaceCharacters().size())
+        .isEqualTo(numRows);
+
+    // The average of cat and mat for uf8mb4_0900_ai_ci won't be HAT!
+    // utf8mb4 has a wide range of characters and the latin gamma
+    // (https://en.wikipedia.org/wiki/Latin_gamma) sorts at the midpoint of C and H.
+    // refer to the indexes in TestCollations/collation-output-mysql-utf8mb4-0900-ai-ci.tsv , or
+    // just try
+    // ` SELECT _utf8mb4'ƔAT' > _utf8mb4'cat' COLLATE utf8mb4_0900_ai_ci ` and ` SELECT
+    // _utf8mb4'ƔAT' < _utf8mb4'hat' COLLATE utf8mb4_0900_ai_ci `
+    // on any Mysql instance.
+    BigInteger catAsBigInt = collationMapper.mapString("cat", 3);
+    BigInteger matAsBigInt = collationMapper.mapString("mat", 3);
+    BigInteger average = (catAsBigInt.add(matAsBigInt)).divide(BigInteger.valueOf(2));
+    String averageString = collationMapper.unMapString(average);
+    assertThat(averageString).isEqualTo("ƔAT");
+    // Check insensitive comparisons with padding
+    assertThat(collationMapper.unMapString(collationMapper.mapString("cát", 4))).isEqualTo("CAT\t");
+    // Check that tab compares before space at all positions.
+    assertThat(collationMapper.mapString("a\t", 1).compareTo(collationMapper.mapString("a ", 1)))
+        .isLessThan(0);
+    assertThat(collationMapper.mapString("a\ta", 1).compareTo(collationMapper.mapString("a a", 1)))
+        .isLessThan(0);
+  }
+
+  @Test
+  public void testUtf8Mb40900AsCs() throws SQLException, IOException {
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+    when(mockStatement.execute(any())).thenReturn(false);
+    when(mockStatement.getMoreResults()).thenReturn(false).thenReturn(false).thenReturn(true);
+    when(mockStatement.getUpdateCount()).thenReturn(0);
+    when(mockStatement.getResultSet()).thenReturn(mockResultSet);
+    CollationReference collationReference =
+        CollationReference.builder()
+            .setDbCharacterSet("utf8mb4")
+            .setDbCollation("utf8mb4_0900_as_cs")
+            .setPadSpace(false)
+            .build();
+    int numRows =
+        TestUtils.wireMockResultSet(
+            "TestCollations/collation-output-mysql-utf8mb4-0900-as-cs.tsv", mockResultSet);
+    CollationMapper collationMapper =
+        CollationMapper.fromDB(
+            mockConnection, new MysqlDialectAdapter(MySqlVersion.DEFAULT), collationReference);
+    // All characters are mapped.
+    assertThat(
+            collationMapper.allPositionsIndex().characterToIndex().size()
+                + collationMapper.emptyCharacters().size())
+        .isEqualTo(numRows);
+    assertThat(
+            collationMapper.trailingPositionsPadSpace().characterToIndex().size()
+                + collationMapper.emptyCharacters().size()
+                + collationMapper.spaceCharacters().size())
+        .isEqualTo(numRows);
+
+    // Check case and accent sensitive comparisons with padding
+    assertThat(collationMapper.unMapString(collationMapper.mapString("cát", 4))).isEqualTo("cát̲");
+    // Check that tab compares before space at all positions.
+    assertThat(collationMapper.mapString("a\t", 1).compareTo(collationMapper.mapString("a ", 1)))
+        .isLessThan(0);
+    assertThat(collationMapper.mapString("a\ta", 1).compareTo(collationMapper.mapString("a a", 1)))
+        .isLessThan(0);
+  }
+
+  @Test
+  public void testUtf8Mb4UnicodeCi() throws SQLException, IOException {
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+    when(mockStatement.execute(any())).thenReturn(false);
+    when(mockStatement.getMoreResults()).thenReturn(false).thenReturn(false).thenReturn(true);
+    when(mockStatement.getUpdateCount()).thenReturn(0);
+    when(mockStatement.getResultSet()).thenReturn(mockResultSet);
+    CollationReference collationReference =
+        CollationReference.builder()
+            .setDbCharacterSet("utf8mb4")
+            .setDbCollation("utf8mb4_unicode_ci")
+            .setPadSpace(true)
+            .build();
+    int numRows =
+        TestUtils.wireMockResultSet(
+            "TestCollations/collation-output-mysql-utf8mb4-unicode-ci.tsv", mockResultSet);
+    CollationMapper collationMapper =
+        CollationMapper.fromDB(
+            mockConnection, new MysqlDialectAdapter(MySqlVersion.DEFAULT), collationReference);
+    // All characters are mapped.
+    assertThat(
+            collationMapper.allPositionsIndex().characterToIndex().size()
+                + collationMapper.emptyCharacters().size())
+        .isEqualTo(numRows);
+    assertThat(
+            collationMapper.trailingPositionsPadSpace().characterToIndex().size()
+                + collationMapper.emptyCharacters().size()
+                + collationMapper.spaceCharacters().size())
+        .isEqualTo(numRows);
+
+    // Check case and accent insensitive comparisons.
+    assertThat(collationMapper.unMapString(collationMapper.mapString("cát", 3))).isEqualTo("CAT");
+    // Check that tab compares before space at non-trailing positions.
+    assertThat(collationMapper.mapString("a\ta", 1).compareTo(collationMapper.mapString("a a", 1)))
+        .isLessThan(0);
+    // Check that tab compares after space at non-trailing positions.
+    assertThat(collationMapper.mapString("a\t", 1).compareTo(collationMapper.mapString("a ", 1)))
+        .isGreaterThan(0);
+    // Check that trailing spaces are ignored.
+    assertThat(collationMapper.mapString("a", 1).equals(collationMapper.mapString("a ", 1)));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/CollationOrderRowTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/CollationOrderRowTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper;
+
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.CHARSET_CHAR_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.CODEPOINT_RANK_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.CODEPOINT_RANK_PAD_SPACE_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.EQUIVALENT_CHARSET_CHAR_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.EQUIVALENT_CHARSET_CHAR_PAD_SPACE_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.IS_EMPTY_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.IS_SPACE_COL;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link CollationOrderRow}. */
+@RunWith(MockitoJUnitRunner.class)
+public class CollationOrderRowTest {
+  @Mock ResultSet mockResultSet;
+
+  @Test
+  public void testCollationOrderRowBasic() {
+    CollationOrderRow collationOrderRow =
+        CollationOrderRow.builder()
+            .setCharsetChar('a')
+            .setEquivalentChar('A')
+            .setEquivalentCharPadSpace('A')
+            .setCodepointRank(1L)
+            .setCodepointRankPadSpace(0L)
+            .setIsEmpty(false)
+            .setIsSpace(false)
+            .build();
+    assertThat(collationOrderRow.codepointRank()).isEqualTo(1L);
+    assertThat(collationOrderRow.codepointRankPadSpace()).isEqualTo(0L);
+    assertThat(collationOrderRow.charsetChar()).isEqualTo('a');
+    assertThat(collationOrderRow.equivalentChar()).isEqualTo('A');
+    assertThat(collationOrderRow.equivalentCharPadSpace()).isEqualTo('A');
+    assertThat(collationOrderRow.isEmpty()).isFalse();
+    assertThat(collationOrderRow.isSpace()).isFalse();
+  }
+
+  @Test
+  public void testCollationOrderRowFromRsBasic() throws SQLException {
+
+    when(mockResultSet.getString(CHARSET_CHAR_COL)).thenReturn("a");
+    when(mockResultSet.getString(EQUIVALENT_CHARSET_CHAR_COL)).thenReturn("a");
+    when(mockResultSet.getLong(CODEPOINT_RANK_COL)).thenReturn(0L);
+    when(mockResultSet.getString(EQUIVALENT_CHARSET_CHAR_PAD_SPACE_COL)).thenReturn("a");
+    when(mockResultSet.getLong(CODEPOINT_RANK_PAD_SPACE_COL)).thenReturn(0L);
+    when(mockResultSet.getBoolean(IS_EMPTY_COL)).thenReturn(false);
+    when(mockResultSet.getBoolean(IS_SPACE_COL)).thenReturn(false);
+
+    CollationOrderRow collationOrderRow = CollationOrderRow.fromRS(mockResultSet);
+    assertThat(collationOrderRow)
+        .isEqualTo(
+            CollationOrderRow.builder()
+                .setCharsetChar('a')
+                .setEquivalentChar('a')
+                .setEquivalentCharPadSpace('a')
+                .setCodepointRank(0L)
+                .setCodepointRankPadSpace(0L)
+                .setIsEmpty(false)
+                .setIsSpace(false)
+                .build());
+  }
+
+  @Test
+  public void testCollationOrderRowFromRsException() throws SQLException {
+    int expcetedIllegalArgumentExceptionCount = 0;
+    when(mockResultSet.getString(CHARSET_CHAR_COL)).thenReturn("aa").thenReturn("a");
+    expcetedIllegalArgumentExceptionCount++;
+    when(mockResultSet.getString(EQUIVALENT_CHARSET_CHAR_COL)).thenReturn("a").thenReturn("aa");
+    expcetedIllegalArgumentExceptionCount++;
+    when(mockResultSet.getString(EQUIVALENT_CHARSET_CHAR_PAD_SPACE_COL))
+        .thenReturn("a")
+        .thenReturn("a")
+        .thenReturn("aa");
+    expcetedIllegalArgumentExceptionCount++;
+    when(mockResultSet.getLong(CODEPOINT_RANK_COL)).thenReturn(0L);
+    when(mockResultSet.getLong(CODEPOINT_RANK_COL)).thenReturn(0L);
+    when(mockResultSet.getBoolean(IS_EMPTY_COL)).thenReturn(false);
+    when(mockResultSet.getBoolean(IS_SPACE_COL)).thenReturn(false);
+
+    for (int i = 0; i < expcetedIllegalArgumentExceptionCount; i++) {
+      assertThrows(IllegalArgumentException.class, () -> CollationOrderRow.fromRS(mockResultSet));
+    }
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/TestUtils.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/stringmapper/TestUtils.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.net.URL;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import org.apache.commons.collections.map.HashedMap;
+import org.apache.commons.text.StringEscapeUtils;
+
+public class TestUtils {
+  public static int wireMockResultSet(String tsvFilePath, ResultSet mockResultSet)
+      throws IOException, SQLException {
+    URL url = Resources.getResource(tsvFilePath);
+    List<String> lines = Resources.readLines(url, Charsets.UTF_8);
+    String header = lines.get(0);
+    String[] columnNames = header.split("\t");
+    Map<String, Integer> colToIdx = new HashedMap();
+    for (int i = 0; i < columnNames.length; i++) {
+      colToIdx.put(columnNames[i], i);
+    }
+
+    // Skip the header line
+    lines = lines.subList(1, lines.size());
+
+    Iterator<String> lineIterator = lines.iterator();
+
+    AtomicReferenceArray<String> values = new AtomicReferenceArray<>(colToIdx.size());
+
+    when(mockResultSet.next())
+        .thenAnswer(
+            invocation -> {
+              boolean ret = lineIterator.hasNext();
+              if (ret) {
+                String[] valuesCur = lineIterator.next().split("\t");
+                for (int i = 0; i < valuesCur.length; i++) {
+                  values.set(i, valuesCur[i]);
+                }
+              }
+              return ret;
+            });
+
+    when(mockResultSet.getString(anyString()))
+        .thenAnswer(
+            invocation -> {
+              String colName = invocation.getArgument(0);
+              return StringEscapeUtils.unescapeJava(values.get(colToIdx.get(colName)));
+            });
+
+    when(mockResultSet.getLong(anyString()))
+        .thenAnswer(
+            invocation -> {
+              String colName = invocation.getArgument(0);
+              return Long.parseLong(values.get(colToIdx.get(colName)));
+            });
+
+    when(mockResultSet.getBoolean(anyString()))
+        .thenAnswer(
+            invocation -> {
+              String colName = invocation.getArgument(0);
+              return (values.get(colToIdx.get(colName)).equals("1")
+                  || Boolean.parseBoolean(values.get(colToIdx.get(colName))));
+            });
+    return lines.size();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/CollationMapperDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/CollationMapperDoFnTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.CHARSET_CHAR_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.CODEPOINT_RANK_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.CODEPOINT_RANK_PAD_SPACE_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.EQUIVALENT_CHARSET_CHAR_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.EQUIVALENT_CHARSET_CHAR_PAD_SPACE_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.IS_EMPTY_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.IS_SPACE_COL;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationMapper;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.KV;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link CollationMapperDoFn}. */
+@RunWith(MockitoJUnitRunner.class)
+public class CollationMapperDoFnTest {
+  SerializableFunction<Void, DataSource> mockDataSourceProviderFn =
+      Mockito.mock(SerializableFunction.class, withSettings().serializable());
+  DataSource mockDataSource = Mockito.mock(DataSource.class, withSettings().serializable());
+
+  Connection mockConnection = Mockito.mock(Connection.class, withSettings().serializable());
+
+  Statement mockStatement = Mockito.mock(Statement.class, withSettings().serializable());
+
+  ResultSet mockResultSet = Mockito.mock(ResultSet.class, withSettings().serializable());
+
+  @Mock OutputReceiver mockOut;
+  @Captor ArgumentCaptor<KV<CollationReference, CollationMapper>> collationMapperCaptor;
+
+  @Test
+  public void testCollationMapperDoFnBasic() throws Exception {
+
+    when(mockDataSourceProviderFn.apply(any())).thenReturn(mockDataSource);
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+    when(mockStatement.execute(any())).thenReturn(false);
+    when(mockStatement.getMoreResults()).thenReturn(false).thenReturn(false).thenReturn(true);
+    when(mockStatement.getUpdateCount()).thenReturn(0);
+    when(mockStatement.getResultSet()).thenReturn(mockResultSet);
+
+    when(mockResultSet.next()).thenReturn(true).thenReturn(true).thenReturn(false);
+    when(mockResultSet.getString(CHARSET_CHAR_COL)).thenReturn("a").thenReturn("A");
+    when(mockResultSet.getString(EQUIVALENT_CHARSET_CHAR_COL)).thenReturn("A").thenReturn("A");
+    when(mockResultSet.getLong(CODEPOINT_RANK_COL)).thenReturn(0L).thenReturn(0L);
+    when(mockResultSet.getString(EQUIVALENT_CHARSET_CHAR_PAD_SPACE_COL))
+        .thenReturn("A")
+        .thenReturn("A");
+    when(mockResultSet.getLong(CODEPOINT_RANK_PAD_SPACE_COL)).thenReturn(0L).thenReturn(0L);
+    when(mockResultSet.getBoolean(IS_EMPTY_COL)).thenReturn(false).thenReturn(false);
+    when(mockResultSet.getBoolean(IS_SPACE_COL)).thenReturn(false).thenReturn(false);
+
+    CollationReference testCollationReference =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharSet")
+            .setDbCollation("testCollation")
+            .setPadSpace(false)
+            .build();
+
+    CollationMapperDoFn collationMapperDoFn =
+        new CollationMapperDoFn(
+            mockDataSourceProviderFn, new MysqlDialectAdapter(MySqlVersion.DEFAULT));
+    collationMapperDoFn.setup();
+    collationMapperDoFn.processElement(testCollationReference, mockOut);
+    verify(mockOut).output(collationMapperCaptor.capture());
+    KV<CollationReference, CollationMapper> mapperKV = collationMapperCaptor.getValue();
+    assertThat(mapperKV.getKey()).isEqualTo(testCollationReference);
+    assertThat(mapperKV.getValue().allPositionsIndex().getCharsetSize()).isEqualTo(1);
+    assertThat(mapperKV.getValue().unMapString(mapperKV.getValue().mapString("a", 1)))
+        .isEqualTo("A");
+  }
+
+  @Test
+  public void testCollationMapperDoFnException() throws Exception {
+
+    when(mockDataSourceProviderFn.apply(any())).thenReturn(mockDataSource);
+    when(mockDataSource.getConnection())
+        .thenThrow(new SQLException("test"))
+        .thenReturn(mockConnection);
+    when(mockConnection.createStatement()).thenThrow(new SQLException("test"));
+
+    CollationReference testCollationReference =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharSet")
+            .setDbCollation("testCollation")
+            .setPadSpace(false)
+            .build();
+
+    CollationMapperDoFn collationMapperDoFn =
+        new CollationMapperDoFn(
+            mockDataSourceProviderFn, new MysqlDialectAdapter(MySqlVersion.DEFAULT));
+    collationMapperDoFn.setup();
+    assertThrows(
+        SQLException.class,
+        () -> collationMapperDoFn.processElement(testCollationReference, mockOut));
+    assertThrows(
+        SQLException.class,
+        () -> collationMapperDoFn.processElement(testCollationReference, mockOut));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/CollationMapperTransformTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/CollationMapperTransformTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.CHARSET_CHAR_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.CODEPOINT_RANK_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.CODEPOINT_RANK_PAD_SPACE_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.EQUIVALENT_CHARSET_CHAR_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.EQUIVALENT_CHARSET_CHAR_PAD_SPACE_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.IS_EMPTY_COL;
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.IS_SPACE_COL;
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationMapper;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.quality.Strictness;
+
+/** Test class for {@link CollationMapperTransform}. */
+@RunWith(MockitoJUnitRunner.class)
+public class CollationMapperTransformTest implements Serializable {
+
+  SerializableFunction<Void, DataSource> mockDataSourceProviderFn =
+      Mockito.mock(
+          SerializableFunction.class, withSettings().serializable().strictness(Strictness.LENIENT));
+
+  DataSource mockDataSource =
+      Mockito.mock(DataSource.class, withSettings().serializable().strictness(Strictness.LENIENT));
+
+  Connection mockConnection =
+      Mockito.mock(Connection.class, withSettings().serializable().strictness(Strictness.LENIENT));
+
+  Statement mockStatementFirst =
+      Mockito.mock(Statement.class, withSettings().serializable().strictness(Strictness.LENIENT));
+
+  Statement mockStatementSecond =
+      Mockito.mock(Statement.class, withSettings().serializable().strictness(Strictness.LENIENT));
+
+  ResultSet mockResultSetFirst =
+      Mockito.mock(ResultSet.class, withSettings().serializable().strictness(Strictness.LENIENT));
+  ResultSet mockResultSetSecond =
+      Mockito.mock(ResultSet.class, withSettings().serializable().strictness(Strictness.LENIENT));
+
+  @Mock OutputReceiver mockOut;
+  @Captor ArgumentCaptor<KV<CollationReference, CollationMapper>> collationMapperCaptor;
+
+  @Rule public final transient TestPipeline testPipeline = TestPipeline.create();
+
+  @Test
+  public void testCollationMapperTransform() throws SQLException {
+    when(mockDataSourceProviderFn.apply(any())).thenReturn(mockDataSource);
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.createStatement())
+        .thenReturn(mockStatementFirst)
+        .thenReturn(mockStatementSecond);
+
+    when(mockStatementFirst.execute(any())).thenReturn(false);
+    when(mockStatementFirst.getMoreResults()).thenReturn(false).thenReturn(false).thenReturn(true);
+    when(mockStatementFirst.getUpdateCount()).thenReturn(0);
+    when(mockStatementFirst.getResultSet()).thenReturn(mockResultSetFirst);
+
+    when(mockStatementSecond.execute(any())).thenReturn(false);
+    when(mockStatementSecond.getMoreResults()).thenReturn(false).thenReturn(false).thenReturn(true);
+    when(mockStatementSecond.getUpdateCount()).thenReturn(0);
+    when(mockStatementSecond.getResultSet()).thenReturn(mockResultSetSecond);
+
+    when(mockResultSetFirst.next()).thenReturn(true).thenReturn(true).thenReturn(false);
+    when(mockResultSetFirst.getString(CHARSET_CHAR_COL)).thenReturn("A").thenReturn("a");
+    when(mockResultSetFirst.getString(EQUIVALENT_CHARSET_CHAR_COL)).thenReturn("a").thenReturn("a");
+    when(mockResultSetFirst.getLong(CODEPOINT_RANK_COL)).thenReturn(0L).thenReturn(0L);
+    when(mockResultSetFirst.getString(EQUIVALENT_CHARSET_CHAR_PAD_SPACE_COL))
+        .thenReturn("a")
+        .thenReturn("a");
+    when(mockResultSetFirst.getLong(CODEPOINT_RANK_PAD_SPACE_COL)).thenReturn(0L).thenReturn(0L);
+    when(mockResultSetFirst.getBoolean(IS_EMPTY_COL)).thenReturn(false).thenReturn(false);
+    when(mockResultSetFirst.getBoolean(IS_SPACE_COL)).thenReturn(false).thenReturn(false);
+
+    when(mockResultSetSecond.next()).thenReturn(true).thenReturn(true).thenReturn(false);
+    when(mockResultSetSecond.getString(CHARSET_CHAR_COL)).thenReturn("a").thenReturn("A");
+    when(mockResultSetSecond.getString(EQUIVALENT_CHARSET_CHAR_COL))
+        .thenReturn("A")
+        .thenReturn("A");
+    when(mockResultSetSecond.getLong(CODEPOINT_RANK_COL)).thenReturn(0L).thenReturn(0L);
+    when(mockResultSetSecond.getString(EQUIVALENT_CHARSET_CHAR_PAD_SPACE_COL))
+        .thenReturn("A")
+        .thenReturn("A");
+    when(mockResultSetSecond.getLong(CODEPOINT_RANK_PAD_SPACE_COL)).thenReturn(0L).thenReturn(0L);
+    when(mockResultSetSecond.getBoolean(IS_EMPTY_COL)).thenReturn(false).thenReturn(false);
+    when(mockResultSetSecond.getBoolean(IS_SPACE_COL)).thenReturn(false).thenReturn(false);
+
+    CollationReference testCollationReferenceFirst =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharSet")
+            .setDbCollation("testCollationFirst")
+            .setPadSpace(false)
+            .build();
+
+    CollationReference testCollationReferenceSecond =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharSet")
+            .setDbCollation("testCollationSecond")
+            .setPadSpace(false)
+            .build();
+    CollationMapperTransform collationMapperTransform =
+        CollationMapperTransform.builder()
+            .setCollationReferences(
+                ImmutableList.of(
+                    testCollationReferenceFirst,
+                    testCollationReferenceSecond,
+                    /* test that pick distinct collationReferences to avoid un-necessary collation discovery work. */ testCollationReferenceFirst))
+            .setDataSourceProviderFn(mockDataSourceProviderFn)
+            .setDbAdapter(new MysqlDialectAdapter(MySqlVersion.DEFAULT))
+            .build();
+    PCollectionView<Map<CollationReference, CollationMapper>> collationMapperView =
+        testPipeline.apply(collationMapperTransform);
+    PCollection<Void> output =
+        testPipeline
+            .apply(Create.of("test"))
+            .apply(
+                "testTransform",
+                ParDo.of(
+                        new VerifyMapper(
+                            collationMapperView,
+                            testCollationReferenceFirst,
+                            testCollationReferenceSecond))
+                    .withSideInputs(collationMapperView));
+    testPipeline.run().waitUntilFinish();
+  }
+
+  static class VerifyMapper extends DoFn<String, Void> implements Serializable {
+    private PCollectionView<Map<CollationReference, CollationMapper>> collationMapperView;
+    private CollationReference testCollationReferenceFirst;
+    private CollationReference testCollationReferenceSecond;
+
+    VerifyMapper(
+        PCollectionView<Map<CollationReference, CollationMapper>> collationMapperView,
+        CollationReference testCollationReferenceFirst,
+        CollationReference testCollationReferenceSecond) {
+      this.collationMapperView = collationMapperView;
+      this.testCollationReferenceFirst = testCollationReferenceFirst;
+      this.testCollationReferenceSecond = testCollationReferenceSecond;
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      Map<CollationReference, CollationMapper> collationMap = c.sideInput(collationMapperView);
+      assertThat(collationMap.size()).isEqualTo(2);
+      assertThat(collationMap.get(testCollationReferenceFirst).collationReference())
+          .isEqualTo(testCollationReferenceFirst);
+      assertThat(collationMap.get(testCollationReferenceSecond).collationReference())
+          .isEqualTo(testCollationReferenceSecond);
+    }
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitionsTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitionsTest.java
@@ -88,7 +88,7 @@ public class ReadWithUniformPartitionsTest implements Serializable {
   @Test
   public void testReadWithUniformPartitionsPartitionTillSingleRow() throws Exception {
     // In this test we expect all the entries to split till single row. And hence each range to have
-    // atmost 2 count (mean being 1, there will be atmost 2 rows in the partitions).
+    // at most 2 count (mean being 1, there will be at most 2 rows in the partitions).
     TestRangesPeekVerification testRangesPeekVerification =
         (capturedRanges) -> {
           long totalCount = 0;

--- a/v2/sourcedb-to-spanner/src/test/resources/TestCollations/README.md
+++ b/v2/sourcedb-to-spanner/src/test/resources/TestCollations/README.md
@@ -1,0 +1,31 @@
+# Collation outputs for unit test.
+## Overview
+As we can't run the entire collation query on derby during unit tests (due to variations in sql syntax and collation support), we have dumps of outputs of the collation query for a few cases to test in our unit tests.
+
+| Dialect | Collation Name     | Resource File name                                                                                            | Remark                                                            |
+|---------|--------------------|---------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
+| Mysql   | utf8mb4_0900_ai_ci | [TestCollations/collation-output-mysql-utf8mb4-0900-ai-ci.tsv](collation-output-mysql-utf8mb4-0900-ai-ci.tsv) | Recommended case and accent insensitive collation (No Pad Space). |
+| Mysql   | utf8mb4_0900_as_cs | [TestCollations/collation-output-mysql-utf8mb4-0900-as-cs.tsv](collation-output-mysql-utf8mb4-0900-as-cs.tsv) | Recommended case and accent sensitive collation (No Pad Space).   |
+| Mysql   | utf8mb4_unicode_ci | [TestCollations/collation-output-mysql-utf8mb4-unicode-ci.tsv](collation-output-mysql-utf8mb4-unicode-ci.tsv) | Allows us test Pad Space collations.                              |
+
+## How to generate a resource file for testing
+You will need to run your query file like src/main/resources/sql/mysql_collation_oder_query.sql on a mysql instance and dump it's output to a file by following:
+
+1. Replace the `charset_replacement_tag` and `collation_replacement_tag` with the required character-set and collation like:
+```sql
+SET @db_charset = '<character_set>';
+SET @db_collation = '<collation>';  
+```
+Note it's recommended to make a copy of the sql file before editing to avoid un-intended or temporary changes in the script being pushed to a code review.
+
+2. Run the edited copy of the sql file and dump the output to a tsv.
+```bash
+time mysql -u '<user_name>' -p'<password>' -h <ip> <db> <  mysql_collation_oder_query.sql 2>&1 > /tmp/output.tsv 
+```
+3. Ensure that the dump has all the control characters escaped. Mysql does a good job at escaping most of the control characters when it dumps the output to a file, execept for \r which causes a line break.
+
+4. Copy the output to the resources folder.
+
+5. Add a test case that uses the new output in CollationMapperTest.java. While you will add the collation specific cases to this test (like say case sensitivity or pad space comparison etc), the CollationMapper class also runs checks during construction to ensure that the collation query output passes basic sanity checks (like no duplicate entries, an equivalent-character must map to itself, no holes in the index-ranking etc)
+
+6. Update this [READMe](./README.md) as needed.


### PR DESCRIPTION
# Implementing Logic for Splitting of strings. 
## Limitation
This PR has complete support for characters upto 3 byte codepoints.
If a source dataset has characters which are longer than 3 codepoint-bytes there could be an exception due to characters that cant be mapped.
A followup to fix this limitation is under the works.

## Overview
In order to do parallel range queries in order to read a table with String column in it's index, we need to split the space of string from min to max into chunks. Unlike integers, strings can't be directly 
The logic for mapping the string has to take care of various database nuances like:

- Control Characters like `control-z` are ignored for comparisons at all positions.
- Space is ignored for comparison at trailing positions. Depending on the character-set, there could be more than one character that represents a space like [EM quad](https://www.compart.com/en/unicode/U+2001), [non-breaking space](https://www.compart.com/en/unicode/U+00A0).
- Space is not ignored at non-trailing positions in the comparison and characters like `tab` or `new-line` could compare less then space at non-trailing positions depending on the collation.
## Note on Unit testing to collation order query
It's not possible to directly unit test the collation-order query on derby. To circumvent this, we have dumped the output of 
`utf8mb4_0900_ai_ci` (case and accent insensitive), `utf8mb4_0900_as_cs` (case and accent sensitive) and `utf8mb4_unicode_ci` (pad space) collations for the purpose of unit tests. The process to add such an output to the tests is documented as well. 

## TODOS (for current PR)
1. End to End migration manual test.

## TODOS (for followup PR)
1. MySQL 5.7 compatible Collation order and index-discovery queries.
2. Making the side-input at a DB level (instead of current table level)