### PR TITLE
Add JSON userOption to MongoDbToBigQuery templates

### DIFF
--- a/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/options/MongoDbToBigQueryOptions.java
+++ b/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/options/MongoDbToBigQueryOptions.java
@@ -63,7 +63,7 @@ public class MongoDbToBigQueryOptions {
         enumOptions = {@TemplateEnumOption("FLATTEN"), @TemplateEnumOption("NONE")},
         description = "User option",
         helpText =
-            "`FLATTEN` or `NONE`. `FLATTEN` flattens the documents to the single level. `NONE` stores the whole document as a JSON string.")
+            "`FLATTEN`, `JSON`, or `NONE`. `FLATTEN` flattens the documents to the single level. `JSON` stores document in BigQuery JSON format. `NONE` stores the whole document as a JSON-formatted STRING.")
     @Default.String("NONE")
     String getUserOption();
 

--- a/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbUtils.java
+++ b/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbUtils.java
@@ -21,6 +21,8 @@ import com.google.api.services.bigquery.model.TableFieldSchema;
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
@@ -37,6 +39,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.script.Invocable;
@@ -81,7 +84,10 @@ public class MongoDbUtils implements Serializable {
           });
     } else {
       bigquerySchemaFields.add(new TableFieldSchema().setName("id").setType("STRING"));
-      bigquerySchemaFields.add(new TableFieldSchema().setName("source_data").setType("STRING"));
+      bigquerySchemaFields.add(
+          new TableFieldSchema()
+              .setName("source_data")
+              .setType(userOption.equals("JSON") ? "JSON" : "STRING"));
     }
     bigquerySchemaFields.add(new TableFieldSchema().setName("timestamp").setType("TIMESTAMP"));
     TableSchema bigquerySchema = new TableSchema().setFields(bigquerySchemaFields);
@@ -115,6 +121,7 @@ public class MongoDbUtils implements Serializable {
 
   public static TableRow getTableSchema(Document document, String userOption) {
     TableRow row = new TableRow();
+    LocalDateTime localDate = LocalDateTime.now(ZoneId.of("UTC"));
     if (userOption.equals("FLATTEN")) {
       document.forEach(
           (key, value) -> {
@@ -140,14 +147,23 @@ public class MongoDbUtils implements Serializable {
                 row.set(key, value.toString());
             }
           });
-      LocalDateTime localdate = LocalDateTime.now(ZoneId.of("UTC"));
-      row.set("timestamp", localdate.format(TIMEFORMAT));
+      row.set("timestamp", localDate.format(TIMEFORMAT));
+    } else if (userOption.equals("JSON")) {
+      JsonObject sourceDataJsonObject = GSON.toJsonTree(document).getAsJsonObject();
+
+      // Convert to a Map
+      Map<String, Object> sourceDataMap =
+          GSON.fromJson(sourceDataJsonObject, new TypeToken<Map<String, Object>>() {}.getType());
+
+      row.set("id", document.get("_id").toString())
+          .set("source_data", sourceDataMap)
+          .set("timestamp", localDate.format(TIMEFORMAT));
     } else {
-      LocalDateTime localdate = LocalDateTime.now(ZoneId.of("UTC"));
       String sourceData = GSON.toJson(document);
+
       row.set("id", document.get("_id").toString())
           .set("source_data", sourceData)
-          .set("timestamp", localdate.format(TIMEFORMAT));
+          .set("timestamp", localDate.format(TIMEFORMAT));
     }
     return row;
   }
@@ -195,7 +211,10 @@ public class MongoDbUtils implements Serializable {
           });
     } else {
       bigquerySchemaFields.add(new TableFieldSchema().setName("id").setType("STRING"));
-      bigquerySchemaFields.add(new TableFieldSchema().setName("source_data").setType("STRING"));
+      bigquerySchemaFields.add(
+          new TableFieldSchema()
+              .setName("source_data")
+              .setType(userOption.equals("JSON") ? "JSON" : "STRING"));
     }
 
     bigquerySchemaFields.add(new TableFieldSchema().setName("timestamp").setType("TIMESTAMP"));


### PR DESCRIPTION
Adds back changes from #1796 but now requires user to specify `--userOption=JSON` to enable (rather than using as default behavior)