### PR TITLE
Adding support for bigInt Unsigned as Primary Key for partitioning and connectionProperties in shard-config

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/OptionsToConfigBuilder.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/OptionsToConfigBuilder.java
@@ -61,6 +61,7 @@ public final class OptionsToConfigBuilder {
         tables,
         sourceDbURL,
         null,
+        null,
         0,
         username,
         password,
@@ -78,6 +79,7 @@ public final class OptionsToConfigBuilder {
       List<String> tables,
       String sourceDbURL,
       String host,
+      String connectionProperties,
       int port,
       String username,
       String password,
@@ -108,6 +110,9 @@ public final class OptionsToConfigBuilder {
       case MYSQL:
         if (sourceDbURL == null) {
           sourceDbURL = "jdbc:mysql://" + host + ":" + port + "/" + dbName;
+          if (StringUtils.isNotBlank(connectionProperties)) {
+            sourceDbURL = sourceDbURL + "?" + connectionProperties;
+          }
         }
         for (Entry<String, String> entry :
             MySqlConfigDefaults.DEFAULT_MYSQL_URL_PROPERTIES.entrySet()) {
@@ -117,6 +122,9 @@ public final class OptionsToConfigBuilder {
       case POSTGRESQL:
         if (sourceDbURL == null) {
           sourceDbURL = "jdbc:postgresql://" + host + ":" + port + "/" + dbName;
+        }
+        if (StringUtils.isNotBlank(connectionProperties)) {
+          sourceDbURL = sourceDbURL + "?" + connectionProperties;
         }
         break;
     }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapter.java
@@ -354,6 +354,7 @@ public final class MysqlDialectAdapter implements DialectAdapter {
 
   private static final ImmutableMap<String, SourceColumnIndexInfo.IndexType> INDEX_TYPE_MAPPING =
       ImmutableMap.<String, SourceColumnIndexInfo.IndexType>builder()
+          .put("BIGINT UNSIGNED", IndexType.BIG_INT_UNSIGNED)
           .put("BIGINT", IndexType.NUMERIC)
           .put("DATETIME", IndexType.DATE_TIME)
           .put("INTEGER", IndexType.NUMERIC)

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceColumnIndexInfo.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceColumnIndexInfo.java
@@ -18,6 +18,8 @@ package com.google.cloud.teleport.v2.source.reader.io.schema;
 import com.google.auto.value.AutoValue;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import java.math.BigInteger;
 import javax.annotation.Nullable;
 
 @AutoValue
@@ -135,8 +137,16 @@ public abstract class SourceColumnIndexInfo implements Comparable<SourceColumnIn
 
   public enum IndexType {
     NUMERIC,
+    BIG_INT_UNSIGNED,
     STRING,
     DATE_TIME,
     OTHER
   };
+
+  // TODO(vardhanvthigle): handle other types
+  public static final ImmutableMap<IndexType, Class> INDEX_TYPE_TO_CLASS =
+      ImmutableMap.of(
+          IndexType.NUMERIC, Long.class,
+          IndexType.STRING, String.class,
+          IndexType.BIG_INT_UNSIGNED, BigInteger.class);
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/PipelineController.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/PipelineController.java
@@ -214,6 +214,7 @@ public class PipelineController {
                           List.of(srcTable),
                           null,
                           shard.getHost(),
+                          shard.getConnectionProperties(),
                           Integer.parseInt(shard.getPort()),
                           shard.getUserName(),
                           shard.getPassword(),

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/options/OptionsToConfigBuilderTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/options/OptionsToConfigBuilderTest.java
@@ -72,12 +72,13 @@ public class OptionsToConfigBuilderTest {
   public void testConfigWithMySqlUrlFromOptions() {
     PCollection<Integer> dummyPCollection = pipeline.apply(Create.of(1));
     pipeline.run();
-    JdbcIOWrapperConfig config =
+    JdbcIOWrapperConfig configWithConnectionProperties =
         OptionsToConfigBuilder.getJdbcIOWrapperConfig(
             SQLDialect.MYSQL,
             List.of("table1", "table2"),
             null,
             "myhost",
+            "testParam=testValue",
             3306,
             "myuser",
             "mypassword",
@@ -88,7 +89,29 @@ public class OptionsToConfigBuilderTest {
             10,
             0,
             Wait.on(dummyPCollection));
-    assertThat(config.sourceDbURL())
+
+    JdbcIOWrapperConfig configWithoutConnectionProperties =
+        OptionsToConfigBuilder.getJdbcIOWrapperConfig(
+            SQLDialect.MYSQL,
+            List.of("table1", "table2"),
+            null,
+            "myhost",
+            null,
+            3306,
+            "myuser",
+            "mypassword",
+            "mydb",
+            null,
+            "com.mysql.jdbc.Driver",
+            "mysql-jar",
+            10,
+            0,
+            Wait.on(dummyPCollection));
+
+    assertThat(configWithConnectionProperties.sourceDbURL())
+        .isEqualTo(
+            "jdbc:mysql://myhost:3306/mydb?testParam=testValue&allowMultiQueries=true&autoReconnect=true&maxReconnects=10");
+    assertThat(configWithoutConnectionProperties.sourceDbURL())
         .isEqualTo(
             "jdbc:mysql://myhost:3306/mydb?allowMultiQueries=true&autoReconnect=true&maxReconnects=10");
   }
@@ -130,12 +153,13 @@ public class OptionsToConfigBuilderTest {
   public void testConfigWithPostgreSqlUrlFromOptions() {
     PCollection<Integer> dummyPCollection = pipeline.apply(Create.of(1));
     pipeline.run();
-    JdbcIOWrapperConfig config =
+    JdbcIOWrapperConfig configWithConnectionParameters =
         OptionsToConfigBuilder.getJdbcIOWrapperConfig(
             SQLDialect.POSTGRESQL,
             List.of("table1", "table2"),
             null,
             "myhost",
+            "testParam=testValue",
             5432,
             "myuser",
             "mypassword",
@@ -146,7 +170,27 @@ public class OptionsToConfigBuilderTest {
             10,
             0,
             Wait.on(dummyPCollection));
-    assertThat(config.sourceDbURL()).isEqualTo("jdbc:postgresql://myhost:5432/mydb");
+    JdbcIOWrapperConfig configWithoutConnectionParameters =
+        OptionsToConfigBuilder.getJdbcIOWrapperConfig(
+            SQLDialect.POSTGRESQL,
+            List.of("table1", "table2"),
+            null,
+            "myhost",
+            "",
+            5432,
+            "myuser",
+            "mypassword",
+            "mydb",
+            null,
+            "com.mysql.jdbc.Driver",
+            "mysql-jar",
+            10,
+            0,
+            Wait.on(dummyPCollection));
+    assertThat(configWithoutConnectionParameters.sourceDbURL())
+        .isEqualTo("jdbc:postgresql://myhost:5432/mydb");
+    assertThat(configWithConnectionParameters.sourceDbURL())
+        .isEqualTo("jdbc:postgresql://myhost:5432/mydb?testParam=testValue");
   }
 
   @Test

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
@@ -38,6 +38,7 @@ import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableSchema;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.math.BigInteger;
 import java.sql.SQLException;
 import org.apache.beam.sdk.io.jdbc.JdbcIO;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -308,5 +309,35 @@ public class JdbcIoWrapperTest {
     assertThat(
             jdbcIOWrapperWithFeatureEnabled.getTableReaders().values().stream().findFirst().get())
         .isInstanceOf(ReadWithUniformPartitions.class);
+  }
+
+  @Test
+  public void testIndexTypeToColumnClass() {
+
+    assertThat(
+            JdbcIoWrapper.indexTypeToColumnClass(
+                SourceColumnIndexInfo.builder()
+                    .setColumnName("col1")
+                    .setIndexType(IndexType.BIG_INT_UNSIGNED)
+                    .setOrdinalPosition(1)
+                    .setIndexName("PRIMARY")
+                    .setIsPrimary(true)
+                    .setCardinality(42L)
+                    .setIsUnique(true)
+                    .build()))
+        .isEqualTo(BigInteger.class);
+    assertThrows(
+        SuitableIndexNotFoundException.class,
+        () ->
+            JdbcIoWrapper.indexTypeToColumnClass(
+                SourceColumnIndexInfo.builder()
+                    .setColumnName("col1")
+                    .setIndexType(IndexType.OTHER)
+                    .setOrdinalPosition(1)
+                    .setIndexName("PRIMARY")
+                    .setIsPrimary(true)
+                    .setCardinality(42L)
+                    .setIsUnique(true)
+                    .build()));
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataTypesIt.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataTypesIt.java
@@ -221,6 +221,9 @@ public class DataTypesIt extends SourceDbToSpannerITBase {
     expectedData.put("set", createRows("set", "v1,v2", "NULL"));
     expectedData.put(
         "integer_unsigned", createRows("integer_unsigned", "0", "42", "4294967296", "NULL"));
+    expectedData.put(
+        "bigint_unsigned_pk", createRows("bigint_unsigned", "0", "42", "18446744073709551615"));
+    expectedData.put("string_pk", createRows("string", "Cloud", "Google", "Spanner"));
     return expectedData;
   }
 

--- a/v2/sourcedb-to-spanner/src/test/resources/DataTypesIt/data-types.sql
+++ b/v2/sourcedb-to-spanner/src/test/resources/DataTypesIt/data-types.sql
@@ -177,6 +177,17 @@ CREATE TABLE set_table (
     set_col SET('v1', 'v2', 'v3') DEFAULT NULL
 );
 
+
+CREATE TABLE `bigint_unsigned_pk_table` (
+    `id` BIGINT UNSIGNED PRIMARY KEY,
+    `bigint_unsigned_col` BIGINT UNSIGNED NOT NULL
+);
+
+CREATE TABLE `string_pk_table` (
+     `id` STRING(50) PRIMARY KEY,
+     `string_col` STRING(50) NOT NULL
+);
+
 ALTER TABLE `bigint_table` MODIFY `id` INT AUTO_INCREMENT;
 ALTER TABLE `bigint_unsigned_table` MODIFY `id` INT AUTO_INCREMENT;
 ALTER TABLE `binary_table` MODIFY `id` INT AUTO_INCREMENT;
@@ -297,6 +308,8 @@ INSERT INTO `year_table` (`year_col`) VALUES (2022);
 INSERT INTO `year_table` (`year_col`) VALUES (1901);
 INSERT INTO `year_table` (`year_col`) VALUES (2155);
 INSERT INTO `set_table` (`set_col`) VALUES ('v1,v2');
+INSERT INTO `bigint_unsigned_pk_table` (`id`, `bigint_unsigned_col`) VALUES ('0', '0'), ('42', '42'), ('18446744073709551615', '18446744073709551615');
+INSERT INTO `string_pk_table` (`id`, `string_col`) VALUES ('Cloud', 'Cloud'), ('Google', 'Google'), ('Spanner','Spanner');
 
 INSERT INTO `bigint_table` (`bigint_col`) VALUES (NULL);
 INSERT INTO `bigint_unsigned_table` (`bigint_unsigned_col`) VALUES (NULL);

--- a/v2/sourcedb-to-spanner/src/test/resources/DataTypesIt/spanner-schema.sql
+++ b/v2/sourcedb-to-spanner/src/test/resources/DataTypesIt/spanner-schema.sql
@@ -204,3 +204,12 @@ CREATE TABLE spatial_polygon (
   id INT64 NOT NULL,
   area STRING(MAX),
 ) PRIMARY KEY(id);
+CREATE TABLE `bigint_unsigned_pk_table` (
+  id NUMERIC NOT NULL,
+  bigint_unsigned_col NUMERIC NOT NULL,
+) PRIMARY KEY(id);
+
+CREATE TABLE `string_pk_table` (
+  id STRING(max) NOT NULL,
+  string_col STRING(max) NOT NULL
+) PRIMARY KEY(id);

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/shard/Shard.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/shard/Shard.java
@@ -29,6 +29,7 @@ public class Shard implements Serializable {
   private String password;
   private String dbName;
   private String secretManagerUri;
+  private String connectionProperties;
 
   private Map<String, String> dbNameToLogicalShardIdMap = new HashMap<>();
 
@@ -39,7 +40,8 @@ public class Shard implements Serializable {
       String user,
       String password,
       String dbName,
-      String secretManagerUri) {
+      String secretManagerUri,
+      String connectionProperties) {
     this.logicalShardId = logicalShardId;
     this.host = host;
     this.port = port;
@@ -47,6 +49,7 @@ public class Shard implements Serializable {
     this.password = password;
     this.dbName = dbName;
     this.secretManagerUri = secretManagerUri;
+    this.connectionProperties = connectionProperties;
   }
 
   public Shard() {}
@@ -107,6 +110,14 @@ public class Shard implements Serializable {
     this.secretManagerUri = input;
   }
 
+  public String getConnectionProperties() {
+    return connectionProperties;
+  }
+
+  public void setConnectionProperties(String input) {
+    this.connectionProperties = input;
+  }
+
   public Map<String, String> getDbNameToLogicalShardIdMap() {
     return dbNameToLogicalShardIdMap;
   }
@@ -129,6 +140,9 @@ public class Shard implements Serializable {
         + ", dbName='"
         + dbName
         + '\''
+        + ", connectionProperties='"
+        + connectionProperties
+        + '\''
         + ", dbNameToLogicalShardIdMap="
         + dbNameToLogicalShardIdMap
         + '}';
@@ -149,6 +163,7 @@ public class Shard implements Serializable {
         && Objects.equals(user, shard.user)
         && Objects.equals(password, shard.password)
         && Objects.equals(dbName, shard.dbName)
+        && Objects.equals(connectionProperties, shard.connectionProperties)
         && Objects.equals(secretManagerUri, shard.secretManagerUri)
         && Objects.equals(dbNameToLogicalShardIdMap, shard.dbNameToLogicalShardIdMap);
   }
@@ -162,6 +177,7 @@ public class Shard implements Serializable {
         user,
         password,
         dbName,
+        connectionProperties,
         secretManagerUri,
         dbNameToLogicalShardIdMap);
   }

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/utils/ShardFileReader.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/utils/ShardFileReader.java
@@ -18,6 +18,7 @@ package com.google.cloud.teleport.v2.spanner.migrations.utils;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.GsonBuilder;
+import com.google.gson.ToNumberPolicy;
 import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 import java.io.InputStream;
@@ -184,6 +185,7 @@ public class ShardFileReader {
     Map shardConfigMap =
         new GsonBuilder()
             .setFieldNamingPolicy(FieldNamingPolicy.IDENTITY)
+            .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
             .create()
             .fromJson(jsonString, shardConfiguration);
 
@@ -225,7 +227,8 @@ public class ShardFileReader {
               (String) (dataShard.get("user")),
               password,
               "",
-              (String) (dataShard.get("secretManagerUri")));
+              (String) (dataShard.get("secretManagerUri")),
+              dataShard.getOrDefault("connectionProperties", "").toString());
 
       for (Map database : databases) {
         shard

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/utils/ShardFileReaderTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/utils/ShardFileReaderTest.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.spanner.migrations.utils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
@@ -43,8 +44,8 @@ public final class ShardFileReaderTest {
     List<Shard> shards = shardFileReader.getOrderedShardDetails("src/test/resources/shard.json");
     List<Shard> expectedShards =
         Arrays.asList(
-            new Shard("shardA", "hostShardA", "3306", "test", "test", "test", null),
-            new Shard("shardB", "hostShardB", "3306", "test", "test", "test", null));
+            new Shard("shardA", "hostShardA", "3306", "test", "test", "test", null, null),
+            new Shard("shardB", "hostShardB", "3306", "test", "test", "test", null, null));
 
     assertEquals(shards, expectedShards);
   }
@@ -82,7 +83,8 @@ public final class ShardFileReaderTest {
                 "test",
                 "secretA",
                 "test",
-                "projects/123/secrets/secretA/versions/latest"),
+                "projects/123/secrets/secretA/versions/latest",
+                null),
             new Shard(
                 "shardB",
                 "hostShardB",
@@ -90,7 +92,8 @@ public final class ShardFileReaderTest {
                 "test",
                 "secretB",
                 "test",
-                "projects/123/secrets/secretB"),
+                "projects/123/secrets/secretB",
+                null),
             new Shard(
                 "shardC",
                 "hostShardC",
@@ -98,8 +101,9 @@ public final class ShardFileReaderTest {
                 "test",
                 "secretC",
                 "test",
-                "projects/123/secrets/secretC/"),
-            new Shard("shardD", "hostShardD", "3306", "test", "test", "test", null));
+                "projects/123/secrets/secretC/",
+                null),
+            new Shard("shardD", "hostShardD", "3306", "test", "test", "test", null, null));
 
     assertEquals(shards, expectedShards);
   }
@@ -136,19 +140,31 @@ public final class ShardFileReaderTest {
 
   @Test
   public void readBulkMigrationShardFile() {
+    String testConnectionProperties =
+        "useUnicode=yes&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull";
     ShardFileReader shardFileReader = new ShardFileReader(new SecretManagerAccessorImpl());
     List<Shard> shards =
         shardFileReader.readForwardMigrationShardingConfig(
             "src/test/resources/bulk-migration-shards.json");
-    Shard shard1 = new Shard("", "1.1.1.1", "3306", "test1", "pass1", "", null);
+    Shard shard1 =
+        new Shard("", "1.1.1.1", "3306", "test1", "pass1", "", null, testConnectionProperties);
     shard1.getDbNameToLogicalShardIdMap().put("person1", "1-1-1-1-person");
     shard1.getDbNameToLogicalShardIdMap().put("person2", "1-1-1-1-person2");
-    Shard shard2 = new Shard("", "1.1.1.2", "3306", "test1", "pass1", "", null);
+    Shard shard2 = new Shard("", "1.1.1.2", "3306", "test1", "pass1", "", null, "");
     shard2.getDbNameToLogicalShardIdMap().put("person1", "1-1-1-2-person");
     shard2.getDbNameToLogicalShardIdMap().put("person20", "1-1-1-2-person2");
     List<Shard> expectedShards = new ArrayList<>(Arrays.asList(shard1, shard2));
 
-    assertEquals(shards, expectedShards);
+    assertEquals(expectedShards, shards);
+    assertEquals(shard1.toString().contains(testConnectionProperties), true);
+    assertEquals(shard1.getConnectionProperties(), testConnectionProperties);
+    var originalHarshCode = shard1.hashCode();
+    shard1.setConnectionProperties("");
+    assertNotEquals(originalHarshCode, shard1.hashCode());
+    // Cover the equality override.
+    assertEquals(shard1, shard1);
+    assertNotEquals(shard1, "");
+    assertNotEquals(shard1, shards.get(0));
   }
 
   @Test
@@ -169,7 +185,8 @@ public final class ShardFileReaderTest {
             "test1",
             "secretA",
             "",
-            "projects/123/secrets/secretA/versions/latest");
+            "projects/123/secrets/secretA/versions/latest",
+            "");
     shard1.getDbNameToLogicalShardIdMap().put("person1", "1-1-1-1-person");
     shard1.getDbNameToLogicalShardIdMap().put("person2", "1-1-1-1-person2");
     Shard shard2 =
@@ -180,7 +197,8 @@ public final class ShardFileReaderTest {
             "test1",
             "secretB",
             "",
-            "projects/123/secrets/secretB/versions/latest");
+            "projects/123/secrets/secretB/versions/latest",
+            "");
     shard2.getDbNameToLogicalShardIdMap().put("person1", "1-1-1-2-person");
     shard2.getDbNameToLogicalShardIdMap().put("person20", "1-1-1-2-person2");
     List<Shard> expectedShards = new ArrayList<>(Arrays.asList(shard1, shard2));

--- a/v2/spanner-common/src/test/resources/bulk-migration-shards.json
+++ b/v2/spanner-common/src/test/resources/bulk-migration-shards.json
@@ -17,6 +17,7 @@
         "password": "pass1",
         "port": "3306",
         "dbName": "",
+        "connectionProperties": "useUnicode=yes&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull",
         "databases": [
           {
             "dbName": "person1",
@@ -35,7 +36,7 @@
         "host": "1.1.1.2",
         "user": "test1",
         "password": "pass1",
-        "port": "3306",
+        "port": 3306,
         "dbName": "",
         "databases": [
           {


### PR DESCRIPTION
## Overview
This PR covers a few cases keeping in view upcoming use-cases of bulk migration template.

1. Adding Support for `BigInt Unsigned` as primary key for partitioning. This is the next type we are addeding as primary key to the earlier list of everything that's subset of `long` and `string`.
2. Adding support for `connectionProperties` in Shard-Config
3. Allowing `portNumber` to be an integer in shard-config.

## Testing
1. UT coverage for the changes.
2. IT coverage for `BigInt Unsigned` and `String` as primary keys. `Long` primary key is already covered by existing integration tests.
3. End to End migration on 10 physical shard migration with `BigInt Unsigned` as primary key.
    The shard-config used for the end-to-end migration, also adds connectionProperties and integer Port number for test
    ```json
      "dataShardId": "X-X-X-X",
        "host": "X.X.X.X",
        "user": "root",
        "password": "XXXX",
        "port": 3306,
        "connectionProperties": "tcpKeepAlive=false",
        "dbName": "",
     ```
