### PR TITLE
Add DLQ support to JdbcToBigQuery using BQ Storage Write API

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/ErrorConverters.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/ErrorConverters.java
@@ -59,6 +59,7 @@ import org.apache.beam.sdk.values.TypeDescriptors;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Ascii;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
+import org.joda.time.Instant;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
@@ -83,11 +84,15 @@ public class ErrorConverters {
 
     public abstract String getErrorRecordsTableSchema();
 
+    public abstract boolean getUseWindowedTimestamp();
+
     @Override
     public WriteResult expand(PCollection<FailsafeElement<String, String>> failedRecords) {
 
       return failedRecords
-          .apply("FailedRecordToTableRow", ParDo.of(new FailedStringToTableRowFn()))
+          .apply(
+              "FailedRecordToTableRow",
+              ParDo.of(new FailedStringToTableRowFn(getUseWindowedTimestamp())))
           .apply(
               "WriteFailedRecordsToBigQuery",
               BigQueryIO.writeTableRows()
@@ -104,6 +109,8 @@ public class ErrorConverters {
 
       public abstract Builder setErrorRecordsTableSchema(String errorRecordsTableSchema);
 
+      public abstract Builder setUseWindowedTimestamp(boolean useWindowedTimestamp);
+
       public abstract WriteStringMessageErrors build();
     }
   }
@@ -114,6 +121,16 @@ public class ErrorConverters {
    */
   public static class FailedStringToTableRowFn
       extends DoFn<FailsafeElement<String, String>, TableRow> {
+
+    private boolean useWindowedTimestamp;
+
+    public FailedStringToTableRowFn() {
+      this(true);
+    }
+
+    public FailedStringToTableRowFn(boolean useWindowedTimestamp) {
+      this.useWindowedTimestamp = useWindowedTimestamp;
+    }
 
     /**
      * The formatter used to convert timestamps into a BigQuery compatible <a
@@ -129,7 +146,9 @@ public class ErrorConverters {
 
       // Format the timestamp for insertion
       String timestamp =
-          TIMESTAMP_FORMATTER.print(context.timestamp().toDateTime(DateTimeZone.UTC));
+          TIMESTAMP_FORMATTER.print(
+              (useWindowedTimestamp ? context.timestamp() : Instant.now())
+                  .toDateTime(DateTimeZone.UTC));
 
       // Build the table row
       TableRow failedRow =

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/ErrorConverters.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/ErrorConverters.java
@@ -77,7 +77,8 @@ public class ErrorConverters {
       extends PTransform<PCollection<FailsafeElement<String, String>>, WriteResult> {
 
     public static Builder newBuilder() {
-      return new AutoValue_ErrorConverters_WriteStringMessageErrors.Builder();
+      return new AutoValue_ErrorConverters_WriteStringMessageErrors.Builder()
+          .setUseWindowedTimestamp(true);
     }
 
     public abstract String getErrorRecordsTable();

--- a/v2/jdbc-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/JdbcToBigQueryOptions.java
+++ b/v2/jdbc-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/JdbcToBigQueryOptions.java
@@ -256,4 +256,19 @@ public interface JdbcToBigQueryOptions
   String getBigQuerySchemaPath();
 
   void setBigQuerySchemaPath(String path);
+
+  @TemplateParameter.BigQueryTable(
+      order = 21,
+      optional = true,
+      description =
+          "Table for messages that failed to reach the output table (i.e., Deadletter table) when using Storage Write API",
+      helpText =
+          "The BigQuery table to use for messages that failed to reach the output table, "
+              + "formatted as `\"PROJECT_ID:DATASET_NAME.TABLE_NAME\"`. If the table "
+              + "doesn't exist, it is created when the pipeline runs. "
+              + "If this parameter is not specified, the pipeline will fail on write errors."
+              + "This parameter can only be specified if `useStorageWriteApi` or `useStorageWriteApiAtLeastOnce` is set to true.")
+  String getOutputDeadletterTable();
+
+  void setOutputDeadletterTable(String value);
 }

--- a/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryIT.java
+++ b/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryIT.java
@@ -425,10 +425,10 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
                 .addParameter("useColumnAlias", "true")
                 .addParameter("fetchSize", "100000")
                 .addParameter("connectionProperties", "characterEncoding=UTF-8")
-                .addParameter("disabledAlgorithms", "SSLv3, GCM")
-                .addParameter(
-                    "outputDeadletterTable",
-                    useDlq ? toTableSpecLegacy(table) + "_error_records" : ""));
+                .addParameter("disabledAlgorithms", "SSLv3, GCM"));
+    if (useDlq) {
+      options.addParameter("outputDeadletterTable", toTableSpecLegacy(table) + "_error_records");
+    }
 
     // Act
     PipelineLauncher.LaunchInfo info = launchTemplate(options);

--- a/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryIT.java
+++ b/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryIT.java
@@ -66,6 +66,8 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
 
   private static final Logger LOG = LoggerFactory.getLogger(JdbcToBigQueryIT.class);
 
+  private static final Integer NUM_ROWS = 100;
+
   private static final String ROW_ID = "row_id";
   private static final String NAME = "name";
   private static final String FULL_NAME = "full_name";
@@ -73,6 +75,7 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
   private static final String MEMBER = "member";
   private static final String IS_MEMBER = "is_member";
   private static final String ENTRY_ADDED = "entry_added";
+  private static final String FAKE = "FAKE";
 
   private static final String KMS_REGION = "global";
   private static final String KEYRING_ID = "JDBCToBigQuery";
@@ -125,11 +128,42 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
         mySqlDriverGCSPath(),
         mySQLResourceManager,
         true,
+        false,
         config ->
             config.addParameter(
                 "query",
                 "SELECT ROW_ID, NAME AS FULL_NAME, AGE, MEMBER AS IS_MEMBER, ENTRY_ADDED FROM "
                     + testName));
+  }
+
+  @Test
+  public void testMySqlToBigQueryFlexWithDlq() throws IOException {
+    // Create MySQL Resource manager
+    mySQLResourceManager = MySQLResourceManager.builder(testName).build();
+
+    // Arrange MySQL-compatible schema
+    HashMap<String, String> columns = new HashMap<>();
+    columns.put(ROW_ID, "NUMERIC NOT NULL");
+    columns.put(NAME, "VARCHAR(200)");
+    columns.put(AGE, "NUMERIC");
+    columns.put(MEMBER, "VARCHAR(200)");
+    columns.put(ENTRY_ADDED, "VARCHAR(200)");
+    columns.put(FAKE, "VARCHAR(200)");
+    JDBCResourceManager.JDBCSchema schema = new JDBCResourceManager.JDBCSchema(columns, ROW_ID);
+
+    // Run a simple IT
+    simpleJdbcToBigQueryTest(
+        testName,
+        schema,
+        MYSQL_DRIVER,
+        mySqlDriverGCSPath(),
+        mySQLResourceManager,
+        true,
+        true,
+        config ->
+            config
+                .addParameter("query", "select * from " + testName)
+                .addParameter("useStorageWriteApi", "true"));
   }
 
   @Test
@@ -156,6 +190,7 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
         mySqlDriverGCSPath(),
         mySQLResourceManager,
         true,
+        false,
         config ->
             config
                 .addParameter(
@@ -186,6 +221,7 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
         postgresDriverGCSPath(),
         postgresResourceManager,
         true,
+        false,
         config ->
             config.addParameter(
                 "query",
@@ -220,6 +256,7 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
         postgresDriverGCSPath(),
         postgresResourceManager,
         true,
+        false,
         config -> config.addParameter("query", getGcsPath("input/query.sql")));
   }
 
@@ -251,6 +288,7 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
         oracleDriverGCSPath(),
         oracleResourceManager,
         true,
+        false,
         config ->
             config.addParameter(
                 "query",
@@ -280,6 +318,7 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
         msSqlDriverGCSPath(),
         msSQLResourceManager,
         true,
+        false,
         config ->
             config.addParameter(
                 "query",
@@ -307,6 +346,7 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
         postgresDriverGCSPath(),
         postgresResourceManager,
         false,
+        false,
         config -> config.addParameter("table", testName).addParameter("partitionColumn", ROW_ID));
   }
 
@@ -317,6 +357,7 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
       String driverJars,
       JDBCResourceManager jdbcResourceManager,
       boolean useColumnAlias,
+      boolean useDlq,
       Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder)
       throws IOException {
     simpleJdbcToBigQueryTest(
@@ -328,6 +369,7 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
         driverJars,
         jdbcResourceManager,
         useColumnAlias,
+        useDlq,
         paramsAdder);
   }
 
@@ -340,12 +382,16 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
       String driverJars,
       JDBCResourceManager jdbcResourceManager,
       boolean useColumnAlias,
+      boolean useDlq,
       Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder)
       throws IOException {
 
     // Arrange
-    List<Map<String, Object>> jdbcData =
-        getJdbcData(List.of(ROW_ID, NAME, AGE, MEMBER, ENTRY_ADDED));
+    List<String> columns = new ArrayList<>(List.of(ROW_ID, NAME, AGE, MEMBER, ENTRY_ADDED));
+    if (useDlq) {
+      columns.add(FAKE);
+    }
+    List<Map<String, Object>> jdbcData = getJdbcData(columns, useDlq);
     jdbcResourceManager.createTable(sourceTableName, schema);
     jdbcResourceManager.write(sourceTableName, jdbcData);
 
@@ -379,7 +425,10 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
                 .addParameter("useColumnAlias", "true")
                 .addParameter("fetchSize", "100000")
                 .addParameter("connectionProperties", "characterEncoding=UTF-8")
-                .addParameter("disabledAlgorithms", "SSLv3, GCM"));
+                .addParameter("disabledAlgorithms", "SSLv3, GCM")
+                .addParameter(
+                    "outputDeadletterTable",
+                    useDlq ? toTableSpecLegacy(table) + "_error_records" : ""));
 
     // Act
     PipelineLauncher.LaunchInfo info = launchTemplate(options);
@@ -397,8 +446,15 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
             row.put("is_member", row.remove("member"));
           });
     }
-    assertThatBigQueryRecords(bigQueryResourceManager.readTable(targetTableName))
-        .hasRecordsUnorderedCaseInsensitiveColumns(jdbcData);
+    if (useDlq) {
+      assertThatBigQueryRecords(bigQueryResourceManager.readTable(targetTableName)).hasRows(0);
+      assertThatBigQueryRecords(
+              bigQueryResourceManager.readTable(targetTableName + "_error_records"))
+          .hasRows(NUM_ROWS);
+    } else {
+      assertThatBigQueryRecords(bigQueryResourceManager.readTable(targetTableName))
+          .hasRecordsUnorderedCaseInsensitiveColumns(jdbcData);
+    }
   }
 
   /**
@@ -407,15 +463,18 @@ public class JdbcToBigQueryIT extends JDBCBaseIT {
    * @param columns List of column names.
    * @return A map containing the rows of data to be stored in each JDBC table.
    */
-  private List<Map<String, Object>> getJdbcData(List<String> columns) {
+  private List<Map<String, Object>> getJdbcData(List<String> columns, boolean useDlq) {
     List<Map<String, Object>> data = new ArrayList<>();
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < NUM_ROWS; i++) {
       Map<String, Object> values = new HashMap<>();
       values.put(columns.get(0), i);
       values.put(columns.get(1), RandomStringUtils.randomAlphabetic(10));
       values.put(columns.get(2), new Random().nextInt(100));
       values.put(columns.get(3), i % 2 == 0 ? "Y" : "N");
       values.put(columns.get(4), Instant.now().toString());
+      if (useDlq) {
+        values.put(columns.get(5), RandomStringUtils.randomAlphabetic(10));
+      }
       data.add(values);
     }
 


### PR DESCRIPTION
This PR adds proper error handling to the JdbcToBigQueryFlex template when using Storage Write API.

Before this change, the WriteToBigQuery step would succeed even when there were write failures. These errors were never captured or handled, thus resulting in dropped rows. This PR will now fail the pipeline on write errors by default when using Storage Write API. If a deadletter table is specified, then errors will instead be written the the DLQ table (created if needed).