### PR TITLE
Terraform template for Reverse replication for sharded MySQL

### DIFF
--- a/v2/spanner-to-sourcedb/terraform/samples/README.md
+++ b/v2/spanner-to-sourcedb/terraform/samples/README.md
@@ -1,0 +1,43 @@
+## Terraform samples for reverse replication
+
+This repository provides samples for common scenarios users might have while trying to run a replication from Spanner to a source database.
+
+Pick a sample that is closest to your use-case, use it as a starting point, and tailor it to your own specific needs.
+
+## Other Sample Repositories
+
+The following sample repositories provide additional examples -
+
+1. [Sample environment setups](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v2/spanner-common/terraform/samples)
+2. [Bulk migration](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v2/sourcedb-to-spanner/terraform/samples)
+3. [Live migration](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v2/datastream-to-spanner/terraform/samples/)
+
+## List of examples
+
+1. [Spanner to sharded MySQL](spanner-to-sharded-mysql/README.md)
+
+## Sample structure
+
+Each sample contains the following (and potentially more) files -
+
+1. `main.tf` - This contains the Terraform resources which will be created.
+2. `outputs.tf` - This declares the outputs that will be output as part of
+   running the terraform example.
+3. `variables.tf` - This declares the input variables that are required to
+   configure the resources.
+4. `terraform.tf` - This contains the required providers and APIs/project
+   configurations for the sample.
+5. `terraform.tfvars` - This contains the dummy inputs that need to be populated
+   to run the example.
+6. `terraform_simple.tfvars` - This contains the minimal list of dummy inputs
+   that need to be populated to run the example.
+
+## How to add a new sample
+
+It is strongly recommended to copy an existing sample and modify it according to the scenario you are trying to cover.
+This ensures uniformity in the style in which terraform samples are written.
+
+```shell
+mkdir my-new-sample
+cp -r spanner-to-sharded-mysql/* my-new-sample/
+```

--- a/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/README.md
+++ b/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/README.md
@@ -2,7 +2,7 @@
 
 > **_SCENARIO:_** This Terraform example illustrates launching a reverse replication
 > jobs to replicate spanner writes for a sharded MySQL source, setting up all the required cloud infrastructure.
-> **Only the source details of physical shards are needed as input.**
+> **Details of MySQL shards are needed as input.**
 
 ## Terraform permissions
 
@@ -109,13 +109,13 @@ provides instructions to add these roles to an existing service account.
 It takes the following assumptions -
 
 1. Ensure that the MySQL instance is correctly setup.  
