### PR TITLE
custom transformation implementation

### DIFF
--- a/v2/spanner-to-sourcedb/pom.xml
+++ b/v2/spanner-to-sourcedb/pom.xml
@@ -82,6 +82,12 @@
             <artifactId>beam-it-jdbc</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.cloud.teleport.v2</groupId>
+            <artifactId>spanner-custom-shard</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!--        TODO - Remove when https://github.com/apache/beam/pull/29732 is released. -->
         <dependency>
             <groupId>com.google.cloud.teleport</groupId>

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/constants/Constants.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/constants/Constants.java
@@ -59,6 +59,9 @@ public class Constants {
   // The Tag for skipped records
   public static final TupleTag<String> SKIPPED_TAG = new TupleTag<String>() {};
 
+  // The Tag for records filtered via custom transformation.
+  public static final TupleTag<String> FILTERED_TAG = new TupleTag<String>() {};
+
   // Message written to the file for skipped records
   public static final String SKIPPED_TAG_MESSAGE = "Skipped record from reverse replication";
 
@@ -72,4 +75,8 @@ public class Constants {
   public static final String DEFAULT_SHARD_ID = "single_shard";
 
   public static final String SOURCE_MYSQL = "mysql";
+
+  // Message written to the file for filtered records
+  public static final String FILTERED_TAG_MESSAGE =
+      "Filtered record from custom transformation in reverse replication";
 }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/dml/MySQLDMLGenerator.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/dml/MySQLDMLGenerator.java
@@ -82,7 +82,8 @@ public class MySQLDMLGenerator implements IDMLGenerator {
             sourceTable,
             dmlGeneratorRequest.getNewValuesJson(),
             dmlGeneratorRequest.getKeyValuesJson(),
-            dmlGeneratorRequest.getSourceDbTimezoneOffset());
+            dmlGeneratorRequest.getSourceDbTimezoneOffset(),
+            dmlGeneratorRequest.getCustomTransformationResponse());
     if (pkcolumnNameValues == null) {
       LOG.warn(
           "Cannot reverse replicate for table {} without primary key, skipping the record",
@@ -194,7 +195,8 @@ public class MySQLDMLGenerator implements IDMLGenerator {
             sourceTable,
             dmlGeneratorRequest.getNewValuesJson(),
             dmlGeneratorRequest.getKeyValuesJson(),
-            dmlGeneratorRequest.getSourceDbTimezoneOffset());
+            dmlGeneratorRequest.getSourceDbTimezoneOffset(),
+            dmlGeneratorRequest.getCustomTransformationResponse());
     return getUpsertStatement(
         sourceTable.getName(),
         sourceTable.getPrimaryKeySet(),
@@ -207,7 +209,8 @@ public class MySQLDMLGenerator implements IDMLGenerator {
       SourceTable sourceTable,
       JSONObject newValuesJson,
       JSONObject keyValuesJson,
-      String sourceDbTimezoneOffset) {
+      String sourceDbTimezoneOffset,
+      Map<String, Object> customTransformationResponse) {
     Map<String, String> response = new HashMap<>();
 
     /*
@@ -224,12 +227,20 @@ public class MySQLDMLGenerator implements IDMLGenerator {
       as the column will be stored with default/null values
     */
     Set<String> sourcePKs = sourceTable.getPrimaryKeySet();
+    Set<String> customTransformColumns = null;
+    if (customTransformationResponse != null) {
+      customTransformColumns = customTransformationResponse.keySet();
+    }
     for (Map.Entry<String, SourceColumnDefinition> entry : sourceTable.getColDefs().entrySet()) {
       SourceColumnDefinition sourceColDef = entry.getValue();
 
       String colName = sourceColDef.getName();
       if (sourcePKs.contains(colName)) {
         continue; // we only need non-primary keys
+      }
+      if (customTransformColumns != null && customTransformColumns.contains(colName)) {
+        response.put(colName, (String) customTransformationResponse.get(colName));
+        continue;
       }
 
       String colId = entry.getKey();
@@ -272,7 +283,8 @@ public class MySQLDMLGenerator implements IDMLGenerator {
       SourceTable sourceTable,
       JSONObject newValuesJson,
       JSONObject keyValuesJson,
-      String sourceDbTimezoneOffset) {
+      String sourceDbTimezoneOffset,
+      Map<String, Object> customTransformationResponse) {
     Map<String, String> response = new HashMap<>();
     /*
     Get all primary key col ids from source table
@@ -286,6 +298,10 @@ public class MySQLDMLGenerator implements IDMLGenerator {
     if the column does not exist in any of the JSON - return null
     */
     ColumnPK[] sourcePKs = sourceTable.getPrimaryKeys();
+    Set<String> customTransformColumns = null;
+    if (customTransformationResponse != null) {
+      customTransformColumns = customTransformationResponse.keySet();
+    }
 
     for (int i = 0; i < sourcePKs.length; i++) {
       ColumnPK currentSourcePK = sourcePKs[i];
@@ -297,6 +313,13 @@ public class MySQLDMLGenerator implements IDMLGenerator {
             "The corresponding primary key column {} was not found in Spanner",
             sourceColDef.getName());
         return null;
+      }
+      if (customTransformColumns != null
+          && customTransformColumns.contains(sourceColDef.getName())) {
+        response.put(
+            sourceColDef.getName(),
+            (String) customTransformationResponse.get(sourceColDef.getName()));
+        continue;
       }
       String spannerColumnName = spannerColDef.getName();
       String columnValue = "";

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/dml/MySQLDMLGenerator.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/dml/MySQLDMLGenerator.java
@@ -239,7 +239,7 @@ public class MySQLDMLGenerator implements IDMLGenerator {
         continue; // we only need non-primary keys
       }
       if (customTransformColumns != null && customTransformColumns.contains(colName)) {
-        response.put(colName, (String) customTransformationResponse.get(colName));
+        response.put(colName, customTransformationResponse.get(colName).toString());
         continue;
       }
 
@@ -318,7 +318,7 @@ public class MySQLDMLGenerator implements IDMLGenerator {
           && customTransformColumns.contains(sourceColDef.getName())) {
         response.put(
             sourceColDef.getName(),
-            (String) customTransformationResponse.get(sourceColDef.getName()));
+            customTransformationResponse.get(sourceColDef.getName()).toString());
         continue;
       }
       String spannerColumnName = spannerColDef.getName();

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/models/DMLGeneratorRequest.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/models/DMLGeneratorRequest.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.templates.models;
 
 import com.google.cloud.teleport.v2.spanner.migrations.schema.Schema;
+import java.util.Map;
 import org.json.JSONObject;
 
 /**
@@ -51,6 +52,8 @@ public class DMLGeneratorRequest {
   // The timezone offset of the source database, used for handling timezone-specific data.
   private final String sourceDbTimezoneOffset;
 
+  private Map<String, Object> customTransformationResponse;
+
   public DMLGeneratorRequest(Builder builder) {
     this.modType = builder.modType;
     this.spannerTableName = builder.spannerTableName;
@@ -58,6 +61,7 @@ public class DMLGeneratorRequest {
     this.newValuesJson = builder.newValuesJson;
     this.keyValuesJson = builder.keyValuesJson;
     this.sourceDbTimezoneOffset = builder.sourceDbTimezoneOffset;
+    this.customTransformationResponse = builder.customTransformationResponse;
   }
 
   public String getModType() {
@@ -84,6 +88,10 @@ public class DMLGeneratorRequest {
     return sourceDbTimezoneOffset;
   }
 
+  public Map<String, Object> getCustomTransformationResponse() {
+    return customTransformationResponse;
+  }
+
   public static class Builder {
     private final String modType;
     private final String spannerTableName;
@@ -91,6 +99,7 @@ public class DMLGeneratorRequest {
     private final JSONObject keyValuesJson;
     private final String sourceDbTimezoneOffset;
     private Schema schema;
+    private Map<String, Object> customTransformationResponse;
 
     public Builder(
         String modType,
@@ -107,6 +116,12 @@ public class DMLGeneratorRequest {
 
     public Builder setSchema(Schema schema) {
       this.schema = schema;
+      return this;
+    }
+
+    public Builder setCustomTransformationResponse(
+        Map<String, Object> customTransformationResponse) {
+      this.customTransformationResponse = customTransformationResponse;
       return this;
     }
 

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFn.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFn.java
@@ -23,10 +23,14 @@ import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.ddl.IndexColumn;
 import com.google.cloud.teleport.v2.spanner.ddl.Table;
+import com.google.cloud.teleport.v2.spanner.exceptions.InvalidTransformationException;
 import com.google.cloud.teleport.v2.spanner.migrations.convertors.ChangeEventSpannerConvertor;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.ChangeEventConvertorException;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.Schema;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
+import com.google.cloud.teleport.v2.spanner.migrations.transformation.CustomTransformation;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.CustomTransformationImplFetcher;
+import com.google.cloud.teleport.v2.spanner.utils.ISpannerMigrationTransformer;
 import com.google.cloud.teleport.v2.templates.changestream.ChangeStreamErrorRecord;
 import com.google.cloud.teleport.v2.templates.changestream.TrimmedShardedDataChangeRecord;
 import com.google.cloud.teleport.v2.templates.constants.Constants;
@@ -75,6 +79,9 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
   private final Distribution lagMetric =
       Metrics.distribution(SourceWriterFn.class, "replication_lag_in_milli");
 
+  private final Counter invalidTransformationException =
+      Metrics.counter(SourceWriterFn.class, "custom_transformation_exception");
+
   private final Schema schema;
   private final String sourceDbTimezoneOffset;
   private final List<Shard> shards;
@@ -86,6 +93,8 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
   private final int maxThreadPerDataflowWorker;
   private final String source;
   private SourceProcessor sourceProcessor;
+  private final CustomTransformation customTransformation;
+  private ISpannerMigrationTransformer spannerToSourceTransformer;
 
   public SourceWriterFn(
       List<Shard> shards,
@@ -96,7 +105,8 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
       String shadowTablePrefix,
       String skipDirName,
       int maxThreadPerDataflowWorker,
-      String source) {
+      String source,
+      CustomTransformation customTransformation) {
 
     this.schema = schema;
     this.sourceDbTimezoneOffset = sourceDbTimezoneOffset;
@@ -107,6 +117,7 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
     this.skipDirName = skipDirName;
     this.maxThreadPerDataflowWorker = maxThreadPerDataflowWorker;
     this.source = source;
+    this.customTransformation = customTransformation;
   }
 
   // for unit testing purposes
@@ -124,6 +135,12 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
     this.sourceProcessor = sourceProcessor;
   }
 
+  // for unit testing purposes
+  public void setSpannerToSourceTransformer(
+      ISpannerMigrationTransformer spannerToSourceTransformer) {
+    this.spannerToSourceTransformer = spannerToSourceTransformer;
+  }
+
   /** Setup function connects to Cloud Spanner. */
   @Setup
   public void setup() throws UnsupportedSourceException {
@@ -132,6 +149,8 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
     sourceProcessor =
         SourceProcessorFactory.createSourceProcessor(source, shards, maxThreadPerDataflowWorker);
     spannerDao = new SpannerDao(spannerConfig);
+    spannerToSourceTransformer =
+        CustomTransformationImplFetcher.getCustomTransformationLogicImpl(customTransformation);
   }
 
   /** Teardown function disconnects from the Cloud Spanner. */
@@ -184,13 +203,18 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
         if (!isSourceAhead) {
           IDao sourceDao = sourceProcessor.getSourceDao(shardId);
 
-          InputRecordProcessor.processRecord(
-              spannerRec,
-              schema,
-              sourceDao,
-              shardId,
-              sourceDbTimezoneOffset,
-              sourceProcessor.getDmlGenerator());
+          boolean isEventFiltered =
+              InputRecordProcessor.processRecord(
+                  spannerRec,
+                  schema,
+                  sourceDao,
+                  shardId,
+                  sourceDbTimezoneOffset,
+                  sourceProcessor.getDmlGenerator(),
+                  spannerToSourceTransformer);
+          if (isEventFiltered) {
+            outputWithTag(c, Constants.FILTERED_TAG, Constants.FILTERED_TAG_MESSAGE, spannerRec);
+          }
 
           spannerDao.updateShadowTable(
               getShadowTableMutation(
@@ -206,6 +230,9 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
         }
         com.google.cloud.Timestamp timestamp = com.google.cloud.Timestamp.now();
         c.output(Constants.SUCCESS_TAG, timestamp.toString());
+      } catch (InvalidTransformationException ex) {
+        invalidTransformationException.inc();
+        outputWithTag(c, Constants.PERMANENT_ERROR_TAG, ex.getMessage(), spannerRec);
       } catch (ChangeEventConvertorException ex) {
         outputWithTag(c, Constants.PERMANENT_ERROR_TAG, ex.getMessage(), spannerRec);
       } catch (SpannerException

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterTransform.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterTransform.java
@@ -19,6 +19,7 @@ import com.google.auto.value.AutoValue;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.Schema;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
+import com.google.cloud.teleport.v2.spanner.migrations.transformation.CustomTransformation;
 import com.google.cloud.teleport.v2.templates.changestream.TrimmedShardedDataChangeRecord;
 import com.google.cloud.teleport.v2.templates.constants.Constants;
 import com.google.common.base.Preconditions;
@@ -52,6 +53,7 @@ public class SourceWriterTransform
   private final String skipDirName;
   private final int maxThreadPerDataflowWorker;
   private final String source;
+  private final CustomTransformation customTransformation;
 
   public SourceWriterTransform(
       List<Shard> shards,
@@ -62,7 +64,8 @@ public class SourceWriterTransform
       String shadowTablePrefix,
       String skipDirName,
       int maxThreadPerDataflowWorker,
-      String source) {
+      String source,
+      CustomTransformation customTransformation) {
 
     this.schema = schema;
     this.sourceDbTimezoneOffset = sourceDbTimezoneOffset;
@@ -73,6 +76,7 @@ public class SourceWriterTransform
     this.skipDirName = skipDirName;
     this.maxThreadPerDataflowWorker = maxThreadPerDataflowWorker;
     this.source = source;
+    this.customTransformation = customTransformation;
   }
 
   @Override
@@ -91,18 +95,21 @@ public class SourceWriterTransform
                         this.shadowTablePrefix,
                         this.skipDirName,
                         this.maxThreadPerDataflowWorker,
-                        this.source))
+                        this.source,
+                        this.customTransformation))
                 .withOutputTags(
                     Constants.SUCCESS_TAG,
                     TupleTagList.of(Constants.PERMANENT_ERROR_TAG)
                         .and(Constants.RETRYABLE_ERROR_TAG)
-                        .and(Constants.SKIPPED_TAG)));
+                        .and(Constants.SKIPPED_TAG)
+                        .and(Constants.FILTERED_TAG)));
 
     return Result.create(
         sourceWriteResults.get(Constants.SUCCESS_TAG),
         sourceWriteResults.get(Constants.PERMANENT_ERROR_TAG),
         sourceWriteResults.get(Constants.RETRYABLE_ERROR_TAG),
-        sourceWriteResults.get(Constants.SKIPPED_TAG));
+        sourceWriteResults.get(Constants.SKIPPED_TAG),
+        sourceWriteResults.get(Constants.FILTERED_TAG));
   }
 
   /** Container class for the results of this transform. */
