### PR TITLE
Fixing Flaky tests

### DIFF
--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/spanner/SpannerResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/spanner/SpannerResourceManager.java
@@ -318,7 +318,7 @@ public final class SpannerResourceManager implements ResourceManager {
                           instanceId, databaseId, statements, /* operationId= */ null)
                       .get());
       LOG.info("Successfully executed DDL statements '{}' on database {}.", statements, databaseId);
-    } catch (SpannerException e) {
+    } catch (Exception e) {
       throw new SpannerResourceManagerException("Failed to execute statement.", e);
     }
   }

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/spanner/SpannerResourceManagerTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/spanner/SpannerResourceManagerTest.java
@@ -155,8 +155,7 @@ public final class SpannerResourceManagerTest {
             + ") PRIMARY KEY (SingerId)";
 
     // act & assert
-    assertThrows(
-        FailsafeException.class, () -> testManager.executeDdlStatement(statement));
+    assertThrows(FailsafeException.class, () -> testManager.executeDdlStatement(statement));
   }
 
   @Test

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/spanner/SpannerResourceManagerTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/spanner/SpannerResourceManagerTest.java
@@ -43,6 +43,7 @@ import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.Struct;
 import com.google.common.collect.ImmutableList;
+import dev.failsafe.FailsafeException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -155,7 +156,7 @@ public final class SpannerResourceManagerTest {
 
     // act & assert
     assertThrows(
-        SpannerResourceManagerException.class, () -> testManager.executeDdlStatement(statement));
+        FailsafeException.class, () -> testManager.executeDdlStatement(statement));
   }
 
   @Test

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/spanner/SpannerResourceManagerTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/spanner/SpannerResourceManagerTest.java
@@ -43,7 +43,6 @@ import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.Struct;
 import com.google.common.collect.ImmutableList;
-import dev.failsafe.FailsafeException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -155,7 +154,8 @@ public final class SpannerResourceManagerTest {
             + ") PRIMARY KEY (SingerId)";
 
     // act & assert
-    assertThrows(FailsafeException.class, () -> testManager.executeDdlStatement(statement));
+    assertThrows(
+        SpannerResourceManagerException.class, () -> testManager.executeDdlStatement(statement));
   }
 
   @Test
@@ -181,6 +181,50 @@ public final class SpannerResourceManagerTest {
     verify(spanner.getInstanceAdminClient(), times(2)).createInstance(any());
     verify(spanner.getDatabaseAdminClient(), times(2)).createDatabase(any(), any());
     verify(spanner.getDatabaseAdminClient(), times(2))
+        .updateDatabaseDdl(
+            instanceIdCaptor.capture(),
+            databaseIdCaptor.capture(),
+            statementCaptor.capture(),
+            any());
+
+    String actualInstanceId = instanceIdCaptor.getValue();
+    String actualDatabaseId = databaseIdCaptor.getValue();
+    Iterable<String> actualStatement = statementCaptor.getValue();
+
+    assertThat(actualInstanceId).matches(TEST_ID + "-\\d{8}-\\d{6}-[a-zA-Z0-9]{6}");
+
+    assertThat(actualDatabaseId).matches(TEST_ID + "_\\d{8}_\\d{6}_[a-zA-Z0-9]{6}");
+    assertThat(actualStatement).containsExactlyElementsIn(ImmutableList.of(statement));
+  }
+
+  @Test
+  public void testExecuteDdlStatementShouldRetryOnResourceExhaustedError()
+      throws ExecutionException, InterruptedException {
+    //   arrange
+    prepareCreateInstanceMock();
+    prepareCreateDatabaseMock();
+    String statement =
+        "CREATE TABLE Singers (\n"
+            + "  SingerId   INT64 NOT NULL,\n"
+            + "  FirstName  STRING(1024),\n"
+            + "  LastName   STRING(1024),\n"
+            + ") PRIMARY KEY (SingerId)";
+
+    RuntimeException resourceExhaustedException =
+        new RuntimeException(
+            "com.google.cloud.spanner.SpannerException: RESOURCE_EXHAUSTED: io.grpc.StatusRuntimeException: RESOURCE_EXHAUSTED: CPU overload detected");
+    when(spanner.getDatabaseAdminClient().updateDatabaseDdl(any(), any(), any(), any()).get())
+        .thenThrow(resourceExhaustedException)
+        .thenReturn(null);
+
+    // act
+    testManager.executeDdlStatement(statement);
+
+    // assert
+    // verify createInstance, createDatabase, and updateDatabaseDdl were called.
+    verify(spanner.getInstanceAdminClient(), times(2)).createInstance(any());
+    verify(spanner.getDatabaseAdminClient(), times(2)).createDatabase(any(), any());
+    verify(spanner.getDatabaseAdminClient(), times(3))
         .updateDatabaseDdl(
             instanceIdCaptor.capture(),
             databaseIdCaptor.capture(),

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerDDLIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerDDLIT.java
@@ -176,6 +176,12 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Assert Conditions
     assertThatResult(result).meetsConditions();
 
+    // Sleep for cutover time to wait till all CDCs propagate.
+    // A real world customer also has a small cut over time to reach consistency.
+    try {
+      Thread.sleep(CUTOVER_MILLIS);
+    } catch (InterruptedException e) {
+    }
     assertAllDatatypeColumnsTableCdcContents();
   }
 
@@ -228,7 +234,12 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
-
+    // Sleep for cutover time to wait till all CDCs propagate.
+    // A real world customer also has a small cut over time to reach consistency.
+    try {
+      Thread.sleep(CUTOVER_MILLIS);
+    } catch (InterruptedException e) {
+    }
     assertAllDatatypeColumns2TableCdcContents();
   }
 
