### PR TITLE
Fixing Custom Transforms for `BigInt Unsigned` and `Boolean` types.

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/rowmapper/provider/MysqlJdbcValueMappings.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/rowmapper/provider/MysqlJdbcValueMappings.java
@@ -66,6 +66,10 @@ public class MysqlJdbcValueMappings implements JdbcValueMappingsProvider {
                   .unscaledValue()
                   .toByteArray());
 
+  /** Map BigInt Unsigned type to Avro Number. */
+  private static final ResultSetValueMapper<BigDecimal> bigDecimalToAvroNumber =
+      (value, schema) -> value.toString();
+
   /* Hex Encoded string for bytes type. */
   private static final ResultSetValueMapper<byte[]> bytesToHexString =
       (value, schema) -> new String(Hex.encodeHex(value));
@@ -191,7 +195,7 @@ public class MysqlJdbcValueMappings implements JdbcValueMappingsProvider {
   private static final ImmutableMap<String, JdbcValueMapper<?>> SCHEMA_MAPPINGS =
       ImmutableMap.<String, Pair<ResultSetValueExtractor<?>, ResultSetValueMapper<?>>>builder()
           .put("BIGINT", Pair.of(ResultSet::getLong, valuePassThrough))
-          .put("BIGINT UNSIGNED", Pair.of(ResultSet::getBigDecimal, bigDecimalToByteArray))
+          .put("BIGINT UNSIGNED", Pair.of(ResultSet::getBigDecimal, bigDecimalToAvroNumber))
           .put("BINARY", Pair.of(ResultSet::getBytes, bytesToHexString))
           .put("BIT", Pair.of(ResultSet::getBytes, bytesToLong))
           .put("BLOB", Pair.of(ResultSet::getBlob, blobToHexString))

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/MysqlMappingProvider.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/MysqlMappingProvider.java
@@ -33,7 +33,7 @@ public final class MysqlMappingProvider {
   private static final ImmutableMap<String, UnifiedTypeMapping> MAPPING =
       ImmutableMap.<String, UnifiedMappingProvider.Type>builder()
           .put("BIGINT", UnifiedMappingProvider.Type.LONG)
-          .put("BIGINT UNSIGNED", UnifiedMappingProvider.Type.DECIMAL)
+          .put("BIGINT UNSIGNED", UnifiedMappingProvider.Type.NUMBER)
           .put("BINARY", UnifiedMappingProvider.Type.STRING)
           .put("BIT", UnifiedMappingProvider.Type.LONG)
           .put("BLOB", UnifiedMappingProvider.Type.STRING)

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/rowmapper/JdbcSourceRowMapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/rowmapper/JdbcSourceRowMapperTest.java
@@ -272,7 +272,7 @@ public class JdbcSourceRowMapperTest {
                 .derbyColumnType("BIGINT")
                 .sourceColumnType("BIGINT UNSIGNED", new Long[] {20L, 0L})
                 .inputValue(12345L)
-                .mappedValue(ByteBuffer.wrap(new byte[] {(byte) 0x30, (byte) 0x39}))
+                .mappedValue("12345")
                 .build())
         .add(
             Column.builder()

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/MysqlMappingProviderTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/MysqlMappingProviderTest.java
@@ -49,9 +49,7 @@ public class MysqlMappingProviderTest {
   private ImmutableMap<String, String> expectedMapping() {
     return ImmutableMap.<String, String>builder()
         .put("BIGINT", "\"long\"")
-        .put(
-            "BIGINT UNSIGNED",
-            "{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":1,\"scale\":1}")
+        .put("BIGINT UNSIGNED", "{\"type\":\"string\",\"logicalType\":\"number\"}")
         .put("BINARY", "\"string\"")
         .put("BIT", "\"long\"")
         .put("BLOB", "\"string\"")

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertor.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertor.java
@@ -47,6 +47,7 @@ import org.apache.avro.data.TimeConversions;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.metrics.Distribution;
 import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.kerby.util.Hex;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -252,15 +253,20 @@ public class GenericRecordTypeConvertor {
       switch (fieldType) {
         case INT:
         case LONG:
+          fieldValue = Long.valueOf(fieldValue.toString());
+          break;
         case BOOLEAN:
-          fieldValue = (fieldValue == null) ? null : Long.valueOf(fieldValue.toString());
+          fieldValue = Boolean.valueOf(fieldValue.toString());
           break;
         case FLOAT:
         case DOUBLE:
-          fieldValue = (fieldValue == null) ? null : Double.valueOf(fieldValue.toString());
+          fieldValue = Double.valueOf(fieldValue.toString());
+          break;
+        case BYTES:
+          fieldValue = Hex.encode(((ByteBuffer) fieldValue).array());
           break;
         default:
-          fieldValue = (fieldValue == null) ? null : fieldValue.toString();
+          fieldValue = fieldValue.toString();
       }
       map.put(fieldName, fieldValue);
     }


### PR DESCRIPTION
# Fixing Custom Transforms for `BigInt Unsigned` and `Boolean` types.
## Overview of Changes
1. Fixing Custom Transforms handling for `Bytes` and `Boolean`.
2. Mapping `BigInt Unsigned` to `Avro Number Logical Type` as per updates in [unified mapping](https://cloud.google.com/datastream/docs/unified-types).
3. Improved UT coverage for custom transformations code.