### PR TITLE
Load test observability: automated regression detection framework

### DIFF
--- a/.github/ISSUE_TEMPLATE/spanner-load-test-failure-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/spanner-load-test-failure-issue-template.md
@@ -1,0 +1,5 @@
+---
+title: Spanner templates Load test failure!
+labels: bug
+---
+Check: {{ env.JOB_URL }}

--- a/.github/ISSUE_TEMPLATE/spanner-load-test-failure-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/spanner-load-test-failure-issue-template.md
@@ -1,5 +1,5 @@
 ---
-title: Spanner templates Load test failure!
+title: Spanner templates Load test failure! {{ env.DATE }}
 labels: bug
 ---
-Check: {{ env.JOB_URL }}
+{{ env.DATE }} Check: {{ env.JOB_URL }}

--- a/.github/workflows/spanner-load-tests.yml
+++ b/.github/workflows/spanner-load-tests.yml
@@ -22,7 +22,7 @@ on:
   - cron: '0 2 * * *'
   workflow_dispatch:
 
-permissions: read-all
+permissions: write-all
 
 jobs:
   load_tests:
@@ -49,8 +49,56 @@ jobs:
         --lt-export-project="cloud-teleport-testing" \
         --lt-export-dataset="performance_tests" \
         --lt-export-table="template_performance_metrics" \
-
+    - name: Create Github issue on failure
+      if: failure()
+      uses: JasonEtco/create-an-issue@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      with:
+        filename: .github/ISSUE_TEMPLATE/spanner-load-test-failure-issue-template.md
     - name: Upload Load Tests Report
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      if: always() # always run even if the previous step fails
+      with:
+        name: surefire-test-results
+        path: '**/surefire-reports/TEST-*.xml'
+        retention-days: 1
+    - name: Cleanup Java Environment
+      uses: ./.github/actions/cleanup-java-env
+  observe_load_tests:
+    name: Observe Spanner Dataflow Templates Load tests
+    needs: [load_tests]
+    timeout-minutes: 60
+    # Run on any runner that matches all the specified runs-on values.
+    runs-on: [ self-hosted, perf ]
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      with:
+        fetch-depth: 0
+    - name: Setup Environment
+      id: setup-env
+      uses: ./.github/actions/setup-env
+    - name: Run Load Test Observers
+      run: |
+        ./cicd/run-load-test-observer \
+        --modules-to-build="lt/observability" \
+        --it-region="us-central1" \
+        --it-project="cloud-teleport-testing" \
+        --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \
+        --lt-export-project="cloud-teleport-testing" \
+        --lt-export-dataset="performance_tests" \
+        --lt-export-table="template_performance_metrics"
+    - name: Create Github issue on failure
+      if: failure()
+      uses: JasonEtco/create-an-issue@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      with:
+        filename: .github/ISSUE_TEMPLATE/spanner-load-test-failure-issue-template.md
+    - name: Upload Load Test Observer Report
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       if: always() # always run even if the previous step fails
       with:

--- a/.github/workflows/spanner-load-tests.yml
+++ b/.github/workflows/spanner-load-tests.yml
@@ -38,6 +38,9 @@ jobs:
     - name: Setup Environment
       id: setup-env
       uses: ./.github/actions/setup-env
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
     - name: Run Load Tests
       run: |
         ./cicd/run-load-tests \
@@ -55,6 +58,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        DATE: ${{ steps.date.outputs.date }}
       with:
         filename: .github/ISSUE_TEMPLATE/spanner-load-test-failure-issue-template.md
     - name: Upload Load Tests Report
@@ -80,6 +84,9 @@ jobs:
     - name: Setup Environment
       id: setup-env
       uses: ./.github/actions/setup-env
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
     - name: Run Load Test Observers
       run: |
         ./cicd/run-load-test-observer \
@@ -96,6 +103,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        DATE: ${{ steps.date.outputs.date }}
       with:
         filename: .github/ISSUE_TEMPLATE/spanner-load-test-failure-issue-template.md
     - name: Upload Load Test Observer Report

--- a/.github/workflows/spanner-load-tests.yml
+++ b/.github/workflows/spanner-load-tests.yml
@@ -18,8 +18,8 @@ name: Spanner Load Tests
 
 on:
   schedule:
-  # at 02:00 every Day.
-  - cron: '0 2 * * *'
+  # at 02:00 weekly on every Monday.
+  - cron: '0 2 * * 1'
   workflow_dispatch:
 
 permissions: write-all

