### PR TITLE
Bump hadoop version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <derby.version>10.14.2.0</derby.version>
     <grpc.gen.version>1.13.1</grpc.gen.version>
     <guava.version>32.0.1-jre</guava.version>
-    <hadoop.version>3.3.6</hadoop.version>
+    <hadoop.version>3.4.0</hadoop.version>
     <hamcrest.version>2.1</hamcrest.version>
     <hbase.client.version>2.5.3-hadoop3</hbase.client.version>
     <mockito.version>4.11.0</mockito.version>

--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -37,7 +37,7 @@
     <mock-server-netty.version>5.14.0</mock-server-netty.version>
     <open-census.version>0.24.0</open-census.version>
     <!-- TODO: check if this could be declared on a Beam BOM instead of here -->
-    <bigtable-beam-import.version>2.14.3</bigtable-beam-import.version>
+    <bigtable-beam-import.version>2.14.2</bigtable-beam-import.version>
     <protobuf.version>3.21.7</protobuf.version>
     <nashorn.version>15.4</nashorn.version>
     <junit.jupiter.version>5.5.2</junit.jupiter.version>

--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -37,7 +37,7 @@
     <mock-server-netty.version>5.14.0</mock-server-netty.version>
     <open-census.version>0.24.0</open-census.version>
     <!-- TODO: check if this could be declared on a Beam BOM instead of here -->
-    <bigtable-beam-import.version>2.14.2</bigtable-beam-import.version>
+    <bigtable-beam-import.version>2.14.3</bigtable-beam-import.version>
     <protobuf.version>3.21.7</protobuf.version>
     <nashorn.version>15.4</nashorn.version>
     <junit.jupiter.version>5.5.2</junit.jupiter.version>


### PR DESCRIPTION
* To resolve vulneribility from transitive dependencies
including CVE-2023-44981 org.apache.zookeeper:zookeeper 3.6.3, transitive dependency of org.apache.hadoop:hadoop-common:3.3.6