### PR TITLE
Allow SourceSchemaReference and DataSource to represent Cassandra (and other similar non-jdbc) values

### DIFF
--- a/v2/sourcedb-to-spanner/pom.xml
+++ b/v2/sourcedb-to-spanner/pom.xml
@@ -70,6 +70,11 @@
       <version>${postgresql.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.datastax.cassandra</groupId>
+      <artifactId>cassandra-driver-core</artifactId>
+      <version>3.1.0</version>
+    </dependency>
     <!-- Test Dependencies -->
     <dependency>
       <groupId>com.google.cloud.teleport</groupId>
@@ -127,6 +132,12 @@
       <artifactId>datastream-to-spanner</artifactId>
       <version>1.0-SNAPSHOT</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>cassandra</artifactId>
+      <version>1.15.3</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/OptionsToConfigBuilder.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/OptionsToConfigBuilder.java
@@ -19,6 +19,7 @@ import static com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.confi
 import static com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.JdbcIOWrapperConfig.builderWithPostgreSQLDefaults;
 
 import com.google.cloud.teleport.v2.source.reader.auth.dbauth.LocalCredentialsProvider;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.JdbcSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.JdbcIOWrapperConfig;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.SQLDialect;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.defaults.MySqlConfigDefaults;
@@ -130,7 +131,7 @@ public final class OptionsToConfigBuilder {
         if (sourceDbURL == null) {
           sourceDbURL = "jdbc:postgresql://" + host + ":" + port + "/" + dbName;
         }
-        sourceDbURL = sourceDbURL + "?currentSchema=" + sourceSchemaReference.namespace();
+        sourceDbURL = sourceDbURL + "?currentSchema=" + sourceSchemaReference.jdbc().namespace();
         if (StringUtils.isNotBlank(connectionProperties)) {
           sourceDbURL = sourceDbURL + "&" + connectionProperties;
         }
@@ -236,9 +237,10 @@ public final class OptionsToConfigBuilder {
     return builderWithMySqlDefaults();
   }
 
+  // TODO(vardhanvthigle): Standardize for Css.
   private static SourceSchemaReference sourceSchemaReferenceFrom(
       SQLDialect dialect, String dbName, String namespace) {
-    SourceSchemaReference.Builder builder = SourceSchemaReference.builder();
+    JdbcSchemaReference.Builder builder = JdbcSchemaReference.builder();
     // Namespaces are not supported for MySQL
     if (dialect == SQLDialect.POSTGRESQL) {
       if (StringUtils.isBlank(namespace)) {
@@ -247,7 +249,7 @@ public final class OptionsToConfigBuilder {
         builder.setNamespace(namespace);
       }
     }
-    return builder.setDbName(dbName).build();
+    return SourceSchemaReference.ofJdbc(builder.setDbName(dbName).build());
   }
 
   private OptionsToConfigBuilder() {}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraDataSource.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraDataSource.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.net.InetSocketAddress;
+import java.util.List;
+
+/**
+ * Encapsulates details of a Cassandra Cluster. Cassandra Cluster can connect to multiple KeySpaces,
+ * just like a Mysql instance can have multiple databases.
+ */
+@AutoValue
+public abstract class CassandraDataSource implements Serializable {
+
+  /** Name of the Cassandra Cluster. */
+  public abstract String clusterName();
+
+  /** Contact points for connecting to a Cassandra Cluster. */
+  public abstract ImmutableList<InetSocketAddress> contactPoints();
+
+  public static Builder builder() {
+    return new AutoValue_CassandraDataSource.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setClusterName(String value);
+
+    public abstract Builder setContactPoints(ImmutableList<InetSocketAddress> value);
+
+    public Builder setContactPoints(List<InetSocketAddress> value) {
+      return setContactPoints(ImmutableList.copyOf(value));
+    }
+
+    public abstract CassandraDataSource build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIoWrapper.java
@@ -13,8 +13,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.teleport.v2.source.reader.io;
+package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;
 
+import com.google.cloud.teleport.v2.source.reader.io.IoWrapper;
 import com.google.cloud.teleport.v2.source.reader.io.row.SourceRow;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchema;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableReference;
@@ -23,12 +24,21 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 
-/** IO Wrapper Interface for adding new IO sources. */
-public interface IoWrapper {
+/** IOWrapper for Cassandra Source. */
+public class CassandraIoWrapper implements IoWrapper {
 
-  /** Get a list of reader transforms. */
-  ImmutableMap<SourceTableReference, PTransform<PBegin, PCollection<SourceRow>>> getTableReaders();
+  /** Get a list of reader transforms for Cassandra source. */
+  @Override
+  public ImmutableMap<SourceTableReference, PTransform<PBegin, PCollection<SourceRow>>>
+      getTableReaders() {
+    // TODO(vardhanvthigle)
+    return null;
+  }
 
-  /** Discover source schema. */
-  SourceSchema discoverTableSchema();
+  /** Discover source schema for Cassandra. */
+  @Override
+  public SourceSchema discoverTableSchema() {
+    // TODO(vardhanvthigle)
+    return null;
+  }
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/package-info.java
@@ -13,6 +13,5 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
-/** IoWrapper for various sources. */
-package com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper;
+/** IoWrapper for cassandra source. */
+package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/package-info.java
@@ -14,5 +14,5 @@
  * the License.
  */
 
-/** IoWrapper for various sources. */
-package com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper;
+/** Cassandra source for reader. */
+package com.google.cloud.teleport.v2.source.reader.io.cassandra;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/schema/CassandraSchemaReference.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/schema/CassandraSchemaReference.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.cassandra.schema;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper.CassandraDataSource;
+import java.io.Serializable;
+
+@AutoValue
+public abstract class CassandraSchemaReference implements Serializable {
+
+  /**
+   * Name of the Cassandra KeySpace. This is equivalent of the JDBC database name.
+   *
+   * <p>Note that Cassandra also has a clusterName, which is at the level of MySQL instance and
+   * hence encapsulated in {@link CassandraDataSource DataSource}
+   */
+  public abstract String keyspaceName();
+
+  public static Builder builder() {
+    return new AutoValue_CassandraSchemaReference.Builder();
+  }
+
+  /**
+   * Returns a stable unique name to be used in PTransforms.
+   *
+   * @return name of the {@link CassandraSchemaReference}
+   */
+  public String getName() {
+    return "KeySpace." + keyspaceName();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setKeyspaceName(String value);
+
+    public abstract CassandraSchemaReference build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/schema/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/schema/package-info.java
@@ -14,5 +14,5 @@
  * the License.
  */
 
-/** IoWrapper for various sources. */
-package com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper;
+/** Schema Discovery and Mapping for Cassandra Source. */
+package com.google.cloud.teleport.v2.source.reader.io.cassandra.schema;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/datasource/DataSource.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/datasource/DataSource.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.datasource;
+
+import com.google.auto.value.AutoOneOf;
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper.CassandraDataSource;
+
+@AutoOneOf(DataSource.Kind.class)
+public abstract class DataSource {
+  public enum Kind {
+    JDBC,
+    CASSANDRA
+  };
+
+  public abstract Kind getKind();
+
+  public abstract javax.sql.DataSource jdbc();
+
+  public abstract CassandraDataSource cassandra();
+
+  public static DataSource ofJdbc(javax.sql.DataSource dataSource) {
+    return AutoOneOf_DataSource.jdbc(dataSource);
+  }
+
+  public static DataSource ofCassandra(CassandraDataSource dataSource) {
+    return AutoOneOf_DataSource.cassandra(dataSource);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/datasource/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/datasource/package-info.java
@@ -14,5 +14,5 @@
  * the License.
  */
 
-/** IoWrapper for various sources. */
-package com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper;
+/** Enclosing datasource for various reader sources. */
+package com.google.cloud.teleport.v2.source.reader.io.datasource;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/JdbcSchemaReference.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/JdbcSchemaReference.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc;
+
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+import javax.annotation.Nullable;
+
+/** Value class to enclose the database name and PG namespace. */
+@AutoValue
+public abstract class JdbcSchemaReference implements Serializable {
+
+  /** Name of the JDBC Database. */
+  public abstract String dbName();
+
+  /** NameSpace if needed for PG source. Null for all other sources. */
+  @Nullable
+  public abstract String namespace();
+
+  public static JdbcSchemaReference.Builder builder() {
+    return new AutoValue_JdbcSchemaReference.Builder();
+  }
+
+  /**
+   * Returns a stable unique name to be used in PTransforms.
+   *
+   * @return name of the {@link JdbcSchemaReference}.
+   */
+  public String getName() {
+    StringBuilder stringBuilder = new StringBuilder();
+    stringBuilder.append("Db.").append(this.dbName());
+    if (this.namespace() != null) {
+      stringBuilder.append(".Namespace.").append(this.namespace());
+    }
+    return stringBuilder.toString();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract JdbcSchemaReference.Builder setDbName(String value);
+
+    public abstract JdbcSchemaReference.Builder setNamespace(String value);
+
+    public abstract JdbcSchemaReference build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/DialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/DialectAdapter.java
@@ -15,8 +15,19 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter;
 
+import com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource;
+import com.google.cloud.teleport.v2.source.reader.io.exception.RetriableSchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.JdbcSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.schema.RetriableSchemaDiscovery;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceColumnIndexInfo;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference.Kind;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Interface to support various dialects of JDBC databases.
@@ -24,4 +35,80 @@ import com.google.cloud.teleport.v2.source.reader.io.schema.RetriableSchemaDisco
  * <p><b>Note:</b>As a prt of M2 effort, this interface will expose more mehtods than just extending
  * {@link RetriableSchemaDiscovery}.
  */
-public interface DialectAdapter extends RetriableSchemaDiscovery, UniformSplitterDBAdapter {}
+public interface DialectAdapter extends RetriableSchemaDiscovery, UniformSplitterDBAdapter {
+
+  /**
+   * Discover Tables to migrate. This method could be used to auto infer tables to migrate if not
+   * passed via options.
+   *
+   * @param dataSource Provider for JDBC connection.
+   * @param sourceSchemaReference Source database name and (optionally namespace)
+   * @return The list of table names for the given database.
+   * @throws SchemaDiscoveryException - Fatal exception during Schema Discovery.
+   * @throws RetriableSchemaDiscoveryException - Retriable exception during Schema Discovery.
+   *     <p><b>Note:</b>
+   *     <p>The Implementations must log every exception and generate metrics as appropriate.
+   */
+  default ImmutableList<String> discoverTables(
+      DataSource dataSource, SourceSchemaReference sourceSchemaReference)
+      throws SchemaDiscoveryException, RetriableSchemaDiscoveryException {
+    Preconditions.checkArgument(sourceSchemaReference.getKind() == Kind.JDBC);
+    return discoverTables(dataSource.jdbc(), sourceSchemaReference.jdbc());
+  }
+
+  ImmutableList<String> discoverTables(
+      javax.sql.DataSource dataSource, JdbcSchemaReference sourceSchemaReference)
+      throws SchemaDiscoveryException, RetriableSchemaDiscoveryException;
+
+  /**
+   * Discover the schema of tables to migrate.
+   *
+   * @param dataSource Provider for JDBC connection.
+   * @param schemaReference Source database name and (optionally namespace)
+   * @param tables Tables to migrate.
+   * @return The discovered schema.
+   * @throws SchemaDiscoveryException - Fatal exception during Schema Discovery.
+   * @throws RetriableSchemaDiscoveryException - Retriable exception during Schema Discovery.
+   *     <p><b>Note:</b>
+   *     <p>The Implementations must log every exception and generate metrics as appropriate.
+   */
+  default ImmutableMap<String, ImmutableMap<String, SourceColumnType>> discoverTableSchema(
+      DataSource dataSource, SourceSchemaReference schemaReference, ImmutableList<String> tables)
+      throws SchemaDiscoveryException, RetriableSchemaDiscoveryException {
+    Preconditions.checkArgument(schemaReference.getKind() == Kind.JDBC);
+    return discoverTableSchema(dataSource.jdbc(), schemaReference.jdbc(), tables);
+  }
+
+  ImmutableMap<String, ImmutableMap<String, SourceColumnType>> discoverTableSchema(
+      javax.sql.DataSource dataSource,
+      JdbcSchemaReference schemaReference,
+      ImmutableList<String> tables)
+      throws SchemaDiscoveryException, RetriableSchemaDiscoveryException;
+
+  /**
+   * Discover the indexes of tables to migrate.
+   *
+   * @param dataSource Provider for JDBC connection.
+   * @param sourceSchemaReference Source database name and (optionally namespace)
+   * @param tables Tables to migrate.
+   * @return The discovered indexes.
+   * @throws SchemaDiscoveryException - Fatal exception during Schema Discovery.
+   * @throws RetriableSchemaDiscoveryException - Retriable exception during Schema Discovery.
+   *     <p><b>Note:</b>
+   *     <p>The Implementations must log every exception and generate metrics as appropriate.
+   */
+  default ImmutableMap<String, ImmutableList<SourceColumnIndexInfo>> discoverTableIndexes(
+      DataSource dataSource,
+      SourceSchemaReference sourceSchemaReference,
+      ImmutableList<String> tables)
+      throws SchemaDiscoveryException, RetriableSchemaDiscoveryException {
+    Preconditions.checkArgument(sourceSchemaReference.getKind() == Kind.JDBC);
+    return discoverTableIndexes(dataSource.jdbc(), sourceSchemaReference.jdbc(), tables);
+  }
+
+  ImmutableMap<String, ImmutableList<SourceColumnIndexInfo>> discoverTableIndexes(
+      javax.sql.DataSource dataSource,
+      JdbcSchemaReference sourceSchemaReference,
+      ImmutableList<String> tables)
+      throws SchemaDiscoveryException, RetriableSchemaDiscoveryException;
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapter.java
@@ -24,13 +24,13 @@ import static org.apache.curator.shaded.com.google.common.collect.Sets.newHashSe
 import com.google.cloud.teleport.v2.constants.MetricCounters;
 import com.google.cloud.teleport.v2.source.reader.io.exception.RetriableSchemaDiscoveryException;
 import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.JdbcSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.DialectAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.rowmapper.JdbcSourceRowMapper;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceColumnIndexInfo;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceColumnIndexInfo.IndexType;
-import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -119,7 +119,7 @@ public final class MysqlDialectAdapter implements DialectAdapter {
    */
   @Override
   public ImmutableList<String> discoverTables(
-      DataSource dataSource, SourceSchemaReference sourceSchemaReference)
+      DataSource dataSource, JdbcSchemaReference sourceSchemaReference)
       throws SchemaDiscoveryException, RetriableSchemaDiscoveryException {
 
     logger.info(String.format("Discovering tables for DataSource: %s", dataSource));
@@ -184,12 +184,12 @@ public final class MysqlDialectAdapter implements DialectAdapter {
   @Override
   public ImmutableMap<String, ImmutableMap<String, SourceColumnType>> discoverTableSchema(
       DataSource dataSource,
-      SourceSchemaReference sourceSchemaReference,
+      JdbcSchemaReference sourceSchemaReference,
       ImmutableList<String> tables)
       throws SchemaDiscoveryException, RetriableSchemaDiscoveryException {
     logger.info(
         String.format(
-            "Discovering table schema for Datasource: %s, SourceSchemaReference: %s, tables: %s",
+            "Discovering table schema for Datasource: %s, JdbcSchemaReference: %s, tables: %s",
             dataSource, sourceSchemaReference, tables));
 
     String discoveryQuery = getSchemaDiscoveryQuery(sourceSchemaReference);
@@ -229,7 +229,7 @@ public final class MysqlDialectAdapter implements DialectAdapter {
         tableSchemaBuilder.build();
     logger.info(
         String.format(
-            "Discovered table schema for Datasource: %s, SourceSchemaReference: %s, tables: %s, schema: %s",
+            "Discovered table schema for Datasource: %s, JdbcSchemaReference: %s, tables: %s, schema: %s",
             dataSource, sourceSchemaReference, tables, tableSchema));
 
     return tableSchema;
@@ -248,12 +248,12 @@ public final class MysqlDialectAdapter implements DialectAdapter {
   @Override
   public ImmutableMap<String, ImmutableList<SourceColumnIndexInfo>> discoverTableIndexes(
       DataSource dataSource,
-      SourceSchemaReference sourceSchemaReference,
+      JdbcSchemaReference sourceSchemaReference,
       ImmutableList<String> tables)
       throws SchemaDiscoveryException, RetriableSchemaDiscoveryException {
     logger.info(
         String.format(
-            "Discovering Indexes for DataSource: %s, SourceSchemaReference: %s, Tables: %s",
+            "Discovering Indexes for DataSource: %s, JdbcSchemaReference: %s, Tables: %s",
             dataSource, sourceSchemaReference, tables));
     String discoveryQuery = getIndexDiscoveryQuery(sourceSchemaReference);
     ImmutableMap.Builder<String, ImmutableList<SourceColumnIndexInfo>> tableIndexesBuilder =
@@ -292,12 +292,12 @@ public final class MysqlDialectAdapter implements DialectAdapter {
         tableIndexesBuilder.build();
     logger.info(
         String.format(
-            "Discovered Indexes for DataSource: %s, SourceSchemaReference: %s, Tables: %s.\nIndexes: %s",
+            "Discovered Indexes for DataSource: %s, JdbcSchemaReference: %s, Tables: %s.\nIndexes: %s",
             dataSource, sourceSchemaReference, tables, tableIndexes));
     return tableIndexes;
   }
 
-  protected static String getSchemaDiscoveryQuery(SourceSchemaReference sourceSchemaReference) {
+  protected static String getSchemaDiscoveryQuery(JdbcSchemaReference sourceSchemaReference) {
     return "SELECT "
         + String.join(",", InformationSchemaCols.colList())
         + " FROM INFORMATION_SCHEMA.Columns WHERE TABLE_SCHEMA = "
@@ -315,7 +315,7 @@ public final class MysqlDialectAdapter implements DialectAdapter {
    * @param sourceSchemaReference
    * @return
    */
-  protected static String getIndexDiscoveryQuery(SourceSchemaReference sourceSchemaReference) {
+  protected static String getIndexDiscoveryQuery(JdbcSchemaReference sourceSchemaReference) {
     return "SELECT *"
         + " FROM INFORMATION_SCHEMA.STATISTICS stats"
         + " JOIN "
@@ -382,7 +382,7 @@ public final class MysqlDialectAdapter implements DialectAdapter {
 
   /**
    * Get the PadSpace attribute from {@link ResultSet} for index discovery query {@link
-   * #getIndexDiscoveryQuery(SourceSchemaReference)}. This method takes care of the fact that older
+   * #getIndexDiscoveryQuery(JdbcSchemaReference)}. This method takes care of the fact that older
    * versions of MySQL notably Mysql5.7 don't have a {@link
    * InformationSchemaStatsCols#PAD_SPACE_COL} column and default to PAD SPACE comparisons.
    */

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
@@ -24,12 +24,12 @@ import static com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.
 import com.google.cloud.teleport.v2.constants.MetricCounters;
 import com.google.cloud.teleport.v2.source.reader.io.exception.RetriableSchemaDiscoveryException;
 import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.JdbcSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.DialectAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.rowmapper.JdbcSourceRowMapper;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceColumnIndexInfo;
-import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -100,7 +100,7 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
    */
   @Override
   public ImmutableList<String> discoverTables(
-      DataSource dataSource, SourceSchemaReference sourceSchemaReference)
+      DataSource dataSource, JdbcSchemaReference sourceSchemaReference)
       throws SchemaDiscoveryException, RetriableSchemaDiscoveryException {
     logger.info("Discovering tables for DataSource: {}", dataSource);
 
@@ -158,11 +158,11 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
   @Override
   public ImmutableMap<String, ImmutableMap<String, SourceColumnType>> discoverTableSchema(
       DataSource dataSource,
-      SourceSchemaReference sourceSchemaReference,
+      JdbcSchemaReference sourceSchemaReference,
       ImmutableList<String> tables)
       throws SchemaDiscoveryException, RetriableSchemaDiscoveryException {
     logger.info(
-        "Discovering table schema for Datasource: {}, SourceSchemaReference: {}, tables: {}",
+        "Discovering table schema for Datasource: {}, JdbcSchemaReference: {}, tables: {}",
         dataSource,
         sourceSchemaReference,
         tables);
@@ -251,7 +251,7 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
     ImmutableMap<String, ImmutableMap<String, SourceColumnType>> tableSchema =
         tableSchemaBuilder.build();
     logger.info(
-        "Discovered table schema for Datasource: {}, SourceSchemaReference: {}, tables: {}, schema: {}",
+        "Discovered table schema for Datasource: {}, JdbcSchemaReference: {}, tables: {}, schema: {}",
         dataSource,
         sourceSchemaReference,
         tables,
@@ -274,11 +274,11 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
   @Override
   public ImmutableMap<String, ImmutableList<SourceColumnIndexInfo>> discoverTableIndexes(
       DataSource dataSource,
-      SourceSchemaReference sourceSchemaReference,
+      JdbcSchemaReference sourceSchemaReference,
       ImmutableList<String> tables)
       throws SchemaDiscoveryException, RetriableSchemaDiscoveryException {
     logger.info(
-        "Discovering Indexes for DataSource: {}, SourceSchemaReference: {}, Tables: {}",
+        "Discovering Indexes for DataSource: {}, JdbcSchemaReference: {}, Tables: {}",
         dataSource,
         sourceSchemaReference,
         tables);
@@ -387,7 +387,7 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
     ImmutableMap<String, ImmutableList<SourceColumnIndexInfo>> tableIndexes =
         tableIndexesBuilder.build();
     logger.info(
-        "Discovered Indexes for DataSource: {}, SourceSchemaReference: {}, Tables: {}.\nIndexes: {}",
+        "Discovered Indexes for DataSource: {}, JdbcSchemaReference: {}, Tables: {}.\nIndexes: {}",
         dataSource,
         sourceSchemaReference,
         tables,

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/JdbcIOWrapperConfig.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/JdbcIOWrapperConfig.java
@@ -15,8 +15,11 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config;
 
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
+
 import com.google.auto.value.AutoValue;
 import com.google.cloud.teleport.v2.source.reader.auth.dbauth.DbAuth;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.JdbcSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.DialectAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.defaults.MySqlConfigDefaults;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.defaults.PostgreSQLConfigDefaults;
@@ -24,6 +27,7 @@ import com.google.cloud.teleport.v2.source.reader.io.jdbc.rowmapper.JdbcValueMap
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms.ReadWithUniformPartitions;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference.Kind;
 import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedTypeMapper.MapperType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -46,8 +50,12 @@ public abstract class JdbcIOWrapperConfig {
   /** Source URL. */
   public abstract String sourceDbURL();
 
-  /** {@link SourceSchemaReference}. */
+  /** {@link SoucreSchemaReference}. */
   public abstract SourceSchemaReference sourceSchemaReference();
+
+  public JdbcSchemaReference jdbcSourceSchemaReference() {
+    return sourceSchemaReference().jdbc();
+  }
 
   /** List of Tables to migrate. Auto-inferred if emtpy. */
   public abstract ImmutableList<String> tables();
@@ -301,6 +309,10 @@ public abstract class JdbcIOWrapperConfig {
 
     public abstract Builder setSourceSchemaReference(SourceSchemaReference value);
 
+    public Builder setSourceSchemaReference(JdbcSchemaReference value) {
+      return setSourceSchemaReference(SourceSchemaReference.ofJdbc(value));
+    }
+
     public abstract Builder setTables(ImmutableList<String> value);
 
     public abstract Builder setTableVsPartitionColumns(
@@ -357,6 +369,12 @@ public abstract class JdbcIOWrapperConfig {
 
     public abstract Builder setMaxConnections(Long value);
 
-    public abstract JdbcIOWrapperConfig build();
+    public abstract JdbcIOWrapperConfig autoBuild();
+
+    public JdbcIOWrapperConfig build() {
+      JdbcIOWrapperConfig config = autoBuild();
+      checkState(config.sourceSchemaReference().getKind() == Kind.JDBC);
+      return config;
+    }
   }
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/jdbc/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/jdbc/package-info.java
@@ -14,5 +14,5 @@
  * the License.
  */
 
-/** IoWrapper for various sources. */
-package com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper;
+/** IoWrapper for jdbc sources. */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.jdbc;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/package-info.java
@@ -14,5 +14,5 @@
  * the License.
  */
 
-/** IoWrapper for various sources. */
-package com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper;
+/** Jdbc Source for reader. */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/RetriableSchemaDiscovery.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/RetriableSchemaDiscovery.java
@@ -15,12 +15,12 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.schema;
 
+import com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource;
 import com.google.cloud.teleport.v2.source.reader.io.exception.RetriableSchemaDiscoveryException;
 import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryException;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import javax.sql.DataSource;
 
 /**
  * Discover the schema of tables to migrate. Implementation must adapt to requirements of the source
@@ -39,7 +39,7 @@ public interface RetriableSchemaDiscovery {
    * Discover Tables to migrate. This method could be used to auto infer tables to migrate if not
    * passed via options.
    *
-   * @param dataSource Provider for JDBC connection.
+   * @param dataSource Provider for source connection.
    * @param sourceSchemaReference Source database name and (optionally namespace)
    * @return The list of table names for the given database.
    * @throws SchemaDiscoveryException - Fatal exception during Schema Discovery.
@@ -54,7 +54,7 @@ public interface RetriableSchemaDiscovery {
   /**
    * Discover the schema of tables to migrate.
    *
-   * @param dataSource Provider for JDBC connection.
+   * @param dataSource Provider for source connection.
    * @param schemaReference Source database name and (optionally namespace)
    * @param tables Tables to migrate.
    * @return The discovered schema.
@@ -70,7 +70,7 @@ public interface RetriableSchemaDiscovery {
   /**
    * Discover the indexes of tables to migrate.
    *
-   * @param dataSource Provider for JDBC connection.
+   * @param dataSource Provider for source connection.
    * @param sourceSchemaReference Source database name and (optionally namespace)
    * @param tables Tables to migrate.
    * @return The discovered indexes.

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaDiscovery.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaDiscovery.java
@@ -15,11 +15,11 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.schema;
 
+import com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource;
 import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryException;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import javax.sql.DataSource;
 
 /**
  * Discover Schema of Source Tables. The main Reader code must use the {@link SchemaDiscovery}
@@ -31,7 +31,7 @@ public interface SchemaDiscovery {
    * Discover Tables to migrate. This method could be used to auto infer tables to migrate if not
    * passed via options.
    *
-   * @param dataSource Provider for JDBC connection.
+   * @param dataSource Provider for source connection.
    * @param sourceSchemaReference Source database name and (optionally namespace)
    * @return The list of table names for the given database.
    * @throws SchemaDiscoveryException - Fatal exception during Schema Discovery.
@@ -46,7 +46,7 @@ public interface SchemaDiscovery {
   /**
    * Discover the schema of tables to migrate.
    *
-   * @param dataSource Provider for JDBC connection.
+   * @param dataSource Provider for source connection.
    * @param sourceSchemaReference Source database name and (optionally namespace)
    * @param tables Tables to migrate.
    * @return The discovered schema.
@@ -64,7 +64,7 @@ public interface SchemaDiscovery {
   /**
    * Discover the indexes of tables to migrate.
    *
-   * @param dataSource Provider for JDBC connection.
+   * @param dataSource Provider for source connection.
    * @param sourceSchemaReference Source database name and (optionally namespace)
    * @param tables Tables to migrate.
    * @return The discovered indexes.

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaDiscoveryImpl.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaDiscoveryImpl.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.schema;
 
+import com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource;
 import com.google.cloud.teleport.v2.source.reader.io.exception.RetriableSchemaDiscoveryException;
 import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryException;
 import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryRetriesExhaustedException;
@@ -22,7 +23,6 @@ import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
-import javax.sql.DataSource;
 import org.apache.beam.sdk.util.BackOff;
 import org.apache.beam.sdk.util.FluentBackoff;
 
@@ -48,7 +48,7 @@ public final class SchemaDiscoveryImpl implements SchemaDiscovery {
    * Discover Tables to migrate. This method could be used to auto infer tables to migrate if not
    * passed via options.
    *
-   * @param dataSource Provider for JDBC connection.
+   * @param dataSource Provider for source connection.
    * @param sourceSchemaReference Source database name and (optionally namespace)
    * @return The list of table names for the given database.
    * @throws SchemaDiscoveryException - Fatal exception during Schema Discovery.
@@ -67,7 +67,7 @@ public final class SchemaDiscoveryImpl implements SchemaDiscovery {
   /**
    * Discover the schema of tables to migrate.
    *
-   * @param dataSource - Provider for JDBC connection.
+   * @param dataSource - Provider for source connection.
    * @param sourceSchemaReference - Source database name and (optionally namespace)
    * @param tables - Tables to migrate.
    * @return - The discovered schema
@@ -88,7 +88,7 @@ public final class SchemaDiscoveryImpl implements SchemaDiscovery {
   /**
    * Discover the indexes of tables to migrate.
    *
-   * @param dataSource Provider for JDBC connection.
+   * @param dataSource Provider for source connection.
    * @param sourceSchemaReference Source database name and (optionally namespace)
    * @param tables Tables to migrate.
    * @return The discovered indexes.

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/FakeReader.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/FakeReader.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.v2.source.reader;
 
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.JdbcSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchema;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.transform.ReaderTransform;
@@ -32,7 +33,8 @@ public class FakeReader implements Reader {
   FakeReader(int rowCount, int tableCount) {
     this.rowCountPerTable = rowCount;
     this.tableCount = tableCount;
-    this.sourceSchemaReference = SourceSchemaReference.builder().setDbName(this.dbName).build();
+    this.sourceSchemaReference =
+        SourceSchemaReference.ofJdbc(JdbcSchemaReference.builder().setDbName(this.dbName).build());
     this.readerTransformTestUtils =
         new ReaderTransformTestUtils(
             this.rowCountPerTable, this.tableCount, this.sourceSchemaReference);

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraDataSourceTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraDataSourceTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+/** Test class for {@link CassandraDataSource}. */
+@RunWith(MockitoJUnitRunner.class)
+public class CassandraDataSourceTest {
+  @Test
+  public void testCassandraDataSoureBasic() {
+    String testCluster = "testCluster";
+    String testHost = "testHost";
+    int testPort = 9042;
+    CassandraDataSource cassandraDataSource =
+        CassandraDataSource.builder()
+            .setClusterName(testCluster)
+            .setContactPoints(List.of(new InetSocketAddress(testHost, testPort)))
+            .build();
+    assertThat(cassandraDataSource.clusterName()).isEqualTo(testCluster);
+    assertThat(cassandraDataSource.contactPoints())
+        .isEqualTo(ImmutableList.of(new InetSocketAddress(testHost, testPort)));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIoWrapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIoWrapperTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link CassandraIoWrapper}. */
+@RunWith(MockitoJUnitRunner.class)
+public class CassandraIoWrapperTest {
+  @Test
+  public void testCassandraIoWrapperBasic() {
+    // Todo(vardhanvthigle)
+    assertThat((new CassandraIoWrapper()).getTableReaders()).isNull();
+    assertThat((new CassandraIoWrapper()).discoverTableSchema()).isNull();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/schema/CassandraSchemaReferenceTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/schema/CassandraSchemaReferenceTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.cassandra.schema;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link CassandraSchemaReference}. */
+@RunWith(MockitoJUnitRunner.class)
+public class CassandraSchemaReferenceTest extends TestCase {
+
+  @Test
+  public void testCassandraSchemaReferenceBasic() {
+    String testKeySpace = "testKeySpace";
+    CassandraSchemaReference ref =
+        CassandraSchemaReference.builder().setKeyspaceName(testKeySpace).build();
+    assertThat(ref.keyspaceName()).isEqualTo(testKeySpace);
+    assertThat(ref.getName()).isEqualTo("KeySpace." + testKeySpace);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/datasource/DataSourceTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/datasource/DataSourceTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.datasource;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper.CassandraDataSource;
+import com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource.Kind;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link DataSource}. */
+@RunWith(MockitoJUnitRunner.class)
+public class DataSourceTest {
+  @Mock javax.sql.DataSource mockJdbcDataSource;
+  @Mock CassandraDataSource mockCassandraDataSource;
+
+  @Test
+  public void testDataSourceBasic() {
+    assertThat(DataSource.ofJdbc(mockJdbcDataSource).getKind()).isEqualTo(Kind.JDBC);
+    assertThat(DataSource.ofJdbc(mockJdbcDataSource).jdbc()).isEqualTo(mockJdbcDataSource);
+    assertThat(DataSource.ofCassandra(mockCassandraDataSource).cassandra())
+        .isEqualTo(mockCassandraDataSource);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/JdbcSchemaReferenceTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/JdbcSchemaReferenceTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link JdbcSchemaReference}. */
+@RunWith(MockitoJUnitRunner.class)
+public class JdbcSchemaReferenceTest extends TestCase {
+
+  @Test
+  public void testDbNameWithNullNamespaceBuilds() {
+    final String testDB = "testDb";
+    JdbcSchemaReference ref = JdbcSchemaReference.builder().setDbName(testDB).build();
+    assertThat(ref.namespace()).isNull();
+    assertThat(ref.dbName()).isEqualTo(testDB);
+    assertThat(ref.getName()).isEqualTo("Db." + testDB);
+  }
+
+  @Test
+  public void testDbNameWithNamespaceBuilds() {
+    final String testDB = "testDb";
+    final String testNamespace = "testNamespace";
+    JdbcSchemaReference ref =
+        JdbcSchemaReference.builder().setDbName(testDB).setNamespace(testNamespace).build();
+    assertThat(ref.dbName()).isEqualTo(testDB);
+    assertThat(ref.namespace()).isEqualTo(testNamespace);
+    assertThat(ref.getName()).isEqualTo("Db." + testDB + ".Namespace." + testNamespace);
+  }
+
+  @Test
+  public void testNullDbNameThrowsIllegalStateException() {
+    // As dbName is a required property, we expect "java.lang.IllegalStateException"
+    Assert.assertThrows(
+        java.lang.IllegalStateException.class, () -> JdbcSchemaReference.builder().build());
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/DialectAdapterTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/DialectAdapterTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter;
+
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper.CassandraDataSource;
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.schema.CassandraSchemaReference;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DialectAdapterTest {
+  @Mock CassandraSchemaReference mockCassandraSchemaReference;
+  @Mock CassandraDataSource mockCassandraDataSource;
+
+  @Test
+  public void testMismatchedSource() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new MysqlDialectAdapter(MySqlVersion.DEFAULT)
+                .discoverTableSchema(
+                    com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource.ofCassandra(
+                        mockCassandraDataSource),
+                    SourceSchemaReference.ofCassandra(mockCassandraSchemaReference),
+                    ImmutableList.of()));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new MysqlDialectAdapter(MySqlVersion.DEFAULT)
+                .discoverTables(
+                    com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource.ofCassandra(
+                        mockCassandraDataSource),
+                    SourceSchemaReference.ofCassandra(mockCassandraSchemaReference)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new MysqlDialectAdapter(MySqlVersion.DEFAULT)
+                .discoverTableIndexes(
+                    com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource.ofCassandra(
+                        mockCassandraDataSource),
+                    SourceSchemaReference.ofCassandra(mockCassandraSchemaReference),
+                    ImmutableList.of()));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapterTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapterTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import com.google.auto.value.AutoValue;
 import com.google.cloud.teleport.v2.source.reader.io.exception.RetriableSchemaDiscoveryException;
 import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.JdbcSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.InformationSchemaCols;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.InformationSchemaStatsCols;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
@@ -65,8 +66,8 @@ public class MysqlDialectAdapterTest {
   @Test
   public void testDiscoverTableSchema() throws SQLException, RetriableSchemaDiscoveryException {
     final String testTable = "testTable";
-    final SourceSchemaReference sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
     final ResultSet mockResultSet = getMockInfoSchemaRs();
 
     when(mockDataSource.getConnection()).thenReturn(mockConnection);
@@ -77,15 +78,18 @@ public class MysqlDialectAdapterTest {
     assertThat(
             new MysqlDialectAdapter(MySqlVersion.DEFAULT)
                 .discoverTableSchema(
-                    mockDataSource, sourceSchemaReference, ImmutableList.of(testTable)))
+                    com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource.ofJdbc(
+                        mockDataSource),
+                    SourceSchemaReference.ofJdbc(sourceSchemaReference),
+                    ImmutableList.of(testTable)))
         .isEqualTo(getExpectedColumnMapping(testTable));
   }
 
   @Test
   public void testDiscoverTableSchemaGetConnectionException() throws SQLException {
     final String testTable = "testTable";
-    final SourceSchemaReference sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
 
     when(mockDataSource.getConnection())
         .thenThrow(new SQLTransientConnectionException("test"))
@@ -109,8 +113,8 @@ public class MysqlDialectAdapterTest {
   @Test
   public void testDiscoverTableSchemaPrepareStatementException() throws SQLException {
     final String testTable = "testTable";
-    final SourceSchemaReference sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
 
     when(mockConnection.prepareStatement(anyString())).thenThrow(new SQLException("test"));
     when(mockDataSource.getConnection()).thenReturn(mockConnection);
@@ -126,8 +130,8 @@ public class MysqlDialectAdapterTest {
   @Test
   public void testDiscoverTableSchemaSetStringException() throws SQLException {
     final String testTable = "testTable";
-    final SourceSchemaReference sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
 
     when(mockDataSource.getConnection()).thenReturn(mockConnection);
     when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
@@ -145,8 +149,8 @@ public class MysqlDialectAdapterTest {
   public void testDiscoverTableSchemaExecuteQueryException() throws SQLException {
 
     final String testTable = "testTable";
-    final SourceSchemaReference sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
 
     when(mockDataSource.getConnection()).thenReturn(mockConnection);
     when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
@@ -165,8 +169,8 @@ public class MysqlDialectAdapterTest {
   public void testDiscoverTableSchemaRsException() throws SQLException {
 
     final String testTable = "testTable";
-    final SourceSchemaReference sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
     ResultSet mockResultSet = mock(ResultSet.class);
 
     when(mockDataSource.getConnection()).thenReturn(mockConnection);
@@ -187,7 +191,7 @@ public class MysqlDialectAdapterTest {
   public void testGetSchemaDiscoveryQuery() {
     assertThat(
             MysqlDialectAdapter.getSchemaDiscoveryQuery(
-                SourceSchemaReference.builder().setDbName("testDB").build()))
+                JdbcSchemaReference.builder().setDbName("testDB").build()))
         .isEqualTo(
             "SELECT COLUMN_NAME,COLUMN_TYPE,CHARACTER_MAXIMUM_LENGTH,NUMERIC_PRECISION,NUMERIC_SCALE FROM INFORMATION_SCHEMA.Columns WHERE TABLE_SCHEMA = 'testDB' AND TABLE_NAME = ?");
   }
@@ -197,8 +201,8 @@ public class MysqlDialectAdapterTest {
     ImmutableList<String> testTables =
         ImmutableList.of("testTable1", "testTable2", "testTable3", "testTable4");
 
-    final SourceSchemaReference sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
     ResultSet mockResultSet = mock(ResultSet.class);
     when(mockDataSource.getConnection()).thenReturn(mockConnection);
     when(mockConnection.createStatement()).thenReturn(mockStatement);
@@ -219,7 +223,10 @@ public class MysqlDialectAdapterTest {
 
     ImmutableList<String> tables =
         new MysqlDialectAdapter(MySqlVersion.DEFAULT)
-            .discoverTables(mockDataSource, sourceSchemaReference);
+            .discoverTables(
+                com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource.ofJdbc(
+                    mockDataSource),
+                SourceSchemaReference.ofJdbc(sourceSchemaReference));
 
     assertThat(tables).isEqualTo(testTables);
   }
@@ -227,8 +234,8 @@ public class MysqlDialectAdapterTest {
   @Test
   public void testDiscoverTablesGetConnectionException() throws SQLException {
 
-    final SourceSchemaReference sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
 
     when(mockDataSource.getConnection())
         .thenThrow(new SQLTransientConnectionException("test"))
@@ -250,8 +257,8 @@ public class MysqlDialectAdapterTest {
   @Test
   public void testDiscoverTablesRsException() throws SQLException {
 
-    final SourceSchemaReference sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
     ResultSet mockResultSet = mock(ResultSet.class);
     when(mockDataSource.getConnection()).thenReturn(mockConnection);
     when(mockConnection.createStatement()).thenReturn(mockStatement);
@@ -343,8 +350,8 @@ public class MysqlDialectAdapterTest {
                 .setStringMaxLength(255)
                 .build());
 
-    final SourceSchemaReference sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
     ResultSet mockResultSet = mock(ResultSet.class);
     ResultSetMetaData mockMetadata = mock(ResultSetMetaData.class);
 
@@ -364,7 +371,11 @@ public class MysqlDialectAdapterTest {
 
     ImmutableMap<String, ImmutableList<SourceColumnIndexInfo>> discoveredIndexes =
         new MysqlDialectAdapter(MySqlVersion.DEFAULT)
-            .discoverTableIndexes(mockDataSource, sourceSchemaReference, testTables);
+            .discoverTableIndexes(
+                com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource.ofJdbc(
+                    mockDataSource),
+                SourceSchemaReference.ofJdbc(sourceSchemaReference),
+                testTables);
 
     assertThat(discoveredIndexes)
         .isEqualTo(ImmutableMap.of(testTables.get(0), expectedSourceColumnIndexInfos));
@@ -418,8 +429,8 @@ public class MysqlDialectAdapterTest {
                 .setStringMaxLength(100)
                 .build());
 
-    final SourceSchemaReference sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
     ResultSet mockResultSet = mock(ResultSet.class);
     ResultSetMetaData mockMetadata = mock(ResultSetMetaData.class);
     when(mockResultSet.getMetaData()).thenReturn(mockMetadata);
@@ -545,7 +556,7 @@ public class MysqlDialectAdapterTest {
   public void testGetIndexDiscoveryQuery() {
     assertThat(
             MysqlDialectAdapter.getIndexDiscoveryQuery(
-                SourceSchemaReference.builder().setDbName("testDB").build()))
+                JdbcSchemaReference.builder().setDbName("testDB").build()))
         .isEqualTo(
             "SELECT * FROM INFORMATION_SCHEMA.STATISTICS stats JOIN INFORMATION_SCHEMA.COLUMNS cols ON stats.table_schema = cols.table_schema AND stats.table_name = cols.table_name AND stats.column_name = cols.column_name LEFT JOIN INFORMATION_SCHEMA.COLLATIONS collations ON cols.COLLATION_NAME = collations.COLLATION_NAME WHERE stats.TABLE_SCHEMA = 'testDB' AND stats.TABLE_NAME = ?");
   }
@@ -553,8 +564,8 @@ public class MysqlDialectAdapterTest {
   @Test
   public void testDiscoverTableIndexesGetConnectionException() throws SQLException {
     final String testTable = "testTable";
-    final SourceSchemaReference sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
 
     when(mockDataSource.getConnection())
         .thenThrow(new SQLTransientConnectionException("test"))
@@ -581,8 +592,8 @@ public class MysqlDialectAdapterTest {
     ImmutableList<String> testTables = ImmutableList.of("testTable1");
     long exceptionCount = 0;
 
-    final SourceSchemaReference sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
     ResultSet mockResultSet = mock(ResultSet.class);
     when(mockDataSource.getConnection()).thenReturn(mockConnection);
     when(mockConnection.prepareStatement(anyString()))

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapterTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapterTest.java
@@ -22,12 +22,12 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.teleport.v2.source.reader.io.exception.RetriableSchemaDiscoveryException;
 import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.JdbcSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.ResourceUtils;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.postgresql.PostgreSQLDialectAdapter.PostgreSQLVersion;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceColumnIndexInfo;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceColumnIndexInfo.IndexType;
-import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -57,13 +57,13 @@ public class PostgreSQLDialectAdapterTest {
 
   @Mock ResultSet mockResultSet;
 
-  private SourceSchemaReference sourceSchemaReference;
+  private JdbcSchemaReference sourceSchemaReference;
   private PostgreSQLDialectAdapter adapter;
 
   @Before
   public void setUp() throws Exception {
     sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").setNamespace("public").build();
+        JdbcSchemaReference.builder().setDbName("testDB").setNamespace("public").build();
     adapter = new PostgreSQLDialectAdapter(PostgreSQLVersion.DEFAULT);
   }
 
@@ -82,8 +82,8 @@ public class PostgreSQLDialectAdapterTest {
 
   @Test
   public void testDiscoverTableExceptions() throws SQLException {
-    final SourceSchemaReference sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
 
     when(mockDataSource.getConnection())
         .thenThrow(new SQLTransientConnectionException("test"))
@@ -158,8 +158,8 @@ public class PostgreSQLDialectAdapterTest {
   @Test
   public void testDiscoverTableSchemaExceptions() throws SQLException {
     final String testTable = "testTable";
-    final SourceSchemaReference sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
 
     when(mockDataSource.getConnection())
         .thenThrow(new SQLTransientConnectionException("test"))
@@ -277,8 +277,8 @@ public class PostgreSQLDialectAdapterTest {
   @Test
   public void testDiscoverTableIndexesExceptions() throws SQLException {
     final String testTable = "testTable";
-    final SourceSchemaReference sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
 
     when(mockDataSource.getConnection())
         .thenThrow(new SQLTransientConnectionException("test"))

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcDataSourceTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcDataSourceTest.java
@@ -18,10 +18,10 @@ package com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.cloud.teleport.v2.source.reader.auth.dbauth.LocalCredentialsProvider;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.JdbcSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.DialectAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.JdbcIOWrapperConfig;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.defaults.MySqlConfigDefaults;
-import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
 import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -45,8 +45,8 @@ public class JdbcDataSourceTest {
   @Test
   public void testJdbcDataSourceBasic() throws IOException, ClassNotFoundException {
 
-    SourceSchemaReference testSourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+    JdbcSchemaReference testSourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
 
     JdbcIOWrapperConfig jdbcIOWrapperConfig =
         JdbcIOWrapperConfig.builderWithMySqlDefaults()
@@ -90,8 +90,8 @@ public class JdbcDataSourceTest {
   @Test
   public void testJdbcDataSourceSerDe() throws IOException, ClassNotFoundException {
 
-    SourceSchemaReference testSourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+    JdbcSchemaReference testSourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
 
     JdbcIOWrapperConfig jdbcIOWrapperConfig =
         JdbcIOWrapperConfig.builderWithMySqlDefaults()

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.teleport.v2.source.reader.auth.dbauth.LocalCredentialsProvider;
 import com.google.cloud.teleport.v2.source.reader.io.exception.RetriableSchemaDiscoveryException;
 import com.google.cloud.teleport.v2.source.reader.io.exception.SuitableIndexNotFoundException;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.JdbcSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.DialectAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.JdbcIOWrapperConfig;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.SQLDialect;
@@ -80,11 +81,12 @@ public class JdbcIoWrapperTest {
   @Test
   public void testJdbcIoWrapperBasic() throws RetriableSchemaDiscoveryException {
     SourceSchemaReference testSourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+        SourceSchemaReference.ofJdbc(JdbcSchemaReference.builder().setDbName("testDB").build());
     String testCol = "ID";
     SourceColumnType testColType = new SourceColumnType("INTEGER", new Long[] {}, null);
-    when(mockDialectAdapter.discoverTables(any(), any())).thenReturn(ImmutableList.of("testTable"));
-    when(mockDialectAdapter.discoverTableIndexes(any(), any(), any()))
+    when(mockDialectAdapter.discoverTables(any(), (SourceSchemaReference) any()))
+        .thenReturn(ImmutableList.of("testTable"));
+    when(mockDialectAdapter.discoverTableIndexes(any(), (SourceSchemaReference) any(), any()))
         .thenReturn(
             ImmutableMap.of(
                 "testTable",
@@ -98,7 +100,7 @@ public class JdbcIoWrapperTest {
                         .setIsUnique(true)
                         .setOrdinalPosition(1)
                         .build())));
-    when(mockDialectAdapter.discoverTableSchema(any(), any(), any()))
+    when(mockDialectAdapter.discoverTableSchema(any(), (SourceSchemaReference) any(), any()))
         .thenReturn(ImmutableMap.of("testTable", ImmutableMap.of(testCol, testColType)));
     JdbcIoWrapper jdbcIoWrapper =
         JdbcIoWrapper.of(
@@ -130,11 +132,12 @@ public class JdbcIoWrapperTest {
   @Test
   public void testJdbcIoWrapperWithoutInference() throws RetriableSchemaDiscoveryException {
     SourceSchemaReference testSourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+        SourceSchemaReference.ofJdbc(JdbcSchemaReference.builder().setDbName("testDB").build());
     String testCol = "ID";
     SourceColumnType testColType = new SourceColumnType("INTEGER", new Long[] {}, null);
-    when(mockDialectAdapter.discoverTables(any(), any())).thenReturn(ImmutableList.of("testTable"));
-    when(mockDialectAdapter.discoverTableIndexes(any(), any(), any()))
+    when(mockDialectAdapter.discoverTables(any(), (SourceSchemaReference) any()))
+        .thenReturn(ImmutableList.of("testTable"));
+    when(mockDialectAdapter.discoverTableIndexes(any(), (SourceSchemaReference) any(), any()))
         .thenReturn(
             ImmutableMap.of(
                 "testTable",
@@ -148,7 +151,7 @@ public class JdbcIoWrapperTest {
                         .setIsUnique(true)
                         .setOrdinalPosition(1)
                         .build())));
-    when(mockDialectAdapter.discoverTableSchema(any(), any(), any()))
+    when(mockDialectAdapter.discoverTableSchema(any(), (SourceSchemaReference) any(), any()))
         .thenReturn(ImmutableMap.of("testTable", ImmutableMap.of(testCol, testColType)));
     JdbcIoWrapper jdbcIoWrapper =
         JdbcIoWrapper.of(
@@ -181,11 +184,12 @@ public class JdbcIoWrapperTest {
   @Test
   public void testJdbcIoWrapperNoIndexException() throws RetriableSchemaDiscoveryException {
     SourceSchemaReference testSourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+        SourceSchemaReference.ofJdbc(JdbcSchemaReference.builder().setDbName("testDB").build());
     String testCol = "ID";
     SourceColumnType testColType = new SourceColumnType("INTEGER", new Long[] {}, null);
-    when(mockDialectAdapter.discoverTables(any(), any())).thenReturn(ImmutableList.of("testTable"));
-    when(mockDialectAdapter.discoverTableIndexes(any(), any(), any()))
+    when(mockDialectAdapter.discoverTables(any(), (SourceSchemaReference) any()))
+        .thenReturn(ImmutableList.of("testTable"));
+    when(mockDialectAdapter.discoverTableIndexes(any(), (SourceSchemaReference) any(), any()))
         .thenReturn(ImmutableMap.of(/* No Index on testTable */ ))
         .thenReturn(
             ImmutableMap.of(
@@ -244,11 +248,12 @@ public class JdbcIoWrapperTest {
   public void testJdbcIoWrapperDifferentTables() throws RetriableSchemaDiscoveryException {
     // Test to check what happens if config passes tables not present in source
     SourceSchemaReference testSourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+        SourceSchemaReference.ofJdbc(JdbcSchemaReference.builder().setDbName("testDB").build());
     String testCol = "ID";
     SourceColumnType testColType = new SourceColumnType("INTEGER", new Long[] {}, null);
-    when(mockDialectAdapter.discoverTables(any(), any())).thenReturn(ImmutableList.of("testTable"));
-    when(mockDialectAdapter.discoverTableIndexes(any(), any(), any()))
+    when(mockDialectAdapter.discoverTables(any(), (SourceSchemaReference) any()))
+        .thenReturn(ImmutableList.of("testTable"));
+    when(mockDialectAdapter.discoverTableIndexes(any(), (SourceSchemaReference) any(), any()))
         .thenReturn(
             ImmutableMap.of(
                 "testTable",
@@ -262,7 +267,7 @@ public class JdbcIoWrapperTest {
                         .setIsUnique(true)
                         .setOrdinalPosition(1)
                         .build())));
-    when(mockDialectAdapter.discoverTableSchema(any(), any(), any()))
+    when(mockDialectAdapter.discoverTableSchema(any(), (SourceSchemaReference) any(), any()))
         .thenReturn(ImmutableMap.of("testTable", ImmutableMap.of(testCol, testColType)));
     JdbcIoWrapper jdbcIoWrapper =
         JdbcIoWrapper.of(
@@ -317,8 +322,9 @@ public class JdbcIoWrapperTest {
 
     String testCol = "ID";
     SourceColumnType testColType = new SourceColumnType("INTEGER", new Long[] {}, null);
-    when(mockDialectAdapter.discoverTables(any(), any())).thenReturn(ImmutableList.of("testTable"));
-    when(mockDialectAdapter.discoverTableIndexes(any(), any(), any()))
+    when(mockDialectAdapter.discoverTables(any(), (SourceSchemaReference) any()))
+        .thenReturn(ImmutableList.of("testTable"));
+    when(mockDialectAdapter.discoverTableIndexes(any(), (SourceSchemaReference) any(), any()))
         .thenReturn(
             ImmutableMap.of(
                 "testTable",
@@ -332,11 +338,11 @@ public class JdbcIoWrapperTest {
                         .setIsUnique(true)
                         .setOrdinalPosition(1)
                         .build())));
-    when(mockDialectAdapter.discoverTableSchema(any(), any(), any()))
+    when(mockDialectAdapter.discoverTableSchema(any(), (SourceSchemaReference) any(), any()))
         .thenReturn(ImmutableMap.of("testTable", ImmutableMap.of(testCol, testColType)));
 
     SourceSchemaReference testSourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+        SourceSchemaReference.ofJdbc(JdbcSchemaReference.builder().setDbName("testDB").build());
 
     JdbcIOWrapperConfig configWithFeatureEnabled =
         JdbcIOWrapperConfig.builderWithMySqlDefaults()
@@ -392,7 +398,7 @@ public class JdbcIoWrapperTest {
         .addConnectionProperty("loginTimeout", String.valueOf(testLoginTimeoutSeconds));
 
     SourceSchemaReference testSourceSchemaReference =
-        SourceSchemaReference.builder().setDbName("testDB").build();
+        SourceSchemaReference.ofJdbc(JdbcSchemaReference.builder().setDbName("testDB").build());
 
     JdbcIOWrapperConfig config =
         JdbcIOWrapperConfig.builderWithMySqlDefaults()

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaDiscoveryImplTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaDiscoveryImplTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource;
 import com.google.cloud.teleport.v2.source.reader.io.exception.RetriableSchemaDiscoveryException;
 import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryRetriesExhaustedException;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceColumnIndexInfo.IndexType;
@@ -31,7 +32,6 @@ import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.SQLTransientConnectionException;
-import javax.sql.DataSource;
 import org.apache.beam.sdk.util.BackOff;
 import org.apache.beam.sdk.util.FluentBackoff;
 import org.joda.time.Duration;
@@ -46,6 +46,7 @@ public class SchemaDiscoveryImplTest {
   @Mock RetriableSchemaDiscovery mockRetriableSchemaDiscovery;
 
   @Mock DataSource mockDataSource;
+  @Mock javax.sql.DataSource mockJdbcDataSource;
 
   @Mock SourceSchemaReference mockSourceSchemaReference;
 
@@ -53,6 +54,7 @@ public class SchemaDiscoveryImplTest {
   public void testSchemaDiscoveryImpl() throws RetriableSchemaDiscoveryException {
     final int testRetryCount = 2;
     final int expectedCallsCount = testRetryCount + 1;
+    when(mockDataSource.jdbc()).thenReturn(mockJdbcDataSource);
     when(mockRetriableSchemaDiscovery.discoverTableSchema(
             mockDataSource, mockSourceSchemaReference, ImmutableList.of()))
         .thenThrow(new RetriableSchemaDiscoveryException(new SQLTransientConnectionException()))
@@ -80,6 +82,7 @@ public class SchemaDiscoveryImplTest {
 
     when(mockFluentBackoff.backoff()).thenReturn(mockBackoff);
     when(mockBackoff.nextBackOffMillis()).thenThrow(new IOException("test"));
+    when(mockDataSource.jdbc()).thenReturn(mockJdbcDataSource);
     when(mockRetriableSchemaDiscovery.discoverTableSchema(
             mockDataSource, mockSourceSchemaReference, ImmutableList.of()))
         .thenThrow(new RetriableSchemaDiscoveryException(new SQLTransientConnectionException()));
@@ -100,6 +103,7 @@ public class SchemaDiscoveryImplTest {
 
     final int testRetryCount = 2;
     final int expectedCallsCount = testRetryCount + 1;
+    when(mockDataSource.jdbc()).thenReturn(mockJdbcDataSource);
     when(mockRetriableSchemaDiscovery.discoverTableSchema(
             mockDataSource, mockSourceSchemaReference, ImmutableList.of()))
         .thenThrow(new RetriableSchemaDiscoveryException(new SQLTransientConnectionException()));
@@ -124,6 +128,7 @@ public class SchemaDiscoveryImplTest {
     final int testRetryCount = 2;
     final int expectedCallsCount = testRetryCount + 1;
     final ImmutableList<String> testTables = ImmutableList.of("testTable1", "testTable2");
+    when(mockDataSource.jdbc()).thenReturn(mockJdbcDataSource);
     when(mockRetriableSchemaDiscovery.discoverTables(mockDataSource, mockSourceSchemaReference))
         .thenThrow(new RetriableSchemaDiscoveryException(new SQLTransientConnectionException()))
         .thenThrow(new RetriableSchemaDiscoveryException(new SQLTransientConnectionException()))
@@ -157,6 +162,7 @@ public class SchemaDiscoveryImplTest {
                     .setOrdinalPosition(1)
                     .setIndexType(IndexType.NUMERIC)
                     .build()));
+    when(mockDataSource.jdbc()).thenReturn(mockJdbcDataSource);
     when(mockRetriableSchemaDiscovery.discoverTableIndexes(
             mockDataSource, mockSourceSchemaReference, ImmutableList.of("testTable1")))
         .thenThrow(new RetriableSchemaDiscoveryException(new SQLTransientConnectionException()))

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaTestUtils.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaTestUtils.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.schema;
 
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.JdbcSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.SQLDialect;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 
@@ -25,7 +26,8 @@ public class SchemaTestUtils {
   static final String TEST_FIELD_NAME_2 = "lastName";
 
   public static SourceSchemaReference generateSchemaReference(String namespace, String dbName) {
-    return SourceSchemaReference.builder().setNamespace(namespace).setDbName(dbName).build();
+    return SourceSchemaReference.ofJdbc(
+        JdbcSchemaReference.builder().setNamespace(namespace).setDbName(dbName).build());
   }
 
   public static SourceTableSchema generateTestTableSchema(String tableName) {

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceSchemaReferenceTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceSchemaReferenceTest.java
@@ -17,40 +17,31 @@ package com.google.cloud.teleport.v2.source.reader.io.schema;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import junit.framework.TestCase;
-import org.junit.Assert;
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.schema.CassandraSchemaReference;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.JdbcSchemaReference;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference.Kind;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
-/** Test class for {@link SourceSchemaReference}. */
 @RunWith(MockitoJUnitRunner.class)
-public class SourceSchemaReferenceTest extends TestCase {
-
+public class SourceSchemaReferenceTest {
   @Test
-  public void testDbNameWithNullNamespaceBuilds() {
-    final String testDB = "testDb";
-    SourceSchemaReference ref = SourceSchemaReference.builder().setDbName(testDB).build();
-    assertThat(ref.namespace()).isNull();
-    assertThat(ref.dbName()).isEqualTo(testDB);
-    assertThat(ref.getName()).isEqualTo("Db." + testDB);
-  }
-
-  @Test
-  public void testDbNameWithNamespaceBuilds() {
-    final String testDB = "testDb";
-    final String testNamespace = "testNamespace";
-    SourceSchemaReference ref =
-        SourceSchemaReference.builder().setDbName(testDB).setNamespace(testNamespace).build();
-    assertThat(ref.dbName()).isEqualTo(testDB);
-    assertThat(ref.namespace()).isEqualTo(testNamespace);
-    assertThat(ref.getName()).isEqualTo("Db." + testDB + ".Namespace." + testNamespace);
-  }
-
-  @Test
-  public void testNullDbNameThrowsIllegalStateException() {
-    // As dbName is a required property, we expect "java.lang.IllegalStateException"
-    Assert.assertThrows(
-        java.lang.IllegalStateException.class, () -> SourceSchemaReference.builder().build());
+  public void testSourceSchemaReferenceBasic() {
+    JdbcSchemaReference jdbcSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
+    CassandraSchemaReference cassandraSchemaReference =
+        CassandraSchemaReference.builder().setKeyspaceName("testKeySpace").build();
+    assertThat(SourceSchemaReference.ofJdbc(jdbcSchemaReference).getName())
+        .isEqualTo(jdbcSchemaReference.getName());
+    assertThat(SourceSchemaReference.ofJdbc(jdbcSchemaReference).getKind()).isEqualTo(Kind.JDBC);
+    assertThat(SourceSchemaReference.ofJdbc(jdbcSchemaReference).jdbc())
+        .isEqualTo(jdbcSchemaReference);
+    assertThat(SourceSchemaReference.ofCassandra(cassandraSchemaReference).getKind())
+        .isEqualTo(Kind.CASSANDRA);
+    assertThat(SourceSchemaReference.ofCassandra(cassandraSchemaReference).getName())
+        .isEqualTo(cassandraSchemaReference.getName());
+    assertThat(SourceSchemaReference.ofCassandra(cassandraSchemaReference).cassandra())
+        .isEqualTo(cassandraSchemaReference);
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceSchemaTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceSchemaTest.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.source.reader.io.schema;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.JdbcSchemaReference;
 import junit.framework.TestCase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,10 +34,12 @@ public class SourceSchemaTest extends TestCase {
 
     SourceSchema testSchema =
         SourceSchema.builder()
-            .setSchemaReference(SourceSchemaReference.builder().setDbName(testDb).build())
+            .setSchemaReference(
+                SourceSchemaReference.ofJdbc(
+                    JdbcSchemaReference.builder().setDbName(testDb).build()))
             .addTableSchema(SchemaTestUtils.generateTestTableSchema(testTable))
             .build();
-    assertThat(testSchema.schemaReference().dbName()).isEqualTo(testDb);
+    assertThat(testSchema.schemaReference().jdbc().dbName()).isEqualTo(testDb);
     assertThat(testSchema.tableSchemas()).hasSize(1);
     assertThat(testSchema.tableSchemas().get(0).avroSchema().getFields()).hasSize(2);
   }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceTableReferenceTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceTableReferenceTest.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.source.reader.io.schema;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.JdbcSchemaReference;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -31,12 +32,14 @@ public class SourceTableReferenceTest {
     final String testTableUUID = "10a03145-47bd-4d6c-8168-3eab0f9f847b";
     SourceTableReference ref =
         SourceTableReference.builder()
-            .setSourceSchemaReference(SourceSchemaReference.builder().setDbName(testDB).build())
+            .setSourceSchemaReference(
+                SourceSchemaReference.ofJdbc(
+                    JdbcSchemaReference.builder().setDbName(testDB).build()))
             .setSourceTableName(testTable)
             .setSourceTableSchemaUUID(testTableUUID)
             .build();
-    assertThat(ref.sourceSchemaReference().namespace()).isNull();
-    assertThat(ref.sourceSchemaReference().dbName()).isEqualTo(testDB);
+    assertThat(ref.sourceSchemaReference().jdbc().namespace()).isNull();
+    assertThat(ref.sourceSchemaReference().jdbc().dbName()).isEqualTo(testDB);
     assertThat(ref.sourceTableName()).isEqualTo(testTable);
     assertThat(ref.sourceTableSchemaUUID()).isEqualTo(testTableUUID);
     assertThat(ref.getName()).isEqualTo("Db.testDb.Table.testTable");

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/transform/AccumulatingTableReaderTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/transform/AccumulatingTableReaderTest.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.transform;
 
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.JdbcSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.row.SourceRow;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableReference;
@@ -39,7 +40,7 @@ public class AccumulatingTableReaderTest implements Serializable {
   public void testAccumulatingTableReader() {
     final String dbName = "testDB";
     final SourceSchemaReference sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName(dbName).build();
+        SourceSchemaReference.ofJdbc(JdbcSchemaReference.builder().setDbName(dbName).build());
     final long rowCountPerTable = 10;
     final long tableCount = 1;
     final TupleTag<SourceRow> sourceRowTupleTag = new TupleTag<>();

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/transform/ReaderTransformTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/transform/ReaderTransformTest.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.source.reader.io.transform;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.JdbcSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,7 +31,7 @@ public class ReaderTransformTest {
   public void testReaderTransformBuilds() {
     final String dbName = "testDB";
     final SourceSchemaReference sourceSchemaReference =
-        SourceSchemaReference.builder().setDbName(dbName).build();
+        SourceSchemaReference.ofJdbc(JdbcSchemaReference.builder().setDbName(dbName).build());
     final long rowCountPerTable = 10;
     final long tableCount = 1;
     ReaderTransformTestUtils readerTransformTestUtils =


### PR DESCRIPTION
## Overview
One time Refactoring DataSource and SchemaReference to allow non-jdbc sources.

This refactoring is a small step from the point of view of having standardized io interfaces for various sources that we might need in future. With this one-time change, the code base will be able to accomodate a `DataSource` and `SchemaReference` of any generic type. 

## Gist
Although the change looks big, the gist is:

1. The earlier `SourceSchemaReference` is named as `JdbcSchemaReference` and now `SouceSchemaReference` is a `oneOf` of `Cassandra` or `Jdbc`
2. Similarly `DataSource` is a `oneOf` of `Cassandra` or `javax.sql.DataSource`.

## Note on Choice of `OneOf` vs `inhertence`
Generally inheritance is preferred to represent related classes. In this case however, we have value classes with completely different set of `getter` methods. 
For example, what a Cassandra SchemaReference might call is `keySpace` is what a Jdbc SchemaReference would call as `dbName()`. Similarly a `session` on CassandraDataSource comes close to a `Connection` on `Jdbc`.
So in this specific use case, having `oneOf` for value classes keeps the code more readable and catches many (though not all) unwanted references at compile time. For example, `sourceSchemaReference.cassandra().dbName()` will not compile and help the IDE show warning immediately.

Please refer to Google's [example](https://github.com/google/auto/blob/main/value/userguide/howto.md#-make-a-class-where-only-one-of-its-properties-is-ever-set) of `AutoOneOf` used to represent one-of between 2 completely varied classes like String and Integer which don't share a lot of methods.

## Scope of this PR
1. Currently this PR focusses on `SchemaReference` and `DataSource` value types
2. The changes to config layer is out of the scope of this PR and will be taken up as a followon.