### PR TITLE
Improve bulk terraform template to work seamlessly

### DIFF
--- a/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/README.md
+++ b/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/README.md
@@ -20,11 +20,15 @@ There are two ways to add permissions -
 Following permissions are required -
 
 ```shell
+- compute.firewalls.create
+- compute.firewalls.delete
+- compute.firewalls.update
 - dataflow.jobs.cancel
 - dataflow.jobs.create
 - dataflow.jobs.updateContents
 - iam.roles.get
 - iam.serviceAccounts.actAs
+- resourcemanager.projects.setIamPolicy
 - storage.objects.delete
 - storage.objects.create
 - serviceusage.services.use
@@ -41,10 +45,12 @@ provides instructions to add these permissions to an existing service account.
 Following roles are required -
 
 ```shell
-roles/dataflow.admin
-roles/iam.serviceAccountUser 
+roles/dataflow.admin 
+roles/iam.securityAdmin
+roles/iam.serviceAccountUser
 roles/storage.admin
 roles/viewer
+roles/compute.networkAdmin
 ```
 
 [This](#adding-access-to-terraform-service-account) section in the FAQ
@@ -248,6 +254,9 @@ for allowing connectivity:
 3. If only certain source network tags are allowlisted via a firewall, specify the  
    network tags via
    the [additional-experiments flag](https://cloud.google.com/dataflow/docs/guides/routes-firewall#network-tags-flex).
+   Dataflow automatically assigns
+   the `dataflow` network tag if any network tag is additionally specified. You need
+   specify the tag for both worker VMs and launcher VMs.
 
 > **_NOTE:_** You can use a shared VPC by specifying the `host_project` in the subnet path.
 > This will result in the Dataflow jobs being launched inside the shared VPC.

--- a/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/main.tf
+++ b/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/main.tf
@@ -28,7 +28,7 @@ resource "google_storage_bucket_object" "source_config_upload" {
 # Setup network firewalls rules to enable Dataflow access to source.
 resource "google_compute_firewall" "allow-dataflow-to-source" {
   depends_on  = [google_project_service.enabled_apis]
-  project     = var.common_params.host_project != null ?  var.common_params.host_project : var.common_params.project
+  project     = var.common_params.host_project != null ? var.common_params.host_project : var.common_params.project
   name        = "allow-dataflow-to-source"
   network     = var.common_params.network != null ? var.common_params.host_project != null ? "projects/${var.common_params.host_project}/global/networks/${var.common_params.network}" : "projects/${var.common_params.project}/global/networks/${var.common_params.network}" : "default"
   description = "Allow traffic from Dataflow to source databases"
@@ -67,7 +67,7 @@ resource "google_project_iam_member" "live_migration_roles" {
 }
 
 resource "google_dataflow_flex_template_job" "generated" {
-  count      = length(local.source_configs)
+  count = length(local.source_configs)
   depends_on = [
     google_project_service.enabled_apis, google_storage_bucket_object.source_config_upload,
     google_storage_bucket_object.session_file_object

--- a/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/terraform.tfvars
+++ b/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/terraform.tfvars
@@ -39,7 +39,7 @@ data_shards = [
     user        = "deep"
     password    = "welcome1"
     port        = "3306"
-    databases   = [
+    databases = [
       {
         dbName         = "tftest"
         databaseId     = "logicaldb1"
@@ -53,7 +53,7 @@ data_shards = [
     user        = "deep"
     password    = "welcome1"
     port        = "3306"
-    databases   = [
+    databases = [
       {
         dbName         = "tftest"
         databaseId     = "logicaldb2"

--- a/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/terraform.tfvars
+++ b/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/terraform.tfvars
@@ -34,35 +34,30 @@ common_params = {
 
 data_shards = [
   {
-    data_shard_id = "data-shard1"
-    host          = "10.1.1.1"
-    user          = "username"
-    password      = "password"
-    port          = 3306
-    databases     = [
+    dataShardId = "data-shard1"
+    host        = "10.128.0.2"
+    user        = "deep"
+    password    = "welcome1"
+    port        = "3306"
+    databases   = [
       {
-        db_name           = "db1"
-        database_id       = "logicaldb1"
-        ref_data_shard_id = "data-shard1"
-      },
-      {
-        db_name           = "db2"
-        database_id       = "logicaldb2"
-        ref_data_shard_id = "data-shard1"
+        dbName         = "tftest"
+        databaseId     = "logicaldb1"
+        refDataShardId = "data-shard1"
       }
     ]
   },
   {
-    data_shard_id = "data-shard2"
-    host          = "10.1.1.2"
-    user          = "username"
-    password      = "password"
-    port          = 3306
-    databases     = [
+    dataShardId = "data-shard2"
+    host        = "10.128.0.3"
+    user        = "deep"
+    password    = "welcome1"
+    port        = "3306"
+    databases   = [
       {
-        db_name           = "db3"
-        database_id       = "logicaldb3"
-        ref_data_shard_id = "data-shard2"
+        dbName         = "tftest"
+        databaseId     = "logicaldb2"
+        refDataShardId = "data-shard2"
       }
     ]
   }

--- a/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/terraform.tfvars
+++ b/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/terraform.tfvars
@@ -36,8 +36,8 @@ data_shards = [
   {
     dataShardId = "data-shard1"
     host        = "10.128.0.2"
-    user        = "deep"
-    password    = "welcome1"
+    user        = "user"
+    password    = "password"
     port        = "3306"
     databases = [
       {
@@ -50,8 +50,8 @@ data_shards = [
   {
     dataShardId = "data-shard2"
     host        = "10.128.0.3"
-    user        = "deep"
-    password    = "welcome1"
+    user        = "user"
+    password    = "password"
     port        = "3306"
     databases = [
       {

--- a/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/terraform.tfvars
+++ b/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/terraform.tfvars
@@ -1,6 +1,7 @@
 common_params = {
   run_id                   = "sharded-run"
   project                  = "project-name"
+  host_project             = "host-project"
   region                   = "us-central1"               # Or your desired region
   working_directory_bucket = "bucket-name"               # example "test-bucket"
   working_directory_prefix = "path/to/working/directory" # should not start or end with a '/'
@@ -10,20 +11,19 @@ common_params = {
   max_connections          = 320
   instance_id              = "my-spanner-instance"
   database_id              = "my-spanner-database"
-  project_id               = "my-spanner-project"
+  spanner_project_id       = "my-spanner-project"
   spanner_host             = "https://batch-spanner.googleapis.com"
   local_session_file_path  = "/local/path/to/smt/session/file"
 
-  additional_experiments = ["disable_runner_v2"] # This option is required for bulk jobs. Do not remove.
-  network                = "network-name"
-  subnetwork             = "regions/<region>/subnetworks/<subnetwork-name>"
-  service_account_email  = "your-service-account-email@your-project-id.iam.gserviceaccount.com"
-  launcher_machine_type  = "n1-highmem-32" # Recommend using larger launcher VMs
-  machine_type           = "n1-highmem-4"
-  max_workers            = 50
-  ip_configuration       = "WORKER_IP_PRIVATE"
-  num_workers            = 1
-  default_log_level      = "INFO"
+  network               = "network-name"
+  subnetwork            = "subnetwork-name"
+  service_account_email = "your-service-account-email@your-project-id.iam.gserviceaccount.com"
+  launcher_machine_type = "n1-highmem-32" # Recommend using larger launcher VMs
+  machine_type          = "n1-highmem-4"
+  max_workers           = 50
+  ip_configuration      = "WORKER_IP_PRIVATE"
+  num_workers           = 1
+  default_log_level     = "INFO"
 
   # This parameters decides the number of physical shards to migrate using a single dataflow job.
   # Set this in a way that restricts the total number of tables to 150 within a single job.
@@ -39,7 +39,7 @@ data_shards = [
     user          = "username"
     password      = "password"
     port          = 3306
-    databases = [
+    databases     = [
       {
         db_name           = "db1"
         database_id       = "logicaldb1"
@@ -58,7 +58,7 @@ data_shards = [
     user          = "username"
     password      = "password"
     port          = 3306
-    databases = [
+    databases     = [
       {
         db_name           = "db3"
         database_id       = "logicaldb3"

--- a/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/terraform_simple.tfvars
+++ b/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/terraform_simple.tfvars
@@ -17,16 +17,16 @@ common_params = {
 
 data_shards = [
   {
-    data_shard_id = "data-shard1"
-    host          = "10.1.1.1"
-    user          = "username"
-    password      = "password"
-    port          = 3306
-    databases     = [
+    dataShardId = "data-shard1"
+    host        = "10.1.1.1"
+    user        = "username"
+    password    = "password"
+    port        = "3306"
+    databases   = [
       {
-        db_name           = "db1"
-        database_id       = "logicaldb1"
-        ref_data_shard_id = "data-shard1"
+        dbName         = "db1"
+        databaseId     = "logicaldb1"
+        refDataShardId = "data-shard1"
       }
     ]
   }

--- a/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/terraform_simple.tfvars
+++ b/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/terraform_simple.tfvars
@@ -22,7 +22,7 @@ data_shards = [
     user        = "username"
     password    = "password"
     port        = "3306"
-    databases   = [
+    databases = [
       {
         dbName         = "db1"
         databaseId     = "logicaldb1"

--- a/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/terraform_simple.tfvars
+++ b/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/terraform_simple.tfvars
@@ -9,10 +9,8 @@ common_params = {
   working_directory_prefix = "path/to/working/directory" # should not start or end with a '/'
   instance_id              = "my-spanner-instance"
   database_id              = "my-spanner-database"
-  project_id               = "my-spanner-project"
+  spanner_project_id       = "my-spanner-project"
   local_session_file_path  = "/local/path/to/smt/session/file"
-
-  additional_experiments = ["disable_runner_v2"] # This option is required for bulk jobs. Do not remove.
 
   batch_size = 1
 }
@@ -24,7 +22,7 @@ data_shards = [
     user          = "username"
     password      = "password"
     port          = 3306
-    databases = [
+    databases     = [
       {
         db_name           = "db1"
         database_id       = "logicaldb1"

--- a/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/variables.tf
+++ b/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/variables.tf
@@ -1,6 +1,6 @@
 variable "common_params" {
   type = object({
-    add_policies_to_service_account  = optional(bool, true)
+    add_policies_to_service_account = optional(bool, true)
     # Template parameters
     run_id                           = string
     project                          = string
@@ -52,7 +52,7 @@ variable "data_shards" {
     user        = string
     password    = string
     port        = string
-    databases   = list(object({
+    databases = list(object({
       dbName         = string
       databaseId     = string
       refDataShardId = string

--- a/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/variables.tf
+++ b/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/variables.tf
@@ -1,5 +1,6 @@
 variable "common_params" {
   type = object({
+    add_policies_to_service_account  = optional(bool, true)
     # Template parameters
     run_id                           = string
     project                          = string
@@ -25,12 +26,12 @@ variable "common_params" {
     subnetwork             = optional(string)
     service_account_email  = optional(string)
     # Recommend using larger launcher VMs. Machine with >= 16 vCPUs should be safe.
-    launcher_machine_type = optional(string, "n1-highmem-32")
-    machine_type          = optional(string, "n1-highmem-4")
-    max_workers           = optional(number)
-    ip_configuration      = optional(string)
-    num_workers           = optional(number)
-    default_log_level     = optional(string)
+    launcher_machine_type  = optional(string, "n1-highmem-32")
+    machine_type           = optional(string, "n1-highmem-4")
+    max_workers            = optional(number)
+    ip_configuration       = optional(string)
+    num_workers            = optional(number)
+    default_log_level      = optional(string)
 
     # This parameters decides the number of physical shards to migrate using a single dataflow job.
     # Set this in a way that restricts the total number of tables to 150 within a single job.
@@ -48,7 +49,7 @@ variable "data_shards" {
     user          = string
     password      = string
     port          = number
-    databases = list(object({
+    databases     = list(object({
       db_name           = string
       database_id       = string
       ref_data_shard_id = string

--- a/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/variables.tf
+++ b/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/variables.tf
@@ -4,6 +4,7 @@ variable "common_params" {
     # Template parameters
     run_id                           = string
     project                          = string
+    host_project                     = optional(string)
     region                           = string
     working_directory_bucket         = string # example "test-bucket"
     working_directory_prefix         = string # should not start or end with a '/'
@@ -13,7 +14,7 @@ variable "common_params" {
     max_connections                  = optional(number)
     instance_id                      = string
     database_id                      = string
-    project_id                       = string
+    spanner_project_id               = string
     spanner_host                     = optional(string)
     local_session_file_path          = string
     transformation_jar_path          = optional(string)
@@ -21,17 +22,19 @@ variable "common_params" {
     transformation_class_name        = optional(string)
 
     # Dataflow runtime parameters
-    additional_experiments = list(string) # disable_runner_v2 experiment is a must for bulk jobs.
-    network                = optional(string)
-    subnetwork             = optional(string)
-    service_account_email  = optional(string)
+    additional_experiments = optional(list(string), [
+      "disable_runner_v2", "use_network_tags=allow-dataflow", "use_network_tags_for_flex_templates=allow-dataflow"
+    ])
+    network               = optional(string)
+    subnetwork            = optional(string)
+    service_account_email = optional(string)
     # Recommend using larger launcher VMs. Machine with >= 16 vCPUs should be safe.
-    launcher_machine_type  = optional(string, "n1-highmem-32")
-    machine_type           = optional(string, "n1-highmem-4")
-    max_workers            = optional(number)
-    ip_configuration       = optional(string)
-    num_workers            = optional(number)
-    default_log_level      = optional(string)
+    launcher_machine_type = optional(string, "n1-highmem-32")
+    machine_type          = optional(string, "n1-highmem-4")
+    max_workers           = optional(number)
+    ip_configuration      = optional(string)
+    num_workers           = optional(number)
+    default_log_level     = optional(string)
 
     # This parameters decides the number of physical shards to migrate using a single dataflow job.
     # Set this in a way that restricts the total number of tables to 150 within a single job.

--- a/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/variables.tf
+++ b/v2/sourcedb-to-spanner/terraform/samples/sharded-bulk-migration/variables.tf
@@ -47,15 +47,15 @@ variable "common_params" {
 
 variable "data_shards" {
   type = list(object({
-    data_shard_id = string
-    host          = string
-    user          = string
-    password      = string
-    port          = number
-    databases     = list(object({
-      db_name           = string
-      database_id       = string
-      ref_data_shard_id = string
+    dataShardId = string
+    host        = string
+    user        = string
+    password    = string
+    port        = string
+    databases   = list(object({
+      dbName         = string
+      databaseId     = string
+      refDataShardId = string
     }))
   }))
 }

--- a/v2/sourcedb-to-spanner/terraform/samples/single-job-bulk-migration/README.md
+++ b/v2/sourcedb-to-spanner/terraform/samples/single-job-bulk-migration/README.md
@@ -20,11 +20,15 @@ There are two ways to add permissions -
 Following permissions are required -
 
 ```shell
