### PR TITLE
Re-enabling unsigned tests

### DIFF
--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataTypesIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataTypesIT.java
@@ -96,10 +96,6 @@ public class DataTypesIT extends SourceDbToSpannerITBase {
     Map<String, List<Map<String, Object>>> expectedData = getExpectedData();
     for (Map.Entry<String, List<Map<String, Object>>> entry : expectedData.entrySet()) {
       String type = entry.getKey();
-      // TODO(b/370698866): Remove this after investigating failures of large unsigned values.
-      if (type.contains("unsigned")) {
-        continue;
-      }
       String tableName = String.format("%s_table", type);
       String colName = String.format("%s_col", type);
       LOG.info("Asserting type: {}", type);
@@ -226,7 +222,7 @@ public class DataTypesIT extends SourceDbToSpannerITBase {
     expectedData.put("year", createRows("year", "2022", "1901", "2155", "NULL"));
     expectedData.put("set", createRows("set", "v1,v2", "NULL"));
     expectedData.put(
-        "integer_unsigned", createRows("integer_unsigned", "0", "42", "4294967296", "NULL"));
+        "integer_unsigned", createRows("integer_unsigned", "0", "42", "4294967295", "NULL"));
     expectedData.put(
         "bigint_unsigned_pk", createRows("bigint_unsigned", "0", "42", "18446744073709551615"));
     return expectedData;

--- a/v2/sourcedb-to-spanner/src/test/resources/DataTypesIT/mysql/spanner-schema.sql
+++ b/v2/sourcedb-to-spanner/src/test/resources/DataTypesIT/mysql/spanner-schema.sql
@@ -1,11 +1,11 @@
 CREATE TABLE bigint_table (
   id INT64 NOT NULL,
-  bigint_col NUMERIC,
+  bigint_col int64,
 ) PRIMARY KEY(id);
 
 CREATE TABLE bigint_unsigned_table (
   id INT64 NOT NULL,
-  bigint_unsigned_col INT64,
+  bigint_unsigned_col NUMERIC,
 ) PRIMARY KEY(id);
 
 CREATE TABLE binary_table (


### PR DESCRIPTION
In the integration tests:
 1. Mapping bigInt unsigned to Numeric in Spanner schema as int64 can't hold the max value.
 2. correcting the test's expected value of integer unsigned max as per https://dev.mysql.com/doc/refman/8.4/en/integer-types.html
 
 Note on IT failure
 
 There's an IT failure on `datastream-to-spanne`r template trying to create table on `Oracle` db which is unrelated to this change (Mysql and `sourcedb-to-spanner`)