### PR TITLE
Correcting Partitioning Logic for `VarBinary` Primary Key Type.

### DIFF
--- a/v2/sourcedb-to-spanner/pom.xml
+++ b/v2/sourcedb-to-spanner/pom.xml
@@ -147,6 +147,12 @@
       <artifactId>beam-sdks-java-io-cassandra</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.microsoft.sqlserver</groupId>
+      <artifactId>mssql-jdbc</artifactId>
+      <version>${mssql-jdbc.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
       <version>4.1</version>

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
@@ -306,7 +306,8 @@ public final class JdbcIoWrapper implements IoWrapper {
             .forEach(tableConfigBuilder::withPartitionColum);
       } else {
         ImmutableSet<IndexType> supportedIndexTypes =
-            ImmutableSet.of(IndexType.NUMERIC, IndexType.STRING, IndexType.BIG_INT_UNSIGNED);
+            ImmutableSet.of(
+                IndexType.NUMERIC, IndexType.STRING, IndexType.BIG_INT_UNSIGNED, IndexType.BINARY);
         // As of now only Primary key index with Numeric type is supported.
         // TODO:
         //    1. support non-primary unique indexes.

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceColumnIndexInfo.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/SourceColumnIndexInfo.java
@@ -16,10 +16,11 @@
 package com.google.cloud.teleport.v2.source.reader.io.schema;
 
 import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundaryExtractorFactory;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import java.math.BigInteger;
+import java.math.BigDecimal;
 import javax.annotation.Nullable;
 
 @AutoValue
@@ -138,6 +139,7 @@ public abstract class SourceColumnIndexInfo implements Comparable<SourceColumnIn
   public enum IndexType {
     NUMERIC,
     BIG_INT_UNSIGNED,
+    BINARY,
     STRING,
     DATE_TIME,
     OTHER
@@ -148,5 +150,6 @@ public abstract class SourceColumnIndexInfo implements Comparable<SourceColumnIn
       ImmutableMap.of(
           IndexType.NUMERIC, Long.class,
           IndexType.STRING, String.class,
-          IndexType.BIG_INT_UNSIGNED, BigInteger.class);
+          IndexType.BIG_INT_UNSIGNED, BigDecimal.class,
+          IndexType.BINARY, BoundaryExtractorFactory.BYTE_ARRAY_CLASS);
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapterTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapterTest.java
@@ -311,8 +311,8 @@ public class MysqlDialectAdapterTest {
                 .setOrdinalPosition(2)
                 .setCollationReference(
                     CollationReference.builder()
-                        .setDbCharacterSet("utf8mb4")
-                        .setDbCollation("utf8mb4_0900_ai_ci")
+                        .setDbCharacterSet("`utf8mb4`")
+                        .setDbCollation("`utf8mb4_0900_ai_ci`")
                         .setPadSpace(false)
                         .build())
                 .setStringMaxLength(42)
@@ -323,15 +323,8 @@ public class MysqlDialectAdapterTest {
                 .setIsUnique(true)
                 .setIsPrimary(true)
                 .setCardinality(42L)
-                .setIndexType(IndexType.STRING)
+                .setIndexType(IndexType.BINARY)
                 .setOrdinalPosition(3)
-                .setCollationReference(
-                    CollationReference.builder()
-                        .setDbCharacterSet("binary")
-                        .setDbCollation("binary")
-                        .setPadSpace(false)
-                        .build())
-                .setStringMaxLength(100)
                 .build(),
             SourceColumnIndexInfo.builder()
                 .setColumnName("testColBinary")
@@ -339,15 +332,8 @@ public class MysqlDialectAdapterTest {
                 .setIsUnique(true)
                 .setIsPrimary(true)
                 .setCardinality(42L)
-                .setIndexType(IndexType.STRING)
+                .setIndexType(IndexType.BINARY)
                 .setOrdinalPosition(4)
-                .setCollationReference(
-                    CollationReference.builder()
-                        .setDbCharacterSet("binary")
-                        .setDbCollation("binary")
-                        .setPadSpace(false)
-                        .build())
-                .setStringMaxLength(255)
                 .build());
 
     final JdbcSchemaReference sourceSchemaReference =
@@ -406,8 +392,8 @@ public class MysqlDialectAdapterTest {
                 .setOrdinalPosition(2)
                 .setCollationReference(
                     CollationReference.builder()
-                        .setDbCharacterSet("big5")
-                        .setDbCollation("big5_chinese_ci")
+                        .setDbCharacterSet("`big5`")
+                        .setDbCollation("`big5_chinese_ci`")
                         .setPadSpace(true)
                         .build())
                 .setStringMaxLength(42)
@@ -418,15 +404,8 @@ public class MysqlDialectAdapterTest {
                 .setIsUnique(true)
                 .setIsPrimary(true)
                 .setCardinality(42L)
-                .setIndexType(IndexType.STRING)
+                .setIndexType(IndexType.BINARY)
                 .setOrdinalPosition(3)
-                .setCollationReference(
-                    CollationReference.builder()
-                        .setDbCharacterSet("binary")
-                        .setDbCollation("binary")
-                        .setPadSpace(false)
-                        .build())
-                .setStringMaxLength(100)
                 .build());
 
     final JdbcSchemaReference sourceSchemaReference =
@@ -512,11 +491,6 @@ public class MysqlDialectAdapterTest {
     for (SourceColumnIndexInfo info : expectedSourceColumnIndexInfos) {
       String ret =
           (info.collationReference() == null) ? null : info.collationReference().dbCharacterSet();
-      if (info.columnName() == "testColVarBinary") {
-        // For columns like varBinary, the charset is null in information schema, but the db uses
-        // "binary" charset and collation.
-        ret = null;
-      }
       stubCharSetCol = stubCharSetCol.thenReturn(ret);
     }
     OngoingStubbing stubCollationCol =
@@ -524,11 +498,6 @@ public class MysqlDialectAdapterTest {
     for (SourceColumnIndexInfo info : expectedSourceColumnIndexInfos) {
       String ret =
           (info.collationReference() == null) ? null : info.collationReference().dbCollation();
-      if (info.columnName() == "testColVarBinary") {
-        // For columns like varBinary, the charset is null in information schema, but the db uses
-        // "binary" charset and collation.
-        ret = null;
-      }
       stubCollationCol = stubCollationCol.thenReturn(ret);
     }
     OngoingStubbing stubPadSpaceCol =
@@ -538,11 +507,6 @@ public class MysqlDialectAdapterTest {
           (info.collationReference() == null)
               ? null
               : (info.collationReference().padSpace() ? "PAD SPACE" : "NO PAD");
-      if (info.columnName() == "testColVarBinary") {
-        // For columns like varBinary, the charset is null in information schema, but the db uses
-        // "binary" charset and collation.
-        ret = null;
-      }
       stubPadSpaceCol = stubPadSpaceCol.thenReturn(ret);
     }
     OngoingStubbing stubNext = when(mockResultSet.next());
@@ -761,6 +725,12 @@ public class MysqlDialectAdapterTest {
             .put("int_unsigned_col", new SourceColumnType("INTEGER UNSIGNED", new Long[] {}, null))
             .put("tiny_int_unsigned_col", new SourceColumnType("TINYINT", new Long[] {}, null))
             .build());
+  }
+
+  @Test
+  public void testEscapeMySql() {
+    assertThat(MysqlDialectAdapter.escapeMySql("binary")).isEqualTo("`binary`");
+    assertThat(MysqlDialectAdapter.escapeMySql("`binary`")).isEqualTo("`binary`");
   }
 }
 

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
@@ -43,7 +43,7 @@ import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableSchema;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.math.BigInteger;
+import java.math.BigDecimal;
 import java.sql.SQLException;
 import org.apache.beam.sdk.io.jdbc.JdbcIO;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -467,7 +467,7 @@ public class JdbcIoWrapperTest {
                     .setCardinality(42L)
                     .setIsUnique(true)
                     .build()))
-        .isEqualTo(BigInteger.class);
+        .isEqualTo(BigDecimal.class);
     assertThrows(
         SuitableIndexNotFoundException.class,
         () ->

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundarySplitterFactoryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundarySplitterFactoryTest.java
@@ -15,11 +15,13 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range;
 
+import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundaryExtractorFactory.BYTE_ARRAY_CLASS;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationMapper;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Map;
 import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
@@ -92,6 +94,56 @@ public class BoundarySplitterFactoryTest {
         .isEqualTo(BigInteger.valueOf(21L));
     assertThat(splitter.getSplitPoint(null, BigInteger.valueOf(42L), null, null, null))
         .isEqualTo(BigInteger.valueOf(21L));
+  }
+
+  @Test
+  public void testBigDecimalBoundarySplitter() {
+    BoundarySplitter<BigDecimal> splitter = BoundarySplitterFactory.create(BigDecimal.class);
+    BigDecimal start =
+        new BigDecimal(BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(10L)));
+    BigDecimal startByTwo =
+        new BigDecimal(BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(5L)));
+    BigDecimal end =
+        new BigDecimal(BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(20L)));
+    BigDecimal mid =
+        new BigDecimal(BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(15L)));
+    BigDecimal zero = new BigDecimal(BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.ZERO));
+    BigDecimal negOne = new BigDecimal(BigInteger.valueOf(-1L));
+    BigDecimal longMax = new BigDecimal(BigInteger.valueOf(Long.MAX_VALUE));
+    BigDecimal longMin = new BigDecimal(BigInteger.valueOf(Long.MIN_VALUE));
+    BigDecimal fortyTwo = new BigDecimal(BigInteger.valueOf(42L));
+    BigDecimal twentyOne = new BigDecimal(BigInteger.valueOf(21L));
+
+    assertThat(splitter.getSplitPoint(start, end, null, null, null)).isEqualTo(mid);
+    assertThat(splitter.getSplitPoint(start, zero, null, null, null)).isEqualTo(startByTwo);
+    assertThat(splitter.getSplitPoint(longMin, longMax, null, null, null)).isEqualTo(negOne);
+    assertThat(splitter.getSplitPoint(null, null, null, null, null)).isNull();
+    assertThat(splitter.getSplitPoint(fortyTwo, null, null, null, null)).isEqualTo(twentyOne);
+    assertThat(splitter.getSplitPoint(null, fortyTwo, null, null, null)).isEqualTo(twentyOne);
+  }
+
+  @Test
+  public void testBytesIntegerBoundarySplitter() {
+    BoundarySplitter<byte[]> splitter = BoundarySplitterFactory.create(BYTE_ARRAY_CLASS);
+    byte[] start =
+        BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(10L)).toByteArray();
+    byte[] startByTwo =
+        BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(5L)).toByteArray();
+    byte[] end = BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(20L)).toByteArray();
+    byte[] mid = BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(15L)).toByteArray();
+    byte[] zero = BigInteger.ZERO.toByteArray();
+    byte[] negOne = BigInteger.valueOf(-1L).toByteArray();
+    byte[] longMax = BigInteger.valueOf(Long.MAX_VALUE).toByteArray();
+    byte[] longMin = BigInteger.valueOf(Long.MIN_VALUE).toByteArray();
+    byte[] fortyTwo = BigInteger.valueOf(42L).toByteArray();
+    byte[] twentyOne = BigInteger.valueOf(21L).toByteArray();
+
+    assertThat(splitter.getSplitPoint(start, end, null, null, null)).isEqualTo(mid);
+    assertThat(splitter.getSplitPoint(start, zero, null, null, null)).isEqualTo(startByTwo);
+    assertThat(splitter.getSplitPoint(longMax, longMin, null, null, null)).isEqualTo(negOne);
+    assertThat(splitter.getSplitPoint(null, null, null, null, null)).isNull();
+    assertThat(splitter.getSplitPoint(fortyTwo, null, null, null, null)).isEqualTo(twentyOne);
+    assertThat(splitter.getSplitPoint(null, fortyTwo, null, null, null)).isEqualTo(twentyOne);
   }
 
   @Test

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLDataTypesIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLDataTypesIT.java
@@ -228,11 +228,29 @@ public class MySQLDataTypesIT extends SourceDbToSpannerITBase {
     expectedData.put("set", createRows("set", "v1,v2", "NULL"));
     expectedData.put(
         "integer_unsigned", createRows("integer_unsigned", "0", "42", "4294967295", "NULL"));
-    // TODO(Vardhanvthigle): Debug thisfurthur
-    /*
+    expectedData.put(
+        "bigint_pk", createRows("bigint_pk", "-9223372036854775808", "0", "9223372036854775807"));
     expectedData.put(
         "bigint_unsigned_pk", createRows("bigint_unsigned_pk", "0", "42", "18446744073709551615"));
-     */
+    expectedData.put("int_pk", createRows("int_pk", "-2147483648", "0", "2147483647"));
+    expectedData.put("int_unsigned_pk", createRows("int_unsigned_pk", "0", "42", "4294967295"));
+    expectedData.put("medium_int_pk", createRows("medium_int_pk", "-8388608", "0", "8388607"));
+    expectedData.put(
+        "medium_int_unsigned_pk", createRows("medium_int_unsigned_pk", "0", "42", "16777215"));
+    expectedData.put("small_int_pk", createRows("small_int_pk", "-32768", "0", "32767"));
+    expectedData.put(
+        "small_int_unsigned_pk", createRows("small_int_unsigned_pk", "0", "42", "65535"));
+    expectedData.put("tiny_int_pk", createRows("tiny_int_pk", "-128", "0", "127"));
+    expectedData.put("tiny_int_unsigned_pk", createRows("tiny_int_unsigned_pk", "0", "42", "255"));
+    // The binary column is padded with 0s
+    expectedData.put(
+        "binary_pk",
+        createRows("binary_pk", "AAAAAAAAAAAAAAAAAAAAAAAAAAA=", "gAAAAAAAAAAAAAAAAAAAAAAAAAA="));
+    expectedData.put("varbinary_pk", createRows("varbinary_pk", "AA==", "gAAAAAAAAAA="));
+    expectedData.put("tiny_blob_pk", createRows("tiny_blob_pk", "AA==", "gAAAAAAAAAA="));
+    expectedData.put("char_pk", createRows("char_pk", "AA==", "gAAAAAAAAAA="));
+    expectedData.put("varchar_pk", createRows("varchar_pk", "AA==", "gAAAAAAAAAA="));
+    expectedData.put("tiny_text_pk", createRows("tiny_text_pk", "AA==", "gAAAAAAAAAA="));
     return expectedData;
   }
 

