### PR TITLE
Load test fixes and multiple PK mutation in same trx handling

### DIFF
--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
@@ -511,7 +511,10 @@ public class SpannerToSourceDb {
                         options.getShardingCustomJarPath(),
                         options.getShardingCustomClassName(),
                         options.getShardingCustomParameters(),
-                        options.getMaxShardConnections())))
+                        options.getMaxShardConnections()
+                            * shards
+                                .size()))) // currently assuming that all shards accept the same
+                                           // number of max connections
             .setCoder(
                 KvCoder.of(
                     VarLongCoder.of(), SerializableCoder.of(TrimmedShardedDataChangeRecord.class)))

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/constants/Constants.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/constants/Constants.java
@@ -44,6 +44,9 @@ public class Constants {
   // Commit timestamp column name in shadow table
   public static final String PROCESSED_COMMIT_TS_COLUMN_NAME = "processed_commit_ts";
 
+  // Record sequence  column name in shadow table
+  public static final String RECORD_SEQ_COLUMN_NAME = "record_seq";
+
   // The tag for events failed with non-retryable errors
   public static final TupleTag<String> PERMANENT_ERROR_TAG = new TupleTag<String>() {};
 
@@ -61,4 +64,7 @@ public class Constants {
 
   // Message written to the file for no shard found records
   public static final String SHARD_NOT_PRESENT_ERROR_MESSAGE = "No shard identified for the record";
+
+  // Default parallelism for the Dataflow workers
+  public static final int DEFAULT_WORKER_HARNESS_THREAD_COUNT = 500;
 }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/AssignShardIdFn.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/AssignShardIdFn.java
@@ -232,9 +232,8 @@ public class AssignShardIdFn
       record.setShard(qualifiedShard);
       String finalKeyString = tableName + "_" + keysJsonStr + "_" + qualifiedShard;
       Long finalKey =
-          finalKeyString.hashCode()
-              % maxConnectionsAcrossAllShards; // The total parallelism is
-                                               // maxConnectionsAcrossAllShards
+          finalKeyString.hashCode() % maxConnectionsAcrossAllShards; // The total parallelism is
+      // maxConnectionsAcrossAllShards
       c.output(KV.of(finalKey, record));
 
     } catch (Exception e) {

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/AssignShardIdFn.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/AssignShardIdFn.java
@@ -88,7 +88,7 @@ public class AssignShardIdFn
 
   private IShardIdFetcher shardIdFetcher;
 
-  private final Long maxConnectionsPerShard;
+  private final Long maxConnectionsAcrossAllShards;
 
   public AssignShardIdFn(
       SpannerConfig spannerConfig,
@@ -100,7 +100,7 @@ public class AssignShardIdFn
       String customJarPath,
       String shardingCustomClassName,
       String shardingCustomParameters,
-      Long maxConnectionsPerShard) {
+      Long maxConnectionsAcrossAllShards) {
     this.spannerConfig = spannerConfig;
     this.schema = schema;
     this.ddl = ddl;
@@ -110,7 +110,7 @@ public class AssignShardIdFn
     this.customJarPath = customJarPath;
     this.shardingCustomClassName = shardingCustomClassName;
     this.shardingCustomParameters = shardingCustomParameters;
-    this.maxConnectionsPerShard = maxConnectionsPerShard;
+    this.maxConnectionsAcrossAllShards = maxConnectionsAcrossAllShards;
   }
 
   // setSpannerAccessor is added to be used by unit tests
@@ -231,7 +231,10 @@ public class AssignShardIdFn
 
       record.setShard(qualifiedShard);
       String finalKeyString = tableName + "_" + keysJsonStr + "_" + qualifiedShard;
-      Long finalKey = finalKeyString.hashCode() % maxConnectionsPerShard;
+      Long finalKey =
+          finalKeyString.hashCode()
+              % maxConnectionsAcrossAllShards; // The total parallelism is
+                                               // maxConnectionsAcrossAllShards
       c.output(KV.of(finalKey, record));
 
     } catch (Exception e) {
@@ -240,7 +243,7 @@ public class AssignShardIdFn
       LOG.error("Error fetching shard Id column: " + e.getMessage() + ": " + errors.toString());
       // The record has no shard hence will be sent to DLQ in subsequent steps
       String finalKeyString = record.getTableName() + "_" + keysJsonStr + "_" + skipDirName;
-      Long finalKey = finalKeyString.hashCode() % maxConnectionsPerShard;
+      Long finalKey = finalKeyString.hashCode() % maxConnectionsAcrossAllShards;
       c.output(KV.of(finalKey, record));
     }
   }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFn.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFn.java
@@ -30,8 +30,11 @@ import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
 import com.google.cloud.teleport.v2.templates.changestream.ChangeStreamErrorRecord;
 import com.google.cloud.teleport.v2.templates.changestream.TrimmedShardedDataChangeRecord;
 import com.google.cloud.teleport.v2.templates.constants.Constants;
