### PR TITLE
[Do Not Merge] Fix minor issues in markdown files

### DIFF
--- a/contributor-docs/add-flex-template.md
+++ b/contributor-docs/add-flex-template.md
@@ -352,7 +352,7 @@ mvn clean install -pl v2/wordcount -am -Dmaven.test.skip
 ```
 
 The `-am` option guarantees that all the necessary local dependencies are
-included in the build. You can ignore the error releated to `v2/wordcount` if any error occurs.
+included in the build. You can ignore the error related to `v2/wordcount` if any error occurs.
 
 `-pl v2/wordcount` is how we specify the target module, allowing us to only
 build what we need. You can see all the available modules in the

--- a/v1/README_Cloud_PubSub_to_GCS_Text.md
+++ b/v1/README_Cloud_PubSub_to_GCS_Text.md
@@ -19,7 +19,7 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 
 ### Required parameters
 
-* **outputDirectory**: The path and filename prefix for writing output files. For example, `gs://bucket-name/path/`. This value must end in a slash.
+* **outputDirectory**: The path and filename prefix for writing output files. This value must end with a slash, for example, `gs://bucket-name/path/`.
 * **outputFilenamePrefix**: The prefix to place on each windowed file. For example, `output-`. Defaults to: output.
 
 ### Optional parameters

--- a/v1/README_GCS_Text_to_BigQuery.md
+++ b/v1/README_GCS_Text_to_BigQuery.md
@@ -20,7 +20,9 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 ### Required parameters
 
 * **inputFilePattern**: Path of the file pattern glob to read from. For example, `gs://your-bucket/path/*.csv`.
-* **JSONPath**: JSON file with BigQuery Schema description. JSON Example: {
+* **JSONPath**: JSON file with BigQuery Schema description. JSON Example:
+```json
+{
 	"BigQuery Schema": [
 		{
 			"name": "location",
@@ -43,7 +45,8 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 			"type": "STRING"
 		}
 	]
-}.
+}
+```
 * **outputTable**: BigQuery table location to write the output to. The table's schema must match the input objects.
 * **bigQueryLoadingTemporaryDirectory**: Temporary directory for BigQuery loading process For example, `gs://your-bucket/your-files/temp_dir`.
 

--- a/v1/README_Stream_GCS_Text_to_BigQuery.md
+++ b/v1/README_Stream_GCS_Text_to_BigQuery.md
@@ -31,7 +31,9 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 ### Required parameters
 
 * **inputFilePattern**: Path of the file pattern glob to read from. For example, `gs://your-bucket/path/*.csv`.
-* **JSONPath**: JSON file with BigQuery Schema description. JSON Example: {
+* **JSONPath**: JSON file with BigQuery Schema description. JSON Example:
+```json
+{
 	"BigQuery Schema": [
 		{
 			"name": "location",
@@ -54,7 +56,8 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 			"type": "STRING"
 		}
 	]
-}.
+}
+```
 * **outputTable**: BigQuery table location to write the output to. The table's schema must match the input objects.
 * **bigQueryLoadingTemporaryDirectory**: Temporary directory for BigQuery loading process For example, `gs://your-bucket/your-files/temp_dir`.
 

--- a/v1/src/main/java/com/google/cloud/teleport/spanner/README.md
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/README.md
@@ -1,5 +1,9 @@
-This directory contains sources for Beam pipelines related to Cloud Spanner.
+# Cloud Spanner Beam Pipelines
 
-*   Export from Spanner to Avro files in GCS (`ExportPipeline.java`).
-*   Import from Avro files to Spanner (`ImportPipeline.java`).
-*   Import from CSV files to Spanner (`TextImportPipeline.java`).
+This directory contains source code for Apache Beam pipelines that interact with Cloud Spanner.
+
+**Available Pipelines:**
+
+* **Export:** Export data from Spanner to Avro files in Google Cloud Storage (`ExportPipeline.java`)
+* **Import (Avro):** Import data from Avro files in Google Cloud Storage to Spanner (`ImportPipeline.java`)
+* **Import (CSV):** Import data from CSV files in Google Cloud Storage to Spanner (`TextImportPipeline.java`)


### PR DESCRIPTION
Manually reviewed a subset of markdown files, primarily focusing on v1 templates, and corrected the following issues:

* Fixed a typo in .
* Improved formatting of JSON examples in  and .
* Added a title and improved formatting in .
* Fixed a minor issue in .

Automated link checking using grep was attempted but unsuccessful due to issues with regular expression handling in the available tool.  Due to time constraints, a comprehensive review of all markdown files was not possible.  Future work could include implementing a more robust link checking mechanism and reviewing the remaining markdown files.