### PR TITLE
Increase timeout for DataTypesIT#allTypesTest

### DIFF
--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/postgresql/DataTypesIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/postgresql/DataTypesIT.java
@@ -23,6 +23,7 @@ import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
 import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
 import com.google.cloud.teleport.v2.templates.SourceDbToSpanner;
 import com.google.cloud.teleport.v2.templates.SourceDbToSpannerITBase;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -87,7 +88,8 @@ public class DataTypesIT extends SourceDbToSpannerITBase {
             spannerResourceManager,
             jobParameters,
             null);
-    PipelineOperator.Result result = pipelineOperator().waitUntilDone(createConfig(jobInfo));
+    PipelineOperator.Result result =
+        pipelineOperator().waitUntilDone(createConfig(jobInfo, Duration.ofMinutes(30L)));
     assertThatResult(result).isLaunchFinished();
 
     Map<String, List<Map<String, Object>>> expectedData = getExpectedData();


### PR DESCRIPTION
DataTypesIT#allTypesTest has been flaky lately, causing PR failures. Last couple runs took ~25 minutes, so I increased the timeout to at least temporarily fix the failures.