+import com.google.cloud.teleport.v2.templates.utils.ConnectionException;
+import com.google.cloud.teleport.v2.templates.utils.ConnectionHelper;
 import com.google.cloud.teleport.v2.templates.utils.InputRecordProcessor;
 import com.google.cloud.teleport.v2.templates.utils.MySqlDao;
+import com.google.cloud.teleport.v2.templates.utils.ShadowTableRecord;
 import com.google.cloud.teleport.v2.templates.utils.SpannerDao;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
@@ -83,6 +86,7 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
   private final Ddl ddl;
   private final String shadowTablePrefix;
   private final String skipDirName;
+  private final int maxThreadPerDataflowWorker;
 
   public SourceWriterFn(
       List<Shard> shards,
@@ -91,7 +95,8 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
       String sourceDbTimezoneOffset,
       Ddl ddl,
       String shadowTablePrefix,
-      String skipDirName) {
+      String skipDirName,
+      int maxThreadPerDataflowWorker) {
 
     this.schema = schema;
     this.sourceDbTimezoneOffset = sourceDbTimezoneOffset;
@@ -100,6 +105,7 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
     this.ddl = ddl;
     this.shadowTablePrefix = shadowTablePrefix;
     this.skipDirName = skipDirName;
+    this.maxThreadPerDataflowWorker = maxThreadPerDataflowWorker;
   }
 
   // for unit testing purposes
@@ -122,6 +128,7 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
   public void setup() {
     mapper = new ObjectMapper();
     mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+    ConnectionHelper.init(shards, null, maxThreadPerDataflowWorker);
 
     // TODO: Support multiple databases
     for (Shard shard : shards) {
@@ -138,11 +145,6 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
   /** Teardown function disconnects from the Cloud Spanner. */
   @Teardown
   public void teardown() throws Exception {
-    if (mySqlDaoMap != null) {
-      for (MySqlDao mySqlDao : mySqlDaoMap.values()) {
-        mySqlDao.cleanup();
-      }
-    }
     spannerDao.close();
     mySqlDaoMap.clear();
   }
@@ -170,12 +172,22 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
                 tableName, ddl, keysJson, /* convertNameToLowerCase= */ false);
         String shadowTableName = shadowTablePrefix + tableName;
         boolean isSourceAhead = false;
-
-        com.google.cloud.Timestamp processedCommitTimestamp =
-            spannerDao.getProcessedCommitTimestamp(shadowTableName, primaryKey);
+        ShadowTableRecord shadowTableRecord =
+            spannerDao.getShadowTableRecord(shadowTableName, primaryKey);
         isSourceAhead =
-            processedCommitTimestamp != null
-                && (processedCommitTimestamp.compareTo(spannerRec.getCommitTimestamp()) > 0);
+            shadowTableRecord != null
+                && ((shadowTableRecord
+                            .getProcessedCommitTimestamp()
+                            .compareTo(spannerRec.getCommitTimestamp())
+                        > 0) // either the source already has record with greater commit
+                    // timestamp
+                    || (shadowTableRecord // or the source has the same commit timestamp but
+                                // greater record sequence
+                                .getProcessedCommitTimestamp()
+                                .compareTo(spannerRec.getCommitTimestamp())
+                            == 0
+                        && shadowTableRecord.getRecordSequence()
+                            > Long.parseLong(spannerRec.getRecordSequence())));
 
         if (!isSourceAhead) {
           MySqlDao mySqlDao = mySqlDaoMap.get(shardId);
@@ -183,9 +195,13 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
           InputRecordProcessor.processRecord(
               spannerRec, schema, mySqlDao, shardId, sourceDbTimezoneOffset);
 
-          spannerDao.updateProcessedCommitTimestamp(
+          spannerDao.updateShadowTable(
               getShadowTableMutation(
-                  tableName, shadowTableName, keysJson, spannerRec.getCommitTimestamp()));
+                  tableName,
+                  shadowTableName,
+                  keysJson,
+                  spannerRec.getCommitTimestamp(),
+                  spannerRec.getRecordSequence()));
         }
         successRecordCountMetric.inc();
         if (spannerRec.isRetryRecord()) {
@@ -196,20 +212,28 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
       } catch (ChangeEventConvertorException ex) {
         outputWithTag(c, Constants.PERMANENT_ERROR_TAG, ex.getMessage(), spannerRec);
       } catch (SpannerException | IllegalStateException ex) {
-        if (!spannerRec.isRetryRecord()) {
-          retryableRecordCountMetric.inc();
+        outputWithTag(c, Constants.RETRYABLE_ERROR_TAG, ex.getMessage(), spannerRec);
+      } catch (com.mysql.cj.jdbc.exceptions.CommunicationsException
+          | java.sql.SQLTransientConnectionException ex) {
+        outputWithTag(c, Constants.RETRYABLE_ERROR_TAG, ex.getMessage(), spannerRec);
+      } catch (java.sql.SQLNonTransientConnectionException ex) {
+        if (ex.getMessage().contains("Server shutdown in progress")) {
+          outputWithTag(c, Constants.RETRYABLE_ERROR_TAG, ex.getMessage(), spannerRec);
+        } else {
+          outputWithTag(c, Constants.PERMANENT_ERROR_TAG, ex.getMessage(), spannerRec);
         }
+      } catch (ConnectionException ex) {
         outputWithTag(c, Constants.RETRYABLE_ERROR_TAG, ex.getMessage(), spannerRec);
       } catch (Exception ex) {
         LOG.error("Failed to write to source", ex);
         // we are only interested in the retryable errors
         // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
-        // Error 1452 and 1451
+        // Error 1452 and 1451 and transient communication errors
 
-        if (ex.getMessage().contains("a foreign key constraint fails")) {
-          if (!spannerRec.isRetryRecord()) {
-            retryableRecordCountMetric.inc();
-          }
+        if (ex.getMessage().contains("a foreign key constraint fails")
+            || ex.getMessage().contains("No operations allowed after statement closed")
+            || ex.getMessage().contains("Got timeout reading communication packets")) {
+
           outputWithTag(c, Constants.RETRYABLE_ERROR_TAG, ex.getMessage(), spannerRec);
         } else {
           outputWithTag(c, Constants.PERMANENT_ERROR_TAG, ex.getMessage(), spannerRec);
@@ -222,7 +246,8 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
       String tableName,
       String shadowTableName,
       JsonNode keysJson,
-      com.google.cloud.Timestamp commitTimestamp)
+      com.google.cloud.Timestamp commitTimestamp,
+      String recordSequence)
       throws ChangeEventConvertorException {
     Mutation.WriteBuilder mutationBuilder = null;
 
@@ -240,6 +265,7 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
             keyColumnNamesSet,
             /* convertNameToLowerCase= */ false);
     mutationBuilder.set(Constants.PROCESSED_COMMIT_TS_COLUMN_NAME).to(commitTimestamp);
+    mutationBuilder.set(Constants.RECORD_SEQ_COLUMN_NAME).to(Long.parseLong(recordSequence));
 
     return mutationBuilder.build();
   }
@@ -251,6 +277,11 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
       TrimmedShardedDataChangeRecord record) {
     String jsonRec = gson.toJson(record, TrimmedShardedDataChangeRecord.class);
     ChangeStreamErrorRecord errorRecord = new ChangeStreamErrorRecord(jsonRec, message);
+
+    // Permanent error metrics are inceremented differently based on regular or retryDLQ mode
+    if (!record.isRetryRecord() && tag.equals(Constants.RETRYABLE_ERROR_TAG)) {
+      retryableRecordCountMetric.inc();
+    }
     c.output(tag, gson.toJson(errorRecord, ChangeStreamErrorRecord.class));
   }
 }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterTransform.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterTransform.java
