### PR TITLE
Support Timestamp in proto to bigquery schema conversion

### DIFF
--- a/v2/common/pom.xml
+++ b/v2/common/pom.xml
@@ -119,6 +119,10 @@
           <groupId>com.google.cloud</groupId>
           <artifactId>google-cloud-kms</artifactId>
         </dependency>
+        <dependency>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </dependency>
 
         <!-- UDFs -->
         <dependency>

--- a/v2/common/src/test/java/com/google/cloud/teleport/v2/utils/SchemaUtilsTest.java
+++ b/v2/common/src/test/java/com/google/cloud/teleport/v2/utils/SchemaUtilsTest.java
@@ -53,6 +53,8 @@ public class SchemaUtilsTest {
       "com.google.cloud.teleport.v2.proto.testing.MyMessage";
   private static final String PROTO_MESSAGE_INVALID_FOR_BQ =
       "com.google.cloud.teleport.v2.proto.testing.CircularlyReferencedMessage";
+  private static final String PROTO_MESSAGE_WITH_TIMESTAMP =
+      "com.google.cloud.teleport.v2.proto.testing.TimestampMessage";
 
   /**
    * Test whether {@link SchemaUtils#getAvroSchema(String)} reads an Avro schema correctly and
@@ -111,6 +113,23 @@ public class SchemaUtilsTest {
     TableSchema actual =
         SchemaUtils.createBigQuerySchema(descriptor, /* preserveProtoFieldNames= */ true);
     assertEquals(getProtoTableSchema(/* preserveProtoNames= */ true), actual);
+  }
+
+  @Test
+  public void testFromProtoDescriptorHandlesTimestamp() {
+    String expected =
+        "{\"fields\": ["
+            + "{\"mode\":\"NULLABLE\", \"name\":\"timestamp\", \"type\":\"TIMESTAMP\"},"
+            + "{\"fields\":[{\"mode\":\"NULLABLE\", \"name\":\"field1\", \"type\":\"STRING\"},"
+            + "{\"mode\":\"NULLABLE\", \"name\":\"field2\", \"type\":\"TIMESTAMP\"}],"
+            + "\"mode\":\"NULLABLE\", \"name\":\"nested\", \"type\":\"RECORD\""
+            + "}]}";
+    Descriptor descriptor =
+        SchemaUtils.getProtoDomain(PROTO_SCHEMA_FILE_PATH)
+            .getDescriptor(PROTO_MESSAGE_WITH_TIMESTAMP);
+    TableSchema actual =
+        SchemaUtils.createBigQuerySchema(descriptor, /* preserveProtoFieldNames= */ false);
+    assertEquals(new Gson().fromJson(expected, TableSchema.class), actual);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/v2/common/src/test/proto/proto_definition.proto
+++ b/v2/common/src/test/proto/proto_definition.proto
@@ -18,6 +18,7 @@ syntax = "proto3";
 
 package com.google.cloud.teleport.v2.proto.testing;
 
+import "google/protobuf/timestamp.proto";
 import "import_proto_definition.proto";
 
 option java_package = "com.google.cloud.teleport.v2.proto.testing";
@@ -54,4 +55,13 @@ message MyMessage {
 message CircularlyReferencedMessage {
   string non_circular = 1;
   CircularlyReferencedMessage circular = 2;
+}
+
+message TimestampMessage {
+  message NestedTimestamp {
+    string field1 = 1;
+    .google.protobuf.Timestamp field2 = 2;
+  }
+  .google.protobuf.Timestamp timestamp = 1;
+  NestedTimestamp nested = 2;
 }


### PR DESCRIPTION
For example, in PubSub_Proto_to_BigQuery_Xlang, when there is a Timestamp field, it get inferred to a BigQuery RECORD field of {"seconds": "INTEGER", "nanos": "INTEGER"}, i.e., google.protobuf.Timestamp gets expanded.

