### PR TITLE
Modified BigQueryDynamicDestination destination to support write API with exactly once semantics

### DIFF
--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/BigQueryDynamicDestinationsTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/BigQueryDynamicDestinationsTest.java
@@ -80,6 +80,8 @@ import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.Big
 import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils.BigQueryUtils;
 import com.google.common.collect.ImmutableSet;
 import java.util.List;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.values.KV;
@@ -277,5 +279,20 @@ public final class BigQueryDynamicDestinationsTest {
                 + " name=_metadata_spanner_number_of_partitions_in_transaction, type=INT64}},"
                 + " {{mode=REQUIRED, name=_metadata_big_query_commit_timestamp,"
                 + " type=TIMESTAMP}}]}}");
+  }
+
+  // Test that the custome destination coder is able to encode/decode destination.
+  @Test
+  public void testGetDestinationCoder() throws Exception {
+    fillTableRow();
+    tableNameToFields =
+        KV.of(
+            String.format(
+                "%s:%s.%s",
+                TEST_PROJECT, TEST_BIG_QUERY_DATESET, TEST_SPANNER_TABLE + "_changelog"),
+            bigQueryDynamicDestinations.getFields(tableRow));
+    Coder<KV<String, List<TableFieldSchema>>> coder =
+        bigQueryDynamicDestinations.getDestinationCoder();
+    CoderProperties.coderDecodeEncodeEqual(coder, tableNameToFields);
   }
 }


### PR DESCRIPTION
Spanner change stream to BQ template fails to launch with error "ParDo requires a deterministic key coder in order to use state and timers" when using `useStorageWriteApi=true` and `useStorageWriteApiAtLeastOnce=false` with:

```
com.google.cloud.teleport.v2.common.UncaughtExceptionLogger - The template launch failed.
java.lang.IllegalArgumentException: ParDo requires a deterministic key coder in order to use state and timers, the reason is:
 ShardedKey$Coder(KvCoder(SerializableCoder(com.google.cloud.bigquery.TableId),TableRowJsonCoder)) is not deterministic because:
	Key coder must be deterministic
	at org.apache.beam.sdk.transforms.ParDo.validateStateApplicableForInput(ParDo.java:448)
	at org.apache.beam.sdk.transforms.ParDo.access$300(ParDo.java:394)
	at org.apache.beam.sdk.transforms.ParDo$MultiOutput.expand(ParDo.java:953)
	at org.apache.beam.sdk.transforms.ParDo$MultiOutput.expand(ParDo.java:872)
	at org.apache.beam.sdk.Pipeline.applyInternal(Pipeline.java:559)
	at org.apache.beam.sdk.Pipeline.applyTransform(Pipeline.java:491)
	at org.apache.beam.sdk.values.PCollection.apply(PCollection.java:352)
	at org.apache.beam.sdk.transforms.ParDo$SingleOutput.expand(ParDo.java:797)
	at org.apache.beam.sdk.transforms.ParDo$SingleOutput.expand(ParDo.java:712)
	at org.apache.beam.sdk.Pipeline.applyInternal(Pipeline.java:559)
	at org.apache.beam.sdk.Pipeline.applyTransform(Pipeline.java:491)
	at org.apache.beam.sdk.values.PCollection.apply(PCollection.java:352)
	at org.apache.beam.sdk.transforms.GroupIntoBatches.expand(GroupIntoBatches.java:338)
	at org.apache.beam.sdk.transforms.GroupIntoBatches.expand(GroupIntoBatches.java:103)
	at org.apache.beam.sdk.Pipeline.applyInternal(Pipeline.java:559)
	at org.apache.beam.sdk.Pipeline.applyTransform(Pipeline.java:508)
	at org.apache.beam.sdk.values.PCollection.apply(PCollection.java:365)
	at org.apache.beam.sdk.io.gcp.bigquery.StorageApiLoads.expandTriggered(StorageApiLoads.java:231)
	at org.apache.beam.sdk.io.gcp.bigquery.StorageApiLoads.expand(StorageApiLoads.java:125)
	at org.apache.beam.sdk.io.gcp.bigquery.StorageApiLoads.expand(StorageApiLoads.java:46)
	at org.apache.beam.sdk.Pipeline.applyInternal(Pipeline.java:559)
	at org.apache.beam.sdk.Pipeline.applyTransform(Pipeline.java:508)
	at org.apache.beam.sdk.values.PCollection.apply(PCollection.java:365)
	at org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO$Write.continueExpandTyped(BigQueryIO.java:3718)
	at org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO$Write.expandTyped(BigQueryIO.java:3502)
	at org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO$Write.expand(BigQueryIO.java:3374)
	at org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO$Write.expand(BigQueryIO.java:2214)
	at org.apache.beam.sdk.Pipeline.applyInternal(Pipeline.java:559)
	at org.apache.beam.sdk.Pipeline.applyTransform(Pipeline.java:508)
	at org.apache.beam.sdk.values.PCollection.apply(PCollection.java:365)
	at com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.SpannerChangeStreamsToBigQuery.run(SpannerChangeStreamsToBigQuery.java:382)
	at com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.SpannerChangeStreamsToBigQuery.main(SpannerChangeStreamsToBigQuery.java:198)
```

Given that `TableRowJsonCoder`'s verifyDeterministic method always throws we need to implement a custom deterministic coder for the value