@@ -50,6 +50,7 @@ public class SourceWriterTransform
   private final Ddl ddl;
   private final String shadowTablePrefix;
   private final String skipDirName;
+  private final int maxThreadPerDataflowWorker;
 
   public SourceWriterTransform(
       List<Shard> shards,
@@ -58,7 +59,8 @@ public class SourceWriterTransform
       String sourceDbTimezoneOffset,
       Ddl ddl,
       String shadowTablePrefix,
-      String skipDirName) {
+      String skipDirName,
+      int maxThreadPerDataflowWorker) {
 
     this.schema = schema;
     this.sourceDbTimezoneOffset = sourceDbTimezoneOffset;
@@ -67,6 +69,7 @@ public class SourceWriterTransform
     this.ddl = ddl;
     this.shadowTablePrefix = shadowTablePrefix;
     this.skipDirName = skipDirName;
+    this.maxThreadPerDataflowWorker = maxThreadPerDataflowWorker;
   }
 
   @Override
@@ -83,7 +86,8 @@ public class SourceWriterTransform
                         this.sourceDbTimezoneOffset,
                         this.ddl,
                         this.shadowTablePrefix,
-                        this.skipDirName))
+                        this.skipDirName,
+                        this.maxThreadPerDataflowWorker))
                 .withOutputTags(
                     Constants.SUCCESS_TAG,
                     TupleTagList.of(Constants.PERMANENT_ERROR_TAG)

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/ConnectionException.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/ConnectionException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.utils;
+
+/** Exception when connecting to the source database. */
+public class ConnectionException extends Exception {
+  public ConnectionException(Exception e) {
+    super(e);
+  }
+
+  public ConnectionException(String message) {
+    super(message);
+  }
+
+  public ConnectionException(String message, Exception e) {
+    super(message, e);
+  }
+}

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/ConnectionHelper.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/ConnectionHelper.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.utils;
+
+import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import java.io.IOException;
+import java.io.StringReader;
+import java.sql.Connection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** This is a per Dataflow worker singleton that holds connection pool. */
+public class ConnectionHelper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ConnectionHelper.class);
+  private static final String JDBC_DRIVER = "com.mysql.jdbc.Driver";
+  private static Map<String, HikariDataSource> connectionPoolMap = null;
+
+  public static synchronized void init(List<Shard> shards, String properties, int maxConnections) {
+    if (connectionPoolMap != null) {
+      return;
+    }
+    LOG.info("Initializing connection pool with size: ", maxConnections);
+    connectionPoolMap = new HashMap<>();
+    for (Shard shard : shards) {
+      String sourceConnectionUrl =
+          "jdbc:mysql://" + shard.getHost() + ":" + shard.getPort() + "/" + shard.getDbName();
+      HikariConfig config = new HikariConfig();
+      config.setJdbcUrl(sourceConnectionUrl);
+      config.setUsername(shard.getUserName());
+      config.setPassword(shard.getPassword());
+      config.setDriverClassName(JDBC_DRIVER);
+      config.setMaximumPoolSize(maxConnections);
+      config.setConnectionInitSql(
+          "SET SESSION net_read_timeout=1200"); // to avoid timeouts at network level layer
+      HikariDataSource ds = new HikariDataSource(config);
+      Properties jdbcProperties = new Properties();
+      if (properties != null && !properties.isEmpty()) {
+        try (StringReader reader = new StringReader(properties)) {
+          jdbcProperties.load(reader);
+        } catch (IOException e) {
+          System.err.println("Error converting string to properties: " + e.getMessage());
+        }
+      }
+
+      for (String key : jdbcProperties.stringPropertyNames()) {
+        String value = jdbcProperties.getProperty(key);
+        config.addDataSourceProperty(key, value);
+      }
+      connectionPoolMap.put(sourceConnectionUrl + shard.getUserName() + shard.getPassword(), ds);
+    }
+  }
+
+  public static Connection getConnection(String sourceConnectionUrl, String user, String password)
+      throws java.sql.SQLException {
+    HikariDataSource ds = connectionPoolMap.get(sourceConnectionUrl + user + password);
+    if (ds == null) {
+      LOG.warn("Connection pool not found for source connection url: {}", sourceConnectionUrl);
+      return null;
+    }
+
+    return ds.getConnection();
+  }
+}

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/ConnectionHelper.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/ConnectionHelper.java
@@ -52,13 +52,12 @@ public class ConnectionHelper {
       config.setMaximumPoolSize(maxConnections);
       config.setConnectionInitSql(
           "SET SESSION net_read_timeout=1200"); // to avoid timeouts at network level layer
-      HikariDataSource ds = new HikariDataSource(config);
       Properties jdbcProperties = new Properties();
       if (properties != null && !properties.isEmpty()) {
         try (StringReader reader = new StringReader(properties)) {
           jdbcProperties.load(reader);
         } catch (IOException e) {
-          System.err.println("Error converting string to properties: " + e.getMessage());
+          LOG.error("Error converting string to properties: {}", e.getMessage());
         }
       }
 
@@ -66,6 +65,8 @@ public class ConnectionHelper {
         String value = jdbcProperties.getProperty(key);
         config.addDataSourceProperty(key, value);
       }
+      HikariDataSource ds = new HikariDataSource(config);
+
       connectionPoolMap.put(sourceConnectionUrl + shard.getUserName() + shard.getPassword(), ds);
     }
   }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/InputRecordProcessor.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/InputRecordProcessor.java
