### PR TITLE
Escaping column names to handle reserved keywords

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
@@ -347,9 +347,21 @@ public final class JdbcIoWrapper implements IoWrapper {
     }
   }
 
+  /**
+   * Delimit the Column Names as per <a
+   * href=https://github.com/ronsavage/SQL/blob/master/sql-99.bnf>sql-99</a>.
+   *
+   * @param columnName
+   * @return
+   */
+  @VisibleForTesting
+  protected static String delimitColumnName(String columnName) {
+    return "\"" + columnName.replaceAll("\"", "\"\"") + "\"";
+  }
+
   private static PartitionColumn partitionColumnFromIndexInfo(SourceColumnIndexInfo idxInfo) {
     return PartitionColumn.builder()
-        .setColumnName(idxInfo.columnName())
+        .setColumnName(delimitColumnName(idxInfo.columnName()))
         .setColumnClass(indexTypeToColumnClass(idxInfo))
         .setStringCollation(idxInfo.collationReference())
         .setStringMaxLength(idxInfo.stringMaxLength())

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/Boundary.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/Boundary.java
@@ -146,7 +146,7 @@ public abstract class Boundary<T extends Serializable>
    */
   public boolean isSplittable(@Nullable ProcessContext processContext) {
     T mid = splitPoint(processContext);
-    return !(end().equals(mid)) && !(start().equals(mid));
+    return !(Objects.equal(end(), mid)) && !(Objects.equal(start(), mid));
   }
 
   /**

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
@@ -466,4 +466,10 @@ public class JdbcIoWrapperTest {
                     .setIsUnique(true)
                     .build()));
   }
+
+  @Test
+  public void testColumnNameEscaping() {
+    assertThat(JdbcIoWrapper.delimitColumnName("key")).isEqualTo("\"key\"");
+    assertThat(JdbcIoWrapper.delimitColumnName("ke\"y")).isEqualTo("\"ke\"\"y\"");
+  }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryExtractorFactoryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryExtractorFactoryTest.java
@@ -96,15 +96,24 @@ public class BoundaryExtractorFactoryTest {
         PartitionColumn.builder().setColumnName("col1").setColumnClass(BigInteger.class).build();
     BoundaryExtractor<BigInteger> extractor = BoundaryExtractorFactory.create(BigInteger.class);
     when(mockResultSet.next()).thenReturn(true);
-    when(mockResultSet.getBigDecimal(1)).thenReturn(new BigDecimal(BigInteger.ZERO));
+    when(mockResultSet.getBigDecimal(1))
+        .thenReturn(new BigDecimal(BigInteger.ZERO))
+        .thenReturn(null);
     // BigInt Unsigned Max in MySQL
-    when(mockResultSet.getBigDecimal(2)).thenReturn(new BigDecimal(unsignedBigIntMax));
-    Boundary<BigInteger> boundary = extractor.getBoundary(partitionColumn, mockResultSet, null);
+    when(mockResultSet.getBigDecimal(2))
+        .thenReturn(new BigDecimal(unsignedBigIntMax))
+        .thenReturn(null);
+    Boundary<BigInteger> boundaryMinMax =
+        extractor.getBoundary(partitionColumn, mockResultSet, null);
+    Boundary<BigInteger> boundaryNull = extractor.getBoundary(partitionColumn, mockResultSet, null);
 
-    assertThat(boundary.start()).isEqualTo(BigInteger.ZERO);
-    assertThat(boundary.end()).isEqualTo(unsignedBigIntMax);
-    assertThat(boundary.split(null).getLeft().end())
+    assertThat(boundaryMinMax.start()).isEqualTo(BigInteger.ZERO);
+    assertThat(boundaryMinMax.end()).isEqualTo(unsignedBigIntMax);
+    assertThat(boundaryMinMax.split(null).getLeft().end())
         .isEqualTo((unsignedBigIntMax.divide(BigInteger.TWO)));
+    assertThat(boundaryNull.start()).isNull();
+    assertThat(boundaryNull.end()).isNull();
+    assertThat(boundaryNull.isSplittable(null)).isFalse();
     // Mismatched Type
     assertThrows(
         IllegalArgumentException.class,


### PR DESCRIPTION
#Overview
1. Escaping column names to handle reserved keywords #1979
2. Addition of UT for the bigInt fix.

TODO:
Integration test for these changes will be taken up as a follow on.