### PR TITLE
Avro format Import/Export support for Spanner NOT ENFORCED Foreign Key

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/ForeignKey.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/ForeignKey.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.spanner.ddl;
 
+import static com.google.cloud.spanner.Dialect.GOOGLE_STANDARD_SQL;
 import static com.google.cloud.teleport.spanner.common.NameUtils.quoteIdentifier;
 import static com.google.common.base.Strings.isNullOrEmpty;
 
@@ -137,7 +138,8 @@ public abstract class ForeignKey implements Serializable {
               "Foreign Key action not supported: " + action.get().getSqlString());
       }
     }
-    if (isEnforced() != null && !isEnforced()) {
+    if (dialect() == GOOGLE_STANDARD_SQL && isEnforced() != null && !isEnforced()) {
+      // TODO: Add Postgresql support for NOT ENFORCED foreign keys
       appendable.append(" NOT ENFORCED");
     }
   }

--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/ForeignKey.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/ForeignKey.java
@@ -25,11 +25,12 @@ import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /** Cloud Spanner foreign key definition. */
 @AutoValue
 public abstract class ForeignKey implements Serializable {
-  private static final long serialVersionUID = 519932875L;
+  private static final long serialVersionUID = 779301367L;
 
   /** Referential actions supported in Foreign Keys. */
   public enum ReferentialAction {
@@ -92,6 +93,9 @@ public abstract class ForeignKey implements Serializable {
 
   abstract Optional<ReferentialAction> referentialAction();
 
+  @Nullable
+  abstract Boolean isEnforced();
+
   public static Builder builder(Dialect dialect) {
     return new AutoValue_ForeignKey.Builder().dialect(dialect);
   }
@@ -133,6 +137,9 @@ public abstract class ForeignKey implements Serializable {
               "Foreign Key action not supported: " + action.get().getSqlString());
       }
     }
+    if (isEnforced() != null && !isEnforced()) {
+      appendable.append(" NOT ENFORCED");
+    }
   }
 
   public String prettyPrint() {
@@ -167,6 +174,8 @@ public abstract class ForeignKey implements Serializable {
     public abstract ImmutableList.Builder<String> referencedColumnsBuilder();
 
     public abstract Builder referentialAction(Optional<ReferentialAction> action);
+
+    public abstract Builder isEnforced(Boolean enforced);
 
     public abstract ForeignKey build();
   }

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/AvroSchemaToDdlConverterTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/AvroSchemaToDdlConverterTest.java
@@ -201,6 +201,12 @@ public class AvroSchemaToDdlConverterTest {
             + "  \"spannerForeignKey_1\" : "
             + "  \"ALTER TABLE `Users` ADD CONSTRAINT `fk_odc` FOREIGN KEY (`last_name`) "
             + "  REFERENCES `AllowedNames` (`last_name`) ON DELETE CASCADE\","
+            + "  \"spannerForeignKey_2\" : "
+            + "  \"ALTER TABLE `Users` ADD CONSTRAINT `fk_not_enforced_no_action` FOREIGN KEY (`last_name`) "
+            + "  REFERENCES `AllowedNames` (`last_name`) ON DELETE NO ACTION NOT ENFORCED\","
+            + "  \"spannerForeignKey_3\" : "
+            + "  \"ALTER TABLE `Users` ADD CONSTRAINT `fk_enforced` FOREIGN KEY (`last_name`) "
+            + "  REFERENCES `AllowedNames` (`last_name`) ENFORCED\","
             + "  \"spannerCheckConstraint_0\" : "
             + "  \"CONSTRAINT `ck` CHECK(`first_name` != 'last_name')\""
             + "}";
@@ -254,7 +260,13 @@ public class AvroSchemaToDdlConverterTest {
                 + " FOREIGN KEY (`first_name`) REFERENCES `AllowedNames` (`first_name`)"
                 + " ALTER TABLE `Users` ADD CONSTRAINT `fk_odc`"
                 + " FOREIGN KEY (`last_name`) REFERENCES "
-                + "`AllowedNames` (`last_name`) ON DELETE CASCADE"));
+                + "`AllowedNames` (`last_name`) ON DELETE CASCADE"
+                + " ALTER TABLE `Users` ADD CONSTRAINT `fk_not_enforced_no_action`"
+                + " FOREIGN KEY (`last_name`) REFERENCES "
+                + "`AllowedNames` (`last_name`) ON DELETE NO ACTION NOT ENFORCED"
+                + " ALTER TABLE `Users` ADD CONSTRAINT `fk_enforced`"
+                + " FOREIGN KEY (`last_name`) REFERENCES "
+                + "`AllowedNames` (`last_name`) ENFORCED"));
   }
 
   @Test

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/CopyDbTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/CopyDbTest.java
@@ -674,8 +674,9 @@ public class CopyDbTest {
            "ALTER TABLE `Child` ADD CONSTRAINT `fk1` FOREIGN KEY (`id1`) REFERENCES `Ref` (`id1`)",
            "ALTER TABLE `Child` ADD CONSTRAINT `fk2` FOREIGN KEY (`id2`) REFERENCES `Ref` (`id2`)",
            "ALTER TABLE `Child` ADD CONSTRAINT `fk3` FOREIGN KEY (`id2`) REFERENCES `Ref` (`id2`)",
-           "ALTER TABLE `Child` ADD CONSTRAINT `fk4` FOREIGN KEY (`id2`, `id1`) "
-               + "REFERENCES `Ref` (`id2`, `id1`)"))
+           "ALTER TABLE `Child` ADD CONSTRAINT `fk4` FOREIGN KEY (`id2`, `id1`) REFERENCES `Ref` (`id2`, `id1`)",
+           "ALTER TABLE `Child` ADD CONSTRAINT `fk5` FOREIGN KEY (`id2`) REFERENCES `Ref` (`id2`) NOT ENFORCED",
+           "ALTER TABLE `Child` ADD CONSTRAINT `fk6` FOREIGN KEY (`id2`) REFERENCES `Ref` (`id2`) ENFORCED"))
         .endTable()
         .build();
     // spotless:on

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/DdlToAvroSchemaConverterTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/DdlToAvroSchemaConverterTest.java
@@ -143,7 +143,13 @@ public class DdlToAvroSchemaConverterTest {
                     "ALTER TABLE `Users` ADD CONSTRAINT `fk` FOREIGN KEY (`first_name`)"
                         + " REFERENCES `AllowedNames` (`first_name`)",
                     "ALTER TABLE `Users` ADD CONSTRAINT `fk_odc` FOREIGN KEY (`last_name`)"
-                        + " REFERENCES `AllowedNames` (`last_name`) ON DELETE CASCADE"))
+                        + " REFERENCES `AllowedNames` (`last_name`) ON DELETE CASCADE",
+                    "ALTER TABLE `Users` ADD CONSTRAINT `fk_not_enforced_no_action`"
+                        + " FOREIGN KEY (`last_name`) REFERENCES "
+                        + "`AllowedNames` (`last_name`) ON DELETE NO ACTION NOT ENFORCED",
+                    "ALTER TABLE `Users` ADD CONSTRAINT `fk_enforced`"
+                        + " FOREIGN KEY (`last_name`) REFERENCES "
+                        + "`AllowedNames` (`last_name`) ENFORCED"))
             .checkConstraints(ImmutableList.of("CONSTRAINT ck CHECK (`first_name` != `last_name`)"))
             .endTable()
             .build();
