### PR TITLE
Add code markers around the sample URL

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ImportPipeline.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ImportPipeline.java
@@ -98,8 +98,8 @@ public class ImportPipeline {
         optional = true,
         description = "Cloud Spanner Endpoint to call",
         helpText = "The Cloud Spanner endpoint to call in the template. Only used for testing.",
-        example = "https://batch-spanner.googleapis.com")
-    @Default.String("https://batch-spanner.googleapis.com")
+        example = "`https://batch-spanner.googleapis.com`")
+    @Default.String("`https://batch-spanner.googleapis.com`")
     ValueProvider<String> getSpannerHost();
 
     void setSpannerHost(ValueProvider<String> value);


### PR DESCRIPTION
Add code markers around the sample URL so that it renders as an example rather than as a URL when it's imported to DevSite.