### PR TITLE
add KMS key support to BigQueryConverters

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java
@@ -78,6 +78,7 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Supplier;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Suppliers;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Throwables;
 import org.apache.commons.text.StringSubstitutor;
+import org.apache.parquet.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -241,6 +242,18 @@ public class BigQueryConverters {
     String getQueryTempDataset();
 
     void setQueryTempDataset(String queryTempDataset);
+
+    @TemplateParameter.KmsEncryptionKey(
+        order = 8,
+        optional = true,
+        description = "Google Cloud KMS key",
+        helpText =
+            "If reading from BigQuery using query source, use this Cloud KMS key to encrypt any temporary tables created.",
+        example =
+            "projects/your-project/locations/global/keyRings/your-keyring/cryptoKeys/your-key")
+    String getKMSEncryptionKey();
+
+    void setKMSEncryptionKey(String keyName);
   }
 
   /**
@@ -340,11 +353,17 @@ public class BigQueryConverters {
     @Override
     public PCollection<T> expand(PBegin pipeline) {
 
+      BigQueryIO.TypedRead<T> readFunction = readFunction();
+
+      if (!Strings.isNullOrEmpty(options().getKMSEncryptionKey())) {
+        readFunction = readFunction.withKmsKey(options().getKMSEncryptionKey());
+      }
+
       if (options().getQuery() == null) {
         LOG.info("No query provided, reading directly from: " + options().getInputTableSpec());
         return pipeline.apply(
             "ReadFromBigQuery",
-            readFunction()
+            readFunction
                 .from(options().getInputTableSpec())
                 .withTemplateCompatibility()
                 .withMethod(Method.DIRECT_READ));
@@ -357,7 +376,7 @@ public class BigQueryConverters {
           LOG.info("Using Standard SQL");
           return pipeline.apply(
               "ReadFromBigQueryWithQuery",
-              readFunction()
+              readFunction
                   .fromQuery(options().getQuery())
                   .withTemplateCompatibility()
                   .withQueryLocation(options().getQueryLocation())
@@ -368,7 +387,7 @@ public class BigQueryConverters {
           LOG.info("Using Legacy SQL");
           return pipeline.apply(
               "ReadFromBigQueryWithQuery",
-              readFunction()
+              readFunction
                   .fromQuery(options().getQuery())
                   .withTemplateCompatibility()
                   .withQueryLocation(options().getQueryLocation())

--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/BigQueryConverters.java
@@ -244,7 +244,7 @@ public class BigQueryConverters {
     void setQueryTempDataset(String queryTempDataset);
 
     @TemplateParameter.KmsEncryptionKey(
-        order = 8,
+        order = 7,
         optional = true,
         description = "Google Cloud KMS key",
         helpText =


### PR DESCRIPTION
This PR adds support for encrypting temporary table created during BigQueryIO read for any templates that use the BigQueryConverters class (v2) to read from BigQuery.

This only applies when using `query` to read from the BigQuery source