-     1. Check that the MySQL credentials are correctly specified in the [source shards file](#sample-source-shards-file). 
+     1. Check that the MySQL credentials are correctly specified in the `tfvars` file. 
      2. Check that the MySQL server is up. 
-     3. The MySQL user configured in the [source shards file](#sample-source-shards-file) should have [INSERT](https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_insert), [UPDATE](https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_update) and [DELETE](https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_delete) privileges on the database. 
+     3. The MySQL user configured in the `tfvars` file should have [INSERT](https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_insert), [UPDATE](https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_update) and [DELETE](https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_delete) privileges on the database. 
 2. Ensure that the MySQL instance and Dataflow workers can establish connectivity with each other. Template automatically adds networking firewalls rules to enable this access. This can differ depending on the source configuration. Please validate the template rules and ensure that network connectivity can be established.
-3. The source instance with database containing reverse-replication compatible
+3. The MySQL instance with database containing reverse-replication compatible
    schema is created.
-4. A session file has been generated to perform the spanner to source schema mapping.
+4. A session file has been generated to perform the spanner to MySQL schema mapping.
 
 > **_NOTE:_**
 [SMT](https://googlecloudplatform.github.io/spanner-migration-tool/quickstart.html)
@@ -234,8 +234,8 @@ This will result in Dataflow jobs will be launched inside the shared VPC.
 
 > **_NOTE:_** Usage of shared VPC requires cross-project permissions. They
 > are available as a Terraform
->
-template [here](../../../../spanner-common/terraform/samples/configure-shared-vpc/README.md).
+>template [here](../../../../spanner-common/terraform/samples/configure-shared-vpc/README.md).
+
 > Dataflow service account permissions are
 > documented [here](https://cloud.google.com/dataflow/docs/guides/specifying-networks#shared).
 
@@ -304,6 +304,8 @@ Source shard configuration file that is supplied to the dataflow is automaticall
 created by Terraform. A sample file that this uploaded to GCS looks like
 below - 
 
+#### Using Secrets Manager to specify password 
+
 ```json
 [
     {
@@ -319,6 +321,29 @@ below -
     "host": "10.11.12.14",
     "user": "root",
     "secretManagerUri":"projects/123/secrets/rev-cmek-cred-shard2/versions/latest",
+    "port": "3306",
+    "dbName": "db2"
+    }
+]
+```
+
+#### Specifying plaintext password
+
+```json
+[
+    {
+    "logicalShardId": "shard1",
+    "host": "10.11.12.13",
+    "user": "root",
+    "password":"<YOUR_PWD_HERE>",
+    "port": "3306",
+    "dbName": "db1"
+    },
+    {
+    "logicalShardId": "shard2",
+    "host": "10.11.12.14",
+    "user": "root",
+    "password":"<YOUR_PWD_HERE>",
     "port": "3306",
     "dbName": "db2"
     }

--- a/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/README.md
+++ b/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/README.md
@@ -1,0 +1,711 @@
+## Sample Scenario: Spanner to Sharded MySQL reverse replication
+
+> **_SCENARIO:_** This Terraform example illustrates launching a reverse replication
+> jobs to replicate spanner writes for a sharded MySQL source, setting up all the required cloud infrastructure.
+> **Only the source details of physical shards are needed as input.**
+
+## Terraform permissions
+
+In order to create the resources in this sample,
+the`Service account`/`User account` being used to run Terraform
+should have the
+required [permissions](https://cloud.google.com/iam/docs/manage-access-service-accounts#multiple-roles-console).
+There are two ways to add permissions -
+
+1. Adding pre-defined roles to the service account running Terraform.
+2. Creating a custom role with the granular permissions and attaching it to the
+   service account running Terraform.
+
+### Using custom role and granular permissions (recommended)
+
+Following permissions are required -
+
+```shell
+- compute.globalAddresses.create
+- compute.globalAddresses.createInternal
+- compute.globalAddresses.delete
+- compute.globalAddresses.deleteInternal
+- compute.globalAddresses.get
+- compute.globalOperations.get
+- compute.firewalls.create
+- compute.firewalls.delete
+- compute.firewalls.update
+- compute.networks.addPeering
+- compute.networks.get
+- compute.networks.listPeeringRoutes
+- compute.networks.removePeering
+- compute.networks.use
+- compute.routes.get
+- compute.routes.list
+- compute.subnetworks.get
+- compute.subnetworks.list
+- dataflow.jobs.cancel
+- dataflow.jobs.create
+- dataflow.jobs.updateContents
+- datastream.connectionProfiles.create
+- datastream.connectionProfiles.delete
+- datastream.privateConnections.create
+- datastream.privateConnections.delete
+- datastream.streams.create
+- datastream.streams.delete
+- datastream.streams.update
+- iam.roles.get
+- iam.serviceAccounts.actAs
+- pubsub.subscriptions.create
+- pubsub.subscriptions.delete
+- pubsub.topics.attachSubscription
+- pubsub.topics.create
+- pubsub.topics.delete
+- pubsub.topics.getIamPolicy
+- pubsub.topics.setIamPolicy
+- resourcemanager.projects.setIamPolicy
+- storage.buckets.create
+- storage.buckets.delete
+- storage.buckets.update
+- storage.objects.delete
+- storage.objects.create
+- serviceusage.services.use
+- serviceusage.services.enable
+```
+
+**Note**: Add the `roles/viewer` role as well to the service account.
+
+> **_Note on IAM:_**
+>
+> 1. For ease of use, this sample automatically adds the
+> required
+> roles to the service account used for running the migration. In order to
+> do this, we need the `resourcemanager.projects.setIamPolicy` permission. If granting
+> this role is unacceptable, please set
+> the `var.common_params.add_policies_to_service_account`
+> to **false**. This will skip adding the roles.
+> They will have to be added manually. Note that if they are not added, **the
+> migration will fail.**
+> Two service accounts will need to be modified manually -
+>    1. Dataflow service account - The list of roles can be found in the `main.tf`
+      file, in the `live_migration_roles` resource.
+>    2. GCS service account - The list of roles can be found in the `main.tf` file,
+        in the `gcs_publisher_role` resource.
+>
+>
+>2. In order to create private connectivity configuration for Datastream,
+>`compute.*` permissions are required, [as documented here](https://cloud.google.com/datastream/docs/create-a-private-connectivity-configuration#shared-vpc).
+> Private connectivity cannot be created without these permissions. If you don't want to grant these permissions,
+> you can use the [pre-configured connection profiles template](../pre-configured-conn-profiles/README.md). This template
+> assumes you have created connection profiles outside of Terraform.
+
+[This](#adding-access-to-terraform-service-account) section in the FAQ
+provides instructions to add these permissions to an existing service account.
+
+### Using pre-defined roles
+
+Following roles are required -
+
+```shell
+roles/dataflow.admin
+roles/datastream.admin
+roles/iam.securityAdmin
+roles/iam.serviceAccountUser
+roles/pubsub.admin
+roles/storage.admin
+roles/viewer
+roles/compute.networkAdmin
+```
+
+> **_Note on IAM:_**
+>
+> 1. For ease of use, this sample automatically adds the
+> required
+> roles to the service account used for running the migration. In order to
+> do this, we need the `roles/iam.securityAdmin` role. If granting
+> this role is unacceptable, please set
+> the `var.common_params.add_policies_to_service_account`
+> to **false**. This will skip adding the roles.
+> They will have to be added manually. Note that if they are not added, **the
+> migration will fail.**
+> Two service accounts will need to be modified manually -
+>    1. Dataflow service account - The list of roles can be found in the `main.tf`
+       file, in the `live_migration_roles` resource.
+
+>    2. GCS service account - The list of roles can be found in the `main.tf` file,
+  in the `gcs_publisher_role` resource.
+>
+>
+>2. In order to create private connectivity configuration for Datastream,
+> `networkAdmin` role is
+    required, [as documented here](https://cloud.google.com/datastream/docs/create-a-private-connectivity-configuration#shared-vpc).
+> Private connectivity cannot be created without these permissions. If you don't want to grant these permissions,
+> you can use the [pre-configured connection profiles template](../pre-configured-conn-profiles/README.md). This
+    template
+> assumes you have created connection profiles outside of Terraform.
+
+[This](#adding-access-to-terraform-service-account) section in the FAQ
+provides instructions to add these roles to an existing service account.
+
+## Assumptions
+
+It takes the following assumptions -
+
+1. MySQL source is accessible via Datastream either via
+   [IP Allowlisting guide](https://cloud.google.com/datastream/docs/network-connectivity-options#ipallowlists)
+   or [Private connectivity](https://cloud.google.com/datastream/docs/create-a-private-connectivity-configuration).
+2. If using a VPC, VPC has already been configured to work with Datastream.
+3. MySQL source has been configured to be read by Datastream by following
+   [configure your source MySQL guide](https://cloud.google.com/datastream/docs/configure-your-source-mysql-database).
+4. A Spanner instance with database containing the data-migration compatible
+   schema is created.
+
+> **_NOTE:_**
+[SMT](https://googlecloudplatform.github.io/spanner-migration-tool/quickstart.html)
+> can be used for converting a MySQL schema to a Spanner compatible schema.
+
+## Description
+
+This sample contains the following files -
+
+1. `main.tf` - This contains the Terraform resources which will be created.
+2. `outputs.tf` - This declares the outputs that will be output as part of
+   running this terraform example.
+3. `variables.tf` - This declares the input variables that are required to
+   configure the resources.
+4. `terraform.tf` - This contains the required providers and APIs/project
+   configurations for this sample.
+5. `terraform.tfvars` - This contains the dummy inputs that need to be populated
+   to run this example.
+6. `terraform_simple.tfvars` - This contains the minimal list of dummy inputs
+   that need to be populated to run this example.
+
+## Resources Created
+
+Given these assumptions, it uses a supplied source database connection
+configuration and creates the following resources -
+
+1. **Datastream private connection** - If configured, a Datastream private
+   connection will be deployed for your configured VPC. If not configured, IP
+   allowlisting will be assumed as the mode of Datastream access. A single private connection is created for all shards.
+2. **Source datastream connection profiles** - This allows Datastream to connect
+   to the MySQL instance (using IP allowlisting or private connectivity). A source connection profile is created per
+   physical shard.
+3. **GCS buckets** - A GCS bucket to for Datastream to write the source data to. A bucket is created per physical shard.
+4. **Target datastream connection profiles** - The connection profile to
+   configure the created bucket in Datastream. A target connection profile is created per physical shard.
+5. **Pubsub topics and subscriptions** - This contains GCS object notifications as
+   files are written to GCS for consumption by the Dataflow job. A pubsub topic & subscription is created per physical
+   shard.
+6. **Datastream streams** - A datastream stream which reads from the source
+   specified in the source connection profile and writes the data to the bucket
+   specified in the target connection profile. Note that it uses a mandatory
+   prefix path inside the bucket where it will write the data to. The default
+   prefix path is `data` (can be overridden). A stream is created per physical shard.
+7. **Bucket notifications** - Creates the GCS bucket notification which publish
+   to the pubsub topic created. Note that the bucket notification is created on
+   the mandatory prefix path specified for the stream above. A notification is created per bucket.
+8. **Dataflow job** - The Dataflow job which reads from GCS and writes to
+   Spanner. A dataflow job is created per shard.
+9. **Permissions** - It adds the required roles to the specified (or the
+   default) service accounts for the live migration to work.
+
+> **_NOTE:_** A label is attached to all the resources created via Terraform.
+> The key is `migration_id` and the value is auto-generated. The auto-generated
+> value is used as a global identifier for a migration job across resources. The
+> auto-generated value is always pre-fixed with a `smt-`.
+
+## How to run
+
+1. Clone this repository or the sample locally.
+2. Edit the `terraform.tfvars` or `terraform_simple.tfvars` file and replace the
+   dummy variables with real values. Extend the configuration to meet your
+   needs. It is recommended to get started with `terraform_simple.tfvars`.
+3. Run the following commands -
+
+### Initialise Terraform
+
+```shell
+# Initialise terraform - You only need to do this once for a directory.
+terraform init
+```
+
+### Run `plan` and `apply`
+
+Validate the terraform files with -
+
+```shell
+terraform plan --var-file=terraform_simple.tfvars
+```
+
+Run the terraform script with -
+
+```shell
+terraform apply --var-file=terraform_simple.tfvars
+```
+
+This will launch the configured jobs and produce an output like below -
+
+```shell
+resource_ids = {
+  "smt-neat-walrus" = {
+    "dataflow_job" = "2024-06-27_01_16_13-12477287004098198325"
+    "datastream_source_connection_profile" = "smt-neat-walrus-source-mysql"
+    "datastream_stream" = "-smt-neat-walrus-mysql-stream"
+    "datastream_target_connection_profile" = "smt-neat-walrus-target-gcs"
+    "gcs_bucket" = "smt-neat-walrus-live-migration"
+    "pubsub_subscription" = "smt-neat-walrus-live-migration-sub"
+    "pubsub_topic" = "smt-neat-walrus-live-migration"
+  }
+  "smt-suitable-platypus" = {
+    "dataflow_job" = "2024-06-27_01_16_13-4726070354537731492"
+    "datastream_source_connection_profile" = "smt-suitable-platypus-source-mysql"
+    "datastream_stream" = "-smt-suitable-platypus-mysql-stream"
+    "datastream_target_connection_profile" = "smt-suitable-platypus-target-gcs"
+    "gcs_bucket" = "smt-suitable-platypus-live-migration"
+    "pubsub_subscription" = "smt-suitable-platypus-live-migration-sub"
+    "pubsub_topic" = "smt-suitable-platypus-live-migration"
+  }
+}
+resource_urls = {
+  "smt-neat-walrus" = {
+    "dataflow_job" = "https://console.cloud.google.com/dataflow/jobs/us-central1/2024-06-27_01_16_13-12477287004098198325?project=your-project-here"
+    "datastream_source_connection_profile" = "https://console.cloud.google.com/datastream/connection-profiles/locations/us-central1/instances/smt-neat-walrus-source-mysql?project=your-project-here"
+    "datastream_stream" = "https://console.cloud.google.com/datastream/streams/locations/us-central1/instances/-smt-neat-walrus-mysql-stream?project=your-project-here"
+    "datastream_target_connection_profile" = "https://console.cloud.google.com/datastream/connection-profiles/locations/us-central1/instances/smt-neat-walrus-target-gcs?project=your-project-here"
+    "gcs_bucket" = "https://console.cloud.google.com/storage/browser/smt-neat-walrus-live-migration?project=your-project-here"
+    "pubsub_subscription" = "https://console.cloud.google.com/cloudpubsub/subscription/detail/smt-neat-walrus-live-migration-sub?project=your-project-here"
+    "pubsub_topic" = "https://console.cloud.google.com/cloudpubsub/topic/detail/smt-neat-walrus-live-migration?project=your-project-here"
+  }
+  "smt-suitable-platypus" = {
+    "dataflow_job" = "https://console.cloud.google.com/dataflow/jobs/us-central1/2024-06-27_01_16_13-4726070354537731492?project=your-project-here"
+    "datastream_source_connection_profile" = "https://console.cloud.google.com/datastream/connection-profiles/locations/us-central1/instances/smt-suitable-platypus-source-mysql?project=your-project-here"
+    "datastream_stream" = "https://console.cloud.google.com/datastream/streams/locations/us-central1/instances/-smt-suitable-platypus-mysql-stream?project=your-project-here"
+    "datastream_target_connection_profile" = "https://console.cloud.google.com/datastream/connection-profiles/locations/us-central1/instances/smt-suitable-platypus-target-gcs?project=your-project-here"
+    "gcs_bucket" = "https://console.cloud.google.com/storage/browser/smt-suitable-platypus-live-migration?project=your-project-here"
+    "pubsub_subscription" = "https://console.cloud.google.com/cloudpubsub/subscription/detail/smt-suitable-platypus-live-migration-sub?project=your-project-here"
+    "pubsub_topic" = "https://console.cloud.google.com/cloudpubsub/topic/detail/smt-suitable-platypus-live-migration?project=your-project-here"
+  }
+}
+```
+
+**Note:** Each of the jobs will have a random suffix added to it to prevent name
+collisions.
+
+### Cleanup
+
+Once the jobs have finished running, you can clean up by running -
+
+```shell
+terraform destroy --var-file=terraform_simple.tfvars
+```
+
+#### Note on GCS buckets
+
+The GCS bucket that is created will be cleaned up during `terraform destroy`.
+If you want to exclude the GCS bucket from deletion due to any reason, you
+can exclude it from the state file using `terraform state rm` command.
+
+## FAQ
+
+### Configuring to run using a VPC
+
+#### Specifying a shared VPC
+
+You can specify the shared VPC using the `host_project` configuration.
+This will result in -
+
+1. Datastream private connectivity link will be created in the shared VPC.
+2. Dataflow jobs will be launched inside the shared VPC.
+
+> **_NOTE:_** Usage of shared VPC requires cross-project permissions. They
+> are available as a Terraform
+> template [here](../../../../spanner-common/terraform/samples/configure-shared-vpc/README.md).
+>
+> 1. Datastream service account permissions are
+     documented [here](https://cloud.google.com/datastream/docs/create-a-private-connectivity-configuration#shared-vpc).
+> 2. Dataflow service account permissions are
+     documented [here](https://cloud.google.com/dataflow/docs/guides/specifying-networks#shared).
+
+#### Datastream Private Connectivity
+
+> **_NOTE:_** By default, **IP Allowlisting** based connectivity is assumed.
+
+There are two variables of the type below in `variables.tf` -
+
+```shell
+private_connectivity = optional(object({
+      private_connectivity_id = string
+      vpc_name                = string
+      range                   = string
+    }))
+```
+
+and
+
+```shell
+private_connectivity_id = optional(string)
+```
+
+You have the option of either specifying the `id` of an existing private
+connectivity configuration or letting Terraform create one for you.
+
+To re-use an existing private connectivity configuration, specify the `id` in
+the `private_connectivity_id` variable.
+
+Alternatively, to create a private connectivity configuration via Terraform for Datastream, specify this
+configuration in your `*.tfvars`. For example -
+
+```shell
+ ...
+ mysql_databases = [
+    {
+      database = "lorem"
+    }
+  ]
+  private_connectivity = {
+    private_connectivity_id = "abc"
+    range                   = "xyz"
+    vpc_name                = "pqr"
+  }
+  ...
+```
+
+Note that `vpc_name` and `range` are mandatory and for the [private connectivity
+configuration](https://cloud.google.com/datastream/docs/create-a-private-connectivity-configuration).
+
+In the `mysql_host` configuration, specify the private IP instead of the
+public IP.
+
+This configuration creates a private connection configuration in Datastream
+and configures it in the source profile created for the Datastream stream.
+
+> **_NOTE:_** Private connectivity resource creation can take a long time to
+> create.
+
+
+If this is not specified, configurations are created assuming **IP Allowlisting
+**.
+
+If you are facing issue with Datastream connectivity, check the following
+Datastream [guide](https://cloud.google.com/datastream/docs/diagnose-issues#connectivity-errors)
+to debug common networking issues.
+
+#### Dataflow
+
+1. Set the `network` and the `subnetwork` parameters to run the Dataflow job
+   inside a VPC.
+   Specify [network](https://cloud.google.com/dataflow/docs/guides/specifying-networks#network_parameter)
+   and [subnetwork](https://cloud.google.com/dataflow/docs/guides/specifying-networks#subnetwork_parameter)
+   according to the
+   linked guidelines.
+2. Set the `ip_configuration` to `WORKER_IP_PRIVATE` to disable public IP
+   addresses for the worker VMs.
+
+> **_NOTE:_** The VPC should already exist. This template does not create a VPC.
+
+If you are facing issue with VPC connectivity, check the following Dataflow
+[guide](https://cloud.google.com/dataflow/docs/guides/troubleshoot-networking)
+to debug common networking issues.
+
+### Updating template parameters for an existing job
+
+Template parameters can be updated in place. Terraform and Dataflow will take
+care of `UPDATING` a Dataflow job. This works internally by terminating the
+existing job with an `UPDATED` state and creating a new job in its place. All
+of this is done seamlessly by Dataflow and there is no risk to the fidelity of
+an already executing job.
+
+Example update: Changing `round_json_decimals` to `true` from `false`.
+
+Look for the following log during `terraform apply` -
+
+```shell
+  # google_dataflow_flex_template_job.live_migration_job will be updated in-place
+```
+
+### Updating workers of a Dataflow job
+
+Currently, the Terraform `google_dataflow_flex_template_job` resource does not
+support updating the workers of a Dataflow job.
+If the worker counts are changed in `tfvars` and a Terraform apply is run,
+Terraform will attempt to cancel/drain the existing Dataflow job and replace it
+with a new one.
+**This is not recommended**. Instead use the `gcloud` CLI to update the worker
+counts of a launched Dataflow job.
+
+```shell
+gcloud dataflow jobs update-options \                                                                                                                                                                                                                                                                                                                      (base) 
+        --region=us-central1 \
+        --min-num-workers=5 \
+        --max-num-workers=20 \
+      2024-06-17_01_21_44-12198433486526363702
+```
+
+### Long time to delete SMT bucket
+
+A GCS bucket can only be deleted if all its comprising objects are deleted
+first. This template attempts to delete all objects in the created GCS bucket
+and then deletes the bucket as well.
+**This may take a long time, depending on the size of the data in the bucket.**
+If you want Terraform to only create the GCS bucket but skip its deletion
+during `terraform destroy`, you will have to use the `terraform state rm` API to
+delete GCS resource from being traced by Terraform after the `apply` command.
+
+### Configuring Databases and Tables in Datastream
+
+Which databases and tables to replicate can be configured via the following
+variable definition -
+
+In `variables.tf`, following definition exists -
+
+```shell
+mysql_databases = list(object({
+      database = string
+      tables   = optional(list(string))
+    }))
+```
+
+To configure, create `*.tfvars` as follows -
+
+```shell
+mysql_databases = [
+    {
+      database = "<YOUR_DATABASE_NAME>"
+      tables   = ["TABLE_1", "TABLE_2"]
+      # Optionally list specific tables, or remove "tables" all together for all tables
+    },
+    {
+      database = "<YOUR_DATABASE_NAME>"
+      tables   = ["TABLE_1", "TABLE_2"]
+      # Optionally list specific tables, or remove "tables" all together for all tables
+    },
+  ]
+```
+
+### Specifying schema overrides
+
+By default, the Dataflow job performs a like-like mapping between
+source and Spanner. Any schema changes between source and Spanner can be
+specified using the `session file`. To specify a session file -
+
+1. Copy the SMT generated `session file` to the Terraform working directory.
+   Name this file `session.json`.
+2. Set
+   the `var.common_params.dataflow_params.template_params.local_session_file_path`
+   variable to `"session.json"` (or the relative path to the name of the
+   session file).
+
+This will automatically upload the GCS bucket and configure it in the Dataflow
+job.
+
+### Specifying transformation context
+
+Transformation context is used to populate the `migration_shard_id` column
+added by SMT to each table of your schema. This allows the customer to trace
+the source of each record in Spanner, back to the source shards.
+
+By default, `migration_shard_id` is populated with
+the `"${mysql_host_ip}-${dbName}"`.
+Alternatively, for each shard, a transformation context file can be specified.
+To
+specify a transformation context file -
+
+1. Create a transformation context file per shard.
+2. Set
+   the `var.shard_list[*].dataflow_params.template_params.local_transformation_context_path`
+   variable to the relative path from working directory to the transformation
+   context file.
+
+### Overriding Dataflow workers per shard
+
+The values configured in `var.common_params.dataflow_params.runner_params`
+define
+the `num_workers`, `max_workers` and `machine_type` for all the Dataflow jobs.
+This can be overridden by specifying the same values at the shard level.
+Do so by specifying the same values
+in `var.shard_list[*].dataflow_params.runner_params`.
+
+This can be useful when trying to provide asymmetric resources to different
+shards as well as selective update scenarios.
+
+### Cross project writes to Spanner
+
+The dataflow job can write to Spanner in a different project. In order to do so,
+the service account running the Dataflow job needs to have the
+`roles/spanner.databaseAdmin`role (or the corresponding permissions to write
+data to Spanner).
+
+After adding these permissions, configure the
+`var.dataflow_params.template_params.spanner_project_id` variable.
+
+### Adding access to Terraform service account
+
+#### Using custom role and granular permissions (recommended)
+
+You can run the following gcloud command to create a custom role in your GCP
+project.
+
+```shell
+gcloud iam roles create live_migrations_role --project=<YOUR-PROJECT-ID> --file=perms.yaml --quiet
+```
+
+The `YAML` file required for the above will be like so -
+
+```shell
+title: "Live Migrations Custom Role"
+description: "Custom role for Spanner live migrations."
+stage: "GA"
+includedPermissions:
+- iam.roles.get
+- iam.serviceAccounts.actAs
+- datastream.connectionProfiles.create
+....add all permissions from the list defined above.
+```
+
+Then attach the role to the service account -
+
+```shell
+gcloud iam service-accounts add-iam-policy-binding <YOUR-SERVICE-ACCOUNT>@<YOUR-PROJECT-ID>.iam.gserviceaccount.com \
+    --member=<YOUR-SERVICE-ACCOUNT>@<YOUR-PROJECT-ID>.iam.gserviceaccount.com --role=projects/<YOUR-PROJECT-ID>/roles/live_migrations_role \
+    --condition=CONDITION
+```
+
+#### Using pre-defined roles
+
+You can run the following shell script to add roles to the service account
+being used to run Terraform. This will have to done by a user which has the
+authority to grant the specified roles to a service account -
+
+```shell
+#!/bin/bash
+
+# Service account to be granted roles
+SERVICE_ACCOUNT="<YOUR-SERVICE-ACCOUNT>@<YOUR-PROJECT-ID>.iam.gserviceaccount.com"
+
+# Project ID where roles will be granted
+PROJECT_ID="<YOUR-PROJECT-ID>"
+
+# Array of roles to grant
+ROLES=(
+  "roles/<role1>"
+  "roles/<role2>"
+)
+
+# Loop through each role and grant it to the service account
+for ROLE in "${ROLES[@]}"
+do
+  gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+    --member="serviceAccount:${SERVICE_ACCOUNT}" \
+    --role="$ROLE"
+done
+```
+
+### Verifying access in the Terraform service account
+
+#### Using custom role and granular permissions (recommended)
+
+Verify that the custom role is attached to the service account -
+
+```shell
+gcloud projects get-iam-policy <YOUR-PROJECT-ID>  \
+--flatten="bindings[].members" \
+--format='table(bindings.role)' \
+--filter="bindings.members:<YOUR-SERVICE-ACCOUNT>@<YOUR-PROJECT-ID>.iam.gserviceaccount.com"
+```
+
+Verify that the role has the correct set of permissions
+
+```shell
+gcloud iam roles describe live_migrations_role --project=<YOUR-PROJECT-ID> 
+```
+
+##### Using pre-defined roles
+
+Once the roles are added, run the following command to verify them -
+
+```shell
+gcloud projects get-iam-policy <YOUR-PROJECT-ID>  \
+--flatten="bindings[].members" \
+--format='table(bindings.role)' \
+--filter="bindings.members:<YOUR-SERVICE-ACCOUNT>@<YOUR-PROJECT-ID>.iam.gserviceaccount.com"
+```
+
+Sample output -
+
+```shell
+ROLE
+roles/dataflow.admin
+roles/datastream.admin
+roles/iam.securityAdmin
+roles/iam.serviceAccountUser
+roles/pubsub.admin
+roles/storage.admin
+roles/viewer
+```
+
+### Impersonating the Terraform service account
+
+#### Using GCE VM instance (recommended)
+
+A GCE VM created using the service account setup above will automatically
+use the service account for all API requests triggered by Terraform. Running
+terraform from such a GCE VM does not require downloading service keys and is
+the recommended approach.
+
+#### Using key file
+
+1. Activate the service account -
+   ```shell
+   gcloud auth activate-service-account <YOUR-SERVICE-ACCOUNT>@<YOUR-PROJECT-ID>.iam.gserviceaccount.com --key-file=path/to/key_file --project=project_id
+   ```
+2. Impersonate service account while fetching the ADC credentials -
+   ```shell
+   gcloud auth application-default login --impersonate-service-account <YOUR-SERVICE-ACCOUNT>@<YOUR-PROJECT-ID>.iam.gserviceaccount.com
+   ```
+
+## Advanced Topics
+
+### Specifying parallelism for Terraform
+
+Terraform limits the number of concurrent operations while walking the graph.
+[The default](https://developer.hashicorp.com/terraform/cli/commands/apply#parallelism-n)
+is 10.
+
+Increasing this value can
+potentially speed up orchestration execution
+when orchestrating a large sharded migration. We strongly recommend against
+setting this value > 20. In most cases, the default value should suffice.
+
+### Correlating the `count.index` with the `shard_id`
+
+In the Terraform output, you should see resources being referred to by their
+index. This is how Terraform works internally when it has to create multiple
+resources of the same type.
+
+In order to correlate the `count.index` with the `shard_id` that is either
+user specified or auto-generated, `terraform.tf.state` can be used.
+
+For example, a snippet of XX looks like -
+
+```json
+{
+  "mode": "managed",
+  "type": "google_datastream_connection_profile",
+  "name": "source_mysql",
+  "provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+  "instances": [
+    {
+      "index_key": 0,
+      "schema_version": 0,
+      "attributes": {
+        "bigquery_profile": [],
+        "connection_profile_id": "smt-elegant-ape-source-mysql",
+        "create_without_validation": false,
+        "display_name": "smt-elegant-ape-source-mysql",
+        "effective_labels": {
+          "migration_id": "smt-elegant-ape"
+        }
+      }
+    }
+  ]
+}
+```
+
+As you can see in this example, the `index_key` = `0`, correlates with the
+auto-generated `shard_id` = `smt-elegant-ape`.

--- a/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/main.tf
+++ b/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/main.tf
@@ -127,11 +127,13 @@ resource "null_resource" "create_spanner_change_stream" {
     database_id   = var.dataflow_params.template_params.database_id
     instance_id   = var.dataflow_params.template_params.instance_id
     change_stream = local.change_stream
+    project       = var.common_params.project
   }
   provisioner "local-exec" {
     command = <<EOT
 gcloud spanner databases ddl update ${self.triggers.database_id} \
   --instance=${self.triggers.instance_id} \
+  --project=${self.triggers.project} \
   --ddl="CREATE CHANGE STREAM ${self.triggers.change_stream}
           FOR ALL OPTIONS (
             retention_period = '7d',

--- a/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/main.tf
+++ b/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/main.tf
@@ -1,0 +1,187 @@
+resource "random_pet" "migration_id" {
+  prefix = "smt-rev"
+}
+
+locals {
+  migration_id = var.common_params.migration_id != null ? var.common_params.migration_id : random_pet.migration_id.id
+}
+
+# Setup network firewalls rules to enable Dataflow access to source.
+resource "google_compute_firewall" "allow_dataflow_to_source" {
+  depends_on  = [google_project_service.enabled_apis]
+  project     = var.common_params.host_project != null ? var.common_params.host_project : var.common_params.project
+  name        = "allow-dataflow-to-source"
+  network     = var.dataflow_params.runner_params.network != null ? var.common_params.host_project != null ? "projects/${var.common_params.host_project}/global/networks/${var.dataflow_params.runner_params.network}" : "projects/${var.common_params.project}/global/networks/${var.dataflow_params.runner_params.network}" : "default"
+  description = "Allow traffic from Dataflow to source databases"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["3306"]
+  }
+  source_tags = ["dataflow"]
+  target_tags = ["databases"]
+}
+
+# Setup network firewalls rules to enable Dataflow VMs to talk to each other
+resource "google_compute_firewall" "allow_dataflow_vms_communication" {
+  depends_on  = [google_project_service.enabled_apis]
+  project     = var.common_params.host_project != null ? var.common_params.host_project : var.common_params.project
+  name        = "allow-dataflow-vms-communication"
+  network     = var.dataflow_params.runner_params.network != null ? var.common_params.host_project != null ? "projects/${var.common_params.host_project}/global/networks/${var.dataflow_params.runner_params.network}" : "projects/${var.common_params.project}/global/networks/${var.dataflow_params.runner_params.network}" : "default"
+  description = "Allow traffic between Dataflow VMs"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["12345", "12346"]
+  }
+  source_tags = ["dataflow"]
+  target_tags = ["dataflow"]
+}
+
+# GCS bucket for holding configuration objects
+resource "google_storage_bucket" "reverse_replication_bucket" {
+  depends_on                  = [google_project_service.enabled_apis]
+  name                        = "${local.migration_id}-${var.common_params.replication_bucket}"
+  location                    = var.common_params.region
+  uniform_bucket_level_access = true
+  force_destroy               = true
+  labels = {
+    "migration_id" = local.migration_id
+  }
+}
+
+# upload local session file to the created GCS bucket
+resource "google_storage_bucket_object" "session_file_object" {
+  depends_on   = [google_project_service.enabled_apis]
+  name         = "session.json"
+  source       = var.dataflow_params.template_params.local_session_file_path
+  content_type = "application/json"
+  bucket       = google_storage_bucket.reverse_replication_bucket.id
+}
+
+# Auto-generate the source shards file from the Terraform configuration and
+# upload it to GCS.
+resource "google_storage_bucket_object" "source_shards_file_object" {
+  depends_on   = [google_project_service.enabled_apis]
+  name         = "source_shards.json"
+  content_type = "application/json"
+  bucket       = google_storage_bucket.reverse_replication_bucket.id
+  content = jsonencode(var.shard_list)
+}
+
+# Pub/Sub topic for reverse replication DLQ
+resource "google_pubsub_topic" "dlq_pubsub_topic" {
+  depends_on = [google_project_service.enabled_apis]
+  name       = "${local.migration_id}-dlq-topic"
+  project    = var.common_params.project
+  labels = {
+    "migration_id" = local.migration_id
+  }
+}
+
+# Configure permissions to publish Pub/Sub notifications
+resource "google_pubsub_topic_iam_member" "gcs_publisher_role" {
+  depends_on = [google_project_service.enabled_apis]
+  topic      = google_pubsub_topic.dlq_pubsub_topic.name
+  role       = "roles/pubsub.publisher"
+  member     = "serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"
+}
+
+# Pub/Sub Notification on GCS Bucket
+resource "google_storage_notification" "dlq_bucket_notification" {
+  depends_on = [
+    google_project_service.enabled_apis,
+    google_pubsub_topic_iam_member.gcs_publisher_role
+  ] # Create a bucket notification using the created pubsub topic.
+  bucket             = google_storage_bucket.reverse_replication_bucket.name
+  object_name_prefix = "dlq"
+  payload_format     = "JSON_API_V1"
+  topic              = google_pubsub_topic.dlq_pubsub_topic.id
+  event_types        = ["OBJECT_FINALIZE"]
+}
+
+# Pub/Sub subscription for the created notification
+resource "google_pubsub_subscription" "dlq_pubsub_subscription" {
+  depends_on = [
+    google_project_service.enabled_apis,
+    google_storage_notification.dlq_bucket_notification
+  ] # Create the subscription once the notification is created.
+  name  = "${google_pubsub_topic.dlq_pubsub_topic.name}-sub"
+  topic = google_pubsub_topic.dlq_pubsub_topic.id
+  labels = {
+    "migration_id" = local.migration_id
+  }
+}
+
+# Add roles to the service account that will run Dataflow for reverse replication
+resource "google_project_iam_member" "reverse_replication_roles" {
+  for_each = var.common_params.add_policies_to_service_account ? toset([
+    "roles/spanner.databaseUser",
+    "roles/secretManager.secretAccessor",
+    "roles/secretmanager.viewer"
+  ]) : toset([])
+  project = data.google_project.project.id
+  role    = each.key
+  member  = var.dataflow_params.runner_params.service_account_email != null ? "serviceAccount:${var.dataflow_params.runner_params.service_account_email}" : "serviceAccount:${data.google_compute_default_service_account.gce_account.email}"
+}
+
+# Dataflow Flex Template Job (for Spanner to SourceDB)
+resource "google_dataflow_flex_template_job" "reverse_replication_job" {
+  depends_on = [
+    google_project_service.enabled_apis, google_project_iam_member.reverse_replication_roles
+  ] # Launch the template once the stream is created.
+  provider                = google-beta
+  container_spec_gcs_path = "gs://dataflow-templates-${var.common_params.region}/latest/flex/Spanner_to_SourceDb"
+
+  # Parameters from Dataflow Template
+  parameters = {
+    changeStreamName                 = var.dataflow_params.template_params.change_stream_name
+    instanceId                = var.dataflow_params.template_params.instance_id
+    databaseId                 = var.dataflow_params.template_params.database_id
+    spannerProjectId                      = var.dataflow_params.template_params.spanner_project_id != null ? var.dataflow_params.template_params.spanner_project_id : var.common_params.project
+    metadataInstance                      = var.dataflow_params.template_params.metadata_instance_id != null ? var.dataflow_params.template_params.metadata_instance_id : var.dataflow_params.template_params.instance_id
+    metadataDatabase                       = var.dataflow_params.template_params.metadata_database_id
+    sourceShardsFilePath                     = "gs://${google_storage_bucket_object.source_shards_file_object.bucket}/${google_storage_bucket_object.source_shards_file_object.name}"
+    startTimestamp           = var.dataflow_params.template_params.start_timestamp
+    endTimestamp                      = var.dataflow_params.template_params.end_timestamp
+    shadowTablePrefix               = var.dataflow_params.template_params.shadow_table_prefix
+    sessionFilePath        = "gs://${google_storage_bucket_object.session_file_object.bucket}/${google_storage_bucket_object.session_file_object.name}"
+    filtrationMode                = var.dataflow_params.template_params.filtration_mode
+    shardingCustomJarPath             = var.dataflow_params.template_params.sharding_custom_jar_path
+    shardingCustomClassName        = var.dataflow_params.template_params.sharding_custom_class_name
+    shardingCustomParameters                 = var.dataflow_params.template_params.sharding_custom_parameters
+    sourceDbTimezoneOffset                = var.dataflow_params.template_params.source_db_timezone_offset
+    dlqGcsPubSubSubscription               = google_pubsub_subscription.dlq_pubsub_subscription.id
+    skipDirectoryName            = var.dataflow_params.template_params.skip_directory_name
+    maxShardConnections               = var.dataflow_params.template_params.max_shard_connections
+    deadLetterQueueDirectory                         = "${google_storage_bucket.reverse_replication_bucket.url}/dlq"
+    dlqMaxRetryCount   = var.dataflow_params.template_params.dlq_max_retry_count
+    runMode = var.dataflow_params.template_params.run_mode
+    dlqRetryMinutes                 = var.dataflow_params.template_params.dlq_retry_minutes
+  }
+
+  # Additional Job Configurations
+  additional_experiments       = var.dataflow_params.runner_params.additional_experiments
+  autoscaling_algorithm        = var.dataflow_params.runner_params.autoscaling_algorithm
+  enable_streaming_engine      = var.dataflow_params.runner_params.enable_streaming_engine
+  kms_key_name                 = var.dataflow_params.runner_params.kms_key_name
+  launcher_machine_type        = var.dataflow_params.runner_params.launcher_machine_type
+  machine_type                 = var.dataflow_params.runner_params.machine_type
+  max_workers                  = var.dataflow_params.runner_params.max_workers
+  name                         = "${local.migration_id}-${var.dataflow_params.runner_params.job_name}"
+  network                      = var.dataflow_params.runner_params.network
+  num_workers                  = var.dataflow_params.runner_params.num_workers
+  sdk_container_image          = var.dataflow_params.runner_params.sdk_container_image
+  service_account_email        = var.dataflow_params.runner_params.service_account_email
+  skip_wait_on_job_termination = var.dataflow_params.runner_params.skip_wait_on_job_termination
+  staging_location             = var.dataflow_params.runner_params.staging_location
+  subnetwork                   = var.dataflow_params.runner_params.subnetwork != null ? var.common_params.host_project != null ? "https://www.googleapis.com/compute/v1/projects/${var.common_params.host_project}/regions/${var.common_params.region}/subnetworks/${var.dataflow_params.runner_params.subnetwork}" : "https://www.googleapis.com/compute/v1/projects/${var.common_params.project}/regions/${var.common_params.region}/subnetworks/${var.dataflow_params.runner_params.subnetwork}" : null
+  temp_location                = var.dataflow_params.runner_params.temp_location
+  on_delete                    = var.dataflow_params.runner_params.on_delete
+  region                       = var.common_params.region
+  ip_configuration             = var.dataflow_params.runner_params.ip_configuration
+  labels = {
+    "migration_id" = local.migration_id
+  }
+}
+

--- a/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/outputs.tf
+++ b/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/outputs.tf
@@ -1,0 +1,10 @@
+output "dataflow_job_id" {
+  value       = google_dataflow_flex_template_job.reverse_replication_job.id
+  description = "Job id for the created Dataflow Flex Template job."
+}
+
+output "dataflow_job_url" {
+  value       = "https://console.cloud.google.com/dataflow/jobs/${var.common_params.region}/${google_dataflow_flex_template_job.reverse_replication_job.id}"
+  description = "URL for the created Dataflow Flex Template job."
+}
+

--- a/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/session.json
+++ b/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/session.json
@@ -1,0 +1,7 @@
+{
+  "SessionName": "NewSession",
+  "DatabaseType": "mysql",
+  "Dialect": "google_standard_sql",
+  "SpSchema": {},
+  "SrcSchema": {}
+}

--- a/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/terraform.tf
+++ b/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/terraform.tf
@@ -1,0 +1,52 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0" # Or the latest compatible version
+    }
+  }
+  required_version = "~>1.2"
+}
+
+#Set the project
+provider "google-beta" {
+  project = var.common_params.project
+  region  = var.common_params.region
+}
+
+provider "google" {
+  project = var.common_params.project
+  region  = var.common_params.region
+}
+
+#Enable the APIs
+resource "google_project_service" "enabled_apis" {
+  for_each = toset([
+    "iam.googleapis.com",
+    "dataflow.googleapis.com",
+    "storage.googleapis.com",
+    "pubsub.googleapis.com",
+    "cloudprofiler.googleapis.com",
+    "spanner.googleapis.com"
+  ])
+  service            = each.key
+  project            = var.common_params.project
+  disable_on_destroy = false
+}
+# To fetch project number
+data "google_project" "project" {
+}
+
+# Fetch the service account for GCS
+data "google_storage_project_service_account" "gcs_account" {
+  depends_on = [google_project_service.enabled_apis]
+}
+
+# Fetch the default service account for Compute Engine (used by Dataflow)
+data "google_compute_default_service_account" "gce_account" {
+  depends_on = [google_project_service.enabled_apis]
+}

--- a/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/terraform.tfvars
+++ b/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/terraform.tfvars
@@ -1,0 +1,138 @@
+common_params = {
+  # The project where the resources will be deployed
+  project                         = "<YOUR_PROJECT_ID>"      # Replace with your GCP project ID
+  # The host project in case of Shared VPC setup
+  host_project                    = "<YOUR_HOST_PROJECT_ID>" # If you are using a shared VPC
+  # The region where the resources will be deployed
+  region                          = "us-central1"
+  # Optional ID for the migration process
+  migration_id                    = "migration-123"
+  # Optional name for the replication bucket (defaults to "rr-bucket")
+  replication_bucket              = "my-replication-bucket"
+  # Optional flag to control adding policies to the service account (defaults to true)
+  add_policies_to_service_account = false
+}
+
+dataflow_params = {
+  template_params = {
+    # Optional name for the change stream
+    change_stream_name           = "my-change-stream"
+    # The ID of the Spanner instance
+    instance_id                  = "<YOUR_SPANNER_INSTANCE_ID>" # Replace with your Spanner instance ID
+    # The ID of the Spanner database
+    database_id                  = "<YOUR_SPANNER_DATABASE_ID>" # Replace with your Spanner database ID
+    # Optional ID of the Spanner project
+    spanner_project_id           = "<YOUR_SPANNER_PROJECT_ID>" # Replace with your Spanner project ID (if different from the main project)
+    # Optional ID of the metadata instance
+    metadata_instance_id         = "<YOUR_METADATA_INSTANCE_ID>" # Replace with your metadata instance ID (if applicable)
+    # Optional ID of the metadata database
+    metadata_database_id         = "<YOUR_METADATA_DATABASE_ID>" # Replace with your metadata database ID (if applicable)
+    # Optional start timestamp for replication
+    start_timestamp              = "2024-10-01T00:00:00Z"
+    # Optional end timestamp for replication
+    end_timestamp                = "2024-10-31T23:59:59Z"
+    # Optional prefix for shadow tables
+    shadow_table_prefix          = "shadow_"
+    # Optional path to a local session file
+    local_session_file_path      = "/path/to/session/file"
+    # Optional filtration mode
+    filtration_mode              = "column-list"
+    # Optional path to a custom sharding JAR file
+    sharding_custom_jar_path     = "/path/to/sharding/jar"
+    # Optional name of the custom sharding class
+    sharding_custom_class_name   = "com.example.ShardingClass"
+    # Optional parameters for custom sharding
+    sharding_custom_parameters   = "param1=value1,param2=value2"
+    # Optional timezone offset for the source database
+    source_db_timezone_offset    = "+08:00"
+    # Optional DLQ GCS Pub/Sub subscription
+    dlq_gcs_pub_sub_subscription = "projects/<YOUR_PROJECT_ID>/subscriptions/my-subscription" # Replace with your project ID and subscription name
+    # Optional name of the directory to skip
+    skip_directory_name          = "skip-directory"
+    # Optional maximum number of shard connections
+    max_shard_connections        = "10"
+    # Optional dead letter queue directory
+    dead_letter_queue_directory  = "gs://my-bucket/dlq"
+    # Optional maximum retry count for DLQ
+    dlq_max_retry_count          = "5"
+    # Optional run mode
+    run_mode                     = "parallel"
+    # Optional retry minutes for DLQ
+    dlq_retry_minutes            = "10"
+  }
+  runner_params = {
+    # Optional additional experiments for the Dataflow runner
+    additional_experiments = ["enable_google_cloud_profiler", "use_runner_v2"]
+    # Optional autoscaling algorithm for the Dataflow runner
+    autoscaling_algorithm        = "THROUGHPUT_BASED"
+    # Optional flag to enable Streaming Engine (defaults to true)
+    enable_streaming_engine      = false
+    # Optional KMS key name for encryption
+    kms_key_name                 = "projects/<YOUR_PROJECT_ID>/locations/<YOUR_LOCATION>/keyRings/<YOUR_KEYRING>/cryptoKeys/<YOUR_KEY>" # Replace with your project ID, location, keyring and key
+    # Optional labels for the Dataflow job
+    labels                       = { env = "dev", team = "data-eng" }
+    # Optional machine type for the launcher VM
+    launcher_machine_type        = "n2-standard-4"
+    # Optional machine type for worker VMs (defaults to "n2-standard-2")
+    machine_type                 = "n1-standard-1"
+    # Maximum number of workers for the Dataflow job
+    max_workers                  = 100
+    # Optional name for the Dataflow job (defaults to "reverse-replication-job")
+    job_name                     = "my-replication-job"
+    # Optional network for the Dataflow job
+    network                      = "default"
+    # Number of workers for the Dataflow job
+    num_workers                  = 10
+    # Optional SDK container image for the Dataflow job
+    sdk_container_image          = "gcr.io/dataflow-templates/spanner-to-sourcedb:latest"
+    # Optional service account email for the Dataflow job
+    service_account_email        = "dataflow-sa@<YOUR_PROJECT_ID>.iam.gserviceaccount.com" # Replace with your project ID
+    # Optional flag to skip waiting on job termination (defaults to false)
+    skip_wait_on_job_termination = true
+    # Optional staging location for the Dataflow job
+    staging_location             = "gs://<YOUR_BUCKET_NAME>/staging" # Replace with your bucket name
+    # Optional subnetwork for the Dataflow job
+    subnetwork                   = "regions/us-central1/subnetworks/<YOUR_SUBNETWORK>" # Replace with your subnetwork
+    # Optional temporary location for the Dataflow job
+    temp_location                = "gs://<YOUR_BUCKET_NAME>/temp" # Replace with your bucket name
+    # Optional action on delete (defaults to "drain")
+    on_delete                    = "cancel"
+    # Optional IP configuration for the Dataflow job
+    ip_configuration             = "WORKER_IP_PRIVATE"
+  }
+}
+
+shard_list = [
+  {
+    # Logical ID of the shard
+    logicalShardId   = "shard1"
+    # Hostname or IP address of the shard
+    host               = "<YOUR_SHARD_HOST_OR_IP>" # Replace with the shard's hostname or IP address
+    # Username for connecting to the shard
+    user               = "root"
+    # URI of the Secret Manager secret containing the password (optional)
+    secretManagerUri = "projects/<YOUR_PROJECT_ID>/secrets/shard1-password/versions/latest" # Replace with your project ID and secret name
+    # Password for connecting to the shard (optional, use either this or secretManagerUri)
+    password           = null
+    # Port number for connecting to the shard
+    port               = "3306"
+    # Name of the database on the shard
+    dbName            = "db1"
+  },
+  {
+    # Logical ID of the shard
+    logicalShardId   = "shard2"
+    # Hostname or IP address of the shard
+    host               = "<YOUR_SHARD_HOST_OR_IP>" # Replace with the shard's hostname or IP address
+    # Username for connecting to the shard
+    user               = "root"
+    # URI of the Secret Manager secret containing the password (optional)
+    secretManagerUri = "projects/<YOUR_PROJECT_ID>/secrets/shard2-password/versions/latest" # Replace with your project ID and secret name
+    # Password for connecting to the shard (optional, use either this or secretManagerUri)
+    password           = null
+    # Port number for connecting to the shard
+    port               = "3306"
+    # Name of the database on the shard
+    dbName            = "db2"
+  }
+]

--- a/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/terraform.tfvars
+++ b/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/terraform.tfvars
@@ -1,14 +1,14 @@
 common_params = {
   # The project where the resources will be deployed
-  project                         = "<YOUR_PROJECT_ID>"      # Replace with your GCP project ID
+  project = "<YOUR_PROJECT_ID>" # Replace with your GCP project ID
   # The host project in case of Shared VPC setup
-  host_project                    = "<YOUR_HOST_PROJECT_ID>" # If you are using a shared VPC
+  host_project = "<YOUR_HOST_PROJECT_ID>" # If you are using a shared VPC
   # The region where the resources will be deployed
-  region                          = "us-central1"
+  region = "us-central1"
   # Optional ID for the migration process
-  migration_id                    = "migration-123"
+  migration_id = "migration-123"
   # Optional name for the replication bucket (defaults to "rr-bucket")
-  replication_bucket              = "my-replication-bucket"
+  replication_bucket = "my-replication-bucket"
   # Optional flag to control adding policies to the service account (defaults to true)
   add_policies_to_service_account = false
 }
@@ -16,123 +16,123 @@ common_params = {
 dataflow_params = {
   template_params = {
     # Optional name for the change stream
-    change_stream_name           = "my-change-stream"
+    change_stream_name = "my-change-stream"
     # The ID of the Spanner instance
-    instance_id                  = "<YOUR_SPANNER_INSTANCE_ID>" # Replace with your Spanner instance ID
+    instance_id = "<YOUR_SPANNER_INSTANCE_ID>" # Replace with your Spanner instance ID
     # The ID of the Spanner database
-    database_id                  = "<YOUR_SPANNER_DATABASE_ID>" # Replace with your Spanner database ID
+    database_id = "<YOUR_SPANNER_DATABASE_ID>" # Replace with your Spanner database ID
     # Optional ID of the Spanner project
-    spanner_project_id           = "<YOUR_SPANNER_PROJECT_ID>" # Replace with your Spanner project ID (if different from the main project)
+    spanner_project_id = "<YOUR_SPANNER_PROJECT_ID>" # Replace with your Spanner project ID (if different from the main project)
     # Optional ID of the metadata instance
-    metadata_instance_id         = "<YOUR_METADATA_INSTANCE_ID>" # Replace with your metadata instance ID (if applicable)
+    metadata_instance_id = "<YOUR_METADATA_INSTANCE_ID>" # Replace with your metadata instance ID (if applicable)
     # Optional ID of the metadata database
-    metadata_database_id         = "<YOUR_METADATA_DATABASE_ID>" # Replace with your metadata database ID (if applicable)
+    metadata_database_id = "<YOUR_METADATA_DATABASE_ID>" # Replace with your metadata database ID (if applicable)
     # Optional start timestamp for replication
-    start_timestamp              = "2024-10-01T00:00:00Z"
+    start_timestamp = "2024-10-01T00:00:00Z"
     # Optional end timestamp for replication
-    end_timestamp                = "2024-10-31T23:59:59Z"
+    end_timestamp = "2024-10-31T23:59:59Z"
     # Optional prefix for shadow tables
-    shadow_table_prefix          = "shadow_"
+    shadow_table_prefix = "shadow_"
     # Optional path to a local session file
-    local_session_file_path      = "/path/to/session/file"
+    local_session_file_path = "/path/to/session/file"
     # Optional filtration mode
-    filtration_mode              = "column-list"
+    filtration_mode = "column-list"
     # Optional path to a custom sharding JAR file
-    sharding_custom_jar_path     = "/path/to/sharding/jar"
+    sharding_custom_jar_path = "/path/to/sharding/jar"
     # Optional name of the custom sharding class
-    sharding_custom_class_name   = "com.example.ShardingClass"
+    sharding_custom_class_name = "com.example.ShardingClass"
     # Optional parameters for custom sharding
-    sharding_custom_parameters   = "param1=value1,param2=value2"
+    sharding_custom_parameters = "param1=value1,param2=value2"
     # Optional timezone offset for the source database
-    source_db_timezone_offset    = "+08:00"
+    source_db_timezone_offset = "+08:00"
     # Optional DLQ GCS Pub/Sub subscription
     dlq_gcs_pub_sub_subscription = "projects/<YOUR_PROJECT_ID>/subscriptions/my-subscription" # Replace with your project ID and subscription name
     # Optional name of the directory to skip
-    skip_directory_name          = "skip-directory"
+    skip_directory_name = "skip-directory"
     # Optional maximum number of shard connections
-    max_shard_connections        = "10"
+    max_shard_connections = "10"
     # Optional dead letter queue directory
-    dead_letter_queue_directory  = "gs://my-bucket/dlq"
+    dead_letter_queue_directory = "gs://my-bucket/dlq"
     # Optional maximum retry count for DLQ
-    dlq_max_retry_count          = "5"
+    dlq_max_retry_count = "5"
     # Optional run mode
-    run_mode                     = "parallel"
+    run_mode = "parallel"
     # Optional retry minutes for DLQ
-    dlq_retry_minutes            = "10"
+    dlq_retry_minutes = "10"
   }
   runner_params = {
     # Optional additional experiments for the Dataflow runner
     additional_experiments = ["enable_google_cloud_profiler", "use_runner_v2"]
     # Optional autoscaling algorithm for the Dataflow runner
-    autoscaling_algorithm        = "THROUGHPUT_BASED"
+    autoscaling_algorithm = "THROUGHPUT_BASED"
     # Optional flag to enable Streaming Engine (defaults to true)
-    enable_streaming_engine      = false
+    enable_streaming_engine = false
     # Optional KMS key name for encryption
-    kms_key_name                 = "projects/<YOUR_PROJECT_ID>/locations/<YOUR_LOCATION>/keyRings/<YOUR_KEYRING>/cryptoKeys/<YOUR_KEY>" # Replace with your project ID, location, keyring and key
+    kms_key_name = "projects/<YOUR_PROJECT_ID>/locations/<YOUR_LOCATION>/keyRings/<YOUR_KEYRING>/cryptoKeys/<YOUR_KEY>" # Replace with your project ID, location, keyring and key
     # Optional labels for the Dataflow job
-    labels                       = { env = "dev", team = "data-eng" }
+    labels = { env = "dev", team = "data-eng" }
     # Optional machine type for the launcher VM
-    launcher_machine_type        = "n2-standard-4"
+    launcher_machine_type = "n2-standard-4"
     # Optional machine type for worker VMs (defaults to "n2-standard-2")
-    machine_type                 = "n1-standard-1"
+    machine_type = "n1-standard-1"
     # Maximum number of workers for the Dataflow job
-    max_workers                  = 100
+    max_workers = 100
     # Optional name for the Dataflow job (defaults to "reverse-replication-job")
-    job_name                     = "my-replication-job"
+    job_name = "my-replication-job"
     # Optional network for the Dataflow job
-    network                      = "default"
+    network = "default"
     # Number of workers for the Dataflow job
-    num_workers                  = 10
+    num_workers = 10
     # Optional SDK container image for the Dataflow job
-    sdk_container_image          = "gcr.io/dataflow-templates/spanner-to-sourcedb:latest"
+    sdk_container_image = "gcr.io/dataflow-templates/spanner-to-sourcedb:latest"
     # Optional service account email for the Dataflow job
-    service_account_email        = "dataflow-sa@<YOUR_PROJECT_ID>.iam.gserviceaccount.com" # Replace with your project ID
+    service_account_email = "dataflow-sa@<YOUR_PROJECT_ID>.iam.gserviceaccount.com" # Replace with your project ID
     # Optional flag to skip waiting on job termination (defaults to false)
     skip_wait_on_job_termination = true
     # Optional staging location for the Dataflow job
-    staging_location             = "gs://<YOUR_BUCKET_NAME>/staging" # Replace with your bucket name
+    staging_location = "gs://<YOUR_BUCKET_NAME>/staging" # Replace with your bucket name
     # Optional subnetwork for the Dataflow job
-    subnetwork                   = "regions/us-central1/subnetworks/<YOUR_SUBNETWORK>" # Replace with your subnetwork
+    subnetwork = "regions/us-central1/subnetworks/<YOUR_SUBNETWORK>" # Replace with your subnetwork
     # Optional temporary location for the Dataflow job
-    temp_location                = "gs://<YOUR_BUCKET_NAME>/temp" # Replace with your bucket name
+    temp_location = "gs://<YOUR_BUCKET_NAME>/temp" # Replace with your bucket name
     # Optional action on delete (defaults to "drain")
-    on_delete                    = "cancel"
+    on_delete = "cancel"
     # Optional IP configuration for the Dataflow job
-    ip_configuration             = "WORKER_IP_PRIVATE"
+    ip_configuration = "WORKER_IP_PRIVATE"
   }
 }
 
 shard_list = [
   {
     # Logical ID of the shard
-    logicalShardId   = "shard1"
+    logicalShardId = "shard1"
     # Hostname or IP address of the shard
-    host               = "<YOUR_SHARD_HOST_OR_IP>" # Replace with the shard's hostname or IP address
+    host = "<YOUR_SHARD_HOST_OR_IP>" # Replace with the shard's hostname or IP address
     # Username for connecting to the shard
-    user               = "root"
+    user = "root"
     # URI of the Secret Manager secret containing the password (optional)
     secretManagerUri = "projects/<YOUR_PROJECT_ID>/secrets/shard1-password/versions/latest" # Replace with your project ID and secret name
     # Password for connecting to the shard (optional, use either this or secretManagerUri)
-    password           = null
+    password = null
     # Port number for connecting to the shard
-    port               = "3306"
+    port = "3306"
     # Name of the database on the shard
-    dbName            = "db1"
+    dbName = "db1"
   },
   {
     # Logical ID of the shard
-    logicalShardId   = "shard2"
+    logicalShardId = "shard2"
     # Hostname or IP address of the shard
-    host               = "<YOUR_SHARD_HOST_OR_IP>" # Replace with the shard's hostname or IP address
+    host = "<YOUR_SHARD_HOST_OR_IP>" # Replace with the shard's hostname or IP address
     # Username for connecting to the shard
-    user               = "root"
+    user = "root"
     # URI of the Secret Manager secret containing the password (optional)
     secretManagerUri = "projects/<YOUR_PROJECT_ID>/secrets/shard2-password/versions/latest" # Replace with your project ID and secret name
     # Password for connecting to the shard (optional, use either this or secretManagerUri)
-    password           = null
+    password = null
     # Port number for connecting to the shard
-    port               = "3306"
+    port = "3306"
     # Name of the database on the shard
-    dbName            = "db2"
+    dbName = "db2"
   }
 ]

--- a/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/terraform.tfvars
+++ b/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/terraform.tfvars
@@ -56,7 +56,7 @@ dataflow_params = {
     # Optional maximum retry count for DLQ
     dlq_max_retry_count = "5"
     # Optional run mode
-    run_mode = "parallel"
+    run_mode = "regular"
     # Optional retry minutes for DLQ
     dlq_retry_minutes = "10"
   }

--- a/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/terraform_simple.tfvars
+++ b/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/terraform_simple.tfvars
@@ -27,7 +27,7 @@ shard_list = [
     logicalShardId = "<YOUR_SHARD_ID1>"            # Value of the shard populated in Spanner
     host           = "<YOUR_IP_ADDRESS"            # Public or private IP address of shard
     user           = "<YOUR_USERNAME>"             # user of the source MySQL shard
-    password       = "<YOUR_PASSWORD>",            # password of the source MySQL shard
+    password       = "<YOUR_PASSWORD>",            # password of the source MySQL shard. For production migrations, use the secretManagerUri variable instead.
     port           = "<YOUR_PORT>"                 # Port, usually 3306
     dbName         = "<YOUR_SOURCE_DATABASE_NAME>" # name of the source database to replicate to
   },

--- a/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/terraform_simple.tfvars
+++ b/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/terraform_simple.tfvars
@@ -2,41 +2,41 @@
 common_params = {
   project = "<YOUR_PROJECT_ID>" # Replace with your GCP project ID
   region  = "<YOUR_GCP_REGION>" # Replace with your desired GCP region
-  }
+}
 
 # Dataflow parameters
 dataflow_params = {
-    template_params = {
-      instance_id     = "<YOUR_SPANNER_INSTANCE_ID>" # Spanner instance ID
-      database_id     = "<YOUR_SPANNER_DATABASE_ID>" # Spanner database ID
-      local_session_file_path = "session.json"
-    }
-    runner_params = {
-      max_workers      = "<YOUR_MAX_WORKERS>"         # Maximum number of worker VMs
-      num_workers      = "<YOUR_NUM_WORKERS>"         # Initial number of worker VMs
-      machine_type     = "<YOUR_MACHINE_TYPE>"        # Machine type for worker VMs (e.g., "n2-standard-2")
-      network          = "<YOUR_VPC_NETWORK>"         # VPC network for the Dataflow job
-      subnetwork       = "<YOUR-FULL-PATH-SUBNETWORK" # Give the full path to the subnetwork
-      ip_configuration = "WORKER_IP_PRIVATE"
-    }
+  template_params = {
+    instance_id             = "<YOUR_SPANNER_INSTANCE_ID>" # Spanner instance ID
+    database_id             = "<YOUR_SPANNER_DATABASE_ID>" # Spanner database ID
+    local_session_file_path = "session.json"
+  }
+  runner_params = {
+    max_workers      = "<YOUR_MAX_WORKERS>"         # Maximum number of worker VMs
+    num_workers      = "<YOUR_NUM_WORKERS>"         # Initial number of worker VMs
+    machine_type     = "<YOUR_MACHINE_TYPE>"        # Machine type for worker VMs (e.g., "n2-standard-2")
+    network          = "<YOUR_VPC_NETWORK>"         # VPC network for the Dataflow job
+    subnetwork       = "<YOUR-FULL-PATH-SUBNETWORK" # Give the full path to the subnetwork
+    ip_configuration = "WORKER_IP_PRIVATE"
+  }
 }
 
 # Shards
 shard_list = [
   {
-    logicalShardId = "<YOUR_SHARD_ID1>" # Value of the shard populated in Spanner
-    host             = "<YOUR_IP_ADDRESS" # Public or private IP address of shard
-    user             = "<YOUR_USERNAME>" # user of the source MySQL shard
-    password         = "<YOUR_PASSWORD>", # password of the source MySQL shard
-    port             = "<YOUR_PORT>" # Port, usually 3306
-    dbName          = "<YOUR_SOURCE_DATABASE_NAME>" # name of the source database to replicate to
+    logicalShardId = "<YOUR_SHARD_ID1>"            # Value of the shard populated in Spanner
+    host           = "<YOUR_IP_ADDRESS"            # Public or private IP address of shard
+    user           = "<YOUR_USERNAME>"             # user of the source MySQL shard
+    password       = "<YOUR_PASSWORD>",            # password of the source MySQL shard
+    port           = "<YOUR_PORT>"                 # Port, usually 3306
+    dbName         = "<YOUR_SOURCE_DATABASE_NAME>" # name of the source database to replicate to
   },
   {
     logicalShardId = "<YOUR_SHARD_ID2>"
-    host             = "<YOUR_IP_ADDRESS>"
-    user             = "<YOUR_USERNAME>"
-    password         = "<YOUR_PASSWORD>",
-    port             = "<YOUR_PORT>"
-    dbName          = "<YOUR_SOURCE_DATABASE_NAME>"
+    host           = "<YOUR_IP_ADDRESS>"
+    user           = "<YOUR_USERNAME>"
+    password       = "<YOUR_PASSWORD>",
+    port           = "<YOUR_PORT>"
+    dbName         = "<YOUR_SOURCE_DATABASE_NAME>"
   }
 ]

--- a/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/terraform_simple.tfvars
+++ b/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/terraform_simple.tfvars
@@ -1,0 +1,42 @@
+# Common Parameters
+common_params = {
+  project = "<YOUR_PROJECT_ID>" # Replace with your GCP project ID
+  region  = "<YOUR_GCP_REGION>" # Replace with your desired GCP region
+  }
+
+# Dataflow parameters
+dataflow_params = {
+    template_params = {
+      instance_id     = "<YOUR_SPANNER_INSTANCE_ID>" # Spanner instance ID
+      database_id     = "<YOUR_SPANNER_DATABASE_ID>" # Spanner database ID
+      local_session_file_path = "session.json"
+    }
+    runner_params = {
+      max_workers      = "<YOUR_MAX_WORKERS>"         # Maximum number of worker VMs
+      num_workers      = "<YOUR_NUM_WORKERS>"         # Initial number of worker VMs
+      machine_type     = "<YOUR_MACHINE_TYPE>"        # Machine type for worker VMs (e.g., "n2-standard-2")
+      network          = "<YOUR_VPC_NETWORK>"         # VPC network for the Dataflow job
+      subnetwork       = "<YOUR-FULL-PATH-SUBNETWORK" # Give the full path to the subnetwork
+      ip_configuration = "WORKER_IP_PRIVATE"
+    }
+}
+
+# Shards
+shard_list = [
+  {
+    logicalShardId = "<YOUR_SHARD_ID1>" # Value of the shard populated in Spanner
+    host             = "<YOUR_IP_ADDRESS" # Public or private IP address of shard
+    user             = "<YOUR_USERNAME>" # user of the source MySQL shard
+    password         = "<YOUR_PASSWORD>", # password of the source MySQL shard
+    port             = "<YOUR_PORT>" # Port, usually 3306
+    dbName          = "<YOUR_SOURCE_DATABASE_NAME>" # name of the source database to replicate to
+  },
+  {
+    logicalShardId = "<YOUR_SHARD_ID2>"
+    host             = "<YOUR_IP_ADDRESS>"
+    user             = "<YOUR_USERNAME>"
+    password         = "<YOUR_PASSWORD>",
+    port             = "<YOUR_PORT>"
+    dbName          = "<YOUR_SOURCE_DATABASE_NAME>"
+  }
+]

--- a/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/variables.tf
+++ b/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/variables.tf
@@ -1,18 +1,19 @@
 variable "common_params" {
   description = "Parameters that are common to multiple resources"
-  type        = object({
+  type = object({
     project                         = string
     host_project                    = optional(string)
     region                          = string
     migration_id                    = optional(string)
     replication_bucket              = optional(string, "rr-bucket")
     add_policies_to_service_account = optional(bool, true)
+    target_tags                     = optional(list(string))
   })
 }
 
 variable "dataflow_params" {
   description = "Parameters for the Dataflow job. Please refer to https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v2/spanner-to-sourcedb/README.md for the description of the parameters below."
-  type        = object({
+  type = object({
     template_params = object({
       change_stream_name           = optional(string)
       instance_id                  = string
@@ -66,13 +67,13 @@ variable "dataflow_params" {
 
 variable "shard_list" {
   description = "Details of the source shards to do the reverse replication to"
-  type        = list(object({
+  type = list(object({
     logicalShardId   = string
-    host               = string
-    user               = string
+    host             = string
+    user             = string
     secretManagerUri = optional(string)
-    password           = optional(string)
-    port               = string
-    dbName            = string
+    password         = optional(string)
+    port             = string
+    dbName           = string
   }))
 }

--- a/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/variables.tf
+++ b/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/variables.tf
@@ -1,0 +1,78 @@
+variable "common_params" {
+  description = "Parameters that are common to multiple resources"
+  type        = object({
+    project                         = string
+    host_project                    = optional(string)
+    region                          = string
+    migration_id                    = optional(string)
+    replication_bucket  = optional(string, "rr-bucket")
+    add_policies_to_service_account = optional(bool, true)
+  })
+}
+
+variable "dataflow_params" {
+  description = "Parameters for the Dataflow job. Please refer to https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v2/spanner-to-sourcedb/README.md for the description of the parameters below."
+  type        = object({
+    template_params = object({
+      change_stream_name            = string
+      instance_id                   = string
+      database_id                   = string
+      spanner_project_id            = optional(string)
+      metadata_instance_id          = optional(string)
+      metadata_database_id          = optional(string, "rr-metadatadb")
+      local_source_shards_file_path = string
+      start_timestamp               = optional(string)
+      end_timestamp                 = optional(string)
+      shadow_table_prefix           = optional(string)
+      local_session_file_path       = optional(string)
+      filtration_mode               = optional(string)
+      sharding_custom_jar_path      = optional(string)
+      sharding_custom_class_name    = optional(string)
+      sharding_custom_parameters    = optional(string)
+      source_db_timezone_offset     = optional(string)
+      dlq_gcs_pub_sub_subscription  = optional(string)
+      skip_directory_name           = optional(string)
+      max_shard_connections         = optional(string)
+      dead_letter_queue_directory   = optional(string)
+      dlq_max_retry_count           = optional(string)
+      run_mode                      = optional(string)
+      dlq_retry_minutes             = optional(string)
+    })
+    runner_params = object({
+      additional_experiments = optional(set(string), [
+        "enable_google_cloud_profiler", "enable_stackdriver_agent_metrics",
+        "disable_runner_v2", "enable_google_cloud_heap_sampling"
+      ])
+      autoscaling_algorithm        = optional(string)
+      enable_streaming_engine      = optional(bool, true)
+      kms_key_name                 = optional(string)
+      labels                       = optional(map(string))
+      launcher_machine_type        = optional(string)
+      machine_type                 = optional(string, "n2-standard-2")
+      max_workers                  = number
+      job_name                     = optional(string, "reverse-replication-job")
+      network                      = optional(string)
+      num_workers                  = number
+      sdk_container_image          = optional(string)
+      service_account_email        = optional(string)
+      skip_wait_on_job_termination = optional(bool, false)
+      staging_location             = optional(string)
+      subnetwork                   = optional(string)
+      temp_location                = optional(string)
+      on_delete                    = optional(string, "drain")
+      ip_configuration             = optional(string)
+    })
+  })
+}
+
+variable "shard_list" {
+  description = "Details of the source shards to do the reverse replication to"
+  type        = list(object({
+    logical_shard_id   = string
+    host               = string
+    user               = string
+    secret_manager_uri = string
+    port               = string
+    db_name            = string
+  }))
+}

--- a/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/variables.tf
+++ b/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/variables.tf
@@ -5,7 +5,7 @@ variable "common_params" {
     host_project                    = optional(string)
     region                          = string
     migration_id                    = optional(string)
-    replication_bucket  = optional(string, "rr-bucket")
+    replication_bucket              = optional(string, "rr-bucket")
     add_policies_to_service_account = optional(bool, true)
   })
 }
@@ -14,29 +14,28 @@ variable "dataflow_params" {
   description = "Parameters for the Dataflow job. Please refer to https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v2/spanner-to-sourcedb/README.md for the description of the parameters below."
   type        = object({
     template_params = object({
-      change_stream_name            = string
-      instance_id                   = string
-      database_id                   = string
-      spanner_project_id            = optional(string)
-      metadata_instance_id          = optional(string)
-      metadata_database_id          = optional(string, "rr-metadatadb")
-      local_source_shards_file_path = string
-      start_timestamp               = optional(string)
-      end_timestamp                 = optional(string)
-      shadow_table_prefix           = optional(string)
-      local_session_file_path       = optional(string)
-      filtration_mode               = optional(string)
-      sharding_custom_jar_path      = optional(string)
-      sharding_custom_class_name    = optional(string)
-      sharding_custom_parameters    = optional(string)
-      source_db_timezone_offset     = optional(string)
-      dlq_gcs_pub_sub_subscription  = optional(string)
-      skip_directory_name           = optional(string)
-      max_shard_connections         = optional(string)
-      dead_letter_queue_directory   = optional(string)
-      dlq_max_retry_count           = optional(string)
-      run_mode                      = optional(string)
-      dlq_retry_minutes             = optional(string)
+      change_stream_name           = optional(string)
+      instance_id                  = string
+      database_id                  = string
+      spanner_project_id           = optional(string)
+      metadata_instance_id         = optional(string)
+      metadata_database_id         = optional(string, "rr_metadata")
+      start_timestamp              = optional(string)
+      end_timestamp                = optional(string)
+      shadow_table_prefix          = optional(string)
+      local_session_file_path      = optional(string)
+      filtration_mode              = optional(string)
+      sharding_custom_jar_path     = optional(string)
+      sharding_custom_class_name   = optional(string)
+      sharding_custom_parameters   = optional(string)
+      source_db_timezone_offset    = optional(string)
+      dlq_gcs_pub_sub_subscription = optional(string)
+      skip_directory_name          = optional(string)
+      max_shard_connections        = optional(string)
+      dead_letter_queue_directory  = optional(string)
+      dlq_max_retry_count          = optional(string)
+      run_mode                     = optional(string)
+      dlq_retry_minutes            = optional(string)
     })
     runner_params = object({
       additional_experiments = optional(set(string), [
@@ -71,7 +70,8 @@ variable "shard_list" {
     logical_shard_id   = string
     host               = string
     user               = string
-    secret_manager_uri = string
+    secret_manager_uri = optional(string)
+    password           = optional(string)
     port               = string
     db_name            = string
   }))

--- a/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/variables.tf
+++ b/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/variables.tf
@@ -24,7 +24,7 @@ variable "dataflow_params" {
       start_timestamp              = optional(string)
       end_timestamp                = optional(string)
       shadow_table_prefix          = optional(string)
-      local_session_file_path      = optional(string)
+      local_session_file_path      = string
       filtration_mode              = optional(string)
       sharding_custom_jar_path     = optional(string)
       sharding_custom_class_name   = optional(string)

--- a/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/variables.tf
+++ b/v2/spanner-to-sourcedb/terraform/samples/spanner-to-sharded-mysql/variables.tf
@@ -19,7 +19,7 @@ variable "dataflow_params" {
       database_id                  = string
       spanner_project_id           = optional(string)
       metadata_instance_id         = optional(string)
-      metadata_database_id         = optional(string, "rr_metadata")
+      metadata_database_id         = optional(string)
       start_timestamp              = optional(string)
       end_timestamp                = optional(string)
       shadow_table_prefix          = optional(string)
@@ -40,7 +40,7 @@ variable "dataflow_params" {
     runner_params = object({
       additional_experiments = optional(set(string), [
         "enable_google_cloud_profiler", "enable_stackdriver_agent_metrics",
-        "disable_runner_v2", "enable_google_cloud_heap_sampling"
+        "use_runner_v2", "enable_google_cloud_heap_sampling"
       ])
       autoscaling_algorithm        = optional(string)
       enable_streaming_engine      = optional(bool, true)
@@ -67,12 +67,12 @@ variable "dataflow_params" {
 variable "shard_list" {
   description = "Details of the source shards to do the reverse replication to"
   type        = list(object({
-    logical_shard_id   = string
+    logicalShardId   = string
     host               = string
     user               = string
-    secret_manager_uri = optional(string)
+    secretManagerUri = optional(string)
     password           = optional(string)
     port               = string
-    db_name            = string
+    dbName            = string
   }))
 }


### PR DESCRIPTION
Adds a terraform template for reverse replication for sharded MySQL. Tested in VPC and non-VPC environments. Uses `null_resource` to create and destroy changestreams via terraform since Spanner does not expose terraform constructs to manage the lifecycle of a changestream.

