### PR TITLE
Use GITHUB_TOKEN instead of special release token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@1e31de5234b9f8995739874a8ce0492dc87873e2 # v4.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create release branch
         run: git checkout -b $RELEASE_BRANCH_NAME $BRANCH_COMMIT
         env:


### PR DESCRIPTION
There's no reason to use a special token, we can just use the built in GITHUB_TOKEN. This workflow recently started failing because the release token was expired - https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/workflows/release.yml

I verified the first few steps work with this change - https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/runs/12583262964/job/35070439286 - but didn't let it complete because I didn't want it to create a release (and this step used the GITHUB_TOKEN already)