### PR TITLE
feat: update pg index discovery query for 9.4+

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
@@ -259,7 +259,7 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
 
   /**
    * Discover the indexes of tables to migrate. You can try this in <a
-   * href="https://www.db-fiddle.com/f/bWFaWkW6dMw1tcNDaFnChc/0">db-fiddle</a>.
+   * href="https://www.db-fiddle.com/f/kTanXYXoM2VgCjSf6NZHjD/1">db-fiddle</a>.
    *
    * @param dataSource Provider for JDBC connection.
    * @param sourceSchemaReference Source database name and (optionally namespace)


### PR DESCRIPTION
Update the SourceDbToSpanner index discovery query for PostgreSQL as a source to work in PG versions older than 11 (9.4+).

Before version 11, PG did not support the INCLUDE clause in indexes, so the pg_catalog.pg_index table did not contain the column 'indnkeyatts' (number of key columns in an index). It only contained the column 'indnatts' (number of columns in an index).

In this change, we first try to read from the 'indnkeyatts' and fallback to 'indnatts'.