### PR TITLE
Sync hadoop version for v2/bigtable-changestream-to-hbase

### DIFF
--- a/v2/bigtable-changestreams-to-hbase/pom.xml
+++ b/v2/bigtable-changestreams-to-hbase/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-mapreduce-client-core</artifactId>
-      <version>2.10.2</version>
+      <version>${hadoop.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Resolve 
Vulnerability: Upgrade org.apache.hadoop:hadoop-mapreduce-client-core to 3.4.0 in GoB repo dataflow/cloud-teleport
