### PR TITLE
Make codecov informational only.

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -9,7 +9,7 @@ coverage:
     patch:
       default:
         target: 80%
-        informational: false
+        informational: true
 
 component_management:
   individual_components:
@@ -32,7 +32,7 @@ component_management:
       informational: true
     - type: patch
       target: 80%
-      informational: false
+      informational: true
   - component_id: spanner-import-export
     name: spanner-import-export
     paths:


### PR DESCRIPTION
Right now, codecov repeatedly fails, and we don't do anything about it. This means that we can't enforce that all of our checks pass because we'll always have a red x. This addresses that problem.