### PR TITLE
feat: bump to Neo4j driver v5

### DIFF
--- a/v2/googlecloud-to-neo4j/pom.xml
+++ b/v2/googlecloud-to-neo4j/pom.xml
@@ -33,6 +33,11 @@
         <artifactId>snakeyaml</artifactId>
         <version>1.33</version>
       </dependency>
+      <dependency>
+        <groupId>org.neo4j.driver</groupId>
+        <artifactId>neo4j-java-driver</artifactId>
+        <version>5.27.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnectionTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnectionTest.java
@@ -41,6 +41,7 @@ import org.mockito.junit.MockitoRule;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.internal.InternalRecord;
@@ -59,7 +60,7 @@ public class Neo4jConnectionTest {
   @Before
   public void setUp() {
     when(session.run(anyString(), anyMap(), any())).thenReturn(result);
-    when(driver.session(any())).thenReturn(session);
+    when(driver.session(any(SessionConfig.class))).thenReturn(session);
     neo4jConnection = new Neo4jConnection("a-database", () -> driver);
   }
 


### PR DESCRIPTION
Now that the templates have a JDK 17 baseline, the Neo4j template can use the v5 Neo4j Java driver.