### PR TITLE
Revert "adding datastream as owners of our templates (#1798)"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,7 +26,7 @@ v2/datastream-to-sql/ @GoogleCloudPlatform/datastream
 v2/datastream-to-bigquery/ @GoogleCloudPlatform/datastream
 v2/datastream-to-postgres/ @GoogleCloudPlatform/datastream
 v2/datastream-to-mongodb/ @GoogleCloudPlatform/datastream
-v2/datastream-common/ @GoogleCloudPlatform/datastream @GoogleCloudPlatform/spanner-migrations-team
+v2/datastream-common/ @GoogleCloudPlatform/datastream
 
 # Spanner Bulk migration template
 v2/sourcedb-to-spanner/ @GoogleCloudPlatform/spanner-migrations-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,12 +21,6 @@ v2/spanner-migrations-sdk/ @GoogleCloudPlatform/spanner-migrations-team
 v2/spanner-custom-shard/ @GoogleCloudPlatform/spanner-migrations-team
 v2/spanner-to-sourcedb/ @GoogleCloudPlatform/spanner-migrations-team
 
-# Datastream Templates
-v2/datastream-to-sql/ @GoogleCloudPlatform/datastream
-v2/datastream-to-bigquery/ @GoogleCloudPlatform/datastream
-v2/datastream-to-postgres/ @GoogleCloudPlatform/datastream
-v2/datastream-to-mongodb/ @GoogleCloudPlatform/datastream
-v2/datastream-common/ @GoogleCloudPlatform/datastream
 
 # Spanner Bulk migration template
 v2/sourcedb-to-spanner/ @GoogleCloudPlatform/spanner-migrations-team


### PR DESCRIPTION
Also Revert "add spanner-migrations-team as CODEOWNERS for v2/datastream-common (#1842)"

#1798 added a "GoogleCloudPlatform/datastream" to some code path owners, however, this team currently only has one member, and real datastream team is prevented from making code changes to datastream templates. Revert it for now until the GitHub team settings are correctly configured