### PR TITLE
[KafkaToBigQuery & KafkaToGcs] - Add OAuth Authentication Support For Schema Registries 

### DIFF
--- a/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/options/SchemaRegistryOptions.java
+++ b/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/options/SchemaRegistryOptions.java
@@ -114,10 +114,11 @@ public interface SchemaRegistryOptions extends PipelineOptions {
       enumOptions = {
         @TemplateParameter.TemplateEnumOption(KafkaAuthenticationMethod.NONE),
         @TemplateParameter.TemplateEnumOption(KafkaAuthenticationMethod.TLS),
+        @TemplateParameter.TemplateEnumOption(KafkaAuthenticationMethod.OAUTH),
       },
       optional = true,
       description = "Authentication Mode",
-      helpText = "Schema Registry authentication mode. Can be NONE or TLS.")
+      helpText = "Schema Registry authentication mode. Can be NONE, TLS or OAUTH.")
   @Default.String(KafkaAuthenticationMethod.NONE)
   String getSchemaRegistryAuthenticationMode();
 
@@ -188,4 +189,59 @@ public interface SchemaRegistryOptions extends PipelineOptions {
   String getSchemaRegistryKeyPasswordSecretId();
 
   void setSchemaRegistryKeyPasswordSecretId(String keyPasswordSecretId);
+
+  @TemplateParameter.Text(
+      order = 11,
+      parentName = "SchemaRegistryOauthAuthenticationMode",
+      parentTriggerValues = {KafkaAuthenticationMethod.OAUTH},
+      optional = true,
+      description = "Client ID",
+      helpText =
+          "Client ID used to authenticate the Schema Registry client in OAUTH mode. Required for "
+              + "AVRO_CONFLUENT_WIRE_FORMAT message format.")
+  String getSchemaRegistryOauthClientId();
+
+  void setSchemaRegistryOauthClientId(String schemaRegistryOauthClientId);
+
+  @TemplateParameter.Text(
+      order = 11,
+      parentName = "SchemaRegistryOauthAuthenticationMode",
+      parentTriggerValues = {KafkaAuthenticationMethod.OAUTH},
+      optional = true,
+      description = "Token Endpoint URL",
+      helpText =
+          "The HTTP(S)-based URL for the OAuth/OIDC identity provider used to authenticate the "
+              + "Schema Registry client in OAUTH mode. Required for AVRO_CONFLUENT_WIRE_FORMAT message format.")
+  String getSchemaRegistryOauthTokenEndpointUrl();
+
+  void setSchemaRegistryOauthTokenEndpointUrl(String schemaRegistryOauthTokenEndpointUrl);
+
+  @TemplateParameter.Text(
+      order = 11,
+      parentName = "SchemaRegistryOauthAuthenticationMode",
+      parentTriggerValues = {KafkaAuthenticationMethod.OAUTH},
+      optional = true,
+      description = "Scope",
+      helpText =
+          "The access token scope used to authenticate the "
+              + "Schema Registry client in OAUTH mode. This field is optional, as the request can be made without a scope "
+              + "parameter passed.",
+      example = "openid")
+  String getSchemaRegistryOauthScope();
+
+  void setSchemaRegistryOauthScope(String schemaRegistryOauthScope);
+
+  @TemplateParameter.Text(
+      order = 11,
+      parentName = "SchemaRegistryOauthAuthenticationMode",
+      parentTriggerValues = {KafkaAuthenticationMethod.OAUTH},
+      optional = true,
+      description = "Client Secret ID",
+      helpText =
+          "The Google Cloud Secret Manager secret ID that contains the Client Secret to use to authenticate the "
+              + "Schema Registry client in OAUTH mode. Required for AVRO_CONFLUENT_WIRE_FORMAT message format.",
+      example = "projects/<PROJECT_ID>/secrets/<SECRET_ID>/versions/<SECRET_VERSION>")
+  String getSchemaRegistryOauthClientSecretId();
+
+  void setSchemaRegistryOauthClientSecretId(String schemaRegistryOauthClientSecretId);
 }