@@ -113,13 +120,18 @@ public class SourceWriterTransform
         PCollection<String> successfulSourceWrites,
         PCollection<String> permanentErrors,
         PCollection<String> retryableErrors,
-        PCollection<String> skippedSourceWrites) {
+        PCollection<String> skippedSourceWrites,
+        PCollection<String> filteredWrites) {
       Preconditions.checkNotNull(successfulSourceWrites);
       Preconditions.checkNotNull(permanentErrors);
       Preconditions.checkNotNull(retryableErrors);
       Preconditions.checkNotNull(skippedSourceWrites);
       return new AutoValue_SourceWriterTransform_Result(
-          successfulSourceWrites, permanentErrors, retryableErrors, skippedSourceWrites);
+          successfulSourceWrites,
+          permanentErrors,
+          retryableErrors,
+          skippedSourceWrites,
+          filteredWrites);
     }
 
     public abstract PCollection<String> successfulSourceWrites();
@@ -129,6 +141,8 @@ public class SourceWriterTransform
     public abstract PCollection<String> retryableErrors();
 
     public abstract PCollection<String> skippedSourceWrites();
+
+    public abstract PCollection<String> filteredWrites();
 
     @Override
     public void finishSpecifyingOutput(
@@ -151,7 +165,9 @@ public class SourceWriterTransform
           Constants.RETRYABLE_ERROR_TAG,
           retryableErrors(),
           Constants.SKIPPED_TAG,
-          skippedSourceWrites());
+          skippedSourceWrites(),
+          Constants.FILTERED_TAG,
+          filteredWrites());
     }
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/dml/MySQLDMLGeneratorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/dml/MySQLDMLGeneratorTest.java
@@ -1088,6 +1088,33 @@ public final class MySQLDMLGeneratorTest {
     assertTrue(sql.isEmpty());
   }
 