@@ -38,7 +38,7 @@ public class InputRecordProcessor {
       MySqlDao dao,
       String shardId,
       String sourceDbTimezoneOffset)
-      throws java.sql.SQLException {
+      throws java.sql.SQLException, ConnectionException {
 
     try {
 

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/MySqlDao.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/MySqlDao.java
@@ -17,10 +17,8 @@ package com.google.cloud.teleport.v2.templates.utils;
 
 import java.io.Serializable;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
-import org.apache.beam.sdk.metrics.Metrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,71 +38,33 @@ public class MySqlDao implements Serializable {
     } catch (ClassNotFoundException e) {
       LOG.error("There was not able to find the driver class");
     }
-
-    // TODO: add the connection pool as needed
     this.sqlUrl = sqlUrl;
     this.sqlUser = sqlUser;
     this.sqlPasswd = sqlPasswd;
   }
 
   // writes to database
-  public void write(String sqlStatement) throws SQLException {
+  public void write(String sqlStatement) throws SQLException, ConnectionException {
     Connection connObj = null;
     Statement statement = null;
-    boolean status = false;
-    while (!status) {
-      try {
 
-        connObj = DriverManager.getConnection(this.sqlUrl, this.sqlUser, this.sqlPasswd);
-        connObj.setAutoCommit(false);
-        statement = connObj.createStatement();
-        statement.executeUpdate(sqlStatement);
-        connObj.commit();
-        status = true;
-      } catch (com.mysql.cj.jdbc.exceptions.CommunicationsException
-          | java.sql.SQLTransientConnectionException e) {
+    try {
 
-        // TODO: retry handling is configurable with retry count
-        LOG.warn("Connection exception while executing SQL, will retry : " + e.getMessage());
-        // gives indication that the shard is being retried
-        Metrics.counter(MySqlDao.class, "mySQL_retry_sql").inc();
-      } catch (java.sql.SQLNonTransientConnectionException e) {
-        if (e.getMessage().contains("Server shutdown in progress")) {
-          LOG.warn(
-              "Connection exception while executing SQL for shard : "
-                  + ", will retry : "
-                  + e.getMessage());
-          // gives indication that the shard is being retried
-          Metrics.counter(MySqlDao.class, "mySQL_retry_sql").inc();
-        } else {
-          throw e;
-        }
-      } catch (java.sql.SQLException e) {
-        // This exception happens when the DB is shutting down
-        if (e.getMessage().contains("No operations allowed after statement closed")) {
-          LOG.warn(
-              "Connection exception while executing SQL for shard : "
-                  + ", will retry : "
-                  + e.getMessage());
-          // gives indication that the shard is being retried
-          Metrics.counter(MySqlDao.class, "mySQL_retry_sql").inc();
-        } else {
-          throw e;
-        }
-      } finally {
+      connObj = ConnectionHelper.getConnection(this.sqlUrl, this.sqlUser, this.sqlPasswd);
+      if (connObj == null) {
+        throw new ConnectionException("Connection is null");
+      }
+      statement = connObj.createStatement();
+      statement.executeUpdate(sqlStatement);
 
-        if (statement != null) {
-          statement.close();
-        }
-        if (connObj != null) {
-          connObj.close();
-        }
+    } finally {
+
+      if (statement != null) {
+        statement.close();
+      }
+      if (connObj != null) {
+        connObj.close();
       }
     }
-  }
-
-  // frees up the pooling resources
-  public void cleanup() throws Exception {
-    // TODO: add the cleanup logic when connection pool is added
   }
 }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/ShadowTableCreator.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/ShadowTableCreator.java
@@ -171,6 +171,14 @@ public class ShadowTableCreator {
     shadowTableBuilder.addColumn(
         processedCommitTimestampColumnBuilder.type(Type.timestamp()).notNull(false).autoBuild());
 
+    // Add record sequence column to hold the record sequence change stream record written
+    // to source
+    // by the pipeline.
+    Column.Builder recordSequenceColumnBuilder =
+        shadowTableBuilder.column(Constants.RECORD_SEQ_COLUMN_NAME);
+    shadowTableBuilder.addColumn(
+        recordSequenceColumnBuilder.type(Type.int64()).notNull(false).autoBuild());
+
     return shadowTableBuilder.build();
   }
 

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/ShadowTableRecord.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/ShadowTableRecord.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.utils;
+
+import com.google.cloud.Timestamp;
+
+/** Represents a record in the shadow table. */
+public class ShadowTableRecord {
+  private Timestamp processedCommitTimestamp;
+  private long recordSequence;
+
+  public ShadowTableRecord(Timestamp processedCommitTimestamp, long recordSequence) {
+    this.processedCommitTimestamp = processedCommitTimestamp;
+    this.recordSequence = recordSequence;
+  }
+
+  public Timestamp getProcessedCommitTimestamp() {
+    return processedCommitTimestamp;
+  }
+
+  public long getRecordSequence() {
+    return recordSequence;
+  }
+
+  public void setProcessedCommitTimestamp(Timestamp processedCommitTimestamp) {
+    this.processedCommitTimestamp = processedCommitTimestamp;
+  }
+
+  public void setRecordSequence(long recordSequence) {
+    this.recordSequence = recordSequence;
+  }
+}

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/SpannerDao.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/SpannerDao.java
@@ -18,6 +18,7 @@ package com.google.cloud.teleport.v2.templates.utils;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Struct;
+import com.google.cloud.teleport.v2.templates.constants.Constants;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -48,21 +49,25 @@ public class SpannerDao {
     this.spannerAccessor = SpannerAccessor.getOrCreate(spannerConfig);
   }
 
-  public com.google.cloud.Timestamp getProcessedCommitTimestamp(
+  public ShadowTableRecord getShadowTableRecord(
       String tableName, com.google.cloud.spanner.Key primaryKey) {
     try {
       DatabaseClient databaseClient = spannerAccessor.getDatabaseClient();
       Struct row =
           databaseClient
               .singleUse()
-              .readRow(tableName, primaryKey, Arrays.asList("processed_commit_ts"));
+              .readRow(
+                  tableName,
+                  primaryKey,
+                  Arrays.asList(
+                      Constants.PROCESSED_COMMIT_TS_COLUMN_NAME, Constants.RECORD_SEQ_COLUMN_NAME));
 
       // This is the first event for the primary key and hence the latest event.
       if (row == null) {
         return null;
       }
 
-      return row.getTimestamp(0);
+      return new ShadowTableRecord(row.getTimestamp(0), row.getLong(1));
     } catch (Exception e) {
       LOG.warn("The " + tableName + " table could not be read. ", e);
       // We need to throw the original exception such that the caller can
@@ -71,7 +76,7 @@ public class SpannerDao {
     }
   }
 
-  public void updateProcessedCommitTimestamp(Mutation mutation) {
+  public void updateShadowTable(Mutation mutation) {
     List<Mutation> mutations = new ArrayList<>();
     mutations.add(mutation);
     spannerAccessor.getDatabaseClient().write(mutations);

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFnTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFnTest.java
@@ -36,6 +36,7 @@ import com.google.cloud.teleport.v2.templates.changestream.ChangeStreamErrorReco
 import com.google.cloud.teleport.v2.templates.changestream.TrimmedShardedDataChangeRecord;
 import com.google.cloud.teleport.v2.templates.constants.Constants;
 import com.google.cloud.teleport.v2.templates.utils.MySqlDao;
+import com.google.cloud.teleport.v2.templates.utils.ShadowTableRecord;
 import com.google.cloud.teleport.v2.templates.utils.SpannerDao;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
@@ -75,13 +76,13 @@ public class SourceWriterFnTest {
   @Before
   public void doBeforeEachTest() throws Exception {
     when(mockMySqlDaoMap.get(any())).thenReturn(mockMySqlDao);
-    when(mockSpannerDao.getProcessedCommitTimestamp(eq("shadow_parent1"), any())).thenReturn(null);
-    when(mockSpannerDao.getProcessedCommitTimestamp(eq("shadow_parent2"), any()))
+    when(mockSpannerDao.getShadowTableRecord(eq("shadow_parent1"), any())).thenReturn(null);
+    when(mockSpannerDao.getShadowTableRecord(eq("shadow_parent2"), any()))
         .thenThrow(new IllegalStateException("Test exception"));
-    when(mockSpannerDao.getProcessedCommitTimestamp(eq("shadow_child11"), any()))
-        .thenReturn(Timestamp.parseTimestamp("2025-02-02T00:00:00Z"));
-    when(mockSpannerDao.getProcessedCommitTimestamp(eq("shadow_child21"), any())).thenReturn(null);
-    doNothing().when(mockSpannerDao).updateProcessedCommitTimestamp(any());
+    when(mockSpannerDao.getShadowTableRecord(eq("shadow_child11"), any()))
+        .thenReturn(new ShadowTableRecord(Timestamp.parseTimestamp("2025-02-02T00:00:00Z"), 1));
+    when(mockSpannerDao.getShadowTableRecord(eq("shadow_child21"), any())).thenReturn(null);
+    doNothing().when(mockSpannerDao).updateShadowTable(any());
     doThrow(new SQLException("a foreign key constraint fails"))
         .when(mockMySqlDao)
         .write(contains("child21"));
@@ -112,16 +113,44 @@ public class SourceWriterFnTest {
             testSourceDbTimezoneOffset,
             testDdl,
             "shadow_",
-            "skip");
+            "skip",
+            500);
     ObjectMapper mapper = new ObjectMapper();
     mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
     sourceWriterFn.setObjectMapper(mapper);
     sourceWriterFn.setSpannerDao(mockSpannerDao);
     sourceWriterFn.setMySqlDaoMap(mockMySqlDaoMap);
     sourceWriterFn.processElement(processContext);
-    verify(mockSpannerDao, atLeast(1)).getProcessedCommitTimestamp(any(), any());
+    verify(mockSpannerDao, atLeast(1)).getShadowTableRecord(any(), any());
     verify(mockMySqlDao, never()).write(any());
-    verify(mockSpannerDao, never()).updateProcessedCommitTimestamp(any());
+    verify(mockSpannerDao, never()).updateShadowTable(any());
+  }
+
+  @Test
+  public void testSourceIsAheadWithSameCommitTimestamp() throws Exception {
+    TrimmedShardedDataChangeRecord record =
+        getChild11TrimmedDataChangeRecordWithSameCommitTimestamp("shardA");
+    record.setShard("shardA");
+    when(processContext.element()).thenReturn(KV.of(1L, record));
+    SourceWriterFn sourceWriterFn =
+        new SourceWriterFn(
+            ImmutableList.of(testShard),
+            testSchema,
+            mockSpannerConfig,
+            testSourceDbTimezoneOffset,
+            testDdl,
+            "shadow_",
+            "skip",
+            500);
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+    sourceWriterFn.setObjectMapper(mapper);
+    sourceWriterFn.setSpannerDao(mockSpannerDao);
+    sourceWriterFn.setMySqlDaoMap(mockMySqlDaoMap);
+    sourceWriterFn.processElement(processContext);
+    verify(mockSpannerDao, atLeast(1)).getShadowTableRecord(any(), any());
+    verify(mockMySqlDao, never()).write(any());
+    verify(mockSpannerDao, never()).updateShadowTable(any());
   }
 
   @Test
@@ -137,16 +166,17 @@ public class SourceWriterFnTest {
             testSourceDbTimezoneOffset,
             testDdl,
             "shadow_",
-            "skip");
+            "skip",
+            500);
     ObjectMapper mapper = new ObjectMapper();
     mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
     sourceWriterFn.setObjectMapper(mapper);
     sourceWriterFn.setSpannerDao(mockSpannerDao);
     sourceWriterFn.setMySqlDaoMap(mockMySqlDaoMap);
     sourceWriterFn.processElement(processContext);
-    verify(mockSpannerDao, atLeast(1)).getProcessedCommitTimestamp(any(), any());
+    verify(mockSpannerDao, atLeast(1)).getShadowTableRecord(any(), any());
     verify(mockMySqlDao, atLeast(1)).write(any());
-    verify(mockSpannerDao, atLeast(1)).updateProcessedCommitTimestamp(any());
+    verify(mockSpannerDao, atLeast(1)).updateShadowTable(any());
   }
 
   @Test
@@ -161,7 +191,8 @@ public class SourceWriterFnTest {
             testSourceDbTimezoneOffset,
             testDdl,
             "shadow_",
-            "skip");
+            "skip",
+            500);
     ObjectMapper mapper = new ObjectMapper();
     mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
     sourceWriterFn.setObjectMapper(mapper);
@@ -190,7 +221,8 @@ public class SourceWriterFnTest {
             testSourceDbTimezoneOffset,
             testDdl,
             "shadow_",
-            "skip");
+            "skip",
+            500);
     ObjectMapper mapper = new ObjectMapper();
     mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
     sourceWriterFn.setObjectMapper(mapper);
@@ -217,7 +249,8 @@ public class SourceWriterFnTest {
             testSourceDbTimezoneOffset,
             testDdl,
             "shadow_",
-            "skip");
+            "skip",
+            500);
     ObjectMapper mapper = new ObjectMapper();
     mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
     sourceWriterFn.setObjectMapper(mapper);
@@ -248,7 +281,8 @@ public class SourceWriterFnTest {
             testSourceDbTimezoneOffset,
             testDdl,
             "shadow_",
-            "skip");
+            "skip",
+            500);
     ObjectMapper mapper = new ObjectMapper();
     mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
     sourceWriterFn.setObjectMapper(mapper);
@@ -275,7 +309,8 @@ public class SourceWriterFnTest {
             testSourceDbTimezoneOffset,
             testDdl,
             "shadow_",
-            "skip");
+            "skip",
+            500);
     ObjectMapper mapper = new ObjectMapper();
     mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
     sourceWriterFn.setObjectMapper(mapper);
@@ -377,7 +412,23 @@ public class SourceWriterFnTest {
     return new TrimmedShardedDataChangeRecord(
         Timestamp.parseTimestamp("2024-12-01T10:15:30.000Z"),
         "serverTxnId",
-        "recordSeq",
+        "0",
+        "child11",
+        new Mod(
+            "{\"child_id\": \"42\" , \"parent_id\": \"42\"}",
+            "{}",
+            "{ \"migration_shard_id\": \"" + shardId + "\"}"),
+        ModType.valueOf("INSERT"),
+        1,
+        "");
+  }
+
+  private TrimmedShardedDataChangeRecord getChild11TrimmedDataChangeRecordWithSameCommitTimestamp(
+      String shardId) {
+    return new TrimmedShardedDataChangeRecord(
+        Timestamp.parseTimestamp("2025-02-02T00:00:00Z"),
+        "serverTxnId",
+        "0",
         "child11",
         new Mod(
             "{\"child_id\": \"42\" , \"parent_id\": \"42\"}",
@@ -392,7 +443,7 @@ public class SourceWriterFnTest {
     return new TrimmedShardedDataChangeRecord(
         Timestamp.parseTimestamp("2020-12-01T10:15:30.000Z"),
         "serverTxnId",
-        "recordSeq",
+        "0",
         "parent1",
         new Mod("{\"id\": \"42\"}", "{}", "{ \"migration_shard_id\": \"" + shardId + "\"}"),
         ModType.valueOf("INSERT"),
@@ -405,7 +456,7 @@ public class SourceWriterFnTest {
     return new TrimmedShardedDataChangeRecord(
         Timestamp.parseTimestamp("2020-12-01T10:15:30.000Z"),
         "serverTxnId",
-        "recordSeq",
+        "0",
         "parent1",
         new Mod(
             "{\"junk_colm\": \"hello\"}", "{}", "{ \"migration_shard_id\": \"" + shardId + "\"}"),
@@ -418,7 +469,7 @@ public class SourceWriterFnTest {
     return new TrimmedShardedDataChangeRecord(
         Timestamp.parseTimestamp("2020-12-01T10:15:30.000Z"),
         "serverTxnId",
-        "recordSeq",
+        "0",
         "parent2",
         new Mod("{\"id\": \"42\"}", "{}", "{ \"migration_shard_id\": \"" + shardId + "\"}"),
         ModType.valueOf("INSERT"),
@@ -430,7 +481,7 @@ public class SourceWriterFnTest {
     return new TrimmedShardedDataChangeRecord(
         Timestamp.parseTimestamp("2024-12-01T10:15:30.000Z"),
         "serverTxnId",
-        "recordSeq",
+        "0",
         "child21",
         new Mod(
             "{\"child_id\": \"42\" , \"parent_id\": \"42\"}",

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFnTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFnTest.java
@@ -40,7 +40,6 @@ import com.google.cloud.teleport.v2.templates.utils.ShadowTableRecord;
 import com.google.cloud.teleport.v2.templates.utils.SpannerDao;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
-import java.sql.SQLException;
 import java.util.HashMap;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.Mod;
@@ -83,7 +82,7 @@ public class SourceWriterFnTest {
         .thenReturn(new ShadowTableRecord(Timestamp.parseTimestamp("2025-02-02T00:00:00Z"), 1));
     when(mockSpannerDao.getShadowTableRecord(eq("shadow_child21"), any())).thenReturn(null);
     doNothing().when(mockSpannerDao).updateShadowTable(any());
-    doThrow(new SQLException("a foreign key constraint fails"))
+    doThrow(new java.sql.SQLIntegrityConstraintViolationException("a foreign key constraint fails"))
         .when(mockMySqlDao)
         .write(contains("child21"));
     doNothing().when(mockMySqlDao).write(contains("parent1"));

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/utils/ShadowTableCreatorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/utils/ShadowTableCreatorTest.java
@@ -43,21 +43,23 @@ public final class ShadowTableCreatorTest {
 
     Table shadowTable = shadowTableCreator.constructShadowTable("table1");
     assertThat(shadowTable.name()).isEqualTo("shadow_table1");
-    assertThat(shadowTable.columns()).hasSize(2);
+    assertThat(shadowTable.columns()).hasSize(3);
     assertThat(shadowTable.columns().get(0).name()).isEqualTo("id");
     assertThat(shadowTable.columns().get(1).name())
         .isEqualTo(Constants.PROCESSED_COMMIT_TS_COLUMN_NAME);
+    assertThat(shadowTable.columns().get(2).name()).isEqualTo(Constants.RECORD_SEQ_COLUMN_NAME);
     assertThat(shadowTable.primaryKeys()).hasSize(1);
     assertThat(shadowTable.primaryKeys().get(0).name()).isEqualTo("id");
     assertThat(shadowTable.primaryKeys().get(0).order()).isEqualTo(IndexColumn.Order.ASC);
 
     Table shadowTable4 = shadowTableCreator.constructShadowTable("table4");
     assertThat(shadowTable4.name()).isEqualTo("shadow_table4");
-    assertThat(shadowTable4.columns()).hasSize(3);
+    assertThat(shadowTable4.columns()).hasSize(4);
     assertThat(shadowTable4.columns().get(0).name()).isEqualTo("id4");
     assertThat(shadowTable4.columns().get(1).name()).isEqualTo("id5");
     assertThat(shadowTable4.columns().get(2).name())
         .isEqualTo(Constants.PROCESSED_COMMIT_TS_COLUMN_NAME);
+    assertThat(shadowTable4.columns().get(3).name()).isEqualTo(Constants.RECORD_SEQ_COLUMN_NAME);
     assertThat(shadowTable4.primaryKeys()).hasSize(2);
     assertThat(shadowTable4.primaryKeys().get(0).name()).isEqualTo("id4");
     assertThat(shadowTable4.primaryKeys().get(0).order()).isEqualTo(IndexColumn.Order.ASC);


### PR DESCRIPTION
The PR has following changes:
1. Connection pool is added - a singleton at Dataflow worker level with pool size dependent on the worker harness thread number 
2. If there are multiple changes to the same PK in a given transaction- then to check if the source already has latest data - there is logic added to also consider the request sequence number in addition to the commit timestamp