--- a/v2/sourcedb-to-spanner/src/test/resources/DataTypesIT/mysql-data-types.sql
+++ b/v2/sourcedb-to-spanner/src/test/resources/DataTypesIT/mysql-data-types.sql
@@ -178,9 +178,86 @@ CREATE TABLE set_table (
 );
 
 
+CREATE TABLE bigint_pk_table (
+    id BIGINT PRIMARY KEY,
+    bigint_pk_col BIGINT NOT NULL
+);
+
 CREATE TABLE bigint_unsigned_pk_table (
     id BIGINT UNSIGNED PRIMARY KEY,
     bigint_unsigned_pk_col BIGINT UNSIGNED NOT NULL
+);
+
+CREATE TABLE int_pk_table (
+    id INT PRIMARY KEY,
+    int_pk_col INT NOT NULL
+);
+
+CREATE TABLE int_unsigned_pk_table (
+    id INT UNSIGNED PRIMARY KEY,
+    int_unsigned_pk_col INT UNSIGNED NOT NULL
+);
+
+CREATE TABLE medium_int_pk_table (
+    id MEDIUMINT PRIMARY KEY,
+    medium_int_pk_col MEDIUMINT NOT NULL
+);
+
+CREATE TABLE medium_int_unsigned_pk_table (
+    id MEDIUMINT UNSIGNED PRIMARY KEY,
+    medium_int_unsigned_pk_col MEDIUMINT UNSIGNED NOT NULL
+);
+
+CREATE TABLE small_int_pk_table (
+    id SMALLINT PRIMARY KEY,
+    small_int_pk_col SMALLINT NOT NULL
+);
+
+CREATE TABLE small_int_unsigned_pk_table (
+    id SMALLINT UNSIGNED PRIMARY KEY,
+    small_int_unsigned_pk_col SMALLINT UNSIGNED NOT NULL
+);
+
+CREATE TABLE tiny_int_pk_table (
+     id TINYINT PRIMARY KEY,
+     tiny_int_pk_col TINYINT NOT NULL
+);
+
+CREATE TABLE tiny_int_unsigned_pk_table (
+     id TINYINT UNSIGNED PRIMARY KEY,
+     tiny_int_unsigned_pk_col TINYINT UNSIGNED NOT NULL
+);
+
+CREATE TABLE binary_pk_table (
+   id BINARY(20) PRIMARY KEY,
+   binary_pk_col BINARY(20) NOT NULL
+);
+
+CREATE TABLE varbinary_pk_table (
+   id VARBINARY(20) PRIMARY KEY,
+   varbinary_pk_col VARBINARY(20) NOT NULL
+);
+
+CREATE TABLE tiny_blob_pk_table (
+   id TINYBLOB,
+   tiny_blob_pk_col TINYBLOB NOT NULL,
+   CONSTRAINT PRIMARY KEY (id(20))
+);
+
+CREATE TABLE char_pk_table (
+   id CHAR(20) PRIMARY KEY,
+   char_pk_col CHAR(20) NOT NULL
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+
+CREATE TABLE varchar_pk_table (
+   id VARCHAR(20) PRIMARY KEY,
+   varchar_pk_col VARCHAR(20) NOT NULL
+) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci;
+
+CREATE TABLE tiny_text_pk_table (
+   id TINYTEXT,
+   tiny_text_pk_col TINYTEXT NOT NULL,
+   CONSTRAINT PRIMARY KEY (id(20))
 );
 
 ALTER TABLE `bigint_table` MODIFY `id` INT AUTO_INCREMENT;
@@ -303,7 +380,22 @@ INSERT INTO `year_table` (`year_col`) VALUES (2022);
 INSERT INTO `year_table` (`year_col`) VALUES (1901);
 INSERT INTO `year_table` (`year_col`) VALUES (2155);
 INSERT INTO `set_table` (`set_col`) VALUES ('v1,v2');
+INSERT INTO `bigint_pk_table` (`id`, `bigint_pk_col`) VALUES ('-9223372036854775808', '-9223372036854775808'), ('0', '0'), ('9223372036854775807', '9223372036854775807');
 INSERT INTO `bigint_unsigned_pk_table` (`id`, `bigint_unsigned_pk_col`) VALUES ('0', '0'), ('42', '42'), ('18446744073709551615', '18446744073709551615');
+INSERT INTO `int_pk_table` (`id`, `int_pk_col`) VALUES ('-2147483648', '-2147483648'), ('0', '0'), ('2147483647', '2147483647');
+INSERT INTO `int_unsigned_pk_table` (`id`, `int_unsigned_pk_col`) VALUES ('0', '0'), ('42', '42'), ('4294967295', '4294967295');
+INSERT INTO `medium_int_pk_table` (`id`, `medium_int_pk_col`) VALUES ('-8388608', '-8388608'), ('0', '0'), ('8388607', '8388607');
+INSERT INTO `medium_int_unsigned_pk_table` (`id`, `medium_int_unsigned_pk_col`) VALUES ('0', '0'), ('42', '42'), ('16777215', '16777215');
+INSERT INTO `small_int_pk_table` (`id`, `small_int_pk_col`) VALUES ('-32768', '-32768'), ('0', '0'), ('32767', '32767');
+INSERT INTO `small_int_unsigned_pk_table` (`id`, `small_int_unsigned_pk_col`) VALUES ('0', '0'), ('42', '42'), ('65535', '65535');
+INSERT INTO `tiny_int_pk_table` (`id`, `tiny_int_pk_col`) VALUES ('-128', '-128'), ('0', '0'), ('127', '127');
+INSERT INTO `tiny_int_unsigned_pk_table` (`id`, `tiny_int_unsigned_pk_col`) VALUES ('0', '0'), ('42', '42'), ('255', '255');
+INSERT INTO `binary_pk_table` (`id`, `binary_pk_col`) VALUES (FROM_BASE64('AA=='), FROM_BASE64('AA==')), (FROM_BASE64('gAAAAAAAAAA='), FROM_BASE64('gAAAAAAAAAA='));
+INSERT INTO `varbinary_pk_table` (`id`, `varbinary_pk_col`) VALUES (FROM_BASE64('AA=='), FROM_BASE64('AA==')), (FROM_BASE64('gAAAAAAAAAA='), FROM_BASE64('gAAAAAAAAAA='));
+INSERT INTO `tiny_blob_pk_table` (`id`, `tiny_blob_pk_col`) VALUES (FROM_BASE64('AA=='), FROM_BASE64('AA==')), (FROM_BASE64('gAAAAAAAAAA='), FROM_BASE64('gAAAAAAAAAA='));
+INSERT INTO `char_pk_table` (`id`, `char_pk_col`) VALUES ('AA==', 'AA=='), ('gAAAAAAAAAA=', 'gAAAAAAAAAA=');
+INSERT INTO `varchar_pk_table` (`id`, `varchar_pk_col`) VALUES ('AA==', 'AA=='), ('gAAAAAAAAAA=', 'gAAAAAAAAAA=');
+INSERT INTO `tiny_text_pk_table` (`id`, `tiny_text_pk_col`) VALUES ('AA==', 'AA=='), ('gAAAAAAAAAA=', 'gAAAAAAAAAA=');
 
 INSERT INTO `bigint_table` (`bigint_col`) VALUES (NULL);
 INSERT INTO `bigint_unsigned_table` (`bigint_unsigned_col`) VALUES (NULL);

--- a/v2/sourcedb-to-spanner/src/test/resources/DataTypesIT/mysql-spanner-schema.sql
+++ b/v2/sourcedb-to-spanner/src/test/resources/DataTypesIT/mysql-spanner-schema.sql
@@ -209,7 +209,84 @@ CREATE TABLE spatial_polygon (
   id INT64 NOT NULL,
   area STRING(MAX),
 ) PRIMARY KEY(id);
+
+CREATE TABLE bigint_pk_table (
+  id INT64 NOT NULL,
+  bigint_pk_col INT64 NOT NULL,
+) PRIMARY KEY(id);
+
 CREATE TABLE bigint_unsigned_pk_table (
   id NUMERIC NOT NULL,
   bigint_unsigned_pk_col NUMERIC NOT NULL,
+) PRIMARY KEY(id);
+
+CREATE TABLE int_pk_table (
+   id INT64 NOT NULL,
+   int_pk_col INT64 NOT NULL,
+) PRIMARY KEY(id);
+
+CREATE TABLE int_unsigned_pk_table (
+   id INT64 NOT NULL,
+   int_unsigned_pk_col INT64 NOT NULL,
+) PRIMARY KEY(id);
+
+CREATE TABLE medium_int_pk_table (
+   id INT64 NOT NULL,
+   medium_int_pk_col INT64 NOT NULL,
+) PRIMARY KEY(id);
+
+CREATE TABLE medium_int_unsigned_pk_table (
+   id INT64 NOT NULL,
+   medium_int_unsigned_pk_col INT64 NOT NULL,
+) PRIMARY KEY(id);
+
+CREATE TABLE small_int_pk_table (
+   id INT64 NOT NULL,
+   small_int_pk_col INT64 NOT NULL,
+) PRIMARY KEY(id);
+
+CREATE TABLE small_int_unsigned_pk_table (
+   id INT64 NOT NULL,
+   small_int_unsigned_pk_col INT64 NOT NULL,
+) PRIMARY KEY(id);
+
+CREATE TABLE tiny_int_pk_table (
+   id INT64 NOT NULL,
+   tiny_int_pk_col INT64 NOT NULL,
+) PRIMARY KEY(id);
+
+CREATE TABLE tiny_int_unsigned_pk_table (
+   id INT64 NOT NULL,
+   tiny_int_unsigned_pk_col INT64 NOT NULL,
+) PRIMARY KEY(id);
+
+CREATE TABLE binary_pk_table (
+  id BYTES(20) NOT NULL,
+  binary_pk_col BYTES(20) NOT NULL,
+) PRIMARY KEY(id);
+
+
+CREATE TABLE varbinary_pk_table (
+  id BYTES(20) NOT NULL,
+  varbinary_pk_col BYTES(20) NOT NULL,
+) PRIMARY KEY(id);
+
+CREATE TABLE tiny_blob_pk_table (
+  id BYTES(20) NOT NULL,
+  tiny_blob_pk_col BYTES(20) NOT NULL,
+) PRIMARY KEY(id);
+
+CREATE TABLE char_pk_table (
+  id STRING(20) NOT NULL,
+  char_pk_col STRING(20) NOT NULL,
+) PRIMARY KEY(id);
+
+CREATE TABLE varchar_pk_table (
+  id STRING(20) NOT NULL,
+  varchar_pk_col STRING(20) NOT NULL,
+) PRIMARY KEY(id);
+
+CREATE TABLE tiny_text_pk_table (
+  id STRING(20) NOT NULL,
+  tiny_text_pk_col STRING(20) NOT NULL,
 ) PRIMARY KEY(id);


### PR DESCRIPTION
# Correcting Collation Mapping Query for Varbinary. Adding Integration test for all supported Pkey types on MySql.

## Overview
For `VarBinary`, the collation used is `binary` which also happens to be a reserved keyword. We need to escape it.
With Support for mapping to `bigIntegers` in this PR, we are directly mapping binary columns to bigIntegers as the `binary` collation is always ordered by the value of the byte.
Also for future proofing, all the collations and character sets on `MySql` will be escaped with a `backtick`.

Please refer to https://dev.mysql.com/doc/refman/8.4/en/charset-binary-collations.html for more details.
## Testing
1. End to End manual run for `Big Int Unsigned` and `VarBinary` succeeds.
2. Integration tests for Supported PK types
## TODO (For Followup PR):
1. Similar Integration Testing on PG
2. List of Supported Primary types in README.md