### PR TITLE
Add extra validation to SpannerToBigQuery Template

### DIFF
--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerToBigQueryOptions.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerToBigQueryOptions.java
@@ -96,7 +96,7 @@ public interface SpannerToBigQueryOptions
       optional = true,
       description = "Cloud Storage path to BigQuery JSON schema",
       helpText =
-          "The Cloud Storage path (gs://) to the JSON file that defines your BigQuery schema.",
+          "The Cloud Storage path (gs://) to the JSON file that defines your BigQuery schema. This is required if the Create Disposition is not CREATE_NEVER",
       example = "gs://your-bucket/your-schema.json")
   String getBigQuerySchemaPath();
 

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToBigQuery.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToBigQuery.java
@@ -79,6 +79,10 @@ public final class SpannerToBigQuery {
     } else {
       throw new IllegalArgumentException("either sqlQuery or spannerTableId required");
     }
+    if (Strings.isNullOrEmpty(options.getBigQuerySchemaPath())
+            && CreateDisposition.valueOf(options.getCreateDisposition()) != CREATE_NEVER) {
+      throw new IllegalArgumentException("bigQuerySchemaPath is required if CreateDisposition is not CREATE_NEVER");
+    }
     pipeline
         .apply(read)
         .apply(new StructToJson())

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToBigQuery.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToBigQuery.java
@@ -81,7 +81,8 @@ public final class SpannerToBigQuery {
     }
     if (Strings.isNullOrEmpty(options.getBigQuerySchemaPath())
             && CreateDisposition.valueOf(options.getCreateDisposition()) != CREATE_NEVER) {
-      throw new IllegalArgumentException("bigQuerySchemaPath is required if CreateDisposition is not CREATE_NEVER");
+      throw new IllegalArgumentException(
+              "bigQuerySchemaPath is required if CreateDisposition is not CREATE_NEVER");
     }
     pipeline
         .apply(read)

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToBigQuery.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToBigQuery.java
@@ -80,9 +80,9 @@ public final class SpannerToBigQuery {
       throw new IllegalArgumentException("either sqlQuery or spannerTableId required");
     }
     if (Strings.isNullOrEmpty(options.getBigQuerySchemaPath())
-            && CreateDisposition.valueOf(options.getCreateDisposition()) != CREATE_NEVER) {
+        && CreateDisposition.valueOf(options.getCreateDisposition()) != CREATE_NEVER) {
       throw new IllegalArgumentException(
-              "bigQuerySchemaPath is required if CreateDisposition is not CREATE_NEVER");
+          "bigQuerySchemaPath is required if CreateDisposition is not CREATE_NEVER");
     }
     pipeline
         .apply(read)


### PR DESCRIPTION
The SpannerToBigQuery template wasn't failing with a clear error if the create disposition was not CREATE_NEVER but no BigQuery schema was provided, instead just throwing a vague NullPointerException in the write step. This replaces that exception with an IllegalArgumentException and a clear message before runtime. 