### PR TITLE
Remove PIP_NO_DEPS from YamlTemplate Dockerfile

### DIFF
--- a/plugins/core-plugin/src/main/resources/Dockerfile-template-xlang
+++ b/plugins/core-plugin/src/main/resources/Dockerfile-template-xlang
@@ -40,7 +40,6 @@ ARG PY_VERSION=${pythonVersion}
 
 # Set environment variables
 ENV DATAFLOW_JAVA_COMMAND_SPEC=${commandSpec}
-ENV PIP_NO_DEPS=True
 
 # Copy template, python wheels and python launcher script from python-base
 COPY --from=python-base /template /template

--- a/plugins/core-plugin/src/main/resources/Dockerfile-template-yaml
+++ b/plugins/core-plugin/src/main/resources/Dockerfile-template-yaml
@@ -44,7 +44,6 @@ ARG PY_VERSION=${pythonVersion}
 
 # Set python environment variables
 ENV FLEX_TEMPLATE_PYTHON_PY_FILE=main.py
-ENV PIP_NO_DEPS=True
 
 # Copy template, python wheels and python launcher script from python-base
 COPY --from=python-base /template /template


### PR DESCRIPTION
PIP_NO_DEPS is typically added to custom python templates to speedup launch, but since the YamlTemplate image already has all dependencies, it won't affect startup of native Beam YAML pipelines.

It does, however, prevent transitive dependencies from being installed for packages defined by a pythonPackage provider.

This PR removes the PIP_NO_DEPS to allow for proper compilation/expansion of custom pythonPackage provider transforms.