### PR TITLE
Reducing JDBC SchemaDiscovery error timeout

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapter.java
@@ -151,7 +151,8 @@ public final class MysqlDialectAdapter implements DialectAdapter {
     } catch (SQLException e) {
       logger.error(
           String.format(
-              "Sql exception while discovering table list for datasource=%s", dataSource, e));
+              "Sql exception while discovering table list for datasource=%s cause=%s",
+              dataSource, e));
       schemaDiscoveryErrors.inc();
       throw new SchemaDiscoveryException(e);
     }
@@ -184,7 +185,7 @@ public final class MysqlDialectAdapter implements DialectAdapter {
       throws SchemaDiscoveryException, RetriableSchemaDiscoveryException {
     logger.info(
         String.format(
-            "Discovering tale schema for Datasource: %s, SourceSchemaReference: %s, tables: %s",
+            "Discovering table schema for Datasource: %s, SourceSchemaReference: %s, tables: %s",
             dataSource, sourceSchemaReference, tables));
 
     String discoveryQuery = getSchemaDiscoveryQuery(sourceSchemaReference);
@@ -224,7 +225,7 @@ public final class MysqlDialectAdapter implements DialectAdapter {
         tableSchemaBuilder.build();
     logger.info(
         String.format(
-            "Discovered tale schema for Datasource: %s, SourceSchemaReference: %s, tables: %s, schema: %s",
+            "Discovered table schema for Datasource: %s, SourceSchemaReference: %s, tables: %s, schema: %s",
             dataSource, sourceSchemaReference, tables, tableSchema));
 
     return tableSchema;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
@@ -248,7 +248,7 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
     ImmutableMap<String, ImmutableMap<String, SourceColumnType>> tableSchema =
         tableSchemaBuilder.build();
     logger.info(
-        "Discovered tale schema for Datasource: {}, SourceSchemaReference: {}, tables: {}, schema: {}",
+        "Discovered table schema for Datasource: {}, SourceSchemaReference: {}, tables: {}, schema: {}",
         dataSource,
         sourceSchemaReference,
         tables,

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcDataSource.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcDataSource.java
@@ -177,4 +177,11 @@ public final class JdbcDataSource extends BasicDataSource implements Serializabl
     // Call initializeSuper after deserialization
     initializeSuper();
   }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "JdbcDataSource: {\"sourceDbURL\":\"%s\", \"initSql\":\"%s\", \"maxConnections\",\"%s\" }",
+        sourceDbURL, initSql, maxConnections);
+  }
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/JdbcIOWrapperConfig.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/JdbcIOWrapperConfig.java
@@ -194,6 +194,12 @@ public abstract class JdbcIOWrapperConfig {
 
   private static final String DEFAULT_VALIDATEION_QUERY = "SELECT 1";
 
+  /** Sets the connectivity timeout in seconds during schema discovery. * */
+  public abstract Integer schemaDiscoveryConnectivityTimeoutMilliSeconds();
+
+  private static final Integer DEFAULT_SCHEMA_DISCOVERY_CONNECTIVITY_TIMEOUT_MILLISECONDS =
+      30 * 1000;
+
   /**
    * The timeout in seconds before an abandoned connection can be removed.
    *
@@ -252,7 +258,9 @@ public abstract class JdbcIOWrapperConfig {
         .setTestWhileIdle(DEFAULT_TEST_WILE_IDLE)
         .setValidationQuery(DEFAULT_VALIDATEION_QUERY)
         .setRemoveAbandonedTimeout(DEFAULT_REMOVE_ABANDONED_TIMEOUT)
-        .setMinEvictableIdleTimeMillis(DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS);
+        .setMinEvictableIdleTimeMillis(DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS)
+        .setSchemaDiscoveryConnectivityTimeoutMilliSeconds(
+            DEFAULT_SCHEMA_DISCOVERY_CONNECTIVITY_TIMEOUT_MILLISECONDS);
   }
 
   public static Builder builderWithPostgreSQLDefaults() {
@@ -280,7 +288,9 @@ public abstract class JdbcIOWrapperConfig {
         .setTestWhileIdle(DEFAULT_TEST_WILE_IDLE)
         .setValidationQuery(DEFAULT_VALIDATEION_QUERY)
         .setRemoveAbandonedTimeout(DEFAULT_REMOVE_ABANDONED_TIMEOUT)
-        .setMinEvictableIdleTimeMillis(DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS);
+        .setMinEvictableIdleTimeMillis(DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS)
+        .setSchemaDiscoveryConnectivityTimeoutMilliSeconds(
+            DEFAULT_SCHEMA_DISCOVERY_CONNECTIVITY_TIMEOUT_MILLISECONDS);
   }
 
   @AutoValue.Builder
@@ -338,6 +348,8 @@ public abstract class JdbcIOWrapperConfig {
     public abstract Builder setTestWhileIdle(Boolean value);
 
     public abstract Builder setValidationQuery(String value);
+
+    public abstract Builder setSchemaDiscoveryConnectivityTimeoutMilliSeconds(Integer value);
 
     public abstract Builder setRemoveAbandonedTimeout(Integer value);
 

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/defaults/MySqlConfigDefaults.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/defaults/MySqlConfigDefaults.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Calendar;
 import org.apache.beam.sdk.util.FluentBackoff;
+import org.joda.time.Duration;
 
 // TODO: Fine-tune the defaults based on benchmarking.
 
@@ -62,7 +63,8 @@ public class MySqlConfigDefaults {
           "autoReconnect", "true",
           "maxReconnects", "10");
 
-  public static final FluentBackoff DEFAULT_MYSQL_SCHEMA_DISCOVERY_BACKOFF = FluentBackoff.DEFAULT;
+  public static final FluentBackoff DEFAULT_MYSQL_SCHEMA_DISCOVERY_BACKOFF =
+      FluentBackoff.DEFAULT.withMaxCumulativeBackoff(Duration.standardMinutes(5L));
 
   /**
    * Default Initialization Sequence for the JDBC connection.
@@ -83,6 +85,8 @@ public class MySqlConfigDefaults {
   // TODO: Add innodb_parallel_read_threads for better performance tuning.
   public static final ImmutableList<String> DEFAULT_MYSQL_INIT_SEQ =
       ImmutableList.of(
+          // Using an offset of 0 instead of UTC, as it's possible for a customer's database to not
+          // have named timezone information pre-installed.
           "SET TIME_ZONE = '+00:00'",
           "SET SESSION NET_WRITE_TIMEOUT=1200",
           "SET SESSION NET_READ_TIMEOUT=1200");

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/defaults/PostgreSQLConfigDefaults.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/defaults/PostgreSQLConfigDefaults.java
@@ -23,6 +23,7 @@ import com.google.cloud.teleport.v2.source.reader.io.jdbc.rowmapper.provider.Pos
 import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedTypeMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.beam.sdk.util.FluentBackoff;
+import org.joda.time.Duration;
 
 // TODO(thiagotnunes): Fine-tune the defaults based on benchmarking.
 
@@ -41,11 +42,14 @@ public class PostgreSQLConfigDefaults {
   public static final Long DEFAULT_POSTGRESQL_MAX_CONNECTIONS = 160L;
 
   public static final FluentBackoff DEFAULT_POSTGRESQL_SCHEMA_DISCOVERY_BACKOFF =
-      FluentBackoff.DEFAULT;
+      FluentBackoff.DEFAULT.withMaxCumulativeBackoff(Duration.standardMinutes(5L));
 
   /** Default Initialization Sequence for the JDBC connection. */
   public static final ImmutableList<String> DEFAULT_POSTGRESQL_INIT_SEQ =
-      ImmutableList.of("SET TIME ZONE 'UTC'");
+      ImmutableList.of(
+          // Using an offset of 0 instead of UTC, as it's possible for a customer's database to not
+          // have named timezone information pre-installed.
+          "SET TIME ZONE '+00:00'");
 
   private PostgreSQLConfigDefaults() {}
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcDataSourceTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcDataSourceTest.java
@@ -79,6 +79,9 @@ public class JdbcDataSourceTest {
         .isEqualTo(jdbcIOWrapperConfig.minEvictableIdleTimeMillis());
     assertThat(testJdbcDataSource.getValidationQuery())
         .isEqualTo(jdbcIOWrapperConfig.validationQuery());
+    assertThat(testJdbcDataSource.toString())
+        .isEqualTo(
+            "JdbcDataSource: {\"sourceDbURL\":\"jdbc:derby://myhost/memory:TestingDB;create=true\", \"initSql\":\"[SET TIME_ZONE = '+00:00', SET SESSION NET_WRITE_TIMEOUT=1200, SET SESSION NET_READ_TIMEOUT=1200]\", \"maxConnections\",\"160\" }");
   }
 
   @Test

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
@@ -20,6 +20,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.teleport.v2.source.reader.auth.dbauth.LocalCredentialsProvider;
@@ -27,6 +30,7 @@ import com.google.cloud.teleport.v2.source.reader.io.exception.RetriableSchemaDi
 import com.google.cloud.teleport.v2.source.reader.io.exception.SuitableIndexNotFoundException;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.DialectAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.JdbcIOWrapperConfig;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.SQLDialect;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms.ReadWithUniformPartitions;
 import com.google.cloud.teleport.v2.source.reader.io.row.SourceRow;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceColumnIndexInfo;
@@ -44,6 +48,7 @@ import org.apache.beam.sdk.io.jdbc.JdbcIO;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -55,6 +60,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class JdbcIoWrapperTest {
   @Mock DialectAdapter mockDialectAdapter;
+
+  @Mock BasicDataSource mockBasicDataSource;
 
   @BeforeClass
   public static void beforeClass() {
@@ -309,6 +316,75 @@ public class JdbcIoWrapperTest {
     assertThat(
             jdbcIOWrapperWithFeatureEnabled.getTableReaders().values().stream().findFirst().get())
         .isInstanceOf(ReadWithUniformPartitions.class);
+  }
+
+  @Test
+  public void testLoginTimeout() throws RetriableSchemaDiscoveryException {
+
+    int testLoginTimeoutMilliseconds = 1000;
+    int testLoginTimeoutSeconds = 1;
+
+    doNothing().when(mockBasicDataSource).setMaxWaitMillis(testLoginTimeoutMilliseconds);
+    when(mockBasicDataSource.getUrl())
+        .thenReturn("jdbc://testIp:3306/testDB")
+        .thenReturn("jdbc://testIp:3306/testDB")
+        .thenReturn("jdbc://testIp:3306/testDB?connectTimeout=2000&socketTimeout=2000")
+        .thenReturn("jdbc://testIp:3306/testDB?connectTimeout=2000&socketTimeout=2000")
+        .thenReturn("jdbc://testIp:3306/testDB?connectTimeout=2000&socketTimeout=2000");
+    doNothing()
+        .when(mockBasicDataSource)
+        .addConnectionProperty("connectTimeout", String.valueOf(testLoginTimeoutMilliseconds));
+    doNothing()
+        .when(mockBasicDataSource)
+        .addConnectionProperty("socketTimeout", String.valueOf(testLoginTimeoutMilliseconds));
+    doNothing()
+        .when(mockBasicDataSource)
+        .addConnectionProperty("loginTimeout", String.valueOf(testLoginTimeoutSeconds));
+
+    SourceSchemaReference testSourceSchemaReference =
+        SourceSchemaReference.builder().setDbName("testDB").build();
+
+    JdbcIOWrapperConfig config =
+        JdbcIOWrapperConfig.builderWithMySqlDefaults()
+            .setSourceDbURL("jdbc:derby://myhost/memory:TestingDB;create=true")
+            .setSourceSchemaReference(testSourceSchemaReference)
+            .setSchemaDiscoveryConnectivityTimeoutMilliSeconds(testLoginTimeoutMilliseconds)
+            .setShardID("test")
+            .setTableVsPartitionColumns(ImmutableMap.of("testTable", ImmutableList.of("ID")))
+            .setDbAuth(
+                LocalCredentialsProvider.builder()
+                    .setUserName("testUser")
+                    .setPassword("testPassword")
+                    .build())
+            .setJdbcDriverJars("")
+            .setJdbcDriverClassName("org.apache.derby.jdbc.EmbeddedDriver")
+            .setDialectAdapter(mockDialectAdapter)
+            .build();
+    JdbcIOWrapperConfig configWithTimeoutSet =
+        config.toBuilder()
+            .setSourceDbDialect(SQLDialect.MYSQL)
+            .setSchemaDiscoveryConnectivityTimeoutMilliSeconds(testLoginTimeoutMilliseconds)
+            .build();
+    JdbcIOWrapperConfig configWithUrlTimeout =
+        config.toBuilder()
+            .setSourceDbDialect(SQLDialect.POSTGRESQL)
+            .setSourceDbURL(
+                "jdbc:derby://myhost/memory:TestingDB;create=true?socketTimeout=10&connectTimeout=10")
+            .setSchemaDiscoveryConnectivityTimeoutMilliSeconds(testLoginTimeoutMilliseconds)
+            .build();
+
+    JdbcIoWrapper.setDataSourceLoginTimeout(mockBasicDataSource, configWithTimeoutSet);
+    JdbcIoWrapper.setDataSourceLoginTimeout(mockBasicDataSource, configWithUrlTimeout);
+
+    assertThat(configWithTimeoutSet.schemaDiscoveryConnectivityTimeoutMilliSeconds())
+        .isEqualTo(testLoginTimeoutMilliseconds);
+    verify(mockBasicDataSource, times(2)).setMaxWaitMillis(testLoginTimeoutMilliseconds);
+    verify(mockBasicDataSource, times(1))
+        .addConnectionProperty("connectTimeout", String.valueOf(testLoginTimeoutMilliseconds));
+    verify(mockBasicDataSource, times(1))
+        .addConnectionProperty("socketTimeout", String.valueOf(testLoginTimeoutMilliseconds));
+    verify(mockBasicDataSource, times(1))
+        .addConnectionProperty("loginTimeout", String.valueOf(testLoginTimeoutSeconds));
   }
 
   @Test


### PR DESCRIPTION
# Reducing MySQL SchemaDiscovery error timeout #1899
## Overview
1. The default Backoff used in `sourcedb-to-spanner` for MySQL connections was quite large than Dataflow's pipeline launch failure.
2. Irrespective of the outer backoff, at the layer of jdbc connection pool, dbcp2 has an indefinite wait to acquire connections.
## Fix
1. Added loginTimeout for jdbc (this takes into fact that dbcp2 does not natively support loginTimeOut. In the most Ideal case this can be implemented at the layer of JdbcDataSource too, but, it get's tricky to limit this to only discovery layer and also tricker to unit test)
2. The current loginTimout is limited only for discovery, as we have not faced this issue in runtime and capping run-time timeout could have un-intended side effects needed a thorough scale test. If the connectivity is not correctly configured we will any ways fail fast in the discovery layer.
3. Added stringificaiton of JdbcDataSource for better logging.
4. Minor logging typo fixes. 
## Sample Error logs
### Log-1
```
com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter - Sql exception while discovering table list for datasource=JdbcDataSource: {"sourceDbURL":"jdbc:mysql://X.X.X.X:3306/test?allowMultiQueries=true&autoReconnect=true&maxReconnects=10", "initSql":"[SET TIME_ZONE = '+00:00', SET SESSION NET_WRITE_TIMEOUT=1200, SET SESSION NET_READ_TIMEOUT=1200]", "maxConnections","160" } cause=java.sql.SQLException: Cannot create PoolableConnectionFactory (Could not create connection to database server. Attempted reconnect 10 times. Giving up.)
```
### Log-2
```
com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryException: java.sql.SQLException: Cannot create PoolableConnectionFactory (Could not create connection to database server. Attempted reconnect 10 times. Giving up.)
	at com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.discoverTables(MysqlDialectAdapter.java:157)
	at com.google.cloud.teleport.v2.source.reader.io.schema.SchemaDiscoveryImpl.lambda$discoverTables$0(SchemaDiscoveryImpl.java:64)
	at com.google.cloud.teleport.v2.source.reader.io.schema.SchemaDiscoveryImpl.doRetries(SchemaDiscoveryImpl.java:114)
	at com.google.cloud.teleport.v2.source.reader.io.schema.SchemaDiscoveryImpl.discoverTables(SchemaDiscoveryImpl.java:63)
	at com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.JdbcIoWrapper.autoInferTableConfigs(JdbcIoWrapper.java:259)
	at com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.JdbcIoWrapper.of(JdbcIoWrapper.java:90)
	at com.google.cloud.teleport.v2.templates.PipelineController.executeSingleInstanceMigration(PipelineController.java:120)
	at com.google.cloud.teleport.v2.templates.SourceDbToSpanner.run(SourceDbToSpanner.java:111)
	at com.google.cloud.teleport.v2.templates.SourceDbToSpanner.main(SourceDbToSpanner.java:88)
```
### Note
Note that `Log-1` provides the host details as well as the exception, and is more relevant for debugging the connectivity issues than `Log-2`.