### PR TITLE
Added support for WHERE ... IS NOT NULL for indexes

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/Index.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/Index.java
@@ -47,7 +47,6 @@ public abstract class Index implements Serializable {
   // restricted for gsql
   abstract boolean nullFiltered();
 
-  // restricted for pg
   @Nullable
   abstract String filter();
 
@@ -179,6 +178,11 @@ public abstract class Index implements Serializable {
     if (interleaveIn() != null) {
       appendable.append(", INTERLEAVE IN ").append(quoteIdentifier(interleaveIn(), dialect()));
     }
+
+    if (!nullFiltered() && filter() != null && !filter().isEmpty()) {
+      appendable.append(" WHERE ").append(filter());
+    }
+
     if (options() != null) {
       String optionsString = String.join(",", options());
       if (!optionsString.isEmpty()) {

--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScanner.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScanner.java
@@ -400,25 +400,25 @@ public class InformationSchemaScanner {
               ? resultSet.getBoolean(5)
               : resultSet.getString(5).equalsIgnoreCase("YES");
       String filter =
-          (dialect == Dialect.GOOGLE_STANDARD_SQL || resultSet.isNull(6))
+          resultSet.isNull(6)
               ? null
               : resultSet.getString(6);
 
       // Note that 'type' is only queried from GoogleSQL and is not from Postgres and
       // the number of columns will be different.
       String type =
-          (dialect == Dialect.GOOGLE_STANDARD_SQL && !resultSet.isNull(6))
-              ? resultSet.getString(6)
+          (dialect == Dialect.GOOGLE_STANDARD_SQL && !resultSet.isNull(7))
+              ? resultSet.getString(7)
               : null;
 
       ImmutableList<String> searchPartitionBy =
-          (dialect == Dialect.GOOGLE_STANDARD_SQL && !resultSet.isNull(7))
-              ? ImmutableList.<String>builder().addAll(resultSet.getStringList(7)).build()
+          (dialect == Dialect.GOOGLE_STANDARD_SQL && !resultSet.isNull(8))
+              ? ImmutableList.<String>builder().addAll(resultSet.getStringList(8)).build()
               : null;
 
       ImmutableList<String> searchOrderBy =
-          (dialect == Dialect.GOOGLE_STANDARD_SQL && !resultSet.isNull(8))
-              ? ImmutableList.<String>builder().addAll(resultSet.getStringList(8)).build()
+          (dialect == Dialect.GOOGLE_STANDARD_SQL && !resultSet.isNull(9))
+              ? ImmutableList.<String>builder().addAll(resultSet.getStringList(9)).build()
               : null;
 
       Map<String, Index.Builder> tableIndexes =
@@ -445,7 +445,7 @@ public class InformationSchemaScanner {
       case GOOGLE_STANDARD_SQL:
         return Statement.of(
             "SELECT t.table_schema, t.table_name, t.index_name, t.parent_table_name, t.is_unique,"
-                + " t.is_null_filtered, t.index_type, t.search_partition_by, t.search_order_by"
+                + " t.is_null_filtered, t.filter, t.index_type, t.search_partition_by, t.search_order_by"
                 + " FROM information_schema.indexes AS t"
                 + " WHERE t.table_schema NOT IN"
                 + " ('INFORMATION_SCHEMA', 'SPANNER_SYS') AND"

--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScanner.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScanner.java
@@ -399,10 +399,7 @@ public class InformationSchemaScanner {
           (dialect == Dialect.GOOGLE_STANDARD_SQL)
               ? resultSet.getBoolean(5)
               : resultSet.getString(5).equalsIgnoreCase("YES");
-      String filter =
-          resultSet.isNull(6)
-              ? null
-              : resultSet.getString(6);
+      String filter = resultSet.isNull(6) ? null : resultSet.getString(6);
 
       // Note that 'type' is only queried from GoogleSQL and is not from Postgres and
       // the number of columns will be different.

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
@@ -576,7 +576,7 @@ public class InformationSchemaScannerIT {
                 + " ) PRIMARY KEY (`id` ASC)",
             " CREATE UNIQUE NULL_FILTERED INDEX `a_last_name_idx` ON "
                 + " `Users`(`last_name` ASC) STORING (`first_name`)",
-            " CREATE INDEX `b_age_idx` ON `Users`(`age` DESC)",
+            " CREATE INDEX `b_age_idx` ON `Users`(`age` DESC) WHERE age IS NOT NULL",
             " CREATE UNIQUE INDEX `c_first_name_idx` ON `Users`(`first_name` ASC)");
 
     SPANNER_SERVER.createDatabase(dbId, statements);

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerTest.java
@@ -85,7 +85,7 @@ public class InformationSchemaScannerTest {
         googleSQLInfoScanner.listIndexesSQL().getSql(),
         equalToCompressingWhiteSpace(
             "SELECT t.table_schema, t.table_name, t.index_name, t.parent_table_name, t.is_unique,"
-                + " t.is_null_filtered, t.index_type, t.search_partition_by, t.search_order_by"
+                + " t.is_null_filtered, t.filter, t.index_type, t.search_partition_by, t.search_order_by"
                 + " FROM information_schema.indexes AS t"
                 + " WHERE t.table_schema NOT IN"
                 + " ('INFORMATION_SCHEMA', 'SPANNER_SYS') AND"


### PR DESCRIPTION
- Extended InformationSchemaScanner to support WHERE IS NOT NULL for all index types. 
- Modified the indexes() test to use WHERE IS NOT NULL.
- Manually tested on production by creating a database that contains and a secondary index with WHERE ... IS NOT NULL.

@darshan-sj 