### PR TITLE
Add JsonPropertyOrder for ErrorMessage to print error json in order

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/templates/common/ErrorConverters.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/common/ErrorConverters.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.templates.common;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -94,6 +95,7 @@ public class ErrorConverters {
   /** An entry in the Error Log. */
   @AutoValue
   @JsonDeserialize(builder = ErrorMessage.Builder.class)
+  @JsonPropertyOrder({"message", "data", "stacktrace"})
   public abstract static class ErrorMessage<T> {
     public static <T> Builder<T> newBuilder() {
       return new AutoValue_ErrorConverters_ErrorMessage.Builder<>();


### PR DESCRIPTION
### Issue
When running the test "testCheckNoKeyBothCorrectAndInvalid" in the file "DatastoreConvertersTest.java", met the error:
 
[ERROR] Failures: 
[ERROR] DatastoreConvertersTest.testCheckNoKeyBothCorrectAndInvalid:325 RemoveNoKeys/DetectInvalidEntities.failures: 
Expected: iterable with items ["{\"stacktrace\":null,\"message\":\"Datastore Entity Without Key\",\"data\":\"{\\\"properties\\\":{\\\"street\\\":{\\\"stringValue\\\":\\\"Some street\\\"},\\\"number\\\":{\\\"integerValue\\\":\\\"0\\\"}}}\"}", "{\"data\":\"{\\\"properties\\\":{\\\"street\\\":{\\\"stringValue\\\":\\\"Some street\\\"},\\\"number\\\":{\\\"integerValue\\\":\\\"1\\\"}}}\",\"message\":\"Datastore Entity Without Key\",\"stacktrace\":null}"] in any order
     but: not matched: "{\"message\":\"Datastore Entity Without Key\",\"data\":\"{\\\"properties\\\":{\\\"street\\\":{\\\"stringValue\\\":\\\"Some street\\\"},\\\"number\\\":{\\\"integerValue\\\":\\\"1\\\"}}}\",\"stacktrace\":null}"

### Reason
The class ErrorConverters used ObjectMapper to convert objects to JSON string. Since ObjectMapper doesn't ensure the order of attributes in the object. the JSON string may have different patterns from the expection.

### Change
In the errorConverters, we add JsonPropertyOrder, so ObjectMapper().writeValueAsString() will return JSON string in a certain order.