### PR TITLE
Basic Changes to use Upstream Cassandra io for Bulk Cassandra Migration 

### DIFF
--- a/v2/sourcedb-to-spanner/pom.xml
+++ b/v2/sourcedb-to-spanner/pom.xml
@@ -78,6 +78,15 @@
       <version>4.17.0</version>
     </dependency>
 
+    <!-- Needed for Beam CassandraIO -->
+    <!-- https://mvnrepository.com/artifact/com.codahale.metrics/metrics-core -->
+    <dependency>
+      <groupId>com.codahale.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>3.0.2</version>
+    </dependency>
+
+
     <!-- Test Dependencies -->
     <dependency>
       <groupId>com.google.cloud.teleport</groupId>

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraDefaults.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraDefaults.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;
+
+import org.apache.beam.sdk.util.FluentBackoff;
+import org.joda.time.Duration;
+
+public class CassandraDefaults {
+
+  /** Fluent Backoff for Cassandra Schema Discovery. */
+  public static final FluentBackoff DEFAULT_CASSANDRA_SCHEMA_DISCOVERY_BACKOFF =
+      FluentBackoff.DEFAULT.withMaxCumulativeBackoff(Duration.standardMinutes(5L));
+
+  private CassandraDefaults() {}
+  ;
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperFactory.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperFactory.java
@@ -49,7 +49,7 @@ public abstract class CassandraIOWrapperFactory implements IoWrapperFactory {
   /** Create an {@link IoWrapper} instance for a list of SourceTables. */
   @Override
   public IoWrapper getIOWrapper(List<String> sourceTables, OnSignal<?> waitOnSignal) {
-    /** TODO(vardhanvthigle@) */
-    return null;
+    /** TODO(vardhanvthigle@) incorporate waitOnSignal */
+    return new CassandraIoWrapper(gcsConfigPath(), sourceTables);
   }
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperHelper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperHelper.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;
+
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper.CassandraDefaults.DEFAULT_CASSANDRA_SCHEMA_DISCOVERY_BACKOFF;
+
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.schema.CassandraSchemaDiscovery;
+import com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource;
+import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.row.SourceRow;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SchemaDiscovery;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SchemaDiscoveryImpl;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchema;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableReference;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableSchema;
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedTypeMapper.MapperType;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.io.FileNotFoundException;
+import java.util.List;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Static Utility Class to provide basic functionality to {@link CassandraIoWrapper}. */
+class CassandraIOWrapperHelper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CassandraIOWrapperHelper.class);
+
+  static DataSource buildDataSource(String gcsPath) {
+    DataSource dataSource;
+    try {
+      dataSource =
+          DataSource.ofCassandra(
+              CassandraDataSource.builder().setOptionsMapFromGcsFile(gcsPath).build());
+    } catch (FileNotFoundException e) {
+      LOG.error("Unable to find driver config file in {}. Cause ", gcsPath, e);
+      throw (new SchemaDiscoveryException(e));
+    }
+    return dataSource;
+  }
+
+  static SchemaDiscovery buildSchemaDiscovery() {
+    return new SchemaDiscoveryImpl(
+        new CassandraSchemaDiscovery(), DEFAULT_CASSANDRA_SCHEMA_DISCOVERY_BACKOFF);
+  }
+
+  static ImmutableList<String> getTablesToRead(
+      List<String> sourceTables,
+      DataSource dataSource,
+      SchemaDiscovery schemaDiscovery,
+      SourceSchemaReference sourceSchemaReference) {
+    ImmutableList<String> tablesToRead;
+    if (sourceTables.isEmpty()) {
+      tablesToRead = schemaDiscovery.discoverTables(dataSource, sourceSchemaReference);
+      LOG.info("Auto Discovered SourceTables = {}, Tables = {}", sourceTables, tablesToRead);
+    } else {
+      tablesToRead = ImmutableList.copyOf(sourceTables);
+      LOG.info("Using passed SourceTables = {}", sourceTables);
+    }
+    return tablesToRead;
+  }
+
+  static SourceSchema getSourceSchema(
+      SchemaDiscovery schemaDiscovery,
+      DataSource dataSource,
+      SourceSchemaReference sourceSchemaReference,
+      ImmutableList<String> tables) {
+
+    SourceSchema.Builder sourceSchemaBuilder =
+        SourceSchema.builder().setSchemaReference(sourceSchemaReference);
+    ImmutableMap<String, ImmutableMap<String, SourceColumnType>> tableSchemas =
+        schemaDiscovery.discoverTableSchema(dataSource, sourceSchemaReference, tables);
+    LOG.info("Found table schemas: {}", tableSchemas);
+    tableSchemas.entrySet().stream()
+        .map(
+            tableEntry -> {
+              SourceTableSchema.Builder sourceTableSchemaBuilder =
+                  SourceTableSchema.builder(MapperType.CASSANDRA).setTableName(tableEntry.getKey());
+              tableEntry
+                  .getValue()
+                  .entrySet()
+                  .forEach(
+                      colEntry ->
+                          sourceTableSchemaBuilder.addSourceColumnNameToSourceColumnType(
+                              colEntry.getKey(), colEntry.getValue()));
+              return sourceTableSchemaBuilder.build();
+            })
+        .forEach(sourceSchemaBuilder::addTableSchema);
+    return sourceSchemaBuilder.build();
+  }
+
+  static ImmutableMap<SourceTableReference, PTransform<PBegin, PCollection<SourceRow>>>
+      getTableReaders(DataSource dataSource, SourceSchema sourceSchema) {
+    /*
+     * TODO(vardhanvthigle): Plugin alternate implementation if needed.
+     */
+    CassandraTableReaderFactory cassandraTableReaderFactory =
+        new CassandraTableReaderFactoryCassandraIoImpl();
+    ImmutableMap.Builder<SourceTableReference, PTransform<PBegin, PCollection<SourceRow>>>
+        tableReadersBuilder = ImmutableMap.builder();
+    SourceSchemaReference sourceSchemaReference = sourceSchema.schemaReference();
+    sourceSchema
+        .tableSchemas()
+        .forEach(
+            tableSchema -> {
+              SourceTableReference sourceTableReference =
+                  SourceTableReference.builder()
+                      .setSourceSchemaReference(sourceSchemaReference)
+                      .setSourceTableSchemaUUID(tableSchema.tableSchemaUUID())
+                      .setSourceTableName(tableSchema.tableName())
+                      .build();
+              var tableReader =
+                  cassandraTableReaderFactory.getTableReader(
+                      dataSource.cassandra(), sourceSchemaReference, tableSchema);
+              tableReadersBuilder.put(sourceTableReference, tableReader);
+            });
+    return tableReadersBuilder.build();
+  }
+
+  private CassandraIOWrapperHelper() {}
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIoWrapper.java
@@ -16,29 +16,54 @@
 package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;
 
 import com.google.cloud.teleport.v2.source.reader.io.IoWrapper;
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.schema.CassandraSchemaReference;
+import com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource;
 import com.google.cloud.teleport.v2.source.reader.io.row.SourceRow;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SchemaDiscovery;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchema;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableReference;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 
 /** IOWrapper for Cassandra Source. */
-public class CassandraIoWrapper implements IoWrapper {
+public final class CassandraIoWrapper implements IoWrapper {
+  private SourceSchema sourceSchema;
+  private ImmutableMap<SourceTableReference, PTransform<PBegin, PCollection<SourceRow>>>
+      tableReaders;
+
+  public CassandraIoWrapper(String gcsPath, List<String> sourceTables) {
+    DataSource dataSource = CassandraIOWrapperHelper.buildDataSource(gcsPath);
+    SchemaDiscovery schemaDiscovery = CassandraIOWrapperHelper.buildSchemaDiscovery();
+    SourceSchemaReference sourceSchemaReference =
+        SourceSchemaReference.ofCassandra(
+            CassandraSchemaReference.builder()
+                .setKeyspaceName(dataSource.cassandra().loggedKeySpace())
+                .build());
+
+    ImmutableList<String> tablesToRead =
+        CassandraIOWrapperHelper.getTablesToRead(
+            sourceTables, dataSource, schemaDiscovery, sourceSchemaReference);
+    this.sourceSchema =
+        CassandraIOWrapperHelper.getSourceSchema(
+            schemaDiscovery, dataSource, sourceSchemaReference, tablesToRead);
+    this.tableReaders = CassandraIOWrapperHelper.getTableReaders(dataSource, sourceSchema);
+  }
 
   /** Get a list of reader transforms for Cassandra source. */
   @Override
   public ImmutableMap<SourceTableReference, PTransform<PBegin, PCollection<SourceRow>>>
       getTableReaders() {
-    // TODO(vardhanvthigle)
-    return null;
+    return tableReaders;
   }
 
   /** Discover source schema for Cassandra. */
   @Override
   public SourceSchema discoverTableSchema() {
-    // TODO(vardhanvthigle)
-    return null;
+    return sourceSchema;
   }
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraTableReaderFactory.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraTableReaderFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;
+
+import com.google.cloud.teleport.v2.source.reader.io.row.SourceRow;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableSchema;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+
+public interface CassandraTableReaderFactory {
+
+  /**
+   * Returns a Table Reader for given Cassandra Source.
+   *
+   * @param cassandraDataSource
+   * @param sourceSchemaReference
+   * @param sourceTableSchema
+   * @return table reader for the source.
+   */
+  PTransform<PBegin, PCollection<SourceRow>> getTableReader(
+      CassandraDataSource cassandraDataSource,
+      SourceSchemaReference sourceSchemaReference,
+      SourceTableSchema sourceTableSchema);
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraTableReaderFactoryCassandraIoImpl.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraTableReaderFactoryCassandraIoImpl.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;
+
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.config.TypedDriverOption;
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.rowmapper.CassandraSourceRowMapper;
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.rowmapper.CassandraSourceRowMapperFactoryFn;
+import com.google.cloud.teleport.v2.source.reader.io.row.SourceRow;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableSchema;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.stream.Collectors;
+import org.apache.beam.sdk.coders.SerializableCoder;
+import org.apache.beam.sdk.io.cassandra.CassandraIO;
+import org.apache.beam.sdk.io.cassandra.CassandraIO.Read;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+
+/**
+ * Generate Table Reader For Cassandra using the upstream {@link CassandraIO.Read} implementation.
+ */
+public class CassandraTableReaderFactoryCassandraIoImpl implements CassandraTableReaderFactory {
+
+  /**
+   * Returns a Table Reader for given Cassandra Source using the upstream {@link CassandraIO.Read}.
+   *
+   * @param cassandraDataSource
+   * @param sourceSchemaReference
+   * @param sourceTableSchema
+   * @return table reader for the source.
+   */
+  @Override
+  public PTransform<PBegin, PCollection<SourceRow>> getTableReader(
+      CassandraDataSource cassandraDataSource,
+      SourceSchemaReference sourceSchemaReference,
+      SourceTableSchema sourceTableSchema) {
+    CassandraSourceRowMapper cassandraSourceRowMapper =
+        getSourceRowMapper(sourceSchemaReference, sourceTableSchema);
+    DriverExecutionProfile profile =
+        cassandraDataSource.driverConfigLoader().getInitialConfig().getDefaultProfile();
+    final Read<SourceRow> tableReader =
+        CassandraIO.<SourceRow>read()
+            .withTable(sourceTableSchema.tableName())
+            .withHosts(
+                cassandraDataSource.contactPoints().stream()
+                    .map(p -> p.getHostString())
+                    .collect(Collectors.toList()))
+            .withPort(cassandraDataSource.contactPoints().get(0).getPort())
+            .withKeyspace(cassandraDataSource.loggedKeySpace())
+            .withLocalDc(cassandraDataSource.localDataCenter())
+            .withConsistencyLevel(
+                profile.getString(TypedDriverOption.REQUEST_SERIAL_CONSISTENCY.getRawOption()))
+            .withEntity(SourceRow.class)
+            .withCoder(SerializableCoder.of(SourceRow.class))
+            .withMapperFactoryFn(
+                CassandraSourceRowMapperFactoryFn.create(cassandraSourceRowMapper));
+    return setCredentials(tableReader, profile);
+  }
+
+  @VisibleForTesting
+  protected CassandraIO.Read<SourceRow> setCredentials(
+      CassandraIO.Read<SourceRow> tableReader, DriverExecutionProfile profile) {
+    if (profile.isDefined(TypedDriverOption.AUTH_PROVIDER_USER_NAME.getRawOption())) {
+      tableReader =
+          tableReader.withUsername(
+              profile.getString(TypedDriverOption.AUTH_PROVIDER_USER_NAME.getRawOption()));
+    }
+    if (profile.isDefined(TypedDriverOption.AUTH_PROVIDER_PASSWORD.getRawOption())) {
+      tableReader =
+          tableReader.withPassword(
+              profile.getString(TypedDriverOption.AUTH_PROVIDER_PASSWORD.getRawOption()));
+    }
+    return tableReader;
+  }
+
+  private CassandraSourceRowMapper getSourceRowMapper(
+      SourceSchemaReference sourceSchemaReference, SourceTableSchema sourceTableSchema) {
+    return CassandraSourceRowMapper.builder()
+        .setSourceTableSchema(sourceTableSchema)
+        .setSourceSchemaReference(sourceSchemaReference)
+        .build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/rowmapper/CassandraSourceRowMapperFactoryFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/rowmapper/CassandraSourceRowMapperFactoryFn.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.cassandra.rowmapper;
+
+import com.datastax.driver.core.Session;
+import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.row.SourceRow;
+import org.apache.beam.sdk.io.cassandra.CassandraIO;
+import org.apache.beam.sdk.io.cassandra.Mapper;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+
+/**
+ * A simple utility to wrap {@link CassandraSourceRowMapper} into a mapperFactory. The {@link
+ * CassandraIO.Read} api takes in {@link CassandraIO.Read#withMapperFactoryFn(SerializableFunction)}
+ * which is a {@link SerializableFunction} that returns the actual {@link Mapper}.
+ *
+ * <p>{@link CassandraSourceRowMapper} maps the {@link com.datastax.driver.core.ResultSet Cassandra
+ * ResultSet} to {@link SourceRow}.
+ */
+@AutoValue
+public abstract class CassandraSourceRowMapperFactoryFn
+    implements SerializableFunction<Session, Mapper> {
+  public static CassandraSourceRowMapperFactoryFn create(
+      CassandraSourceRowMapper cassandraSourceRowMapper) {
+    return new AutoValue_CassandraSourceRowMapperFactoryFn(cassandraSourceRowMapper);
+  }
+
+  public abstract CassandraSourceRowMapper cassandraSourceRowMapper();
+
+  @Override
+  public Mapper<SourceRow> apply(Session input) {
+    return cassandraSourceRowMapper();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperFactoryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperFactoryTest.java
@@ -15,24 +15,112 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;
 
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.BASIC_TEST_TABLE;
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.PRIMITIVE_TYPES_TABLE;
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.TEST_KEYSPACE;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+import com.datastax.oss.driver.api.core.config.OptionsMap;
+import com.datastax.oss.driver.api.core.config.TypedDriverOption;
 import com.google.cloud.teleport.v2.options.SourceDbToSpannerOptions;
-import java.util.List;
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.schema.CassandraSchemaReference;
+import com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource;
+import com.google.cloud.teleport.v2.source.reader.io.row.SourceRow;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SchemaDiscovery;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchema;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableReference;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.net.InetSocketAddress;
+import org.apache.beam.sdk.io.cassandra.CassandraIO;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 /** Test class for {@link CassandraIOWrapperFactory}. */
 @RunWith(MockitoJUnitRunner.class)
 public class CassandraIOWrapperFactoryTest {
+  private MockedStatic<CassandraIOWrapperHelper> mockCassandraIoWrapperHelper;
+  private static final String TEST_BUCKET_CASSANDRA_CONFIG_CONF =
+      "gs://smt-test-bucket/cassandraConfig.conf";
+  private static final ImmutableList<String> TABLES_TO_READ =
+      ImmutableList.of(BASIC_TEST_TABLE, PRIMITIVE_TYPES_TABLE);
+  @Mock SourceSchema mockSourceSchema;
+
+  @Before
+  public void setup() {
+    mockCassandraIoWrapperHelper = mockStatic(CassandraIOWrapperHelper.class);
+
+    String testClusterName = "testCluster";
+    InetSocketAddress testHost = new InetSocketAddress("127.0.0.1", 9042);
+    String testLocalDC = "datacenter1";
+    DataSource dataSource =
+        DataSource.ofCassandra(
+            CassandraDataSource.builder()
+                .setOptionsMap(OptionsMap.driverDefaults())
+                .setClusterName(testClusterName)
+                .setContactPoints(ImmutableList.of(testHost))
+                .setLocalDataCenter(testLocalDC)
+                .overrideOptionInOptionsMap(TypedDriverOption.SESSION_KEYSPACE, TEST_KEYSPACE)
+                .build());
+
+    SourceSchemaReference sourceSchemaReference =
+        SourceSchemaReference.ofCassandra(
+            CassandraSchemaReference.builder()
+                .setKeyspaceName(dataSource.cassandra().loggedKeySpace())
+                .build());
+
+    SchemaDiscovery schemaDiscovery = CassandraIOWrapperHelper.buildSchemaDiscovery();
+    SourceTableReference mockSourceTableReference = Mockito.mock(SourceTableReference.class);
+    CassandraIO.Read<SourceRow> mockTableReader = Mockito.mock(CassandraIO.Read.class);
+    ImmutableMap<SourceTableReference, PTransform<PBegin, PCollection<SourceRow>>>
+        mockTableReaders = ImmutableMap.of(mockSourceTableReference, mockTableReader);
+
+    mockCassandraIoWrapperHelper
+        .when(() -> CassandraIOWrapperHelper.buildDataSource(TEST_BUCKET_CASSANDRA_CONFIG_CONF))
+        .thenReturn(dataSource);
+    mockCassandraIoWrapperHelper
+        .when(() -> CassandraIOWrapperHelper.buildSchemaDiscovery())
+        .thenReturn(schemaDiscovery);
+    mockCassandraIoWrapperHelper
+        .when(
+            () ->
+                CassandraIOWrapperHelper.getTablesToRead(
+                    TABLES_TO_READ, dataSource, schemaDiscovery, sourceSchemaReference))
+        .thenReturn(TABLES_TO_READ);
+    mockCassandraIoWrapperHelper
+        .when(
+            () ->
+                CassandraIOWrapperHelper.getSourceSchema(
+                    schemaDiscovery, dataSource, sourceSchemaReference, TABLES_TO_READ))
+        .thenReturn(mockSourceSchema);
+    mockCassandraIoWrapperHelper
+        .when(() -> CassandraIOWrapperHelper.getTableReaders(dataSource, mockSourceSchema))
+        .thenReturn(mockTableReaders);
+  }
+
+  @After
+  public void cleanup() {
+    mockCassandraIoWrapperHelper.close();
+    mockCassandraIoWrapperHelper = null;
+  }
+
   @Test
   public void testCassandraIoWrapperFactoryBasic() {
-    String testConfigPath = "gs://smt-test-bucket/test-conf.conf";
+    String testConfigPath = TEST_BUCKET_CASSANDRA_CONFIG_CONF;
     SourceDbToSpannerOptions mockOptions =
         mock(SourceDbToSpannerOptions.class, Mockito.withSettings().serializable());
     when(mockOptions.getSourceDbDialect()).thenReturn("CASSANDRA");
@@ -40,7 +128,8 @@ public class CassandraIOWrapperFactoryTest {
     CassandraIOWrapperFactory cassandraIOWrapperFactory =
         CassandraIOWrapperFactory.fromPipelineOptions(mockOptions);
     assertThat(cassandraIOWrapperFactory.gcsConfigPath()).isEqualTo(testConfigPath);
-    assertThat(cassandraIOWrapperFactory.getIOWrapper(List.of(), null)).isEqualTo(null);
+    assertThat(cassandraIOWrapperFactory.getIOWrapper(TABLES_TO_READ, null).discoverTableSchema())
+        .isEqualTo(mockSourceSchema);
   }
 
   @Test

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperHelperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperHelperTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;
+
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.BASIC_TEST_TABLE;
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.PRIMITIVE_TYPES_TABLE;
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.TEST_CONFIG;
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.TEST_CQLSH;
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.TEST_KEYSPACE;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+import com.datastax.oss.driver.api.core.config.OptionsMap;
+import com.datastax.oss.driver.api.core.config.TypedDriverOption;
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.schema.CassandraSchemaDiscovery;
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.schema.CassandraSchemaReference;
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.SharedEmbeddedCassandra;
+import com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource;
+import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.row.SourceRow;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchema;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableReference;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.JarFileReader;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.beam.sdk.io.cassandra.CassandraIO;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link CassandraIOWrapperHelper}. */
+@RunWith(MockitoJUnitRunner.class)
+public class CassandraIOWrapperHelperTest {
+
+  private static SharedEmbeddedCassandra sharedEmbeddedCassandra = null;
+
+  @BeforeClass
+  public static void startEmbeddedCassandra() throws IOException {
+    if (sharedEmbeddedCassandra == null) {
+      sharedEmbeddedCassandra = new SharedEmbeddedCassandra(TEST_CONFIG, TEST_CQLSH);
+    }
+  }
+
+  @AfterClass
+  public static void stopEmbeddedCassandra() throws Exception {
+    if (sharedEmbeddedCassandra != null) {
+      sharedEmbeddedCassandra.close();
+      sharedEmbeddedCassandra = null;
+    }
+  }
+
+  @Test
+  public void testBuildDataSource() {
+
+    String testGcsPath = "gs://smt-test-bucket/cassandraConfig.conf";
+    URL testUrl = Resources.getResource("CassandraUT/test-cassandra-config.conf");
+
+    CassandraIO.Read<SourceRow> mockCassandraIORead = mock(CassandraIO.Read.class);
+    try (MockedStatic mockFileReader = mockStatic(JarFileReader.class)) {
+
+      mockFileReader
+          .when(() -> JarFileReader.saveFilesLocally(testGcsPath))
+          .thenReturn(new URL[] {testUrl})
+          /* Empty URL List to test FileNotFoundException handling. */
+          .thenReturn(new URL[] {});
+
+      DataSource dataSource = CassandraIOWrapperHelper.buildDataSource(testGcsPath);
+      assertThat(dataSource.cassandra().loggedKeySpace()).isEqualTo("test-keyspace");
+      assertThat(dataSource.cassandra().localDataCenter()).isEqualTo("datacenter1");
+      assertThrows(
+          SchemaDiscoveryException.class,
+          () -> CassandraIOWrapperHelper.buildDataSource(testGcsPath));
+    }
+  }
+
+  @Test
+  public void testTablesToRead() {
+
+    SourceSchemaReference cassandraSchemaReference =
+        SourceSchemaReference.ofCassandra(
+            CassandraSchemaReference.builder().setKeyspaceName(TEST_KEYSPACE).build());
+
+    DataSource dataSource =
+        DataSource.ofCassandra(
+            CassandraDataSource.builder()
+                .setOptionsMap(OptionsMap.driverDefaults())
+                .setClusterName(sharedEmbeddedCassandra.getInstance().getClusterName())
+                .setContactPoints(sharedEmbeddedCassandra.getInstance().getContactPoints())
+                .setLocalDataCenter(sharedEmbeddedCassandra.getInstance().getLocalDataCenter())
+                .overrideOptionInOptionsMap(TypedDriverOption.SESSION_KEYSPACE, TEST_KEYSPACE)
+                .build());
+    CassandraSchemaDiscovery cassandraSchemaDiscovery = new CassandraSchemaDiscovery();
+    assertThat(
+            CassandraIOWrapperHelper.getTablesToRead(
+                List.of(),
+                dataSource,
+                CassandraIOWrapperHelper.buildSchemaDiscovery(),
+                cassandraSchemaReference))
+        .isEqualTo(List.of(BASIC_TEST_TABLE, PRIMITIVE_TYPES_TABLE));
+    assertThat(
+            CassandraIOWrapperHelper.getTablesToRead(
+                List.of(BASIC_TEST_TABLE),
+                dataSource,
+                CassandraIOWrapperHelper.buildSchemaDiscovery(),
+                cassandraSchemaReference))
+        .isEqualTo(List.of(BASIC_TEST_TABLE));
+  }
+
+  @Test
+  public void testSourceSchema() {
+
+    SourceSchemaReference cassandraSchemaReference =
+        SourceSchemaReference.ofCassandra(
+            CassandraSchemaReference.builder().setKeyspaceName(TEST_KEYSPACE).build());
+
+    DataSource dataSource =
+        DataSource.ofCassandra(
+            CassandraDataSource.builder()
+                .setOptionsMap(OptionsMap.driverDefaults())
+                .setClusterName(sharedEmbeddedCassandra.getInstance().getClusterName())
+                .setContactPoints(sharedEmbeddedCassandra.getInstance().getContactPoints())
+                .setLocalDataCenter(sharedEmbeddedCassandra.getInstance().getLocalDataCenter())
+                .overrideOptionInOptionsMap(TypedDriverOption.SESSION_KEYSPACE, TEST_KEYSPACE)
+                .build());
+    CassandraSchemaDiscovery cassandraSchemaDiscovery = new CassandraSchemaDiscovery();
+    SourceSchema sourceSchema =
+        CassandraIOWrapperHelper.getSourceSchema(
+            CassandraIOWrapperHelper.buildSchemaDiscovery(),
+            dataSource,
+            cassandraSchemaReference,
+            ImmutableList.of(BASIC_TEST_TABLE, PRIMITIVE_TYPES_TABLE));
+    assertThat(sourceSchema.schemaReference()).isEqualTo(cassandraSchemaReference);
+    assertThat(sourceSchema.tableSchemas().asList().stream().count()).isEqualTo(2);
+  }
+
+  @Test
+  public void testTableReaders() {
+
+    SourceSchemaReference cassandraSchemaReference =
+        SourceSchemaReference.ofCassandra(
+            CassandraSchemaReference.builder().setKeyspaceName(TEST_KEYSPACE).build());
+
+    DataSource dataSource =
+        DataSource.ofCassandra(
+            CassandraDataSource.builder()
+                .setOptionsMap(OptionsMap.driverDefaults())
+                .setClusterName(sharedEmbeddedCassandra.getInstance().getClusterName())
+                .setContactPoints(sharedEmbeddedCassandra.getInstance().getContactPoints())
+                .setLocalDataCenter(sharedEmbeddedCassandra.getInstance().getLocalDataCenter())
+                .overrideOptionInOptionsMap(TypedDriverOption.SESSION_KEYSPACE, TEST_KEYSPACE)
+                .build());
+    CassandraSchemaDiscovery cassandraSchemaDiscovery = new CassandraSchemaDiscovery();
+    SourceSchema sourceSchema =
+        CassandraIOWrapperHelper.getSourceSchema(
+            CassandraIOWrapperHelper.buildSchemaDiscovery(),
+            dataSource,
+            cassandraSchemaReference,
+            ImmutableList.of(BASIC_TEST_TABLE, PRIMITIVE_TYPES_TABLE));
+    ImmutableMap<SourceTableReference, PTransform<PBegin, PCollection<SourceRow>>> tableReraders =
+        CassandraIOWrapperHelper.getTableReaders(dataSource, sourceSchema);
+    assertThat(
+            tableReraders.keySet().stream()
+                .map(t -> t.sourceTableName())
+                .collect(Collectors.toList()))
+        .isEqualTo(List.of(BASIC_TEST_TABLE, PRIMITIVE_TYPES_TABLE));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIoWrapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIoWrapperTest.java
@@ -15,19 +15,94 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;
 
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.BASIC_TEST_TABLE;
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.PRIMITIVE_TYPES_TABLE;
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.TEST_KEYSPACE;
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mockStatic;
 
+import com.datastax.oss.driver.api.core.config.OptionsMap;
+import com.datastax.oss.driver.api.core.config.TypedDriverOption;
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.schema.CassandraSchemaReference;
+import com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource;
+import com.google.cloud.teleport.v2.source.reader.io.row.SourceRow;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SchemaDiscovery;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchema;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableReference;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.net.InetSocketAddress;
+import org.apache.beam.sdk.io.cassandra.CassandraIO;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 /** Test class for {@link CassandraIoWrapper}. */
 @RunWith(MockitoJUnitRunner.class)
 public class CassandraIoWrapperTest {
+
   @Test
   public void testCassandraIoWrapperBasic() {
-    // Todo(vardhanvthigle)
-    assertThat((new CassandraIoWrapper()).getTableReaders()).isNull();
-    assertThat((new CassandraIoWrapper()).discoverTableSchema()).isNull();
+    String testClusterName = "testCluster";
+    InetSocketAddress testHost = new InetSocketAddress("127.0.0.1", 9042);
+    String testLocalDC = "datacenter1";
+    DataSource dataSource =
+        DataSource.ofCassandra(
+            CassandraDataSource.builder()
+                .setOptionsMap(OptionsMap.driverDefaults())
+                .setClusterName(testClusterName)
+                .setContactPoints(ImmutableList.of(testHost))
+                .setLocalDataCenter(testLocalDC)
+                .overrideOptionInOptionsMap(TypedDriverOption.SESSION_KEYSPACE, TEST_KEYSPACE)
+                .build());
+
+    SourceSchemaReference sourceSchemaReference =
+        SourceSchemaReference.ofCassandra(
+            CassandraSchemaReference.builder()
+                .setKeyspaceName(dataSource.cassandra().loggedKeySpace())
+                .build());
+
+    String testGcsPath = "gs://smt-test-bucket/cassandraConfig.conf";
+    SchemaDiscovery schemaDiscovery = CassandraIOWrapperHelper.buildSchemaDiscovery();
+    ImmutableList<String> tablesToRead = ImmutableList.of(BASIC_TEST_TABLE, PRIMITIVE_TYPES_TABLE);
+    SourceSchema mockSourceSchema = Mockito.mock(SourceSchema.class);
+    SourceTableReference mockSourceTableReference = Mockito.mock(SourceTableReference.class);
+    CassandraIO.Read<SourceRow> mockTableReader = Mockito.mock(CassandraIO.Read.class);
+    ImmutableMap<SourceTableReference, PTransform<PBegin, PCollection<SourceRow>>>
+        mockTableReaders = ImmutableMap.of(mockSourceTableReference, mockTableReader);
+
+    try (MockedStatic mockCassandraIoWrapperHelper = mockStatic(CassandraIOWrapperHelper.class)) {
+      mockCassandraIoWrapperHelper
+          .when(() -> CassandraIOWrapperHelper.buildDataSource(testGcsPath))
+          .thenReturn(dataSource);
+      mockCassandraIoWrapperHelper
+          .when(() -> CassandraIOWrapperHelper.buildSchemaDiscovery())
+          .thenReturn(schemaDiscovery);
+      mockCassandraIoWrapperHelper
+          .when(
+              () ->
+                  CassandraIOWrapperHelper.getTablesToRead(
+                      tablesToRead, dataSource, schemaDiscovery, sourceSchemaReference))
+          .thenReturn(tablesToRead);
+      mockCassandraIoWrapperHelper
+          .when(
+              () ->
+                  CassandraIOWrapperHelper.getSourceSchema(
+                      schemaDiscovery, dataSource, sourceSchemaReference, tablesToRead))
+          .thenReturn(mockSourceSchema);
+      mockCassandraIoWrapperHelper
+          .when(() -> CassandraIOWrapperHelper.getTableReaders(dataSource, mockSourceSchema))
+          .thenReturn(mockTableReaders);
+
+      CassandraIoWrapper cassandraIoWrapper = new CassandraIoWrapper(testGcsPath, tablesToRead);
+      assertThat(cassandraIoWrapper.discoverTableSchema()).isEqualTo(mockSourceSchema);
+      assertThat(cassandraIoWrapper.getTableReaders()).isEqualTo(mockTableReaders);
+    }
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraTableReaderFactoryCassandraIoImplTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraTableReaderFactoryCassandraIoImplTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper;
+
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.PRIMITIVE_TYPES_TABLE;
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.PRIMITIVE_TYPES_TABLE_ROW_COUNT;
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.TEST_CONFIG;
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.TEST_CQLSH;
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.TEST_KEYSPACE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.config.OptionsMap;
+import com.datastax.oss.driver.api.core.config.TypedDriverOption;
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.schema.CassandraSchemaDiscovery;
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.schema.CassandraSchemaReference;
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.SharedEmbeddedCassandra;
+import com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource;
+import com.google.cloud.teleport.v2.source.reader.io.exception.RetriableSchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.row.SourceRow;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableSchema;
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedTypeMapper.MapperType;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.JarFileReader;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URL;
+import org.apache.beam.sdk.io.cassandra.CassandraIO;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Test class for {@link CassandraTableReaderFactoryCassandraIoImpl}. */
+@RunWith(MockitoJUnitRunner.class)
+public class CassandraTableReaderFactoryCassandraIoImplTest {
+
+  private static SharedEmbeddedCassandra sharedEmbeddedCassandra = null;
+
+  @Rule public final transient TestPipeline testPipeline = TestPipeline.create();
+
+  @BeforeClass
+  public static void startEmbeddedCassandra() throws IOException {
+    if (sharedEmbeddedCassandra == null) {
+      sharedEmbeddedCassandra = new SharedEmbeddedCassandra(TEST_CONFIG, TEST_CQLSH);
+    }
+  }
+
+  @AfterClass
+  public static void stopEmbeddedCassandra() throws Exception {
+    if (sharedEmbeddedCassandra != null) {
+      sharedEmbeddedCassandra.close();
+      sharedEmbeddedCassandra = null;
+    }
+  }
+
+  @Test
+  public void testCassandraTableReaderFactoryBasic() throws RetriableSchemaDiscoveryException {
+
+    SourceSchemaReference cassandraSchemaReference =
+        SourceSchemaReference.ofCassandra(
+            CassandraSchemaReference.builder().setKeyspaceName(TEST_KEYSPACE).build());
+
+    DataSource dataSource =
+        DataSource.ofCassandra(
+            CassandraDataSource.builder()
+                .setOptionsMap(OptionsMap.driverDefaults())
+                .setClusterName(sharedEmbeddedCassandra.getInstance().getClusterName())
+                .setContactPoints(sharedEmbeddedCassandra.getInstance().getContactPoints())
+                .setLocalDataCenter(sharedEmbeddedCassandra.getInstance().getLocalDataCenter())
+                .overrideOptionInOptionsMap(TypedDriverOption.SESSION_KEYSPACE, TEST_KEYSPACE)
+                .build());
+    CassandraSchemaDiscovery cassandraSchemaDiscovery = new CassandraSchemaDiscovery();
+    ImmutableMap<String, ImmutableMap<String, SourceColumnType>> discoverTableSchema =
+        cassandraSchemaDiscovery.discoverTableSchema(
+            dataSource, cassandraSchemaReference, ImmutableList.of(PRIMITIVE_TYPES_TABLE));
+
+    SourceSchemaReference sourceSchemaReference =
+        SourceSchemaReference.ofCassandra(
+            CassandraSchemaReference.builder()
+                .setKeyspaceName(dataSource.cassandra().loggedKeySpace())
+                .build());
+    SourceTableSchema.Builder sourceTableSchemaBuilder =
+        SourceTableSchema.builder(MapperType.CASSANDRA).setTableName(PRIMITIVE_TYPES_TABLE);
+    discoverTableSchema
+        .get(PRIMITIVE_TYPES_TABLE)
+        .forEach(
+            (colName, colType) ->
+                sourceTableSchemaBuilder.addSourceColumnNameToSourceColumnType(colName, colType));
+    SourceTableSchema sourceTableSchema = sourceTableSchemaBuilder.build();
+
+    PTransform<PBegin, PCollection<SourceRow>> tableReader =
+        new CassandraTableReaderFactoryCassandraIoImpl()
+            .getTableReader(dataSource.cassandra(), sourceSchemaReference, sourceTableSchema);
+    PCollection<SourceRow> output = testPipeline.apply(tableReader);
+    PAssert.that(output.apply(Count.globally()))
+        .containsInAnyOrder(PRIMITIVE_TYPES_TABLE_ROW_COUNT);
+    testPipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testSetCredentials() throws FileNotFoundException {
+
+    String testGcsPath = "gs://smt-test-bucket/cassandraConfig.conf";
+    URL testUrl = Resources.getResource("CassandraUT/test-cassandra-config.conf");
+
+    CassandraIO.Read<SourceRow> mockCassandraIORead = mock(CassandraIO.Read.class);
+    try (MockedStatic mockFileReader = mockStatic(JarFileReader.class)) {
+      String testUserName = "testUserName";
+      String testPassword = "testPassword1234@";
+
+      mockFileReader
+          .when(() -> JarFileReader.saveFilesLocally(testGcsPath))
+          .thenReturn(new URL[] {testUrl});
+      when(mockCassandraIORead.withUsername(testUserName)).thenReturn(mockCassandraIORead);
+      when(mockCassandraIORead.withPassword(testPassword)).thenReturn(mockCassandraIORead);
+
+      CassandraDataSource cassandraDataSource =
+          CassandraDataSource.builder().setOptionsMapFromGcsFile(testGcsPath).build();
+      new CassandraTableReaderFactoryCassandraIoImpl()
+          .setCredentials(
+              mockCassandraIORead,
+              cassandraDataSource.driverConfigLoader().getInitialConfig().getDefaultProfile());
+      verify(mockCassandraIORead, times(1)).withUsername(testUserName);
+      verify(mockCassandraIORead, times(1)).withPassword(testPassword);
+    }
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/testutils/BasicTestSchema.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/testutils/BasicTestSchema.java
@@ -31,6 +31,7 @@ public class BasicTestSchema {
   public static final String TEST_CQLSH = TEST_RESOURCE_ROOT + "basicTest.cql";
   public static final String BASIC_TEST_TABLE = "basic_test_table";
   public static final String PRIMITIVE_TYPES_TABLE = "primitive_types_table";
+  public static final Long PRIMITIVE_TYPES_TABLE_ROW_COUNT = 6L;
   public static final ImmutableMap<String, ImmutableMap<String, SourceColumnType>>
       BASIC_TEST_TABLE_SCHEMA =
           ImmutableMap.of(

--- a/v2/sourcedb-to-spanner/src/test/resources/CassandraUT/test-cassandra-config.conf
+++ b/v2/sourcedb-to-spanner/src/test/resources/CassandraUT/test-cassandra-config.conf
@@ -9,4 +9,8 @@
     basic.load-balancing-policy {
       local-datacenter = "datacenter1"
     }
+    advanced.auth-provider {
+      username = "testUserName"
+      password = "testPassword1234@"
+    }
   }


### PR DESCRIPTION
# Overview
This is a Child #2114 , which has the basic changes to enable using UpstreamCassandraIO for bulk Read.
This also has a UT with embedded Cassandra where a read is performed on a table with few rows and all primitive types.