### PR TITLE
KafkaToBigQueryFlex Template: Expose source message offset in DLQ metadata (for Json format only)

### DIFF
--- a/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/transforms/KafkaRecordErrorConverters.java
+++ b/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/transforms/KafkaRecordErrorConverters.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.kafka.transforms;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.transforms.ErrorConverters;
+import com.google.cloud.teleport.v2.transforms.ErrorConverters.PayloadExtractor;
+import com.google.cloud.teleport.v2.transforms.ErrorConverters.WriteAbstractMessageErrors;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import org.apache.beam.sdk.io.kafka.KafkaRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KafkaRecordErrorConverters {
+  private static final Logger LOG = LoggerFactory.getLogger(ErrorConverters.class);
+
+  @AutoValue
+  public abstract static class WriteKafkaRecordMessageErrors
+      extends WriteAbstractMessageErrors<KafkaRecord<String, String>> {
+    public abstract String getErrorRecordsTable();
+
+    public abstract String getErrorRecordsTableSchema();
+
+    @Override
+    protected ErrorConverters.PayloadExtractor<KafkaRecord<String, String>>
+        createPayloadExtractor() {
+      return new KafkaRecordPayloadExtractor();
+    }
+
+    public static Builder newBuilder() {
+      return new AutoValue_KafkaRecordErrorConverters_WriteKafkaRecordMessageErrors.Builder();
+    }
+
+    /** Builder for {@link WriteKafkaRecordMessageErrors}. */
+    @AutoValue.Builder
+    public abstract static class Builder {
+      public abstract Builder setErrorRecordsTable(String errorRecordsTable);
+
+      public abstract Builder setErrorRecordsTableSchema(String errorRecordsTableSchema);
+
+      public abstract WriteKafkaRecordMessageErrors build();
+    }
+  }
+
+  public static class KafkaRecordPayloadExtractor
+      implements PayloadExtractor<KafkaRecord<String, String>>, Serializable {
+
+    @Override
+    public String getPayloadString(KafkaRecord<String, String> message) {
+      ObjectWriter objectWriter = new ObjectMapper().writer().withDefaultPrettyPrinter();
+      String payloadString = "";
+      try {
+        payloadString = objectWriter.writeValueAsString(message);
+      } catch (Exception e) {
+        LOG.error(
+            "Unable to serialize record as JSON. Human readable record attempted via "
+                + ".toString",
+            e);
+        try {
+          payloadString = message.toString();
+        } catch (Exception e2) {
+          LOG.error(
+              "Unable to serialize record via .toString. Human readable record will be " + "null",
+              e2);
+        }
+      }
+      return payloadString;
+    }
+
+    @Override
+    public byte[] getPayloadBytes(KafkaRecord<String, String> message) {
+      if (message == null) {
+        return null;
+      }
+      return (message.getKV().getValue() == null
+          ? "".getBytes(StandardCharsets.UTF_8)
+          : message.getKV().getValue().getBytes(StandardCharsets.UTF_8));
+    }
+  }
+}

--- a/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/transforms/KafkaTransform.java
+++ b/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/transforms/KafkaTransform.java
@@ -51,7 +51,7 @@ public class KafkaTransform {
    * @param config configuration for the Kafka consumer
    * @return PCollection of Kafka Key & Value Pair deserialized in string format
    */
-  public static PTransform<PBegin, PCollection<KV<String, String>>> readStringFromKafka(
+  public static KafkaIO.Read<String, String> readStringFromKafka(
       String bootstrapServers,
       List<String> topicsList,
       Map<String, Object> config,
@@ -72,7 +72,8 @@ public class KafkaTransform {
     if (enableCommitOffsets) {
       kafkaRecords = kafkaRecords.commitOffsetsInFinalize();
     }
-    return kafkaRecords.withoutMetadata();
+    return kafkaRecords;
+    // topic, partition, source offset
   }
 
   /**

--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/KafkaToBigQuery.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/KafkaToBigQuery.java
@@ -28,7 +28,7 @@ import com.google.cloud.teleport.v2.templates.KafkaToBigQuery.KafkaToBQOptions;
 import com.google.cloud.teleport.v2.transforms.BigQueryConverters;
 import com.google.cloud.teleport.v2.transforms.BigQueryConverters.FailsafeJsonToTableRow;
 import com.google.cloud.teleport.v2.transforms.ErrorConverters;
-import com.google.cloud.teleport.v2.transforms.ErrorConverters.WriteKafkaMessageErrors;
+import com.google.cloud.teleport.v2.transforms.ErrorConverters.WriteStringKVMessageErrors;
 import com.google.cloud.teleport.v2.transforms.JavascriptTextTransformer.FailsafeJavascriptUdf;
 import com.google.cloud.teleport.v2.transforms.JavascriptTextTransformer.JavascriptTextTransformerOptions;
 import com.google.cloud.teleport.v2.utils.BigQueryIOUtils;
@@ -397,7 +397,8 @@ public class KafkaToBigQuery {
             .apply(
                 "ReadFromKafka",
                 KafkaTransform.readStringFromKafka(
-                    bootstrapServers, topicsList, kafkaConfig, null, false))
+                        bootstrapServers, topicsList, kafkaConfig, null, false)
+                    .withoutMetadata())
 
             /*
              * Step #2: Transform the Kafka Messages into TableRows
@@ -439,7 +440,7 @@ public class KafkaToBigQuery {
         .apply("Flatten", Flatten.pCollections())
         .apply(
             "WriteTransformationFailedRecords",
-            WriteKafkaMessageErrors.newBuilder()
+            WriteStringKVMessageErrors.newBuilder()
                 .setErrorRecordsTable(
                     ObjectUtils.firstNonNull(
                         options.getOutputDeadletterTable(),
@@ -546,7 +547,7 @@ public class KafkaToBigQuery {
           .apply("Flatten", Flatten.pCollections())
           .apply(
               "WriteTransformationFailedRecords",
-              WriteKafkaMessageErrors.newBuilder()
+              WriteStringKVMessageErrors.newBuilder()
                   .setErrorRecordsTable(
                       ObjectUtils.firstNonNull(
                           options.getOutputDeadletterTable(),


### PR DESCRIPTION
 Modify the Kafka to BigQuery Flex pipeline such that topic, partition, and source offset can be written to the DLQ. Currently, this is only supported for failures converting the records into table rows.