### PR TITLE
Datastream->BigQuery Template Merge Failure

### DIFF
--- a/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/values/DatastreamRow.java
+++ b/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/values/DatastreamRow.java
@@ -24,6 +24,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,7 +113,27 @@ public class DatastreamRow {
       }
     } else {
       if (tableRow.get("_metadata_primary_keys") != null) {
-        primaryKeys = (List<String>) tableRow.get("_metadata_primary_keys");
+        Object primaryKeysObj = tableRow.get("_metadata_primary_keys");
+        if (primaryKeysObj instanceof List) {
+          primaryKeys = (List<String>) primaryKeysObj;
+        } else if (primaryKeysObj instanceof String) {
+          // Fixed because we have seen this once at issue b/358606362
+          // not clear how it can be as DS template always set a List on this field.
+          // we saw this happens  on "UDF to TableRow/Oracle Cleaner" or "BigQuery Merge/Build"
+          // steps.
+          LOG.info("primaryKeysObj is String type {}", primaryKeysObj);
+          String primaryKeysStr = (String) primaryKeysObj;
+          String[] elements = primaryKeysStr.substring(1, primaryKeysStr.length() - 1).split(",");
+          primaryKeys =
+              new ArrayList<>(
+                  Arrays.asList(elements).stream()
+                      .map(s -> StringUtils.unwrap(s.trim(), "\""))
+                      .collect(Collectors.toList()));
+
+        } else {
+          throw new RuntimeException(
+              "_metadata_primary_keys has unsupported type: " + primaryKeysObj.getClass());
+        }
       }
     }
 

--- a/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/values/DatastreamRow.java
+++ b/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/values/DatastreamRow.java
@@ -117,8 +117,8 @@ public class DatastreamRow {
         if (primaryKeysObj instanceof List) {
           primaryKeys = (List<String>) primaryKeysObj;
         } else if (primaryKeysObj instanceof String) {
-          // Fixed because we have seen this once at issue b/358606362
-          // not clear how it can be as DS template always set a List on this field.
+          // Fixed since we have seen this once.
+          // the reason isn't clear as DS template always set a List on this field.
           // we saw this happens  on "UDF to TableRow/Oracle Cleaner" or "BigQuery Merge/Build"
           // steps.
           LOG.info("primaryKeysObj is String type {}", primaryKeysObj);

--- a/v2/datastream-common/src/test/java/com/google/cloud/teleport/v2/datastream/values/DatastreamRowTest.java
+++ b/v2/datastream-common/src/test/java/com/google/cloud/teleport/v2/datastream/values/DatastreamRowTest.java
@@ -1,0 +1,67 @@
+*
+    * Copyright (C) 2019 Google LLC
+    *
+    * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    * use this file except in compliance with the License. You may obtain a copy of
+    * the License at
+    *
+    *   http://www.apache.org/licenses/LICENSE-2.0
+    *
+    * Unless required by applicable law or agreed to in writing, software
+    * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    * License for the specific language governing permissions and limitations under
+    * the License.
+    */
+    package com.google.cloud.teleport.v2.datastream.values;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.api.services.bigquery.model.TableRow;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+public class DatastreamRowTest {
+
+  @Test
+  public void testGetPrimaryKeysAsQuotedString() throws IOException, GeneralSecurityException {
+    TableRow r1 = new TableRow();
+    r1.set("_metadata_primary_keys", "[\"id\",\"name\"]");
+    r1.set("_metadata_source_type", "oracle");
+    DatastreamRow row = DatastreamRow.of(r1);
+    List<String> pks = row.getPrimaryKeys();
+
+    assertEquals(pks.size(), 2);
+    assertEquals(pks.get(0), "id");
+    assertEquals(pks.get(1), "name");
+  }
+
+  @Test
+  public void testGetPrimaryKeysAsString() throws IOException, GeneralSecurityException {
+    TableRow r1 = new TableRow();
+    r1.set("_metadata_primary_keys", "[id, name]");
+    r1.set("_metadata_source_type", "oracle");
+    DatastreamRow row = DatastreamRow.of(r1);
+    List<String> pks = row.getPrimaryKeys();
+
+    assertEquals(pks.size(), 2);
+    assertEquals(pks.get(0), "id");
+    assertEquals(pks.get(1), "name");
+  }
+
+  @Test
+  public void testGetPrimaryKeysAsList() throws IOException, GeneralSecurityException {
+    TableRow r1 = new TableRow();
+    r1.set("_metadata_primary_keys", Arrays.asList(new String[] {"id", "name"}));
+    r1.set("_metadata_source_type", "oracle");
+    DatastreamRow row = DatastreamRow.of(r1);
+    List<String> pks = row.getPrimaryKeys();
+
+    assertEquals(pks.size(), 2);
+    assertEquals(pks.get(0), "id");
+    assertEquals(pks.get(1), "name");
+  }
+}

--- a/v2/datastream-common/src/test/java/com/google/cloud/teleport/v2/datastream/values/DatastreamRowTest.java
+++ b/v2/datastream-common/src/test/java/com/google/cloud/teleport/v2/datastream/values/DatastreamRowTest.java
@@ -1,19 +1,19 @@
-*
-    * Copyright (C) 2019 Google LLC
-    *
-    * Licensed under the Apache License, Version 2.0 (the "License"); you may not
-    * use this file except in compliance with the License. You may obtain a copy of
-    * the License at
-    *
-    *   http://www.apache.org/licenses/LICENSE-2.0
-    *
-    * Unless required by applicable law or agreed to in writing, software
-    * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-    * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-    * License for the specific language governing permissions and limitations under
-    * the License.
-    */
-    package com.google.cloud.teleport.v2.datastream.values;
+/*
+ * Copyright (C) 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.datastream.values;
 
 import static org.junit.Assert.assertEquals;
 


### PR DESCRIPTION
This is a **WORKAROUND** fix for some serialization/deserialization issue which change a List<String> type into List<String>.toString() (String).
We are not sure what causing this issue, but this fix should solve the ClassCastException  which is being thrown because of the typing issue.
For example:
`Error message from worker: java.lang.ClassCastException: class java.lang.String cannot be cast to class java.util.List (java.lang.String and java.util.List are in module java.base of loader 'bootstrap')
        com.google.cloud.teleport.v2.datastream.values.DatastreamRow.getPrimaryKeys(DatastreamRow.java:114)
        com.google.cloud.teleport.v2.transforms.StatefulRowCleaner$StatefulCleanDatastreamRowFn.processElement(StatefulRowCleaner.java:132)
`


