### PR TITLE
feat: introduce new configuration properties for bigquery source

### DIFF
--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/helpers/BigQuerySpec.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/helpers/BigQuerySpec.java
@@ -19,16 +19,25 @@ package com.google.cloud.teleport.v2.neo4j.model.helpers;
  * Convenience object for invoking SQL query as well as providing descriptions for read and cast
  * phase of transform.
  */
-public class SqlQuerySpec {
+public class BigQuerySpec {
 
   private final String readDescription;
   private final String castDescription;
   private final String sql;
+  private final String queryTempProject;
+  private final String queryTempDataset;
 
-  public SqlQuerySpec(String readDescription, String castDescription, String sql) {
+  public BigQuerySpec(
+      String readDescription,
+      String castDescription,
+      String sql,
+      String queryTempProject,
+      String queryTempDataset) {
     this.readDescription = readDescription;
     this.castDescription = castDescription;
     this.sql = sql;
+    this.queryTempProject = queryTempProject;
+    this.queryTempDataset = queryTempDataset;
   }
 
   public String getReadDescription() {
@@ -43,29 +52,50 @@ public class SqlQuerySpec {
     return sql;
   }
 
-  public static class SqlQuerySpecBuilder {
+  public String getQueryTempProject() {
+    return queryTempProject;
+  }
+
+  public String getQueryTempDataset() {
+    return queryTempDataset;
+  }
+
+  public static class BigQuerySpecBuilder {
 
     private String readDescription;
     private String castDescription;
     private String sql;
+    private String queryTempProject;
+    private String queryTempDataset;
 
-    public SqlQuerySpecBuilder readDescription(String readDescription) {
+    public BigQuerySpecBuilder readDescription(String readDescription) {
       this.readDescription = readDescription;
       return this;
     }
 
-    public SqlQuerySpecBuilder castDescription(String castDescription) {
+    public BigQuerySpecBuilder castDescription(String castDescription) {
       this.castDescription = castDescription;
       return this;
     }
 
-    public SqlQuerySpecBuilder sql(String sql) {
+    public BigQuerySpecBuilder sql(String sql) {
       this.sql = sql;
       return this;
     }
 
-    public SqlQuerySpec build() {
-      return new SqlQuerySpec(readDescription, castDescription, sql);
+    public BigQuerySpecBuilder queryTempProject(String queryTempProject) {
+      this.queryTempProject = queryTempProject;
+      return this;
+    }
+
+    public BigQuerySpecBuilder queryTempDataset(String queryTempDataset) {
+      this.queryTempDataset = queryTempDataset;
+      return this;
+    }
+
+    public BigQuerySpec build() {
+      return new BigQuerySpec(
+          readDescription, castDescription, sql, queryTempProject, queryTempDataset);
     }
   }
 }

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/sources/BigQuerySource.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/sources/BigQuerySource.java
@@ -22,11 +22,19 @@ public class BigQuerySource implements Source {
 
   private final String name;
   private final String query;
+  private final String queryTempProject;
+  private final String queryTempDataset;
 
   public BigQuerySource(String name, String query) {
+    this(name, query, null, null);
+  }
 
+  public BigQuerySource(
+      String name, String query, String queryTempProject, String queryTempDataset) {
     this.name = name;
     this.query = query;
+    this.queryTempProject = queryTempProject;
+    this.queryTempDataset = queryTempDataset;
   }
 
   @Override
@@ -41,6 +49,14 @@ public class BigQuerySource implements Source {
 
   public String getQuery() {
     return query;
+  }
+
+  public String getQueryTempProject() {
+    return queryTempProject;
+  }
+
+  public String getQueryTempDataset() {
+    return queryTempDataset;
   }
 
   @Override
@@ -62,6 +78,19 @@ public class BigQuerySource implements Source {
 
   @Override
   public String toString() {
-    return "BigQuerySource{" + "name='" + name + '\'' + ", query='" + query + '\'' + '}';
+    return "BigQuerySource{"
+        + "name='"
+        + name
+        + '\''
+        + ", query='"
+        + query
+        + '\''
+        + ", queryTempProject='"
+        + queryTempProject
+        + '\''
+        + ", queryTempDataset='"
+        + queryTempDataset
+        + '\''
+        + '}';
   }
 }

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/sources/BigQuerySourceProvider.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/sources/BigQuerySourceProvider.java
@@ -15,11 +15,12 @@
  */
 package com.google.cloud.teleport.v2.neo4j.model.sources;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Optional;
 import org.neo4j.importer.v1.sources.SourceProvider;
 
 public class BigQuerySourceProvider implements SourceProvider<BigQuerySource> {
-
   @Override
   public String supportedType() {
     return "bigquery";
@@ -27,6 +28,10 @@ public class BigQuerySourceProvider implements SourceProvider<BigQuerySource> {
 
   @Override
   public BigQuerySource provide(ObjectNode node) {
-    return new BigQuerySource(node.get("name").textValue(), node.get("query").textValue());
+    return new BigQuerySource(
+        node.get("name").textValue(),
+        node.get("query").textValue(),
+        Optional.ofNullable(node.get("query_temp_project")).map(JsonNode::textValue).orElse(null),
+        Optional.ofNullable(node.get("query_temp_dataset")).map(JsonNode::textValue).orElse(null));
   }
 }

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/validation/BigQuerySourceProjectDatasetValidator.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/validation/BigQuerySourceProjectDatasetValidator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.neo4j.model.validation;
+
+import com.google.cloud.teleport.v2.neo4j.model.sources.BigQuerySource;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.neo4j.importer.v1.sources.Source;
+import org.neo4j.importer.v1.validation.SpecificationValidationResult;
+import org.neo4j.importer.v1.validation.SpecificationValidator;
+
+public class BigQuerySourceProjectDatasetValidator implements SpecificationValidator {
+
+  private static final String ERROR_CODE = "DFBQ-001";
+  private final Set<String> paths = new LinkedHashSet<>();
+
+  @Override
+  public void visitSource(int index, Source source) {
+    if (!(source instanceof BigQuerySource)) {
+      return;
+    }
+
+    var queryTempProject = ((BigQuerySource) source).getQueryTempProject();
+    var queryTempDataset = ((BigQuerySource) source).getQueryTempDataset();
+
+    if (queryTempProject != null && queryTempDataset == null) {
+      paths.add(String.format("$.sources[%d]", index));
+    }
+  }
+
+  @Override
+  public boolean report(SpecificationValidationResult.Builder builder) {
+    paths.forEach(
+        path ->
+            builder.addError(
+                path,
+                ERROR_CODE,
+                String.format(
+                    "%s query_temp_project is provided, but query_temp_dataset is missing", path)));
+    return paths.isEmpty();
+  }
+}

--- a/v2/googlecloud-to-neo4j/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
+++ b/v2/googlecloud-to-neo4j/src/main/resources/META-INF/services/org.neo4j.importer.v1.validation.SpecificationValidator
@@ -1,4 +1,5 @@
 # keep this sorted
+com.google.cloud.teleport.v2.neo4j.model.validation.BigQuerySourceProjectDatasetValidator
 com.google.cloud.teleport.v2.neo4j.model.validation.DuplicateAggregateFieldNameValidator
 com.google.cloud.teleport.v2.neo4j.model.validation.DuplicateTextHeaderValidator
 com.google.cloud.teleport.v2.neo4j.model.validation.InlineSourceDataValidator

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/model/validation/BigQuerySourceProjectDatasetValidatorTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/model/validation/BigQuerySourceProjectDatasetValidatorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.neo4j.model.validation;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.neo4j.importer.v1.ImportSpecificationDeserializer.deserialize;
+
+import java.io.StringReader;
+import org.junit.Assert;
+import org.junit.Test;
+import org.neo4j.importer.v1.validation.InvalidSpecificationException;
+
+public class BigQuerySourceProjectDatasetValidatorTest {
+  @Test
+  public void fails_if_bigquery_source_only_has_temp_project_id_but_not_temp_dataset_id() {
+    var spec =
+        "{\n"
+            + "    \"version\": \"1\",\n"
+            + "    \"sources\": [{\n"
+            + "        \"type\": \"bigquery\",\n"
+            + "        \"name\": \"a-source\",\n"
+            + "        \"query\": \"SELECT field_1 FROM project.dataset.table\",\n"
+            + "        \"query_temp_project\": \"project\"\n"
+            + "    }],\n"
+            + "    \"targets\": {\n"
+            + "        \"nodes\": [{\n"
+            + "            \"name\": \"a-target\",\n"
+            + "            \"source\": \"a-source\",\n"
+            + "            \"write_mode\": \"merge\",\n"
+            + "            \"labels\": [\"Placeholder\"],\n"
+            + "            \"properties\": [\n"
+            + "                {\"source_field\": \"field_1\", \"target_property\": \"property\"}\n"
+            + "            ],\n"
+            + "            \"schema\": {\n"
+            + "              \"key_constraints\": [\n"
+            + "                {\"name\": \"key property\", \"label\": \"Placeholder\", \"properties\": [\"property\"]}\n"
+            + "              ]\n"
+            + "            }\n"
+            + "        }]\n"
+            + "    }\n"
+            + "}";
+
+    var exception =
+        Assert.assertThrows(
+            InvalidSpecificationException.class, () -> deserialize(new StringReader(spec)));
+
+    assertThat(exception).hasMessageThat().contains("1 error(s)");
+    assertThat(exception).hasMessageThat().contains("0 warning(s)");
+    assertThat(exception)
+        .hasMessageThat()
+        .contains("$.sources[0] query_temp_project is provided, but query_temp_dataset is missing");
+  }
+}


### PR DESCRIPTION
This PR introduces `query_temp_project` and `query_temp_dataset` configuration properties, allowing temporary data to be written to a specified project and dataset for **BigQuery** sources.

Example configuration;

```
{
     "type": "bigquery",
     "name": "persons",
     "query": "SELECT person_tmdbId, name, bornIn, born, died FROM team-connectors-dev.movies.persons",
     "query_temp_project": "team-connectors-dev",
     "query_temp_dataset": "test_temp_dataset_beam"
}
```