### PR TITLE
Support populating Spanner source database id, instance id and a custom metadata field in Spanner CDC to Pub Sub template

### DIFF
--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerChangeStreamsToPubSubOptions.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerChangeStreamsToPubSubOptions.java
@@ -218,10 +218,9 @@ public interface SpannerChangeStreamsToPubSubOptions extends DataflowPipelineOpt
   @TemplateParameter.Boolean(
       order = 17,
       optional = true,
-      description =
-          "Whether or not to include the spanner database and instance to read the change stream from in the output message data",
+      description = "Include spanner database id and instance id in output message",
       helpText =
-          "Whether or not to include the spanner database and instance to read the change stream from in the output message data. Defaults to: false")
+          "Whether or not to include the spanner database id and instance id to read the change stream from in the output message data. Defaults to: false")
   @Default.Boolean(false)
   Boolean getIncludeSpannerSource();
 

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerChangeStreamsToPubSubOptions.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerChangeStreamsToPubSubOptions.java
@@ -225,4 +225,18 @@ public interface SpannerChangeStreamsToPubSubOptions extends DataflowPipelineOpt
   Boolean getIncludeSpannerSource();
 
   void setIncludeSpannerSource(Boolean value);
+
+  @TemplateParameter.Text(
+      order = 18,
+      optional = true,
+      description = "Custom Value for the optional field outputMessageMetadata",
+      helpText =
+          "The string value for the custom field outputMessageMetadata in output pub/sub message. "
+              + "Defaults to empty and the field outputMessageMetadata is only populated if this "
+              + "value is non-empty. Please escape any special characters when entering the value "
+              + "here(ie: double quotes).")
+  @Default.String("")
+  String getOutputMessageMetadata();
+
+  void setOutputMessageMetadata(String value);
 }

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerChangeStreamsToPubSubOptions.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerChangeStreamsToPubSubOptions.java
@@ -214,4 +214,16 @@ public interface SpannerChangeStreamsToPubSubOptions extends DataflowPipelineOpt
   RpcPriority getRpcPriority();
 
   void setRpcPriority(RpcPriority rpcPriority);
+
+  @TemplateParameter.Boolean(
+      order = 17,
+      optional = true,
+      description =
+          "Whether or not to include the spanner database and instance to read the change stream from in the output message data",
+      helpText =
+          "Whether or not to include the spanner database and instance to read the change stream from in the output message data. Defaults to: false")
+  @Default.Boolean(false)
+  Boolean getIncludeSpannerSource();
+
+  void setIncludeSpannerSource(Boolean value);
 }

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToPubSub.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToPubSub.java
@@ -112,6 +112,7 @@ public class SpannerChangeStreamsToPubSub {
     String pubsubProjectId = getPubsubProjectId(options);
     String pubsubTopicName = options.getPubsubTopic();
     String pubsubAPI = options.getPubsubAPI();
+    Boolean includeSpannerSource = options.getIncludeSpannerSource();
 
     // Retrieve and parse the start / end timestamps.
     Timestamp startTimestamp =
@@ -170,6 +171,9 @@ public class SpannerChangeStreamsToPubSub {
                 .setProjectId(pubsubProjectId)
                 .setPubsubAPI(pubsubAPI)
                 .setPubsubTopicName(pubsubTopicName)
+                .setIncludeSpannerSource(includeSpannerSource)
+                .setSpannerDatabase(databaseId)
+                .setSpannerInstanceId(instanceId)
                 .build());
     return pipeline.run();
   }

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToPubSub.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToPubSub.java
@@ -22,6 +22,7 @@ import com.google.cloud.teleport.metadata.TemplateCategory;
 import com.google.cloud.teleport.v2.common.UncaughtExceptionLogger;
 import com.google.cloud.teleport.v2.options.SpannerChangeStreamsToPubSubOptions;
 import com.google.cloud.teleport.v2.transforms.FileFormatFactorySpannerChangeStreamsToPubSub;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.Pipeline;
@@ -95,6 +96,14 @@ public class SpannerChangeStreamsToPubSub {
         : options.getPubsubProjectId();
   }
 