@@ -281,7 +292,12 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
-
+    // Sleep for cutover time to wait till all CDCs propagate.
+    // A real world customer also has a small cut over time to reach consistency.
+    try {
+      Thread.sleep(CUTOVER_MILLIS);
+    } catch (InterruptedException e) {
+    }
     assertAllDatatypeTransformationTableCdcContents();
   }
 

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerEventsIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerEventsIT.java
@@ -156,6 +156,12 @@ public class DataStreamToSpannerEventsIT extends DataStreamToSpannerITBase {
     // Assert Conditions
     assertThatResult(result).meetsConditions();
 
+    // Sleep for cutover time to wait till all CDCs propagate.
+    // A real world customer also has a small cut over time to reach consistency.
+    try {
+      Thread.sleep(CUTOVER_MILLIS);
+    } catch (InterruptedException e) {
+    }
     // Assert specific rows
     assertUsersTableContents();
   }

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerIT.java
@@ -62,18 +62,15 @@ import org.apache.beam.it.jdbc.JDBCResourceManager;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.junit.runners.MethodSorters;
 
 /** Integration test for {@link DataStreamToSpanner} Flex template. */
 @Category({TemplateIntegrationTest.class, SkipDirectRunnerTest.class})
 @TemplateIntegrationTest(DataStreamToSpanner.class)
 @RunWith(JUnit4.class)
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class DataStreamToSpannerIT extends TemplateTestBase {
 
   enum JDBCType {

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerIT.java
@@ -181,7 +181,7 @@ public class DataStreamToSpannerIT extends TemplateTestBase {
   }
 
   @Test
-  public void testDataStreamOracleToSpannerStaging() throws IOException {
+  public void testDataStreamAracleToSpannerStaging() throws IOException {
     // Run a simple IT
     simpleOracleToSpannerTest(
         DatastreamResourceManager.DestinationOutputFormat.AVRO_FILE_FORMAT,
@@ -251,7 +251,7 @@ public class DataStreamToSpannerIT extends TemplateTestBase {
   }
 
   @Test
-  public void testDataStreamOracleToSpannerJsonStaging() throws IOException {
+  public void testDataStreamAracleToSpannerJsonStaging() throws IOException {
     // Run a simple IT
     simpleOracleToSpannerTest(
         DatastreamResourceManager.DestinationOutputFormat.JSON_FILE_FORMAT,

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerIT.java
@@ -62,15 +62,18 @@ import org.apache.beam.it.jdbc.JDBCResourceManager;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.junit.runners.MethodSorters;
 
 /** Integration test for {@link DataStreamToSpanner} Flex template. */
 @Category({TemplateIntegrationTest.class, SkipDirectRunnerTest.class})
 @TemplateIntegrationTest(DataStreamToSpanner.class)
 @RunWith(JUnit4.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class DataStreamToSpannerIT extends TemplateTestBase {
 
   enum JDBCType {
@@ -181,7 +184,7 @@ public class DataStreamToSpannerIT extends TemplateTestBase {
   }
 
   @Test
-  public void testDataStreamAracleToSpannerStaging() throws IOException {
+  public void testDataStreamOracleToSpannerStaging() throws IOException {
     // Run a simple IT
     simpleOracleToSpannerTest(
         DatastreamResourceManager.DestinationOutputFormat.AVRO_FILE_FORMAT,
@@ -251,7 +254,7 @@ public class DataStreamToSpannerIT extends TemplateTestBase {
   }
 
   @Test
-  public void testDataStreamAracleToSpannerJsonStaging() throws IOException {
+  public void testDataStreamOracleToSpannerJsonStaging() throws IOException {
     // Run a simple IT
     simpleOracleToSpannerTest(
         DatastreamResourceManager.DestinationOutputFormat.JSON_FILE_FORMAT,

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerITBase.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerITBase.java
@@ -47,6 +47,7 @@ public abstract class DataStreamToSpannerITBase extends TemplateTestBase {
   // Format of avro file path in GCS - {table}/2023/12/20/06/57/{fileName}
   public static final String DATA_STREAM_EVENT_FILES_PATH_FORMAT_IN_GCS = "%s/2023/12/20/06/57/%s";
   private static final Logger LOG = LoggerFactory.getLogger(DataStreamToSpannerITBase.class);
+  public static final int CUTOVER_MILLIS = 30 * 1000;
 
   public PubsubResourceManager setUpPubSubResourceManager() throws IOException {
     return PubsubResourceManager.builder(testName, PROJECT, credentialsProvider).build();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerSessionIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerSessionIT.java
@@ -161,6 +161,12 @@ public class DataStreamToSpannerSessionIT extends DataStreamToSpannerITBase {
     // Assert Conditions
     assertThatResult(result).meetsConditions();
 
+    // Sleep for cutover time to wait till all CDCs propagate.
+    // A real world customer also has a small cut over time to reach consistency.
+    try {
+      Thread.sleep(CUTOVER_MILLIS);
+    } catch (InterruptedException e) {
+    }
     assertCategoryTableCdcContents();
   }
 

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerShardedMigrationWithMigrationShardIdColumnIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerShardedMigrationWithMigrationShardIdColumnIT.java
@@ -74,7 +74,6 @@ public class DataStreamToSpannerShardedMigrationWithMigrationShardIdColumnIT
 
   private static final String SPANNER_DDL_RESOURCE =
       "DataStreamToSpannerShardedMigrationWithMigrationShardIdColumnIT/spanner-schema.sql";
-  public static final int CUTOVER_MILLIS = 30 * 1000;
 
   private static HashSet<DataStreamToSpannerShardedMigrationWithMigrationShardIdColumnIT>
       testInstances = new HashSet<>();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerShardedMigrationWithoutMigrationShardIdColumnIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerShardedMigrationWithoutMigrationShardIdColumnIT.java
@@ -217,6 +217,12 @@ public class DataStreamToSpannerShardedMigrationWithoutMigrationShardIdColumnIT
             .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(10)), rowsConditionCheck);
     assertThatResult(result).meetsConditions();
 
+    // Sleep for cutover time to wait till all CDCs propagate.
+    // A real world customer also has a small cut over time to reach consistency.
+    try {
+      Thread.sleep(CUTOVER_MILLIS);
+    } catch (InterruptedException e) {
+    }
     // Assert specific rows
     assertUsersTableContents();
   }

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DatastreamToSpannerSingleDFShardedMigrationIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DatastreamToSpannerSingleDFShardedMigrationIT.java
@@ -185,6 +185,12 @@ public class DatastreamToSpannerSingleDFShardedMigrationIT extends DataStreamToS
             .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(10)), rowsConditionCheck);
     assertThatResult(result).meetsConditions();
 
+    // Sleep for cutover time to wait till all CDCs propagate.
+    // A real world customer also has a small cut over time to reach consistency.
+    try {
+      Thread.sleep(CUTOVER_MILLIS);
+    } catch (InterruptedException e) {
+    }
     // Assert specific rows
     assertUsersTableContents();
   }


### PR DESCRIPTION
**Overview of Fix**
1. Introducing 30 seconds of cut-over time delay for all the tests which have cdc events.
2. Introducing retry in createSpannerDdl in SpannerResourceManager.