### PR TITLE
Removed order attribute from search index tokenlist key parts

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/IndexColumn.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/IndexColumn.java
@@ -140,11 +140,11 @@ public abstract class IndexColumn implements Serializable {
       return set(IndexColumn.create(name, Order.DESC, dialect));
     }
 
-
     public IndexColumnsBuilder<T> none(String name) {
       IndexColumn indexColumn = IndexColumn.create(name, Order.NONE, dialect);
       return set(indexColumn);
     }
+
     public IndexColumnsBuilder<T> storing(String name) {
       return set(IndexColumn.create(name, Order.STORING, dialect));
     }

--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/IndexColumn.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/IndexColumn.java
@@ -52,7 +52,8 @@ public abstract class IndexColumn implements Serializable {
   public enum Order {
     ASC("ASC"),
     DESC("DESC"),
-    STORING("STORING");
+    STORING("STORING"),
+    NONE("");
 
     Order(String title) {
       this.title = title;
@@ -139,6 +140,11 @@ public abstract class IndexColumn implements Serializable {
       return set(IndexColumn.create(name, Order.DESC, dialect));
     }
 
+
+    public IndexColumnsBuilder<T> none(String name) {
+      IndexColumn indexColumn = IndexColumn.create(name, Order.NONE, dialect);
+      return set(indexColumn);
+    }
     public IndexColumnsBuilder<T> storing(String name) {
       return set(IndexColumn.create(name, Order.STORING, dialect));
     }
@@ -177,6 +183,15 @@ public abstract class IndexColumn implements Serializable {
             "Builder is missing. Call create method to initiate a builder first.");
       }
       indexColumnBuilder.order(Order.DESC);
+      return this;
+    }
+
+    public IndexColumnsBuilder<T> none() {
+      if (indexColumnBuilder == null) {
+        throw new IllegalArgumentException(
+            "Builder is missing. Call create method to initiate a builder first.");
+      }
+      indexColumnBuilder.order(Order.NONE);
       return this;
     }
 

--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScanner.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScanner.java
@@ -507,7 +507,7 @@ public class InformationSchemaScanner {
             indexBuilder.columns().create().name(columnName);
 
         if (spannerType.equals("TOKENLIST")) {
-          indexColumnsBuilder.asc();
+          indexColumnsBuilder.none();
         } else if (ordering == null) {
           indexColumnsBuilder.storing();
         }

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ExportPipelineIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ExportPipelineIT.java
@@ -200,7 +200,7 @@ public class ExportPipelineIT extends TemplateTestBase {
     String createSearchIndexStatement =
         String.format(
             "CREATE SEARCH INDEX `%s_SearchIndex`\n"
-                + " ON `%s_Singers`(`MyTokens` ASC)\n"
+                + " ON `%s_Singers`(`MyTokens`)\n"
                 + " OPTIONS (sort_order_sharding=TRUE)",
             testName, testName);
 

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
@@ -601,7 +601,7 @@ public class InformationSchemaScannerIT {
                 + "  `Body_Tokens`                           TOKENLIST AS (TOKENIZE_FULLTEXT(`Body`)) HIDDEN,"
                 + "  `Data`                                  STRING(MAX),"
                 + " ) PRIMARY KEY (`UserId` ASC, `MessageId` ASC), INTERLEAVE IN PARENT `Users`",
-            " CREATE SEARCH INDEX `SearchIndex` ON `Messages`(`Subject_Tokens` ASC, `Body_Tokens` ASC)"
+            " CREATE SEARCH INDEX `SearchIndex` ON `Messages`(`Subject_Tokens` , `Body_Tokens` )"
                 + " STORING (`Data`)"
                 + " PARTITION BY `UserId`,"
                 + " INTERLEAVE IN `Users`"


### PR DESCRIPTION
The order attribute is not longer supported for search indexes in Cloud Spanner. This change allows an IndexColumn to have an empty order value.

@darshan-sj 