--- a/cicd/cmd/run-load-test-observer/main.go
+++ b/cicd/cmd/run-load-test-observer/main.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package main
+
+import (
+	"flag"
+	"log"
+
+	"github.com/GoogleCloudPlatform/DataflowTemplates/cicd/internal/flags"
+	"github.com/GoogleCloudPlatform/DataflowTemplates/cicd/internal/workflows"
+)
+
+func main() {
+	flags.RegisterCommonFlags()
+	flags.RegisterItFlags()
+	flags.RegisterLtFlags()
+	flag.Parse()
+
+	// Run mvn install before running integration tests
+	mvnFlags := workflows.NewMavenFlags()
+	err := workflows.MvnCleanInstall().Run(
+		mvnFlags.IncludeDependencies(),
+		mvnFlags.IncludeDependents(),
+		mvnFlags.SkipDependencyAnalysis(),
+		mvnFlags.SkipCheckstyle(),
+		mvnFlags.SkipJib(),
+		mvnFlags.SkipTests(),
+		mvnFlags.SkipJacoco(),
+		mvnFlags.SkipShade(),
+		mvnFlags.ThreadCount(4))
+	if err != nil {
+		log.Fatalf("%v\n", err)
+	}
+
+	// Run load tests
+	mvnFlags = workflows.NewMavenFlags()
+	err = workflows.MvnVerify().Run(
+		mvnFlags.IncludeDependencies(),
+		mvnFlags.IncludeDependents(),
+		mvnFlags.SkipDependencyAnalysis(),
+		mvnFlags.SkipCheckstyle(),
+		mvnFlags.SkipJib(),
+		mvnFlags.SkipShade(),
+		mvnFlags.FailAtTheEnd(),
+		mvnFlags.RunLoadTestObserver(),
+		mvnFlags.ThreadCount(4),
+		flags.Region(),
+		flags.Project(),
+		flags.ArtifactBucket(),
+		flags.StageBucket(),
+		flags.HostIp(),
+		flags.PrivateConnectivity(),
+		flags.ExportProject(),
+		flags.ExportDataset(),
+		flags.ExportTable(),
+		flags.StaticOracleHost(),
+		flags.StaticOracleSysPassword(),
+		flags.CloudProxyHost(),
+		flags.CloudProxyMySqlPort(),
+		flags.CloudProxyPostgresPort(),
+		flags.CloudProxyPassword())
+	if err != nil {
+		log.Fatalf("%v\n", err)
+	}
+	log.Println("Build Successful!")
+}

