### PR TITLE
Finetuning DbCp2 Parameters for Bulk Reader for string tall table connection drop issue.

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcDataSource.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcDataSource.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper;
+
+import com.google.cloud.teleport.v2.source.reader.auth.dbauth.DbAuth;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.JdbcIOWrapperConfig;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.JarFileReader;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.net.URLClassLoader;
+import javax.sql.DataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.commons.lang3.StringUtils;
+import org.jline.utils.Log;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link Serializable} extension of {@link BasicDataSource}.
+ *
+ * <p>{@link org.apache.beam.sdk.io.jdbc.JdbcIO JdbcIO} provides 2 ways to register a {@lnk
+ * DataSource} for reading:
+ *
+ * <ol>
+ *   <li>Through {@link org.apache.beam.sdk.io.jdbc.JdbcIO.DataSourceConfiguration
+ *       DataSourceConfiguration} - This provides an extremely limited set of tunables like maximum
+ *       connection in the pool.
+ *   <li>By passing a serializable {@link javax.sql.DataSource}
+ * </ol>
+ *
+ * For long lived connections, it's needed to tune the eviction times and idle times of the
+ * connection pool. This needs us to pass a serializable datasource to {@link
+ * org.apache.beam.sdk.io.jdbc.JdbcIO JdbcIO}. Since the native java {@link DataSource} is not
+ * serializable, we extend the DataSource and serialize and deserialize the required properties that
+ * we need to fine tune.
+ *
+ * @see <a
+ *     href=https://commons.apache.org/proper/commons-dbcp/configuration.html>commons-dbcp/configuration</a>
+ */
+public final class JdbcDataSource extends BasicDataSource implements Serializable {
+
+  /*
+   * Implementation Detail, we take required members of JDBCIOWrapperConfig as private members here since there are members of JDBCIOWrapperConfig like FluentBackoff which aren't marked serializable by Apache Beam.
+   */
+
+  private final String sourceDbURL;
+  private final DbAuth dbAuth;
+  private final ImmutableList<String> initSql;
+  private final Long maxConnections;
+  private final String jdbcDriverJars;
+  private final String jdbcDriverClassName;
+  private static final Logger LOG = LoggerFactory.getLogger(JdbcDataSource.class);
+
+  /**
+   * Sets the {@code testOnBorrow} property. This property determines whether or not the pool will
+   * validate objects before they are borrowed from the pool. Defaults to True.
+   */
+  private final Boolean testOnBorrow;
+
+  /**
+   * Sets the {@code testOnCreate} property. This property determines whether or not the pool will
+   * validate objects immediately after they are created by the pool.
+   */
+  private final Boolean testOnCreate;
+
+  /**
+   * Sets the {@code testOnReturn} property. This property determines whether or not the pool will
+   * validate objects before they are returned to the pool.
+   */
+  private final Boolean testOnReturn;
+
+  /**
+   * Sets the {@code testWhileIdle} property. This property determines whether or not the idle
+   * object evictor will validate connections.
+   */
+  private final Boolean testWhileIdle;
+
+  /** Sets the {@code validationQuery}. */
+  private final String validationQuery;
+
+  /**
+   * The timeout in seconds before an abandoned connection can be removed.
+   *
+   * <p>Creating a Statement, PreparedStatement or CallableStatement or using one of these to
+   * execute a query (using one of the execute methods) resets the lastUsed property of the parent
+   * connection.
+   *
+   * <p>Abandoned connection cleanup happens when:
+   *
+   * <ul>
+   *   <li>{@link BasicDataSource#getRemoveAbandonedOnBorrow()} or {@link
+   *       BasicDataSource#getRemoveAbandonedOnMaintenance()} = true
+   *   <li>{@link BasicDataSource#getNumIdle() numIdle} &lt; 2
+   *   <li>{@link BasicDataSource#getNumActive() numActive} &gt; {@link
+   *       BasicDataSource#getMaxTotal() maxTotal} - 3
+   * </ul>
+   *
+   * <p>
+   */
+  private final Integer removeAbandonedTimeout;
+
+  /**
+   * The minimum amount of time an object may sit idle in the pool before it is eligible for
+   * eviction by the idle object evictor.
+   */
+  private final Integer minEvictableIdleTimeMillis;
+
+  public JdbcDataSource(JdbcIOWrapperConfig jdbcIOWrapperConfig) {
+    this.sourceDbURL = jdbcIOWrapperConfig.sourceDbURL();
+    this.dbAuth = jdbcIOWrapperConfig.dbAuth();
+    this.initSql = jdbcIOWrapperConfig.sqlInitSeq();
+    this.maxConnections = jdbcIOWrapperConfig.maxConnections();
+    this.jdbcDriverClassName = jdbcIOWrapperConfig.jdbcDriverClassName();
+    this.jdbcDriverJars = jdbcIOWrapperConfig.jdbcDriverJars();
+    this.testOnBorrow = jdbcIOWrapperConfig.testOnBorrow();
+    this.testOnCreate = jdbcIOWrapperConfig.testOnCreate();
+    this.testOnReturn = jdbcIOWrapperConfig.testOnReturn();
+    this.testWhileIdle = jdbcIOWrapperConfig.testWhileIdle();
+    this.validationQuery = jdbcIOWrapperConfig.validationQuery();
+    this.removeAbandonedTimeout = jdbcIOWrapperConfig.removeAbandonedTimeout();
+    this.minEvictableIdleTimeMillis = jdbcIOWrapperConfig.minEvictableIdleTimeMillis();
+    this.initializeSuper();
+  }
+
+  private void initializeSuper() {
+
+    Log.info("Initializing {}", this);
+
+    super.setDriverClassName(jdbcDriverClassName);
+
+    /**
+     * This has been tested in an end to end migration and can't be unit tested as the jars are not
+     * provided in GCS for UT.
+     */
+    if (!StringUtils.isBlank(jdbcDriverJars)) {
+      URLClassLoader classLoader =
+          URLClassLoader.newInstance(JarFileReader.saveFilesLocally(jdbcDriverJars));
+      super.setDriverClassLoader(classLoader);
+    }
+    super.setUrl(sourceDbURL);
+    super.setUsername(dbAuth.getUserName().get());
+    super.setPassword(dbAuth.getPassword().get());
+
+    if (!initSql.isEmpty()) {
+      super.setConnectionInitSqls(initSql);
+    }
+    if (maxConnections != null) {
+      super.setMaxTotal(maxConnections.intValue());
+    }
+    super.setTestOnBorrow(testOnBorrow);
+    super.setTestOnCreate(testOnCreate);
+    super.setTestOnReturn(testOnReturn);
+    super.setTestWhileIdle(testWhileIdle);
+    /* TODO(vardhanvthigle): move this to config */
+    super.setValidationQuery(validationQuery);
+    super.setRemoveAbandonedTimeout(removeAbandonedTimeout);
+    super.setMinEvictableIdleTimeMillis(minEvictableIdleTimeMillis);
+  }
+
+  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+    // Call initializeSuper after deserialization
+    initializeSuper();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
@@ -45,7 +45,6 @@ import javax.sql.DataSource;
 import org.apache.beam.sdk.io.jdbc.JdbcIO;
 import org.apache.beam.sdk.io.jdbc.JdbcIO.DataSourceConfiguration;
 import org.apache.beam.sdk.io.jdbc.JdbcIO.ReadWithPartitions;
-import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
@@ -389,27 +388,8 @@ public final class JdbcIoWrapper implements IoWrapper {
    * @return {@link DataSourceConfiguration}
    */
   private static DataSourceConfiguration getDataSourceConfiguration(JdbcIOWrapperConfig config) {
-
     DataSourceConfiguration dataSourceConfig =
-        JdbcIO.DataSourceConfiguration.create(
-                StaticValueProvider.of(config.jdbcDriverClassName()),
-                StaticValueProvider.of(config.sourceDbURL()))
-            .withMaxConnections(Math.toIntExact(config.maxConnections()));
-
-    if (!config.sqlInitSeq().isEmpty()) {
-      dataSourceConfig = dataSourceConfig.withConnectionInitSqls(config.sqlInitSeq());
-    }
-
-    if (config.jdbcDriverJars() != null && !config.jdbcDriverJars().isEmpty()) {
-      dataSourceConfig = dataSourceConfig.withDriverJars(config.jdbcDriverJars());
-    }
-    if (!config.dbAuth().getUserName().get().isBlank()) {
-      dataSourceConfig = dataSourceConfig.withUsername(config.dbAuth().getUserName().get());
-    }
-    if (!config.dbAuth().getPassword().get().isBlank()) {
-      dataSourceConfig = dataSourceConfig.withPassword(config.dbAuth().getPassword().get());
-    }
-
+        DataSourceConfiguration.create(new JdbcDataSource(config));
     LOG.info("Final DatasourceConfiguration: {}", dataSourceConfig);
     return dataSourceConfig;
   }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/JdbcIOWrapperConfig.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/JdbcIOWrapperConfig.java
@@ -31,6 +31,7 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.Wait.OnSignal;
 import org.apache.beam.sdk.util.FluentBackoff;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.commons.dbcp2.BasicDataSource;
 
 /**
  * Configuration for {@link
@@ -153,6 +154,76 @@ public abstract class JdbcIOWrapperConfig {
   @Nullable
   public abstract PTransform<PCollection<ImmutableList<Range>>, ?> additionalOperationsOnRanges();
 
+  /**
+   * Sets the {@code testOnBorrow} property. This property determines whether or not the pool will
+   * validate objects before they are borrowed from the pool. Defaults to True.
+   */
+  public abstract Boolean testOnBorrow();
+
+  private static final Boolean DEFAULT_TEST_ON_BORROW = true;
+
+  /**
+   * Sets the {@code testOnCreate} property. This property determines whether or not the pool will
+   * validate objects immediately after they are created by the pool. Defaults to True.
+   */
+  public abstract Boolean testOnCreate();
+
+  private static final Boolean DEFAULT_TEST_ON_CREATE = true;
+
+  /**
+   * Sets the {@code testOnReturn} property. This property determines whether or not the pool will
+   * validate objects before they are returned to the pool. Defaults to True.
+   */
+  public abstract Boolean testOnReturn();
+
+  private static final Boolean DEFAULT_TEST_ON_RETURN = true;
+
+  /**
+   * Sets the {@code testWhileIdle} property. This property determines whether or not the idle
+   * object evictor will validate connections. Defaults to True.
+   */
+  public abstract Boolean testWhileIdle();
+
+  private static final Boolean DEFAULT_TEST_WILE_IDLE = true;
+
+  /** Sets the {@code validationQuery}. */
+  public abstract String validationQuery();
+
+  private static final String DEFAULT_VALIDATEION_QUERY = "SELECT 1";
+
+  /**
+   * The timeout in seconds before an abandoned connection can be removed.
+   *
+   * <p>Creating a Statement, PreparedStatement or CallableStatement or using one of these to
+   * execute a query (using one of the execute methods) resets the lastUsed property of the parent
+   * connection.
+   *
+   * <p>Abandoned connection cleanup happens when:
+   *
+   * <ul>
+   *   <li>{@link BasicDataSource#getRemoveAbandonedOnBorrow()} or {@link
+   *       BasicDataSource#getRemoveAbandonedOnMaintenance()} = true
+   *   <li>{@link BasicDataSource#getNumIdle() numIdle} &lt; 2
+   *   <li>{@link BasicDataSource#getNumActive() numActive} &gt; {@link
+   *       BasicDataSource#getMaxTotal() maxTotal} - 3
+   * </ul>
+   *
+   * Defaults to hours.
+   *
+   * <p>
+   */
+  public abstract Integer removeAbandonedTimeout();
+
+  private static final Integer DEFAULT_REMOVE_ABANDONED_TIMEOUT = 8 * 3600;
+
+  /**
+   * The minimum amount of time an object may sit idle in the pool before it is eligible for
+   * eviction by the idle object evictor. Defaults to hours.
+   */
+  public abstract Integer minEvictableIdleTimeMillis();
+
+  private static final Integer DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS = 8 * 3600 * 1000;
+
   public abstract Builder toBuilder();
 
   public static Builder builderWithMySqlDefaults() {
@@ -170,7 +241,14 @@ public abstract class JdbcIOWrapperConfig {
         .setMaxFetchSize(null)
         .setDbParallelizationForReads(null)
         .setDbParallelizationForSplitProcess(DEFAULT_PARALLELIZATION_FOR_SLIT_PROCESS)
-        .setReadWithUniformPartitionsFeatureEnabled(true);
+        .setReadWithUniformPartitionsFeatureEnabled(true)
+        .setTestOnBorrow(DEFAULT_TEST_ON_BORROW)
+        .setTestOnCreate(DEFAULT_TEST_ON_CREATE)
+        .setTestOnReturn(DEFAULT_TEST_ON_RETURN)
+        .setTestWhileIdle(DEFAULT_TEST_WILE_IDLE)
+        .setValidationQuery(DEFAULT_VALIDATEION_QUERY)
+        .setRemoveAbandonedTimeout(DEFAULT_REMOVE_ABANDONED_TIMEOUT)
+        .setMinEvictableIdleTimeMillis(DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS);
   }
 
   @AutoValue.Builder
@@ -217,6 +295,20 @@ public abstract class JdbcIOWrapperConfig {
 
     public abstract Builder setAdditionalOperationsOnRanges(
         @Nullable PTransform<PCollection<ImmutableList<Range>>, ?> value);
+
+    public abstract Builder setTestOnBorrow(Boolean value);
+
+    public abstract Builder setTestOnCreate(Boolean value);
+
+    public abstract Builder setTestOnReturn(Boolean value);
+
+    public abstract Builder setTestWhileIdle(Boolean value);
+
+    public abstract Builder setValidationQuery(String value);
+
+    public abstract Builder setRemoveAbandonedTimeout(Integer value);
+
+    public abstract Builder setMinEvictableIdleTimeMillis(Integer value);
 
     public abstract Builder setMaxConnections(Long value);
 

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/defaults/MySqlConfigDefaults.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/defaults/MySqlConfigDefaults.java
@@ -82,7 +82,10 @@ public class MySqlConfigDefaults {
    */
   // TODO: Add innodb_parallel_read_threads for better performance tuning.
   public static final ImmutableList<String> DEFAULT_MYSQL_INIT_SEQ =
-      ImmutableList.of("SET TIME_ZONE = 'UTC'");
+      ImmutableList.of(
+          "SET TIME_ZONE = 'UTC'",
+          "SET SESSION NET_WRITE_TIMEOUT=1200",
+          "SET SESSION NET_READ_TIMEOUT=1200");
 
   private MySqlConfigDefaults() {}
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcDataSourceTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcDataSourceTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.teleport.v2.source.reader.auth.dbauth.LocalCredentialsProvider;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.DialectAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.JdbcIOWrapperConfig;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
+import com.google.common.collect.ImmutableList;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link JdbcDataSource}. */
+@RunWith(MockitoJUnitRunner.class)
+public class JdbcDataSourceTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @Mock DialectAdapter mockDialectAdapter;
+
+  @Test
+  public void testJdbcDataSourceBasic() throws IOException, ClassNotFoundException {
+
+    SourceSchemaReference testSourceSchemaReference =
+        SourceSchemaReference.builder().setDbName("testDB").build();
+
+    JdbcIOWrapperConfig jdbcIOWrapperConfig =
+        JdbcIOWrapperConfig.builderWithMySqlDefaults()
+            .setSourceDbURL("jdbc:derby://myhost/memory:TestingDB;create=true")
+            .setSourceSchemaReference(testSourceSchemaReference)
+            .setShardID("test")
+            .setDbAuth(
+                LocalCredentialsProvider.builder()
+                    .setUserName("testUser")
+                    .setPassword("testPassword")
+                    .build())
+            .setJdbcDriverJars("")
+            .setJdbcDriverClassName("org.apache.derby.jdbc.EmbeddedDriver")
+            .setDialectAdapter(mockDialectAdapter)
+            .build();
+    JdbcDataSource testJdbcDataSource = new JdbcDataSource(jdbcIOWrapperConfig);
+
+    // Check that testDataSource is initialized correctly.
+    assertThat(testJdbcDataSource.getConnectionInitSqls())
+        .isEqualTo(jdbcIOWrapperConfig.sqlInitSeq());
+    assertThat(testJdbcDataSource.getDriverClassName())
+        .isEqualTo(jdbcIOWrapperConfig.jdbcDriverClassName());
+    assertThat(testJdbcDataSource.getMaxTotal()).isEqualTo(jdbcIOWrapperConfig.maxConnections());
+    assertThat(testJdbcDataSource.getRemoveAbandonedTimeout())
+        .isEqualTo(jdbcIOWrapperConfig.removeAbandonedTimeout());
+    assertThat(testJdbcDataSource.getTestOnBorrow()).isEqualTo(jdbcIOWrapperConfig.testOnBorrow());
+    assertThat(testJdbcDataSource.getTestOnCreate()).isEqualTo(jdbcIOWrapperConfig.testOnCreate());
+    assertThat(testJdbcDataSource.getTestWhileIdle())
+        .isEqualTo(jdbcIOWrapperConfig.testWhileIdle());
+    assertThat(testJdbcDataSource.getMinEvictableIdleTimeMillis())
+        .isEqualTo(jdbcIOWrapperConfig.minEvictableIdleTimeMillis());
+    assertThat(testJdbcDataSource.getValidationQuery())
+        .isEqualTo(jdbcIOWrapperConfig.validationQuery());
+  }
+
+  @Test
+  public void testJdbcDataSourceSerDe() throws IOException, ClassNotFoundException {
+
+    SourceSchemaReference testSourceSchemaReference =
+        SourceSchemaReference.builder().setDbName("testDB").build();
+
+    JdbcIOWrapperConfig jdbcIOWrapperConfig =
+        JdbcIOWrapperConfig.builderWithMySqlDefaults()
+            .setSourceDbURL("jdbc:derby://myhost/memory:TestingDB;create=true")
+            .setSourceSchemaReference(testSourceSchemaReference)
+            .setShardID("test")
+            .setSqlInitSeq(ImmutableList.of())
+            .setDbAuth(
+                LocalCredentialsProvider.builder()
+                    .setUserName("testUser")
+                    .setPassword("testPassword")
+                    .build())
+            .setJdbcDriverJars("")
+            .setJdbcDriverClassName("org.apache.derby.jdbc.EmbeddedDriver")
+            .setDialectAdapter(mockDialectAdapter)
+            .build();
+    JdbcDataSource testJdbcDataSource = new JdbcDataSource(jdbcIOWrapperConfig);
+
+    // Serialize
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(baos);
+    oos.writeObject(testJdbcDataSource);
+    oos.close();
+
+    // Deserialize
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    ObjectInputStream ois = new ObjectInputStream(bais);
+    JdbcDataSource deserializedDataSource = (JdbcDataSource) ois.readObject();
+    ois.close();
+
+    // Check that the deserialized object initializes the datasource correctly.
+    assertThat(deserializedDataSource.getConnectionInitSqls())
+        .isEqualTo(testJdbcDataSource.getConnectionInitSqls());
+    assertThat(deserializedDataSource.getDriverClassName())
+        .isEqualTo(testJdbcDataSource.getDriverClassName());
+    assertThat(deserializedDataSource.getMaxTotal()).isEqualTo(testJdbcDataSource.getMaxTotal());
+    assertThat(deserializedDataSource.getMaxIdle()).isEqualTo(testJdbcDataSource.getMaxIdle());
+    assertThat(deserializedDataSource.getTestOnBorrow())
+        .isEqualTo(testJdbcDataSource.getTestOnBorrow());
+    assertThat(deserializedDataSource.getTestOnCreate())
+        .isEqualTo(testJdbcDataSource.getTestOnCreate());
+    assertThat(deserializedDataSource.getTestWhileIdle())
+        .isEqualTo(testJdbcDataSource.getTestWhileIdle());
+    assertThat(deserializedDataSource.getRemoveAbandonedTimeout())
+        .isEqualTo(testJdbcDataSource.getRemoveAbandonedTimeout());
+    assertThat(deserializedDataSource.getMinEvictableIdleTimeMillis())
+        .isEqualTo(testJdbcDataSource.getMinEvictableIdleTimeMillis());
+    assertThat(deserializedDataSource.getValidationQuery())
+        .isEqualTo(testJdbcDataSource.getValidationQuery());
+  }
+}


### PR DESCRIPTION
# Overview
While migrating a tall table (5TB+) with string primary keys, there exceptions of the type `java.io.EOFException: Can not read response from server. Expected to read 1,423 bytes, read 1,373 bytes before connection was unexpectedly lost.` causing the job to fail. 
After tuning the DBCP2 parameters to be more tuned towards long lived connections as needed by bulk migration , the exceptions are not seen in the tests.

## TODO:
1. (After the PR)There's is a prevalent issue of GC Thrashing for string tables, this currently needs us to have larger VMs with a single worker thread per VM.



## Exception
```json
{
  "textPayload": "Error message from worker: java.lang.RuntimeException: org.apache.beam.sdk.util.UserCodeException: java.sql.SQLException: Can not read response from server. Expected to read 1,423 bytes, read 1,373 bytes before connection was unexpectedly lost.\n\torg.apache.beam.runners.dataflow.worker.GroupAlsoByWindowsParDoFn$1.output(GroupAlsoByWindowsParDoFn.java:187)\n\torg.apache.beam.runners.dataflow.worker.GroupAlsoByWindowFnRunner$1.outputWindowedValue(GroupAlsoByWindowFnRunner.java:108)\n\torg.apache.beam.runners.dataflow.worker.util.BatchGroupAlsoByWindowReshuffleFn.processElement(BatchGroupAlsoByWindowReshuffleFn.java:56)\n\torg.apache.beam.runners.dataflow.worker.util.BatchGroupAlsoByWindowReshuffleFn.processElement(BatchGroupAlsoByWindowReshuffleFn.java:39)\n\torg.apache.beam.runners.dataflow.worker.GroupAlsoByWindowFnRunner.invokeProcessElement(GroupAlsoByWindowFnRunner.java:121)\n\torg.apache.beam.runners.dataflow.worker.GroupAlsoByWindowFnRunner.processElement(GroupAlsoByWindowFnRunner.java:73)\n\torg.apache.beam.runners.dataflow.worker.GroupAlsoByWindowsParDoFn.processElement(GroupAlsoByWindowsParDoFn.java:117)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.ParDoOperation.process(ParDoOperation.java:44)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.OutputReceiver.process(OutputReceiver.java:54)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.ReadOperation.runReadLoop(ReadOperation.java:218)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.ReadOperation.start(ReadOperation.java:169)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.MapTaskExecutor.execute(MapTaskExecutor.java:83)\n\torg.apache.beam.runners.dataflow.worker.BatchDataflowWorker.executeWork(BatchDataflowWorker.java:304)\n\torg.apache.beam.runners.dataflow.worker.BatchDataflowWorker.doWork(BatchDataflowWorker.java:276)\n\torg.apache.beam.runners.dataflow.worker.BatchDataflowWorker.getAndPerformWork(BatchDataflowWorker.java:206)\n\torg.apache.beam.runners.dataflow.worker.DataflowBatchWorkerHarness$WorkerThread.doWork(DataflowBatchWorkerHarness.java:150)\n\torg.apache.beam.runners.dataflow.worker.DataflowBatchWorkerHarness$WorkerThread.call(DataflowBatchWorkerHarness.java:130)\n\torg.apache.beam.runners.dataflow.worker.DataflowBatchWorkerHarness$WorkerThread.call(DataflowBatchWorkerHarness.java:117)\n\tjava.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)\n\torg.apache.beam.sdk.util.UnboundedScheduledExecutorService$ScheduledFutureTask.run(UnboundedScheduledExecutorService.java:163)\n\tjava.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)\n\tjava.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)\n\tjava.base/java.lang.Thread.run(Thread.java:829)\nCaused by: org.apache.beam.sdk.util.UserCodeException: java.sql.SQLException: Can not read response from server. Expected to read 1,423 bytes, read 1,373 bytes before connection was unexpectedly lost.\n\torg.apache.beam.sdk.util.UserCodeException.wrap(UserCodeException.java:39)\n\torg.apache.beam.sdk.io.jdbc.JdbcIO$ReadFn$DoFnInvoker.invokeProcessElement(Unknown Source)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.invokeProcessElement(SimpleDoFnRunner.java:212)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.processElement(SimpleDoFnRunner.java:189)\n\torg.apache.beam.runners.dataflow.worker.SimpleParDoFn.processElement(SimpleParDoFn.java:340)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.ParDoOperation.process(ParDoOperation.java:44)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.OutputReceiver.process(OutputReceiver.java:54)\n\torg.apache.beam.runners.dataflow.worker.SimpleParDoFn$1.output(SimpleParDoFn.java:285)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.outputWindowedValue(SimpleDoFnRunner.java:276)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.access$900(SimpleDoFnRunner.java:86)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner$DoFnProcessContext.output(SimpleDoFnRunner.java:432)\n\torg.apache.beam.sdk.transforms.DoFnOutputReceivers$WindowedContextOutputReceiver.output(DoFnOutputReceivers.java:89)\n\torg.apache.beam.sdk.transforms.MapElements$2.processElement(MapElements.java:151)\n\torg.apache.beam.sdk.transforms.MapElements$2$DoFnInvoker.invokeProcessElement(Unknown Source)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.invokeProcessElement(SimpleDoFnRunner.java:212)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.processElement(SimpleDoFnRunner.java:189)\n\torg.apache.beam.runners.dataflow.worker.SimpleParDoFn.processElement(SimpleParDoFn.java:340)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.ParDoOperation.process(ParDoOperation.java:44)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.OutputReceiver.process(OutputReceiver.java:54)\n\torg.apache.beam.runners.dataflow.worker.SimpleParDoFn$1.output(SimpleParDoFn.java:285)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.outputWindowedValue(SimpleDoFnRunner.java:276)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.access$900(SimpleDoFnRunner.java:86)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner$DoFnProcessContext.output(SimpleDoFnRunner.java:432)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner$DoFnProcessContext.output(SimpleDoFnRunner.java:412)\n\torg.apache.beam.runners.dataflow.ReshuffleOverrideFactory$ReshuffleWithOnlyTrigger$1.processElement(ReshuffleOverrideFactory.java:86)\n\torg.apache.beam.runners.dataflow.ReshuffleOverrideFactory$ReshuffleWithOnlyTrigger$1$DoFnInvoker.invokeProcessElement(Unknown Source)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.invokeProcessElement(SimpleDoFnRunner.java:212)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.processElement(SimpleDoFnRunner.java:189)\n\torg.apache.beam.runners.dataflow.worker.SimpleParDoFn.processElement(SimpleParDoFn.java:340)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.ParDoOperation.process(ParDoOperation.java:44)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.OutputReceiver.process(OutputReceiver.java:54)\n\torg.apache.beam.runners.dataflow.worker.GroupAlsoByWindowsParDoFn$1.output(GroupAlsoByWindowsParDoFn.java:185)\n\t... 22 more\nCaused by: java.sql.SQLException: Can not read response from server. Expected to read 1,423 bytes, read 1,373 bytes before connection was unexpectedly lost.\n\tcom.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:129)\n\tcom.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)\n\tcom.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:916)\n\tcom.mysql.cj.jdbc.ClientPreparedStatement.executeQuery(ClientPreparedStatement.java:972)\n\torg.apache.commons.dbcp2.DelegatingPreparedStatement.executeQuery(DelegatingPreparedStatement.java:122)\n\torg.apache.commons.dbcp2.DelegatingPreparedStatement.executeQuery(DelegatingPreparedStatement.java:122)\n\torg.apache.commons.dbcp2.DelegatingPreparedStatement.executeQuery(DelegatingPreparedStatement.java:122)\n\torg.apache.commons.dbcp2.DelegatingPreparedStatement.executeQuery(DelegatingPreparedStatement.java:122)\n\torg.apache.beam.sdk.io.jdbc.JdbcIO$ReadFn.processElement(JdbcIO.java:1587)\nCaused by: java.io.EOFException: Can not read response from server. Expected to read 1,423 bytes, read 1,373 bytes before connection was unexpectedly lost.\n\tcom.mysql.cj.protocol.FullReadInputStream.readFully(FullReadInputStream.java:67)\n\tcom.mysql.cj.protocol.a.SimplePacketReader.readMessageLocal(SimplePacketReader.java:137)\n\tcom.mysql.cj.protocol.a.SimplePacketReader.readMessage(SimplePacketReader.java:102)\n\tcom.mysql.cj.protocol.a.SimplePacketReader.readMessage(SimplePacketReader.java:45)\n\tcom.mysql.cj.protocol.a.TimeTrackingPacketReader.readMessage(TimeTrackingPacketReader.java:62)\n\tcom.mysql.cj.protocol.a.TimeTrackingPacketReader.readMessage(TimeTrackingPacketReader.java:41)\n\tcom.mysql.cj.protocol.a.MultiPacketReader.readMessage(MultiPacketReader.java:66)\n\tcom.mysql.cj.protocol.a.MultiPacketReader.readMessage(MultiPacketReader.java:44)\n\tcom.mysql.cj.protocol.a.ResultsetRowReader.read(ResultsetRowReader.java:75)\n\tcom.mysql.cj.protocol.a.ResultsetRowReader.read(ResultsetRowReader.java:42)\n\tcom.mysql.cj.protocol.a.NativeProtocol.read(NativeProtocol.java:1651)\n\tcom.mysql.cj.protocol.a.TextResultsetReader.read(TextResultsetReader.java:87)\n\tcom.mysql.cj.protocol.a.TextResultsetReader.read(TextResultsetReader.java:48)\n\tcom.mysql.cj.protocol.a.NativeProtocol.read(NativeProtocol.java:1664)\n\tcom.mysql.cj.protocol.a.NativeProtocol.readAllResults(NativeProtocol.java:1718)\n\tcom.mysql.cj.protocol.a.NativeProtocol.sendQueryPacket(NativeProtocol.java:1064)\n\tcom.mysql.cj.NativeSession.execSQL(NativeSession.java:665)\n\tcom.mysql.cj.jdbc.ClientPreparedStatement.executeInternal(ClientPreparedStatement.java:893)\n\tcom.mysql.cj.jdbc.ClientPreparedStatement.executeQuery(ClientPreparedStatement.java:972)\n\torg.apache.commons.dbcp2.DelegatingPreparedStatement.executeQuery(DelegatingPreparedStatement.java:122)\n\torg.apache.commons.dbcp2.DelegatingPreparedStatement.executeQuery(DelegatingPreparedStatement.java:122)\n\torg.apache.commons.dbcp2.DelegatingPreparedStatement.executeQuery(DelegatingPreparedStatement.java:122)\n\torg.apache.commons.dbcp2.DelegatingPreparedStatement.executeQuery(DelegatingPreparedStatement.java:122)\n\torg.apache.beam.sdk.io.jdbc.JdbcIO$ReadFn.processElement(JdbcIO.java:1587)\n\torg.apache.beam.sdk.io.jdbc.JdbcIO$ReadFn$DoFnInvoker.invokeProcessElement(Unknown Source)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.invokeProcessElement(SimpleDoFnRunner.java:212)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.processElement(SimpleDoFnRunner.java:189)\n\torg.apache.beam.runners.dataflow.worker.SimpleParDoFn.processElement(SimpleParDoFn.java:340)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.ParDoOperation.process(ParDoOperation.java:44)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.OutputReceiver.process(OutputReceiver.java:54)\n\torg.apache.beam.runners.dataflow.worker.SimpleParDoFn$1.output(SimpleParDoFn.java:285)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.outputWindowedValue(SimpleDoFnRunner.java:276)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.access$900(SimpleDoFnRunner.java:86)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner$DoFnProcessContext.output(SimpleDoFnRunner.java:432)\n\torg.apache.beam.sdk.transforms.DoFnOutputReceivers$WindowedContextOutputReceiver.output(DoFnOutputReceivers.java:89)\n\torg.apache.beam.sdk.transforms.MapElements$2.processElement(MapElements.java:151)\n\torg.apache.beam.sdk.transforms.MapElements$2$DoFnInvoker.invokeProcessElement(Unknown Source)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.invokeProcessElement(SimpleDoFnRunner.java:212)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.processElement(SimpleDoFnRunner.java:189)\n\torg.apache.beam.runners.dataflow.worker.SimpleParDoFn.processElement(SimpleParDoFn.java:340)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.ParDoOperation.process(ParDoOperation.java:44)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.OutputReceiver.process(OutputReceiver.java:54)\n\torg.apache.beam.runners.dataflow.worker.SimpleParDoFn$1.output(SimpleParDoFn.java:285)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.outputWindowedValue(SimpleDoFnRunner.java:276)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.access$900(SimpleDoFnRunner.java:86)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner$DoFnProcessContext.output(SimpleDoFnRunner.java:432)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner$DoFnProcessContext.output(SimpleDoFnRunner.java:412)\n\torg.apache.beam.runners.dataflow.ReshuffleOverrideFactory$ReshuffleWithOnlyTrigger$1.processElement(ReshuffleOverrideFactory.java:86)\n\torg.apache.beam.runners.dataflow.ReshuffleOverrideFactory$ReshuffleWithOnlyTrigger$1$DoFnInvoker.invokeProcessElement(Unknown Source)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.invokeProcessElement(SimpleDoFnRunner.java:212)\n\torg.apache.beam.runners.dataflow.worker.repackaged.org.apache.beam.runners.core.SimpleDoFnRunner.processElement(SimpleDoFnRunner.java:189)\n\torg.apache.beam.runners.dataflow.worker.SimpleParDoFn.processElement(SimpleParDoFn.java:340)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.ParDoOperation.process(ParDoOperation.java:44)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.OutputReceiver.process(OutputReceiver.java:54)\n\torg.apache.beam.runners.dataflow.worker.GroupAlsoByWindowsParDoFn$1.output(GroupAlsoByWindowsParDoFn.java:185)\n\torg.apache.beam.runners.dataflow.worker.GroupAlsoByWindowFnRunner$1.outputWindowedValue(GroupAlsoByWindowFnRunner.java:108)\n\torg.apache.beam.runners.dataflow.worker.util.BatchGroupAlsoByWindowReshuffleFn.processElement(BatchGroupAlsoByWindowReshuffleFn.java:56)\n\torg.apache.beam.runners.dataflow.worker.util.BatchGroupAlsoByWindowReshuffleFn.processElement(BatchGroupAlsoByWindowReshuffleFn.java:39)\n\torg.apache.beam.runners.dataflow.worker.GroupAlsoByWindowFnRunner.invokeProcessElement(GroupAlsoByWindowFnRunner.java:121)\n\torg.apache.beam.runners.dataflow.worker.GroupAlsoByWindowFnRunner.processElement(GroupAlsoByWindowFnRunner.java:73)\n\torg.apache.beam.runners.dataflow.worker.GroupAlsoByWindowsParDoFn.processElement(GroupAlsoByWindowsParDoFn.java:117)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.ParDoOperation.process(ParDoOperation.java:44)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.OutputReceiver.process(OutputReceiver.java:54)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.ReadOperation.runReadLoop(ReadOperation.java:218)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.ReadOperation.start(ReadOperation.java:169)\n\torg.apache.beam.runners.dataflow.worker.util.common.worker.MapTaskExecutor.execute(MapTaskExecutor.java:83)\n\torg.apache.beam.runners.dataflow.worker.BatchDataflowWorker.executeWork(BatchDataflowWorker.java:304)\n\torg.apache.beam.runners.dataflow.worker.BatchDataflowWorker.doWork(BatchDataflowWorker.java:276)\n\torg.apache.beam.runners.dataflow.worker.BatchDataflowWorker.getAndPerformWork(BatchDataflowWorker.java:206)\n\torg.apache.beam.runners.dataflow.worker.DataflowBatchWorkerHarness$WorkerThread.doWork(DataflowBatchWorkerHarness.java:150)\n\torg.apache.beam.runners.dataflow.worker.DataflowBatchWorkerHarness$WorkerThread.call(DataflowBatchWorkerHarness.java:130)\n\torg.apache.beam.runners.dataflow.worker.DataflowBatchWorkerHarness$WorkerThread.call(DataflowBatchWorkerHarness.java:117)\n\tjava.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)\n\torg.apache.beam.sdk.util.UnboundedScheduledExecutorService$ScheduledFutureTask.run(UnboundedScheduledExecutorService.java:163)\n\tjava.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)\n\tjava.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)\n\tjava.base/java.lang.Thread.run(Thread.java:829)\n",
  "insertId": "1qprt2xd1zun",
  "resource": {
    "type": "dataflow_step",
    "labels": {
      "region": "us-central1",
      "step_id": "",
      "job_name": "vvt-string-tall-table-2024-08-09-12-23-19-456130155",
      "project_id": "545418958905",
      "job_id": "2024-08-09_05_23_21-15383100525522619655"
    }
  },
  "timestamp": "2024-08-09T13:53:29.742383026Z",
  "severity": "ERROR",
  "labels": {
    "dataflow.googleapis.com/log_type": "system",
    "dataflow.googleapis.com/job_id": "2024-08-09_05_23_21-15383100525522619655",
    "dataflow.googleapis.com/job_name": "vvt-string-tall-table-2024-08-09-12-23-19-456130155",
    "dataflow.googleapis.com/region": "us-central1"
  },
  "logName": "projects/span-cloud-testing/logs/dataflow.googleapis.com%2Fjob-message",
  "receiveTimestamp": "2024-08-09T13:53:31.200363735Z"
}
```