### PR TITLE
Cassandra io fork

### DIFF
--- a/v2/sourcedb-to-spanner/pom.xml
+++ b/v2/sourcedb-to-spanner/pom.xml
@@ -166,6 +166,31 @@
       <version>${mssql-jdbc.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.apache.beam/beam-sdks-java-io-common -->
+    <!-- test dependencies for localCassandraIO begin -->
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-io-common</artifactId>
+      <version>2.61.0</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/info.archinnov/achilles-embedded -->
+    <!-- https://mvnrepository.com/artifact/com.codahale.metrics/metrics-core -->
+    <dependency>
+      <groupId>com.codahale.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>3.0.2</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/com.github.stefanbirkner/system-rules -->
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.19.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- test dependencies for localCassandraIO end -->
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraDataSource.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraDataSource.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;
 
-import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.core.config.OptionsMap;
 import com.datastax.oss.driver.api.core.config.TypedDriverOption;
@@ -131,9 +130,6 @@ public abstract class CassandraDataSource implements Serializable {
     abstract CassandraDataSource autoBuild();
 
     public CassandraDataSource build() {
-      /* Prefer to use quorum read until we encounter a strong use case to not do so. */
-      this.overrideOptionInOptionsMap(
-          TypedDriverOption.REQUEST_CONSISTENCY, ConsistencyLevel.QUORUM.toString());
       return autoBuild();
     }
   }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraTableReaderFactoryCassandraIoImpl.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraTableReaderFactoryCassandraIoImpl.java
@@ -25,11 +25,15 @@ import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableSchema;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.coders.SerializableCoder;
-import org.apache.beam.sdk.io.cassandra.CassandraIO;
-import org.apache.beam.sdk.io.cassandra.CassandraIO.Read;
+import org.apache.beam.sdk.io.localcassandra.CassandraIO;
+import org.apache.beam.sdk.io.localcassandra.CassandraIO.Read;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
+
+/* Todo(vardhanvthigle)
+ * Switch to upstream cassandra IO once the fix for https://github.com/apache/beam/issues/34160 is available in dataflow.
+ */
 
 /**
  * Generate Table Reader For Cassandra using the upstream {@link CassandraIO.Read} implementation.

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraTableReaderFactoryCassandraIoImpl.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraTableReaderFactoryCassandraIoImpl.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;
 
+import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.config.TypedDriverOption;
 import com.google.cloud.teleport.v2.source.reader.io.cassandra.rowmapper.CassandraSourceRowMapper;
@@ -30,6 +31,8 @@ import org.apache.beam.sdk.io.localcassandra.CassandraIO.Read;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /* Todo(vardhanvthigle)
  * Switch to upstream cassandra IO once the fix for https://github.com/apache/beam/issues/34160 is available in dataflow.
@@ -39,6 +42,16 @@ import org.apache.beam.sdk.values.PCollection;
  * Generate Table Reader For Cassandra using the upstream {@link CassandraIO.Read} implementation.
  */
 public class CassandraTableReaderFactoryCassandraIoImpl implements CassandraTableReaderFactory {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CassandraTableReaderFactoryCassandraIoImpl.class);
+
+  /* Default Connection Timeout in Milliseconds */
+  @VisibleForTesting protected static final Integer DEFAULT_CONNECTION_TIMEOUT_MILLIS = 10 * 1000;
+  /* Default Read timeout. */
+  @VisibleForTesting protected static final Integer DEFAULT_READ_TIMEOUT_MILLIS = 3600 * 1000;
+
+  @VisibleForTesting
+  protected static final String DEFAULT_CONSISTENCY = ConsistencyLevel.QUORUM.name();
 
   /**
    * Returns a Table Reader for given Cassandra Source using the upstream {@link CassandraIO.Read}.
@@ -68,12 +81,47 @@ public class CassandraTableReaderFactoryCassandraIoImpl implements CassandraTabl
             .withKeyspace(cassandraDataSource.loggedKeySpace())
             .withLocalDc(cassandraDataSource.localDataCenter())
             .withConsistencyLevel(
-                profile.getString(TypedDriverOption.REQUEST_SERIAL_CONSISTENCY.getRawOption()))
+                profile.getString(TypedDriverOption.REQUEST_CONSISTENCY.getRawOption()))
+            .withConnectTimeout(getConnectionTimeout(profile))
+            .withReadTimeout(getReadTimeout(profile))
             .withEntity(SourceRow.class)
             .withCoder(SerializableCoder.of(SourceRow.class))
             .withMapperFactoryFn(
                 CassandraSourceRowMapperFactoryFn.create(cassandraSourceRowMapper));
     return setCredentials(tableReader, profile);
+  }
+
+  @VisibleForTesting
+  protected static String getConsistencyLevel(DriverExecutionProfile profile) {
+    String consistencyLevel =
+        profile.isDefined(TypedDriverOption.REQUEST_CONSISTENCY.getRawOption())
+            ? profile.getString(TypedDriverOption.REQUEST_CONSISTENCY.getRawOption())
+            : DEFAULT_CONSISTENCY;
+    LOG.info("Set Consistency Level {}", consistencyLevel);
+    return consistencyLevel;
+  }
+
+  @VisibleForTesting
+  protected static Integer getConnectionTimeout(DriverExecutionProfile profile) {
+    int timeout =
+        profile.isDefined(TypedDriverOption.CONNECTION_CONNECT_TIMEOUT.getRawOption())
+            ? (int)
+                profile
+                    .getDuration(TypedDriverOption.CONNECTION_CONNECT_TIMEOUT.getRawOption())
+                    .toMillis()
+            : DEFAULT_CONNECTION_TIMEOUT_MILLIS;
+    LOG.info("Set Connection Timeout = {} milliseconds", timeout);
+    return timeout;
+  }
+
+  @VisibleForTesting
+  protected static Integer getReadTimeout(DriverExecutionProfile profile) {
+    int timeout =
+        profile.isDefined(TypedDriverOption.REQUEST_TIMEOUT.getRawOption())
+            ? (int) profile.getDuration(TypedDriverOption.REQUEST_TIMEOUT.getRawOption()).toMillis()
+            : DEFAULT_READ_TIMEOUT_MILLIS;
+    LOG.info("Set Read Timeout = {} milliseconds", timeout);
+    return timeout;
   }
 
   @VisibleForTesting

--- a/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/CassandraIO.java
+++ b/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/CassandraIO.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.sdk.io.cassandra;
+package org.apache.beam.sdk.io.localcassandra;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
@@ -43,6 +43,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.SerializableCoder;
+import org.apache.beam.sdk.io.cassandra.Mapper;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.Create;

--- a/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/CassandraIO.java
+++ b/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/CassandraIO.java
@@ -1,0 +1,1095 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.PlainTextAuthProvider;
+import com.datastax.driver.core.QueryOptions;
+import com.datastax.driver.core.SSLOptions;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.SocketOptions;
+import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
+import com.datastax.driver.core.policies.TokenAwarePolicy;
+import com.google.auto.value.AutoValue;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.SerializableCoder;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Reshuffle;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An IO to read and write from/to Apache Cassandra
+ *
+ * <h3>Reading from Apache Cassandra</h3>
+ *
+ * <p>{@code CassandraIO} provides a source to read and returns a bounded collection of entities as
+ * {@code PCollection<Entity>}. An entity is built by Cassandra mapper ({@code
+ * com.datastax.driver.mapping.EntityMapper}) based on a POJO containing annotations (as described
+ * http://docs.datastax .com/en/developer/java-driver/2.1/manual/object_mapper/creating/").
+ *
+ * <p>The following example illustrates various options for configuring the IO:
+ *
+ * <pre>{@code
+ * pipeline.apply(CassandraIO.<Person>read()
+ *     .withHosts(Arrays.asList("host1", "host2"))
+ *     .withPort(9042)
+ *     .withKeyspace("beam")
+ *     .withTable("Person")
+ *     .withEntity(Person.class)
+ *     .withCoder(SerializableCoder.of(Person.class))
+ *     // above options are the minimum set, returns PCollection<Person>
+ *
+ * }</pre>
+ *
+ * <p>Alternatively, one may use {@code CassandraIO.<Person>readAll()
+ * .withCoder(SerializableCoder.of(Person.class))} to query a subset of the Cassandra database by
+ * creating a PCollection of {@code CassandraIO.Read<Person>} each with their own query or
+ * RingRange.
+ *
+ * <h3>Writing to Apache Cassandra</h3>
+ *
+ * <p>{@code CassandraIO} provides a sink to write a collection of entities to Apache Cassandra.
+ *
+ * <p>The following example illustrates various options for configuring the IO write:
+ *
+ * <pre>{@code
+ * pipeline
+ *    .apply(...) // provides a PCollection<Person> where Person is an entity
+ *    .apply(CassandraIO.<Person>write()
+ *        .withHosts(Arrays.asList("host1", "host2"))
+ *        .withPort(9042)
+ *        .withKeyspace("beam")
+ *        .withEntity(Person.class));
+ * }</pre>
+ *
+ * <h3>Cassandra Socket Options</h3>
+ *
+ * <p>The following example illustrates setting timeouts for the Cassandra client:
+ *
+ * <pre>{@code
+ * pipeline.apply(CassandraIO.<Person>read()
+ *     .withHosts(Arrays.asList("host1", "host2"))
+ *     .withPort(9042)
+ *     .withConnectTimeout(1000)
+ *     .withReadTimeout(5000)
+ *     .withKeyspace("beam")
+ *     .withTable("Person")
+ *     .withEntity(Person.class)
+ *     .withCoder(SerializableCoder.of(Person.class))
+ * }</pre>
+ */
+@SuppressWarnings({
+  "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
+  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+})
+public class CassandraIO {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CassandraIO.class);
+
+  private CassandraIO() {}
+
+  /** Provide a {@link Read} {@link PTransform} to read data from a Cassandra database. */
+  public static <T> Read<T> read() {
+    return new AutoValue_CassandraIO_Read.Builder<T>().build();
+  }
+
+  /** Provide a {@link ReadAll} {@link PTransform} to read data from a Cassandra database. */
+  public static <T> ReadAll<T> readAll() {
+    return new AutoValue_CassandraIO_ReadAll.Builder<T>().build();
+  }
+
+  /** Provide a {@link Write} {@link PTransform} to write data to a Cassandra database. */
+  public static <T> Write<T> write() {
+    return Write.<T>builder(MutationType.WRITE).build();
+  }
+
+  /** Provide a {@link Write} {@link PTransform} to delete data to a Cassandra database. */
+  public static <T> Write<T> delete() {
+    return Write.<T>builder(MutationType.DELETE).build();
+  }
+
+  /**
+   * A {@link PTransform} to read data from Apache Cassandra. See {@link CassandraIO} for more
+   * information on usage and configuration.
+   */
+  @AutoValue
+  @AutoValue.CopyAnnotations
+  @SuppressWarnings({"rawtypes"})
+  public abstract static class Read<T> extends PTransform<PBegin, PCollection<T>> {
+
+    abstract @Nullable ValueProvider<List<String>> hosts();
+
+    abstract @Nullable ValueProvider<String> query();
+
+    abstract @Nullable ValueProvider<Integer> port();
+
+    abstract @Nullable ValueProvider<String> keyspace();
+
+    abstract @Nullable ValueProvider<String> table();
+
+    abstract @Nullable Class<T> entity();
+
+    abstract @Nullable Coder<T> coder();
+
+    abstract @Nullable ValueProvider<String> username();
+
+    abstract @Nullable ValueProvider<String> password();
+
+    abstract @Nullable ValueProvider<String> localDc();
+
+    abstract @Nullable ValueProvider<String> consistencyLevel();
+
+    abstract @Nullable ValueProvider<Integer> minNumberOfSplits();
+
+    abstract @Nullable ValueProvider<Integer> connectTimeout();
+
+    abstract @Nullable ValueProvider<Integer> readTimeout();
+
+    abstract @Nullable SerializableFunction<Session, Mapper> mapperFactoryFn();
+
+    @Nullable
+    abstract ValueProvider<Set<RingRange>> ringRanges();
+
+    @Nullable
+    abstract ValueProvider<SSLOptions> sslOptions();
+
+    abstract Builder<T> builder();
+
+    /** Specify the hosts of the Apache Cassandra instances. */
+    public Read<T> withHosts(List<String> hosts) {
+      checkArgument(hosts != null, "hosts can not be null");
+      checkArgument(!hosts.isEmpty(), "hosts can not be empty");
+      return withHosts(ValueProvider.StaticValueProvider.of(hosts));
+    }
+
+    /** Specify the hosts of the Apache Cassandra instances. */
+    public Read<T> withHosts(ValueProvider<List<String>> hosts) {
+      return builder().setHosts(hosts).build();
+    }
+
+    /** Specify the port number of the Apache Cassandra instances. */
+    public Read<T> withPort(int port) {
+      checkArgument(port > 0, "port must be > 0, but was: %s", port);
+      return withPort(ValueProvider.StaticValueProvider.of(port));
+    }
+
+    /** Specify the port number of the Apache Cassandra instances. */
+    public Read<T> withPort(ValueProvider<Integer> port) {
+      return builder().setPort(port).build();
+    }
+
+    /** Specify the Cassandra keyspace where to read data. */
+    public Read<T> withKeyspace(String keyspace) {
+      checkArgument(keyspace != null, "keyspace can not be null");
+      return withKeyspace(ValueProvider.StaticValueProvider.of(keyspace));
+    }
+
+    /** Specify the Cassandra keyspace where to read data. */
+    public Read<T> withKeyspace(ValueProvider<String> keyspace) {
+      return builder().setKeyspace(keyspace).build();
+    }
+
+    /** Specify the Cassandra table where to read data. */
+    public Read<T> withTable(String table) {
+      checkArgument(table != null, "table can not be null");
+      return withTable(ValueProvider.StaticValueProvider.of(table));
+    }
+
+    /** Specify the Cassandra table where to read data. */
+    public Read<T> withTable(ValueProvider<String> table) {
+      return builder().setTable(table).build();
+    }
+
+    /** Specify the query to read data. */
+    public Read<T> withQuery(String query) {
+      checkArgument(query != null && query.length() > 0, "query cannot be null");
+      return withQuery(ValueProvider.StaticValueProvider.of(query));
+    }
+
+    /** Specify the query to read data. */
+    public Read<T> withQuery(ValueProvider<String> query) {
+      return builder().setQuery(query).build();
+    }
+
+    /**
+     * Specify the entity class (annotated POJO). The {@link CassandraIO} will read the data and
+     * convert the data as entity instances. The {@link PCollection} resulting from the read will
+     * contains entity elements.
+     */
+    public Read<T> withEntity(Class<T> entity) {
+      checkArgument(entity != null, "entity can not be null");
+      return builder().setEntity(entity).build();
+    }
+
+    /** Specify the {@link Coder} used to serialize the entity in the {@link PCollection}. */
+    public Read<T> withCoder(Coder<T> coder) {
+      checkArgument(coder != null, "coder can not be null");
+      return builder().setCoder(coder).build();
+    }
+
+    /** Specify the username for authentication. */
+    public Read<T> withUsername(String username) {
+      checkArgument(username != null, "username can not be null");
+      return withUsername(ValueProvider.StaticValueProvider.of(username));
+    }
+
+    /** Specify the username for authentication. */
+    public Read<T> withUsername(ValueProvider<String> username) {
+      return builder().setUsername(username).build();
+    }
+
+    /** Specify the password used for authentication. */
+    public Read<T> withPassword(String password) {
+      checkArgument(password != null, "password can not be null");
+      return withPassword(ValueProvider.StaticValueProvider.of(password));
+    }
+
+    /** Specify the password used for authentication. */
+    public Read<T> withPassword(ValueProvider<String> password) {
+      return builder().setPassword(password).build();
+    }
+
+    /** Specify the local DC used for the load balancing. */
+    public Read<T> withLocalDc(String localDc) {
+      checkArgument(localDc != null, "localDc can not be null");
+      return withLocalDc(ValueProvider.StaticValueProvider.of(localDc));
+    }
+
+    /** Specify the local DC used for the load balancing. */
+    public Read<T> withLocalDc(ValueProvider<String> localDc) {
+      return builder().setLocalDc(localDc).build();
+    }
+
+    /** Specify the consistency level for the request (e.g. ONE, LOCAL_ONE, LOCAL_QUORUM, etc). */
+    public Read<T> withConsistencyLevel(String consistencyLevel) {
+      checkArgument(consistencyLevel != null, "consistencyLevel can not be null");
+      return withConsistencyLevel(ValueProvider.StaticValueProvider.of(consistencyLevel));
+    }
+
+    /** Specify the consistency level for the request (e.g. ONE, LOCAL_ONE, LOCAL_QUORUM, etc). */
+    public Read<T> withConsistencyLevel(ValueProvider<String> consistencyLevel) {
+      return builder().setConsistencyLevel(consistencyLevel).build();
+    }
+
+    /**
+     * It's possible that system.size_estimates isn't populated or that the number of splits
+     * computed by Beam is still to low for Cassandra to handle it. This setting allows to enforce a
+     * minimum number of splits in case Beam cannot compute it correctly.
+     */
+    public Read<T> withMinNumberOfSplits(Integer minNumberOfSplits) {
+      checkArgument(minNumberOfSplits != null, "minNumberOfSplits can not be null");
+      checkArgument(minNumberOfSplits > 0, "minNumberOfSplits must be greater than 0");
+      return withMinNumberOfSplits(ValueProvider.StaticValueProvider.of(minNumberOfSplits));
+    }
+
+    /**
+     * It's possible that system.size_estimates isn't populated or that the number of splits
+     * computed by Beam is still to low for Cassandra to handle it. This setting allows to enforce a
+     * minimum number of splits in case Beam cannot compute it correctly.
+     */
+    public Read<T> withMinNumberOfSplits(ValueProvider<Integer> minNumberOfSplits) {
+      return builder().setMinNumberOfSplits(minNumberOfSplits).build();
+    }
+
+    /**
+     * Specify the Cassandra client connect timeout in ms. See
+     * https://docs.datastax.com/en/drivers/java/3.8/com/datastax/driver/core/SocketOptions.html#setConnectTimeoutMillis-int-
+     */
+    public Read<T> withConnectTimeout(Integer timeout) {
+      checkArgument(timeout != null, "Connect timeout can not be null");
+      checkArgument(timeout > 0, "Connect timeout must be > 0, but was: %s", timeout);
+      return withConnectTimeout(ValueProvider.StaticValueProvider.of(timeout));
+    }
+
+    /**
+     * Specify the Cassandra client connect timeout in ms. See
+     * https://docs.datastax.com/en/drivers/java/3.8/com/datastax/driver/core/SocketOptions.html#setConnectTimeoutMillis-int-
+     */
+    public Read<T> withConnectTimeout(ValueProvider<Integer> timeout) {
+      return builder().setConnectTimeout(timeout).build();
+    }
+
+    /**
+     * Specify the Cassandra client read timeout in ms. See
+     * https://docs.datastax.com/en/drivers/java/3.8/com/datastax/driver/core/SocketOptions.html#setReadTimeoutMillis-int-
+     */
+    public Read<T> withReadTimeout(Integer timeout) {
+      checkArgument(timeout != null, "Read timeout can not be null");
+      checkArgument(timeout > 0, "Read timeout must be > 0, but was: %s", timeout);
+      return withReadTimeout(ValueProvider.StaticValueProvider.of(timeout));
+    }
+
+    /**
+     * Specify the Cassandra client read timeout in ms. See
+     * https://docs.datastax.com/en/drivers/java/3.8/com/datastax/driver/core/SocketOptions.html#setReadTimeoutMillis-int-
+     */
+    public Read<T> withReadTimeout(ValueProvider<Integer> timeout) {
+      return builder().setReadTimeout(timeout).build();
+    }
+
+    /**
+     * A factory to create a specific {@link Mapper} for a given Cassandra Session. This is useful
+     * to provide mappers that don't rely in Cassandra annotated objects.
+     */
+    public Read<T> withMapperFactoryFn(SerializableFunction<Session, Mapper> mapperFactory) {
+      checkArgument(
+          mapperFactory != null,
+          "CassandraIO.withMapperFactory" + "(withMapperFactory) called with null value");
+      return builder().setMapperFactoryFn(mapperFactory).build();
+    }
+
+    public Read<T> withRingRanges(Set<RingRange> ringRange) {
+      return withRingRanges(ValueProvider.StaticValueProvider.of(ringRange));
+    }
+
+    public Read<T> withRingRanges(ValueProvider<Set<RingRange>> ringRange) {
+      return builder().setRingRanges(ringRange).build();
+    }
+
+    /**
+     * Optionally, specify {@link SSLOptions} configuration to utilize SSL. See
+     * https://docs.datastax.com/en/developer/java-driver/3.11/manual/ssl/#jsse-programmatic
+     */
+    public Read<T> withSsl(SSLOptions sslOptions) {
+      return withSsl(ValueProvider.StaticValueProvider.of(sslOptions));
+    }
+
+    /**
+     * Optionally, specify {@link SSLOptions} configuration to utilize SSL. See
+     * https://docs.datastax.com/en/developer/java-driver/3.11/manual/ssl/#jsse-programmatic
+     */
+    public Read<T> withSsl(ValueProvider<SSLOptions> sslOptions) {
+      return builder().setSslOptions(sslOptions).build();
+    }
+
+    @Override
+    public PCollection<T> expand(PBegin input) {
+      checkArgument((hosts() != null && port() != null), "WithHosts() and withPort() are required");
+      checkArgument(keyspace() != null, "withKeyspace() is required");
+      checkArgument(table() != null, "withTable() is required");
+      checkArgument(entity() != null, "withEntity() is required");
+      checkArgument(coder() != null, "withCoder() is required");
+
+      PCollection<Read<T>> splits =
+          input
+              .apply(Create.of(this))
+              .apply("Create Splits", ParDo.of(new SplitFn<T>()))
+              .setCoder(SerializableCoder.of(new TypeDescriptor<Read<T>>() {}));
+
+      return splits.apply("ReadAll", CassandraIO.<T>readAll().withCoder(coder()));
+    }
+
+    private static class SplitFn<T> extends DoFn<Read<T>, Read<T>> {
+      @ProcessElement
+      public void process(
+          @Element CassandraIO.Read<T> read, OutputReceiver<Read<T>> outputReceiver) {
+        Set<RingRange> ringRanges = getRingRanges(read);
+        for (RingRange rr : ringRanges) {
+          outputReceiver.output(read.withRingRanges(ImmutableSet.of(rr)));
+        }
+      }
+
+      private static <T> Set<RingRange> getRingRanges(Read<T> read) {
+        try (Cluster cluster =
+            getCluster(
+                read.hosts(),
+                read.port(),
+                read.username(),
+                read.password(),
+                read.localDc(),
+                read.consistencyLevel(),
+                read.connectTimeout(),
+                read.readTimeout(),
+                read.sslOptions())) {
+          if (isMurmur3Partitioner(cluster)) {
+            LOG.info("Murmur3Partitioner detected, splitting");
+            Integer splitCount;
+            if (read.minNumberOfSplits() != null && read.minNumberOfSplits().get() != null) {
+              splitCount = read.minNumberOfSplits().get();
+            } else {
+              splitCount = cluster.getMetadata().getAllHosts().size();
+            }
+            List<BigInteger> tokens =
+                cluster.getMetadata().getTokenRanges().stream()
+                    .map(tokenRange -> new BigInteger(tokenRange.getEnd().getValue().toString()))
+                    .collect(Collectors.toList());
+            SplitGenerator splitGenerator =
+                new SplitGenerator(cluster.getMetadata().getPartitioner());
+
+            return splitGenerator.generateSplits(splitCount, tokens).stream()
+                .flatMap(List::stream)
+                .collect(Collectors.toSet());
+
+          } else {
+            LOG.warn(
+                "Only Murmur3Partitioner is supported for splitting, using an unique source for "
+                    + "the read");
+            String partitioner = cluster.getMetadata().getPartitioner();
+            RingRange totalRingRange =
+                RingRange.of(
+                    SplitGenerator.getRangeMin(partitioner),
+                    SplitGenerator.getRangeMax(partitioner));
+            return Collections.singleton(totalRingRange);
+          }
+        }
+      }
+    }
+
+    @AutoValue.Builder
+    abstract static class Builder<T> {
+      abstract Builder<T> setHosts(ValueProvider<List<String>> hosts);
+
+      abstract Builder<T> setQuery(ValueProvider<String> query);
+
+      abstract Builder<T> setPort(ValueProvider<Integer> port);
+
+      abstract Builder<T> setKeyspace(ValueProvider<String> keyspace);
+
+      abstract Builder<T> setTable(ValueProvider<String> table);
+
+      abstract Builder<T> setEntity(Class<T> entity);
+
+      abstract Optional<Class<T>> entity();
+
+      abstract Builder<T> setCoder(Coder<T> coder);
+
+      abstract Builder<T> setUsername(ValueProvider<String> username);
+
+      abstract Builder<T> setPassword(ValueProvider<String> password);
+
+      abstract Builder<T> setLocalDc(ValueProvider<String> localDc);
+
+      abstract Builder<T> setConsistencyLevel(ValueProvider<String> consistencyLevel);
+
+      abstract Builder<T> setMinNumberOfSplits(ValueProvider<Integer> minNumberOfSplits);
+
+      abstract Builder<T> setConnectTimeout(ValueProvider<Integer> timeout);
+
+      abstract Builder<T> setReadTimeout(ValueProvider<Integer> timeout);
+
+      abstract Builder<T> setMapperFactoryFn(SerializableFunction<Session, Mapper> mapperFactoryFn);
+
+      abstract Optional<SerializableFunction<Session, Mapper>> mapperFactoryFn();
+
+      abstract Builder<T> setRingRanges(ValueProvider<Set<RingRange>> ringRange);
+
+      abstract Builder<T> setSslOptions(ValueProvider<SSLOptions> sslOptions);
+
+      abstract Read<T> autoBuild();
+
+      public Read<T> build() {
+        if (!mapperFactoryFn().isPresent() && entity().isPresent()) {
+          setMapperFactoryFn(new DefaultObjectMapperFactory(entity().get()));
+        }
+        return autoBuild();
+      }
+    }
+  }
+
+  /** Specify the mutation type: either write or delete. */
+  public enum MutationType {
+    WRITE,
+    DELETE
+  }
+
+  /**
+   * A {@link PTransform} to mutate into Apache Cassandra. See {@link CassandraIO} for details on
+   * usage and configuration.
+   */
+  @AutoValue
+  @AutoValue.CopyAnnotations
+  @SuppressWarnings({"rawtypes"})
+  public abstract static class Write<T> extends PTransform<PCollection<T>, PDone> {
+
+    abstract @Nullable ValueProvider<List<String>> hosts();
+
+    abstract @Nullable ValueProvider<Integer> port();
+
+    abstract @Nullable ValueProvider<String> keyspace();
+
+    abstract @Nullable Class<T> entity();
+
+    abstract @Nullable ValueProvider<String> username();
+
+    abstract @Nullable ValueProvider<String> password();
+
+    abstract @Nullable ValueProvider<String> localDc();
+
+    abstract @Nullable ValueProvider<String> consistencyLevel();
+
+    abstract MutationType mutationType();
+
+    abstract @Nullable ValueProvider<Integer> connectTimeout();
+
+    abstract @Nullable ValueProvider<Integer> readTimeout();
+
+    abstract @Nullable ValueProvider<SSLOptions> sslOptions();
+
+    abstract @Nullable SerializableFunction<Session, Mapper> mapperFactoryFn();
+
+    abstract Builder<T> builder();
+
+    static <T> Builder<T> builder(MutationType mutationType) {
+      return new AutoValue_CassandraIO_Write.Builder<T>().setMutationType(mutationType);
+    }
+
+    /** Specify the Cassandra instance hosts where to write data. */
+    public Write<T> withHosts(List<String> hosts) {
+      checkArgument(
+          hosts != null,
+          "CassandraIO." + getMutationTypeName() + "().withHosts(hosts) called with null hosts");
+      checkArgument(
+          !hosts.isEmpty(),
+          "CassandraIO."
+              + getMutationTypeName()
+              + "().withHosts(hosts) called with empty "
+              + "hosts list");
+      return withHosts(ValueProvider.StaticValueProvider.of(hosts));
+    }
+
+    /** Specify the hosts of the Apache Cassandra instances. */
+    public Write<T> withHosts(ValueProvider<List<String>> hosts) {
+      return builder().setHosts(hosts).build();
+    }
+
+    /** Specify the Cassandra instance port number where to write data. */
+    public Write<T> withPort(int port) {
+      checkArgument(
+          port > 0,
+          "CassandraIO."
+              + getMutationTypeName()
+              + "().withPort(port) called with invalid port "
+              + "number (%s)",
+          port);
+      return withPort(ValueProvider.StaticValueProvider.of(port));
+    }
+
+    /** Specify the port number of the Apache Cassandra instances. */
+    public Write<T> withPort(ValueProvider<Integer> port) {
+      return builder().setPort(port).build();
+    }
+
+    /** Specify the Cassandra keyspace where to write data. */
+    public Write<T> withKeyspace(String keyspace) {
+      checkArgument(
+          keyspace != null,
+          "CassandraIO."
+              + getMutationTypeName()
+              + "().withKeyspace(keyspace) called with "
+              + "null keyspace");
+      return withKeyspace(ValueProvider.StaticValueProvider.of(keyspace));
+    }
+
+    /** Specify the Cassandra keyspace where to read data. */
+    public Write<T> withKeyspace(ValueProvider<String> keyspace) {
+      return builder().setKeyspace(keyspace).build();
+    }
+
+    /**
+     * Specify the entity class in the input {@link PCollection}. The {@link CassandraIO} will map
+     * this entity to the Cassandra table thanks to the annotations.
+     */
+    public Write<T> withEntity(Class<T> entity) {
+      checkArgument(
+          entity != null,
+          "CassandraIO."
+              + getMutationTypeName()
+              + "().withEntity(entity) called with null "
+              + "entity");
+      return builder().setEntity(entity).build();
+    }
+
+    /** Specify the username used for authentication. */
+    public Write<T> withUsername(String username) {
+      checkArgument(
+          username != null,
+          "CassandraIO."
+              + getMutationTypeName()
+              + "().withUsername(username) called with "
+              + "null username");
+      return withUsername(ValueProvider.StaticValueProvider.of(username));
+    }
+
+    /** Specify the username for authentication. */
+    public Write<T> withUsername(ValueProvider<String> username) {
+      return builder().setUsername(username).build();
+    }
+
+    /** Specify the password used for authentication. */
+    public Write<T> withPassword(String password) {
+      checkArgument(
+          password != null,
+          "CassandraIO."
+              + getMutationTypeName()
+              + "().withPassword(password) called with "
+              + "null password");
+      return withPassword(ValueProvider.StaticValueProvider.of(password));
+    }
+
+    /** Specify the password used for authentication. */
+    public Write<T> withPassword(ValueProvider<String> password) {
+      return builder().setPassword(password).build();
+    }
+
+    /** Specify the local DC used by the load balancing policy. */
+    public Write<T> withLocalDc(String localDc) {
+      checkArgument(
+          localDc != null,
+          "CassandraIO."
+              + getMutationTypeName()
+              + "().withLocalDc(localDc) called with null"
+              + " localDc");
+      return withLocalDc(ValueProvider.StaticValueProvider.of(localDc));
+    }
+
+    /** Specify the local DC used for the load balancing. */
+    public Write<T> withLocalDc(ValueProvider<String> localDc) {
+      return builder().setLocalDc(localDc).build();
+    }
+
+    /** Specify the consistency level for the request (e.g. ONE, LOCAL_ONE, LOCAL_QUORUM, etc). */
+    public Write<T> withConsistencyLevel(String consistencyLevel) {
+      checkArgument(
+          consistencyLevel != null,
+          "CassandraIO."
+              + getMutationTypeName()
+              + "().withConsistencyLevel"
+              + "(consistencyLevel) called with null consistencyLevel");
+      return withConsistencyLevel(ValueProvider.StaticValueProvider.of(consistencyLevel));
+    }
+
+    /** Specify the consistency level for the request (e.g. ONE, LOCAL_ONE, LOCAL_QUORUM, etc). */
+    public Write<T> withConsistencyLevel(ValueProvider<String> consistencyLevel) {
+      return builder().setConsistencyLevel(consistencyLevel).build();
+    }
+
+    /** Cassandra client socket option for connect timeout in ms. */
+    public Write<T> withConnectTimeout(Integer timeout) {
+      checkArgument(
+          (timeout != null && timeout > 0),
+          "CassandraIO."
+              + getMutationTypeName()
+              + "().withConnectTimeout(timeout) called with invalid timeout "
+              + "number (%s)",
+          timeout);
+      return withConnectTimeout(ValueProvider.StaticValueProvider.of(timeout));
+    }
+
+    /** Cassandra client socket option for connect timeout in ms. */
+    public Write<T> withConnectTimeout(ValueProvider<Integer> timeout) {
+      return builder().setConnectTimeout(timeout).build();
+    }
+
+    /** Cassandra client socket option to set the read timeout in ms. */
+    public Write<T> withReadTimeout(Integer timeout) {
+      checkArgument(
+          (timeout != null && timeout > 0),
+          "CassandraIO."
+              + getMutationTypeName()
+              + "().withReadTimeout(timeout) called with invalid timeout "
+              + "number (%s)",
+          timeout);
+      return withReadTimeout(ValueProvider.StaticValueProvider.of(timeout));
+    }
+
+    /** Cassandra client socket option to set the read timeout in ms. */
+    public Write<T> withReadTimeout(ValueProvider<Integer> timeout) {
+      return builder().setReadTimeout(timeout).build();
+    }
+
+    public Write<T> withMapperFactoryFn(SerializableFunction<Session, Mapper> mapperFactoryFn) {
+      checkArgument(
+          mapperFactoryFn != null,
+          "CassandraIO."
+              + getMutationTypeName()
+              + "().mapperFactoryFn"
+              + "(mapperFactoryFn) called with null value");
+      return builder().setMapperFactoryFn(mapperFactoryFn).build();
+    }
+
+    /**
+     * Optionally, specify {@link SSLOptions} configuration to utilize SSL. See
+     * https://docs.datastax.com/en/developer/java-driver/3.11/manual/ssl/#jsse-programmatic
+     */
+    public Write<T> withSsl(SSLOptions sslOptions) {
+      return withSsl(ValueProvider.StaticValueProvider.of(sslOptions));
+    }
+
+    /**
+     * Optionally, specify {@link SSLOptions} configuration to utilize SSL. See
+     * https://docs.datastax.com/en/developer/java-driver/3.11/manual/ssl/#jsse-programmatic
+     */
+    public Write<T> withSsl(ValueProvider<SSLOptions> sslOptions) {
+      return builder().setSslOptions(sslOptions).build();
+    }
+
+    @Override
+    public void validate(PipelineOptions pipelineOptions) {
+      checkState(
+          hosts() != null,
+          "CassandraIO."
+              + getMutationTypeName()
+              + "() requires a list of hosts to be set via withHosts(hosts)");
+      checkState(
+          port() != null,
+          "CassandraIO."
+              + getMutationTypeName()
+              + "() requires a "
+              + "valid port number to be set via withPort(port)");
+      checkState(
+          keyspace() != null,
+          "CassandraIO."
+              + getMutationTypeName()
+              + "() requires a keyspace to be set via "
+              + "withKeyspace(keyspace)");
+      checkState(
+          entity() != null,
+          "CassandraIO."
+              + getMutationTypeName()
+              + "() requires an entity to be set via "
+              + "withEntity(entity)");
+    }
+
+    @Override
+    public PDone expand(PCollection<T> input) {
+      if (mutationType() == MutationType.DELETE) {
+        input.apply(ParDo.of(new DeleteFn<>(this)));
+      } else {
+        input.apply(ParDo.of(new WriteFn<>(this)));
+      }
+      return PDone.in(input.getPipeline());
+    }
+
+    private String getMutationTypeName() {
+      return mutationType() == null
+          ? MutationType.WRITE.name().toLowerCase()
+          : mutationType().name().toLowerCase();
+    }
+
+    @AutoValue.Builder
+    abstract static class Builder<T> {
+
+      abstract Builder<T> setHosts(ValueProvider<List<String>> hosts);
+
+      abstract Builder<T> setPort(ValueProvider<Integer> port);
+
+      abstract Builder<T> setKeyspace(ValueProvider<String> keyspace);
+
+      abstract Builder<T> setEntity(Class<T> entity);
+
+      abstract Optional<Class<T>> entity();
+
+      abstract Builder<T> setUsername(ValueProvider<String> username);
+
+      abstract Builder<T> setPassword(ValueProvider<String> password);
+
+      abstract Builder<T> setLocalDc(ValueProvider<String> localDc);
+
+      abstract Builder<T> setConsistencyLevel(ValueProvider<String> consistencyLevel);
+
+      abstract Builder<T> setMutationType(MutationType mutationType);
+
+      abstract Builder<T> setConnectTimeout(ValueProvider<Integer> timeout);
+
+      abstract Builder<T> setReadTimeout(ValueProvider<Integer> timeout);
+
+      abstract Builder<T> setMapperFactoryFn(SerializableFunction<Session, Mapper> mapperFactoryFn);
+
+      abstract Optional<SerializableFunction<Session, Mapper>> mapperFactoryFn();
+
+      abstract Builder<T> setSslOptions(ValueProvider<SSLOptions> sslOptions);
+
+      abstract Write<T> autoBuild(); // not public
+
+      public Write<T> build() {
+
+        if (!mapperFactoryFn().isPresent() && entity().isPresent()) {
+          setMapperFactoryFn(new DefaultObjectMapperFactory(entity().get()));
+        }
+        return autoBuild();
+      }
+    }
+  }
+
+  private static class WriteFn<T> extends DoFn<T, Void> {
+    private final Write<T> spec;
+    private transient Mutator<T> writer;
+
+    WriteFn(Write<T> spec) {
+      this.spec = spec;
+    }
+
+    @Setup
+    public void setup() {
+      writer = new Mutator<>(spec, Mapper::saveAsync, "writes");
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext c) throws ExecutionException, InterruptedException {
+      writer.mutate(c.element());
+    }
+
+    @FinishBundle
+    public void finishBundle() throws Exception {
+      writer.flush();
+    }
+
+    @Teardown
+    public void teardown() throws Exception {
+      writer.close();
+      writer = null;
+    }
+  }
+
+  private static class DeleteFn<T> extends DoFn<T, Void> {
+    private final Write<T> spec;
+    private transient Mutator<T> deleter;
+
+    DeleteFn(Write<T> spec) {
+      this.spec = spec;
+    }
+
+    @Setup
+    public void setup() {
+      deleter = new Mutator<>(spec, Mapper::deleteAsync, "deletes");
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext c) throws ExecutionException, InterruptedException {
+      deleter.mutate(c.element());
+    }
+
+    @FinishBundle
+    public void finishBundle() throws Exception {
+      deleter.flush();
+    }
+
+    @Teardown
+    public void teardown() throws Exception {
+      deleter.close();
+      deleter = null;
+    }
+  }
+
+  /** Get a Cassandra cluster using hosts and port. */
+  static Cluster getCluster(
+      ValueProvider<List<String>> hosts,
+      ValueProvider<Integer> port,
+      ValueProvider<String> username,
+      ValueProvider<String> password,
+      ValueProvider<String> localDc,
+      ValueProvider<String> consistencyLevel,
+      ValueProvider<Integer> connectTimeout,
+      ValueProvider<Integer> readTimeout,
+      ValueProvider<SSLOptions> sslOptions) {
+
+    Cluster.Builder builder =
+        Cluster.builder().addContactPoints(hosts.get().toArray(new String[0])).withPort(port.get());
+
+    if (username != null) {
+      builder.withAuthProvider(new PlainTextAuthProvider(username.get(), password.get()));
+    }
+
+    DCAwareRoundRobinPolicy.Builder dcAwarePolicyBuilder = new DCAwareRoundRobinPolicy.Builder();
+    if (localDc != null) {
+      dcAwarePolicyBuilder.withLocalDc(localDc.get());
+    }
+
+    builder.withLoadBalancingPolicy(new TokenAwarePolicy(dcAwarePolicyBuilder.build()));
+
+    if (consistencyLevel != null) {
+      builder.withQueryOptions(
+          new QueryOptions().setConsistencyLevel(ConsistencyLevel.valueOf(consistencyLevel.get())));
+    }
+
+    SocketOptions socketOptions = new SocketOptions();
+
+    builder.withSocketOptions(socketOptions);
+
+    if (connectTimeout != null) {
+      socketOptions.setConnectTimeoutMillis(connectTimeout.get());
+    }
+
+    if (readTimeout != null) {
+      socketOptions.setReadTimeoutMillis(readTimeout.get());
+    }
+
+    if (sslOptions != null) {
+      builder.withSSL(sslOptions.get());
+    }
+
+    return builder.build();
+  }
+
+  /** Mutator allowing to do side effects into Apache Cassandra database. */
+  private static class Mutator<T> {
+    /**
+     * The threshold of 100 concurrent async queries is a heuristic commonly used by the Apache
+     * Cassandra community. There is no real gain to expect in tuning this value.
+     */
+    private static final int CONCURRENT_ASYNC_QUERIES = 100;
+
+    private final Cluster cluster;
+    private final Session session;
+    private final SerializableFunction<Session, Mapper> mapperFactoryFn;
+    private List<Future<Void>> mutateFutures;
+    private final BiFunction<Mapper<T>, T, Future<Void>> mutator;
+    private final String operationName;
+
+    Mutator(Write<T> spec, BiFunction<Mapper<T>, T, Future<Void>> mutator, String operationName) {
+      this.cluster =
+          getCluster(
+              spec.hosts(),
+              spec.port(),
+              spec.username(),
+              spec.password(),
+              spec.localDc(),
+              spec.consistencyLevel(),
+              spec.connectTimeout(),
+              spec.readTimeout(),
+              spec.sslOptions());
+      this.session = cluster.connect(spec.keyspace().get());
+      this.mapperFactoryFn = spec.mapperFactoryFn();
+      this.mutateFutures = new ArrayList<>();
+      this.mutator = mutator;
+      this.operationName = operationName;
+    }
+
+    /**
+     * Mutate the entity to the Cassandra instance, using {@link Mapper} obtained with the Mapper
+     * factory, the DefaultObjectMapperFactory uses {@link
+     * com.datastax.driver.mapping.MappingManager}. This method uses {@link
+     * Mapper#saveAsync(Object)} method, which is asynchronous. Beam will wait for all futures to
+     * complete, to guarantee all writes have succeeded.
+     */
+    void mutate(T entity) throws ExecutionException, InterruptedException {
+      Mapper<T> mapper = mapperFactoryFn.apply(session);
+      this.mutateFutures.add(mutator.apply(mapper, entity));
+      if (this.mutateFutures.size() == CONCURRENT_ASYNC_QUERIES) {
+        // We reached the max number of allowed in flight queries.
+        // Write methods are synchronous in Beam,
+        // so we wait for each async query to return before exiting.
+        LOG.debug(
+            "Waiting for a batch of {} Cassandra {} to be executed...",
+            CONCURRENT_ASYNC_QUERIES,
+            operationName);
+        waitForFuturesToFinish();
+        this.mutateFutures = new ArrayList<>();
+      }
+    }
+
+    void flush() throws ExecutionException, InterruptedException {
+      if (this.mutateFutures.size() > 0) {
+        // Waiting for the last in flight async queries to return before finishing the bundle.
+        waitForFuturesToFinish();
+      }
+    }
+
+    void close() {
+      if (session != null) {
+        session.close();
+      }
+      if (cluster != null) {
+        cluster.close();
+      }
+    }
+
+    private void waitForFuturesToFinish() throws ExecutionException, InterruptedException {
+      for (Future<Void> future : mutateFutures) {
+        future.get();
+      }
+    }
+  }
+
+  /**
+   * A {@link PTransform} to read data from Apache Cassandra. See {@link CassandraIO} for more
+   * information on usage and configuration.
+   */
+  @AutoValue
+  public abstract static class ReadAll<T> extends PTransform<PCollection<Read<T>>, PCollection<T>> {
+    @AutoValue.Builder
+    abstract static class Builder<T> {
+
+      abstract Builder<T> setCoder(Coder<T> coder);
+
+      abstract ReadAll<T> autoBuild();
+
+      public ReadAll<T> build() {
+        return autoBuild();
+      }
+    }
+
+    @Nullable
+    abstract Coder<T> coder();
+
+    abstract Builder<T> builder();
+
+    /** Specify the {@link Coder} used to serialize the entity in the {@link PCollection}. */
+    public ReadAll<T> withCoder(Coder<T> coder) {
+      checkArgument(coder != null, "coder can not be null");
+      return builder().setCoder(coder).build();
+    }
+
+    @Override
+    public PCollection<T> expand(PCollection<Read<T>> input) {
+      checkArgument(coder() != null, "withCoder() is required");
+      return input
+          .apply("Reshuffle", Reshuffle.viaRandomKey())
+          .apply("Read", ParDo.of(new ReadFn<>()))
+          .setCoder(this.coder());
+    }
+  }
+
+  /**
+   * Check if the current partitioner is the Murmur3 (default in Cassandra version newer than 2).
+   */
+  @VisibleForTesting
+  private static boolean isMurmur3Partitioner(Cluster cluster) {
+    return MURMUR3PARTITIONER.equals(cluster.getMetadata().getPartitioner());
+  }
+
+  private static final String MURMUR3PARTITIONER = "org.apache.cassandra.dht.Murmur3Partitioner";
+}