+- compute.firewalls.create
+- compute.firewalls.delete
+- compute.firewalls.update
 - dataflow.jobs.cancel
 - dataflow.jobs.create
 - dataflow.jobs.updateContents
 - iam.roles.get
 - iam.serviceAccounts.actAs
+- resourcemanager.projects.setIamPolicy
 - storage.objects.delete
 - storage.objects.create
 - storage.buckets.create
@@ -42,10 +46,12 @@ provides instructions to add these permissions to an existing service account.
 Following roles are required -
 
 ```shell
-roles/dataflow.admin
-roles/iam.serviceAccountUser 
+roles/dataflow.admin 
+roles/iam.securityAdmin
+roles/iam.serviceAccountUser
 roles/storage.admin
 roles/viewer
+roles/compute.networkAdmin
 ```
 
 [This](#adding-access-to-terraform-service-account) section in the FAQ
@@ -234,6 +240,9 @@ for allowing connectivity:
 3. If only certain source network tags are allowlisted via a firewall, specify the  
    network tags via
    the [additional-experiments flag](https://cloud.google.com/dataflow/docs/guides/routes-firewall#network-tags-flex).
+   Dataflow automatically assigns
+   the `dataflow` network tag if any network tag is additionally specified. You need
+   specify the tag for both worker VMs and launcher VMs.
 
 > **_NOTE:_** You can use a shared VPC by specifying the `host_project` in the subnet path.
 > This will result in the Dataflow jobs being launched inside the shared VPC.

--- a/v2/sourcedb-to-spanner/terraform/samples/single-job-bulk-migration/main.tf
+++ b/v2/sourcedb-to-spanner/terraform/samples/single-job-bulk-migration/main.tf
@@ -11,7 +11,7 @@ resource "google_storage_bucket_object" "session_file_object" {
 # Setup network firewalls rules to enable Dataflow access to source.
 resource "google_compute_firewall" "allow-dataflow-to-source" {
   depends_on  = [google_project_service.enabled_apis]
-  project     = var.host_project != null ?  var.host_project : var.project
+  project     = var.host_project != null ? var.host_project : var.project
   name        = "allow-dataflow-to-source"
   network     = var.network != null ? var.host_project != null ? "projects/${var.host_project}/global/networks/${var.network}" : "projects/${var.project}/global/networks/${var.network}" : "default"
   description = "Allow traffic from Dataflow to source databases"

--- a/v2/sourcedb-to-spanner/terraform/samples/single-job-bulk-migration/main.tf
+++ b/v2/sourcedb-to-spanner/terraform/samples/single-job-bulk-migration/main.tf
@@ -8,6 +8,22 @@ resource "google_storage_bucket_object" "session_file_object" {
   bucket       = var.working_directory_bucket
 }
 
+# Setup network firewalls rules to enable Dataflow access to source.
+resource "google_compute_firewall" "allow-dataflow-to-source" {
+  depends_on  = [google_project_service.enabled_apis]
+  project     = var.host_project != null ?  var.host_project : var.project
+  name        = "allow-dataflow-to-source"
+  network     = var.network != null ? var.host_project != null ? "projects/${var.host_project}/global/networks/${var.network}" : "projects/${var.project}/global/networks/${var.network}" : "default"
+  description = "Allow traffic from Dataflow to source databases"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["3306"]
+  }
+  source_tags = ["dataflow"]
+  target_tags = ["databases"]
+}
+
 # Add roles to the service account that will run Dataflow for bulk migration
 resource "google_project_iam_member" "live_migration_roles" {
   for_each = var.add_policies_to_service_account ? toset([
@@ -42,7 +58,7 @@ resource "google_dataflow_flex_template_job" "generated" {
     numPartitions                  = tostring(var.num_partitions)
     instanceId                     = var.instance_id
     databaseId                     = var.database_id
-    projectId                      = var.project_id
+    projectId                      = var.spanner_project_id
     spannerHost                    = var.spanner_host
     sessionFilePath                = var.local_session_file_path != null ? "gs://${var.working_directory_bucket}/${var.working_directory_prefix}/session.json" : null
     outputDirectory                = "gs://${var.working_directory_bucket}/${var.working_directory_prefix}/output/"
@@ -59,8 +75,8 @@ resource "google_dataflow_flex_template_job" "generated" {
   max_workers            = var.max_workers
   name                   = var.job_name
   ip_configuration       = var.ip_configuration
-  network                = var.network
-  subnetwork             = var.subnetwork
+  network                = var.network != null ? var.host_project != null ? "projects/${var.host_project}/global/networks/${var.network}" : "projects/${var.project}/global/networks/${var.network}" : null
+  subnetwork             = var.subnetwork != null ? var.host_project != null ? "https://www.googleapis.com/compute/v1/projects/${var.host_project}/regions/${var.region}/subnetworks/${var.subnetwork}" : "https://www.googleapis.com/compute/v1/projects/${var.project}/regions/${var.region}/subnetworks/${var.subnetwork}" : null
   num_workers            = var.num_workers
   project                = var.project
   region                 = var.region

--- a/v2/sourcedb-to-spanner/terraform/samples/single-job-bulk-migration/main.tf
+++ b/v2/sourcedb-to-spanner/terraform/samples/single-job-bulk-migration/main.tf
@@ -8,6 +8,22 @@ resource "google_storage_bucket_object" "session_file_object" {
   bucket       = var.working_directory_bucket
 }
 
+# Add roles to the service account that will run Dataflow for bulk migration
+resource "google_project_iam_member" "live_migration_roles" {
+  for_each = var.add_policies_to_service_account ? toset([
+    "roles/viewer",
+    "roles/storage.objectAdmin",
+    "roles/dataflow.worker",
+    "roles/dataflow.admin",
+    "roles/spanner.databaseAdmin",
+    "roles/monitoring.metricWriter",
+    "roles/cloudprofiler.agent"
+  ]) : toset([])
+  project = data.google_project.project.id
+  role    = each.key
+  member  = var.service_account_email != null ? "serviceAccount:${var.service_account_email}" : "serviceAccount:${data.google_compute_default_service_account.gce_account.email}"
+}
+
 resource "google_dataflow_flex_template_job" "generated" {
   depends_on = [
     google_project_service.enabled_apis,

--- a/v2/sourcedb-to-spanner/terraform/samples/single-job-bulk-migration/terraform.tfvars
+++ b/v2/sourcedb-to-spanner/terraform/samples/single-job-bulk-migration/terraform.tfvars
@@ -1,5 +1,6 @@
 job_name                 = "test-job"
 project                  = "project-name"
+host_project             = "host-project"
 region                   = "us-central1"               # Or your desired region
 working_directory_bucket = "bucket-name"               # example "test-bucket"
 working_directory_prefix = "path/to/working/directory" # should not start or end with a '/'
@@ -12,17 +13,17 @@ num_partitions           = 4000
 max_connections          = 320
 instance_id              = "my-spanner-instance"
 database_id              = "my-spanner-database"
-project_id               = "my-spanner-project"
+spanner_project_id       = "my-spanner-project"
 spanner_host             = "https://batch-spanner.googleapis.com"
 local_session_file_path  = "/local/path/to/smt/session/file"
 
-additional_experiments = ["disable_runner_v2"] # This option is required for bulk jobs. Do not remove.
-network                = "network-name"
-subnetwork             = "regions/<region>/subnetworks/<subnetwork-name>"
-service_account_email  = "your-service-account-email@your-project-id.iam.gserviceaccount.com"
-launcher_machine_type  = "n1-highmem-32" # Recommend using larger launcher VMs
-machine_type           = "n1-highmem-4"
-max_workers            = 50
-ip_configuration       = "WORKER_IP_PRIVATE"
-num_workers            = 1
-default_log_level      = "INFO"
+network               = "network-name"
+subnetwork            = "subnetwork-name"
+service_account_email = "your-service-account-email@your-project-id.iam.gserviceaccount.com"
+launcher_machine_type = "n1-highmem-32" # Recommend using larger launcher VMs
+machine_type          = "n1-highmem-4"
+max_workers           = 50
+ip_configuration      = "WORKER_IP_PRIVATE"
+num_workers           = 1
+default_log_level     = "INFO"
+

--- a/v2/sourcedb-to-spanner/terraform/samples/single-job-bulk-migration/terraform_simple.tfvars
+++ b/v2/sourcedb-to-spanner/terraform/samples/single-job-bulk-migration/terraform_simple.tfvars
@@ -10,6 +10,4 @@ username                 = "root"
 password                 = "abc"
 instance_id              = "my-spanner-instance"
 database_id              = "my-spanner-database"
-project_id               = "my-spanner-project"
-
-additional_experiments = ["disable_runner_v2"] # This option is required for bulk jobs. Do not remove.
+spanner_project_id       = "my-spanner-project"

--- a/v2/sourcedb-to-spanner/terraform/samples/single-job-bulk-migration/variables.tf
+++ b/v2/sourcedb-to-spanner/terraform/samples/single-job-bulk-migration/variables.tf
@@ -14,6 +14,12 @@ variable "project" {
   description = "Google Cloud Project ID where Dataflow will run."
 }
 
+variable "host_project" {
+  type        = string
+  description = "Project id hosting the network in case of a shared vpc setup."
+  default     = null
+}
+
 variable "region" {
   type        = string
   description = "Google Cloud region to run Dataflow in."
@@ -78,7 +84,7 @@ variable "database_id" {
   description = "Cloud Spanner database ID."
 }
 
-variable "project_id" {
+variable "spanner_project_id" {
   type        = string
   description = "Google Cloud Project ID (for Spanner)."
 }
@@ -117,7 +123,9 @@ variable "transformation_class_name" {
 variable "additional_experiments" {
   type        = list(string)
   description = "Additional Dataflow experiments. 'disable_runner_v2' is required for bulk jobs."
-  default     = ["disable_runner_v2"]
+  default     = [
+    "disable_runner_v2", "use_network_tags=allow-dataflow", "use_network_tags_for_flex_templates=allow-dataflow"
+  ]
 }
 
 variable "network" {

--- a/v2/sourcedb-to-spanner/terraform/samples/single-job-bulk-migration/variables.tf
+++ b/v2/sourcedb-to-spanner/terraform/samples/single-job-bulk-migration/variables.tf
@@ -123,7 +123,7 @@ variable "transformation_class_name" {
 variable "additional_experiments" {
   type        = list(string)
   description = "Additional Dataflow experiments. 'disable_runner_v2' is required for bulk jobs."
-  default     = [
+  default = [
     "disable_runner_v2", "use_network_tags=allow-dataflow", "use_network_tags_for_flex_templates=allow-dataflow"
   ]
 }

--- a/v2/sourcedb-to-spanner/terraform/samples/single-job-bulk-migration/variables.tf
+++ b/v2/sourcedb-to-spanner/terraform/samples/single-job-bulk-migration/variables.tf
@@ -1,3 +1,9 @@
+variable "add_policies_to_service_account" {
+  type        = bool
+  description = "Terraform will add the required permission to the dataflow service account."
+  default     = true
+}
+
 variable "job_name" {
   type        = string
   description = "Dataflow job name."


### PR DESCRIPTION
Added permission and firewall rules along with other changes to make shared VPC bulk orchestration seamless.
Tests:
Orchestrated a sharded bulk migration in a fresh shared VPC setup done via spanner-common samples.

Follow-up PR: Move allow-datastream firewall rule from infra-setup script to live migration terraform template.