@@ -246,6 +252,16 @@ public class DdlToAvroSchemaConverterTest {
         equalTo(
             "ALTER TABLE `Users` ADD CONSTRAINT `fk_odc` FOREIGN KEY (`last_name`)"
                 + " REFERENCES `AllowedNames` (`last_name`) ON DELETE CASCADE"));
+    assertThat(
+        avroSchema.getProp(SPANNER_FOREIGN_KEY + "2"),
+        equalTo(
+            "ALTER TABLE `Users` ADD CONSTRAINT `fk_not_enforced_no_action` FOREIGN KEY (`last_name`)"
+                + " REFERENCES `AllowedNames` (`last_name`) ON DELETE NO ACTION NOT ENFORCED"));
+    assertThat(
+        avroSchema.getProp(SPANNER_FOREIGN_KEY + "3"),
+        equalTo(
+            "ALTER TABLE `Users` ADD CONSTRAINT `fk_enforced` FOREIGN KEY (`last_name`)"
+                + " REFERENCES `AllowedNames` (`last_name`) ENFORCED"));
     assertThat(
         avroSchema.getProp(SPANNER_CHECK_CONSTRAINT + "0"),
         equalTo("CONSTRAINT ck CHECK (`first_name` != `last_name`)"));

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
@@ -671,7 +671,13 @@ public class InformationSchemaScannerIT {
                 + " `id2`                               INT64 NOT NULL,"
                 + " ) PRIMARY KEY (`key` ASC)",
             " ALTER TABLE `Tab` ADD CONSTRAINT `fk` FOREIGN KEY (`id1`, `id2`)"
-                + " REFERENCES `Ref` (`id2`, `id1`)");
+                + " REFERENCES `Ref` (`id2`, `id1`)",
+            " ALTER TABLE `Tab` ADD CONSTRAINT `fk_2` FOREIGN KEY (`id1`, `id2`)"
+                + " REFERENCES `Ref` (`id1`, `id2`) ON DELETE CASCADE ENFORCED",
+            " ALTER TABLE `Tab` ADD CONSTRAINT `fk_3` FOREIGN KEY (`id1`, `id2`)"
+                + " REFERENCES `Ref` (`id1`, `id2`) NOT ENFORCED",
+            " ALTER TABLE `Tab` ADD CONSTRAINT `fk_4` FOREIGN KEY (`id1`, `id2`)"
+                + " REFERENCES `Ref` (`id1`, `id2`) ON DELETE NO ACTION NOT ENFORCED");
 
     List<String> dbVerificationStatements =
         Arrays.asList(
@@ -686,7 +692,14 @@ public class InformationSchemaScannerIT {
                 + " ) PRIMARY KEY (`key` ASC)",
             " ALTER TABLE `Tab` ADD CONSTRAINT `fk` FOREIGN KEY (`id1`, `id2`)"
                 // Unspecified DELETE action defaults to "NO ACTION"
-                + " REFERENCES `Ref` (`id2`, `id1`) ON DELETE NO ACTION");
+                + " REFERENCES `Ref` (`id2`, `id1`) ON DELETE NO ACTION",
+            // "ENFORCED" keyword is dropped.
+            " ALTER TABLE `Tab` ADD CONSTRAINT `fk_2` FOREIGN KEY (`id1`, `id2`)"
+                + " REFERENCES `Ref` (`id1`, `id2`) ON DELETE CASCADE",
+            " ALTER TABLE `Tab` ADD CONSTRAINT `fk_3` FOREIGN KEY (`id1`, `id2`)"
+                + " REFERENCES `Ref` (`id1`, `id2`) ON DELETE NO ACTION NOT ENFORCED",
+            " ALTER TABLE `Tab` ADD CONSTRAINT `fk_4` FOREIGN KEY (`id1`, `id2`)"
+                + " REFERENCES `Ref` (`id1`, `id2`) ON DELETE NO ACTION NOT ENFORCED");
 
     SPANNER_SERVER.createDatabase(dbId, dbCreationStatements);
     Ddl ddl = getDatabaseDdl();

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/RandomDdlGenerator.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/RandomDdlGenerator.java
@@ -490,6 +490,9 @@ public abstract class RandomDdlGenerator {
         if (rnd.nextBoolean()) {
           foreignKeyBuilder.referentialAction(Optional.of(generateRandomReferentialAction(rnd)));
         }
+        if (rnd.nextBoolean()) {
+          foreignKeyBuilder.isEnforced(rnd.nextBoolean());
+        }
         ForeignKey foreignKey = foreignKeyBuilder.build();
         if (foreignKey.columns().size() > 0) {
           foreignKeys.add(foreignKey.prettyPrint());


### PR DESCRIPTION
Adds Avro format Import/Export support for NOT ENFORCED Spanner Foreign Key (GoogleSQL dialect)

- Foreign keys are `ENFORCED` by default. When exporting unenforced foreign keys, the `NOT ENFORCED` keyword is attached. The `ENFORCED` is omitted when exporting enforced foreign keys.
 
I ran manual testing in staging & prod, Postgresql & Googlesql, by exporting a database with NOT ENFORCED foreign keys and was able to successfully import it with the correct resulting schema and all rows restored. 
