### PR TITLE
fix release staging

### DIFF
--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
@@ -1165,7 +1165,7 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
             directory,
             cloudBuildLogs);
 
-    // Ideally this should raise an exception, but in GitHub Actions this returns NZE even for
+    // Ideally this should raise an exception, but this returns NZE even for
     // successful runs.
     if (stageProcess.waitFor() != 0) {
       LOG.warn(
@@ -1263,9 +1263,10 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
             buildDir,
             cloudBuildLogs);
 
+    // Ideally this should raise an exception, but this returns NZE even for
+    // successful runs.
     if (stageProcess.waitFor() != 0) {
-      throw new IllegalStateException(
-          "Error scanning container. Check logs for details. " + cloudBuildLogs);
+      LOG.warn("Error scanning container. Check logs for details. " + cloudBuildLogs);
     }
   }
 


### PR DESCRIPTION
The release is failing to stage because for some reason Cloud Build commands always return non-zero exit code when run as java subprocess (even when successful). This PR refactors the recently added cloud build command from throwing an exception to logging a WARN.