+  @Test
+  public void customTransformationMatch() {
+    Schema schema = SessionFileReader.read("src/test/resources/customTransformation.json");
+    String tableName = "Singers";
+    String newValuesString = "{\"FirstName\":\"kk\",\"LastName\":\"ll\"}";
+    JSONObject newValuesJson = new JSONObject(newValuesString);
+    String keyValueString = "{\"SingerId\":\"999\"}";
+    JSONObject keyValuesJson = new JSONObject(keyValueString);
+    String modType = "INSERT";
+    Map<String, Object> customTransformation = new HashMap<>();
+    customTransformation.put("FullName", "\'kk ll\'");
+    customTransformation.put("SingerId", "1");
+
+    MySQLDMLGenerator mySQLDMLGenerator = new MySQLDMLGenerator();
+    DMLGeneratorResponse dmlGeneratorResponse =
+        mySQLDMLGenerator.getDMLStatement(
+            new DMLGeneratorRequest.Builder(
+                    modType, tableName, newValuesJson, keyValuesJson, "+00:00")
+                .setSchema(schema)
+                .setCustomTransformationResponse(customTransformation)
+                .build());
+    String sql = dmlGeneratorResponse.getDmlStatement();
+
+    assertTrue(sql.contains("`FullName` = 'kk ll'"));
+    assertTrue(sql.contains("VALUES (1,'kk ll')"));
+  }
+
   public static Schema getSchemaObject() {
     Map<String, SyntheticPKey> syntheticPKeys = new HashMap<String, SyntheticPKey>();
     Map<String, SourceTable> srcSchema = new HashMap<String, SourceTable>();

--- a/v2/spanner-to-sourcedb/src/test/resources/customTransformation.json
+++ b/v2/spanner-to-sourcedb/src/test/resources/customTransformation.json
@@ -1,0 +1,169 @@
+{
+  "SessionName": "NewSession",
+  "EditorName": "",
+  "DatabaseType": "mysql",
+  "DatabaseName": "ui_demo",
+  "Dialect": "google_standard_sql",
+  "Notes": null,
+  "Tags": null,
+  "SpSchema": {
+    "t1": {
+      "Name": "Singers",
+      "ColIds": [
+        "c5",
+        "c6",
+        "c7"
+      ],
+      "ColDefs": {
+        "c5": {
+          "Name": "SingerId",
+          "T": {
+            "Name": "INT64",
+            "Len": 0,
+            "IsArray": false
+          },
+          "NotNull": true,
+          "Comment": "From: SingerId int",
+          "Id": "c5"
+        },
+        "c6": {
+          "Name": "FirstName",
+          "T": {
+            "Name": "STRING",
+            "Len": 1024,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: FirstName varchar(1024)",
+          "Id": "c6"
+        },
+        "c7": {
+          "Name": "LastName",
+          "T": {
+            "Name": "STRING",
+            "Len": 1024,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: LastName varchar(1024)",
+          "Id": "c7"
+        }
+      },
+      "PrimaryKeys": [
+        {
+          "ColId": "c5",
+          "Desc": false,
+          "Order": 1
+        }
+      ],
+      "ForeignKeys": null,
+      "Indexes": [
+        {
+          "Name": "ind1",
+          "TableId": "t1",
+          "Unique": false,
+          "Keys": [
+            {
+              "ColId": "c5",
+              "Desc": false,
+              "Order": 1
+            }
+          ],
+          "Id": "i9",
+          "StoredColumnIds": null
+        }
+      ],
+      "ParentId": "",
+      "Comment": "Spanner schema for source table Singers",
+      "Id": "t1"
+    }
+  },
+  "SyntheticPKeys": {},
+  "SrcSchema": {
+    "t1": {
+      "Name": "Singers",
+      "Schema": "ui_demo",
+      "ColIds": [
+        "c5",
+        "c6"
+      ],
+      "ColDefs": {
+        "c5": {
+          "Name": "SingerId",
+          "Type": {
+            "Name": "int",
+            "Mods": null,
+            "ArrayBounds": null
+          },
+          "NotNull": true,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c5"
+        },
+        "c6": {
+          "Name": "FullName",
+          "Type": {
+            "Name": "varchar",
+            "Mods": [
+              1024
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c6"
+        }
+      },
+      "PrimaryKeys": [
+        {
+          "ColId": "c5",
+          "Desc": false,
+          "Order": 1
+        }
+      ],
+      "ForeignKeys": null,
+      "Indexes": [
+        {
+          "Name": "ind1",
+          "Unique": false,
+          "Keys": [
+            {
+              "ColId": "c5",
+              "Desc": false,
+              "Order": 1
+            }
+          ],
+          "Id": "i9",
+          "StoredColumnIds": null
+        }
+      ],
+      "Id": "t1"
+    }
+  },
+  "SchemaIssues": {
+    "t1": {
+      "c5": [
+        13,
+        18
+      ]
+    }
+  },
+  "Location": {},
+  "TimezoneOffset": "+00:00",
+  "SpDialect": "google_standard_sql",
+  "UniquePKey": {},
+  "Rules": []
+}


### PR DESCRIPTION
1. Added support for custom transformations in the `spanner-to-sourcedb` reverse replication template
2. Added support for filtered events, they will be written to a new directory `FilterEventsDirectoryName`
3. Added metrics for calculating transformation latency and counting invalid transformation exceptions
4. Updated unit tests