### PR TITLE
Remove gcs notification tests from Datastream Spanner ITs

### DIFF
--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerIT.java
@@ -141,36 +141,6 @@ public class DataStreamToSpannerIT extends TemplateTestBase {
   }
 
   @Test
-  public void testDataStreamMySqlToSpannerGCSNotifications() throws IOException {
-    createPubSubNotifications();
-
-    // Run a simple IT
-    simpleMySqlToSpannerTest(
-        DatastreamResourceManager.DestinationOutputFormat.AVRO_FILE_FORMAT,
-        Dialect.GOOGLE_STANDARD_SQL,
-        false,
-        config ->
-            config
-                .addParameter("gcsPubSubSubscription", subscription.toString())
-                .addParameter("dlqGcsPubSubSubscription", dlqSubscription.toString()));
-  }
-
-  @Test
-  public void testDataStreamOracleToSpannerGCSNotifications() throws IOException {
-    createPubSubNotifications();
-
-    // Run a simple IT
-    simpleOracleToSpannerTest(
-        DatastreamResourceManager.DestinationOutputFormat.AVRO_FILE_FORMAT,
-        Dialect.GOOGLE_STANDARD_SQL,
-        false,
-        config ->
-            config
-                .addParameter("gcsPubSubSubscription", subscription.toString())
-                .addParameter("dlqGcsPubSubSubscription", dlqSubscription.toString()));
-  }
-
-  @Test
   public void testDataStreamMySqlToSpannerStaging() throws IOException {
     // Run a simple IT
     simpleMySqlToSpannerTest(


### PR DESCRIPTION
Removing these tests as they are redundant as of #1674