--- a/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/transforms/AvroDynamicTransform.java
+++ b/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/transforms/AvroDynamicTransform.java
@@ -44,7 +44,7 @@ public class AvroDynamicTransform
         PCollection<FailsafeElement<KafkaRecord<byte[], byte[]>, GenericRecord>>> {
   private String schemaRegistryConnectionUrl;
 
-  private Map<String, Object> schemaRegistrySslConfig;
+  private Map<String, Object> schemaRegistryAuthenticationConfig;
 
   private ErrorHandler<BadRecord, ?> errorHandler;
   private BadRecordRouter badRecordRouter;
@@ -53,36 +53,37 @@ public class AvroDynamicTransform
 
   private AvroDynamicTransform(
       String schemaRegistryConnectionUrl,
-      Map<String, Object> schemaRegistrySslConfig,
+      Map<String, Object> schemaRegistryAuthenticationConfig,
       ErrorHandler<BadRecord, ?> errorHandler,
       BadRecordRouter badRecordRouter) {
     this.schemaRegistryConnectionUrl = schemaRegistryConnectionUrl;
-    this.schemaRegistrySslConfig = schemaRegistrySslConfig;
+    this.schemaRegistryAuthenticationConfig = schemaRegistryAuthenticationConfig;
     this.errorHandler = errorHandler;
     this.badRecordRouter = badRecordRouter;
   }
 
   private AvroDynamicTransform(
-      String schemaRegistryConnectionUrl, Map<String, Object> schemaRegistrySslConfig) {
+      String schemaRegistryConnectionUrl, Map<String, Object> schemaRegistryAuthenticationConfig) {
     this.schemaRegistryConnectionUrl = schemaRegistryConnectionUrl;
-    this.schemaRegistrySslConfig = schemaRegistrySslConfig;
+    this.schemaRegistryAuthenticationConfig = schemaRegistryAuthenticationConfig;
     this.errorHandler = new ErrorHandler.DefaultErrorHandler<>();
     this.badRecordRouter = BadRecordRouter.THROWING_ROUTER;
   }
 
   public static AvroDynamicTransform of(
-      String schemaRegistryConnectionUrl, Map<String, Object> schemaRegistrySslConfig) {
-    return new AvroDynamicTransform(schemaRegistryConnectionUrl, schemaRegistrySslConfig);
+      String schemaRegistryConnectionUrl, Map<String, Object> schemaRegistryAuthenticationConfig) {
+    return new AvroDynamicTransform(
+        schemaRegistryConnectionUrl, schemaRegistryAuthenticationConfig);
   }
 
   public static AvroDynamicTransform of(
       String schemaRegistryConnectionUrl,
-      Map<String, Object> schemaRegistrySslConfig,
+      Map<String, Object> schemaRegistryAuthenticationConfig,
       ErrorHandler<BadRecord, ?> badRecordErrorHandler,
       BadRecordRouter badRecordRouter) {
     return new AvroDynamicTransform(
         schemaRegistryConnectionUrl,
-        schemaRegistrySslConfig,
+        schemaRegistryAuthenticationConfig,
         badRecordErrorHandler,
         badRecordRouter);
   }
@@ -96,7 +97,7 @@ public class AvroDynamicTransform
             ParDo.of(
                     new KafkaRecordToGenericRecordFailsafeElementFn(
                         this.schemaRegistryConnectionUrl,
-                        this.schemaRegistrySslConfig,
+                        this.schemaRegistryAuthenticationConfig,
                         this.badRecordRouter,
                         SUCCESS_GENERIC_RECORDS))
                 .withOutputTags(

--- a/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/transforms/KafkaRecordToGenericRecordFailsafeElementFn.java
+++ b/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/transforms/KafkaRecordToGenericRecordFailsafeElementFn.java
@@ -48,7 +48,7 @@ public class KafkaRecordToGenericRecordFailsafeElementFn
   private Schema schema;
   private final String topicName = "fake_topic";
   private String schemaRegistryConnectionUrl;
-  private Map<String, Object> schemaRegistrySslConfig;
+  private Map<String, Object> schemaRegistryAuthenticationConfig;
   private String messageFormat; // "AVRO_BINARY_ENCODING" or "AVRO_CONFLUENT_WIRE_FORMAT"
   private static final int DEFAULT_CACHE_CAPACITY = 1000;
   private BadRecordRouter badRecordRouter;
@@ -58,12 +58,12 @@ public class KafkaRecordToGenericRecordFailsafeElementFn
   // Constructors for different configurations
   public KafkaRecordToGenericRecordFailsafeElementFn(
       String schemaRegistryConnectionUrl,
-      Map<String, Object> schemaRegistrySslConfig,
+      Map<String, Object> schemaRegistryAuthenticationConfig,
       BadRecordRouter badRecordRouter,
       TupleTag<FailsafeElement<KafkaRecord<byte[], byte[]>, GenericRecord>>
           successGenericRecordTag) {
     this.schemaRegistryConnectionUrl = schemaRegistryConnectionUrl;
-    this.schemaRegistrySslConfig = schemaRegistrySslConfig;
+    this.schemaRegistryAuthenticationConfig = schemaRegistryAuthenticationConfig;
     this.badRecordRouter = badRecordRouter;
     this.successGenericRecordTag = successGenericRecordTag;
   }
@@ -89,7 +89,7 @@ public class KafkaRecordToGenericRecordFailsafeElementFn
           new CachedSchemaRegistryClient(
               this.schemaRegistryConnectionUrl,
               DEFAULT_CACHE_CAPACITY,
-              processor.apply(this.schemaRegistrySslConfig));
+              processor.apply(this.schemaRegistryAuthenticationConfig));
       this.kafkaDeserializer = new KafkaAvroDeserializer(this.schemaRegistryClient);
     } else if (schema != null && messageFormat.equals("AVRO_BINARY_ENCODING")) {
       this.binaryDeserializer = new BinaryAvroDeserializer(schema);

--- a/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/utils/KafkaConfig.java
+++ b/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/utils/KafkaConfig.java
@@ -20,6 +20,7 @@ import com.google.cloud.teleport.v2.kafka.options.KafkaWriteOptions;
 import com.google.cloud.teleport.v2.kafka.options.SchemaRegistryOptions;
 import com.google.cloud.teleport.v2.kafka.values.KafkaAuthenticationMethod;
 import com.google.cloud.teleport.v2.utils.SecretManagerUtils;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.CommonClientConfigs;
@@ -89,6 +90,26 @@ public class KafkaConfig {
           FileAwareFactoryFn.SECRET_MANAGER_VALUE_PREFIX
               + options.getSchemaRegistryKeyPasswordSecretId());
       properties.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
+    } else if (options
+        .getSchemaRegistryAuthenticationMode()
+        .equals(KafkaAuthenticationMethod.OAUTH)) {
+      properties.put(
+          SCHEMA_REGISTRY_PREFIX + SchemaRegistryClientConfig.BEARER_AUTH_CREDENTIALS_SOURCE,
+          "OAUTHBEARER");
+      properties.put(
+          SCHEMA_REGISTRY_PREFIX + SchemaRegistryClientConfig.BEARER_AUTH_ISSUER_ENDPOINT_URL,
+          options.getSchemaRegistryOauthTokenEndpointUrl());
+      properties.put(
+          SCHEMA_REGISTRY_PREFIX + SchemaRegistryClientConfig.BEARER_AUTH_CLIENT_ID,
+          options.getSchemaRegistryOauthClientId());
+      properties.put(
+          SCHEMA_REGISTRY_PREFIX + SchemaRegistryClientConfig.BEARER_AUTH_CLIENT_SECRET,
+          SecretManagerUtils.getSecret(options.getSchemaRegistryOauthClientSecretId()));
+      if (options.getSchemaRegistryOauthScope() != null) {
+        properties.put(
+            SCHEMA_REGISTRY_PREFIX + SchemaRegistryClientConfig.BEARER_AUTH_SCOPE,
+            options.getSchemaRegistryOauthScope());
+      }
     }
     return properties;
   }

