### PR TITLE
Upgrade Beam version to 2.58.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
     <jacoco.version>0.8.8</jacoco.version>
 
     <!-- Beam and linked versions -->
-    <beam.version>2.57.0</beam.version>
-    <beam-python.version>2.57.0</beam-python.version>
+    <beam.version>2.58.0</beam.version>
+    <beam-python.version>2.58.0</beam-python.version>
     <beam-maven-repo></beam-maven-repo>
 
     <!-- Common dependency versions -->


### PR DESCRIPTION
Bumps the Beam version to the newly released 2.58.0. 