### PR TITLE
fix: PG index cardinality estimate

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
@@ -259,7 +259,7 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
 
   /**
    * Discover the indexes of tables to migrate. You can try this in <a
-   * href="https://www.db-fiddle.com/f/kTanXYXoM2VgCjSf6NZHjD/1">db-fiddle</a>.
+   * href="https://www.db-fiddle.com/f/kTanXYXoM2VgCjSf6NZHjD/2">db-fiddle</a>.
    *
    * @param dataSource Provider for JDBC connection.
    * @param sourceSchemaReference Source database name and (optionally namespace)
@@ -286,13 +286,7 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
                 + "  ixs.indexname AS index_name,"
                 + "  ix.indisunique AS is_unique,"
                 + "  ix.indisprimary AS is_primary,"
-                // PG < 11 does not have the indnkeyatts column (total key columns in index), since
-                // the INCLUDE SQL feature was not available then. We use the indnatts column
-                // instead (total columns in index).
-                + "  COALESCE("
-                + "    (row_to_json(ix)->>'indnkeyatts')::int8,"
-                + "    (row_to_json(ix)->>'indnatts')::int8"
-                + "  ) AS cardinality,"
+                + "  c.reltuples AS cardinality,"
                 + "  a.attnum AS ordinal_position,"
                 + "  t.typname AS type_name,"
                 + "  information_schema._pg_char_max_length(a.atttypid, a.atttypmod) AS type_length,"


### PR DESCRIPTION
Fixes the cardinality when using the PostgreSQL adapter to estimate the number of rows indexed, instead of the number of columns in the index.