### PR TITLE
Adding JSON enum to userOption for MongoDB templates

### DIFF
--- a/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/options/MongoDbToBigQueryOptions.java
+++ b/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/options/MongoDbToBigQueryOptions.java
@@ -60,7 +60,11 @@ public class MongoDbToBigQueryOptions {
 
     @TemplateParameter.Enum(
         order = 4,
-        enumOptions = {@TemplateEnumOption("FLATTEN"), @TemplateEnumOption("JSON"), @TemplateEnumOption("NONE")},
+        enumOptions = {
+          @TemplateEnumOption("FLATTEN"),
+          @TemplateEnumOption("JSON"),
+          @TemplateEnumOption("NONE")
+        },
         description = "User option",
         helpText =
             "`FLATTEN`, `JSON`, or `NONE`. `FLATTEN` flattens the documents to the single level. `JSON` stores document in BigQuery JSON format. `NONE` stores the whole document as a JSON-formatted STRING.")

--- a/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/options/MongoDbToBigQueryOptions.java
+++ b/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/options/MongoDbToBigQueryOptions.java
@@ -60,7 +60,7 @@ public class MongoDbToBigQueryOptions {
 
     @TemplateParameter.Enum(
         order = 4,
-        enumOptions = {@TemplateEnumOption("FLATTEN"), @TemplateEnumOption("NONE")},
+        enumOptions = {@TemplateEnumOption("FLATTEN"), @TemplateEnumOption("JSON"), @TemplateEnumOption("NONE")},
         description = "User option",
         helpText =
             "`FLATTEN`, `JSON`, or `NONE`. `FLATTEN` flattens the documents to the single level. `JSON` stores document in BigQuery JSON format. `NONE` stores the whole document as a JSON-formatted STRING.")


### PR DESCRIPTION
Currently, JSON option is shown in the hint text but it doesn't appear in the dropdown. 
<img width="555" alt="Screenshot 2024-10-02 at 8 14 15 PM" src="https://github.com/user-attachments/assets/fbced53b-477e-4d86-8a11-98a5b74a1aa5">
<img width="570" alt="Screenshot 2024-10-02 at 8 14 24 PM" src="https://github.com/user-attachments/assets/51d750ae-eeef-4864-9d21-79ee0a1f2065">
