### PR TITLE
Fixing exception in String .isSplittable

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryExtractorFactory.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryExtractorFactory.java
@@ -98,7 +98,7 @@ public class BoundaryExtractorFactory {
         .setPartitionColumn(partitionColumn)
         .setStart(resultSet.getString(1))
         .setEnd(resultSet.getString(2))
-        .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
+        .setBoundarySplitter(BoundarySplitterFactory.create(String.class))
         .setBoundaryTypeMapper(boundaryTypeMapper)
         .build();
   }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryExtractorFactoryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryExtractorFactoryTest.java
@@ -136,6 +136,7 @@ public class BoundaryExtractorFactoryTest {
 
     assertThat(boundary.start()).isEqualTo("cloud");
     assertThat(boundary.end()).isEqualTo("spanner");
+    assertThat(boundary.isSplittable(null)).isTrue();
     // Null type mapper check
     assertThrows(
         IllegalArgumentException.class,


### PR DESCRIPTION
# Overview
There's a bug in String handling that causes a typecasting exception which checkin if a string is splittable.
## Root Cause of the Bug
For string, the boundary extractor was created of type long.
This did not trigger while testing a small migration of few strings in different languages as there was no need to check if the range is splittable.