### PR TITLE
Fix node target reference lookup and node match mode

### DIFF
--- a/v2/googlecloud-to-neo4j/pom.xml
+++ b/v2/googlecloud-to-neo4j/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.neo4j.importer</groupId>
       <artifactId>import-spec</artifactId>
-      <version>1.0.0-rc02</version>
+      <version>1.0.0-rc03</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.teleport.v2</groupId>

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/validation/NodeMatchModeValidator.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/validation/NodeMatchModeValidator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.neo4j.model.validation;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.neo4j.importer.v1.targets.RelationshipTarget;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult.Builder;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class NodeMatchModeValidator implements SpecificationValidator {
+
+  private static final String ERROR_CODE = "RNMM-001";
+
+  private final Set<String> paths;
+
+  public NodeMatchModeValidator() {
+    paths = new LinkedHashSet<>();
+  }
+
+  @Override
+  public void visitRelationshipTarget(int index, RelationshipTarget target) {
+    if (target.getNodeMatchMode() == null) {
+      paths.add(String.format("$.targets.relationships[%d].node_match_mode", index));
+    }
+  }
+
+  @Override
+  public boolean report(Builder builder) {
+    paths.forEach(
+        path ->
+            builder.addError(
+                path,
+                ERROR_CODE,
+                String.format("%s is missing: please specify a node match mode", path)));
+    return paths.isEmpty();
+  }
+}

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/templates/GoogleCloudToNeo4j.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/templates/GoogleCloudToNeo4j.java
@@ -274,7 +274,10 @@ public class GoogleCloudToNeo4j {
                     Entry::getKey, mapping(Entry::getValue, Collectors.<PCollection<?>>toList())));
     var sourceRows = new ArrayList<PCollection<?>>(importSpecification.getSources().size());
     var targetRows = new HashMap<TargetType, List<PCollection<?>>>(targetCount());
-    var allActiveNodeTargets = importSpecification.getTargets().getNodes();
+    var allActiveNodeTargets =
+        importSpecification.getTargets().getNodes().stream()
+            .filter(Target::isActive)
+            .collect(toList());
 
     ////////////////////////////
     // Process sources

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/utils/BeamBlock.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/utils/BeamBlock.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.neo4j.utils;
 
 import com.google.cloud.teleport.v2.neo4j.model.enums.ArtifactType;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,7 +82,8 @@ public class BeamBlock {
     executionContexts.put(artifactType.name() + ":" + name, executionContext);
   }
 
