### PR TITLE
use `working-directory` instead of bash commands

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -59,12 +59,11 @@ runs:
     # make running the target program easier
     - name: Build CI/CD
       shell: bash
+      working-directory: ./cicd
       run: |
-        cd cicd/
         for CMD in $(ls cmd); do
           go build ./cmd/$CMD
         done
-        cd ..
     - name: Setup Java
       uses: ./.github/actions/setup-java-env
       with:


### PR DESCRIPTION
It is generally considered best practice to use `working-directory` instead of bash commands.