### PR TITLE
Avoid illegal-mutation error

### DIFF
--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/utils/BigQueryAvroUtils.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/utils/BigQueryAvroUtils.java
@@ -386,8 +386,10 @@ public class BigQueryAvroUtils {
       case "BYTES":
         verify(v instanceof ByteBuffer, "Expected ByteBuffer, got %s", v.getClass());
         ByteBuffer byteBuffer = (ByteBuffer) v;
+        //Prevent inplace modifications of the byte buffer by the .get() method
+        ByteBuffer readOnlyBuffer = byteBuffer.asReadOnlyBuffer();
         byte[] bytes = new byte[byteBuffer.limit()];
-        byteBuffer.get(bytes);
+        readOnlyBuffer.get(bytes);
         return BaseEncoding.base64().encode(bytes);
       default:
         throw new UnsupportedOperationException(

--- a/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/utils/BigQueryAvroUtils.java
+++ b/v2/kafka-to-bigquery/src/main/java/com/google/cloud/teleport/v2/utils/BigQueryAvroUtils.java
@@ -386,7 +386,7 @@ public class BigQueryAvroUtils {
       case "BYTES":
         verify(v instanceof ByteBuffer, "Expected ByteBuffer, got %s", v.getClass());
         ByteBuffer byteBuffer = (ByteBuffer) v;
-        //Prevent inplace modifications of the byte buffer by the .get() method
+        // Prevent inplace modifications of the byte buffer by the .get() method
         ByteBuffer readOnlyBuffer = byteBuffer.asReadOnlyBuffer();
         byte[] bytes = new byte[byteBuffer.limit()];
         readOnlyBuffer.get(bytes);


### PR DESCRIPTION
Small fix to prevent illegal mutations of input elements by the .get() method of the ByteBuffer object.

Please refer to [[Bug]: Illegal mutation in kafka-to-bigquery #2036](https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/2036) for more information