### PR TITLE
Add CommonTemplateJvmInitializerIT

### DIFF
--- a/plugins/core-plugin/src/main/java/com/google/cloud/teleport/plugin/TemplateDefinitionsParser.java
+++ b/plugins/core-plugin/src/main/java/com/google/cloud/teleport/plugin/TemplateDefinitionsParser.java
@@ -48,9 +48,7 @@ public final class TemplateDefinitionsParser {
     Set<Class<?>> templates = new Reflections(classLoader).getTypesAnnotatedWith(Template.class);
     for (Class<?> templateClass : templates) {
       Template templateAnnotation = templateClass.getAnnotation(Template.class);
-      if (!templateAnnotation.testOnly()) {
-        allDefinitions.add(new TemplateDefinitions(templateClass, templateAnnotation));
-      }
+      allDefinitions.add(new TemplateDefinitions(templateClass, templateAnnotation));
     }
 
     // Scan every @MultiTemplate class

--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesReleaseMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesReleaseMojo.java
@@ -104,6 +104,20 @@ public class TemplatesReleaseMojo extends TemplatesBaseMojo {
       List<TemplateDefinitions> templateDefinitions =
           TemplateDefinitionsParser.scanDefinitions(loader);
 
+      // Filter for template name, if specified.
+      // Also filter out testOnly templates.
+      templateDefinitions =
+          templateDefinitions.stream()
+              .filter(
+                  candidate -> {
+                    boolean filterName = true;
+                    if (templateName != null && !templateName.isEmpty()) {
+                      filterName = candidate.getTemplateAnnotation().name().equals(templateName);
+                    }
+                    return filterName && !candidate.getTemplateAnnotation().testOnly();
+                  })
+              .collect(Collectors.toList());
+
       if (templateName != null && !templateName.isEmpty()) {
         templateDefinitions =
             templateDefinitions.stream()

--- a/v1/src/main/java/com/google/cloud/teleport/templates/common/JvmInitializerTemplate.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/common/JvmInitializerTemplate.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.templates.common;
+
+import com.google.cloud.teleport.metadata.Template;
+import com.google.cloud.teleport.metadata.TemplateCategory;
+import com.google.cloud.teleport.metadata.TemplateParameter;
+import com.google.cloud.teleport.options.CommonTemplateOptions;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.ValueProvider;
+
+@Template(
+    name = "Jvm_Initializer_Template",
+    displayName = "Jvm Initializer Template",
+    description =
+        "This template is for testing purposes only. "
+            + "Ensures that templates run with CommonTemplateOptions invoke the CommonTemplateJvmInitializer "
+            + "class on the worker before pipeline execution.",
+    category = TemplateCategory.UTILITIES,
+    optionsClass = JvmInitializerTemplate.Options.class,
+    testOnly = true)
+class JvmInitializerTemplate {
+
+  public interface Options extends CommonTemplateOptions {
+    @TemplateParameter.Text(
+        order = 1,
+        description = "Input file(s)",
+        helpText = "The input file pattern Dataflow reads from local filesystem on worker.")
+    ValueProvider<String> getInputFile();
+
+    void setInputFile(ValueProvider<String> value);
+
+    @TemplateParameter.GcsWriteFolder(
+        order = 2,
+        description = "Output Cloud Storage file prefix",
+        helpText = "Path and filename prefix for writing output files. Ex: gs://your-bucket/counts")
+    ValueProvider<String> getOutput();
+
+    void setOutput(ValueProvider<String> value);
+  }
+
+  public static void main(String[] args) {
+    Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+
+    Pipeline p = Pipeline.create(options);
+    p.apply("ReadLines", TextIO.read().from(options.getInputFile()))
+        .apply("WriteLines", TextIO.write().to(options.getOutput()));
+
+    p.run();
+  }
+}

--- a/v1/src/test/java/com/google/cloud/teleport/templates/common/CommonTemplateJvmInitializerIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/common/CommonTemplateJvmInitializerIT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.templates.common;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
+
+import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import java.io.IOException;
+import java.util.regex.Pattern;
+import org.apache.beam.it.common.PipelineLauncher;
+import org.apache.beam.it.common.PipelineOperator;
+import org.apache.beam.it.gcp.TemplateTestBase;
+import org.apache.beam.it.gcp.artifacts.Artifact;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for CommonTemplateJvmInitializer. */
+@Category({TemplateIntegrationTest.class, SkipDirectRunnerTest.class})
+@TemplateIntegrationTest(JvmInitializerTemplate.class)
+@RunWith(JUnit4.class)
+public final class CommonTemplateJvmInitializerIT extends TemplateTestBase {
+
+  @Before
+  public void setUp() {
+    // Arrange
+    gcsClient.createArtifact("test.txt", "This is a test file.");
+  }
+
+  @Test
+  public void testCommonTemplateJvmInitializerCopiesExtraFiles() throws IOException {
+    // Act
+    PipelineLauncher.LaunchInfo info =
+        launchTemplate(
+            PipelineLauncher.LaunchConfig.builder(testName, specPath)
+                .addParameter("inputFile", "/extra_files/test.txt")
+                .addParameter("output", getGcsPath("output/result"))
+                .addParameter("extraFilesToStage", getGcsPath("test.txt")));
+
+    assertThatPipeline(info).isRunning();
+
+    PipelineOperator.Result result = pipelineOperator().waitUntilDone(createConfig(info));
+
+    // Assert
+    assertThatResult(result).isLaunchFinished();
+
+    Artifact artifact = gcsClient.listArtifacts("output/", Pattern.compile(".*")).get(0);
+    String output = new String(artifact.contents()).replace("\n", "");
+    assertThat(output).isEqualTo("This is a test file.");
+  }
+}

--- a/v2/common/pom.xml
+++ b/v2/common/pom.xml
@@ -160,6 +160,12 @@
               </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.google.cloud.teleport</groupId>
+            <artifactId>it-google-cloud-platform</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/common/JvmInitializerTemplate.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/common/JvmInitializerTemplate.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.common;
+
+import com.google.cloud.teleport.metadata.Template;
+import com.google.cloud.teleport.metadata.TemplateCategory;
+import com.google.cloud.teleport.metadata.TemplateParameter;
+import com.google.cloud.teleport.v2.options.CommonTemplateOptions;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.io.TextIO;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+
+@Template(
+    name = "Jvm_Initializer_Template_Flex",
+    displayName = "Jvm Initializer Template",
+    description =
+        "This template is for testing purposes only. "
+            + "Ensures that templates run with CommonTemplateOptions invoke the CommonTemplateJvmInitializer "
+            + "class on the worker before pipeline execution.",
+    category = TemplateCategory.UTILITIES,
+    optionsClass = JvmInitializerTemplate.Options.class,
+    testOnly = true)
+class JvmInitializerTemplate {
+
+  public interface Options extends CommonTemplateOptions {
+    @TemplateParameter.Text(
+        order = 1,
+        description = "Input file(s)",
+        helpText = "The input file pattern Dataflow reads from local filesystem on worker.")
+    String getInputFile();
+
+    void setInputFile(String value);
+
+    @TemplateParameter.GcsWriteFolder(
+        order = 2,
+        description = "Output Cloud Storage file prefix",
+        helpText = "Path and filename prefix for writing output files. Ex: gs://your-bucket/counts")
+    String getOutput();
+
+    void setOutput(String value);
+  }
+
+  public static void main(String[] args) {
+    Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+
+    Pipeline p = Pipeline.create(options);
+    p.apply("ReadLines", TextIO.read().from(options.getInputFile()))
+        .apply("WriteLines", TextIO.write().to(options.getOutput()));
+
+    p.run();
+  }
+}

--- a/v2/common/src/test/java/com/google/cloud/teleport/v2/common/CommonTemplateJvmInitializerIT.java
+++ b/v2/common/src/test/java/com/google/cloud/teleport/v2/common/CommonTemplateJvmInitializerIT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.common;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
+
+import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import java.io.IOException;
+import java.util.regex.Pattern;
+import org.apache.beam.it.common.PipelineLauncher;
+import org.apache.beam.it.common.PipelineOperator;
+import org.apache.beam.it.gcp.TemplateTestBase;
+import org.apache.beam.it.gcp.artifacts.Artifact;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Integration test for {@link CommonTemplateJvmInitializer}. */
+@Category({TemplateIntegrationTest.class, SkipDirectRunnerTest.class})
+@TemplateIntegrationTest(JvmInitializerTemplate.class)
+@RunWith(JUnit4.class)
+public final class CommonTemplateJvmInitializerIT extends TemplateTestBase {
+
+  @Before
+  public void setUp() {
+    // Arrange
+    gcsClient.createArtifact("test.txt", "This is a test file.");
+  }
+
+  @Test
+  public void testCommonTemplateJvmInitializerCopiesExtraFiles() throws IOException {
+    // Act
+    PipelineLauncher.LaunchInfo info =
+        launchTemplate(
+            PipelineLauncher.LaunchConfig.builder(testName, specPath)
+                .addParameter("inputFile", "/extra_files/test.txt")
+                .addParameter("output", getGcsPath("output/result"))
+                .addParameter("extraFilesToStage", getGcsPath("test.txt")));
+
+    assertThatPipeline(info).isRunning();
+
+    PipelineOperator.Result result = pipelineOperator().waitUntilDone(createConfig(info));
+
+    // Assert
+    assertThatResult(result).isLaunchFinished();
+
+    Artifact artifact = gcsClient.listArtifacts("output/", Pattern.compile(".*")).get(0);
+    String output = new String(artifact.contents()).replace("\n", "");
+    assertThat(output).isEqualTo("This is a test file.");
+  }
+}


### PR DESCRIPTION
Follow up to #1744

Adds IT's to ensure that `CommonTemplateJvmInitializer.beforeProcessing()` is called by Dataflow worker before executing pipeline.