### PR TITLE
Fix for job-builder image release

### DIFF
--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesReleaseMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesReleaseMojo.java
@@ -185,12 +185,15 @@ public class TemplatesReleaseMojo extends TemplatesBaseMojo {
                 unifiedWorker);
 
         String templatePath = configuredMojo.stageTemplate(definition, imageSpec, pluginManager);
-        LOG.info("Template staged: {}", templatePath);
 
-        // Export the specs for collection
-        generator.saveMetadata(definition, imageSpec.getMetadata(), targetDirectory);
-        if (definition.isFlex()) {
-          generator.saveImageSpec(definition, imageSpec, targetDirectory);
+        if (!definition.getTemplateAnnotation().stageImageOnly()) {
+          LOG.info("Template staged: {}", templatePath);
+
+          // Export the specs for collection
+          generator.saveMetadata(definition, imageSpec.getMetadata(), targetDirectory);
+          if (definition.isFlex()) {
+            generator.saveImageSpec(definition, imageSpec, targetDirectory);
+          }
         }
       }
 


### PR DESCRIPTION
The new Job Builder image will fail during release when trying to write metadata since this metadata file is never generated due to skipping the `gcloud dataflow flex-template build...` step as this is not needed for Job Builder.