--- a/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/ConnectionManager.java
+++ b/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/ConnectionManager.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.beam.sdk.io.cassandra.CassandraIO.Read;
+import org.apache.beam.sdk.options.ValueProvider;
+
+@SuppressWarnings({
+  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+})
+public class ConnectionManager {
+
+  private static final ConcurrentHashMap<String, Cluster> clusterMap =
+      new ConcurrentHashMap<String, Cluster>();
+  private static final ConcurrentHashMap<String, Session> sessionMap =
+      new ConcurrentHashMap<String, Session>();
+
+  static {
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  for (Session session : sessionMap.values()) {
+                    if (!session.isClosed()) {
+                      session.close();
+                    }
+                  }
+                }));
+  }
+
+  private static String readToClusterHash(Read<?> read) {
+    return Objects.requireNonNull(read.hosts()).get().stream().reduce(",", (a, b) -> a + b)
+        + Objects.requireNonNull(read.port()).get()
+        + safeVPGet(read.localDc())
+        + safeVPGet(read.consistencyLevel());
+  }
+
+  private static String readToSessionHash(Read<?> read) {
+    return readToClusterHash(read) + read.keyspace().get();
+  }
+
+  static Session getSession(Read<?> read) {
+    Cluster cluster =
+        clusterMap.computeIfAbsent(
+            readToClusterHash(read),
+            k ->
+                CassandraIO.getCluster(
+                    Objects.requireNonNull(read.hosts()),
+                    Objects.requireNonNull(read.port()),
+                    read.username(),
+                    read.password(),
+                    read.localDc(),
+                    read.consistencyLevel(),
+                    read.connectTimeout(),
+                    read.readTimeout(),
+                    read.sslOptions()));
+    return sessionMap.computeIfAbsent(
+        readToSessionHash(read),
+        k -> cluster.connect(Objects.requireNonNull(read.keyspace()).get()));
+  }
+
+  private static String safeVPGet(ValueProvider<String> s) {
+    return s != null ? s.get() : "";
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/ConnectionManager.java
+++ b/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/ConnectionManager.java
@@ -15,13 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.sdk.io.cassandra;
+package org.apache.beam.sdk.io.localcassandra;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import org.apache.beam.sdk.io.cassandra.CassandraIO.Read;
+import org.apache.beam.sdk.io.localcassandra.CassandraIO.Read;
 import org.apache.beam.sdk.options.ValueProvider;
 
 @SuppressWarnings({

--- a/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/DefaultObjectMapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/DefaultObjectMapper.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import com.datastax.driver.core.ResultSet;
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.concurrent.Future;
+
+/**
+ * Default Object mapper implementation that uses the <a
+ * href="https://docs.datastax.com/en/developer/java-driver/3.1/manual/object_mapper">Cassandra
+ * Object Mapper</a> for mapping POJOs to CRUD events in Cassandra.
+ *
+ * @see org.apache.beam.sdk.io.cassandra.DefaultObjectMapperFactory
+ */
+@SuppressWarnings({
+  "rawtypes" // TODO(https://github.com/apache/beam/issues/20447)
+})
+class DefaultObjectMapper<T> implements Mapper<T>, Serializable {
+
+  private final transient com.datastax.driver.mapping.Mapper<T> mapper;
+
+  DefaultObjectMapper(com.datastax.driver.mapping.Mapper mapper) {
+    this.mapper = mapper;
+  }
+
+  @Override
+  public Iterator<T> map(ResultSet resultSet) {
+    return mapper.map(resultSet).iterator();
+  }
+
+  @Override
+  public Future<Void> deleteAsync(T entity) {
+    return mapper.deleteAsync(entity);
+  }
+
+  @Override
+  public Future<Void> saveAsync(T entity) {
+    return mapper.saveAsync(entity);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/DefaultObjectMapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/DefaultObjectMapper.java
@@ -15,19 +15,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.sdk.io.cassandra;
+package org.apache.beam.sdk.io.localcassandra;
 
 import com.datastax.driver.core.ResultSet;
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.concurrent.Future;
+import org.apache.beam.sdk.io.cassandra.Mapper;
 
 /**
  * Default Object mapper implementation that uses the <a
  * href="https://docs.datastax.com/en/developer/java-driver/3.1/manual/object_mapper">Cassandra
  * Object Mapper</a> for mapping POJOs to CRUD events in Cassandra.
  *
- * @see org.apache.beam.sdk.io.cassandra.DefaultObjectMapperFactory
+ * @see DefaultObjectMapperFactory
  */
 @SuppressWarnings({
   "rawtypes" // TODO(https://github.com/apache/beam/issues/20447)

--- a/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/DefaultObjectMapperFactory.java
+++ b/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/DefaultObjectMapperFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import com.datastax.driver.core.Session;
+import com.datastax.driver.mapping.MappingManager;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+
+/**
+ * Factory implementation that CassandraIO uses to initialize the Default Object Mapper for mapping
+ * POJOs to CRUD events in Cassandra.
+ *
+ * @see org.apache.beam.sdk.io.cassandra.DefaultObjectMapper
+ */
+@SuppressWarnings({
+  "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
+  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+})
+class DefaultObjectMapperFactory<T> implements SerializableFunction<Session, Mapper> {
+
+  private transient MappingManager mappingManager;
+  final Class<T> entity;
+
+  DefaultObjectMapperFactory(Class<T> entity) {
+    this.entity = entity;
+  }
+
+  @Override
+  public Mapper apply(Session session) {
+    if (mappingManager == null) {
+      this.mappingManager = new MappingManager(session);
+    }
+
+    return new DefaultObjectMapper<T>(mappingManager.mapper(entity));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/DefaultObjectMapperFactory.java
+++ b/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/DefaultObjectMapperFactory.java
@@ -15,17 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.sdk.io.cassandra;
+package org.apache.beam.sdk.io.localcassandra;
 
 import com.datastax.driver.core.Session;
 import com.datastax.driver.mapping.MappingManager;
+import org.apache.beam.sdk.io.cassandra.Mapper;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 
 /**
  * Factory implementation that CassandraIO uses to initialize the Default Object Mapper for mapping
  * POJOs to CRUD events in Cassandra.
  *
- * @see org.apache.beam.sdk.io.cassandra.DefaultObjectMapper
+ * @see DefaultObjectMapper
  */
 @SuppressWarnings({
   "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)

--- a/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/ReadFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/ReadFn.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.sdk.io.cassandra;
+package org.apache.beam.sdk.io.localcassandra;
 
 import com.datastax.driver.core.ColumnMetadata;
 import com.datastax.driver.core.PreparedStatement;
@@ -27,7 +27,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.beam.sdk.io.cassandra.CassandraIO.Read;
+import org.apache.beam.sdk.io.cassandra.Mapper;
+import org.apache.beam.sdk.io.localcassandra.CassandraIO.Read;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Joiner;
 import org.slf4j.Logger;

--- a/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/ReadFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/ReadFn.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import com.datastax.driver.core.ColumnMetadata;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Token;
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.beam.sdk.io.cassandra.CassandraIO.Read;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Joiner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings({
+  "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
+  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+})
+class ReadFn<T> extends DoFn<Read<T>, T> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ReadFn.class);
+
+  @ProcessElement
+  public void processElement(@Element Read<T> read, OutputReceiver<T> receiver) throws Exception {
+    try {
+      Session session = ConnectionManager.getSession(read);
+      Mapper<T> mapper = read.mapperFactoryFn().apply(session);
+      String partitionKey =
+          session.getCluster().getMetadata().getKeyspace(read.keyspace().get())
+              .getTable(read.table().get()).getPartitionKey().stream()
+              .map(ColumnMetadata::getName)
+              .collect(Collectors.joining(","));
+
+      String query = generateRangeQuery(read, partitionKey, read.ringRanges() != null);
+      PreparedStatement preparedStatement = session.prepare(query);
+      Set<RingRange> ringRanges =
+          read.ringRanges() == null ? Collections.emptySet() : read.ringRanges().get();
+
+      for (RingRange rr : ringRanges) {
+        Token startToken = session.getCluster().getMetadata().newToken(rr.getStart().toString());
+        Token endToken = session.getCluster().getMetadata().newToken(rr.getEnd().toString());
+        if (rr.isWrapping()) {
+          // A wrapping range is one that overlaps from the end of the partitioner range and its
+          // start (ie : when the start token of the split is greater than the end token)
+          // We need to generate two queries here : one that goes from the start token to the end
+          // of
+          // the partitioner range, and the other from the start of the partitioner range to the
+          // end token of the split.
+          outputResults(
+              session.execute(getLowestSplitQuery(read, partitionKey, rr.getEnd())),
+              receiver,
+              mapper);
+          outputResults(
+              session.execute(getHighestSplitQuery(read, partitionKey, rr.getStart())),
+              receiver,
+              mapper);
+        } else {
+          ResultSet rs =
+              session.execute(
+                  preparedStatement.bind().setToken(0, startToken).setToken(1, endToken));
+          outputResults(rs, receiver, mapper);
+        }
+      }
+
+      if (read.ringRanges() == null) {
+        ResultSet rs = session.execute(preparedStatement.bind());
+        outputResults(rs, receiver, mapper);
+      }
+    } catch (Exception ex) {
+      LOG.error("error", ex);
+      throw ex;
+    }
+  }
+
+  private static <T> void outputResults(
+      ResultSet rs, OutputReceiver<T> outputReceiver, Mapper<T> mapper) {
+    Iterator<T> iter = mapper.map(rs);
+    while (iter.hasNext()) {
+      T n = iter.next();
+      outputReceiver.output(n);
+    }
+  }
+
+  private static String getHighestSplitQuery(
+      Read<?> spec, String partitionKey, BigInteger highest) {
+    String highestClause = String.format("(token(%s) >= %d)", partitionKey, highest);
+    String finalHighQuery =
+        (spec.query() == null)
+            ? buildInitialQuery(spec, true) + highestClause
+            : spec.query().get() + getJoinerClause(spec.query().get()) + highestClause;
+    LOG.debug("CassandraIO generated a wrapAround query : {}", finalHighQuery);
+    return finalHighQuery;
+  }
+
+  private static String getLowestSplitQuery(Read<?> spec, String partitionKey, BigInteger lowest) {
+    String lowestClause = String.format("(token(%s) < %d)", partitionKey, lowest);
+    String finalLowQuery =
+        (spec.query() == null)
+            ? buildInitialQuery(spec, true) + lowestClause
+            : spec.query().get() + getJoinerClause(spec.query().get()) + lowestClause;
+    LOG.debug("CassandraIO generated a wrapAround query : {}", finalLowQuery);
+    return finalLowQuery;
+  }
+
+  private static String generateRangeQuery(
+      Read<?> spec, String partitionKey, Boolean hasRingRange) {
+    final String rangeFilter =
+        hasRingRange
+            ? Joiner.on(" AND ")
+                .skipNulls()
+                .join(
+                    String.format("(token(%s) >= ?)", partitionKey),
+                    String.format("(token(%s) < ?)", partitionKey))
+            : "";
+    final String combinedQuery = buildInitialQuery(spec, hasRingRange) + rangeFilter;
+    LOG.debug("CassandraIO generated query : {}", combinedQuery);
+    return combinedQuery;
+  }
+
+  private static String buildInitialQuery(Read<?> spec, Boolean hasRingRange) {
+    return (spec.query() == null)
+        ? String.format("SELECT * FROM %s.%s", spec.keyspace().get(), spec.table().get())
+            + " WHERE "
+        : spec.query().get() + (hasRingRange ? getJoinerClause(spec.query().get()) : "");
+  }
+
+  private static String getJoinerClause(String queryString) {
+    return queryString.toUpperCase().contains("WHERE") ? " AND " : " WHERE ";
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/RingRange.java
+++ b/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/RingRange.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import java.io.Serializable;
+import java.math.BigInteger;
+import javax.annotation.Nullable;
+
+/** Models a Cassandra token range. */
+@SuppressWarnings({
+  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+})
+public final class RingRange implements Serializable {
+  private final BigInteger start;
+  private final BigInteger end;
+
+  private RingRange(BigInteger start, BigInteger end) {
+    this.start = start;
+    this.end = end;
+  }
+
+  public BigInteger getStart() {
+    return start;
+  }
+
+  public BigInteger getEnd() {
+    return end;
+  }
+
+  /**
+   * Returns the size of this range.
+   *
+   * @return size of the range, max - range, in case of wrap
+   */
+  BigInteger span(BigInteger ringSize) {
+    return (start.compareTo(end) >= 0) ? end.subtract(start).add(ringSize) : end.subtract(start);
+  }
+
+  /** @return true if 0 is inside of this range. Note that if start == end, then wrapping is true */
+  public boolean isWrapping() {
+    return start.compareTo(end) >= 0;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("(%s,%s]", start.toString(), end.toString());
+  }
+
+  public static RingRange of(BigInteger start, BigInteger end) {
+    return new RingRange(start, end);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    RingRange ringRange = (RingRange) o;
+
+    if (getStart() != null
+        ? !getStart().equals(ringRange.getStart())
+        : ringRange.getStart() != null) {
+      return false;
+    }
+    return getEnd() != null ? getEnd().equals(ringRange.getEnd()) : ringRange.getEnd() == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = getStart() != null ? getStart().hashCode() : 0;
+    result = 31 * result + (getEnd() != null ? getEnd().hashCode() : 0);
+    return result;
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/RingRange.java
+++ b/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/RingRange.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.sdk.io.cassandra;
+package org.apache.beam.sdk.io.localcassandra;
 
 import java.io.Serializable;
 import java.math.BigInteger;

--- a/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/SplitGenerator.java
+++ b/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/SplitGenerator.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Splits given Cassandra table's token range into splits. */
+final class SplitGenerator {
+  private static final Logger LOG = LoggerFactory.getLogger(SplitGenerator.class);
+
+  private final String partitioner;
+  private final BigInteger rangeMin;
+  private final BigInteger rangeMax;
+  private final BigInteger rangeSize;
+
+  SplitGenerator(String partitioner) {
+    rangeMin = getRangeMin(partitioner);
+    rangeMax = getRangeMax(partitioner);
+    rangeSize = getRangeSize(partitioner);
+    this.partitioner = partitioner;
+  }
+
+  static BigInteger getRangeMin(String partitioner) {
+    if (partitioner.endsWith("RandomPartitioner")) {
+      return BigInteger.ZERO;
+    } else if (partitioner.endsWith("Murmur3Partitioner")) {
+      return BigInteger.valueOf(2).pow(63).negate();
+    } else {
+      throw new UnsupportedOperationException(
+          "Unsupported partitioner. " + "Only Random and Murmur3 are supported");
+    }
+  }
+
+  static BigInteger getRangeMax(String partitioner) {
+    if (partitioner.endsWith("RandomPartitioner")) {
+      return BigInteger.valueOf(2).pow(127).subtract(BigInteger.ONE);
+    } else if (partitioner.endsWith("Murmur3Partitioner")) {
+      return BigInteger.valueOf(2).pow(63).subtract(BigInteger.ONE);
+    } else {
+      throw new UnsupportedOperationException(
+          "Unsupported partitioner. " + "Only Random and Murmur3 are supported");
+    }
+  }
+
+  static BigInteger getRangeSize(String partitioner) {
+    return getRangeMax(partitioner).subtract(getRangeMin(partitioner)).add(BigInteger.ONE);
+  }
+
+  /**
+   * Given big0 properly ordered list of tokens, compute at least {@code totalSplitCount} splits.
+   * Each split can contain several token ranges in order to reduce the overhead of vnodes.
+   * Currently, token range grouping is not smart and doesn't check if they share the same replicas.
+   * This is planned to change once Beam is able to handle collocation with the Cassandra nodes.
+   *
+   * @param totalSplitCount requested total amount of splits. This function may generate more
+   *     splits.
+   * @param ringTokens list of all start tokens in big0 cluster. They have to be in ring order.
+   * @return big0 list containing at least {@code totalSplitCount} splits.
+   */
+  List<List<RingRange>> generateSplits(long totalSplitCount, List<BigInteger> ringTokens) {
+    int tokenRangeCount = ringTokens.size();
+
+    List<RingRange> splits = new ArrayList<>();
+    for (int i = 0; i < tokenRangeCount; i++) {
+      BigInteger start = ringTokens.get(i);
+      BigInteger stop = ringTokens.get((i + 1) % tokenRangeCount);
+
+      if (!isInRange(start) || !isInRange(stop)) {
+        throw new RuntimeException(
+            String.format("Tokens (%s,%s) not in range of %s", start, stop, partitioner));
+      }
+      if (start.equals(stop) && tokenRangeCount != 1) {
+        throw new RuntimeException(
+            String.format("Tokens (%s,%s): two nodes have the same token", start, stop));
+      }
+
+      BigInteger rs = stop.subtract(start);
+      if (rs.compareTo(BigInteger.ZERO) <= 0) {
+        // wrap around case
+        rs = rs.add(rangeSize);
+      }
+
+      // the below, in essence, does this:
+      // splitCount = ceiling((rangeSize / RANGE_SIZE) * totalSplitCount)
+      BigInteger[] splitCountAndRemainder =
+          rs.multiply(BigInteger.valueOf(totalSplitCount)).divideAndRemainder(rangeSize);
+
+      int splitCount =
+          splitCountAndRemainder[0].intValue()
+              + (splitCountAndRemainder[1].equals(BigInteger.ZERO) ? 0 : 1);
+
+      LOG.debug("Dividing token range [{},{}) into {} splits", start, stop, splitCount);
+
+      // Make big0 list of all the endpoints for the splits, including both start and stop
+      List<BigInteger> endpointTokens = new ArrayList<>();
+      for (int j = 0; j <= splitCount; j++) {
+        BigInteger offset =
+            rs.multiply(BigInteger.valueOf(j)).divide(BigInteger.valueOf(splitCount));
+        BigInteger token = start.add(offset);
+        if (token.compareTo(rangeMax) > 0) {
+          token = token.subtract(rangeSize);
+        }
+        // Long.MIN_VALUE is not a valid token and has to be silently incremented.
+        // See https://issues.apache.org/jira/browse/CASSANDRA-14684
+        endpointTokens.add(
+            token.equals(BigInteger.valueOf(Long.MIN_VALUE)) ? token.add(BigInteger.ONE) : token);
+      }
+
+      // Append the splits between the endpoints
+      for (int j = 0; j < splitCount; j++) {
+        splits.add(RingRange.of(endpointTokens.get(j), endpointTokens.get(j + 1)));
+        LOG.debug("Split #{}: [{},{})", j + 1, endpointTokens.get(j), endpointTokens.get(j + 1));
+      }
+    }
+
+    BigInteger total = BigInteger.ZERO;
+    for (RingRange split : splits) {
+      BigInteger size = split.span(rangeSize);
+      total = total.add(size);
+    }
+    if (!total.equals(rangeSize)) {
+      throw new RuntimeException(
+          "Some tokens are missing from the splits. " + "This should not happen.");
+    }
+    return coalesceSplits(getTargetSplitSize(totalSplitCount), splits);
+  }
+
+  private boolean isInRange(BigInteger token) {
+    return !(token.compareTo(rangeMin) < 0 || token.compareTo(rangeMax) > 0);
+  }
+
+  private List<List<RingRange>> coalesceSplits(BigInteger targetSplitSize, List<RingRange> splits) {
+    List<List<RingRange>> coalescedSplits = new ArrayList<>();
+    List<RingRange> tokenRangesForCurrentSplit = new ArrayList<>();
+    BigInteger tokenCount = BigInteger.ZERO;
+
+    for (RingRange tokenRange : splits) {
+      if (tokenRange.span(rangeSize).add(tokenCount).compareTo(targetSplitSize) > 0
+          && !tokenRangesForCurrentSplit.isEmpty()) {
+        // enough tokens in that segment
+        LOG.debug(
+            "Got enough tokens for one split ({}) : {}", tokenCount, tokenRangesForCurrentSplit);
+        coalescedSplits.add(tokenRangesForCurrentSplit);
+        tokenRangesForCurrentSplit = new ArrayList<>();
+        tokenCount = BigInteger.ZERO;
+      }
+
+      tokenCount = tokenCount.add(tokenRange.span(rangeSize));
+      tokenRangesForCurrentSplit.add(tokenRange);
+    }
+
+    if (!tokenRangesForCurrentSplit.isEmpty()) {
+      coalescedSplits.add(tokenRangesForCurrentSplit);
+    }
+
+    return coalescedSplits;
+  }
+
+  private BigInteger getTargetSplitSize(long splitCount) {
+    return rangeMax.subtract(rangeMin).divide(BigInteger.valueOf(splitCount));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/SplitGenerator.java
+++ b/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/SplitGenerator.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.sdk.io.cassandra;
+package org.apache.beam.sdk.io.localcassandra;
 
 import java.math.BigInteger;
 import java.util.ArrayList;

--- a/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Transforms for reading and writing from/to Apache Cassandra.
+ *
+ * @see org.apache.beam.sdk.io.cassandra.CassandraIO
+ */
+package org.apache.beam.sdk.io.cassandra;

--- a/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/org/apache/beam/sdk/io/localcassandra/package-info.java
@@ -19,6 +19,6 @@
 /**
  * Transforms for reading and writing from/to Apache Cassandra.
  *
- * @see org.apache.beam.sdk.io.cassandra.CassandraIO
+ * @see org.apache.beam.sdk.io.localcassandra.CassandraIO
  */
-package org.apache.beam.sdk.io.cassandra;
+package org.apache.beam.sdk.io.localcassandra;

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraDataSourceTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraDataSourceTest.java
@@ -26,8 +26,6 @@ import java.io.FileNotFoundException;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.List;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockedStatic;
@@ -37,12 +35,6 @@ import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 /** Test class for {@link CassandraDataSource}. */
 @RunWith(MockitoJUnitRunner.class)
 public class CassandraDataSourceTest {
-  MockedStatic mockFileReader;
-
-  @Before
-  public void initialize() {
-    mockFileReader = mockStatic(JarFileReader.class);
-  }
 
   @Test
   public void testCassandraDataSourceBasic() {
@@ -80,23 +72,20 @@ public class CassandraDataSourceTest {
   public void testLoadFromGCS() throws FileNotFoundException {
     String testGcsPath = "gs://smt-test-bucket/cassandraConfig.conf";
     URL testUrl = Resources.getResource("CassandraUT/test-cassandra-config.conf");
-    mockFileReader
-        .when(() -> JarFileReader.saveFilesLocally(testGcsPath))
-        .thenReturn(new URL[] {testUrl});
-    CassandraDataSource cassandraDataSource =
-        CassandraDataSource.builder().setOptionsMapFromGcsFile(testGcsPath).build();
+    try (MockedStatic mockFileReader = mockStatic(JarFileReader.class)) {
+      mockFileReader
+          .when(() -> JarFileReader.saveFilesLocally(testGcsPath))
+          .thenReturn(new URL[] {testUrl});
+      CassandraDataSource cassandraDataSource =
+          CassandraDataSource.builder().setOptionsMapFromGcsFile(testGcsPath).build();
 
-    assertThat(cassandraDataSource.loggedKeySpace()).isEqualTo("test-keyspace");
-    assertThat(cassandraDataSource.localDataCenter()).isEqualTo("datacenter1");
-    assertThat(cassandraDataSource.contactPoints())
-        .isEqualTo(
-            ImmutableList.of(
-                new InetSocketAddress("127.0.0.1", 9042),
-                new InetSocketAddress("127.0.0.1", 9043)));
-  }
-
-  @After
-  public void cleanup() {
-    mockFileReader.close();
+      assertThat(cassandraDataSource.loggedKeySpace()).isEqualTo("test-keyspace");
+      assertThat(cassandraDataSource.localDataCenter()).isEqualTo("datacenter1");
+      assertThat(cassandraDataSource.contactPoints())
+          .isEqualTo(
+              ImmutableList.of(
+                  new InetSocketAddress("127.0.0.1", 9042),
+                  new InetSocketAddress("127.0.0.1", 9043)));
+    }
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraTableReaderFactoryCassandraIoImplTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraTableReaderFactoryCassandraIoImplTest.java
@@ -45,7 +45,7 @@ import com.google.common.io.Resources;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
-import org.apache.beam.sdk.io.cassandra.CassandraIO;
+import org.apache.beam.sdk.io.localcassandra.CassandraIO;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Count;

--- a/v2/sourcedb-to-spanner/src/test/java/org/apache/beam/sdk/io/localcassandra/CassandraIOTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/org/apache/beam/sdk/io/localcassandra/CassandraIOTest.java
@@ -1,0 +1,847 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Metadata;
+import com.datastax.driver.core.ProtocolVersion;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.TypeCodec;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import com.datastax.driver.mapping.annotations.ClusteringColumn;
+import com.datastax.driver.mapping.annotations.Column;
+import com.datastax.driver.mapping.annotations.Computed;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+import info.archinnov.achilles.embedded.CassandraEmbeddedServerBuilder;
+import info.archinnov.achilles.embedded.CassandraShutDownHook;
+import java.io.IOException;
+import java.io.Serializable;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.management.JMX;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import org.apache.beam.sdk.coders.SerializableCoder;
+import org.apache.beam.sdk.io.common.NetworkTestHelper;
+import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Objects;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.ListeningExecutorService;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.MoreExecutors;
+import org.apache.cassandra.service.StorageServiceMBean;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Tests of {@link CassandraIO}. */
+@RunWith(JUnit4.class)
+@SuppressWarnings({
+  "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
+})
+public class CassandraIOTest implements Serializable {
+  private static final long NUM_ROWS = 22L;
+  private static final String CASSANDRA_KEYSPACE = "beam_ks";
+  private static final String CASSANDRA_HOST = "127.0.0.1";
+  private static final String CASSANDRA_TABLE = "scientist";
+  private static final String CASSANDRA_TABLE_SIMPLEDATA = "simpledata";
+  private static final Logger LOG = LoggerFactory.getLogger(CassandraIOTest.class);
+  private static final String STORAGE_SERVICE_MBEAN = "org.apache.cassandra.db:type=StorageService";
+  private static final int FLUSH_TIMEOUT = 30000;
+  private static final int JMX_CONF_TIMEOUT = 1000;
+  private static int jmxPort;
+  private static int cassandraPort;
+
+  private static Cluster cluster;
+  private static Session session;
+
+  @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+  @Rule public transient TestPipeline pipeline = TestPipeline.create();
+  private static CassandraShutDownHook shutdownHook;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    jmxPort = NetworkTestHelper.getAvailableLocalPort();
+    shutdownHook = new CassandraShutDownHook();
+    String data = TEMPORARY_FOLDER.newFolder("data").getAbsolutePath();
+    String commitLog = TEMPORARY_FOLDER.newFolder("commit-log").getAbsolutePath();
+    String cdcRaw = TEMPORARY_FOLDER.newFolder("cdc-raw").getAbsolutePath();
+    String hints = TEMPORARY_FOLDER.newFolder("hints").getAbsolutePath();
+    String savedCache = TEMPORARY_FOLDER.newFolder("saved-cache").getAbsolutePath();
+    Files.createDirectories(Paths.get(savedCache));
+    CassandraEmbeddedServerBuilder builder =
+        CassandraEmbeddedServerBuilder.builder()
+            .withKeyspaceName(CASSANDRA_KEYSPACE)
+            .withDataFolder(data)
+            .withCommitLogFolder(commitLog)
+            .withCdcRawFolder(cdcRaw)
+            .withHintsFolder(hints)
+            .withSavedCachesFolder(savedCache)
+            .withShutdownHook(shutdownHook)
+            // randomized CQL port at startup
+            .withJMXPort(jmxPort)
+            .cleanDataFilesAtStartup(false);
+
+    // under load we get a NoHostAvailable exception at cluster creation,
+    // so retry to create it every 1 sec up to 3 times.
+    cluster = buildCluster(builder);
+
+    cassandraPort = cluster.getConfiguration().getProtocolOptions().getPort();
+    session = CassandraIOTest.cluster.newSession();
+    insertData();
+    disableAutoCompaction();
+  }
+
+  private static Cluster buildCluster(CassandraEmbeddedServerBuilder builder) {
+    int tried = 0;
+    int delay = 5000;
+    Exception exception = null;
+    while (tried < 5) {
+      try {
+        return builder.buildNativeCluster();
+      } catch (NoHostAvailableException e) {
+        if (exception == null) {
+          exception = e;
+        } else {
+          exception.addSuppressed(e);
+        }
+        tried++;
+        try {
+          Thread.sleep(delay);
+        } catch (InterruptedException e1) {
+          Thread thread = Thread.currentThread();
+          thread.interrupt();
+          throw new RuntimeException(String.format("Thread %s was interrupted", thread.getName()));
+        }
+      }
+    }
+    throw new RuntimeException(
+        String.format(
+            "Unable to create embedded Cassandra cluster: tried %d times with %d delay",
+            tried, delay),
+        exception);
+  }
+
+  @AfterClass
+  public static void afterClass() throws InterruptedException, IOException {
+    shutdownHook.shutDownNow();
+  }
+
+  private static void insertData() throws Exception {
+    LOG.info("Create Cassandra tables");
+    session.execute(
+        String.format(
+            "CREATE TABLE IF NOT EXISTS %s.%s(person_department text, person_id int, person_name text, PRIMARY KEY"
+                + "((person_department), person_id));",
+            CASSANDRA_KEYSPACE, CASSANDRA_TABLE));
+    session.execute(
+        String.format(
+            "CREATE TABLE IF NOT EXISTS %s.%s(person_department text, person_id int, person_name text, PRIMARY KEY"
+                + "((person_department), person_id));",
+            CASSANDRA_KEYSPACE, CASSANDRA_TABLE_WRITE));
+    session.execute(
+        String.format(
+            "CREATE TABLE IF NOT EXISTS %s.%s(id int, data text, PRIMARY KEY (id))",
+            CASSANDRA_KEYSPACE, CASSANDRA_TABLE_SIMPLEDATA));
+
+    LOG.info("Insert records");
+    String[][] scientists = {
+      new String[] {"phys", "Einstein"},
+      new String[] {"bio", "Darwin"},
+      new String[] {"phys", "Copernicus"},
+      new String[] {"bio", "Pasteur"},
+      new String[] {"bio", "Curie"},
+      new String[] {"phys", "Faraday"},
+      new String[] {"math", "Newton"},
+      new String[] {"phys", "Bohr"},
+      new String[] {"phys", "Galileo"},
+      new String[] {"math", "Maxwell"},
+      new String[] {"logic", "Russel"},
+    };
+    for (int i = 0; i < NUM_ROWS; i++) {
+      int index = i % scientists.length;
+      String insertStr =
+          String.format(
+              "INSERT INTO %s.%s(person_department, person_id, person_name) values("
+                  + "'"
+                  + scientists[index][0]
+                  + "', "
+                  + i
+                  + ", '"
+                  + scientists[index][1]
+                  + "');",
+              CASSANDRA_KEYSPACE,
+              CASSANDRA_TABLE);
+      session.execute(insertStr);
+    }
+    for (int i = 0; i < 100; i++) {
+      String insertStr =
+          String.format(
+              "INSERT INTO %s.%s(id, data) VALUES(" + i + ",' data_" + i + "');",
+              CASSANDRA_KEYSPACE,
+              CASSANDRA_TABLE_SIMPLEDATA);
+      session.execute(insertStr);
+    }
+
+    flushMemTablesAndRefreshSizeEstimates();
+  }
+
+  /**
+   * Force the flush of cassandra memTables to SSTables to update size_estimates.
+   * https://wiki.apache.org/cassandra/MemtableSSTable This is what cassandra spark connector does
+   * through nodetool binary call. See:
+   * https://github.com/datastax/spark-cassandra-connector/blob/master/spark-cassandra-connector
+   * /src/it/scala/com/datastax/spark/connector/rdd/partitioner/DataSizeEstimatesSpec.scala which
+   * uses the same JMX service as bellow. See:
+   * https://github.com/apache/cassandra/blob/cassandra-3.X
+   * /src/java/org/apache/cassandra/tools/nodetool/Flush.java
+   */
+  @SuppressWarnings("unused")
+  private static void flushMemTablesAndRefreshSizeEstimates() throws Exception {
+    JMXServiceURL url =
+        new JMXServiceURL(
+            String.format(
+                "service:jmx:rmi://%s/jndi/rmi://%s:%s/jmxrmi",
+                CASSANDRA_HOST, CASSANDRA_HOST, jmxPort));
+    JMXConnector jmxConnector = JMXConnectorFactory.connect(url, null);
+    MBeanServerConnection mBeanServerConnection = jmxConnector.getMBeanServerConnection();
+    ObjectName objectName = new ObjectName(STORAGE_SERVICE_MBEAN);
+    StorageServiceMBean mBeanProxy =
+        JMX.newMBeanProxy(mBeanServerConnection, objectName, StorageServiceMBean.class);
+    mBeanProxy.forceKeyspaceFlush(CASSANDRA_KEYSPACE, CASSANDRA_TABLE);
+    mBeanProxy.refreshSizeEstimates();
+    jmxConnector.close();
+    Thread.sleep(FLUSH_TIMEOUT);
+  }
+
+  /**
+   * Disable auto compaction on embedded cassandra host, to avoid race condition in temporary files
+   * cleaning.
+   */
+  @SuppressWarnings("unused")
+  private static void disableAutoCompaction() throws Exception {
+    JMXServiceURL url =
+        new JMXServiceURL(
+            String.format(
+                "service:jmx:rmi://%s/jndi/rmi://%s:%s/jmxrmi",
+                CASSANDRA_HOST, CASSANDRA_HOST, jmxPort));
+    JMXConnector jmxConnector = JMXConnectorFactory.connect(url, null);
+    MBeanServerConnection mBeanServerConnection = jmxConnector.getMBeanServerConnection();
+    ObjectName objectName = new ObjectName(STORAGE_SERVICE_MBEAN);
+    StorageServiceMBean mBeanProxy =
+        JMX.newMBeanProxy(mBeanServerConnection, objectName, StorageServiceMBean.class);
+    mBeanProxy.disableAutoCompaction(CASSANDRA_KEYSPACE, CASSANDRA_TABLE);
+    jmxConnector.close();
+    Thread.sleep(JMX_CONF_TIMEOUT);
+  }
+
+  /*
+   Since we have enough data we will be able to detect if any get put in the ring range that wraps around
+  */
+  @Test
+  public void testWrapAroundRingRanges() throws Exception {
+    PCollection<SimpleData> simpledataPCollection =
+        pipeline.apply(
+            CassandraIO.<SimpleData>read()
+                .withHosts(Collections.singletonList(CASSANDRA_HOST))
+                .withPort(cassandraPort)
+                .withKeyspace(CASSANDRA_KEYSPACE)
+                .withTable(CASSANDRA_TABLE_SIMPLEDATA)
+                .withMinNumberOfSplits(50)
+                .withCoder(SerializableCoder.of(SimpleData.class))
+                .withEntity(SimpleData.class));
+    PCollection<Long> countPCollection = simpledataPCollection.apply("counting", Count.globally());
+    PAssert.that(countPCollection)
+        .satisfies(
+            i -> {
+              long total = 0;
+              for (Long aLong : i) {
+                total = total + aLong;
+              }
+              assertEquals(100, total);
+              return null;
+            });
+    pipeline.run();
+  }
+
+  @Test
+  public void testRead() throws Exception {
+    PCollection<Scientist> output =
+        pipeline.apply(
+            CassandraIO.<Scientist>read()
+                .withHosts(Collections.singletonList(CASSANDRA_HOST))
+                .withPort(cassandraPort)
+                .withKeyspace(CASSANDRA_KEYSPACE)
+                .withTable(CASSANDRA_TABLE)
+                .withMinNumberOfSplits(50)
+                .withCoder(SerializableCoder.of(Scientist.class))
+                .withEntity(Scientist.class));
+
+    PAssert.thatSingleton(output.apply("Count", Count.globally())).isEqualTo(NUM_ROWS);
+
+    PCollection<KV<String, Integer>> mapped =
+        output.apply(
+            MapElements.via(
+                new SimpleFunction<Scientist, KV<String, Integer>>() {
+                  @Override
+                  public KV<String, Integer> apply(Scientist scientist) {
+                    return KV.of(scientist.name, scientist.id);
+                  }
+                }));
+    PAssert.that(mapped.apply("Count occurrences per scientist", Count.perKey()))
+        .satisfies(
+            input -> {
+              int count = 0;
+              for (KV<String, Long> element : input) {
+                count++;
+                assertEquals(element.getKey(), NUM_ROWS / 10, element.getValue().longValue());
+              }
+              assertEquals(11, count);
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  private CassandraIO.Read<Scientist> getReadWithRingRange(RingRange... rr) {
+    return CassandraIO.<Scientist>read()
+        .withHosts(Collections.singletonList(CASSANDRA_HOST))
+        .withPort(cassandraPort)
+        .withRingRanges(new HashSet<>(Arrays.asList(rr)))
+        .withKeyspace(CASSANDRA_KEYSPACE)
+        .withTable(CASSANDRA_TABLE)
+        .withCoder(SerializableCoder.of(Scientist.class))
+        .withEntity(Scientist.class);
+  }
+
+  private CassandraIO.Read<Scientist> getReadWithQuery(String query) {
+    return CassandraIO.<Scientist>read()
+        .withHosts(Collections.singletonList(CASSANDRA_HOST))
+        .withPort(cassandraPort)
+        .withQuery(query)
+        .withKeyspace(CASSANDRA_KEYSPACE)
+        .withTable(CASSANDRA_TABLE)
+        .withCoder(SerializableCoder.of(Scientist.class))
+        .withEntity(Scientist.class);
+  }
+
+  @Test
+  public void testReadAllQuery() {
+    String physQuery =
+        String.format(
+            "SELECT * From %s.%s WHERE person_department='phys' AND person_id=0;",
+            CASSANDRA_KEYSPACE, CASSANDRA_TABLE);
+
+    String mathQuery =
+        String.format(
+            "SELECT * From %s.%s WHERE person_department='math' AND person_id=6;",
+            CASSANDRA_KEYSPACE, CASSANDRA_TABLE);
+
+    PCollection<Scientist> output =
+        pipeline
+            .apply(Create.of(getReadWithQuery(physQuery), getReadWithQuery(mathQuery)))
+            .apply(
+                CassandraIO.<Scientist>readAll().withCoder(SerializableCoder.of(Scientist.class)));
+
+    PCollection<String> mapped =
+        output.apply(
+            MapElements.via(
+                new SimpleFunction<Scientist, String>() {
+                  @Override
+                  public String apply(Scientist scientist) {
+                    return scientist.name;
+                  }
+                }));
+    PAssert.that(mapped).containsInAnyOrder("Einstein", "Newton");
+    PAssert.thatSingleton(output.apply("count", Count.globally())).isEqualTo(2L);
+    pipeline.run();
+  }
+
+  @Test
+  public void testReadAllRingRange() {
+    RingRange physRR =
+        fromEncodedKey(
+            cluster.getMetadata(), TypeCodec.varchar().serialize("phys", ProtocolVersion.V3));
+
+    RingRange mathRR =
+        fromEncodedKey(
+            cluster.getMetadata(), TypeCodec.varchar().serialize("math", ProtocolVersion.V3));
+
+    RingRange logicRR =
+        fromEncodedKey(
+            cluster.getMetadata(), TypeCodec.varchar().serialize("logic", ProtocolVersion.V3));
+
+    PCollection<Scientist> output =
+        pipeline
+            .apply(Create.of(getReadWithRingRange(physRR), getReadWithRingRange(mathRR, logicRR)))
+            .apply(
+                CassandraIO.<Scientist>readAll().withCoder(SerializableCoder.of(Scientist.class)));
+
+    PCollection<KV<String, Integer>> mapped =
+        output.apply(
+            MapElements.via(
+                new SimpleFunction<Scientist, KV<String, Integer>>() {
+                  @Override
+                  public KV<String, Integer> apply(Scientist scientist) {
+                    return KV.of(scientist.department, scientist.id);
+                  }
+                }));
+
+    PAssert.that(mapped.apply("Count occurrences per department", Count.perKey()))
+        .satisfies(
+            input -> {
+              HashMap<String, Long> map = new HashMap<>();
+              for (KV<String, Long> element : input) {
+                map.put(element.getKey(), element.getValue());
+              }
+              assertEquals(3, map.size()); // do we have all three departments
+              assertEquals(10L, (long) map.get("phys"));
+              assertEquals(4L, (long) map.get("math"));
+              assertEquals(2L, (long) map.get("logic"));
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testReadWithQuery() throws Exception {
+    String query =
+        String.format(
+            "select person_id, writetime(person_name) from %s.%s where person_id=10 AND person_department='logic'",
+            CASSANDRA_KEYSPACE, CASSANDRA_TABLE);
+
+    PCollection<Scientist> output =
+        pipeline.apply(
+            CassandraIO.<Scientist>read()
+                .withHosts(Collections.singletonList(CASSANDRA_HOST))
+                .withPort(cassandraPort)
+                .withKeyspace(CASSANDRA_KEYSPACE)
+                .withTable(CASSANDRA_TABLE)
+                .withMinNumberOfSplits(20)
+                .withQuery(query)
+                .withCoder(SerializableCoder.of(Scientist.class))
+                .withEntity(Scientist.class));
+
+    PAssert.thatSingleton(output.apply("Count", Count.globally())).isEqualTo(1L);
+    PAssert.that(output)
+        .satisfies(
+            input -> {
+              for (Scientist sci : input) {
+                assertNull(sci.name);
+                assertTrue(sci.nameTs != null && sci.nameTs > 0);
+              }
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  /**
+   * Create a mock value provider class that tests how the query gets expanded in
+   * CassandraIO.ReadFn.
+   */
+  static class MockQueryProvider implements ValueProvider<String> {
+    private volatile String query;
+
+    MockQueryProvider(String query) {
+      this.query = query;
+    }
+
+    @Override
+    public String get() {
+      return query;
+    }
+
+    @Override
+    public boolean isAccessible() {
+      return !query.isEmpty();
+    }
+  }
+
+  @Test
+  public void testReadWithQueryProvider() throws Exception {
+    String query =
+        String.format(
+            "select person_id, writetime(person_name) from %s.%s",
+            CASSANDRA_KEYSPACE, CASSANDRA_TABLE);
+
+    PCollection<Scientist> output =
+        pipeline.apply(
+            CassandraIO.<Scientist>read()
+                .withHosts(Collections.singletonList(CASSANDRA_HOST))
+                .withPort(cassandraPort)
+                .withKeyspace(CASSANDRA_KEYSPACE)
+                .withTable(CASSANDRA_TABLE)
+                .withMinNumberOfSplits(20)
+                .withQuery(new MockQueryProvider(query))
+                .withCoder(SerializableCoder.of(Scientist.class))
+                .withEntity(Scientist.class));
+
+    PAssert.thatSingleton(output.apply("Count", Count.globally())).isEqualTo(NUM_ROWS);
+    PAssert.that(output)
+        .satisfies(
+            input -> {
+              for (Scientist sci : input) {
+                assertNull(sci.name);
+                assertTrue(sci.nameTs != null && sci.nameTs > 0);
+              }
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testReadWithQueryProviderWithWhereQuery() throws Exception {
+    String query =
+        String.format(
+            "select person_id, writetime(person_name) from %s.%s where person_id=10 AND person_department='logic'",
+            CASSANDRA_KEYSPACE, CASSANDRA_TABLE);
+
+    PCollection<Scientist> output =
+        pipeline.apply(
+            CassandraIO.<Scientist>read()
+                .withHosts(Collections.singletonList(CASSANDRA_HOST))
+                .withPort(cassandraPort)
+                .withKeyspace(CASSANDRA_KEYSPACE)
+                .withTable(CASSANDRA_TABLE)
+                .withMinNumberOfSplits(20)
+                .withQuery(new MockQueryProvider(query))
+                .withCoder(SerializableCoder.of(Scientist.class))
+                .withEntity(Scientist.class));
+
+    PAssert.thatSingleton(output.apply("Count", Count.globally())).isEqualTo(1L);
+    PAssert.that(output)
+        .satisfies(
+            input -> {
+              for (Scientist sci : input) {
+                assertNull(sci.name);
+                assertTrue(sci.nameTs != null && sci.nameTs > 0);
+              }
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testReadWithUnfilteredQuery() throws Exception {
+    String query =
+        String.format(
+            "select person_id, writetime(person_name) from %s.%s",
+            CASSANDRA_KEYSPACE, CASSANDRA_TABLE);
+
+    PCollection<Scientist> output =
+        pipeline.apply(
+            CassandraIO.<Scientist>read()
+                .withHosts(Collections.singletonList(CASSANDRA_HOST))
+                .withPort(cassandraPort)
+                .withKeyspace(CASSANDRA_KEYSPACE)
+                .withTable(CASSANDRA_TABLE)
+                .withMinNumberOfSplits(20)
+                .withQuery(query)
+                .withCoder(SerializableCoder.of(Scientist.class))
+                .withEntity(Scientist.class));
+
+    PAssert.thatSingleton(output.apply("Count", Count.globally())).isEqualTo(NUM_ROWS);
+    PAssert.that(output)
+        .satisfies(
+            input -> {
+              for (Scientist sci : input) {
+                assertNull(sci.name);
+                assertTrue(sci.nameTs != null && sci.nameTs > 0);
+              }
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testWrite() {
+    ArrayList<ScientistWrite> data = new ArrayList<>();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      ScientistWrite scientist = new ScientistWrite();
+      scientist.id = i;
+      scientist.name = "Name " + i;
+      scientist.department = "bio";
+      data.add(scientist);
+    }
+
+    pipeline
+        .apply(Create.of(data))
+        .apply(
+            CassandraIO.<ScientistWrite>write()
+                .withHosts(Collections.singletonList(CASSANDRA_HOST))
+                .withPort(cassandraPort)
+                .withKeyspace(CASSANDRA_KEYSPACE)
+                .withEntity(ScientistWrite.class));
+    // table to write to is specified in the entity in @Table annotation (in that case
+    // scientist_write)
+    pipeline.run();
+
+    List<Row> results = getRows(CASSANDRA_TABLE_WRITE);
+    assertEquals(NUM_ROWS, results.size());
+    for (Row row : results) {
+      assertTrue(row.getString("person_name").matches("Name (\\d*)"));
+    }
+  }
+
+  private static final AtomicInteger counter = new AtomicInteger();
+
+  private static class NOOPMapperFactory implements SerializableFunction<Session, Mapper> {
+
+    @Override
+    public Mapper apply(Session input) {
+      return new NOOPMapper();
+    }
+  }
+
+  private static class NOOPMapper implements Mapper<String>, Serializable {
+
+    private final ListeningExecutorService executor =
+        MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(10));
+
+    final Callable<Void> asyncTask = () -> null;
+
+    @Override
+    public Iterator map(ResultSet resultSet) {
+      if (!resultSet.isExhausted()) {
+        resultSet.iterator().forEachRemaining(r -> counter.getAndIncrement());
+      }
+      return Collections.emptyIterator();
+    }
+
+    @Override
+    public Future<Void> deleteAsync(String entity) {
+      counter.incrementAndGet();
+      return executor.submit(asyncTask);
+    }
+
+    @Override
+    public Future<Void> saveAsync(String entity) {
+      counter.incrementAndGet();
+      return executor.submit(asyncTask);
+    }
+  }
+
+  @Test
+  public void testReadWithMapper() throws Exception {
+    counter.set(0);
+
+    SerializableFunction<Session, Mapper> factory = new NOOPMapperFactory();
+
+    pipeline.apply(
+        CassandraIO.<String>read()
+            .withHosts(Collections.singletonList(CASSANDRA_HOST))
+            .withPort(cassandraPort)
+            .withKeyspace(CASSANDRA_KEYSPACE)
+            .withTable(CASSANDRA_TABLE)
+            .withCoder(SerializableCoder.of(String.class))
+            .withEntity(String.class)
+            .withMapperFactoryFn(factory));
+    pipeline.run();
+
+    assertEquals(NUM_ROWS, counter.intValue());
+  }
+
+  @Test
+  public void testCustomMapperImplWrite() throws Exception {
+    counter.set(0);
+
+    SerializableFunction<Session, Mapper> factory = new NOOPMapperFactory();
+
+    pipeline
+        .apply(Create.of(""))
+        .apply(
+            CassandraIO.<String>write()
+                .withHosts(Collections.singletonList(CASSANDRA_HOST))
+                .withPort(cassandraPort)
+                .withKeyspace(CASSANDRA_KEYSPACE)
+                .withMapperFactoryFn(factory)
+                .withEntity(String.class));
+    pipeline.run();
+
+    assertEquals(1, counter.intValue());
+  }
+
+  @Test
+  public void testCustomMapperImplDelete() {
+    counter.set(0);
+
+    SerializableFunction<Session, Mapper> factory = new NOOPMapperFactory();
+
+    pipeline
+        .apply(Create.of(""))
+        .apply(
+            CassandraIO.<String>delete()
+                .withHosts(Collections.singletonList(CASSANDRA_HOST))
+                .withPort(cassandraPort)
+                .withKeyspace(CASSANDRA_KEYSPACE)
+                .withMapperFactoryFn(factory)
+                .withEntity(String.class));
+    pipeline.run();
+
+    assertEquals(1, counter.intValue());
+  }
+
+  private List<Row> getRows(String table) {
+    ResultSet result =
+        session.execute(
+            String.format("select person_id,person_name from %s.%s", CASSANDRA_KEYSPACE, table));
+    return result.all();
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    List<Row> results = getRows(CASSANDRA_TABLE);
+    assertEquals(NUM_ROWS, results.size());
+
+    Scientist einstein = new Scientist();
+    einstein.id = 0;
+    einstein.department = "phys";
+    einstein.name = "Einstein";
+    pipeline
+        .apply(Create.of(einstein))
+        .apply(
+            CassandraIO.<Scientist>delete()
+                .withHosts(Collections.singletonList(CASSANDRA_HOST))
+                .withPort(cassandraPort)
+                .withKeyspace(CASSANDRA_KEYSPACE)
+                .withEntity(Scientist.class));
+
+    pipeline.run();
+    results = getRows(CASSANDRA_TABLE);
+    assertEquals(NUM_ROWS - 1, results.size());
+    // re-insert suppressed doc to make the test autonomous
+    session.execute(
+        String.format(
+            "INSERT INTO %s.%s(person_department, person_id, person_name) values("
+                + "'phys', "
+                + einstein.id
+                + ", '"
+                + einstein.name
+                + "');",
+            CASSANDRA_KEYSPACE,
+            CASSANDRA_TABLE));
+  }
+
+  /** Simple Cassandra entity used in read tests. */
+  @Table(name = CASSANDRA_TABLE, keyspace = CASSANDRA_KEYSPACE)
+  static class Scientist implements Serializable {
+
+    @Column(name = "person_name")
+    String name;
+
+    @Computed("writetime(person_name)")
+    Long nameTs;
+
+    @ClusteringColumn()
+    @Column(name = "person_id")
+    int id;
+
+    @PartitionKey
+    @Column(name = "person_department")
+    String department;
+
+    @Override
+    public String toString() {
+      return id + ":" + name;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Scientist scientist = (Scientist) o;
+      return id == scientist.id
+          && Objects.equal(name, scientist.name)
+          && Objects.equal(department, scientist.department);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(name, id);
+    }
+  }
+
+  @Table(name = CASSANDRA_TABLE_SIMPLEDATA, keyspace = CASSANDRA_KEYSPACE)
+  static class SimpleData implements Serializable {
+    @PartitionKey int id;
+
+    @Column String data;
+
+    @Override
+    public String toString() {
+      return id + ", " + data;
+    }
+  }
+
+  private static RingRange fromEncodedKey(Metadata metadata, ByteBuffer... bb) {
+    BigInteger bi = BigInteger.valueOf((long) metadata.newToken(bb).getValue());
+    return RingRange.of(bi, bi.add(BigInteger.valueOf(1L)));
+  }
+
+  private static final String CASSANDRA_TABLE_WRITE = "scientist_write";
+  /** Simple Cassandra entity used in write tests. */
+  @Table(name = CASSANDRA_TABLE_WRITE, keyspace = CASSANDRA_KEYSPACE)
+  static class ScientistWrite extends Scientist {}
+}

--- a/v2/sourcedb-to-spanner/src/test/java/org/apache/beam/sdk/io/localcassandra/SplitGeneratorTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/org/apache/beam/sdk/io/localcassandra/SplitGeneratorTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.Test;
+
+/** Tests on {@link SplitGenerator}. */
+public final class SplitGeneratorTest {
+
+  @Test
+  public void testGenerateSegments() {
+    List<BigInteger> tokens =
+        Stream.of(
+                "0",
+                "1",
+                "56713727820156410577229101238628035242",
+                "56713727820156410577229101238628035243",
+                "113427455640312821154458202477256070484",
+                "113427455640312821154458202477256070485")
+            .map(BigInteger::new)
+            .collect(Collectors.toList());
+
+    SplitGenerator generator = new SplitGenerator("foo.bar.RandomPartitioner");
+    List<List<RingRange>> segments = generator.generateSplits(10, tokens);
+
+    assertEquals(12, segments.size());
+    assertEquals("[(0,1], (1,14178431955039102644307275309657008811]]", segments.get(0).toString());
+    assertEquals(
+        "[(14178431955039102644307275309657008811,28356863910078205288614550619314017621]]",
+        segments.get(1).toString());
+    assertEquals(
+        "[(70892159775195513221536376548285044053,85070591730234615865843651857942052863]]",
+        segments.get(5).toString());
+
+    tokens =
+        Stream.of(
+                "5",
+                "6",
+                "56713727820156410577229101238628035242",
+                "56713727820156410577229101238628035243",
+                "113427455640312821154458202477256070484",
+                "113427455640312821154458202477256070485")
+            .map(BigInteger::new)
+            .collect(Collectors.toList());
+
+    segments = generator.generateSplits(10, tokens);
+
+    assertEquals(12, segments.size());
+    assertEquals("[(5,6], (6,14178431955039102644307275309657008815]]", segments.get(0).toString());
+    assertEquals(
+        "[(70892159775195513221536376548285044053,85070591730234615865843651857942052863]]",
+        segments.get(5).toString());
+    assertEquals(
+        "[(141784319550391026443072753096570088109,155962751505430129087380028406227096921]]",
+        segments.get(10).toString());
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testZeroSizeRange() {
+    List<String> tokenStrings =
+        Arrays.asList(
+            "0",
+            "1",
+            "56713727820156410577229101238628035242",
+            "56713727820156410577229101238628035242",
+            "113427455640312821154458202477256070484",
+            "113427455640312821154458202477256070485");
+
+    List<BigInteger> tokens =
+        tokenStrings.stream().map(BigInteger::new).collect(Collectors.toList());
+
+    SplitGenerator generator = new SplitGenerator("foo.bar.RandomPartitioner");
+    generator.generateSplits(10, tokens);
+  }
+
+  @Test
+  public void testRotatedRing() {
+    List<String> tokenStrings =
+        Arrays.asList(
+            "56713727820156410577229101238628035243",
+            "113427455640312821154458202477256070484",
+            "113427455640312821154458202477256070485",
+            "5",
+            "6",
+            "56713727820156410577229101238628035242");
+
+    List<BigInteger> tokens =
+        tokenStrings.stream().map(BigInteger::new).collect(Collectors.toList());
+
+    SplitGenerator generator = new SplitGenerator("foo.bar.RandomPartitioner");
+    List<List<RingRange>> segments = generator.generateSplits(5, tokens);
+    assertEquals(6, segments.size());
+    assertEquals(
+        "[(85070591730234615865843651857942052863,113427455640312821154458202477256070484],"
+            + " (113427455640312821154458202477256070484,113427455640312821154458202477256070485]]",
+        segments.get(1).toString());
+    assertEquals(
+        "[(113427455640312821154458202477256070485," + "141784319550391026443072753096570088109]]",
+        segments.get(2).toString());
+    assertEquals(
+        "[(141784319550391026443072753096570088109,5], (5,6]]", segments.get(3).toString());
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testDisorderedRing() {
+    List<String> tokenStrings =
+        Arrays.asList(
+            "0",
+            "113427455640312821154458202477256070485",
+            "1",
+            "56713727820156410577229101238628035242",
+            "56713727820156410577229101238628035243",
+            "113427455640312821154458202477256070484");
+
+    List<BigInteger> tokens =
+        tokenStrings.stream().map(BigInteger::new).collect(Collectors.toList());
+
+    SplitGenerator generator = new SplitGenerator("foo.bar.RandomPartitioner");
+    generator.generateSplits(10, tokens);
+    // Will throw an exception when concluding that the repair segments don't add up.
+    // This is because the tokens were supplied out of order.
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/org/apache/beam/sdk/io/localcassandra/SplitGeneratorTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/org/apache/beam/sdk/io/localcassandra/SplitGeneratorTest.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.sdk.io.cassandra;
+package org.apache.beam.sdk.io.localcassandra;
 
 import static org.junit.Assert.assertEquals;
 

--- a/v2/sourcedb-to-spanner/src/test/resources/CassandraUT/beamUTConfig.yaml
+++ b/v2/sourcedb-to-spanner/src/test/resources/CassandraUT/beamUTConfig.yaml
@@ -1,0 +1,1416 @@
+# Cassandra storage config YAML
+# Note this file is borrowed from test dependency of nosan/embedded-cassandra
+
+# NOTE:
+#   See https://cassandra.apache.org/doc/latest/configuration/ for
+#   full explanations of configuration directives
+# /NOTE
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+# We set this in the test case.
+cluster_name: 'Test Cluster'
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+#
+# If you leave this unspecified, Cassandra will use the default of 1 token for legacy compatibility,
+# and will use the initial_token as described below.
+#
+# Specifying initial_token will override this setting on the node's initial start,
+# on subsequent starts, this setting will apply even if initial token is set.
+#
+num_tokens: 256
+
+# Triggers automatic allocation of num_tokens tokens for this node. The allocation
+# algorithm attempts to choose tokens in a way that optimizes replicated load over
+# the nodes in the datacenter for the replica factor.
+#
+# The load assigned to each node will be close to proportional to its number of
+# vnodes.
+#
+# Only supported with the Murmur3Partitioner.
+
+# Replica factor is determined via the replication strategy used by the specified
+# keyspace.
+# allocate_tokens_for_keyspace: KEYSPACE
+
+# Replica factor is explicitly set, regardless of keyspace or datacenter.
+# This is the replica factor within the datacenter, like NTS.
+# allocate_tokens_for_local_replication_factor: 3
+
+# initial_token allows you to specify tokens manually.  While you can use it with
+# vnodes (num_tokens > 1, above) -- in which case you should provide a
+# comma-separated list -- it's primarily used when adding nodes to legacy clusters
+# that do not have vnodes enabled.
+# initial_token:
+
+# May either be "true" or "false" to enable globally
+hinted_handoff_enabled: true
+
+# When hinted_handoff_enabled is true, a black list of data centers that will not
+# perform hinted handoff
+# hinted_handoff_disabled_datacenters:
+#    - DC1
+#    - DC2
+
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+max_hint_window_in_ms: 10800000 # 3 hours
+
+# Maximum throttle in KBs per second, per delivery thread.  This will be
+# reduced proportionally to the number of nodes in the cluster.  (If there
+# are two nodes in the cluster, each delivery thread will use the maximum
+# rate; if there are three, each will throttle to half of the maximum,
+# since we expect two nodes to be delivering hints simultaneously.)
+hinted_handoff_throttle_in_kb: 1024
+
+# Number of threads with which to deliver hints;
+# Consider increasing this number when you have multi-dc deployments, since
+# cross-dc handoff tends to be slower
+max_hints_delivery_threads: 2
+
+# Directory where Cassandra should store hints.
+# If not set, the default directory is $CASSANDRA_HOME/data/hints.
+# hints_directory: /var/lib/cassandra/hints
+
+# How often hints should be flushed from the internal buffers to disk.
+# Will *not* trigger fsync.
+hints_flush_period_in_ms: 10000
+
+# Maximum size for a single hints file, in megabytes.
+max_hints_file_size_in_mb: 128
+
+# Compression to apply to the hint files. If omitted, hints files
+# will be written uncompressed. LZ4, Snappy, and Deflate compressors
+# are supported.
+#hints_compression:
+#   - class_name: LZ4Compressor
+#     parameters:
+#         -
+
+# Maximum throttle in KBs per second, total. This will be
+# reduced proportionally to the number of nodes in the cluster.
+batchlog_replay_throttle_in_kb: 1024
+
+# Authentication backend, implementing IAuthenticator; used to identify users
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+# PasswordAuthenticator}.
+#
+# - AllowAllAuthenticator performs no checks - set it to disable authentication.
+# - PasswordAuthenticator relies on username/password pairs to authenticate
+#   users. It keeps usernames and hashed passwords in system_auth.roles table.
+#   Please increase system_auth keyspace replication factor if you use this authenticator.
+#   If using PasswordAuthenticator, CassandraRoleManager must also be used (see below)
+authenticator: AllowAllAuthenticator
+
+# Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+# CassandraAuthorizer}.
+#
+# - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+# - CassandraAuthorizer stores permissions in system_auth.role_permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer.
+authorizer: AllowAllAuthorizer
+
+# Part of the Authentication & Authorization backend, implementing IRoleManager; used
+# to maintain grants and memberships between roles.
+# Out of the box, Cassandra provides org.apache.cassandra.auth.CassandraRoleManager,
+# which stores role information in the system_auth keyspace. Most functions of the
+# IRoleManager require an authenticated login, so unless the configured IAuthenticator
+# actually implements authentication, most of this functionality will be unavailable.
+#
+# - CassandraRoleManager stores role data in the system_auth keyspace. Please
+#   increase system_auth keyspace replication factor if you use this role manager.
+role_manager: CassandraRoleManager
+
+# Network authorization backend, implementing INetworkAuthorizer; used to restrict user
+# access to certain DCs
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllNetworkAuthorizer,
+# CassandraNetworkAuthorizer}.
+#
+# - AllowAllNetworkAuthorizer allows access to any DC to any user - set it to disable authorization.
+# - CassandraNetworkAuthorizer stores permissions in system_auth.network_permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer.
+network_authorizer: AllowAllNetworkAuthorizer
+
+# Validity period for roles cache (fetching granted roles can be an expensive
+# operation depending on the role manager, CassandraRoleManager is one example)
+# Granted roles are cached for authenticated sessions in AuthenticatedUser and
+# after the period specified here, become eligible for (async) reload.
+# Defaults to 2000, set to 0 to disable caching entirely.
+# Will be disabled automatically for AllowAllAuthenticator.
+roles_validity_in_ms: 2000
+
+# Refresh interval for roles cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If roles_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as roles_validity_in_ms.
+# roles_update_interval_in_ms: 2000
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 2000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+permissions_validity_in_ms: 2000
+
+# Refresh interval for permissions cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If permissions_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as permissions_validity_in_ms.
+# permissions_update_interval_in_ms: 2000
+
+# Validity period for credentials cache. This cache is tightly coupled to
+# the provided PasswordAuthenticator implementation of IAuthenticator. If
+# another IAuthenticator implementation is configured, this cache will not
+# be automatically used and so the following settings will have no effect.
+# Please note, credentials are cached in their encrypted form, so while
+# activating this cache may reduce the number of queries made to the
+# underlying table, it may not  bring a significant reduction in the
+# latency of individual authentication attempts.
+# Defaults to 2000, set to 0 to disable credentials caching.
+credentials_validity_in_ms: 2000
+
+# Refresh interval for credentials cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If credentials_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as credentials_validity_in_ms.
+# credentials_update_interval_in_ms: 2000
+
+# The partitioner is responsible for distributing groups of rows (by
+# partition key) across nodes in the cluster. The partitioner can NOT be
+# changed without reloading all data.  If you are adding nodes or upgrading,
+# you should set this to the same partitioner that you are currently using.
+#
+# The default partitioner is the Murmur3Partitioner. Older partitioners
+# such as the RandomPartitioner, ByteOrderedPartitioner, and
+# OrderPreservingPartitioner have been included for backward compatibility only.
+# For new clusters, you should NOT change this value.
+#
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# Directories where Cassandra should store data on disk. If multiple
+# directories are specified, Cassandra will spread data evenly across
+# them by partitioning the token ranges.
+# If not set, the default directory is $CASSANDRA_HOME/data/data.
+# data_file_directories:
+#     - /var/lib/cassandra/data
+
+# commit log.  when running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+# If not set, the default directory is $CASSANDRA_HOME/data/commitlog.
+# commitlog_directory: /var/lib/cassandra/commitlog
+
+# Enable / disable CDC functionality on a per-node basis. This modifies the logic used
+# for write path allocation rejection (standard: never reject. cdc: reject Mutation
+# containing a CDC-enabled table if at space limit in cdc_raw_directory).
+cdc_enabled: false
+
+# CommitLogSegments are moved to this directory on flush if cdc_enabled: true and the
+# segment contains mutations for a CDC-enabled table. This should be placed on a
+# separate spindle than the data directories. If not set, the default directory is
+# $CASSANDRA_HOME/data/cdc_raw.
+# cdc_raw_directory: /var/lib/cassandra/cdc_raw
+
+# Policy for data disk failures:
+#
+# die
+#   shut down gossip and client transports and kill the JVM for any fs errors or
+#   single-sstable errors, so the node can be replaced.
+#
+# stop_paranoid
+#   shut down gossip and client transports even for single-sstable errors,
+#   kill the JVM for errors during startup.
+#
+# stop
+#   shut down gossip and client transports, leaving the node effectively dead, but
+#   can still be inspected via JMX, kill the JVM for errors during startup.
+#
+# best_effort
+#    stop using the failed disk and respond to requests based on
+#    remaining available sstables.  This means you WILL see obsolete
+#    data at CL.ONE!
+#
+# ignore
+#    ignore fatal errors and let requests fail, as in pre-1.2 Cassandra
+disk_failure_policy: stop
+
+# Policy for commit disk failures:
+#
+# die
+#   shut down the node and kill the JVM, so the node can be replaced.
+#
+# stop
+#   shut down the node, leaving the node effectively dead, but
+#   can still be inspected via JMX.
+#
+# stop_commit
+#   shutdown the commit log, letting writes collect but
+#   continuing to service reads, as in pre-2.0.5 Cassandra
+#
+# ignore
+#   ignore fatal errors and let the batches fail
+commit_failure_policy: stop
+
+# Maximum size of the native protocol prepared statement cache
+#
+# Valid values are either "auto" (omitting the value) or a value greater 0.
+#
+# Note that specifying a too large value will result in long running GCs and possbily
+# out-of-memory errors. Keep the value at a small fraction of the heap.
+#
+# If you constantly see "prepared statements discarded in the last minute because
+# cache limit reached" messages, the first step is to investigate the root cause
+# of these messages and check whether prepared statements are used correctly -
+# i.e. use bind markers for variable parts.
+#
+# Do only change the default value, if you really have more prepared statements than
+# fit in the cache. In most cases it is not neccessary to change this value.
+# Constantly re-preparing statements is a performance penalty.
+#
+# Default value ("auto") is 1/256th of the heap or 10MB, whichever is greater
+prepared_statements_cache_size_mb:
+
+# Maximum size of the key cache in memory.
+#
+# Each key cache hit saves 1 seek and each row cache hit saves 2 seeks at the
+# minimum, sometimes more. The key cache is fairly tiny for the amount of
+# time it saves, so it's worthwhile to use it at large numbers.
+# The row cache saves even more time, but must contain the entire row,
+# so it is extremely space-intensive. It's best to only use the
+# row cache if you have hot rows or static rows.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(5% of Heap (in MB), 100MB)). Set to 0 to disable key cache.
+key_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# save the key cache. Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 14400 or 4 hours.
+key_cache_save_period: 14400
+
+# Number of keys from the key cache to save
+# Disabled by default, meaning all keys are going to be saved
+# key_cache_keys_to_save: 100
+
+# Row cache implementation class name. Available implementations:
+#
+# org.apache.cassandra.cache.OHCProvider
+#   Fully off-heap row cache implementation (default).
+#
+# org.apache.cassandra.cache.SerializingCacheProvider
+#   This is the row cache implementation availabile
+#   in previous releases of Cassandra.
+# row_cache_class_name: org.apache.cassandra.cache.OHCProvider
+
+# Maximum size of the row cache in memory.
+# Please note that OHC cache implementation requires some additional off-heap memory to manage
+# the map structures and some in-flight memory during operations before/after cache entries can be
+# accounted against the cache capacity. This overhead is usually small compared to the whole capacity.
+# Do not specify more memory that the system can afford in the worst usual situation and leave some
+# headroom for OS block level cache. Do never allow your system to swap.
+#
+# Default value is 0, to disable row caching.
+row_cache_size_in_mb: 0
+
+# Duration in seconds after which Cassandra should save the row cache.
+# Caches are saved to saved_caches_directory as specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 0 to disable saving the row cache.
+row_cache_save_period: 0
+
+# Number of keys from the row cache to save.
+# Specify 0 (which is the default), meaning all keys are going to be saved
+# row_cache_keys_to_save: 100
+
+# Maximum size of the counter cache in memory.
+#
+# Counter cache helps to reduce counter locks' contention for hot counter cells.
+# In case of RF = 1 a counter cache hit will cause Cassandra to skip the read before
+# write entirely. With RF > 1 a counter cache hit will still help to reduce the duration
+# of the lock hold, helping with hot counter cell updates, but will not allow skipping
+# the read entirely. Only the local (clock, count) tuple of a counter cell is kept
+# in memory, not the whole counter, so it's relatively cheap.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(2.5% of Heap (in MB), 50MB)). Set to 0 to disable counter cache.
+# NOTE: if you perform counter deletes and rely on low gcgs, you should disable the counter cache.
+counter_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# save the counter cache (keys only). Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Default is 7200 or 2 hours.
+counter_cache_save_period: 7200
+
+# Number of keys from the counter cache to save
+# Disabled by default, meaning all keys are going to be saved
+# counter_cache_keys_to_save: 100
+
+# saved caches
+# If not set, the default directory is $CASSANDRA_HOME/data/saved_caches.
+# saved_caches_directory: /var/lib/cassandra/saved_caches
+
+# commitlog_sync may be either "periodic", "group", or "batch."
+#
+# When in batch mode, Cassandra won't ack writes until the commit log
+# has been flushed to disk.  Each incoming write will trigger the flush task.
+# commitlog_sync_batch_window_in_ms is a deprecated value. Previously it had
+# almost no value, and is being removed.
+#
+# commitlog_sync_batch_window_in_ms: 2
+#
+# group mode is similar to batch mode, where Cassandra will not ack writes
+# until the commit log has been flushed to disk. The difference is group
+# mode will wait up to commitlog_sync_group_window_in_ms between flushes.
+#
+# commitlog_sync_group_window_in_ms: 1000
+#
+# the default option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds.
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+
+# When in periodic commitlog mode, the number of milliseconds to block writes
+# while waiting for a slow disk flush to complete.
+# periodic_commitlog_sync_lag_block_in_ms:
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+# Max mutation size is also configurable via max_mutation_size_in_kb setting in
+# cassandra.yaml. The default is half the size commitlog_segment_size_in_mb * 1024.
+# This should be positive and less than 2048.
+#
+# NOTE: If max_mutation_size_in_kb is set explicitly then commitlog_segment_size_in_mb must
+# be set to at least twice the size of max_mutation_size_in_kb / 1024
+#
+commitlog_segment_size_in_mb: 32
+
+# Compression to apply to the commit log. If omitted, the commit log
+# will be written uncompressed.  LZ4, Snappy, and Deflate compressors
+# are supported.
+# commitlog_compression:
+#   - class_name: LZ4Compressor
+#     parameters:
+#         -
+
+# Compression to apply to SSTables as they flush for compressed tables.
+# Note that tables without compression enabled do not respect this flag.
+#
+# As high ratio compressors like LZ4HC, Zstd, and Deflate can potentially
+# block flushes for too long, the default is to flush with a known fast
+# compressor in those cases. Options are:
+#
+# none : Flush without compressing blocks but while still doing checksums.
+# fast : Flush with a fast compressor. If the table is already using a
+#        fast compressor that compressor is used.
+# table: Always flush with the same compressor that the table uses. This
+#        was the pre 4.0 behavior.
+#
+# flush_compression: fast
+
+# any class that implements the SeedProvider interface and has a
+# constructor that takes a Map<String, String> of parameters will do.
+seed_provider:
+# Addresses of hosts that are deemed contact points.
+# Cassandra nodes use this list of hosts to find each other and learn
+# the topology of the ring.  You must change this if you are running
+# multiple nodes!
+- class_name: org.apache.cassandra.locator.SimpleSeedProvider
+  parameters:
+  # seeds is actually a comma-delimited list of addresses.
+  # Ex: "<ip1>,<ip2>,<ip3>"
+  - seeds: "127.0.0.1"
+
+# For workloads with more data than can fit in memory, Cassandra's
+# bottleneck will be reads that need to fetch data from
+# disk. "concurrent_reads" should be set to (16 * number_of_drives) in
+# order to allow the operations to enqueue low enough in the stack
+# that the OS and drives can reorder them. Same applies to
+# "concurrent_counter_writes", since counter writes read the current
+# values before incrementing and writing them back.
+#
+# On the other hand, since writes are almost never IO bound, the ideal
+# number of "concurrent_writes" is dependent on the number of cores in
+# your system; (8 * number_of_cores) is a good rule of thumb.
+concurrent_reads: 32
+concurrent_writes: 32
+concurrent_counter_writes: 32
+
+# For materialized view writes, as there is a read involved, so this should
+# be limited by the less of concurrent reads or concurrent writes.
+concurrent_materialized_view_writes: 32
+
+# Maximum memory to use for inter-node and client-server networking buffers.
+#
+# Defaults to the smaller of 1/16 of heap or 128MB. This pool is allocated off-heap,
+# so is in addition to the memory allocated for heap. The cache also has on-heap
+# overhead which is roughly 128 bytes per chunk (i.e. 0.2% of the reserved size
+# if the default 64k chunk size is used).
+# Memory is only allocated when needed.
+# networking_cache_size_in_mb: 128
+
+# Enable the sstable chunk cache.  The chunk cache will store recently accessed
+# sections of the sstable in-memory as uncompressed buffers.
+# file_cache_enabled: false
+
+# Maximum memory to use for sstable chunk cache and buffer pooling.
+# 32MB of this are reserved for pooling buffers, the rest is used for chunk cache
+# that holds uncompressed sstable chunks.
+# Defaults to the smaller of 1/4 of heap or 512MB. This pool is allocated off-heap,
+# so is in addition to the memory allocated for heap. The cache also has on-heap
+# overhead which is roughly 128 bytes per chunk (i.e. 0.2% of the reserved size
+# if the default 64k chunk size is used).
+# Memory is only allocated when needed.
+# file_cache_size_in_mb: 512
+
+# Flag indicating whether to allocate on or off heap when the sstable buffer
+# pool is exhausted, that is when it has exceeded the maximum memory
+# file_cache_size_in_mb, beyond which it will not cache buffers but allocate on request.
+
+# buffer_pool_use_heap_if_exhausted: true
+
+# The strategy for optimizing disk read
+# Possible values are:
+# ssd (for solid state disks, the default)
+# spinning (for spinning disks)
+# disk_optimization_strategy: ssd
+
+# Total permitted memory to use for memtables. Cassandra will stop
+# accepting writes when the limit is exceeded until a flush completes,
+# and will trigger a flush based on memtable_cleanup_threshold
+# If omitted, Cassandra will set both to 1/4 the size of the heap.
+# memtable_heap_space_in_mb: 2048
+# memtable_offheap_space_in_mb: 2048
+
+# memtable_cleanup_threshold is deprecated. The default calculation
+# is the only reasonable choice. See the comments on  memtable_flush_writers
+# for more information.
+#
+# Ratio of occupied non-flushing memtable size to total permitted size
+# that will trigger a flush of the largest memtable. Larger mct will
+# mean larger flushes and hence less compaction, but also less concurrent
+# flush activity which can make it difficult to keep your disks fed
+# under heavy write load.
+#
+# memtable_cleanup_threshold defaults to 1 / (memtable_flush_writers + 1)
+# memtable_cleanup_threshold: 0.11
+
+# Specify the way Cassandra allocates and manages memtable memory.
+# Options are:
+#
+# heap_buffers
+#   on heap nio buffers
+#
+# offheap_buffers
+#   off heap (direct) nio buffers
+#
+# offheap_objects
+#    off heap objects
+memtable_allocation_type: heap_buffers
+
+# Limit memory usage for Merkle tree calculations during repairs. The default
+# is 1/16th of the available heap. The main tradeoff is that smaller trees
+# have less resolution, which can lead to over-streaming data. If you see heap
+# pressure during repairs, consider lowering this, but you cannot go below
+# one megabyte. If you see lots of over-streaming, consider raising
+# this or using subrange repair.
+#
+# For more details see https://issues.apache.org/jira/browse/CASSANDRA-14096.
+#
+# repair_session_space_in_mb:
+
+# Total space to use for commit logs on disk.
+#
+# If space gets above this value, Cassandra will flush every dirty CF
+# in the oldest segment and remove it.  So a small total commitlog space
+# will tend to cause more flush activity on less-active columnfamilies.
+#
+# The default value is the smaller of 8192, and 1/4 of the total space
+# of the commitlog volume.
+#
+# commitlog_total_space_in_mb: 8192
+
+# This sets the number of memtable flush writer threads per disk
+# as well as the total number of memtables that can be flushed concurrently.
+# These are generally a combination of compute and IO bound.
+#
+# Memtable flushing is more CPU efficient than memtable ingest and a single thread
+# can keep up with the ingest rate of a whole server on a single fast disk
+# until it temporarily becomes IO bound under contention typically with compaction.
+# At that point you need multiple flush threads. At some point in the future
+# it may become CPU bound all the time.
+#
+# You can tell if flushing is falling behind using the MemtablePool.BlockedOnAllocation
+# metric which should be 0, but will be non-zero if threads are blocked waiting on flushing
+# to free memory.
+#
+# memtable_flush_writers defaults to two for a single data directory.
+# This means that two  memtables can be flushed concurrently to the single data directory.
+# If you have multiple data directories the default is one memtable flushing at a time
+# but the flush will use a thread per data directory so you will get two or more writers.
+#
+# Two is generally enough to flush on a fast disk [array] mounted as a single data directory.
+# Adding more flush writers will result in smaller more frequent flushes that introduce more
+# compaction overhead.
+#
+# There is a direct tradeoff between number of memtables that can be flushed concurrently
+# and flush size and frequency. More is not better you just need enough flush writers
+# to never stall waiting for flushing to free memory.
+#
+#memtable_flush_writers: 2
+
+# Total space to use for change-data-capture logs on disk.
+#
+# If space gets above this value, Cassandra will throw WriteTimeoutException
+# on Mutations including tables with CDC enabled. A CDCCompactor is responsible
+# for parsing the raw CDC logs and deleting them when parsing is completed.
+#
+# The default value is the min of 4096 mb and 1/8th of the total space
+# of the drive where cdc_raw_directory resides.
+# cdc_total_space_in_mb: 4096
+
+# When we hit our cdc_raw limit and the CDCCompactor is either running behind
+# or experiencing backpressure, we check at the following interval to see if any
+# new space for cdc-tracked tables has been made available. Default to 250ms
+# cdc_free_space_check_interval_ms: 250
+
+# A fixed memory pool size in MB for for SSTable index summaries. If left
+# empty, this will default to 5% of the heap size. If the memory usage of
+# all index summaries exceeds this limit, SSTables with low read rates will
+# shrink their index summaries in order to meet this limit.  However, this
+# is a best-effort process. In extreme conditions Cassandra may need to use
+# more than this amount of memory.
+index_summary_capacity_in_mb:
+
+# How frequently index summaries should be resampled.  This is done
+# periodically to redistribute memory from the fixed-size pool to sstables
+# proportional their recent read rates.  Setting to -1 will disable this
+# process, leaving existing index summaries at their current sampling level.
+index_summary_resize_interval_in_minutes: 60
+
+# Whether to, when doing sequential writing, fsync() at intervals in
+# order to force the operating system to flush the dirty
+# buffers. Enable this to avoid sudden dirty buffer flushing from
+# impacting read latencies. Almost always a good idea on SSDs; not
+# necessarily on platters.
+trickle_fsync: false
+trickle_fsync_interval_in_kb: 10240
+
+# TCP port, for commands and data
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+# storage_port: 7000
+
+# SSL port, for legacy encrypted communication. This property is unused unless enabled in
+# server_encryption_options (see below). As of cassandra 4.0, this property is deprecated
+# as a single port can be used for either/both secure and insecure connections.
+# For security reasons, you should not expose this port to the internet. Firewall it if needed.
+# ssl_storage_port: 7001
+
+# Address or interface to bind to and tell other Cassandra nodes to connect to.
+# You _must_ change this if you want multiple nodes to be able to communicate!
+#
+# Set listen_address OR listen_interface, not both.
+#
+# Leaving it blank leaves it up to InetAddress.getLocalHost(). This
+# will always do the Right Thing _if_ the node is properly configured
+# (hostname, name resolution, etc), and the Right Thing is to use the
+# address associated with the hostname (it might not be). If unresolvable
+# it will fall back to InetAddress.getLoopbackAddress(), which is wrong for production systems.
+#
+# Setting listen_address to 0.0.0.0 is always wrong.
+#
+listen_address: localhost
+
+# Set listen_address OR listen_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+# listen_interface: eth0
+
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using listen_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+# listen_interface_prefer_ipv6: false
+
+# Address to broadcast to other Cassandra nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+
+# When using multiple physical network interfaces, set this
+# to true to listen on broadcast_address in addition to
+# the listen_address, allowing nodes to communicate in both
+# interfaces.
+# Ignore this property if the network configuration automatically
+# routes  between the public and private networks such as EC2.
+# listen_on_broadcast_address: false
+
+# Internode authentication backend, implementing IInternodeAuthenticator;
+# used to allow/disallow connections from peer nodes.
+# internode_authenticator: org.apache.cassandra.auth.AllowAllInternodeAuthenticator
+
+# Whether to start the native transport server.
+# The address on which the native transport is bound is defined by rpc_address.
+start_native_transport: true
+# port for the CQL native transport to listen for clients on
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+# native_transport_port: 9042
+# Enabling native transport encryption in client_encryption_options allows you to either use
+# encryption for the standard port or to use a dedicated, additional port along with the unencrypted
+# standard native_transport_port.
+# Enabling client encryption and keeping native_transport_port_ssl disabled will use encryption
+# for native_transport_port. Setting native_transport_port_ssl to a different value
+# from native_transport_port will use encryption for native_transport_port_ssl while
+# keeping native_transport_port unencrypted.
+# native_transport_port_ssl: 9142
+# The maximum threads for handling requests (note that idle threads are stopped
+# after 30 seconds so there is not corresponding minimum setting).
+# native_transport_max_threads: 128
+#
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 256MB. If you're changing this parameter,
+# you may want to adjust max_value_size_in_mb accordingly. This should be positive and less than 2048.
+# native_transport_max_frame_size_in_mb: 256
+
+# If checksumming is enabled as a protocol option, denotes the size of the chunks into which frame
+# are bodies will be broken and checksummed.
+# native_transport_frame_block_size_in_kb: 32
+
+# The maximum number of concurrent client connections.
+# The default is -1, which means unlimited.
+# native_transport_max_concurrent_connections: -1
+
+# The maximum number of concurrent client connections per source ip.
+# The default is -1, which means unlimited.
+# native_transport_max_concurrent_connections_per_ip: -1
+
+# Controls whether Cassandra honors older, yet currently supported, protocol versions.
+# The default is true, which means all supported protocols will be honored.
+native_transport_allow_older_protocols: true
+
+# Controls when idle client connections are closed. Idle connections are ones that had neither reads
+# nor writes for a time period.
+#
+# Clients may implement heartbeats by sending OPTIONS native protocol message after a timeout, which
+# will reset idle timeout timer on the server side. To close idle client connections, corresponding
+# values for heartbeat intervals have to be set on the client side.
+#
+# Idle connection timeouts are disabled by default.
+# native_transport_idle_timeout_in_ms: 60000
+
+# The address or interface to bind the native transport server to.
+#
+# Set rpc_address OR rpc_interface, not both.
+#
+# Leaving rpc_address blank has the same effect as on listen_address
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike listen_address, you can specify 0.0.0.0, but you must also
+# set broadcast_rpc_address to a value other than 0.0.0.0.
+#
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+rpc_address: localhost
+
+# Set rpc_address OR rpc_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+# rpc_interface: eth1
+
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+# rpc_interface_prefer_ipv6: false
+
+# RPC address to broadcast to drivers and other Cassandra nodes. This cannot
+# be set to 0.0.0.0. If left blank, this will be set to the value of
+# rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+# be set.
+# broadcast_rpc_address: 1.2.3.4
+
+# enable or disable keepalive on rpc/native connections
+rpc_keepalive: true
+
+# Uncomment to set socket buffer size for internode communication
+# Note that when setting this, the buffer size is limited by net.core.wmem_max
+# and when not setting it it is defined by net.ipv4.tcp_wmem
+# See also:
+# /proc/sys/net/core/wmem_max
+# /proc/sys/net/core/rmem_max
+# /proc/sys/net/ipv4/tcp_wmem
+# /proc/sys/net/ipv4/tcp_wmem
+# and 'man tcp'
+# internode_send_buff_size_in_bytes:
+
+# Uncomment to set socket buffer size for internode communication
+# Note that when setting this, the buffer size is limited by net.core.wmem_max
+# and when not setting it it is defined by net.ipv4.tcp_wmem
+# internode_recv_buff_size_in_bytes:
+
+# Set to true to have Cassandra create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# keyspace data.  Removing these links is the operator's
+# responsibility.
+incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Cassandra won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: true
+
+# Granularity of the collation index of rows within a partition.
+# Increase if your rows are large, or if you have a very large
+# number of rows per partition.  The competing goals are these:
+#
+# - a smaller granularity means more index entries are generated
+#   and looking up rows withing the partition by collation column
+#   is faster
+# - but, Cassandra will keep the collation index in memory for hot
+#   rows (as part of the key cache), so a larger granularity means
+#   you can cache more hot rows
+column_index_size_in_kb: 64
+
+# Per sstable indexed key cache entries (the collation index in memory
+# mentioned above) exceeding this size will not be held on heap.
+# This means that only partition information is held on heap and the
+# index entries are read from disk.
+#
+# Note that this size refers to the size of the
+# serialized index information and not the size of the partition.
+column_index_cache_size_in_kb: 2
+
+# Number of simultaneous compactions to allow, NOT including
+# validation "compactions" for anti-entropy repair.  Simultaneous
+# compactions can help preserve read performance in a mixed read/write
+# workload, by mitigating the tendency of small sstables to accumulate
+# during a single long running compactions. The default is usually
+# fine and if you experience problems with compaction running too
+# slowly or too fast, you should look at
+# compaction_throughput_mb_per_sec first.
+#
+# concurrent_compactors defaults to the smaller of (number of disks,
+# number of cores), with a minimum of 2 and a maximum of 8.
+#
+# If your data directories are backed by SSD, you should increase this
+# to the number of cores.
+#concurrent_compactors: 1
+
+# Number of simultaneous repair validations to allow. If not set or set to
+# a value less than 1, it defaults to the value of concurrent_compactors.
+# To set a value greeater than concurrent_compactors at startup, the system
+# property cassandra.allow_unlimited_concurrent_validations must be set to
+# true. To dynamically resize to a value > concurrent_compactors on a running
+# node, first call the bypassConcurrentValidatorsLimit method on the
+# org.apache.cassandra.db:type=StorageService mbean
+# concurrent_validations: 0
+
+# Number of simultaneous materialized view builder tasks to allow.
+concurrent_materialized_view_builders: 1
+
+# Throttles compaction to the given total throughput across the entire
+# system. The faster you insert data, the faster you need to compact in
+# order to keep the sstable count down, but in general, setting this to
+# 16 to 32 times the rate you are inserting data is more than sufficient.
+# Setting this to 0 disables throttling. Note that this accounts for all types
+# of compaction, including validation compaction (building Merkle trees
+# for repairs).
+compaction_throughput_mb_per_sec: 64
+
+# When compacting, the replacement sstable(s) can be opened before they
+# are completely written, and used in place of the prior sstables for
+# any range that has been written. This helps to smoothly transfer reads
+# between the sstables, reducing page cache churn and keeping hot rows hot
+sstable_preemptive_open_interval_in_mb: 50
+
+# When enabled, permits Cassandra to zero-copy stream entire eligible
+# SSTables between nodes, including every component.
+# This speeds up the network transfer significantly subject to
+# throttling specified by stream_throughput_outbound_megabits_per_sec.
+# Enabling this will reduce the GC pressure on sending and receiving node.
+# When unset, the default is enabled. While this feature tries to keep the
+# disks balanced, it cannot guarantee it. This feature will be automatically
+# disabled if internode encryption is enabled. Currently this can be used with
+# Leveled Compaction. Once CASSANDRA-14586 is fixed other compaction strategies
+# will benefit as well when used in combination with CASSANDRA-6696.
+# stream_entire_sstables: true
+
+# Throttles all outbound streaming file transfers on this node to the
+# given total throughput in Mbps. This is necessary because Cassandra does
+# mostly sequential IO when streaming data during bootstrap or repair, which
+# can lead to saturating the network connection and degrading rpc performance.
+# When unset, the default is 200 Mbps or 25 MB/s.
+# stream_throughput_outbound_megabits_per_sec: 200
+
+# Throttles all streaming file transfer between the datacenters,
+# this setting allows users to throttle inter dc stream throughput in addition
+# to throttling all network stream traffic as configured with
+# stream_throughput_outbound_megabits_per_sec
+# When unset, the default is 200 Mbps or 25 MB/s
+# inter_dc_stream_throughput_outbound_megabits_per_sec: 200
+
+# How long the coordinator should wait for read operations to complete.
+# Lowest acceptable value is 10 ms.
+read_request_timeout_in_ms: 5000
+# How long the coordinator should wait for seq or index scans to complete.
+# Lowest acceptable value is 10 ms.
+range_request_timeout_in_ms: 10000
+# How long the coordinator should wait for writes to complete.
+# Lowest acceptable value is 10 ms.
+write_request_timeout_in_ms: 2000
+# How long the coordinator should wait for counter writes to complete.
+# Lowest acceptable value is 10 ms.
+counter_write_request_timeout_in_ms: 5000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row.
+# Lowest acceptable value is 10 ms.
+cas_contention_timeout_in_ms: 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+# Lowest acceptable value is 10 ms.
+truncate_request_timeout_in_ms: 60000
+# The default timeout for other, miscellaneous operations.
+# Lowest acceptable value is 10 ms.
+request_timeout_in_ms: 10000
+
+# Defensive settings for protecting Cassandra from true network partitions.
+# See (CASSANDRA-14358) for details.
+#
+# The amount of time to wait for internode tcp connections to establish.
+# internode_tcp_connect_timeout_in_ms = 2000
+#
+# The amount of time unacknowledged data is allowed on a connection before we throw out the connection
+# Note this is only supported on Linux + epoll, and it appears to behave oddly above a setting of 30000
+# (it takes much longer than 30s) as of Linux 4.12. If you want something that high set this to 0
+# which picks up the OS default and configure the net.ipv4.tcp_retries2 sysctl to be ~8.
+# internode_tcp_user_timeout_in_ms = 30000
+
+# The maximum continuous period a connection may be unwritable in application space
+# internode_application_timeout_in_ms = 30000
+
+# Global, per-endpoint and per-connection limits imposed on messages queued for delivery to other nodes
+# and waiting to be processed on arrival from other nodes in the cluster.  These limits are applied to the on-wire
+# size of the message being sent or received.
+#
+# The basic per-link limit is consumed in isolation before any endpoint or global limit is imposed.
+# Each node-pair has three links: urgent, small and large.  So any given node may have a maximum of
+# N*3*(internode_application_send_queue_capacity_in_bytes+internode_application_receive_queue_capacity_in_bytes)
+# messages queued without any coordination between them although in practice, with token-aware routing, only RF*tokens
+# nodes should need to communicate with significant bandwidth.
+#
+# The per-endpoint limit is imposed on all messages exceeding the per-link limit, simultaneously with the global limit,
+# on all links to or from a single node in the cluster.
+# The global limit is imposed on all messages exceeding the per-link limit, simultaneously with the per-endpoint limit,
+# on all links to or from any node in the cluster.
+#
+# internode_application_send_queue_capacity_in_bytes: 4194304                       #4MiB
+# internode_application_send_queue_reserve_endpoint_capacity_in_bytes: 134217728    #128MiB
+# internode_application_send_queue_reserve_global_capacity_in_bytes: 536870912      #512MiB
+# internode_application_receive_queue_capacity_in_bytes: 4194304                    #4MiB
+# internode_application_receive_queue_reserve_endpoint_capacity_in_bytes: 134217728 #128MiB
+# internode_application_receive_queue_reserve_global_capacity_in_bytes: 536870912   #512MiB
+
+
+# How long before a node logs slow queries. Select queries that take longer than
+# this timeout to execute, will generate an aggregated log message, so that slow queries
+# can be identified. Set this value to zero to disable slow query logging.
+slow_query_log_timeout_in_ms: 500
+
+# Enable operation timeout information exchange between nodes to accurately
+# measure request timeouts.  If disabled, replicas will assume that requests
+# were forwarded to them instantly by the coordinator, which means that
+# under overload conditions we will waste that much extra time processing
+# already-timed-out requests.
+#
+# Warning: It is generally assumed that users have setup NTP on their clusters, and that clocks are modestly in sync,
+# since this is a requirement for general correctness of last write wins.
+#cross_node_timeout: true
+
+# Set keep-alive period for streaming
+# This node will send a keep-alive message periodically with this period.
+# If the node does not receive a keep-alive message from the peer for
+# 2 keep-alive cycles the stream session times out and fail
+# Default value is 300s (5 minutes), which means stalled stream
+# times out in 10 minutes by default
+# streaming_keep_alive_period_in_secs: 300
+
+# Limit number of connections per host for streaming
+# Increase this when you notice that joins are CPU-bound rather that network
+# bound (for example a few nodes with big files).
+# streaming_connections_per_host: 1
+
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# endpoint_snitch -- Set this to a class that implements
+# IEndpointSnitch.  The snitch has two functions:
+#
+# - it teaches Cassandra enough about your network topology to route
+#   requests efficiently
+# - it allows Cassandra to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Cassandra will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# CASSANDRA WILL NOT ALLOW YOU TO SWITCH TO AN INCOMPATIBLE SNITCH
+# ONCE DATA IS INSERTED INTO THE CLUSTER.  This would cause data loss.
+# This means that if you start with the default SimpleSnitch, which
+# locates every node on "rack1" in "datacenter1", your only options
+# if you need to add another datacenter are GossipingPropertyFileSnitch
+# (and the older PFS).  From there, if you want to migrate to an
+# incompatible snitch like Ec2Snitch you can do it by adding new nodes
+# under Ec2Snitch (which will locate them in a new "datacenter") and
+# decommissioning the old ones.
+#
+# Out of the box, Cassandra provides:
+#
+# SimpleSnitch:
+#    Treats Strategy order as proximity. This can improve cache
+#    locality when disabling read repair.  Only appropriate for
+#    single-datacenter deployments.
+#
+# GossipingPropertyFileSnitch
+#    This should be your go-to snitch for production use.  The rack
+#    and datacenter for the local node are defined in
+#    cassandra-rackdc.properties and propagated to other nodes via
+#    gossip.  If cassandra-topology.properties exists, it is used as a
+#    fallback, allowing migration from the PropertyFileSnitch.
+#
+# PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#
+# Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region. Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#
+# Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Cassandra will switch to the private IP after
+#    establishing a connection.)
+#
+# RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's IP
+#    address, respectively.  Unless this happens to match your
+#    deployment conventions, this is best used as an example of
+#    writing a custom Snitch class and is provided in that spirit.
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: SimpleSnitch
+
+# controls how often to perform the more expensive part of host score
+# calculation
+dynamic_snitch_update_interval_in_ms: 100
+# controls how often to reset all host scores, allowing a bad host to
+# possibly recover
+dynamic_snitch_reset_interval_in_ms: 600000
+# if set greater than zero, this will allow
+# 'pinning' of replicas to hosts in order to increase cache capacity.
+# The badness threshold will control how much worse the pinned host has to be
+# before the dynamic snitch will prefer other replicas over it.  This is
+# expressed as a double which represents a percentage.  Thus, a value of
+# 0.2 means Cassandra would continue to prefer the static snitch values
+# until the pinned host was 20% worse than the fastest.
+dynamic_snitch_badness_threshold: 0.1
+
+# Configure server-to-server internode encryption
+#
+# JVM and netty defaults for supported SSL socket protocols and cipher suites can
+# be replaced using custom encryption options. This is not recommended
+# unless you have policies in place that dictate certain settings, or
+# need to disable vulnerable ciphers or protocols in case the JVM cannot
+# be updated.
+#
+# FIPS compliant settings can be configured at JVM level and should not
+# involve changing encryption settings here:
+# https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/FIPS.html
+#
+# **NOTE** this default configuration is an insecure configuration. If you need to
+# enable server-to-server encryption generate server keystores (and truststores for mutual
+# authentication) per:
+# http://download.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+# Then perform the following configuration changes:
+#
+# Step 1: Set internode_encryption=<dc|rack|all> and explicitly set optional=true. Restart all nodes
+#
+# Step 2: Set optional=false (or remove it) and if you generated truststores and want to use mutual
+# auth set require_client_auth=true. Restart all nodes
+server_encryption_options:
+  # On outbound connections, determine which type of peers to securely connect to.
+  #   The available options are :
+  #     none : Do not encrypt outgoing connections
+  #     dc   : Encrypt connections to peers in other datacenters but not within datacenters
+  #     rack : Encrypt connections to peers in other racks but not within racks
+  #     all  : Always use encrypted connections
+  internode_encryption: none
+  # When set to true, encrypted and unencrypted connections are allowed on the storage_port
+  # This should _only be true_ while in unencrypted or transitional operation
+  # optional defaults to true if internode_encryption is none
+  # optional: true
+  # If enabled, will open up an encrypted listening socket on ssl_storage_port. Should only be used
+  # during upgrade to 4.0; otherwise, set to false.
+  enable_legacy_ssl_storage_port: false
+  # Set to a valid keystore if internode_encryption is dc, rack or all
+  keystore: conf/.keystore
+  keystore_password: cassandra
+  # Verify peer server certificates
+  require_client_auth: false
+  # Set to a valid trustore if require_client_auth is true
+  truststore: conf/.truststore
+  truststore_password: cassandra
+  # Verify that the host name in the certificate matches the connected host
+  require_endpoint_verification: false
+  # More advanced defaults:
+  # protocol: TLS
+  # store_type: JKS
+  # cipher_suites: [
+  #   TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+  #   TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+  #   TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_128_GCM_SHA256, TLS_RSA_WITH_AES_128_CBC_SHA,
+  #   TLS_RSA_WITH_AES_256_CBC_SHA
+  # ]
+
+# Configure client-to-server encryption.
+#
+# **NOTE** this default configuration is an insecure configuration. If you need to
+# enable client-to-server encryption generate server keystores (and truststores for mutual
+# authentication) per:
+# http://download.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+# Then perform the following configuration changes:
+#
+# Step 1: Set enabled=true and explicitly set optional=true. Restart all nodes
+#
+# Step 2: Set optional=false (or remove it) and if you generated truststores and want to use mutual
+# auth set require_client_auth=true. Restart all nodes
+client_encryption_options:
+  # Enable client-to-server encryption
+  enabled: false
+  # When set to true, encrypted and unencrypted connections are allowed on the native_transport_port
+  # This should _only be true_ while in unencrypted or transitional operation
+  # optional defaults to true when enabled is false, and false when enabled is true.
+  # optional: true
+  # Set keystore and keystore_password to valid keystores if enabled is true
+  keystore: conf/.keystore
+  keystore_password: cassandra
+  # Verify client certificates
+  require_client_auth: false
+  # Set trustore and truststore_password if require_client_auth is true
+  # truststore: conf/.truststore
+  # truststore_password: cassandra
+  # More advanced defaults:
+  # protocol: TLS
+  # store_type: JKS
+  # cipher_suites: [
+  #   TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+  #   TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+  #   TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_128_GCM_SHA256, TLS_RSA_WITH_AES_128_CBC_SHA,
+  #   TLS_RSA_WITH_AES_256_CBC_SHA
+  # ]
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# Can be:
+#
+# all
+#   all traffic is compressed
+#
+# dc
+#   traffic between different datacenters is compressed
+#
+# none
+#   nothing is compressed.
+internode_compression: dc
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+inter_dc_tcp_nodelay: false
+
+# TTL for different trace types used during logging of the repair process.
+tracetype_query_ttl: 86400
+tracetype_repair_ttl: 604800
+
+# If unset, all GC Pauses greater than gc_log_threshold_in_ms will log at
+# INFO level
+# UDFs (user defined functions) are disabled by default.
+# As of Cassandra 3.0 there is a sandbox in place that should prevent execution of evil code.
+enable_user_defined_functions: false
+
+# Enables scripted UDFs (JavaScript UDFs).
+# Java UDFs are always enabled, if enable_user_defined_functions is true.
+# Enable this option to be able to use UDFs with "language javascript" or any custom JSR-223 provider.
+# This option has no effect, if enable_user_defined_functions is false.
+enable_scripted_user_defined_functions: false
+
+# The default Windows kernel timer and scheduling resolution is 15.6ms for power conservation.
+# Lowering this value on Windows can provide much tighter latency and better throughput, however
+# some virtualized environments may see a negative performance impact from changing this setting
+# below their system default. The sysinternals 'clockres' tool can confirm your system's default
+# setting.
+windows_timer_interval: 1
+
+
+# Enables encrypting data at-rest (on disk). Different key providers can be plugged in, but the default reads from
+# a JCE-style keystore. A single keystore can hold multiple keys, but the one referenced by
+# the "key_alias" is the only key that will be used for encrypt opertaions; previously used keys
+# can still (and should!) be in the keystore and will be used on decrypt operations
+# (to handle the case of key rotation).
+#
+# It is strongly recommended to download and install Java Cryptography Extension (JCE)
+# Unlimited Strength Jurisdiction Policy Files for your version of the JDK.
+# (current link: http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html)
+#
+# Currently, only the following file types are supported for transparent data encryption, although
+# more are coming in future cassandra releases: commitlog, hints
+transparent_data_encryption_options:
+  enabled: false
+  chunk_length_kb: 64
+  cipher: AES/CBC/PKCS5Padding
+  key_alias: testing:1
+  # CBC IV length for AES needs to be 16 bytes (which is also the default size)
+  # iv_length: 16
+  key_provider:
+  - class_name: org.apache.cassandra.security.JKSKeyProvider
+    parameters:
+    - keystore: conf/.keystore
+      keystore_password: cassandra
+      store_type: JCEKS
+      key_password: cassandra
+
+
+#####################
+# SAFETY THRESHOLDS #
+#####################
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+tombstone_warn_threshold: 1000
+tombstone_failure_threshold: 100000
+
+# Filtering and secondary index queries at read consistency levels above ONE/LOCAL_ONE use a
+# mechanism called replica filtering protection to ensure that results from stale replicas do
+# not violate consistency. (See CASSANDRA-8272 and CASSANDRA-15907 for more details.) This
+# mechanism materializes replica results by partition on-heap at the coordinator. The more possibly
+# stale results returned by the replicas, the more rows materialized during the query.
+replica_filtering_protection:
+  # These thresholds exist to limit the damage severely out-of-date replicas can cause during these
+  # queries. They limit the number of rows from all replicas individual index and filtering queries
+  # can materialize on-heap to return correct results at the desired read consistency level.
+  #
+  # "cached_replica_rows_warn_threshold" is the per-query threshold at which a warning will be logged.
+  # "cached_replica_rows_fail_threshold" is the per-query threshold at which the query will fail.
+  #
+  # These thresholds may also be adjusted at runtime using the StorageService mbean.
+  #
+  # If the failure threshold is breached, it is likely that either the current page/fetch size
+  # is too large or one or more replicas is severely out-of-sync and in need of repair.
+  cached_rows_warn_threshold: 2000
+  cached_rows_fail_threshold: 32000
+
+# Log WARN on any multiple-partition batch size exceeding this value. 5kb per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+batch_size_warn_threshold_in_kb: 5
+
+# Fail any multiple-partition batch exceeding this value. 50kb (10x warn threshold) by default.
+batch_size_fail_threshold_in_kb: 50
+
+# Log WARN on any batches not of type LOGGED than span across more partitions than this limit
+unlogged_batch_across_partitions_warn_threshold: 10
+
+# Log a warning when compacting partitions larger than this value
+compaction_large_partition_warning_threshold_mb: 100
+
+# GC Pauses greater than 200 ms will be logged at INFO level
+# This threshold can be adjusted to minimize logging if necessary
+# gc_log_threshold_in_ms: 200
+
+# GC Pauses greater than gc_warn_threshold_in_ms will be logged at WARN level
+# Adjust the threshold based on your application throughput requirement. Setting to 0
+# will deactivate the feature.
+# gc_warn_threshold_in_ms: 1000
+
+# Maximum size of any value in SSTables. Safety measure to detect SSTable corruption
+# early. Any value size larger than this threshold will result into marking an SSTable
+# as corrupted. This should be positive and less than 2048.
+# max_value_size_in_mb: 256
+
+# Coalescing Strategies #
+# Coalescing multiples messages turns out to significantly boost message processing throughput (think doubling or more).
+# On bare metal, the floor for packet processing throughput is high enough that many applications won't notice, but in
+# virtualized environments, the point at which an application can be bound by network packet processing can be
+# surprisingly low compared to the throughput of task processing that is possible inside a VM. It's not that bare metal
+# doesn't benefit from coalescing messages, it's that the number of packets a bare metal network interface can process
+# is sufficient for many applications such that no load starvation is experienced even without coalescing.
+# There are other benefits to coalescing network messages that are harder to isolate with a simple metric like messages
+# per second. By coalescing multiple tasks together, a network thread can process multiple messages for the cost of one
+# trip to read from a socket, and all the task submission work can be done at the same time reducing context switching
+# and increasing cache friendliness of network message processing.
+# See CASSANDRA-8692 for details.
+
+# Strategy to use for coalescing messages in OutboundTcpConnection.
+# Can be fixed, movingaverage, timehorizon, disabled (default).
+# You can also specify a subclass of CoalescingStrategies.CoalescingStrategy by name.
+# otc_coalescing_strategy: DISABLED
+
+# How many microseconds to wait for coalescing. For fixed strategy this is the amount of time after the first
+# message is received before it will be sent with any accompanying messages. For moving average this is the
+# maximum amount of time that will be waited as well as the interval at which messages must arrive on average
+# for coalescing to be enabled.
+# otc_coalescing_window_us: 200
+
+# Do not try to coalesce messages if we already got that many messages. This should be more than 2 and less than 128.
+# otc_coalescing_enough_coalesced_messages: 8
+
+# How many milliseconds to wait between two expiration runs on the backlog (queue) of the OutboundTcpConnection.
+# Expiration is done if messages are piling up in the backlog. Droppable messages are expired to free the memory
+# taken by expired messages. The interval should be between 0 and 1000, and in most installations the default value
+# will be appropriate. A smaller value could potentially expire messages slightly sooner at the expense of more CPU
+# time and queue contention while iterating the backlog of messages.
+# An interval of 0 disables any wait time, which is the behavior of former Cassandra versions.
+#
+# otc_backlog_expiration_interval_ms: 200
+
+# Track a metric per keyspace indicating whether replication achieved the ideal consistency
+# level for writes without timing out. This is different from the consistency level requested by
+# each write which may be lower in order to facilitate availability.
+# ideal_consistency_level: EACH_QUORUM
+
+# Automatically upgrade sstables after upgrade - if there is no ordinary compaction to do, the
+# oldest non-upgraded sstable will get upgraded to the latest version
+# automatic_sstable_upgrade: false
+# Limit the number of concurrent sstable upgrades
+# max_concurrent_automatic_sstable_upgrades: 1
+
+# Audit logging - Logs every incoming CQL command request, authentication to a node. See the docs
+# on audit_logging for full details about the various configuration options.
+audit_logging_options:
+  enabled: false
+  logger:
+  - class_name: BinAuditLogger
+  # audit_logs_dir:
+  # included_keyspaces:
+  # excluded_keyspaces: system, system_schema, system_virtual_schema
+  # included_categories:
+  # excluded_categories:
+  # included_users:
+  # excluded_users:
+  # roll_cycle: HOURLY
+  # block: true
+  # max_queue_weight: 268435456 # 256 MiB
+  # max_log_size: 17179869184 # 16 GiB
+  ## archive command is "/path/to/script.sh %path" where %path is replaced with the file being rolled:
+  # archive_command:
+  # max_archive_retries: 10
+
+
+  # default options for full query logging - these can be overridden from command line when executing
+  # nodetool enablefullquerylog
+  #full_query_logging_options:
+  # log_dir:
+  # roll_cycle: HOURLY
+  # block: true
+  # max_queue_weight: 268435456 # 256 MiB
+  # max_log_size: 17179869184 # 16 GiB
+  ## archive command is "/path/to/script.sh %path" where %path is replaced with the file being rolled:
+  # archive_command:
+  # max_archive_retries: 10
+
+# validate tombstones on reads and compaction
+# can be either "disabled", "warn" or "exception"
+# corrupted_tombstone_strategy: disabled
+
+# Diagnostic Events #
+# If enabled, diagnostic events can be helpful for troubleshooting operational issues. Emitted events contain details
+# on internal state and temporal relationships across events, accessible by clients via JMX.
+diagnostic_events_enabled: false
+
+# Use native transport TCP message coalescing. If on upgrade to 4.0 you found your throughput decreasing, and in
+# particular you run an old kernel or have very fewer client connections, this option might be worth evaluating.
+#native_transport_flush_in_batches_legacy: false
+
+# Enable tracking of repaired state of data during reads and comparison between replicas
+# Mismatches between the repaired sets of replicas can be characterized as either confirmed
+# or unconfirmed. In this context, unconfirmed indicates that the presence of pending repair
+# sessions, unrepaired partition tombstones, or some other condition means that the disparity
+# cannot be considered conclusive. Confirmed mismatches should be a trigger for investigation
+# as they may be indicative of corruption or data loss.
+# There are separate flags for range vs partition reads as single partition reads are only tracked
+# when CL > 1 and a digest mismatch occurs. Currently, range queries don't use digests so if
+# enabled for range reads, all range reads will include repaired data tracking. As this adds
+# some overhead, operators may wish to disable it whilst still enabling it for partition reads
+repaired_data_tracking_for_range_reads_enabled: false
+repaired_data_tracking_for_partition_reads_enabled: false
+# If false, only confirmed mismatches will be reported. If true, a separate metric for unconfirmed
+# mismatches will also be recorded. This is to avoid potential signal:noise issues are unconfirmed
+# mismatches are less actionable than confirmed ones.
+report_unconfirmed_repaired_data_mismatches: false
+
+#########################
+# EXPERIMENTAL FEATURES #
+#########################
+
+# Enables materialized view creation on this node.
+# Materialized views are considered experimental and are not recommended for production use.
+enable_materialized_views: false
+
+# Enables SASI index creation on this node.
+# SASI indexes are considered experimental and are not recommended for production use.
+enable_sasi_indexes: false
+
+# Enables creation of transiently replicated keyspaces on this node.
+# Transient replication is experimental and is not recommended for production use.
+enable_transient_replication: false


### PR DESCRIPTION
## Changes to make a local fork of Cassandra IO. 
1. Changes to make a local fork of Cassandra IO and get it to build in Maven env and successfully run UT. 
2. The fork is needed to incorporate fix for https://github.com/apache/beam/issues/34160 in dataflow.
3. The only change  is in the CassandraIOTest UT file, which is necessary to make the UT work on newer versions of Java (please refer to the detailed change note in the code)
4. There are classes like `RingRange` and `ConnectionManager` which we need to fork, since some of the package private functions exposed by them are used by `CassandraIO` and `ReadFn`.
5. The UT coverage is same as that of the upstream `CassandraIO`.