### PR TITLE
Fixing flaky tests - HttpEventPublisherTest.java

### DIFF
--- a/v1/src/test/java/com/google/cloud/teleport/splunk/HttpEventPublisherTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/splunk/HttpEventPublisherTest.java
@@ -23,9 +23,11 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpContent;
 import com.google.api.client.util.ExponentialBackOff;
+import com.google.cloud.teleport.util.TestUtils;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
+import com.google.gson.JsonArray;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
@@ -123,7 +125,10 @@ public class HttpEventPublisherTest {
             + "\"source\":\"test-source-2\",\"sourcetype\":\"test-source-type-2\","
             + "\"index\":\"test-index-2\",\"event\":\"test-event-2\"}";
 
-    assertThat(expected, is(equalTo(actual)));
+    JsonArray jsonArrayActual = TestUtils.parseJsonArray(actual);
+    JsonArray jsonArrayExpected = TestUtils.parseJsonArray(expected);
+
+    assertThat(jsonArrayExpected, is(equalTo(jsonArrayActual)));
   }
 
   /** Test whether {@link HttpContent} is created from the list of {@link SplunkEvent}s. */
@@ -155,7 +160,9 @@ public class HttpEventPublisherTest {
       HttpContent actualContent = publisher.getContent(SPLUNK_EVENTS);
       actualContent.writeTo(bos);
       String actualString = new String(bos.toByteArray(), StandardCharsets.UTF_8);
-      assertThat(actualString, is(equalTo(expectedString)));
+      JsonArray actualArray = TestUtils.parseJsonArray(actualString);
+      JsonArray expectedArray = TestUtils.parseJsonArray(expectedString);
+      assertThat(actualArray, is(equalTo(expectedArray)));
     }
   }
 

--- a/v1/src/test/java/com/google/cloud/teleport/util/TestUtils.java
+++ b/v1/src/test/java/com/google/cloud/teleport/util/TestUtils.java
@@ -16,6 +16,8 @@
 package com.google.cloud.teleport.util;
 
 import com.google.common.io.ByteStreams;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonStreamParser;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
@@ -71,5 +73,19 @@ public class TestUtils {
     }
 
     return resourceId;
+  }
+
+  /**
+   * Method to parse a string containing a list of json objects into a singular json array.
+   *
+   * @param jsonString The string containing a list of json objects.
+   */
+  public static JsonArray parseJsonArray(String jsonString) {
+    JsonStreamParser parser = new JsonStreamParser(jsonString);
+    JsonArray jsonArray = new JsonArray();
+    while (parser.hasNext()) {
+      jsonArray.add(parser.next());
+    }
+    return jsonArray;
   }
 }


### PR DESCRIPTION
### Description

This pull request is intended to fix flakiness in the test [`com.google.cloud.teleport.splunk.HttpEventPublisherTest#stringPayloadTest`](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/b3460b96473e7a78e495584e07a177448ca53d56/v1/src/test/java/com/google/cloud/teleport/splunk/HttpEventPublisherTest.java#L101)

This flakiness presents itself because the test in question compares a list of JSON objects with another in string format. As the order of key-values in a JSON object is not deterministic, the order of the fields occasionally differs, and hence, the test fails.

This behavior can be reproduced by running the test using the [Nondex](https://github.com/TestingResearchIllinois/NonDex) plugin, when after running the below command 

`mvn -pl v1 edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest="com.google.cloud.teleport.splunk.HttpEventPublisherTest#stringPayloadTest" -DnondexRuns=10
`
the test throws the following error - 

```
[ERROR]   HttpEventPublisherTest.stringPayloadTest:126
Expected: is "{\"source\":\"test-source-1\",\"host\":\"test-host-1\",\"sourcetype\":\"test-source-type-1\",\"time\":12345,\"index\":\"test-index-1\",\"event\":\"test-event-1\"}{\"source\":\"test-source-2\",\"host\":\"test-host-2\",\"sourcetype\":\"test-source-type-2\",\"time\":12345,\"index\":\"test-index-2\",\"event\":\"test-event-2\"}"
     but: was "{\"time\":12345,\"host\":\"test-host-1\",\"source\":\"test-source-1\",\"sourcetype\":\"test-source-type-1\",\"index\":\"test-index-1\",\"event\":\"test-event-1\"}{\"time\":12345,\"host\":\"test-host-2\",\"source\":\"test-source-2\",\"sourcetype\":\"test-source-type-2\",\"index\":\"test-index-2\",\"event\":\"test-event-2\"}"

```
### Fix 

This fix writes a helper method in [com.google.cloud.teleport.util.TestUtils](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/0d01accc1cfa29b762a764bc226496bfde25165c/v1/src/test/java/com/google/cloud/teleport/util/TestUtils.java#L31) that parses the provided Strings and then converts them into `JsonArray `objects that can be compared correctly. This ensures that the comparison accounts for the non-determinism in the order of json key-value pairs.

Please let me know if you'd like to see any more changes!

 EDIT - 
Fixing flaky behaviour in [`com.google.cloud.teleport.splunk.HttpEventPublisherTest#contentTest`](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/b3460b96473e7a78e495584e07a177448ca53d56/v1/src/test/java/com/google/cloud/teleport/splunk/HttpEventPublisherTest.java#L131) using the same fix.

Do let me know if there are any further comments.


