### PR TITLE
[KafkaToBigQueryFlex Template]: Add support for Avro ENUM type and fix FLOAT type.

### DIFF
--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/utils/BigQueryAvroUtils.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/utils/BigQueryAvroUtils.java
@@ -46,6 +46,7 @@ import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.Schema.Type;
+import org.apache.avro.generic.GenericData.EnumSymbol;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.extensions.avro.schemas.utils.AvroUtils;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryUtils;
@@ -84,9 +85,11 @@ public class BigQueryAvroUtils {
           .put("INTEGER", Type.INT)
           .put("INT64", Type.LONG)
           .put("INT64", Type.INT)
-          .put("FLOAT", Type.DOUBLE)
-          .put("FLOAT", Type.INT)
+          // BigQueryUtils map both Avro's FLOAT and DOUBLE to BigQuery's FLOAT64:
+          // https://github.com/apache/beam/blob/b70375db84a7ff04a6be3aea8d5ae30f4d7cdbe1/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java#L227-L228
           .put("FLOAT64", Type.DOUBLE)
+          .put("FLOAT64", Type.FLOAT)
+          .put("FLOAT64", Type.LONG)
           .put("FLOAT64", Type.INT)
           .put("NUMERIC", Type.BYTES)
           .put("BIGNUMERIC", Type.BYTES)
@@ -313,11 +316,16 @@ public class BigQueryAvroUtils {
     // BigQuery represents NUMERIC in Avro format as BYTES with a DECIMAL logical type.
     switch (bqType) {
       case "STRING":
+        // Avro will use a CharSequence to represent String objects, but it may not always use
+        // java.lang.String; for example, it may prefer org.apache.avro.util.Utf8.
+        verify(
+            v instanceof CharSequence || v instanceof EnumSymbol,
+            "Expected CharSequence (String) or EnumSymbol, got %s",
+            v.getClass());
+        return v.toString();
       case "DATETIME":
       case "GEOGRAPHY":
       case "JSON":
-        // Avro will use a CharSequence to represent String objects, but it may not always use
-        // java.lang.String; for example, it may prefer org.apache.avro.util.Utf8.
         verify(v instanceof CharSequence, "Expected CharSequence (String), got %s", v.getClass());
         return v.toString();
       case "DATE":
@@ -351,11 +359,16 @@ public class BigQueryAvroUtils {
           verify(v instanceof Long, "Expected Long, got %s", v.getClass());
           return ((Long) v).toString();
         }
-      case "FLOAT":
       case "FLOAT64":
         if (avroType == Type.INT) {
           verify(v instanceof Integer, "Expected Integer, got %s", v.getClass());
           return (Double) ((Integer) v).doubleValue();
+        } else if (avroType == Type.LONG) {
+          verify(v instanceof Long, "Expected Long, got %s", v.getClass());
+          return (Double) ((Long) v).doubleValue();
+        } else if (avroType == Type.FLOAT) {
+          verify(v instanceof Float, "Expected Float, got %s", v.getClass());
+          return (Double) ((Float) v).doubleValue();
         } else {
           verify(v instanceof Double, "Expected Double, got %s", v.getClass());
           return v;

--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/utils/BigQueryAvroUtils.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/utils/BigQueryAvroUtils.java
@@ -77,6 +77,7 @@ public class BigQueryAvroUtils {
   static final ImmutableMultimap<String, Type> BIG_QUERY_TO_AVRO_TYPES =
       ImmutableMultimap.<String, Type>builder()
           .put("STRING", Type.STRING)
+          .put("STRING", Type.ENUM)
           .put("GEOGRAPHY", Type.STRING)
           .put("BYTES", Type.BYTES)
           .put("INTEGER", Type.LONG)

--- a/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
+++ b/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
@@ -93,6 +93,7 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
         Schema.of(
             Field.of("productId", StandardSQLTypeName.INT64),
             Field.newBuilder("productName", StandardSQLTypeName.STRING).setMaxLength(10L).build(),
+            Field.of("productSize", StandardSQLTypeName.FLOAT64),
             Field.of("productUsage", StandardSQLTypeName.STRING));
 
     kafkaResourceManager =

--- a/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
+++ b/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
@@ -454,7 +454,7 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
                       "productName",
                       "Dataflow",
                       "productSize",
-                      2d,
+                      2.5d,
                       "productUsage",
                       "HIGH",
                       "_key",
@@ -480,7 +480,7 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
                       "productName",
                       "Dataflow",
                       "productSize",
-                      2d,
+                      2.5d,
                       "productUsage",
                       "HIGH"),
                   Map.of(
@@ -505,7 +505,7 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
             new StringSerializer(), new KafkaAvroSerializer(registryClient));
 
     for (int i = 1; i <= 10; i++) {
-      GenericRecord dataflow = createRecord(Integer.valueOf(i + "1"), "Dataflow", 2f, "HIGH");
+      GenericRecord dataflow = createRecord(Integer.valueOf(i + "1"), "Dataflow", 2.5f, "HIGH");
       publish(kafkaProducer, topicName, i + "1", dataflow);
 
       GenericRecord pubsub = createRecord(Integer.valueOf(i + "2"), "Pub/Sub", 123.125f, "MEDIUM");
@@ -534,7 +534,7 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
             new StringSerializer(), new KafkaAvroSerializer(registryClient));
 
     for (int i = 1; i <= 10; i++) {
-      GenericRecord dataflow = createRecord(Integer.valueOf(i + "1"), "Dataflow", 2f, "HIGH");
+      GenericRecord dataflow = createRecord(Integer.valueOf(i + "1"), "Dataflow", 2.5f, "HIGH");
       publish(kafkaProducer, topicName, i + "1", dataflow);
 
       GenericRecord pubsub = createRecord(Integer.valueOf(i + "2"), "Pub/Sub", 123.125f, "MEDIUM");
@@ -569,7 +569,7 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
             new StringSerializer(), new BinaryAvroSerializer(avroSchema));
 
     for (int i = 1; i <= 10; i++) {
-      GenericRecord dataflow = createRecord(Integer.valueOf(i + "1"), "Dataflow", 2f, "HIGH");
+      GenericRecord dataflow = createRecord(Integer.valueOf(i + "1"), "Dataflow", 2.5f, "HIGH");
       publishBinary(kafkaProducer, topicName, i + "1", dataflow);
 
       GenericRecord pubsub = createRecord(Integer.valueOf(i + "2"), "Pub/Sub", 123.125f, "MEDIUM");

--- a/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
+++ b/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
@@ -487,7 +487,7 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
       GenericRecord pubsub = createRecord(Integer.valueOf(i + "2"), "Pub/Sub", "MEDIUM");
       publish(kafkaProducer, topicName, i + "2", pubsub);
 
-      GenericRecord invalid = createRecord(Integer.valueOf(i + "3"), "InvalidNameTooLong", "N/A");
+      GenericRecord invalid = createRecord(Integer.valueOf(i + "3"), "InvalidNameTooLong", "UNDEFINED");
       publish(kafkaProducer, topicName, i + "3", invalid);
 
       try {
@@ -515,7 +515,7 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
       GenericRecord pubsub = createRecord(Integer.valueOf(i + "2"), "Pub/Sub", "MEDIUM");
       publish(kafkaProducer, topicName, i + "2", pubsub);
 
-      GenericRecord invalid = createRecord(Integer.valueOf(i + "3"), "InvalidNameTooLong", "N/A");
+      GenericRecord invalid = createRecord(Integer.valueOf(i + "3"), "InvalidNameTooLong", "UNDEFINED");
       publish(kafkaProducer, topicName, i + "3", invalid);
 
       GenericRecord otherDataflow =
@@ -549,7 +549,7 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
       GenericRecord pubsub = createRecord(Integer.valueOf(i + "2"), "Pub/Sub", "MEDIUM");
       publishBinary(kafkaProducer, topicName, i + "2", pubsub);
 
-      GenericRecord invalid = createRecord(Integer.valueOf(i + "3"), "InvalidNameTooLong", "N/A");
+      GenericRecord invalid = createRecord(Integer.valueOf(i + "3"), "InvalidNameTooLong", "UNDEFINED");
       publishBinary(kafkaProducer, topicName, i + "3", invalid);
 
       try {

--- a/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
+++ b/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
@@ -452,6 +452,8 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
                       11,
                       "productName",
                       "Dataflow",
+                      "productSize",
+                      2d,
                       "productUsage",
                       "HIGH",
                       "_key",
@@ -461,6 +463,8 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
                       12,
                       "productName",
                       "Pub/Sub",
+                      "productSize",
+                      123.125d,
                       "productUsage",
                       "MEDIUM",
                       "_key",
@@ -469,8 +473,24 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
       assertThatBigQueryRecords(tableRows)
           .hasRecordsUnordered(
               List.of(
-                  Map.of("productId", 11, "productName", "Dataflow", "productUsage", "HIGH"),
-                  Map.of("productId", 12, "productName", "Pub/Sub", "productUsage", "MEDIUM")));
+                  Map.of(
+                      "productId",
+                      11,
+                      "productName",
+                      "Dataflow",
+                      "productSize",
+                      2d,
+                      "productUsage",
+                      "HIGH"),
+                  Map.of(
+                      "productId",
+                      12,
+                      "productName",
+                      "Pub/Sub",
+                      "productSize",
+                      123.125d,
+                      "productUsage",
+                      "MEDIUM")));
     }
   }
 
@@ -484,14 +504,14 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
             new StringSerializer(), new KafkaAvroSerializer(registryClient));
 
     for (int i = 1; i <= 10; i++) {
-      GenericRecord dataflow = createRecord(Integer.valueOf(i + "1"), "Dataflow", "HIGH");
+      GenericRecord dataflow = createRecord(Integer.valueOf(i + "1"), "Dataflow", 2f, "HIGH");
       publish(kafkaProducer, topicName, i + "1", dataflow);
 
-      GenericRecord pubsub = createRecord(Integer.valueOf(i + "2"), "Pub/Sub", "MEDIUM");
+      GenericRecord pubsub = createRecord(Integer.valueOf(i + "2"), "Pub/Sub", 123.125f, "MEDIUM");
       publish(kafkaProducer, topicName, i + "2", pubsub);
 
       GenericRecord invalid =
-          createRecord(Integer.valueOf(i + "3"), "InvalidNameTooLong", "UNDEFINED");
+          createRecord(Integer.valueOf(i + "3"), "InvalidNameTooLong", 0f, "UNDEFINED");
       publish(kafkaProducer, topicName, i + "3", invalid);
 
       try {
@@ -513,14 +533,14 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
             new StringSerializer(), new KafkaAvroSerializer(registryClient));
 
     for (int i = 1; i <= 10; i++) {
-      GenericRecord dataflow = createRecord(Integer.valueOf(i + "1"), "Dataflow", "HIGH");
+      GenericRecord dataflow = createRecord(Integer.valueOf(i + "1"), "Dataflow", 2f, "HIGH");
       publish(kafkaProducer, topicName, i + "1", dataflow);
 
-      GenericRecord pubsub = createRecord(Integer.valueOf(i + "2"), "Pub/Sub", "MEDIUM");
+      GenericRecord pubsub = createRecord(Integer.valueOf(i + "2"), "Pub/Sub", 123.125f, "MEDIUM");
       publish(kafkaProducer, topicName, i + "2", pubsub);
 
       GenericRecord invalid =
-          createRecord(Integer.valueOf(i + "3"), "InvalidNameTooLong", "UNDEFINED");
+          createRecord(Integer.valueOf(i + "3"), "InvalidNameTooLong", 0f, "UNDEFINED");
       publish(kafkaProducer, topicName, i + "3", invalid);
 
       GenericRecord otherDataflow =
@@ -548,14 +568,14 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
             new StringSerializer(), new BinaryAvroSerializer(avroSchema));
 
     for (int i = 1; i <= 10; i++) {
-      GenericRecord dataflow = createRecord(Integer.valueOf(i + "1"), "Dataflow", "HIGH");
+      GenericRecord dataflow = createRecord(Integer.valueOf(i + "1"), "Dataflow", 2f, "HIGH");
       publishBinary(kafkaProducer, topicName, i + "1", dataflow);
 
-      GenericRecord pubsub = createRecord(Integer.valueOf(i + "2"), "Pub/Sub", "MEDIUM");
+      GenericRecord pubsub = createRecord(Integer.valueOf(i + "2"), "Pub/Sub", 123.125f, "MEDIUM");
       publishBinary(kafkaProducer, topicName, i + "2", pubsub);
 
       GenericRecord invalid =
-          createRecord(Integer.valueOf(i + "3"), "InvalidNameTooLong", "UNDEFINED");
+          createRecord(Integer.valueOf(i + "3"), "InvalidNameTooLong", 0f, "UNDEFINED");
       publishBinary(kafkaProducer, topicName, i + "3", invalid);
 
       try {
@@ -599,10 +619,12 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
     }
   }
 
-  private GenericRecord createRecord(int id, String productName, String productUsage) {
+  private GenericRecord createRecord(
+      int id, String productName, float productSize, String productUsage) {
     return new GenericRecordBuilder(avroSchema)
         .set("productId", id)
         .set("productName", productName)
+        .set("productSize", productSize)
         .set("productUsage", new GenericData.EnumSymbol(avroSchemaUsageEnum, productUsage))
         .build();
   }

--- a/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
+++ b/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
@@ -487,7 +487,8 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
       GenericRecord pubsub = createRecord(Integer.valueOf(i + "2"), "Pub/Sub", "MEDIUM");
       publish(kafkaProducer, topicName, i + "2", pubsub);
 
-      GenericRecord invalid = createRecord(Integer.valueOf(i + "3"), "InvalidNameTooLong", "UNDEFINED");
+      GenericRecord invalid =
+          createRecord(Integer.valueOf(i + "3"), "InvalidNameTooLong", "UNDEFINED");
       publish(kafkaProducer, topicName, i + "3", invalid);
 
       try {
@@ -515,7 +516,8 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
       GenericRecord pubsub = createRecord(Integer.valueOf(i + "2"), "Pub/Sub", "MEDIUM");
       publish(kafkaProducer, topicName, i + "2", pubsub);
 
-      GenericRecord invalid = createRecord(Integer.valueOf(i + "3"), "InvalidNameTooLong", "UNDEFINED");
+      GenericRecord invalid =
+          createRecord(Integer.valueOf(i + "3"), "InvalidNameTooLong", "UNDEFINED");
       publish(kafkaProducer, topicName, i + "3", invalid);
 
       GenericRecord otherDataflow =
@@ -549,7 +551,8 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
       GenericRecord pubsub = createRecord(Integer.valueOf(i + "2"), "Pub/Sub", "MEDIUM");
       publishBinary(kafkaProducer, topicName, i + "2", pubsub);
 
-      GenericRecord invalid = createRecord(Integer.valueOf(i + "3"), "InvalidNameTooLong", "UNDEFINED");
+      GenericRecord invalid =
+          createRecord(Integer.valueOf(i + "3"), "InvalidNameTooLong", "UNDEFINED");
       publishBinary(kafkaProducer, topicName, i + "3", invalid);
 
       try {

--- a/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
+++ b/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
@@ -155,6 +155,10 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
         b ->
             b.addParameter("messageFormat", "AVRO_CONFLUENT_WIRE_FORMAT")
                 .addParameter("schemaFormat", "SCHEMA_REGISTRY")
+                // If this test fails, check if the below schema registry has
+                // correct schemas registered with the following IDs:
+                // - 5 (avro_schema.avsc)
+                // - 4 (other_avro_schema.avsc)
                 .addParameter("schemaRegistryConnectionUrl", "http://10.128.0.60:8081")
                 .addParameter("writeMode", "DYNAMIC_TABLE_NAMES")
                 .addParameter("outputProject", PROJECT)
@@ -171,8 +175,10 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
         b ->
             b.addParameter("messageFormat", "AVRO_CONFLUENT_WIRE_FORMAT")
                 .addParameter("schemaFormat", "SCHEMA_REGISTRY")
-                // Schemas are registered with ids 3 and 4. If this test fails, check if the
-                // below schema registry address contains the expected schema registered.
+                // If this test fails, check if the below schema registry has
+                // correct schemas registered with the following IDs:
+                // - 5 (avro_schema.avsc)
+                // - 4 (other_avro_schema.avsc)
                 .addParameter("schemaRegistryConnectionUrl", "http://10.128.0.60:8081")
                 .addParameter("writeMode", "DYNAMIC_TABLE_NAMES")
                 .addParameter("outputProject", PROJECT)
@@ -404,10 +410,8 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
         && options.getParameter("schemaFormat").equals("SCHEMA_REGISTRY")
         && options.getParameter("schemaRegistryConnectionUrl") != null) {
 
-      // Schemas are registered in schema registry with IDs 3 and 4 for Kafka Reads. So for these
-      // tests
-      // publish the messages with schema IDs 3 and 4.
-      publishDoubleSchemaMessages(topicName, 3, 4);
+      // Schemas are registered with ids 5 (avro_schema.avsc) and 4 (other_avro_schema.avsc).
+      publishDoubleSchemaMessages(topicName, 5, 4);
       tableId = TableId.of(bqDatasetId, avroSchema.getFullName().replace(".", "-"));
       TableId otherTableId =
           TableId.of(bqDatasetId, otherAvroSchema.getFullName().replace(".", "-"));

--- a/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
+++ b/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import net.jcip.annotations.NotThreadSafe;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
@@ -81,6 +82,7 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
   private TableId tableId;
   private Schema bqSchema;
   private org.apache.avro.Schema avroSchema;
+  private org.apache.avro.Schema avroSchemaUsageEnum;
   private org.apache.avro.Schema otherAvroSchema;
 
   @Before
@@ -99,6 +101,7 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
     URL avroSchemaResource = Resources.getResource("KafkaToBigQueryFlexAvroIT/avro_schema.avsc");
     gcsClient.uploadArtifact("avro_schema.avsc", avroSchemaResource.getPath());
     avroSchema = new org.apache.avro.Schema.Parser().parse(avroSchemaResource.openStream());
+    avroSchemaUsageEnum = avroSchema.getField("productUsage").schema();
 
     URL otherAvroSchemaResource =
         Resources.getResource("KafkaToBigQueryFlexAvroIT/other_avro_schema.avsc");
@@ -600,7 +603,7 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
     return new GenericRecordBuilder(avroSchema)
         .set("productId", id)
         .set("productName", productName)
-        .set("productUsage", productUsage)
+        .set("productUsage", new GenericData.EnumSymbol(avroSchemaUsageEnum, productUsage))
         .build();
   }
 

--- a/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
+++ b/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexAvroIT.java
@@ -522,13 +522,11 @@ public final class KafkaToBigQueryFlexAvroIT extends TemplateTestBase {
           createOtherRecord(Integer.valueOf(i + "4"), "Dataflow", "dataflow");
       publish(kafkaProducer, topicName, i + "4", otherDataflow);
 
-      GenericRecord otherPubsub =
-          createOtherRecord(Integer.valueOf(i + "5"), "Pub/Sub", "pubsub");
+      GenericRecord otherPubsub = createOtherRecord(Integer.valueOf(i + "5"), "Pub/Sub", "pubsub");
       publish(kafkaProducer, topicName, i + "5", otherPubsub);
 
       GenericRecord otherInvalid =
-          createOtherRecord(
-              Integer.valueOf(i + "6"), "InvalidNameTooLong", "InvalidNameTooLong");
+          createOtherRecord(Integer.valueOf(i + "6"), "InvalidNameTooLong", "InvalidNameTooLong");
       publish(kafkaProducer, topicName, i + "6", otherInvalid);
 
       try {

--- a/v2/kafka-to-bigquery/src/test/resources/KafkaToBigQueryFlexAvroIT/avro_schema.avsc
+++ b/v2/kafka-to-bigquery/src/test/resources/KafkaToBigQueryFlexAvroIT/avro_schema.avsc
@@ -17,13 +17,13 @@
                 "type": "enum",
                 "name": "Usage",
                 "symbols": [
-                    "N/A",
+                    "UNDEFINED",
                     "LOW",
                     "MEDIUM",
                     "HIGH"
                 ]
             },
-            "default": "N/A"
+            "default": "UNDEFINED"
         }
     ]
 }

--- a/v2/kafka-to-bigquery/src/test/resources/KafkaToBigQueryFlexAvroIT/avro_schema.avsc
+++ b/v2/kafka-to-bigquery/src/test/resources/KafkaToBigQueryFlexAvroIT/avro_schema.avsc
@@ -12,6 +12,10 @@
             "type": "string"
         },
         {
+            "name": "productSize",
+            "type": "float"
+        },
+        {
             "name": "productUsage",
             "type": {
                 "type": "enum",

--- a/v2/kafka-to-bigquery/src/test/resources/KafkaToBigQueryFlexAvroIT/avro_schema.avsc
+++ b/v2/kafka-to-bigquery/src/test/resources/KafkaToBigQueryFlexAvroIT/avro_schema.avsc
@@ -10,6 +10,20 @@
         {
             "name": "productName",
             "type": "string"
+        },
+        {
+            "name": "productUsage",
+            "type": {
+                "type": "enum",
+                "name": "Usage",
+                "symbols": [
+                    "N/A",
+                    "LOW",
+                    "MEDIUM",
+                    "HIGH"
+                ]
+            },
+            "default": "N/A"
         }
     ]
 }


### PR DESCRIPTION
Using Avro format with an ENUM type  field in the KafkaToBigQueryFlex template currently causes the following error:
```
Expected Avro schema types [STRING] for BigQuery STRING field operation, but received ENUM
```
Avro FLOAT type also wasn't handled correctly, resulting in the following error:
```
Expected Avro schema types [DOUBLE, INT] for BigQuery FLOAT64 field <...>, but received FLOAT
```
This PR should fix both.