### PR TITLE
Do not run spanner-pr tests in Java PR

### DIFF
--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -165,6 +165,7 @@ jobs:
       - name: Run Integration Tests
         run: | 
           ./cicd/run-it-tests \
+          --modules-to-build="DEFAULT" \
           --it-region="us-central1" \
           --it-project="cloud-teleport-testing" \
           --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \

--- a/.github/workflows/spanner-pr.yml
+++ b/.github/workflows/spanner-pr.yml
@@ -21,14 +21,20 @@ on:
     branches:
     - 'main'
     paths:
-      # Include spanner paths only
-      - '.github/workflows/spanner-pr.yml'
-      - 'v2/datastream-to-spanner/**'
+      # Template wide common modules
+      - 'v2/common/**'
+      - 'v2/datastream-common/**'
+      - 'it/google-cloud-platform/**'
+      - 'it/conditions/**'
+      # Component common modules
       - 'v2/spanner-common/**'
-      - 'v2/spanner-change-streams-to-sharded-file-sink/**'
-      - 'v2/gcs-to-sourcedb/**'
       - 'v2/spanner-migrations-sdk/**'
       - 'v2/spanner-custom-shard/**'
+      # Include spanner paths
+      - '.github/workflows/spanner-pr.yml'
+      - 'v2/datastream-to-spanner/**'
+      - 'v2/spanner-change-streams-to-sharded-file-sink/**'
+      - 'v2/gcs-to-sourcedb/**'
       - 'v2/sourcedb-to-spanner/**'
       - 'v2/spanner-to-sourcedb/**'
   schedule:

--- a/cicd/internal/flags/common-flags_test.go
+++ b/cicd/internal/flags/common-flags_test.go
@@ -18,6 +18,7 @@ package flags
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -50,5 +51,25 @@ func TestModulesToBuild(t *testing.T) {
 		if !reflect.DeepEqual(actual, test.expected) {
 			t.Errorf("Returned modules are not equal. Expected %v. Got %v.", test.expected, actual)
 		}
+	}
+}
+
+func TestDefaultExcludedSubModules(t *testing.T) {
+	// common modules won't excluded
+	modulesToBuild = "DEFAULT"
+	defaults := ModulesToBuild()
+	mods := []string{"SPANNER"}
+	var s []string
+	for _, m := range mods {
+		modulesToBuild = m
+		ms := ModulesToBuild()
+		for _, n := range ms {
+			if !strings.HasPrefix(n, "plugins/") {
+				s = append(s, "!"+n)
+			}
+		}
+	}
+	if !reflect.DeepEqual(defaults, s) {
+		t.Errorf("Returned modules are not equal. Expected %v. Got %v.", s, defaults)
 	}
 }


### PR DESCRIPTION
spanner-pr tests have been flaky, mostly due to different kind of resource exhausted. This PR moves them out of. the common java pr GHA.