### PR TITLE
Force users to add labels for release note generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: minimum
+          count: 1
+          labels: |
+            ignore-for-release
+            new-template
+            improvement
+            bug-fix
+          add_comment: true
+          message: "This PR is being prevented from merging because you have not added any of the following labels: [ignore-for-release, new-template, improvement, bug-fix]. You'll need to add one before this PR can be merged so that these can be used for release notes."

--- a/.github/workflows/release-notes-labels.yml
+++ b/.github/workflows/release-notes-labels.yml
@@ -19,4 +19,4 @@ jobs:
             improvement
             bug-fix
           add_comment: true
-          message: "This PR is being prevented from merging because you have not added any of the following labels: [ignore-for-release, new-template, improvement, bug-fix]. You'll need to add one before this PR can be merged so that these can be used for release notes."
+          message: "This PR is being prevented from merging because you have not added any of the following labels: [ignore-for-release, new-template, improvement, bug-fix]. You'll need to add one before this PR can be merged so that these can be used for release notes. For more information, see https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/contributor-docs/code-contributions.md#release-notes"

--- a/.github/workflows/release-notes-labels.yml
+++ b/.github/workflows/release-notes-labels.yml
@@ -1,4 +1,4 @@
-name: Pull Request Labels
+name: Enforce labels for release notes
 on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
@@ -9,7 +9,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: mheap/github-action-required-labels@v5
+      - uses: mheap/github-action-required-labels@d25134c992b943fb6ad00c25ea00eb5988c0a9dd
         with:
           mode: minimum
           count: 1

--- a/contributor-docs/code-contributions.md
+++ b/contributor-docs/code-contributions.md
@@ -439,3 +439,9 @@ keep [Google-provided Templates](https://cloud.google.com/dataflow/docs/guides/t
 updated with latest fixes and improvements.
 
 To learn more about this process, or how you can stage your own changes, see [Release Process](./release-process.md).
+
+### Release Notes
+
+Release notes are [automatically generated](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)
+based on the PR labels defined in [release.yml](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/.github/release.yml).
+Before submitting your PR, a repo maintainer must add one of the following labels in order for all checks to pass: `ignore-for-release`, `new-template`, `improvement`, or `bug-fix`.


### PR DESCRIPTION
This will force PRs to have one of the labels used to generate release notes. Follow up to https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/1969

Part of https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/1968