### PR TITLE
[Draft: Not for review] Changes to use Existing cassandra io for Bulk Cassandra Read with SSL

### DIFF
--- a/v2/sourcedb-to-spanner/pom.xml
+++ b/v2/sourcedb-to-spanner/pom.xml
@@ -170,7 +170,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.60</version>
+      <version>1.68</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperHelper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperHelper.java
@@ -32,7 +32,11 @@ import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
@@ -45,6 +49,16 @@ class CassandraIOWrapperHelper {
   private static final Logger LOG = LoggerFactory.getLogger(CassandraIOWrapperHelper.class);
 
   static DataSource buildDataSource(String gcsPath) {
+    // DO NOT SUBMIT
+    try {
+      LOG.info(
+          "Extra Files are {}",
+          Files.list(Paths.get("/extra_files"))
+              .map(p -> p.getFileName())
+              .collect(Collectors.toList()));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
     DataSource dataSource;
     try {
       dataSource =

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraTableReaderFactoryCassandraIoImpl.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraTableReaderFactoryCassandraIoImpl.java
@@ -117,7 +117,10 @@ public class CassandraTableReaderFactoryCassandraIoImpl implements CassandraTabl
           (profile.isDefined(TypedDriverOption.SSL_TRUSTSTORE_PATH.getRawOption()))
               ? profile.getString(TypedDriverOption.SSL_TRUSTSTORE_PASSWORD.getRawOption())
               : null;
-      return tableReader.withSsl(getSSLOptions(trustStorePath, trustStorePassword));
+      return tableReader.withSsl(
+          SSLOptionsProvider.buidler()
+              .setSslOptionsFactory(() -> getSSLOptions(trustStorePath, trustStorePassword))
+              .build());
     }
     return tableReader;
   }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraTableReaderFactoryCassandraIoImpl.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraTableReaderFactoryCassandraIoImpl.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;
 
+import com.datastax.driver.core.RemoteEndpointAwareJdkSSLOptions;
+import com.datastax.driver.core.SSLOptions;
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
 import com.datastax.oss.driver.api.core.config.TypedDriverOption;
 import com.google.cloud.teleport.v2.source.reader.io.cassandra.rowmapper.CassandraSourceRowMapper;
@@ -23,13 +25,20 @@ import com.google.cloud.teleport.v2.source.reader.io.row.SourceRow;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableSchema;
 import com.google.common.annotations.VisibleForTesting;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.KeyStore;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.io.cassandra.CassandraIO;
 import org.apache.beam.sdk.io.cassandra.CassandraIO.Read;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.commons.lang3.ArrayUtils;
 
 /**
  * Generate Table Reader For Cassandra using the upstream {@link CassandraIO.Read} implementation.
@@ -38,6 +47,14 @@ public class CassandraTableReaderFactoryCassandraIoImpl implements CassandraTabl
 
   /**
    * Returns a Table Reader for given Cassandra Source using the upstream {@link CassandraIO.Read}.
+   *
+   * <p>Note on Tech debt:
+   *
+   * <p>Upstream Beam's CassandraIO uses Cassandra Driver's 3.0 driver API. This would mean that the
+   * entire breadth of options and configurations possible by 4.0 driver API out of box, notably
+   * around SSL connectivity, would not be supported out of box. Currently, we are supporting a very
+   * basic use case of client working with SSL enabled server. For a more complete support the
+   * strategy is to first commit 4.0 support upstream and then use it in the template.
    *
    * @param cassandraDataSource
    * @param sourceSchemaReference
@@ -69,7 +86,7 @@ public class CassandraTableReaderFactoryCassandraIoImpl implements CassandraTabl
             .withCoder(SerializableCoder.of(SourceRow.class))
             .withMapperFactoryFn(
                 CassandraSourceRowMapperFactoryFn.create(cassandraSourceRowMapper));
-    return setCredentials(tableReader, profile);
+    return setSslOptions(setCredentials(tableReader, profile), profile);
   }
 
   @VisibleForTesting
@@ -86,6 +103,75 @@ public class CassandraTableReaderFactoryCassandraIoImpl implements CassandraTabl
               profile.getString(TypedDriverOption.AUTH_PROVIDER_PASSWORD.getRawOption()));
     }
     return tableReader;
+  }
+
+  @VisibleForTesting
+  protected static CassandraIO.Read<SourceRow> setSslOptions(
+      CassandraIO.Read<SourceRow> tableReader, DriverExecutionProfile profile) {
+    if (enableSSL(profile)) {
+      String trustStorePath =
+          (profile.isDefined(TypedDriverOption.SSL_TRUSTSTORE_PATH.getRawOption()))
+              ? profile.getString(TypedDriverOption.SSL_TRUSTSTORE_PATH.getRawOption())
+              : null;
+      String trustStorePassword =
+          (profile.isDefined(TypedDriverOption.SSL_TRUSTSTORE_PATH.getRawOption()))
+              ? profile.getString(TypedDriverOption.SSL_TRUSTSTORE_PASSWORD.getRawOption())
+              : null;
+      return tableReader.withSsl(getSSLOptions(trustStorePath, trustStorePassword));
+    }
+    return tableReader;
+  }
+
+  @VisibleForTesting
+  protected static boolean enableSSL(DriverExecutionProfile profile) {
+    return (profile.isDefined(TypedDriverOption.SSL_TRUSTSTORE_PATH.getRawOption())
+        || profile.isDefined(TypedDriverOption.SSL_KEYSTORE_PATH.getRawOption()));
+  }
+
+  @VisibleForTesting
+  protected static SSLOptions getSSLOptions(
+      @Nullable String trustStorePath, @Nullable String trustStorePassword) {
+    try {
+      if (trustStorePath != null) {
+        SSLContext sslContext = buildSSLContext(trustStorePath, trustStorePassword);
+        return RemoteEndpointAwareJdkSSLOptions.builder().withSSLContext(sslContext).build();
+      } else {
+        return RemoteEndpointAwareJdkSSLOptions.builder().build();
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static SSLContext buildSSLContext(
+      String trustStorePath, @Nullable String trustStorePassword)
+      throws java.security.GeneralSecurityException, IOException {
+    // Load the default trust store
+    TrustManagerFactory defaultTrustManagerFactory =
+        TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+    defaultTrustManagerFactory.init((KeyStore) null);
+
+    // Load your custom trust store
+    KeyStore customTrustStore = KeyStore.getInstance("JKS");
+    if (trustStorePassword != null) {
+      customTrustStore.load(new FileInputStream(trustStorePath), trustStorePassword.toCharArray());
+    } else {
+      customTrustStore.load(new FileInputStream(trustStorePath), new char[] {});
+    }
+    TrustManagerFactory customTrustManagerFactory =
+        TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+    customTrustManagerFactory.init(customTrustStore);
+
+    // Create the SSLContext
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    sslContext.init(
+        null,
+        ArrayUtils.addAll(
+            customTrustManagerFactory.getTrustManagers(),
+            defaultTrustManagerFactory.getTrustManagers()),
+        null);
+
+    return sslContext;
   }
 
   private CassandraSourceRowMapper getSourceRowMapper(

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/SSLOptionsProvider.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/SSLOptionsProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;
+
+import com.datastax.driver.core.SSLOptions;
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+import org.apache.beam.sdk.options.ValueProvider;
+import org.checkerframework.checker.initialization.qual.Initialized;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
+
+@AutoValue
+abstract class SSLOptionsProvider implements ValueProvider<SSLOptions>, Serializable {
+
+  abstract SSLOptionsFactory sslOptionsFactory();
+
+  @Override
+  public SSLOptions get() {
+    return sslOptionsFactory().create();
+  }
+
+  @Override
+  public @UnknownKeyFor @NonNull @Initialized boolean isAccessible() {
+    return true;
+  }
+
+  public static Builder buidler() {
+    return new AutoValue_SSLOptionsProvider.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setSslOptionsFactory(SSLOptionsFactory value);
+
+    public abstract SSLOptionsProvider build();
+  }
+
+  public interface SSLOptionsFactory extends Serializable {
+    SSLOptions create();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SourceDbToSpanner.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SourceDbToSpanner.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.templates;
 
 import com.google.cloud.teleport.metadata.Template;
 import com.google.cloud.teleport.metadata.TemplateCategory;
+import com.google.cloud.teleport.v2.common.CommonTemplateJvmInitializer;
 import com.google.cloud.teleport.v2.common.UncaughtExceptionLogger;
 import com.google.cloud.teleport.v2.options.SourceDbToSpannerOptions;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
@@ -85,6 +86,9 @@ public class SourceDbToSpanner {
     // Parse the user options passed from the command-line
     SourceDbToSpannerOptions options =
         PipelineOptionsFactory.fromArgs(args).withValidation().as(SourceDbToSpannerOptions.class);
+    // Stage SSL certificates to extraFiles if required as per the pipeline options.
+    // Ref https://cloud.google.com/dataflow/docs/guides/templates/ssl-certificates
+    new CommonTemplateJvmInitializer().beforeProcessing(options);
     run(options);
   }
 

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/SSLOptionsProviderTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/SSLOptionsProviderTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.datastax.driver.core.SSLOptions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link SSLOptionsProvider}. */
+@RunWith(MockitoJUnitRunner.class)
+public class SSLOptionsProviderTest {
+  @Mock SSLOptions mockSslOptions;
+
+  @Test
+  public void testSSLOptionsProviderBasic() {
+    SSLOptionsProvider sslOptionsProvider =
+        SSLOptionsProvider.buidler().setSslOptionsFactory(() -> mockSslOptions).build();
+    assertThat(sslOptionsProvider.isAccessible()).isTrue();
+    assertThat(sslOptionsProvider.get()).isEqualTo(mockSslOptions);
+  }
+}


### PR DESCRIPTION
# Overview
Changes to use Existing CassandraIO for Cassandra Bulk Read.
# Note on Techdept
The existing CassandraIO works with Cassandra Driver's 3.0 interfaces. This would mean that we won't get out of box support for all the new features and configurations that 4.0 driver provides out of box. With this PR we are enabling the most basic use case of reading a primitive types on SSL enabled Cluster with client side validation. Mutual TLS and other advanced options are not implemented currently.
The strategy to eliminate this techdebt is to enable 4.0 in upstream code, once the Cassandra Bulk is working for basic use cases. 
Till then, if we see any specific customer use case, we can manually incorporate it (the way SSL is currently handled).
# PR Tree:
At the moment the PR is large. To de-risk having a lot of code for review, we have raised 2 child PRs:
1. #2129 - Has the first 2 commits, and gets basic CassandraIO working.
2. #2130 - UT only code to have an ssl enabled Cassandra Server for UT.
3. #2114 - The Current PR which in addition to #2129 and #2130 also enables Read from SSL enabled Cassandra Clusters for the most basic use case. This PR will become smaller once #2129  and #2130  are merged to main line.
 
