### PR TITLE
Don't comment on pull requests

### DIFF
--- a/.github/workflows/release-notes-labels.yml
+++ b/.github/workflows/release-notes-labels.yml
@@ -18,5 +18,4 @@ jobs:
             new-template
             improvement
             bug-fix
-          add_comment: true
           message: "This PR is being prevented from merging because you have not added any of the following labels: [ignore-for-release, new-template, improvement, bug-fix]. You'll need to add one before this PR can be merged so that these can be used for release notes. For more information, see https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/contributor-docs/code-contributions.md#release-notes"


### PR DESCRIPTION
This seems to be breaking the flow, this way the check itself can still run (example failure - https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/runs/11579053939/job/32234587610)

Not sure why there aren't sufficient permissions here

Example success after this change - https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/runs/11579265741/job/32235047020?pr=1973