### PR TITLE
Fix annotation processor

### DIFF
--- a/it/pom.xml
+++ b/it/pom.xml
@@ -130,6 +130,11 @@
               <artifactId>auto-value</artifactId>
               <version>${autovalue.version}</version>
             </path>
+            <path>
+              <groupId>com.google.auto.service</groupId>
+              <artifactId>auto-service</artifactId>
+              <version>${autovalue.service.version}</version>
+            </path>
           </annotationProcessorPaths>
         </configuration>
       </plugin>

--- a/plaintext-logging/pom.xml
+++ b/plaintext-logging/pom.xml
@@ -49,6 +49,11 @@
               <artifactId>auto-value</artifactId>
               <version>${autovalue.version}</version>
             </path>
+            <path>
+              <groupId>com.google.auto.service</groupId>
+              <artifactId>auto-service</artifactId>
+              <version>${autovalue.service.version}</version>
+            </path>
           </annotationProcessorPaths>
         </configuration>
       </plugin>

--- a/plugins/core-plugin/pom.xml
+++ b/plugins/core-plugin/pom.xml
@@ -109,6 +109,11 @@
               <artifactId>auto-value</artifactId>
               <version>${auto-value.version}</version>
             </path>
+            <path>
+              <groupId>com.google.auto.service</groupId>
+              <artifactId>auto-service</artifactId>
+              <version>${autovalue.service.version}</version>
+            </path>
           </annotationProcessorPaths>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
 
     <!-- Common dependency versions -->
     <autovalue.version>1.10.4</autovalue.version>
+    <autovalue.service.version>1.0.2</autovalue.service.version>
     <avro.version>1.11.3</avro.version>
     <caffeine.version>3.1.8</caffeine.version>
     <checkstyle.version>10.7.0</checkstyle.version>

--- a/structured-logging/pom.xml
+++ b/structured-logging/pom.xml
@@ -80,6 +80,11 @@
               <artifactId>auto-value</artifactId>
               <version>${autovalue.version}</version>
             </path>
+            <path>
+              <groupId>com.google.auto.service</groupId>
+              <artifactId>auto-service</artifactId>
+              <version>${autovalue.service.version}</version>
+            </path>
           </annotationProcessorPaths>
         </configuration>
       </plugin>

--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -34,7 +34,6 @@
   </description>
 
   <properties>
-    <autovalue.service.version>1.0.2</autovalue.service.version>
     <mock-server-netty.version>5.14.0</mock-server-netty.version>
     <open-census.version>0.24.0</open-census.version>
     <!-- TODO: check if this could be declared on a Beam BOM instead of here -->
@@ -740,6 +739,11 @@
               <groupId>com.google.auto.value</groupId>
               <artifactId>auto-value</artifactId>
               <version>${autovalue.version}</version>
+            </path>
+            <path>
+              <groupId>com.google.auto.service</groupId>
+              <artifactId>auto-service</artifactId>
+              <version>${autovalue.service.version}</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -362,6 +362,11 @@
                             <artifactId>auto-value</artifactId>
                             <version>${autovalue.version}</version>
                         </path>
+                        <path>
+                            <groupId>com.google.auto.service</groupId>
+                            <artifactId>auto-service</artifactId>
+                            <version>${autovalue.service.version}</version>
+                        </path>
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>


### PR DESCRIPTION
#1677 changed the way that `maven-compiler-plugin` compiles annotation processors from being implicit to explicitly defined. The definition for `@AutoValue` annotations was added, but not `@AutoService`.

This caused the `CommonTemplateJvmInitializer` to not get compiled into the template jars with the `@AutoService` handler, which resulted in Beam not calling the necessary Jvm initialization methods for certain templates to work properly.
https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/0d01accc1cfa29b762a764bc226496bfde25165c/v1/src/main/java/com/google/cloud/teleport/templates/common/CommonTemplateJvmInitializer.java#L40-L44

This was namely an issue with JDBC templates for users that rely on the `--extraFilesToStage` parameter to copy files from GCS to the `extra_files` directory on the Dataflow worker.

This PR adds the definition for the `@AutoService` annotation processor to affected modules.