### PR TITLE
MongoDbToBigQuery - date and timestamp format fix

### DIFF
--- a/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbUtils.java
+++ b/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbUtils.java
@@ -153,7 +153,6 @@ public class MongoDbUtils implements Serializable {
                 row.set(key, value);
                 break;
               case "org.bson.Document":
-                // String data = GSON.toJson(value);
                 String data = ((Document) value).toJson(WRITER_SETTINGS);
                 row.set(key, data);
                 break;
@@ -163,7 +162,6 @@ public class MongoDbUtils implements Serializable {
           });
       row.set("timestamp", localDate.format(TIMEFORMAT));
     } else if (userOption.equals("JSON")) {
-      // JsonObject sourceDataJsonObject = GSON.toJsonTree(document).getAsJsonObject();
       JsonObject sourceDataJsonObject =
           GSON.fromJson(document.toJson(WRITER_SETTINGS), JsonObject.class);
 
@@ -175,7 +173,6 @@ public class MongoDbUtils implements Serializable {
           .set("source_data", sourceDataMap)
           .set("timestamp", localDate.format(TIMEFORMAT));
     } else {
-      // String sourceData = GSON.toJson(document);
       String sourceData = document.toJson(WRITER_SETTINGS);
 
       row.set("id", document.get("_id").toString())

--- a/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbUtils.java
+++ b/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbUtils.java
@@ -55,6 +55,8 @@ import org.apache.beam.sdk.io.fs.MatchResult;
 import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
 import org.apache.beam.sdk.io.fs.MatchResult.Status;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.io.CharStreams;
+import org.apache.commons.codec.binary.Hex;
+import org.bson.BsonBinary;
 import org.bson.BsonTimestamp;
 import org.bson.Document;
 import org.bson.json.Converter;
@@ -83,6 +85,7 @@ public class MongoDbUtils implements Serializable {
       JsonWriterSettings.builder()
           .dateTimeConverter(new JsonDateTimeConverter())
           .timestampConverter(new JsonTimestampConverter())
+          .binaryConverter(new JsonBinaryConverter())
           .build();
 
   public static TableSchema getTableFieldSchema(
@@ -299,6 +302,14 @@ public class MongoDbUtils implements Serializable {
       final LocalDateTime localDatTime =
           LocalDateTime.ofInstant(Instant.ofEpochSecond(value.getTime()), ZoneOffset.UTC);
       writer.writeString(localDatTime.format(DateTimeFormatter.ISO_DATE_TIME));
+    }
+  }
+
+  private static class JsonBinaryConverter implements Converter<BsonBinary> {
+
+    @Override
+    public void convert(BsonBinary value, StrictJsonWriter writer) {
+      writer.writeString(Hex.encodeHexString(value.getData()));
     }
   }
 }

--- a/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbUtils.java
+++ b/v2/mongodb-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbUtils.java
@@ -33,11 +33,14 @@ import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.nio.channels.Channels;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -52,7 +55,11 @@ import org.apache.beam.sdk.io.fs.MatchResult;
 import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
 import org.apache.beam.sdk.io.fs.MatchResult.Status;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.io.CharStreams;
+import org.bson.BsonTimestamp;
 import org.bson.Document;
+import org.bson.json.Converter;
+import org.bson.json.JsonWriterSettings;
+import org.bson.json.StrictJsonWriter;
 import org.openjdk.nashorn.api.scripting.ScriptObjectMirror;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,7 +77,13 @@ public class MongoDbUtils implements Serializable {
 
   private static final Logger LOG = LoggerFactory.getLogger(MongoDbToBigQuery.class);
 
-  static final Gson GSON = new Gson();
+  private static final Gson GSON = new Gson();
+
+  private static final JsonWriterSettings WRITER_SETTINGS =
+      JsonWriterSettings.builder()
+          .dateTimeConverter(new JsonDateTimeConverter())
+          .timestampConverter(new JsonTimestampConverter())
+          .build();
 
   public static TableSchema getTableFieldSchema(
       String uri, String database, String collection, String userOption) {
@@ -140,7 +153,8 @@ public class MongoDbUtils implements Serializable {
                 row.set(key, value);
                 break;
               case "org.bson.Document":
-                String data = GSON.toJson(value);
+                // String data = GSON.toJson(value);
+                String data = ((Document) value).toJson(WRITER_SETTINGS);
                 row.set(key, data);
                 break;
               default:
@@ -149,7 +163,9 @@ public class MongoDbUtils implements Serializable {
           });
       row.set("timestamp", localDate.format(TIMEFORMAT));
     } else if (userOption.equals("JSON")) {
-      JsonObject sourceDataJsonObject = GSON.toJsonTree(document).getAsJsonObject();
+      // JsonObject sourceDataJsonObject = GSON.toJsonTree(document).getAsJsonObject();
+      JsonObject sourceDataJsonObject =
+          GSON.fromJson(document.toJson(WRITER_SETTINGS), JsonObject.class);
 
       // Convert to a Map
       Map<String, Object> sourceDataMap =
@@ -159,7 +175,8 @@ public class MongoDbUtils implements Serializable {
           .set("source_data", sourceDataMap)
           .set("timestamp", localDate.format(TIMEFORMAT));
     } else {
-      String sourceData = GSON.toJson(document);
+      // String sourceData = GSON.toJson(document);
+      String sourceData = document.toJson(WRITER_SETTINGS);
 
       row.set("id", document.get("_id").toString())
           .set("source_data", sourceData)
@@ -265,5 +282,26 @@ public class MongoDbUtils implements Serializable {
     }
 
     return (Invocable) engine;
+  }
+
+  private static class JsonDateTimeConverter implements Converter<Long> {
+    private static final DateTimeFormatter DATE_TIME_FORMATTER =
+        DateTimeFormatter.ISO_INSTANT.withZone(ZoneId.of("UTC"));
+
+    @Override
+    public void convert(Long value, StrictJsonWriter writer) {
+      final Instant instant = new Date(value).toInstant();
+      writer.writeString(DATE_TIME_FORMATTER.format(instant));
+    }
+  }
+
+  private static class JsonTimestampConverter implements Converter<BsonTimestamp> {
+
+    @Override
+    public void convert(BsonTimestamp value, StrictJsonWriter writer) {
+      final LocalDateTime localDatTime =
+          LocalDateTime.ofInstant(Instant.ofEpochSecond(value.getTime()), ZoneOffset.UTC);
+      writer.writeString(localDatTime.format(DateTimeFormatter.ISO_DATE_TIME));
+    }
   }
 }


### PR DESCRIPTION
Thank you very much for your work!
We have noticed that the format of dates and timestamp are broken, compared to the mongodb fields, e.g. a date appears as "Mar 12, 2024, 3:05:34 AM", instead of the original ISO format
We also noticed the base64 encoded version for UUID, instead of the plain string
This PR fixes the issue, please ask me if you have any question or remark
Thanks again!