### PR TITLE
Fix a few dependency conflicts

### DIFF
--- a/it/pom.xml
+++ b/it/pom.xml
@@ -32,7 +32,7 @@
     <commons-math3.version>3.6.1</commons-math3.version>
     <failsafe.version>3.3.0</failsafe.version>
     <testcontainers.version>1.18.3</testcontainers.version>
-    <dataflow-api.version>v1b3-rev20220920-2.0.0</dataflow-api.version>
+    <dataflow-api.version>v1b3-rev20240624-2.0.0</dataflow-api.version>
   </properties>
 
   <dependencies>

--- a/structured-logging/pom.xml
+++ b/structured-logging/pom.xml
@@ -47,6 +47,11 @@
       <artifactId>logback-classic</artifactId>
       <version>${logback.version}</version>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <version>${logback.version}</version>
+    </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>com.google.truth</groupId>

--- a/v2/googlecloud-to-googlecloud/pom.xml
+++ b/v2/googlecloud-to-googlecloud/pom.xml
@@ -182,6 +182,14 @@
           <groupId>asm</groupId>
           <artifactId>asm</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
FIrst fix: Bump dataflow api version to rev20240624 for it-gcp, 

Beam bumped dataflow api version in 2.58.0 - https://github.com/apache/beam/pull/31751 but it-gcp in DataflowTemplates still uses old version, causing `NoSuchMethodError: StreamingOperationalLimits.getOperationalLimits` in streaming integration tests on streaming engine enabled (somehow intermittently)


Second fix:

Fixes #1836. #1791 introduced the following dependency tree for v2/googlecloud-to-googlecloud

```
[INFO] +- org.apache.hadoop:hadoop-common:jar:3.4.0:compile
[INFO] |  +- org.apache.zookeeper:zookeeper:jar:3.8.3:compile
[INFO] |  |  +- org.apache.zookeeper:zookeeper-jute:jar:3.8.3:compile
[INFO] |  |  \- ch.qos.logback:logback-core:jar:1.2.10:compile
[INFO] +- com.google.cloud.teleport:structured-logging:jar:1.0-SNAPSHOT:compile
[INFO] |  \- ch.qos.logback:logback-classic:jar:1.2.13:compile
``` 

causing mismatched logback-classic:1.2.13 and logback-core:jar:1.2.10 dependencies

