### PR TITLE
remove release branch lowercase logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Declare release branch name and tag name
       id: variables
       run: |
-        echo "releaseBranchName=release_${CANDIDATE_NAME,,}" >> $GITHUB_OUTPUT
+        echo "releaseBranchName=release_${CANDIDATE_NAME}" >> $GITHUB_OUTPUT
         echo "tagName=${CANDIDATE_NAME^^}" >> $GITHUB_OUTPUT
       env:
         CANDIDATE_NAME: ${{ inputs.candidateName }}


### PR DESCRIPTION
The new release process expects the release branch to be `release_${CANDIDATE_NAME}`