-  public PCollection<Row> waitOnCollections(List<String> dependencies, String queuingDescription) {
+  public PCollection<Row> waitOnCollections(
+      Collection<String> dependencies, String queuingDescription) {
     List<PCollection<Row>> waitOnQueues = populateQueueForTargets(dependencies);
     if (waitOnQueues.isEmpty()) {
       waitOnQueues.add(defaultCollection);
@@ -101,7 +103,7 @@ public class BeamBlock {
             Flatten.pCollections());
   }
 
-  private List<PCollection<Row>> populateQueueForTargets(List<String> dependencies) {
+  private List<PCollection<Row>> populateQueueForTargets(Collection<String> dependencies) {
     List<PCollection<Row>> waitOnQueues = new ArrayList<>();
     for (String dependency : dependencies) {
       for (ArtifactType type : ArtifactType.values()) {

--- a/v2/googlecloud-to-neo4j/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
+++ b/v2/googlecloud-to-neo4j/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
@@ -5,3 +5,4 @@ com.google.cloud.teleport.v2.neo4j.model.validation.InlineSourceDataValidator
 com.google.cloud.teleport.v2.neo4j.model.validation.NodeKeyValidator
 com.google.cloud.teleport.v2.neo4j.model.validation.TextColumnMappingValidator
 com.google.cloud.teleport.v2.neo4j.model.validation.WriteModeValidator
+com.google.cloud.teleport.v2.neo4j.model.validation.NodeMatchModeValidator

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/templates/MovieImportIT.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/templates/MovieImportIT.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.neo4j.templates;
+
+import static com.google.cloud.teleport.v2.neo4j.templates.Connections.jsonBasicPayload;
+import static com.google.cloud.teleport.v2.neo4j.templates.Resources.contentOf;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
+
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import net.jcip.annotations.NotThreadSafe;
+import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
+import org.apache.beam.it.common.PipelineLauncher.LaunchInfo;
+import org.apache.beam.it.common.TestProperties;
+import org.apache.beam.it.common.utils.ResourceManagerUtils;
+import org.apache.beam.it.gcp.TemplateTestBase;
+import org.apache.beam.it.neo4j.Neo4jResourceManager;
+import org.apache.beam.it.neo4j.conditions.Neo4jQueryCheck;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@Category(TemplateIntegrationTest.class)
+@TemplateIntegrationTest(GoogleCloudToNeo4j.class)
+@RunWith(JUnit4.class)
+@NotThreadSafe
+public class MovieImportIT extends TemplateTestBase {
+  private Neo4jResourceManager neo4jClient;
+
+  @Before
+  public void setup() {
+    neo4jClient =
+        Neo4jResourceManager.builder(testName)
+            .setAdminPassword("letmein!")
+            .setHost(TestProperties.hostIp())
+            .build();
+  }
+
+  @After
+  public void tearDown() {
+    ResourceManagerUtils.cleanResources(neo4jClient);
+  }
+
+  @Test
+  public void importsMovieGraphFromInlineData() throws IOException {
+    gcsClient.createArtifact(
+        "spec.json", contentOf("/testing-specs/import-spec/movie-import/spec.json"));
+    gcsClient.createArtifact("neo4j.json", jsonBasicPayload(neo4jClient));
+
+    LaunchConfig.Builder options =
+        LaunchConfig.builder(testName, specPath)
+            .addParameter("jobSpecUri", getGcsPath("spec.json"))
+            .addParameter("neo4jConnectionUri", getGcsPath("neo4j.json"));
+    LaunchInfo info = launchTemplate(options);
+
+    assertThatPipeline(info).isRunning();
+    assertThatResult(
+            pipelineOperator()
+                .waitForConditionAndCancel(
+                    createConfig(info),
+                    Neo4jQueryCheck.builder(neo4jClient)
+                        .setQuery("MATCH (n:Person) RETURN count(n) AS count")
+                        .setExpectedResult(List.of(Map.of("count", 4L)))
+                        .build(),
+                    Neo4jQueryCheck.builder(neo4jClient)
+                        .setQuery("MATCH (n:Movie) RETURN count(n) AS count")
+                        .setExpectedResult(List.of(Map.of("count", 2L)))
+                        .build(),
+                    Neo4jQueryCheck.builder(neo4jClient)
+                        .setQuery("MATCH (:Person)-[r:ACTED_IN]->(:Movie) RETURN count(r) AS count")
+                        .setExpectedResult(List.of(Map.of("count", 2L)))
+                        .build(),
+                    Neo4jQueryCheck.builder(neo4jClient)
+                        .setQuery("MATCH (:Person)-[r:DIRECTED]->(:Movie) RETURN count(r) AS count")
+                        .setExpectedResult(List.of(Map.of("count", 2L)))
+                        .build()))
+        .meetsConditions();
+  }
+}

--- a/v2/googlecloud-to-neo4j/src/test/resources/testing-specs/import-spec/movie-import/spec.json
+++ b/v2/googlecloud-to-neo4j/src/test/resources/testing-specs/import-spec/movie-import/spec.json
@@ -8,10 +8,10 @@
       "type": "text",
       "name": "persons",
       "data": [
-        ["3","Legendary Hollywood Icon Harrison Ford...","1942-07-13","Chicago, Illinois, USA","","148","Harrison Ford","https://image.tmdb.org/t/p/w440_and_h660_face/5M7oN3sznp99hWYQ9sX0xheswWX.jpg","https://themoviedb.org/person/3"],
-        ["31","Thomas Jeffrey Hanks (born July 9, 1956) is an American actor and filmmaker...","1956-07-09","Concord, California, USA","","158","Tom Hanks","https://image.tmdb.org/t/p/w440_and_h660_face/mKr8PN8sn80LzVaZMg8L52kmakm.jpg","https://themoviedb.org/person/31"],
-        ["2226","Sydney Irwin Pollack was an American film director, producer and actor...","1934-07-01","Lafayette, Indiana, USA","2008-05-26","1628","Sydney Pollack","https://image.tmdb.org/t/p/w440_and_h660_face/dbbMGZ2CWqlTuHD09KpoZdxKyI2.jpg","https://themoviedb.org/person/2226"],
-        ["7879","John Alan Lasseter is an American animator, director and the chief creative officer at Pixar and Walt Disney Animation Studios...","1957-01-12","Hollywood, California, USA","","5124","John Lasseter","https://image.tmdb.org/t/p/w440_and_h660_face/snqz1JZY3xPzZF1PqFUgxzpv2sN.jpg","https://themoviedb.org/person/7879"]
+        ["1","Legendary Hollywood Icon Harrison Ford...","1942-07-13","Chicago, Illinois, USA","","148","Harrison Ford","https://image.tmdb.org/t/p/w440_and_h660_face/5M7oN3sznp99hWYQ9sX0xheswWX.jpg","https://themoviedb.org/person/3"],
+        ["2","Thomas Jeffrey Hanks (born July 9, 1956) is an American actor and filmmaker...","1956-07-09","Concord, California, USA","","158","Tom Hanks","https://image.tmdb.org/t/p/w440_and_h660_face/mKr8PN8sn80LzVaZMg8L52kmakm.jpg","https://themoviedb.org/person/31"],
+        ["3","Sydney Irwin Pollack was an American film director, producer and actor...","1934-07-01","Lafayette, Indiana, USA","2008-05-26","1628","Sydney Pollack","https://image.tmdb.org/t/p/w440_and_h660_face/dbbMGZ2CWqlTuHD09KpoZdxKyI2.jpg","https://themoviedb.org/person/2226"],
+        ["4","John Alan Lasseter is an American animator, director and the chief creative officer at Pixar and Walt Disney Animation Studios...","1957-01-12","Hollywood, California, USA","","5124","John Lasseter","https://image.tmdb.org/t/p/w440_and_h660_face/snqz1JZY3xPzZF1PqFUgxzpv2sN.jpg","https://themoviedb.org/person/7879"]
       ],
       "format": "excel",
       "header": ["person_tmdbId","bio","born","bornIn","died","person_imdbId","name","person_poster","person_url"]
@@ -21,7 +21,7 @@
       "name": "movies",
       "data": [
         ["1","Toy Story","30000000.0","USA","114709","8.3","591836","English","A cowboy doll is profoundly threatened...",",https://image.tmdb.org/t/p/w440_and_h660_face/uXDfjJbdP4ijW5hWSBrPrlKpxab.jpg","1995-11-22","373554033.0","81","862","https://themoviedb.org/movie/862","1995","Adventure|Animation|Children|Comedy|Fantasy"],
-        ["7","Sabrina","58000000.0","Germany|USA","114319","6.2","29091","English|French","An ugly duckling having undergone a remarkable change...","https://image.tmdb.org/t/p/w440_and_h660_face/z1oNjotUI7D06J4LWQFQzdIuPnf.jpg","1995-12-15","53672080.0","127","11860","https://themoviedb.org/movie/11860","1995","Comedy|Romance"]
+        ["2","Sabrina","58000000.0","Germany|USA","114319","6.2","29091","English|French","An ugly duckling having undergone a remarkable change...","https://image.tmdb.org/t/p/w440_and_h660_face/z1oNjotUI7D06J4LWQFQzdIuPnf.jpg","1995-12-15","53672080.0","127","11860","https://themoviedb.org/movie/11860","1995","Comedy|Romance"]
       ],
       "format": "excel",
       "header": ["movieId","title","budget","countries","movie_imdbId","imdbRating","imdbVotes","languages","plot","movie_poster","released","revenue","runtime","movie_tmdbId","movie_url","year","genres"]
@@ -29,22 +29,22 @@
     {
       "type": "text",
       "name": "directed",
+      "header": ["movieId","person_tmdbId"],
       "data": [
-        ["1","7879"],
-        ["7","2226"]
+        ["1","4"],
+        ["2","3"]
       ],
-      "format": "excel",
-      "header": ["movieId","person_tmdbId"]
+      "format": "excel"
     },
     {
       "type": "text",
       "name": "acted_in",
+      "header": ["movieId","person_tmdbId","role"],
       "data": [
-        ["1","31","Woody (voice)"],
-        ["7","3","Linus Larrabee"]
+        ["1","2","Woody (voice)"],
+        ["2","1","Linus Larrabee"]
       ],
-      "format": "excel",
-      "header": ["movieId","person_tmdbId","role"]
+      "format": "excel"
     }
   ],
   "targets": {
@@ -52,25 +52,22 @@
       {
         "source": "persons",
         "name": "Persons",
-        "write_mode": "merge",
+        "write_mode": "create",
         "labels": [
           "Person"
         ],
         "properties": [
           {
             "source_field": "person_tmdbId",
-            "target_property": "id",
-            "target_property_type": "string"
+            "target_property": "id"
           },
           {
             "source_field": "name",
-            "target_property": "name",
-            "target_property_type": "string"
+            "target_property": "name"
           },
           {
             "source_field": "bornIn",
-            "target_property": "bornLocation",
-            "target_property_type": "string"
+            "target_property": "bornLocation"
           }
         ],
         "schema": {
@@ -97,30 +94,26 @@
       {
         "source": "movies",
         "name": "Movies",
-        "write_mode": "merge",
+        "write_mode": "create",
         "labels": [
           "Movie"
         ],
         "properties": [
           {
             "source_field": "movieId",
-            "target_property": "id",
-            "target_property_type": "string"
+            "target_property": "id"
           },
           {
             "source_field": "title",
-            "target_property": "title",
-            "target_property_type": "string"
+            "target_property": "title"
           },
           {
             "source_field": "year",
-            "target_property": "releaseYear",
-            "target_property_type": "string"
+            "target_property": "releaseYear"
           },
           {
             "source_field": "imdbRating",
-            "target_property": "imdbRating",
-            "target_property_type": "float"
+            "target_property": "imdbRating"
           }
         ],
         "schema": {
@@ -150,7 +143,7 @@
         "source": "directed",
         "name": "Directed",
         "type": "DIRECTED",
-        "write_mode": "merge",
+        "write_mode": "create",
         "node_match_mode": "match",
         "start_node_reference": "Persons",
         "end_node_reference": "Movies"
@@ -159,15 +152,14 @@
         "source": "acted_in",
         "name": "Acted_in",
         "type": "ACTED_IN",
-        "write_mode": "merge",
+        "write_mode": "create",
         "node_match_mode": "match",
         "start_node_reference": "Persons",
         "end_node_reference": "Movies",
         "properties": [
           {
             "source_field": "role",
-            "target_property": "role",
-            "target_property_type": "string"
+            "target_property": "role"
           }
         ]
       }

--- a/v2/googlecloud-to-neo4j/src/test/resources/testing-specs/import-spec/movie-import/spec.json
+++ b/v2/googlecloud-to-neo4j/src/test/resources/testing-specs/import-spec/movie-import/spec.json
@@ -1,0 +1,176 @@
+{
+  "version": "1",
+  "config": {
+    "reset_db": true
+  },
+  "sources": [
+    {
+      "type": "text",
+      "name": "persons",
+      "data": [
+        ["3","Legendary Hollywood Icon Harrison Ford...","1942-07-13","Chicago, Illinois, USA","","148","Harrison Ford","https://image.tmdb.org/t/p/w440_and_h660_face/5M7oN3sznp99hWYQ9sX0xheswWX.jpg","https://themoviedb.org/person/3"],
+        ["31","Thomas Jeffrey Hanks (born July 9, 1956) is an American actor and filmmaker...","1956-07-09","Concord, California, USA","","158","Tom Hanks","https://image.tmdb.org/t/p/w440_and_h660_face/mKr8PN8sn80LzVaZMg8L52kmakm.jpg","https://themoviedb.org/person/31"],
+        ["2226","Sydney Irwin Pollack was an American film director, producer and actor...","1934-07-01","Lafayette, Indiana, USA","2008-05-26","1628","Sydney Pollack","https://image.tmdb.org/t/p/w440_and_h660_face/dbbMGZ2CWqlTuHD09KpoZdxKyI2.jpg","https://themoviedb.org/person/2226"],
+        ["7879","John Alan Lasseter is an American animator, director and the chief creative officer at Pixar and Walt Disney Animation Studios...","1957-01-12","Hollywood, California, USA","","5124","John Lasseter","https://image.tmdb.org/t/p/w440_and_h660_face/snqz1JZY3xPzZF1PqFUgxzpv2sN.jpg","https://themoviedb.org/person/7879"]
+      ],
+      "format": "excel",
+      "header": ["person_tmdbId","bio","born","bornIn","died","person_imdbId","name","person_poster","person_url"]
+    },
+    {
+      "type": "text",
+      "name": "movies",
+      "data": [
+        ["1","Toy Story","30000000.0","USA","114709","8.3","591836","English","A cowboy doll is profoundly threatened...",",https://image.tmdb.org/t/p/w440_and_h660_face/uXDfjJbdP4ijW5hWSBrPrlKpxab.jpg","1995-11-22","373554033.0","81","862","https://themoviedb.org/movie/862","1995","Adventure|Animation|Children|Comedy|Fantasy"],
+        ["7","Sabrina","58000000.0","Germany|USA","114319","6.2","29091","English|French","An ugly duckling having undergone a remarkable change...","https://image.tmdb.org/t/p/w440_and_h660_face/z1oNjotUI7D06J4LWQFQzdIuPnf.jpg","1995-12-15","53672080.0","127","11860","https://themoviedb.org/movie/11860","1995","Comedy|Romance"]
+      ],
+      "format": "excel",
+      "header": ["movieId","title","budget","countries","movie_imdbId","imdbRating","imdbVotes","languages","plot","movie_poster","released","revenue","runtime","movie_tmdbId","movie_url","year","genres"]
+    },
+    {
+      "type": "text",
+      "name": "directed",
+      "data": [
+        ["1","7879"],
+        ["7","2226"]
+      ],
+      "format": "excel",
+      "header": ["movieId","person_tmdbId"]
+    },
+    {
+      "type": "text",
+      "name": "acted_in",
+      "data": [
+        ["1","31","Woody (voice)"],
+        ["7","3","Linus Larrabee"]
+      ],
+      "format": "excel",
+      "header": ["movieId","person_tmdbId","role"]
+    }
+  ],
+  "targets": {
+    "nodes": [
+      {
+        "source": "persons",
+        "name": "Persons",
+        "write_mode": "merge",
+        "labels": [
+          "Person"
+        ],
+        "properties": [
+          {
+            "source_field": "person_tmdbId",
+            "target_property": "id",
+            "target_property_type": "string"
+          },
+          {
+            "source_field": "name",
+            "target_property": "name",
+            "target_property_type": "string"
+          },
+          {
+            "source_field": "bornIn",
+            "target_property": "bornLocation",
+            "target_property_type": "string"
+          }
+        ],
+        "schema": {
+          "key_constraints": [
+            {
+              "name": "personIdKey",
+              "label": "Person",
+              "properties": [
+                "id"
+              ]
+            }
+          ],
+          "unique_constraints": [
+            {
+              "name": "personNameUnique",
+              "label": "Person",
+              "properties": [
+                "name"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "source": "movies",
+        "name": "Movies",
+        "write_mode": "merge",
+        "labels": [
+          "Movie"
+        ],
+        "properties": [
+          {
+            "source_field": "movieId",
+            "target_property": "id",
+            "target_property_type": "string"
+          },
+          {
+            "source_field": "title",
+            "target_property": "title",
+            "target_property_type": "string"
+          },
+          {
+            "source_field": "year",
+            "target_property": "releaseYear",
+            "target_property_type": "string"
+          },
+          {
+            "source_field": "imdbRating",
+            "target_property": "imdbRating",
+            "target_property_type": "float"
+          }
+        ],
+        "schema": {
+          "key_constraints": [
+            {
+              "name": "movieIdKey",
+              "label": "Movie",
+              "properties": [
+                "id"
+              ]
+            }
+          ],
+          "unique_constraints": [
+            {
+              "name": "movieTitleUnique",
+              "label": "Movie",
+              "properties": [
+                "title"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "relationships": [
+      {
+        "source": "directed",
+        "name": "Directed",
+        "type": "DIRECTED",
+        "write_mode": "merge",
+        "node_match_mode": "match",
+        "start_node_reference": "Persons",
+        "end_node_reference": "Movies"
+      },
+      {
+        "source": "acted_in",
+        "name": "Acted_in",
+        "type": "ACTED_IN",
+        "write_mode": "merge",
+        "node_match_mode": "match",
+        "start_node_reference": "Persons",
+        "end_node_reference": "Movies",
+        "properties": [
+          {
+            "source_field": "role",
+            "target_property": "role",
+            "target_property_type": "string"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Make node match mode mandatory.

Look up all active node targets when resolving start/end node
target references, not just the active node targets sharing the
relationship target's source.

---

~Note: for the e2e test to pass, https://github.com/neo4j/import-spec/pull/153 needs to be merged and released.~

EDIT: merge & release done