--- a/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/values/KafkaAuthenticationMethod.java
+++ b/v2/kafka-common/src/main/java/com/google/cloud/teleport/v2/kafka/values/KafkaAuthenticationMethod.java
@@ -23,4 +23,5 @@ public class KafkaAuthenticationMethod {
   public static final String TLS = "TLS";
   public static final String SASL_PLAIN = "SASL_PLAIN";
   public static final String APPLICATION_DEFAULT_CREDENTIALS = "APPLICATION_DEFAULT_CREDENTIALS";
+  public static final String OAUTH = "OAUTH";
 }

--- a/v2/kafka-to-gcs/src/main/java/com/google/cloud/teleport/v2/transforms/AvroWriteTransform.java
+++ b/v2/kafka-to-gcs/src/main/java/com/google/cloud/teleport/v2/transforms/AvroWriteTransform.java
@@ -73,7 +73,7 @@ public abstract class AvroWriteTransform
 
   public abstract @Nullable String schemaRegistryURL();
 
-  public abstract Map<String, Object> schemaRegistrySslConfig();
+  public abstract Map<String, Object> schemaRegistryAuthenticationConfig();
 
   public abstract @Nullable String confluentSchemaPath();
 
@@ -109,7 +109,7 @@ public abstract class AvroWriteTransform
             records.apply(
                 AvroDynamicTransform.of(
                     schemaRegistryURL(),
-                    schemaRegistrySslConfig(),
+                    schemaRegistryAuthenticationConfig(),
                     errorHandler(),
                     badRecordRouter()));
       } else {
@@ -160,8 +160,8 @@ public abstract class AvroWriteTransform
     public abstract AvroWriteTransformBuilder setSchemaRegistryURL(
         @Nullable String schemaRegistryURL);
 
-    public abstract AvroWriteTransformBuilder setSchemaRegistrySslConfig(
-        Map<String, Object> schemaRegistrySslConfig);
+    public abstract AvroWriteTransformBuilder setSchemaRegistryAuthenticationConfig(
+        Map<String, Object> schemaRegistryAuthenticationConfig);
 
     public abstract AvroWriteTransformBuilder setConfluentSchemaPath(String value);
 

--- a/v2/kafka-to-gcs/src/main/java/com/google/cloud/teleport/v2/transforms/WriteTransform.java
+++ b/v2/kafka-to-gcs/src/main/java/com/google/cloud/teleport/v2/transforms/WriteTransform.java
@@ -67,7 +67,8 @@ public abstract class WriteTransform
                   .setNumShards(options().getNumShards())
                   .setMessageFormat(options().getMessageFormat())
                   .setSchemaRegistryURL(options().getSchemaRegistryConnectionUrl())
-                  .setSchemaRegistrySslConfig(KafkaConfig.fromSchemaRegistryOptions(options()))
+                  .setSchemaRegistryAuthenticationConfig(
+                      KafkaConfig.fromSchemaRegistryOptions(options()))
                   .setConfluentSchemaPath(options().getConfluentAvroSchemaPath())
                   .setBinaryAvroSchemaPath(options().getBinaryAvroSchemaPath())
                   .setSchemaFormat(options().getSchemaFormat())


### PR DESCRIPTION
Add support for OAuth authentication to schema registry in the Kafka to Big Query Flex and Kafka to GCS flex templates. 