### PR TITLE
Fixed flaky test - DatastoreConvertersTest.testCheckSameKey()

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/templates/common/ErrorConverters.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/common/ErrorConverters.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.templates.common;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -94,6 +95,7 @@ public class ErrorConverters {
   /** An entry in the Error Log. */
   @AutoValue
   @JsonDeserialize(builder = ErrorMessage.Builder.class)
+  @JsonPropertyOrder({"message", "stacktrace", "data"})
   public abstract static class ErrorMessage<T> {
     public static <T> Builder<T> newBuilder() {
       return new AutoValue_ErrorConverters_ErrorMessage.Builder<>();


### PR DESCRIPTION
### Purpose of this change

## Fixed a flaky test
https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v1/src/test/java/com/google/cloud/teleport/templates/common/DatastoreConvertersTest.java#L174.

This is the error being thrown upon executing the NonDex tool with the following command - 

`mvn -pl v1 edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.google.cloud.teleport.templates.common.DatastoreConvertersTest#testCheckSameKey  `

```
Expected: iterable with items ["{\"message\":\"Duplicate Datastore Key\",\"stacktrace\":null,\"data\":\"{\\\"key\\\":{\\\"partitionId\\\":{\\\"projectId\\\":\\\"my-project\\\",\\\"namespaceId\\\":\\\"some-namespace\\\"},\\\"path\\\":[{\\\"kind\\\":\\\"monkey\\\",\\\"id\\\":\\\"1234\\\"}]},\\\"properties\\\":{\\\"someString\\\":{\\\"stringValue\\\":\\\"someValue\\\"}}}\"}", "{\"message\":\"Duplicate Datastore Key\",\"data\":\"{\\\"key\\\":{\\\"partitionId\\\":{\\\"projectId\\\":\\\"my-project\\\",\\\"namespaceId\\\":\\\"some-namespace\\\"},\\\"path\\\":[{\\\"kind\\\":\\\"monkey\\\",\\\"id\\\":\\\"1234\\\"}]},\\\"properties\\\":{\\\"SomeBSProp\\\":{\\\"stringValue\\\":\\\"Some BS Value\\\"}}}\",\"stacktrace\":null}"] in any order
     but: not matched: "{\"data\":\"{\\\"key\\\":{\\\"partitionId\\\":{\\\"projectId\\\":\\\"my-project\\\",\\\"namespaceId\\\":\\\"some-namespace\\\"},\\\"path\\\":[{\\\"kind\\\":\\\"monkey\\\",\\\"id\\\":\\\"1234\\\"}]},\\\"properties\\\":{\\\"someString\\\":{\\\"stringValue\\\":\\\"someValue\\\"}}}\",\"message\":\"Duplicate Datastore Key\",\"stacktrace\":null}
```

## Root Cause

The flakiness seen above presents itself because the line that compares expectedErrors with the errorTag does a string comparison, where both strings are JSON objects. As the order of the key-values of a JSON object is non-deterministic, the order of the fields of both objects is different in the string, and thus the test is failing.

## Fix

This fix attempts to remedy the flakiness by converting the strings within the errorTag as well as the expectedErrors into JSON objects and then sorting them. A new helper method - `sortJsonObject(JsonObject jsonObject)` has been added to `TestUtil.java` for the same.

## Edit 07/11/2024

Changed the fix to fix the JsonOrdering of the ErrorMessage using the @JsonPropertyOrder annotation in jackson. This extends the fix to remove flakiness in `com.google.cloud.teleport.templates.common.DatastoreConvertersTest.testCheckNoKeyAllInvalid` as well.

Please let me know if you'd like further changes!