### PR TITLE
Add TOKENLIST spanner type

### DIFF
--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/Column.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/Column.java
@@ -157,6 +157,8 @@ public abstract class Column implements Serializable {
         return Type.Code.JSON.getName();
       case PG_JSONB:
         return Type.Code.PG_JSONB.getName();
+      case TOKENLIST:
+        return Type.Code.TOKENLIST.getName();
       case ARRAY:
         {
           Type arrayType = type.getArrayElementType();
@@ -366,6 +368,9 @@ public abstract class Column implements Serializable {
           }
           if (spannerType.equals(Type.Code.JSON.getName())) {
             return t(Type.json(), null);
+          }
+          if (spannerType.equals(Type.Code.TOKENLIST.getName())) {
+            return t(Type.tokenlist(), null);
           }
           if (spannerType.startsWith(Type.Code.ARRAY.getName())) {
             // Substring "ARRAY<"xxx">"

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/ISchemaMapper.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/ISchemaMapper.java
@@ -94,8 +94,7 @@ public interface ISchemaMapper extends Serializable {
   String getSyntheticPrimaryKeyColName(String namespace, String spannerTableName);
 
   /**
-   * Returns true if the Spanner column exists at the source. For identity mappers, since there is
-   * no source information, it always returns true.
+   * Returns true if a corresponding source column exists for the provided Spanner column.
    *
    * @param namespace is currently not operational.
    */

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/ISchemaMapper.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/ISchemaMapper.java
@@ -94,7 +94,8 @@ public interface ISchemaMapper extends Serializable {
   String getSyntheticPrimaryKeyColName(String namespace, String spannerTableName);
 
   /**
-   * Returns true if the Spanner column exists at the source.
+   * Returns true if the Spanner column exists at the source. For identity mappers, since there is
+   * no source information, it always returns true.
    *
    * @param namespace is currently not operational.
    */

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/type/Type.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/type/Type.java
@@ -40,6 +40,7 @@ public final class Type implements Serializable {
   private static final Type TYPE_NUMERIC = new Type(Type.Code.NUMERIC, null, null);
   private static final Type TYPE_STRING = new Type(Type.Code.STRING, null, null);
   private static final Type TYPE_JSON = new Type(Type.Code.JSON, null, null);
+  private static final Type TYPE_TOKENLIST = new Type(Code.TOKENLIST, null, null);
   private static final Type TYPE_BYTES = new Type(Type.Code.BYTES, null, null);
   private static final Type TYPE_TIMESTAMP = new Type(Type.Code.TIMESTAMP, null, null);
   private static final Type TYPE_DATE = new Type(Type.Code.DATE, null, null);
@@ -131,6 +132,11 @@ public final class Type implements Serializable {
   /** Returns the descriptor for the {@code JSON} type. */
   public static Type json() {
     return TYPE_JSON;
+  }
+
+  /** Returns the descriptor for the {@code TOKENLIST} type. */
+  public static Type tokenlist() {
+    return TYPE_TOKENLIST;
   }
 
   /** Returns the descriptor for the {@code BYTES} type: a variable-length byte string. */
@@ -306,6 +312,8 @@ public final class Type implements Serializable {
     FLOAT64("FLOAT64", Dialect.GOOGLE_STANDARD_SQL),
     STRING("STRING", Dialect.GOOGLE_STANDARD_SQL),
     JSON("JSON", Dialect.GOOGLE_STANDARD_SQL),
+    // This type is not supported on PG Spanner.
+    TOKENLIST("TOKENLIST", Dialect.GOOGLE_STANDARD_SQL),
     BYTES("BYTES", Dialect.GOOGLE_STANDARD_SQL),
     TIMESTAMP("TIMESTAMP", Dialect.GOOGLE_STANDARD_SQL),
     DATE("DATE", Dialect.GOOGLE_STANDARD_SQL),

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/type/TypeTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/type/TypeTest.java
@@ -22,14 +22,22 @@ import org.junit.Test;
 public class TypeTest {
   @Test
   public void testToString() {
-    // Primitive types
+    // Google Standard SQL primitive types
     assertEquals("BOOL", Type.bool().toString());
     assertEquals("INT64", Type.int64().toString());
+    assertEquals("NUMERIC", Type.numeric().toString());
+    assertEquals("FLOAT32", Type.float32().toString());
     assertEquals("FLOAT64", Type.float64().toString());
     assertEquals("STRING", Type.string().toString());
+    assertEquals("JSON", Type.json().toString());
+    assertEquals("TOKENLIST", Type.tokenlist().toString());
+    assertEquals("BYTES", Type.bytes().toString());
+    assertEquals("TIMESTAMP", Type.timestamp().toString());
+    assertEquals("DATE", Type.date().toString());
 
     // Array types
     assertEquals("ARRAY<INT64>", Type.array(Type.int64()).toString());
+    assertEquals("ARRAY<STRING>", Type.array(Type.string()).toString());
     assertEquals("ARRAY<ARRAY<STRING>>", Type.array(Type.array(Type.string())).toString());
 
     // Struct type
@@ -42,6 +50,16 @@ public class TypeTest {
     // PG types
     assertEquals("PG_BOOL", Type.pgBool().toString());
     assertEquals("PG_INT8", Type.pgInt8().toString());
+    assertEquals("PG_FLOAT4", Type.pgFloat4().toString());
+    assertEquals("PG_FLOAT8", Type.pgFloat8().toString());
+    assertEquals("PG_TEXT", Type.pgText().toString());
+    assertEquals("PG_VARCHAR", Type.pgVarchar().toString());
+    assertEquals("PG_NUMERIC", Type.pgNumeric().toString());
+    assertEquals("PG_JSONB", Type.pgJsonb().toString());
+    assertEquals("PG_BYTEA", Type.pgBytea().toString());
+    assertEquals("PG_TIMESTAMPTZ", Type.pgTimestamptz().toString());
+    assertEquals("PG_DATE", Type.pgDate().toString());
     assertEquals("PG_TEXT[]", Type.pgArray(Type.pgText()).toString());
+    assertEquals("PG_COMMIT_TIMESTAMP", Type.pgCommitTimestamp().toString());
   }
 }


### PR DESCRIPTION
TOKENLIST is a spanner type used only for Full-Text Search and is not supported in PG Spanner. Added the type so the ddl object can parse it.

Testing:
Tested migration on spanner table with additional FTS column, additional generated column, default column and customer transformation column.