### PR TITLE
doc: remove redundancy from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ function transform(inJson) {
 function transform(inJson) {
   var obj = JSON.parse(inJson);
   // only output objects which have an answer to life of 42.
-  if (obj.hasOwnProperty('answerToLife') && obj.answerToLife === 42) {
+  if (obj.answerToLife === 42) {
     return JSON.stringify(obj);
   }
 }


### PR DESCRIPTION
There is no need to verify that the object contains the property, if it does not, the if statement will still return `false`, and will not error.