### PR TITLE
DlqRetry for bulk with the current retry flow

### DIFF
--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToSpanner.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToSpanner.java
@@ -138,17 +138,15 @@ public class DataStreamToSpanner {
    * <p>Inherits standard configuration options.
    */
   public interface Options extends PipelineOptions, StreamingOptions {
-    @Deprecated
     @TemplateParameter.GcsReadFile(
         order = 1,
         groupName = "Source",
         optional = true,
         description =
-            "[Deprecated] File location for Datastream file output in Cloud Storage. Support for this feature has been disabled."
-                + "Please set pubsub subscription instead.",
+            "File location for Datastream file output in Cloud Storage. Support for this feature has been disabled.",
         helpText =
-            "[Deprecated] The Cloud Storage file location that contains the Datastream files to replicate. Typically, "
-                + "this is the root path for a stream. Support for this feature has been disabled. Please set pubsub subscription instead.")
+            "The Cloud Storage file location that contains the Datastream files to replicate. Typically, "
+                + "this is the root path for a stream. Support for this feature has been disabled.")
     String getInputFilePattern();
 
     void setInputFilePattern(String value);
@@ -218,6 +216,7 @@ public class DataStreamToSpanner {
 
     @TemplateParameter.PubsubSubscription(
         order = 8,
+        optional = true,
         description = "The Pub/Sub subscription being used in a Cloud Storage notification policy.",
         helpText =
             "The Pub/Sub subscription being used in a Cloud Storage notification policy. The name"
@@ -374,6 +373,21 @@ public class DataStreamToSpanner {
     String getTransformationContextFilePath();
 
     void setTransformationContextFilePath(String value);
+
+    @TemplateParameter.Integer(
+        order = 22,
+        optional = true,
+        description = "Directory watch duration in minutes. Default: 10 minutes",
+        helpText =
+            "The Duration for which the pipeline should keep polling a directory in GCS. Datastream"
+                + "output files are arranged in a directory structure which depicts the timestamp "
+                + "of the event grouped by minutes. This parameter should be approximately equal to"
+                + "maximum delay which could occur between event occurring in source database and "
+                + "the same event being written to GCS by Datastream. 99.9 percentile = 10 minutes")
+    @Default.Integer(10)
+    Integer getDirectoryWatchDurationInMinutes();
+
+    void setDirectoryWatchDurationInMinutes(Integer value);
 
     @TemplateParameter.Enum(
         order = 23,
@@ -596,11 +610,13 @@ public class DataStreamToSpanner {
           pipeline.apply(
               new DataStreamIO(
                       options.getStreamName(),
-                      null,
+                      options.getInputFilePattern(),
                       options.getInputFileFormat(),
                       options.getGcsPubSubSubscription(),
                       options.getRfcStartDateTime())
-                  .withFileReadConcurrency(options.getFileReadConcurrency()));
+                  .withFileReadConcurrency(options.getFileReadConcurrency())
+                  .withDirectoryWatchDuration(
+                      Duration.standardMinutes(options.getDirectoryWatchDurationInMinutes())));
       jsonRecords =
           PCollectionList.of(datastreamJsonRecords)
               .and(dlqJsonRecords)

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerTest.java
@@ -39,6 +39,22 @@ public class DataStreamToSpannerTest {
   }
 
   @Test
+  public void testGetSourceTypeWithDatastreamInputFilePattern() {
+    String[] args =
+        new String[] {"--inputFilePattern=gs://test-bkt/", "--directoryWatchDurationInMinutes=42"};
+    DataStreamToSpanner.Options options =
+        PipelineOptionsFactory.fromArgs(args)
+            .withValidation()
+            .as(DataStreamToSpanner.Options.class);
+    String inputFilePattern = options.getInputFilePattern();
+    Integer directoryWatchDurationInMinutes = options.getDirectoryWatchDurationInMinutes();
+    Integer expectedWatchDuration = 42;
+
+    assertEquals(inputFilePattern, "gs://test-bkt/");
+    assertEquals(directoryWatchDurationInMinutes, expectedWatchDuration);
+  }
+
+  @Test
   public void testGetSourceTypeWithEmptyStreamName() {
     expectedEx.expect(IllegalArgumentException.class);
     expectedEx.expectMessage("Stream name cannot be empty.");

--- a/v2/sourcedb-to-spanner/pom.xml
+++ b/v2/sourcedb-to-spanner/pom.xml
@@ -122,5 +122,11 @@
       <version>1.0-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.cloud.teleport.v2</groupId>
+      <artifactId>datastream-to-spanner</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/writer/DeadLetterQueue.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/writer/DeadLetterQueue.java
@@ -20,12 +20,15 @@ import com.google.cloud.spanner.Value;
 import com.google.cloud.teleport.v2.cdc.dlq.StringDeadLetterQueueSanitizer;
 import com.google.cloud.teleport.v2.coders.FailsafeElementCoder;
 import com.google.cloud.teleport.v2.constants.MetricCounters;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.SQLDialect;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.templates.RowContext;
+import com.google.cloud.teleport.v2.templates.datastream.DatastreamConstants;
 import com.google.cloud.teleport.v2.transforms.DLQWriteTransform;
 import com.google.cloud.teleport.v2.values.FailsafeElement;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.Serializable;
+import java.time.Instant;
 import java.util.Map;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.generic.GenericRecord;
@@ -40,6 +43,7 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
+import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.initialization.qual.Initialized;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
@@ -58,11 +62,16 @@ public class DeadLetterQueue implements Serializable {
 
   private final PTransform<PCollection<String>, PDone> dlqTransform;
 
+  private final String shardIdColumn;
+
+  private final SQLDialect sqlDialect;
+
   public static final Counter FAILED_MUTATION_COUNTER =
       Metrics.counter(SpannerWriter.class, MetricCounters.FAILED_MUTATION_ERRORS);
 
-  public static DeadLetterQueue create(String dlqDirectory, Ddl ddl) {
-    return new DeadLetterQueue(dlqDirectory, ddl);
+  public static DeadLetterQueue create(
+      String dlqDirectory, Ddl ddl, String shardIdColumn, SQLDialect sqlDialect) {
+    return new DeadLetterQueue(dlqDirectory, ddl, shardIdColumn, sqlDialect);
   }
 
   public String getDlqDirectory() {
@@ -73,10 +82,13 @@ public class DeadLetterQueue implements Serializable {
     return dlqTransform;
   }
 
-  private DeadLetterQueue(String dlqDirectory, Ddl ddl) {
+  private DeadLetterQueue(
+      String dlqDirectory, Ddl ddl, String shardIdColumn, SQLDialect sqlDialect) {
     this.dlqDirectory = dlqDirectory;
     this.dlqTransform = createDLQTransform(dlqDirectory);
     this.ddl = ddl;
+    this.shardIdColumn = shardIdColumn;
+    this.sqlDialect = sqlDialect;
   }
 
   @VisibleForTesting
@@ -167,12 +179,14 @@ public class DeadLetterQueue implements Serializable {
   protected FailsafeElement<String, String> rowContextToDlqElement(RowContext r) {
     GenericRecord record = r.row().getPayload();
     JSONObject json = new JSONObject();
+    initializeJsonNode(json, r.row().tableName(), r.row().getReadTimeMicros());
 
-    String sourceTableName = r.row().tableName();
-    json.put("_metadata_table", sourceTableName);
     for (Field f : record.getSchema().getFields()) {
       Object value = record.get(f.name());
       json.put(f.name(), value == null ? null : value.toString());
+    }
+    if (StringUtils.isNotBlank(this.shardIdColumn)) {
+      json.put(this.shardIdColumn, r.row().shardId());
     }
     FailsafeElement<String, String> dlqElement =
         FailsafeElement.of(json.toString(), json.toString());
@@ -217,8 +231,10 @@ public class DeadLetterQueue implements Serializable {
   @VisibleForTesting
   protected FailsafeElement<String, String> mutationToDlqElement(Mutation m) {
     JSONObject json = new JSONObject();
-    json.put("_metadata_table", m.getTable());
 
+    Instant instant = Instant.now();
+    initializeJsonNode(
+        json, m.getTable(), (instant.getEpochSecond() * 1000_000 + instant.getNano() / 1000));
     Map<String, Value> mutationMap = m.asMap();
     for (Map.Entry<String, Value> entry : mutationMap.entrySet()) {
       Value value = entry.getValue();
@@ -227,5 +243,19 @@ public class DeadLetterQueue implements Serializable {
 
     return FailsafeElement.of(json.toString(), json.toString())
         .setErrorMessage("SpannerWriteFailed");
+  }
+
+  private void initializeJsonNode(JSONObject json, String tableName, long timeStamp) {
+    json.put(DatastreamConstants.EVENT_CHANGE_TYPE_KEY, DatastreamConstants.UPDATE_INSERT_EVENT);
+    json.put(DatastreamConstants.EVENT_TABLE_NAME_KEY, tableName);
+    json.put(DatastreamConstants.MYSQL_TIMESTAMP_KEY, timeStamp);
+    switch (this.sqlDialect) {
+      case POSTGRESQL:
+        json.put(
+            DatastreamConstants.EVENT_SOURCE_TYPE_KEY, DatastreamConstants.POSTGRES_SOURCE_TYPE);
+        break;
+      default:
+        json.put(DatastreamConstants.EVENT_SOURCE_TYPE_KEY, DatastreamConstants.MYSQL_SOURCE_TYPE);
+    }
   }
 }


### PR DESCRIPTION
## Overview
1. Matching the Bulk DLQ event to the structure of live template, in-order to allow a common DLQ retry flow for migration customers.
2. Reverting changes in datastream-to-spanner which are not allowing `retryMode` of severe DLQ w/o pub/sub resources.

## Testing
End to End bulk migration with DLQ created and retried successfully .
### Note on UT
Changes to DLQ entry are covered by UT.
Some of the classes like `MigrateTableTransform`, `PipelineController` or `DataStreamToSpanner` don't have UT coverage implemented as yet (at the head of this patch), as they are pipeline level classes which are hard to UT.