+  public static boolean isValidAsciiString(String outputMessageMetadata) {
+    if (outputMessageMetadata != null
+        && !StandardCharsets.US_ASCII.newEncoder().canEncode(outputMessageMetadata)) {
+      return false;
+    }
+    return true;
+  }
+
   public static PipelineResult run(SpannerChangeStreamsToPubSubOptions options) {
     LOG.info("Requested Message Format is " + options.getOutputDataFormat());
     options.setStreaming(true);
@@ -113,6 +122,12 @@ public class SpannerChangeStreamsToPubSub {
     String pubsubTopicName = options.getPubsubTopic();
     String pubsubAPI = options.getPubsubAPI();
     Boolean includeSpannerSource = options.getIncludeSpannerSource();
+    String outputMessageMetadata = options.getOutputMessageMetadata();
+
+    // Ensure outputMessageMetadata only contains valid ascii characters
+    if (!isValidAsciiString(outputMessageMetadata)) {
+      throw new RuntimeException("outputMessageMetadata contains non ascii characters.");
+    }
 
     // Retrieve and parse the start / end timestamps.
     Timestamp startTimestamp =
@@ -174,6 +189,7 @@ public class SpannerChangeStreamsToPubSub {
                 .setIncludeSpannerSource(includeSpannerSource)
                 .setSpannerDatabaseId(databaseId)
                 .setSpannerInstanceId(instanceId)
+                .setOutputMessageMetadata(outputMessageMetadata)
                 .build());
     return pipeline.run();
   }

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToPubSub.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToPubSub.java
@@ -172,7 +172,7 @@ public class SpannerChangeStreamsToPubSub {
                 .setPubsubAPI(pubsubAPI)
                 .setPubsubTopicName(pubsubTopicName)
                 .setIncludeSpannerSource(includeSpannerSource)
-                .setSpannerDatabase(databaseId)
+                .setSpannerDatabaseId(databaseId)
                 .setSpannerInstanceId(instanceId)
                 .build());
     return pipeline.run();

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/transforms/FileFormatFactorySpannerChangeStreamsToPubSub.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/transforms/FileFormatFactorySpannerChangeStreamsToPubSub.java
@@ -71,6 +71,9 @@ public abstract class FileFormatFactorySpannerChangeStreamsToPubSub
   @Nullable
   protected abstract String spannerInstanceId();
 
+  @Nullable
+  protected abstract String outputMessageMetadata();
+
   @Override
   public PCollection<byte[]> expand(PCollection<DataChangeRecord> records) {
     PCollection<byte[]> encodedRecords = null;
@@ -82,7 +85,9 @@ public abstract class FileFormatFactorySpannerChangeStreamsToPubSub
       case "AVRO":
         AvroCoder<com.google.cloud.teleport.v2.DataChangeRecord> coder =
             AvroCoder.of(com.google.cloud.teleport.v2.DataChangeRecord.class);
-        DataChangeRecordToAvroFn.Builder avroBuilder = new DataChangeRecordToAvroFn.Builder();
+        DataChangeRecordToAvroFn.Builder avroBuilder =
+            new DataChangeRecordToAvroFn.Builder()
+                .setOutputMessageMetadata(outputMessageMetadata());
         if (includeSpannerSource()) {
           avroBuilder
               .setSpannerDatabaseId(spannerDatabaseId())
@@ -116,7 +121,8 @@ public abstract class FileFormatFactorySpannerChangeStreamsToPubSub
         break;
       case "JSON":
         DataChangeRecordToJsonTextFn.Builder jsonBuilder =
-            new DataChangeRecordToJsonTextFn.Builder();
+            new DataChangeRecordToJsonTextFn.Builder()
+                .setOutputMessageMetadata(outputMessageMetadata());
         if (includeSpannerSource()) {
           jsonBuilder
               .setSpannerDatabaseId(spannerDatabaseId())
@@ -207,6 +213,8 @@ public abstract class FileFormatFactorySpannerChangeStreamsToPubSub
     public abstract WriteToPubSubBuilder setSpannerDatabaseId(String value);
 
     public abstract WriteToPubSubBuilder setSpannerInstanceId(String value);
+
+    public abstract WriteToPubSubBuilder setOutputMessageMetadata(String value);
 
     abstract FileFormatFactorySpannerChangeStreamsToPubSub autoBuild();
 

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/transforms/FileFormatFactorySpannerChangeStreamsToPubSub.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/transforms/FileFormatFactorySpannerChangeStreamsToPubSub.java
@@ -18,6 +18,7 @@ package com.google.cloud.teleport.v2.transforms;
 import static com.google.cloud.teleport.v2.transforms.WriteDataChangeRecordsToAvro.DataChangeRecordToAvroFn;
 import static com.google.cloud.teleport.v2.transforms.WriteDataChangeRecordsToJson.DataChangeRecordToJsonTextFn;
 
+import autovalue.shaded.org.jetbrains.annotations.Nullable;
 import com.google.auto.value.AutoValue;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
@@ -61,6 +62,15 @@ public abstract class FileFormatFactorySpannerChangeStreamsToPubSub
 
   protected abstract String pubsubTopicName();
 
+  @Nullable
+  protected abstract Boolean includeSpannerSource();
+
+  @Nullable
+  protected abstract String spannerDatabase();
+
+  @Nullable
+  protected abstract String spannerInstanceId();
+
   @Override
   public PCollection<byte[]> expand(PCollection<DataChangeRecord> records) {
     PCollection<byte[]> encodedRecords = null;
@@ -76,7 +86,12 @@ public abstract class FileFormatFactorySpannerChangeStreamsToPubSub
             records
                 .apply(
                     "Write DataChangeRecord into AVRO",
-                    MapElements.via(new DataChangeRecordToAvroFn()))
+                    MapElements.via(
+                        new DataChangeRecordToAvroFn.Builder()
+                            .setIncludeSpannerSource(includeSpannerSource())
+                            .setSpannerDatabase(spannerDatabase())
+                            .setSpannerInstanceId(spannerInstanceId())
+                            .build()))
                 .apply(
                     "Convert encoded DataChangeRecord in AVRO to bytes to be saved into"
                         + " PubsubMessage.",
@@ -105,7 +120,12 @@ public abstract class FileFormatFactorySpannerChangeStreamsToPubSub
             records
                 .apply(
                     "Write DataChangeRecord into JSON",
-                    MapElements.via(new DataChangeRecordToJsonTextFn()))
+                    MapElements.via(
+                        new DataChangeRecordToJsonTextFn.Builder()
+                            .setIncludeSpannerSource(includeSpannerSource())
+                            .setSpannerDatabase(spannerDatabase())
+                            .setSpannerInstanceId(spannerInstanceId())
+                            .build()))
                 .apply(
                     "Convert encoded DataChangeRecord in JSON to bytes to be saved into"
                         + " PubsubMessage.",
@@ -182,6 +202,12 @@ public abstract class FileFormatFactorySpannerChangeStreamsToPubSub
     public abstract WriteToPubSubBuilder setPubsubAPI(String value);
 
     public abstract WriteToPubSubBuilder setPubsubTopicName(String value);
+
+    public abstract WriteToPubSubBuilder setIncludeSpannerSource(Boolean value);
+
+    public abstract WriteToPubSubBuilder setSpannerDatabase(String value);
+
+    public abstract WriteToPubSubBuilder setSpannerInstanceId(String value);
 
     abstract FileFormatFactorySpannerChangeStreamsToPubSub autoBuild();
 

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/transforms/FileFormatFactorySpannerChangeStreamsToPubSub.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/transforms/FileFormatFactorySpannerChangeStreamsToPubSub.java
@@ -18,8 +18,8 @@ package com.google.cloud.teleport.v2.transforms;
 import static com.google.cloud.teleport.v2.transforms.WriteDataChangeRecordsToAvro.DataChangeRecordToAvroFn;
 import static com.google.cloud.teleport.v2.transforms.WriteDataChangeRecordsToJson.DataChangeRecordToJsonTextFn;
 
-import autovalue.shaded.org.jetbrains.annotations.Nullable;
 import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToAvro.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToAvro.java
@@ -47,18 +47,12 @@ public class WriteDataChangeRecordsToAvro {
   public static class DataChangeRecordToAvroFn
       extends SimpleFunction<DataChangeRecord, com.google.cloud.teleport.v2.DataChangeRecord> {
 
-    private boolean includeSpannerSource = false;
-
-    private String spannerDatabase;
+    private String spannerDatabaseId;
 
     private String spannerInstanceId;
 
-    public boolean includeSpannerSource() {
-      return includeSpannerSource;
-    }
-
-    public String spannerDatabase() {
-      return spannerDatabase;
+    public String spannerDatabaseId() {
+      return spannerDatabaseId;
     }
 
     public String spannerInstanceId() {
@@ -71,11 +65,9 @@ public class WriteDataChangeRecordsToAvro {
     }
 
     public DataChangeRecordToAvroFn() {}
-    ;
 
     private DataChangeRecordToAvroFn(Builder builder) {
-      this.includeSpannerSource = builder.includeSpannerSource;
-      this.spannerDatabase = builder.spannerDatabase;
+      this.spannerDatabaseId = builder.spannerDatabaseId;
       this.spannerInstanceId = builder.spannerInstanceId;
     }
 
@@ -136,8 +128,6 @@ public class WriteDataChangeRecordsToAvro {
                   record.getMetadata().getTotalStreamTimeMillis(),
                   record.getMetadata().getNumberOfRecordsRead());
 
-      String spannerDatabase = includeSpannerSource() ? spannerDatabase() : null;
-      String spannerInstanceId = includeSpannerSource() ? spannerInstanceId() : null;
       // Add ChangeStreamMetadata and spanner source info
       return new com.google.cloud.teleport.v2.DataChangeRecord(
           partitionToken,
@@ -153,23 +143,18 @@ public class WriteDataChangeRecordsToAvro {
           numberOfRecordsInTransaction,
           numberOfPartitionsInTransaction,
           metadata,
-          spannerDatabase,
-          spannerInstanceId);
+          // If includeSpannerSource is false, spannerDatabaseId() and spannerInstanceId() are null.
+          spannerDatabaseId(),
+          spannerInstanceId());
     }
 
     static class Builder {
-      private boolean includeSpannerSource = false;
-      private String spannerDatabase;
+      private String spannerDatabaseId;
 
       private String spannerInstanceId;
 
-      public Builder setIncludeSpannerSource(Boolean value) {
-        this.includeSpannerSource = value;
-        return this;
-      }
-
-      public Builder setSpannerDatabase(String value) {
-        this.spannerDatabase = value;
+      public Builder setSpannerDatabaseId(String value) {
+        this.spannerDatabaseId = value;
         return this;
       }
 

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToAvro.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToAvro.java
@@ -51,12 +51,18 @@ public class WriteDataChangeRecordsToAvro {
 
     private String spannerInstanceId;
 
+    private String outputMessageMetadata;
+
     public String spannerDatabaseId() {
       return spannerDatabaseId;
     }
 
     public String spannerInstanceId() {
       return spannerInstanceId;
+    }
+
+    public String outputMessageMetadata() {
+      return outputMessageMetadata;
     }
 
     @Override
@@ -69,6 +75,7 @@ public class WriteDataChangeRecordsToAvro {
     private DataChangeRecordToAvroFn(Builder builder) {
       this.spannerDatabaseId = builder.spannerDatabaseId;
       this.spannerInstanceId = builder.spannerInstanceId;
+      this.outputMessageMetadata = builder.outputMessageMetadata;
     }
 
     public com.google.cloud.teleport.v2.DataChangeRecord dataChangeRecordToAvro(
@@ -145,13 +152,16 @@ public class WriteDataChangeRecordsToAvro {
           metadata,
           // If includeSpannerSource is false, spannerDatabaseId() and spannerInstanceId() are null.
           spannerDatabaseId(),
-          spannerInstanceId());
+          spannerInstanceId(),
+          outputMessageMetadata());
     }
 
     static class Builder {
       private String spannerDatabaseId;
 
       private String spannerInstanceId;
+
+      private String outputMessageMetadata;
 
       public Builder setSpannerDatabaseId(String value) {
         this.spannerDatabaseId = value;
@@ -160,6 +170,11 @@ public class WriteDataChangeRecordsToAvro {
 
       public Builder setSpannerInstanceId(String value) {
         this.spannerInstanceId = value;
+        return this;
+      }
+
+      public Builder setOutputMessageMetadata(String value) {
+        this.outputMessageMetadata = value;
         return this;
       }
 

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToJson.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToJson.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.transforms;
 
 import com.google.auto.value.AutoValue;
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.DataChangeRecord;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.SimpleFunction;
@@ -37,9 +38,67 @@ public abstract class WriteDataChangeRecordsToJson {
   static class DataChangeRecordToJsonTextFn extends SimpleFunction<DataChangeRecord, String> {
     private static Gson gson = new Gson();
 
+    private boolean includeSpannerResource = false;
+
+    private String spannerDatabase;
+
+    private String spannerInstanceId;
+
+    public Boolean includeSpannerSource() {
+      return includeSpannerResource;
+    }
+
+    public String spannerDatabase() {
+      return spannerDatabase;
+    }
+
+    public String spannerInstanceId() {
+      return spannerInstanceId;
+    }
+
+    public DataChangeRecordToJsonTextFn() {}
+
+    private DataChangeRecordToJsonTextFn(Builder builder) {
+      this.includeSpannerResource = builder.includeSpannerResource;
+      this.spannerDatabase = builder.spannerDatabase;
+      this.spannerInstanceId = builder.spannerInstanceId;
+    }
+
     @Override
     public String apply(DataChangeRecord record) {
+      if (includeSpannerSource()) {
+        JsonElement jsonElement = gson.toJsonTree(record);
+        jsonElement.getAsJsonObject().addProperty("spannerDatabase", spannerDatabase());
+        jsonElement.getAsJsonObject().addProperty("spannerInstanceId", spannerInstanceId());
+        return gson.toJson(jsonElement);
+      }
       return gson.toJson(record, DataChangeRecord.class);
+    }
+
+    static class Builder {
+      private boolean includeSpannerResource = false;
+      private String spannerDatabase;
+
+      private String spannerInstanceId;
+
+      public Builder setIncludeSpannerSource(Boolean value) {
+        this.includeSpannerResource = value;
+        return this;
+      }
+
+      public Builder setSpannerDatabase(String value) {
+        this.spannerDatabase = value;
+        return this;
+      }
+
+      public Builder setSpannerInstanceId(String value) {
+        this.spannerInstanceId = value;
+        return this;
+      }
+
+      public DataChangeRecordToJsonTextFn build() {
+        return new DataChangeRecordToJsonTextFn(this);
+      }
     }
   }
 }

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToJson.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToJson.java
@@ -22,6 +22,7 @@ import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.DataChangeRecord;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,19 +38,12 @@ public abstract class WriteDataChangeRecordsToJson {
 
   static class DataChangeRecordToJsonTextFn extends SimpleFunction<DataChangeRecord, String> {
     private static Gson gson = new Gson();
-
-    private boolean includeSpannerResource = false;
-
-    private String spannerDatabase;
+    private String spannerDatabaseId;
 
     private String spannerInstanceId;
 
-    public Boolean includeSpannerSource() {
-      return includeSpannerResource;
-    }
-
-    public String spannerDatabase() {
-      return spannerDatabase;
+    public String spannerDatabaseId() {
+      return spannerDatabaseId;
     }
 
     public String spannerInstanceId() {
@@ -59,16 +53,15 @@ public abstract class WriteDataChangeRecordsToJson {
     public DataChangeRecordToJsonTextFn() {}
 
     private DataChangeRecordToJsonTextFn(Builder builder) {
-      this.includeSpannerResource = builder.includeSpannerResource;
-      this.spannerDatabase = builder.spannerDatabase;
+      this.spannerDatabaseId = builder.spannerDatabaseId;
       this.spannerInstanceId = builder.spannerInstanceId;
     }
 
     @Override
     public String apply(DataChangeRecord record) {
-      if (includeSpannerSource()) {
+      if (!StringUtils.isEmpty(spannerDatabaseId()) && !StringUtils.isEmpty(spannerInstanceId())) {
         JsonElement jsonElement = gson.toJsonTree(record);
-        jsonElement.getAsJsonObject().addProperty("spannerDatabase", spannerDatabase());
+        jsonElement.getAsJsonObject().addProperty("spannerDatabaseId", spannerDatabaseId());
         jsonElement.getAsJsonObject().addProperty("spannerInstanceId", spannerInstanceId());
         return gson.toJson(jsonElement);
       }
@@ -76,18 +69,11 @@ public abstract class WriteDataChangeRecordsToJson {
     }
 
     static class Builder {
-      private boolean includeSpannerResource = false;
-      private String spannerDatabase;
-
+      private String spannerDatabaseId;
       private String spannerInstanceId;
 
-      public Builder setIncludeSpannerSource(Boolean value) {
-        this.includeSpannerResource = value;
-        return this;
-      }
-
-      public Builder setSpannerDatabase(String value) {
-        this.spannerDatabase = value;
+      public Builder setSpannerDatabaseId(String value) {
+        this.spannerDatabaseId = value;
         return this;
       }
 

--- a/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/datachangerecord.avsc
+++ b/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/datachangerecord.avsc
@@ -60,7 +60,7 @@
       "type" : {
         "name": "ValueCaptureType",
         "type": "enum",
-        "symbols": ["OLD_AND_NEW_VALUES", "NEW_ROW", "NEW_VALUES", "NEW_ROW_AND_OLD_VALUES"]
+        "symbols": ["OLD_AND_NEW_VALUES", "NEW_ROW", "NEW_VALUES"]
       }
     },
     { "name" : "numberOfRecordsInTransaction", "type" : "long"},
@@ -84,7 +84,7 @@
           { "name" : "numberOfRecordsRead","type":"long"}
         ]
         }],"default":null},
-        {"name": "spannerDatabase", "type": ["null", "string"], "default": null },
+        {"name": "spannerDatabaseId", "type": ["null", "string"], "default": null },
         {"name": "spannerInstanceId", "type": ["null", "string"], "default": null }
     ]
     }

--- a/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/datachangerecord.avsc
+++ b/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/datachangerecord.avsc
@@ -60,7 +60,7 @@
       "type" : {
         "name": "ValueCaptureType",
         "type": "enum",
-        "symbols": ["OLD_AND_NEW_VALUES", "NEW_ROW", "NEW_VALUES"]
+        "symbols": ["OLD_AND_NEW_VALUES", "NEW_ROW", "NEW_VALUES", "NEW_ROW_AND_OLD_VALUES"]
       }
     },
     { "name" : "numberOfRecordsInTransaction", "type" : "long"},
@@ -83,6 +83,8 @@
           { "name" : "totalStreamTimeMillis", "type":"long"},
           { "name" : "numberOfRecordsRead","type":"long"}
         ]
-        }],"default":null}
+        }],"default":null},
+        {"name": "spannerDatabase", "type": ["null", "string"], "default": null },
+        {"name": "spannerInstanceId", "type": ["null", "string"], "default": null }
     ]
     }

--- a/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/datachangerecord.avsc
+++ b/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/datachangerecord.avsc
@@ -85,6 +85,7 @@
         ]
         }],"default":null},
         {"name": "spannerDatabaseId", "type": ["null", "string"], "default": null },
-        {"name": "spannerInstanceId", "type": ["null", "string"], "default": null }
+        {"name": "spannerInstanceId", "type": ["null", "string"], "default": null },
+        {"name": "outputMessageMetadata", "type": ["null", "string"], "default": null }
     ]
     }

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToPubSubIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToPubSubIT.java
@@ -18,12 +18,15 @@ package com.google.cloud.teleport.v2.templates;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatRecords;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
+import static org.junit.Assert.assertEquals;
 
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
 import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.google.pubsub.v1.SubscriptionName;
 import com.google.pubsub.v1.TopicName;
 import java.io.IOException;
