### PR TITLE
Adding dataflow timestamp field in datastream-common json flow

### DIFF
--- a/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamJsonToJson.java
+++ b/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamJsonToJson.java
@@ -76,6 +76,7 @@ public final class FormatDatastreamJsonToJson
     outputObject.put("_metadata_stream", getStreamName(record));
     outputObject.put("_metadata_timestamp", getSourceTimestamp(record));
     outputObject.put("_metadata_read_timestamp", getMetadataTimestamp(record));
+    outputObject.put("_metadata_dataflow_timestamp", getCurrentTimestamp());
     outputObject.put("_metadata_read_method", record.get("read_method").textValue());
     outputObject.put("_metadata_source_type", sourceType);
 
@@ -233,5 +234,9 @@ public final class FormatDatastreamJsonToJson
     }
 
     return value.booleanValue();
+  }
+
+  private long getCurrentTimestamp() {
+    return System.currentTimeMillis() / 1000L;
   }
 }


### PR DESCRIPTION
`_metadata_dataflow_timestamp` was added as a field in change event in datastream-common for avro flow as part of this [PR](https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/1913/files#diff-68455d8955cfca529215ed2e64f44213a5b3ab9e2d7cad2c6f4ee8a83d1abcf7). Adding the same field to json flow.