### PR TITLE
Disable testSpannerToGCSAvroStaging

### DIFF
--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ExportPipelineIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ExportPipelineIT.java
@@ -41,6 +41,7 @@ import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -159,6 +160,7 @@ public class ExportPipelineIT extends TemplateTestBase {
   }
 
   @Test
+  @Ignore("https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/1807")
   public void testSpannerToGCSAvroStaging() throws IOException {
     spannerResourceManager =
         SpannerResourceManager.builder(testName, PROJECT, REGION, Dialect.GOOGLE_STANDARD_SQL)


### PR DESCRIPTION
test signal long been red could impose risk that other breakages slipped into the main branch, which is just happened

mitigate #1807