--- a/cicd/internal/workflows/maven-workflows.go
+++ b/cicd/internal/workflows/maven-workflows.go
@@ -52,6 +52,7 @@ type MavenFlags interface {
 	RunIntegrationTests() string
 	RunIntegrationSmokeTests() string
 	RunLoadTests() string
+	RunLoadTestObserver() string
 	ThreadCount(int) string
 	IntegrationTestParallelism(int) string
 	StaticBigtableInstance(string) string
@@ -115,6 +116,10 @@ func (*mvnFlags) RunIntegrationSmokeTests() string {
 
 func (*mvnFlags) RunLoadTests() string {
 	return "-PtemplatesLoadTests"
+}
+
+func (*mvnFlags) RunLoadTestObserver() string {
+	return "-PtemplatesLoadTestObserve"
 }
 
 // The number of modules Maven is going to build in parallel in a multi-module project.

--- a/lt/observability/pom.xml
+++ b/lt/observability/pom.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (C) 2024 Google Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <parent>
+    <groupId>com.google.cloud.teleport</groupId>
+    <artifactId>lt</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>observability</artifactId>
+  <modelVersion>4.0.0</modelVersion>
+
+  <dependencies>
+    <!-- Templates Annotations -->
+    <dependency>
+      <groupId>com.google.cloud.teleport.metadata</groupId>
+      <artifactId>metadata</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.teleport</groupId>
+      <artifactId>it-google-cloud-platform</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>${truth.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Core Maven plugins. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <!-- <compilerArgument>-parameters</compilerArgument> -->
+          <parameters>true</parameters>
+          <testCompilerArgument>-parameters</testCompilerArgument>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.auto.value</groupId>
+              <artifactId>auto-value</artifactId>
+              <version>${autovalue.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless-maven-plugin.version}</version>
+        <configuration combine.self="override">
+          <formats>
+            <!-- Avoid trailing whitespace and require ending newline. -->
+            <format>
+              <includes>
+                <include>*.md</include>
+                <include>.gitignore</include>
+              </includes>
+              <trimTrailingWhitespace/>
+              <endWithNewline/>
+            </format>
+          </formats>
+          <java>
+            <toggleOffOn/>
+            <googleJavaFormat>
+              <version>1.17.0</version>
+              <style>GOOGLE</style>
+            </googleJavaFormat>
+          </java>
+        </configuration>
+        <!-- Bind to verify. -->
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <!-- Skip tests for this common module when profile enabled -->
+  <profiles>
+    <profile>
+      <id>skipCommonTests</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
+    <profile>
+      <id>skipIT</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/lt/observability/src/test/java/com/google/cloud/teleport/lt/AssertAll.java
+++ b/lt/observability/src/test/java/com/google/cloud/teleport/lt/AssertAll.java
@@ -1,0 +1,23 @@
+package com.google.cloud.teleport.lt;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.runners.model.MultipleFailureException;
+
+public class AssertAll {
+
+  private List<Throwable> assertionErrors = new ArrayList<>();
+
+  public void assertAll(Runnable... assertions) throws MultipleFailureException {
+    for (Runnable assertion : assertions) {
+      try {
+        assertion.run();
+      } catch (AssertionError e) {
+        assertionErrors.add(e);
+      }
+    }
+    if (!assertionErrors.isEmpty()) {
+      throw new MultipleFailureException(assertionErrors);
+    }
+  }
+}

--- a/lt/observability/src/test/java/com/google/cloud/teleport/lt/dataset/bigquery/BigQueryPerfDataset.java
+++ b/lt/observability/src/test/java/com/google/cloud/teleport/lt/dataset/bigquery/BigQueryPerfDataset.java
@@ -1,0 +1,30 @@
+package com.google.cloud.teleport.lt.dataset.bigquery;
+
+import com.google.auto.value.AutoValue;
+import java.util.List;
+
+@AutoValue
+public abstract class BigQueryPerfDataset {
+
+  public abstract PerfResultRow latestRow();
+
+  public abstract List<PerfResultRow> previousRows();
+
+  public static BigQueryPerfDataset.Builder builder() {
+    return new AutoValue_BigQueryPerfDataset.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract BigQueryPerfDataset.Builder setLatestRow(PerfResultRow latestRow);
+
+    public abstract BigQueryPerfDataset.Builder setPreviousRows(List<PerfResultRow> previousRows);
+
+    abstract BigQueryPerfDataset autoBuild();
+
+    public BigQueryPerfDataset build() {
+      return autoBuild();
+    }
+  }
+}

--- a/lt/observability/src/test/java/com/google/cloud/teleport/lt/dataset/bigquery/BigQueryPerfDataset.java
+++ b/lt/observability/src/test/java/com/google/cloud/teleport/lt/dataset/bigquery/BigQueryPerfDataset.java
@@ -6,9 +6,7 @@ import java.util.List;
 @AutoValue
 public abstract class BigQueryPerfDataset {
 
-  public abstract PerfResultRow latestRow();
-
-  public abstract List<PerfResultRow> previousRows();
+  public abstract List<PerfResultRow> rows();
 
   public static BigQueryPerfDataset.Builder builder() {
     return new AutoValue_BigQueryPerfDataset.Builder();
@@ -17,9 +15,7 @@ public abstract class BigQueryPerfDataset {
   @AutoValue.Builder
   public abstract static class Builder {
 
-    public abstract BigQueryPerfDataset.Builder setLatestRow(PerfResultRow latestRow);
-
-    public abstract BigQueryPerfDataset.Builder setPreviousRows(List<PerfResultRow> previousRows);
+    public abstract BigQueryPerfDataset.Builder setRows(List<PerfResultRow> previousRows);
 
     abstract BigQueryPerfDataset autoBuild();
 

--- a/lt/observability/src/test/java/com/google/cloud/teleport/lt/dataset/bigquery/BigQueryPerfDataset.java
+++ b/lt/observability/src/test/java/com/google/cloud/teleport/lt/dataset/bigquery/BigQueryPerfDataset.java
@@ -6,6 +6,8 @@ import java.util.List;
 @AutoValue
 public abstract class BigQueryPerfDataset {
 
+  public abstract String query();
+
   public abstract List<PerfResultRow> rows();
 
   public static BigQueryPerfDataset.Builder builder() {
@@ -16,6 +18,8 @@ public abstract class BigQueryPerfDataset {
   public abstract static class Builder {
 
     public abstract BigQueryPerfDataset.Builder setRows(List<PerfResultRow> previousRows);
+
+    public abstract BigQueryPerfDataset.Builder setQuery(String query);
 
     abstract BigQueryPerfDataset autoBuild();
 

--- a/lt/observability/src/test/java/com/google/cloud/teleport/lt/dataset/bigquery/BigQueryPerfDatasetFetcher.java
+++ b/lt/observability/src/test/java/com/google/cloud/teleport/lt/dataset/bigquery/BigQueryPerfDatasetFetcher.java
@@ -1,0 +1,87 @@
+package com.google.cloud.teleport.lt.dataset.bigquery;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.bigquery.FieldValue;
+import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.TableResult;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.it.common.TestProperties;
+import org.apache.beam.it.gcp.bigquery.BigQueryResourceManager;
+
+@AutoValue
+public abstract class BigQueryPerfDatasetFetcher {
+  abstract String templateName();
+
+  abstract String testName();
+
+  abstract int numRows();
+
+  abstract BigQueryResourceManager bigQueryResourceManager();
+
+  private static final String QUERY =
+      "SELECT `timestamp`, template_name, test_name, metrics "
+          + "FROM `%s.%s.%s` "
+          + "WHERE template_name = \"%s\" and test_name = \"%s\" order by `timestamp` desc LIMIT %s";
+
+  public static BigQueryPerfDatasetFetcher.Builder builder() {
+    return new AutoValue_BigQueryPerfDatasetFetcher.Builder();
+  }
+
+  public BigQueryPerfDataset fetch() {
+    String query =
+        String.format(
+            QUERY,
+            TestProperties.exportProject(),
+            TestProperties.exportDataset(),
+            TestProperties.exportTable(),
+            templateName(),
+            testName(),
+            String.valueOf(numRows()));
+
+    TableResult result = bigQueryResourceManager().runQuery(query);
+    List<PerfResultRow> perfResultRows = new ArrayList<>();
+    for (FieldValueList row : result.iterateAll()) {
+      String timestamp = row.get(0).getStringValue();
+      String templateName = row.get(1).getStringValue();
+      String testName = row.get(2).getStringValue();
+      Map<String, Double> metrics = new HashMap<>();
+      for (FieldValue structField : row.get(3).getRepeatedValue()) {
+        String metricName = structField.getRecordValue().get(0).getStringValue();
+        Double metricValue = structField.getRecordValue().get(1).getDoubleValue();
+        metrics.put(metricName, metricValue);
+      }
+      perfResultRows.add(new PerfResultRow(templateName, testName, timestamp, metrics));
+    }
+    PerfResultRow latestRow = null;
+    if (perfResultRows.size() > 0) {
+      latestRow = perfResultRows.get(0);
+      perfResultRows.remove(0);
+    }
+    return BigQueryPerfDataset.builder()
+        .setLatestRow(latestRow)
+        .setPreviousRows(perfResultRows)
+        .build();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract BigQueryPerfDatasetFetcher.Builder setTemplateName(String templateName);
+
+    public abstract BigQueryPerfDatasetFetcher.Builder setTestName(String testName);
+
+    public abstract BigQueryPerfDatasetFetcher.Builder setNumRows(int numRows);
+
+    public abstract BigQueryPerfDatasetFetcher.Builder setBigQueryResourceManager(
+        BigQueryResourceManager bigQueryResourceManager);
+
+    abstract BigQueryPerfDatasetFetcher autoBuild();
+
+    public BigQueryPerfDatasetFetcher build() {
+      return autoBuild();
+    }
+  }
+}

--- a/lt/observability/src/test/java/com/google/cloud/teleport/lt/dataset/bigquery/BigQueryPerfDatasetFetcher.java
+++ b/lt/observability/src/test/java/com/google/cloud/teleport/lt/dataset/bigquery/BigQueryPerfDatasetFetcher.java
@@ -1,82 +1,87 @@
 package com.google.cloud.teleport.lt.dataset.bigquery;
 
 import com.google.auto.value.AutoValue;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.FieldValue;
+import com.google.cloud.bigquery.FieldValue.Attribute;
 import com.google.cloud.bigquery.FieldValueList;
+import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.TableResult;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.beam.it.common.TestProperties;
 import org.apache.beam.it.gcp.bigquery.BigQueryResourceManager;
 
 @AutoValue
 public abstract class BigQueryPerfDatasetFetcher {
-  abstract String templateName();
-
-  abstract String testName();
-
-  abstract int numRows();
 
   abstract BigQueryResourceManager bigQueryResourceManager();
 
-  private static final String QUERY =
-      "SELECT `timestamp`, template_name, test_name, metrics "
-          + "FROM `%s.%s.%s` "
-          + "WHERE template_name = \"%s\" and test_name = \"%s\" order by `timestamp` desc LIMIT %s";
+  abstract String query();
 
   public static BigQueryPerfDatasetFetcher.Builder builder() {
     return new AutoValue_BigQueryPerfDatasetFetcher.Builder();
   }
 
   public BigQueryPerfDataset fetch() {
-    String query =
-        String.format(
-            QUERY,
-            TestProperties.exportProject(),
-            TestProperties.exportDataset(),
-            TestProperties.exportTable(),
-            templateName(),
-            testName(),
-            String.valueOf(numRows()));
-
-    TableResult result = bigQueryResourceManager().runQuery(query);
+    TableResult result = bigQueryResourceManager().runQuery(query());
+    Schema schema = result.getSchema();
     List<PerfResultRow> perfResultRows = new ArrayList<>();
     for (FieldValueList row : result.iterateAll()) {
-      String timestamp = row.get(0).getStringValue();
-      String templateName = row.get(1).getStringValue();
-      String testName = row.get(2).getStringValue();
-      Map<String, Double> metrics = new HashMap<>();
-      for (FieldValue structField : row.get(3).getRepeatedValue()) {
-        String metricName = structField.getRecordValue().get(0).getStringValue();
-        Double metricValue = structField.getRecordValue().get(1).getDoubleValue();
-        metrics.put(metricName, metricValue);
+      PerfResultRow newPerfRow = new PerfResultRow(new HashMap<>());
+      for (Field field : schema.getFields()) {
+        String columnName = field.getName();
+        FieldValue value = row.get(columnName);
+        newPerfRow.row.put(columnName, getValue(field, value));
       }
-      perfResultRows.add(new PerfResultRow(templateName, testName, timestamp, metrics));
+      perfResultRows.add(newPerfRow);
     }
-    PerfResultRow latestRow = null;
-    if (perfResultRows.size() > 0) {
-      latestRow = perfResultRows.get(0);
-      perfResultRows.remove(0);
+    return BigQueryPerfDataset.builder().setRows(perfResultRows).build();
+  }
+
+  public Object getValue(Field columnSchema, FieldValue value) {
+    if (Attribute.REPEATED.equals(value.getAttribute())) {
+      List<FieldValue> repeatedValue = value.getRepeatedValue();
+      List<Object> returnVal = new ArrayList<>();
+      for (int i = 0; i < repeatedValue.size(); ++i) {
+        returnVal.add(getValue(columnSchema, repeatedValue.get(i)));
+      }
+      return returnVal;
+    } else if (Attribute.RECORD.equals(value.getAttribute())) {
+      FieldValueList recordValue = value.getRecordValue();
+      FieldList subFields = columnSchema.getSubFields();
+      Map<String, Object> returnVal = new HashMap<>();
+      for (int i = 0; i < recordValue.size(); ++i) {
+        returnVal.put(subFields.get(i).getName(), getValue(subFields.get(i), recordValue.get(i)));
+      }
+      return returnVal;
+    } else {
+      switch (columnSchema.getType().getStandardType()) {
+        case BOOL:
+          return value.getBooleanValue();
+        case INT64:
+          return value.getLongValue();
+        case FLOAT64:
+          return value.getDoubleValue();
+        case STRING:
+          return value.getStringValue();
+        case TIMESTAMP:
+          return value.getTimestampValue();
+        default:
+          return value.getValue();
+      }
     }
-    return BigQueryPerfDataset.builder()
-        .setLatestRow(latestRow)
-        .setPreviousRows(perfResultRows)
-        .build();
   }
 
   @AutoValue.Builder
   public abstract static class Builder {
 
-    public abstract BigQueryPerfDatasetFetcher.Builder setTemplateName(String templateName);
-
-    public abstract BigQueryPerfDatasetFetcher.Builder setTestName(String testName);
-
-    public abstract BigQueryPerfDatasetFetcher.Builder setNumRows(int numRows);
-
     public abstract BigQueryPerfDatasetFetcher.Builder setBigQueryResourceManager(
         BigQueryResourceManager bigQueryResourceManager);
+
+    public abstract BigQueryPerfDatasetFetcher.Builder setQuery(String query);
 
     abstract BigQueryPerfDatasetFetcher autoBuild();
 

--- a/lt/observability/src/test/java/com/google/cloud/teleport/lt/dataset/bigquery/BigQueryPerfDatasetFetcher.java
+++ b/lt/observability/src/test/java/com/google/cloud/teleport/lt/dataset/bigquery/BigQueryPerfDatasetFetcher.java
@@ -38,7 +38,7 @@ public abstract class BigQueryPerfDatasetFetcher {
       }
       perfResultRows.add(newPerfRow);
     }
-    return BigQueryPerfDataset.builder().setRows(perfResultRows).build();
+    return BigQueryPerfDataset.builder().setRows(perfResultRows).setQuery(query()).build();
   }
 
   public Object getValue(Field columnSchema, FieldValue value) {

--- a/lt/observability/src/test/java/com/google/cloud/teleport/lt/dataset/bigquery/PerfResultRow.java
+++ b/lt/observability/src/test/java/com/google/cloud/teleport/lt/dataset/bigquery/PerfResultRow.java
@@ -1,0 +1,18 @@
+package com.google.cloud.teleport.lt.dataset.bigquery;
+
+import java.util.Map;
+
+public class PerfResultRow {
+  public String templateName;
+  public String testName;
+  public String timestamp;
+  public Map<String, Double> metrics;
+
+  public PerfResultRow(
+      String templateName, String testName, String timestamp, Map<String, Double> metrics) {
+    this.templateName = templateName;
+    this.testName = testName;
+    this.timestamp = timestamp;
+    this.metrics = metrics;
+  }
+}

--- a/lt/observability/src/test/java/com/google/cloud/teleport/lt/dataset/bigquery/PerfResultRow.java
+++ b/lt/observability/src/test/java/com/google/cloud/teleport/lt/dataset/bigquery/PerfResultRow.java
@@ -3,16 +3,9 @@ package com.google.cloud.teleport.lt.dataset.bigquery;
 import java.util.Map;
 
 public class PerfResultRow {
-  public String templateName;
-  public String testName;
-  public String timestamp;
-  public Map<String, Double> metrics;
+  public Map<String, Object> row;
 
-  public PerfResultRow(
-      String templateName, String testName, String timestamp, Map<String, Double> metrics) {
-    this.templateName = templateName;
-    this.testName = testName;
-    this.timestamp = timestamp;
-    this.metrics = metrics;
+  public PerfResultRow(Map<String, Object> row) {
+    this.row = row;
   }
 }

--- a/lt/observability/src/test/java/com/google/cloud/teleport/lt/rules/DetectMetricDeviationConditionCheck.java
+++ b/lt/observability/src/test/java/com/google/cloud/teleport/lt/rules/DetectMetricDeviationConditionCheck.java
@@ -1,0 +1,78 @@
+package com.google.cloud.teleport.lt.rules;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.lt.dataset.bigquery.BigQueryPerfDataset;
+import com.google.cloud.teleport.lt.dataset.bigquery.PerfResultRow;
+import org.apache.beam.it.conditions.ConditionCheck;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The DetectMetricDeviationRule class provides a ConditionCheck which checks if a Metric in the
+ * observed record in a given Dataset is deviating more than the given % from the average of
+ * previous records.
+ */
+@AutoValue
+public abstract class DetectMetricDeviationConditionCheck extends ConditionCheck {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(DetectMetricDeviationConditionCheck.class);
+
+  abstract BigQueryPerfDataset dataset();
+
+  abstract String metricName();
+
+  abstract double percentageDeviation();
+
+  @Override
+  public String getDescription() {
+    return String.format("DetectMetricDeviation ConditionCheck for %s", metricName());
+  }
+
+  @Override
+  protected CheckResult check() {
+    double totalMetricValue = 0.0;
+    for (PerfResultRow perfResultRow : dataset().previousRows()) {
+      totalMetricValue += perfResultRow.metrics.get(metricName());
+    }
+    double average = totalMetricValue / dataset().previousRows().size();
+
+    // Deviating more than x% of average
+    if ((dataset().latestRow().metrics.get(metricName())
+            > average * (100.0 + percentageDeviation()) / 100.0)
+        || (dataset().latestRow().metrics.get(metricName())
+            < average * (100.0 - percentageDeviation()) / 100.0)) {
+      return new ConditionCheck.CheckResult(
+          false,
+          String.format(
+              "Metric %s is deviating more than %.2f %% than the average. %s=%f, Average=%f\n",
+              metricName(),
+              percentageDeviation(),
+              metricName(),
+              dataset().latestRow().metrics.get(metricName()),
+              average));
+    }
+
+    return new ConditionCheck.CheckResult(true);
+  }
+
+  public static Builder builder() {
+    return new AutoValue_DetectMetricDeviationConditionCheck.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setDataset(BigQueryPerfDataset bigQueryPerfDataset);
+
+    public abstract Builder setMetricName(String metricName);
+
+    public abstract Builder setPercentageDeviation(double percentageDeviation);
+
+    abstract DetectMetricDeviationConditionCheck autoBuild();
+
+    public DetectMetricDeviationConditionCheck build() {
+      return autoBuild();
+    }
+  }
+}

--- a/lt/observability/src/test/java/com/google/cloud/teleport/lt/spanner/DataStreamToSpannerLTObserver.java
+++ b/lt/observability/src/test/java/com/google/cloud/teleport/lt/spanner/DataStreamToSpannerLTObserver.java
@@ -1,0 +1,67 @@
+package com.google.cloud.teleport.lt.spanner;
+
+import static org.junit.Assert.assertTrue;
+
+import com.google.auth.Credentials;
+import com.google.cloud.teleport.lt.AssertAll;
+import com.google.cloud.teleport.lt.dataset.bigquery.BigQueryPerfDataset;
+import com.google.cloud.teleport.lt.dataset.bigquery.BigQueryPerfDatasetFetcher;
+import com.google.cloud.teleport.lt.rules.DetectMetricDeviationConditionCheck;
+import org.apache.beam.it.common.TestProperties;
+import org.apache.beam.it.gcp.bigquery.BigQueryResourceManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.junit.runners.model.MultipleFailureException;
+
+@RunWith(JUnit4.class)
+public class DataStreamToSpannerLTObserver {
+
+  protected static final Credentials CREDENTIALS = TestProperties.googleCredentials();
+
+  private BigQueryResourceManager bigQueryResourceManager;
+
+  @Before
+  public void setup() {
+    String projectId = TestProperties.exportProject();
+    bigQueryResourceManager =
+        BigQueryResourceManager.builder("Load-test-analyzer", projectId, CREDENTIALS)
+            .setDatasetId(TestProperties.exportDataset())
+            .build();
+    // *DO NOT CALL cleanup on this bigQueryResourceManager.* It would delete the tables in the
+    // dataset.
+  }
+
+  @Test
+  public void observeDSToSpanner100GBLT() throws MultipleFailureException {
+    // Fetch data
+    BigQueryPerfDatasetFetcher datasetFetcher =
+        BigQueryPerfDatasetFetcher.builder()
+            .setTemplateName("cloud_datastream_to_spanner")
+            .setTestName("backfill100Gb")
+            .setNumRows(11)
+            .setBigQueryResourceManager(bigQueryResourceManager)
+            .build();
+    BigQueryPerfDataset dataset = datasetFetcher.fetch();
+
+    // Assert using condition checks
+    DetectMetricDeviationConditionCheck totalTimeCheck =
+        DetectMetricDeviationConditionCheck.builder()
+            .setDataset(dataset)
+            .setMetricName("RunTime")
+            .setPercentageDeviation(25)
+            .build();
+
+    DetectMetricDeviationConditionCheck totalCostCheck =
+        DetectMetricDeviationConditionCheck.builder()
+            .setDataset(dataset)
+            .setMetricName("EstimatedCost")
+            .setPercentageDeviation(25)
+            .build();
+
+    AssertAll asserts = new AssertAll();
+    asserts.assertAll(
+        () -> assertTrue(totalTimeCheck.get()), () -> assertTrue(totalCostCheck.get()));
+  }
+}

--- a/lt/observability/src/test/java/com/google/cloud/teleport/lt/spanner/DataStreamToSpannerLTObserver.java
+++ b/lt/observability/src/test/java/com/google/cloud/teleport/lt/spanner/DataStreamToSpannerLTObserver.java
@@ -35,12 +35,13 @@ public class DataStreamToSpannerLTObserver {
 
   @Test
   public void observeDSToSpanner100GBLT() throws MultipleFailureException {
+    String query =
+        DetectMetricDeviationConditionCheck.constructQuery(
+            "cloud_datastream_to_spanner", "backfill100Gb", "11");
     // Fetch data
     BigQueryPerfDatasetFetcher datasetFetcher =
         BigQueryPerfDatasetFetcher.builder()
-            .setTemplateName("cloud_datastream_to_spanner")
-            .setTestName("backfill100Gb")
-            .setNumRows(11)
+            .setQuery(query)
             .setBigQueryResourceManager(bigQueryResourceManager)
             .build();
     BigQueryPerfDataset dataset = datasetFetcher.fetch();

--- a/lt/pom.xml
+++ b/lt/pom.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (C) 2024 Google Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <parent>
+    <groupId>com.google.cloud.teleport</groupId>
+    <artifactId>templates</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>lt</artifactId>
+  <packaging>pom</packaging>
+  <modelVersion>4.0.0</modelVersion>
+
+  <dependencies>
+    <!-- Templates Annotations -->
+    <dependency>
+      <groupId>com.google.cloud.teleport.metadata</groupId>
+      <artifactId>metadata</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.teleport</groupId>
+      <artifactId>it-google-cloud-platform</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>${truth.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Core Maven plugins. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+          <parameters>true</parameters>
+          <testCompilerArgument>-parameters</testCompilerArgument>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.auto.value</groupId>
+              <artifactId>auto-value</artifactId>
+              <version>${autovalue.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless-maven-plugin.version}</version>
+        <configuration combine.self="override">
+          <formats>
+            <!-- Avoid trailing whitespace and require ending newline. -->
+            <format>
+              <includes>
+                <include>*.md</include>
+                <include>.gitignore</include>
+              </includes>
+              <trimTrailingWhitespace/>
+              <endWithNewline/>
+            </format>
+          </formats>
+          <java>
+            <toggleOffOn/>
+            <googleJavaFormat>
+              <version>1.17.0</version>
+              <style>GOOGLE</style>
+            </googleJavaFormat>
+          </java>
+        </configuration>
+        <!-- Bind to verify. -->
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <!-- Skip tests for this common module when profile enabled -->
+  <profiles>
+    <profile>
+      <id>skipCommonTests</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
+    <profile>
+      <id>skipIT</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
+  </profiles>
+  <modules>
+    <module>observability</module>
+  </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -677,10 +677,6 @@
           <id>ossrh</id>
           <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
-        <repository>
-          <id>confluent</id>
-          <url>https://packages.confluent.io/maven/</url>
-        </repository>
       </repositories>
       <pluginRepositories>
         <pluginRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -493,6 +493,34 @@
       </build>
     </profile>
     <profile>
+      <id>templatesLoadTestObserve</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <!-- Skip coverage checks, unit tests are skipped -->
+        <jacoco.skip>true</jacoco.skip>
+        <!-- Some modules may yield no load tests -->
+        <failIfNoTests>false</failIfNoTests>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${surefire.version}</version>
+            <configuration combine.self="override">
+              <includes>
+                <include>**/*LTObserver.java</include>
+              </includes>
+              <excludedGroups></excludedGroups>
+              <trimStackTrace>false</trimStackTrace>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>templatesIntegrationDirectTests</id>
       <activation>
         <activeByDefault>false</activeByDefault>
@@ -649,6 +677,10 @@
           <id>ossrh</id>
           <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
+        <repository>
+          <id>confluent</id>
+          <url>https://packages.confluent.io/maven/</url>
+        </repository>
       </repositories>
       <pluginRepositories>
         <pluginRepository>
@@ -710,6 +742,7 @@
     <module>metadata</module>
     <module>plugins</module>
     <module>it</module>
+    <module>lt</module>
     <module>v1</module>
     <module>v2</module>
     <module>structured-logging</module>


### PR DESCRIPTION
Automatic regression detection framework for Dataflow template Load tests.
- Fetch Load test metrics data from a Datasource (Bigquery)
- Run regression detection algorithm on the dataset
- Create a github issue on failure.

PR contents:
- Framework components for automated Load test regression detection
  - BigQueryDatasetFetcher to fetch metrics data from BQ
  - MetricDeviationConditionCheck to detect regression.
- Sample load test observer for DatastreamToSpanner template
- Sets up weekly github workflow to run the Observer along side Load tests for Spanner templates.
