### PR TITLE
Disable flaky test StreamingDataGeneratorIT#testFakeMessagesToKafka

### DIFF
--- a/v2/streaming-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/StreamingDataGeneratorIT.java
+++ b/v2/streaming-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/StreamingDataGeneratorIT.java
@@ -59,6 +59,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -390,6 +391,7 @@ public final class StreamingDataGeneratorIT extends TemplateTestBase {
   }
 
   @Test
+  @Ignore("https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/1752")
   public void testFakeMessagesToKafka() throws IOException {
     // Set up resource manager
     kafkaResourceManager =


### PR DESCRIPTION
Test is consistently failing workflows, and the kafka variant of StreamingDataGenerator is not used in any load testing currently.