### PR TITLE
Fixing flaky test case in BulkDecompressor.java

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/templates/BulkDecompressor.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/BulkDecompressor.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -132,10 +132,10 @@ public class BulkDecompressor {
    * Compression#UNCOMPRESSED}.
    */
   @VisibleForTesting
-  static final Set<Compression> SUPPORTED_COMPRESSIONS =
+  static final List<Compression> SUPPORTED_COMPRESSIONS =
       Stream.of(Compression.values())
           .filter(value -> value != Compression.AUTO && value != Compression.UNCOMPRESSED)
-          .collect(Collectors.toSet());
+          .collect(Collectors.toList());
 
   /** The error msg given when the pipeline matches a file but cannot determine the compression. */
   @VisibleForTesting


### PR DESCRIPTION
### Description

This Pull Request is meant to fix flakiness in the test [BulkDecompressorTest.testDecompressUnknownCompressionFile()](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/0d01accc1cfa29b762a764bc226496bfde25165c/v1/src/test/java/com/google/cloud/teleport/templates/BulkDecompressorTest.java#L215)

The provided test is intermittently failing because it is doing a direct String comparison, in which the elements of a set are being printed in an error message. Since the order of the elements in a set is non-deterministic, the expected String is not matching the actual String. The following code is inducing the flakiness, where the `BulkDecomopressor.SUPPORTED_COMPRESSIONS` is a `Set` of supported compression types.

```
assertThat(
                  kv.getValue(),
                  containsString(
                      String.format(
                          BulkDecompressor.UNCOMPRESSED_ERROR_MSG,
                          unknownCompressionFile.toString(),
                          BulkDecompressor.SUPPORTED_COMPRESSIONS)));
```

The described issue can be reproduced by running the test using the [nondex](https://github.com/TestingResearchIllinois/NonDex) plugin, with the following command - 

`mvn -pl v1 edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest="com.google.cloud.teleport.templates.BulkDecompressorTest"`

which occasionally throws the error - 

```
[ERROR] Failures: 
[ERROR]   BulkDecompressorTest.testDecompressUnknownCompressionFile:237 Decompress.out1: 
Expected: a string containing "Skipping file <sample_filename> because it did not match any compression mode ([SNAPPY, ZSTD, ZIP, BZIP2, LZO, DEFLATE, LZOP, GZIP])"
     but: was "Skipping file <sample_filename> because it did not match any compression mode ([GZIP, DEFLATE, LZO, ZIP, ZSTD, SNAPPY, LZOP, BZIP2])"

```

### Fix

The provided fix changes the type of the [SUPPORTED_COMPRESSIONS](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/02a78dd78d86397ddb88504ee8669fb867621191/v1/src/main/java/com/google/cloud/teleport/templates/BulkDecompressor.java#L135) from `java.util.Set` to `java.util.List`. Since the set has been converted into a list, the ordering of the elements is deterministic, and hence the flakiness has been removed.

I'd love to get feedback on this pull request. Please let me know if you'd like to see any changes!