@@ -40,8 +43,10 @@ import org.apache.beam.it.gcp.artifacts.utils.JsonTestUtil;
 import org.apache.beam.it.gcp.pubsub.PubsubResourceManager;
 import org.apache.beam.it.gcp.pubsub.conditions.PubsubMessagesCheck;
 import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
+import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.DataChangeRecord;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.Mod;
+import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -79,7 +84,7 @@ public class SpannerChangeStreamsToPubSubIT extends TemplateTestBase {
   }
 
   @Test
-  public void testSpannerChangeStreamsToPubsub() throws IOException {
+  public void testSpannerChangeStreamsToPubsubJson() throws IOException {
     // Arrange
     String createTableStatement =
         String.format(
@@ -113,7 +118,8 @@ public class SpannerChangeStreamsToPubSubIT extends TemplateTestBase {
             .addParameter("spannerChangeStreamName", testName + "_stream")
             .addParameter("pubsubTopic", outputTopic.getTopic())
             .addParameter("outputDataFormat", "JSON")
-            .addParameter("rpcPriority", "HIGH");
+            .addParameter("rpcPriority", "HIGH")
+            .addParameter("includeSpannerSource", "true");
 
     PipelineLauncher.LaunchInfo info = launchTemplate(options);
     assertThatPipeline(info).isRunning();
@@ -138,11 +144,17 @@ public class SpannerChangeStreamsToPubSubIT extends TemplateTestBase {
         .getReceivedMessageList()
         .forEach(
             receivedMessage -> {
-              DataChangeRecord s =
-                  new Gson()
-                      .fromJson(
-                          new String(receivedMessage.getMessage().getData().toStringUtf8()),
-                          DataChangeRecord.class);
+              JsonObject o =
+                  new JsonParser()
+                      .parse(receivedMessage.getMessage().getData().toStringUtf8())
+                      .getAsJsonObject();
+              assertEquals(
+                  o.get("spannerDatabase").getAsString(), spannerResourceManager.getDatabaseId());
+              assertEquals(
+                  o.get("spannerInstanceId").getAsString(), spannerResourceManager.getInstanceId());
+              o.remove("spannerDatabase");
+              o.remove("spannerInstanceId");
+              DataChangeRecord s = new Gson().fromJson(o, DataChangeRecord.class);
               for (Mod mod : s.getMods()) {
                 Map<String, Object> record = new HashMap<>();
                 try {
@@ -169,6 +181,83 @@ public class SpannerChangeStreamsToPubSubIT extends TemplateTestBase {
           expectedRecords.add(expectedRecord);
         });
     assertThatRecords(records).hasRecordsUnorderedCaseInsensitiveColumns(expectedRecords);
+  }
+
+  @Test
+  public void testSpannerChangeStreamsToPubsubSpannerSourceAvro() throws IOException {
+    // Arrange
+    String createTableStatement =
+        String.format(
+            "CREATE TABLE `%s` (\n"
+                + "  Id INT64 NOT NULL,\n"
+                + "  FirstName String(1024),\n"
+                + "  LastName String(1024),\n"
+                + "  Float32Col FLOAT32,\n"
+                + "  Float64Col FLOAT64,\n"
+                + ") PRIMARY KEY(Id)",
+            testName);
+    spannerResourceManager.executeDdlStatement(createTableStatement);
+
+    String createChangeStreamStatement =
+        String.format("CREATE CHANGE STREAM %s_stream FOR %s", testName, testName);
+    spannerResourceManager.executeDdlStatement(createChangeStreamStatement);
+
+    TopicName outputTopic = pubsubResourceManager.createTopic(String.format("%s-topic", testName));
+    SubscriptionName outputSubscription =
+        pubsubResourceManager.createSubscription(
+            outputTopic, String.format("%s-subscription", testName));
+
+    // Act
+    PipelineLauncher.LaunchConfig.Builder options =
+        PipelineLauncher.LaunchConfig.builder(testName, specPath)
+            .addParameter("spannerProjectId", PROJECT)
+            .addParameter("spannerInstanceId", spannerResourceManager.getInstanceId())
+            .addParameter("spannerDatabase", spannerResourceManager.getDatabaseId())
+            .addParameter("spannerMetadataInstanceId", spannerResourceManager.getInstanceId())
+            .addParameter("spannerMetadataDatabase", spannerResourceManager.getDatabaseId())
+            .addParameter("spannerChangeStreamName", testName + "_stream")
+            .addParameter("pubsubTopic", outputTopic.getTopic())
+            .addParameter("outputDataFormat", "AVRO")
+            .addParameter("rpcPriority", "HIGH")
+            .addParameter("includeSpannerSource", "true");
+
+    PipelineLauncher.LaunchInfo info = launchTemplate(options);
+    assertThatPipeline(info).isRunning();
+
+    List<Mutation> expectedData = generateTableRows(testName);
+    spannerResourceManager.write(expectedData);
+
+    PubsubMessagesCheck pubsubCheck =
+        PubsubMessagesCheck.builder(pubsubResourceManager, outputSubscription)
+            // Expecting only 1 message, but that message has all of spanner table's data
+            .setMinMessages(1)
+            .build();
+
+    PipelineOperator.Result result =
+        pipelineOperator().waitForConditionAndCancel(createConfig(info), pubsubCheck);
+
+    // Assert
+    assertThatResult(result).meetsConditions();
+
+    AvroCoder<com.google.cloud.teleport.v2.DataChangeRecord> coder =
+        AvroCoder.of(com.google.cloud.teleport.v2.DataChangeRecord.class);
+    pubsubCheck
+        .getReceivedMessageList()
+        .forEach(
+            receivedMessage -> {
+              try {
+                com.google.cloud.teleport.v2.DataChangeRecord avroRecord =
+                    CoderUtils.decodeFromByteArray(
+                        coder, receivedMessage.getMessage().getData().toByteArray());
+                assertEquals(
+                    avroRecord.get("spannerDatabase"), spannerResourceManager.getDatabaseId());
+                assertEquals(
+                    avroRecord.get("spannerInstanceId"), spannerResourceManager.getInstanceId());
+              } catch (IOException e) {
+                throw new RuntimeException(
+                    "Error reading " + outputTopic.toString() + " as AVRO.", e);
+              }
+            });
   }
 
   private static String valueToString(Value val) {

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToPubSubIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToPubSubIT.java
@@ -149,10 +149,10 @@ public class SpannerChangeStreamsToPubSubIT extends TemplateTestBase {
                       .parse(receivedMessage.getMessage().getData().toStringUtf8())
                       .getAsJsonObject();
               assertEquals(
-                  o.get("spannerDatabase").getAsString(), spannerResourceManager.getDatabaseId());
+                  o.get("spannerDatabaseId").getAsString(), spannerResourceManager.getDatabaseId());
               assertEquals(
                   o.get("spannerInstanceId").getAsString(), spannerResourceManager.getInstanceId());
-              o.remove("spannerDatabase");
+              o.remove("spannerDatabaseId");
               o.remove("spannerInstanceId");
               DataChangeRecord s = new Gson().fromJson(o, DataChangeRecord.class);
               for (Mod mod : s.getMods()) {
@@ -184,7 +184,7 @@ public class SpannerChangeStreamsToPubSubIT extends TemplateTestBase {
   }
 
   @Test
-  public void testSpannerChangeStreamsToPubsubSpannerSourceAvro() throws IOException {
+  public void testSpannerChangeStreamsToPubsubAvro() throws IOException {
     // Arrange
     String createTableStatement =
         String.format(
@@ -250,7 +250,7 @@ public class SpannerChangeStreamsToPubSubIT extends TemplateTestBase {
                     CoderUtils.decodeFromByteArray(
                         coder, receivedMessage.getMessage().getData().toByteArray());
                 assertEquals(
-                    avroRecord.get("spannerDatabase"), spannerResourceManager.getDatabaseId());
+                    avroRecord.get("spannerDatabaseId"), spannerResourceManager.getDatabaseId());
                 assertEquals(
                     avroRecord.get("spannerInstanceId"), spannerResourceManager.getInstanceId());
               } catch (IOException e) {

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToPubSubIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToPubSubIT.java
@@ -119,7 +119,8 @@ public class SpannerChangeStreamsToPubSubIT extends TemplateTestBase {
             .addParameter("pubsubTopic", outputTopic.getTopic())
             .addParameter("outputDataFormat", "JSON")
             .addParameter("rpcPriority", "HIGH")
-            .addParameter("includeSpannerSource", "true");
+            .addParameter("includeSpannerSource", "true")
+            .addParameter("outputMessageMetadata", "us-central1");
 
     PipelineLauncher.LaunchInfo info = launchTemplate(options);
     assertThatPipeline(info).isRunning();
@@ -152,8 +153,10 @@ public class SpannerChangeStreamsToPubSubIT extends TemplateTestBase {
                   o.get("spannerDatabaseId").getAsString(), spannerResourceManager.getDatabaseId());
               assertEquals(
                   o.get("spannerInstanceId").getAsString(), spannerResourceManager.getInstanceId());
+              assertEquals(o.get("outputMessageMetadata").getAsString(), "us-central1");
               o.remove("spannerDatabaseId");
               o.remove("spannerInstanceId");
+              o.remove("outputMessageMetadata");
               DataChangeRecord s = new Gson().fromJson(o, DataChangeRecord.class);
               for (Mod mod : s.getMods()) {
                 Map<String, Object> record = new HashMap<>();
@@ -219,7 +222,8 @@ public class SpannerChangeStreamsToPubSubIT extends TemplateTestBase {
             .addParameter("pubsubTopic", outputTopic.getTopic())
             .addParameter("outputDataFormat", "AVRO")
             .addParameter("rpcPriority", "HIGH")
-            .addParameter("includeSpannerSource", "true");
+            .addParameter("includeSpannerSource", "true")
+            .addParameter("outputMessageMetadata", "us-central1");
 
     PipelineLauncher.LaunchInfo info = launchTemplate(options);
     assertThatPipeline(info).isRunning();
@@ -253,6 +257,7 @@ public class SpannerChangeStreamsToPubSubIT extends TemplateTestBase {
                     avroRecord.get("spannerDatabaseId"), spannerResourceManager.getDatabaseId());
                 assertEquals(
                     avroRecord.get("spannerInstanceId"), spannerResourceManager.getInstanceId());
+                assertEquals(avroRecord.get("outputMessageMetadata"), "us-central1");
               } catch (IOException e) {
                 throw new RuntimeException(
                     "Error reading " + outputTopic.toString() + " as AVRO.", e);

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToAvroTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToAvroTest.java
@@ -76,6 +76,12 @@ public class WriteDataChangeRecordsToAvroTest {
 
     PAssert.that(dataChangeRecords)
         .containsInAnyOrder(converter.dataChangeRecordToAvro(dataChangeRecord));
+
+    com.google.cloud.teleport.v2.DataChangeRecord dataChangeRecordAvro =
+        converter.dataChangeRecordToAvro(dataChangeRecord);
+    assertEquals(dataChangeRecordAvro.get("spannerDatabaseId"), null);
+    assertEquals(dataChangeRecordAvro.get("spannerInstanceId"), null);
+
     testPipeline.run();
   }
 
@@ -84,8 +90,7 @@ public class WriteDataChangeRecordsToAvroTest {
     // First run the transform in a separate pipeline.
     DataChangeRecordToAvroFn converter =
         new DataChangeRecordToAvroFn.Builder()
-            .setIncludeSpannerSource(true)
-            .setSpannerDatabase("test-db")
+            .setSpannerDatabaseId("test-db")
             .setSpannerInstanceId("test-instance")
             .build();
     final DataChangeRecord dataChangeRecord = createTestDataChangeRecord();
@@ -97,11 +102,12 @@ public class WriteDataChangeRecordsToAvroTest {
                 ParDo.of(new DataChangeRecordToAvroTestFn(converter)));
     p.run();
 
-    com.google.cloud.teleport.v2.DataChangeRecord dataChangeRecordAvro =
-        converter.dataChangeRecordToAvro(dataChangeRecord);
     PAssert.that(dataChangeRecords)
         .containsInAnyOrder(converter.dataChangeRecordToAvro(dataChangeRecord));
-    assertEquals(dataChangeRecordAvro.get("spannerDatabase"), "test-db");
+
+    com.google.cloud.teleport.v2.DataChangeRecord dataChangeRecordAvro =
+        converter.dataChangeRecordToAvro(dataChangeRecord);
+    assertEquals(dataChangeRecordAvro.get("spannerDatabaseId"), "test-db");
     assertEquals(dataChangeRecordAvro.get("spannerInstanceId"), "test-instance");
     testPipeline.run();
   }

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToAvroTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToAvroTest.java
@@ -15,9 +15,10 @@
  */
 package com.google.cloud.teleport.v2.transforms;
 
-import static com.google.cloud.teleport.v2.transforms.WriteDataChangeRecordsToAvro.dataChangeRecordToAvro;
+import static org.junit.Assert.assertEquals;
 
 import com.google.cloud.Timestamp;
+import com.google.cloud.teleport.v2.transforms.WriteDataChangeRecordsToAvro.DataChangeRecordToAvroFn;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -63,14 +64,45 @@ public class WriteDataChangeRecordsToAvroTest {
   @Test
   public void testBasicWrite() {
     // First run the transform in a separate pipeline.
+    DataChangeRecordToAvroFn converter = new DataChangeRecordToAvroFn.Builder().build();
     final DataChangeRecord dataChangeRecord = createTestDataChangeRecord();
     Pipeline p = Pipeline.create(options);
     PCollection<com.google.cloud.teleport.v2.DataChangeRecord> dataChangeRecords =
         p.apply("CreateInput", Create.of(dataChangeRecord))
-            .apply("Write DataChangeRecord into AVRO", ParDo.of(new DataChangeRecordToAvroFn()));
+            .apply(
+                "Write DataChangeRecord into AVRO",
+                ParDo.of(new DataChangeRecordToAvroTestFn(converter)));
     p.run();
 
-    PAssert.that(dataChangeRecords).containsInAnyOrder(dataChangeRecordToAvro(dataChangeRecord));
+    PAssert.that(dataChangeRecords)
+        .containsInAnyOrder(converter.dataChangeRecordToAvro(dataChangeRecord));
+    testPipeline.run();
+  }
+
+  @Test
+  public void testSpannerSourceFields() {
+    // First run the transform in a separate pipeline.
+    DataChangeRecordToAvroFn converter =
+        new DataChangeRecordToAvroFn.Builder()
+            .setIncludeSpannerSource(true)
+            .setSpannerDatabase("test-db")
+            .setSpannerInstanceId("test-instance")
+            .build();
+    final DataChangeRecord dataChangeRecord = createTestDataChangeRecord();
+    Pipeline p = Pipeline.create(options);
+    PCollection<com.google.cloud.teleport.v2.DataChangeRecord> dataChangeRecords =
+        p.apply("CreateInput", Create.of(dataChangeRecord))
+            .apply(
+                "Write DataChangeRecord into AVRO",
+                ParDo.of(new DataChangeRecordToAvroTestFn(converter)));
+    p.run();
+
+    com.google.cloud.teleport.v2.DataChangeRecord dataChangeRecordAvro =
+        converter.dataChangeRecordToAvro(dataChangeRecord);
+    PAssert.that(dataChangeRecords)
+        .containsInAnyOrder(converter.dataChangeRecordToAvro(dataChangeRecord));
+    assertEquals(dataChangeRecordAvro.get("spannerDatabase"), "test-db");
+    assertEquals(dataChangeRecordAvro.get("spannerInstanceId"), "test-instance");
     testPipeline.run();
   }
 
@@ -99,13 +131,18 @@ public class WriteDataChangeRecordsToAvroTest {
         null);
   }
 
-  static class DataChangeRecordToAvroFn
+  static class DataChangeRecordToAvroTestFn
       extends DoFn<DataChangeRecord, com.google.cloud.teleport.v2.DataChangeRecord> {
+    DataChangeRecordToAvroFn converter;
+
+    public DataChangeRecordToAvroTestFn(DataChangeRecordToAvroFn converter) {
+      this.converter = converter;
+    }
 
     @ProcessElement
     public void processElement(ProcessContext context) {
       DataChangeRecord record = context.element();
-      context.output(dataChangeRecordToAvro(record));
+      context.output(converter.dataChangeRecordToAvro(record));
     }
   }
 }

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToGcsAvroTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToGcsAvroTest.java
@@ -15,8 +15,6 @@
  */
 package com.google.cloud.teleport.v2.transforms;
 
-import static com.google.cloud.teleport.v2.transforms.WriteDataChangeRecordsToAvro.DataChangeRecordToAvroFn.*;
-
 import com.google.cloud.Timestamp;
 import com.google.cloud.teleport.v2.transforms.WriteDataChangeRecordsToAvro.DataChangeRecordToAvroFn;
 import java.io.IOException;

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToGcsAvroTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToGcsAvroTest.java
@@ -15,7 +15,10 @@
  */
 package com.google.cloud.teleport.v2.transforms;
 
+import static com.google.cloud.teleport.v2.transforms.WriteDataChangeRecordsToAvro.DataChangeRecordToAvroFn.*;
+
 import com.google.cloud.Timestamp;
+import com.google.cloud.teleport.v2.transforms.WriteDataChangeRecordsToAvro.DataChangeRecordToAvroFn;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -85,7 +88,8 @@ public class WriteDataChangeRecordsToGcsAvroTest {
             AvroIO.read(com.google.cloud.teleport.v2.DataChangeRecord.class)
                 .from(fakeDir + "/avro-output-GlobalWindow-pane-0-last-00-of-01.avro"));
     PAssert.that(dataChangeRecords)
-        .containsInAnyOrder(WriteDataChangeRecordsToAvro.dataChangeRecordToAvro(dataChangeRecord));
+        .containsInAnyOrder(
+            new DataChangeRecordToAvroFn().dataChangeRecordToAvro(dataChangeRecord));
     pipeline.run();
   }
 

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToJsonTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToJsonTest.java
@@ -83,8 +83,7 @@ public class WriteDataChangeRecordsToJsonTest {
   public void testSpannerSourceFieldsArePopulated() {
     DataChangeRecordToJsonTextFn converter =
         new DataChangeRecordToJsonTextFn.Builder()
-            .setIncludeSpannerSource(true)
-            .setSpannerDatabase("test-db")
+            .setSpannerDatabaseId("test-db")
             .setSpannerInstanceId("test-instance")
             .build();
     // First run the transform in a separate pipeline.
@@ -98,7 +97,8 @@ public class WriteDataChangeRecordsToJsonTest {
     String dataChangeRecordJsonStr = converter.apply(dataChangeRecord);
     assertThat(
         dataChangeRecordJsonStr,
-        containsString("\"spannerDatabase\":\"test-db\",\"spannerInstanceId\":\"test-instance\""));
+        containsString(
+            "\"spannerDatabaseId\":\"test-db\",\"spannerInstanceId\":\"test-instance\""));
 
     PAssert.that(dataChangeRecords).containsInAnyOrder(dataChangeRecordJsonStr);
 

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToJsonTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToJsonTest.java
@@ -16,6 +16,8 @@
 package com.google.cloud.teleport.v2.transforms;
 
 import static com.google.cloud.teleport.v2.transforms.WriteDataChangeRecordsToJson.DataChangeRecordToJsonTextFn;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 
 import com.google.cloud.Timestamp;
 import com.google.gson.Gson;
@@ -64,16 +66,42 @@ public class WriteDataChangeRecordsToJsonTest {
   /** Test the basic WriteDataChangeRecordsToPubSubJsonTest transform. */
   @Test
   public void testBasicWrite() {
+    DataChangeRecordToJsonTextFn converter = new DataChangeRecordToJsonTextFn();
     // First run the transform in a separate pipeline.
     final DataChangeRecord dataChangeRecord = createTestDataChangeRecord();
     Pipeline p = Pipeline.create(options);
     PCollection<String> dataChangeRecords =
         p.apply("CreateInput", Create.of(dataChangeRecord))
-            .apply("WriteToPubSubInJson", MapElements.via(new DataChangeRecordToJsonTextFn()));
+            .apply("WriteToPubSubInJson", MapElements.via(converter));
     p.run();
 
-    PAssert.that(dataChangeRecords)
-        .containsInAnyOrder(gson.toJson(dataChangeRecord, DataChangeRecord.class));
+    PAssert.that(dataChangeRecords).containsInAnyOrder(converter.apply(dataChangeRecord));
+    testPipeline.run();
+  }
+
+  @Test
+  public void testSpannerSourceFieldsArePopulated() {
+    DataChangeRecordToJsonTextFn converter =
+        new DataChangeRecordToJsonTextFn.Builder()
+            .setIncludeSpannerSource(true)
+            .setSpannerDatabase("test-db")
+            .setSpannerInstanceId("test-instance")
+            .build();
+    // First run the transform in a separate pipeline.
+    final DataChangeRecord dataChangeRecord = createTestDataChangeRecord();
+    Pipeline p = Pipeline.create(options);
+    PCollection<String> dataChangeRecords =
+        p.apply("CreateInput", Create.of(dataChangeRecord))
+            .apply("WriteToPubSubInJson", MapElements.via(converter));
+    p.run();
+
+    String dataChangeRecordJsonStr = converter.apply(dataChangeRecord);
+    assertThat(
+        dataChangeRecordJsonStr,
+        containsString("\"spannerDatabase\":\"test-db\",\"spannerInstanceId\":\"test-instance\""));
+
+    PAssert.that(dataChangeRecords).containsInAnyOrder(dataChangeRecordJsonStr);
+
     testPipeline.run();
   }
 


### PR DESCRIPTION
Introduce two new options for Spanner Change Streams to Pub/Sub template.

1. `includeSpannerSource`: boolean option default to false.
If this config is set to true, two new fields `spannerDatabaseId` and `spannerInstanceId` will be populated to the message data field with the associate values.

2. `outputMessageData`: string option default to empty.
If this config has non-empty string value, the string value will be populated to the `outputMessageMetadata` field in output pub sub message body. 

I verified correctness for both AVRO and JSON data formats through integration tests in `SpannerChangeStreamsToPubSubIT.java`.