### PR TITLE
Support shadow table in different database

### DIFF
--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SpannerTransactionWriterDoFn.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SpannerTransactionWriterDoFn.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Options;
 import com.google.cloud.spanner.SpannerException;
-import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
+import com.google.cloud.spanner.TransactionRunner;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.ChangeEventConvertorException;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.DroppedTableException;
@@ -81,8 +81,10 @@ class SpannerTransactionWriterDoFn extends DoFn<FailsafeElement<String, String>,
   private static final Logger LOG = LoggerFactory.getLogger(SpannerTransactionWriterDoFn.class);
 
   private final PCollectionView<Ddl> ddlView;
+  private final PCollectionView<Ddl> shadowTableDdlView;
 
   private final SpannerConfig spannerConfig;
+  private final SpannerConfig shadowTableSpannerConfig;
 
   // The prefix for shadow tables.
   private final String shadowTablePrefix;
@@ -95,6 +97,8 @@ class SpannerTransactionWriterDoFn extends DoFn<FailsafeElement<String, String>,
 
   /* SpannerAccessor must be transient so that its value is not serialized at runtime. */
   private transient SpannerAccessor spannerAccessor;
+  /* SpannerAccessor for shadow table database must be transient so that its value is not serialized at runtime. */
+  private transient SpannerAccessor shadowTableSpannerAccessor;
 
   // Number of events successfully processed.
   private final Counter successfulEvents =
@@ -172,25 +176,35 @@ class SpannerTransactionWriterDoFn extends DoFn<FailsafeElement<String, String>,
   private transient AtomicBoolean keepWatchdogRunning;
   private transient Thread watchdogThread;
 
+  private final boolean usesSeparateShadowTableDb;
+
   SpannerTransactionWriterDoFn(
       SpannerConfig spannerConfig,
+      SpannerConfig shadowTableSpannerConfig,
       PCollectionView<Ddl> ddlView,
+      PCollectionView<Ddl> shadowTableDdlView,
       String shadowTablePrefix,
       String sourceType,
       Boolean isRegularRunMode) {
     Preconditions.checkNotNull(spannerConfig);
     this.spannerConfig = spannerConfig;
+    this.shadowTableSpannerConfig = shadowTableSpannerConfig;
     this.ddlView = ddlView;
+    this.shadowTableDdlView = shadowTableDdlView;
     this.shadowTablePrefix =
         (shadowTablePrefix.endsWith("_")) ? shadowTablePrefix : shadowTablePrefix + "_";
     this.sourceType = sourceType;
     this.isRegularRunMode = isRegularRunMode;
+    this.usesSeparateShadowTableDb =
+        !(spannerConfig.getInstanceId().equals(shadowTableSpannerConfig.getInstanceId())
+            && spannerConfig.getDatabaseId().equals(shadowTableSpannerConfig.getDatabaseId()));
   }
 
   /** Setup function connects to Cloud Spanner. */
   @Setup
   public void setup() {
     spannerAccessor = SpannerAccessor.getOrCreate(spannerConfig);
+    shadowTableSpannerAccessor = SpannerAccessor.getOrCreate(shadowTableSpannerConfig);
     mapper = new ObjectMapper();
     mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
     // Setup and start the watchdog thread.
@@ -217,6 +231,8 @@ class SpannerTransactionWriterDoFn extends DoFn<FailsafeElement<String, String>,
   public void processElement(ProcessContext c) {
     FailsafeElement<String, String> msg = c.element();
     Ddl ddl = c.sideInput(ddlView);
+    // TODO: pass shadow table ddl to shdaow tble mutaiton generator and sequence reader.
+    Ddl shadowTableDdl = c.sideInput(shadowTableDdlView);
     Instant startTimestamp = Instant.now();
     String migrationShardId = null;
     boolean isRetryRecord = false;
@@ -240,43 +256,20 @@ class SpannerTransactionWriterDoFn extends DoFn<FailsafeElement<String, String>,
       }
       ChangeEventContext changeEventContext =
           ChangeEventContextFactory.createChangeEventContext(
-              changeEvent, ddl, shadowTablePrefix, sourceType);
+              changeEvent, ddl, shadowTableDdl, shadowTablePrefix, sourceType);
 
       // Sequence information for the current change event.
       ChangeEventSequence currentChangeEventSequence =
           ChangeEventSequenceFactory.createChangeEventSequenceFromChangeEventContext(
               changeEventContext);
 
-      // Start transaction
-      spannerAccessor
-          .getDatabaseClient()
-          .readWriteTransaction(
-              Options.tag(getTxnTag(c.getPipelineOptions())),
-              Options.priority(spannerConfig.getRpcPriority().get()))
-          .run(
-              (TransactionCallable<Void>)
-                  transaction -> {
-                    isInTransaction.set(true);
-                    transactionAttemptCount.incrementAndGet();
-                    // Sequence information for the last change event.
-                    ChangeEventSequence previousChangeEventSequence =
-                        ChangeEventSequenceFactory.createChangeEventSequenceFromShadowTable(
-                            transaction, changeEventContext);
-
-                    /* There was a previous event recorded with a greater sequence information
-                     * than current. Hence, skip the current event.
-                     */
-                    if (previousChangeEventSequence != null
-                        && previousChangeEventSequence.compareTo(currentChangeEventSequence) >= 0) {
-                      skippedEvents.inc();
-                      return null;
-                    }
-
-                    // Apply shadow and data table mutations.
-                    transaction.buffer(changeEventContext.getMutations());
-                    isInTransaction.set(false);
-                    return null;
-                  });
+      if (usesSeparateShadowTableDb) {
+        processCrossDatabaseTransaction(
+            c, changeEventContext, currentChangeEventSequence, shadowTableDdl);
+      } else {
+        processSingleDatabaseTransaction(
+            c, changeEventContext, currentChangeEventSequence, shadowTableDdl);
+      }
       com.google.cloud.Timestamp timestamp = com.google.cloud.Timestamp.now();
       c.output(timestamp);
       if (migrationShardId != null) {
@@ -345,6 +338,115 @@ class SpannerTransactionWriterDoFn extends DoFn<FailsafeElement<String, String>,
     }
   }
 
+  private void processSingleDatabaseTransaction(
+      ProcessContext c,
+      ChangeEventContext changeEventContext,
+      ChangeEventSequence currentChangeEventSequence,
+      Ddl shadowDdl) {
+
+    spannerAccessor
+        .getDatabaseClient()
+        .readWriteTransaction(
+            Options.tag(getTxnTag(c.getPipelineOptions())),
+            Options.priority(spannerConfig.getRpcPriority().get()))
+        .run(
+            (TransactionRunner.TransactionCallable<Void>)
+                transaction -> {
+                  isInTransaction.set(true);
+                  transactionAttemptCount.incrementAndGet();
+
+                  ChangeEventSequence previousChangeEventSequence =
+                      ChangeEventSequenceFactory.createChangeEventSequenceFromShadowTable(
+                          transaction, changeEventContext, shadowDdl, false);
+
+                  if (previousChangeEventSequence != null
+                      && previousChangeEventSequence.compareTo(currentChangeEventSequence) >= 0) {
+                    skippedEvents.inc();
+                    return null;
+                  }
+
+                  transaction.buffer(changeEventContext.getMutations());
+                  isInTransaction.set(false);
+                  return null;
+                });
+  }
+
+  void processCrossDatabaseTransaction(
+      ProcessContext c,
+      ChangeEventContext changeEventContext,
+      ChangeEventSequence currentChangeEventSequence,
+      Ddl shadowDdl) {
+
+    shadowTableSpannerAccessor
+        .getDatabaseClient()
+        .readWriteTransaction(
+            Options.tag(getTxnTag(c.getPipelineOptions())),
+            Options.priority(spannerConfig.getRpcPriority().get()))
+        .allowNestedTransaction()
+        .run(
+            (TransactionRunner.TransactionCallable<Void>)
+                shadowTxn -> {
+                  isInTransaction.set(true);
+                  transactionAttemptCount.incrementAndGet();
+
+                  // Build lock query based on source type
+                  ChangeEventSequence previousChangeEventSequence =
+                      ChangeEventSequenceFactory.createChangeEventSequenceFromShadowTable(
+                          shadowTxn, changeEventContext, shadowDdl, /* useSqlStatments= */ true);
+
+                  if (previousChangeEventSequence != null
+                      && previousChangeEventSequence.compareTo(currentChangeEventSequence) >= 0) {
+                    skippedEvents.inc();
+                    return null;
+                  }
+
+                  // Start main table transaction
+                  spannerAccessor
+                      .getDatabaseClient()
+                      .readWriteTransaction(
+                          Options.tag(getTxnTag(c.getPipelineOptions())),
+                          Options.priority(spannerConfig.getRpcPriority().get()))
+                      .run(
+                          (TransactionRunner.TransactionCallable<Void>)
+                              mainTxn -> {
+                                // Write to main table
+                                mainTxn.buffer(changeEventContext.getDataMutation());
+
+                                // Validate the row still holds the exclusive lock. In case of
+                                // network
+                                // partitions, it could happen that Spanner releases the lock while
+                                // this
+                                // thread gets killed.
+                                ChangeEventSequence validationSequence =
+                                    ChangeEventSequenceFactory
+                                        .createChangeEventSequenceFromShadowTable(
+                                            shadowTxn,
+                                            changeEventContext,
+                                            shadowDdl,
+                                            /* useSqlStatments= */ true);
+
+                                if (validationSequence != null
+                                    && validationSequence.compareTo(previousChangeEventSequence)
+                                        != 0) {
+                                  // This code path should never execute since Spanner automatically
+                                  // aborts transactions when locks are released.
+                                  LOG.error(
+                                      "Sequence mismatch: validation sequence {}, previous sequence {}",
+                                      validationSequence,
+                                      previousChangeEventSequence);
+                                  throw new Exception(
+                                      "Shadow table sequence changed during transaction");
+                                }
+                                return null;
+                              });
+
+                  // Update shadow table if main transaction succeeded
+                  shadowTxn.buffer(changeEventContext.getShadowMutation());
+                  isInTransaction.set(false);
+                  return null;
+                });
+  }
+
   void updateLatencyMetrics(JsonNode changeEvent, Instant startTimestamp) {
     Instant endTimestamp = Instant.now();
     spannerWriterLatencyMs.update(new Duration(startTimestamp, endTimestamp).getMillis());
@@ -394,6 +496,10 @@ class SpannerTransactionWriterDoFn extends DoFn<FailsafeElement<String, String>,
 
   public void setSpannerAccessor(SpannerAccessor spannerAccessor) {
     this.spannerAccessor = spannerAccessor;
+  }
+
+  public void setShadowTableSpannerAccessor(SpannerAccessor shadowTableSpannerAccessor) {
+    this.shadowTableSpannerAccessor = shadowTableSpannerAccessor;
   }
 
   public void setTransactionAttemptCount(AtomicLong transactionAttemptCount) {

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventContext.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventContext.java
@@ -60,7 +60,7 @@ public abstract class ChangeEventContext {
   abstract Mutation generateShadowTableMutation(Ddl ddl) throws ChangeEventConvertorException;
 
   // Helper method to convert change event to mutation.
-  protected void convertChangeEventToMutation(Ddl ddl)
+  protected void convertChangeEventToMutation(Ddl ddl, Ddl shadowTableDdl)
       throws ChangeEventConvertorException, InvalidChangeEventException, DroppedTableException {
     ChangeEventConvertor.convertChangeEventColumnKeysToLowerCase(changeEvent);
     ChangeEventConvertor.verifySpannerSchema(ddl, changeEvent);
@@ -71,7 +71,7 @@ public abstract class ChangeEventContext {
             changeEvent,
             /* convertNameToLowerCase= */ true);
     this.dataMutation = ChangeEventConvertor.changeEventToMutation(ddl, changeEvent);
-    this.shadowTableMutation = generateShadowTableMutation(ddl);
+    this.shadowTableMutation = generateShadowTableMutation(shadowTableDdl);
   }
 
   public JsonNode getChangeEvent() {
@@ -81,6 +81,16 @@ public abstract class ChangeEventContext {
   // Returns an array of data and shadow table mutations.
   public Iterable<Mutation> getMutations() {
     return Arrays.asList(dataMutation, shadowTableMutation);
+  }
+
+  // Returns the data table mutation
+  public Mutation getDataMutation() {
+    return dataMutation;
+  }
+
+  // Returns the shadow table mutation
+  public Mutation getShadowMutation() {
+    return shadowTableMutation;
   }
 
   // Getter method for the primary key of the change event.

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventContextFactory.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventContextFactory.java
@@ -38,7 +38,11 @@ public class ChangeEventContextFactory {
    * Creates ChangeEventContext depending on the change event type.
    */
   public static ChangeEventContext createChangeEventContext(
-      JsonNode changeEvent, Ddl ddl, String shadowTablePrefix, String sourceType)
+      JsonNode changeEvent,
+      Ddl ddl,
+      Ddl shadowTableDdl,
+      String shadowTablePrefix,
+      String sourceType)
       throws ChangeEventConvertorException, InvalidChangeEventException, DroppedTableException {
     String sourceTypeFromChangeEvent;
     try {
@@ -57,11 +61,11 @@ public class ChangeEventContextFactory {
     }
 
     if (DatastreamConstants.MYSQL_SOURCE_TYPE.equals(sourceType)) {
-      return new MySqlChangeEventContext(changeEvent, ddl, shadowTablePrefix);
+      return new MySqlChangeEventContext(changeEvent, ddl, shadowTableDdl, shadowTablePrefix);
     } else if (DatastreamConstants.ORACLE_SOURCE_TYPE.equals(sourceType)) {
-      return new OracleChangeEventContext(changeEvent, ddl, shadowTablePrefix);
+      return new OracleChangeEventContext(changeEvent, ddl, shadowTableDdl, shadowTablePrefix);
     } else if (DatastreamConstants.POSTGRES_SOURCE_TYPE.equals(sourceType)) {
-      return new PostgresChangeEventContext(changeEvent, ddl, shadowTablePrefix);
+      return new PostgresChangeEventContext(changeEvent, ddl, shadowTableDdl, shadowTablePrefix);
     }
 
     throw new InvalidChangeEventException("Unsupported source database: " + sourceType);

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventSequenceFactory.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventSequenceFactory.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.templates.datastream;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.cloud.spanner.TransactionContext;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.ChangeEventConvertorException;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.InvalidChangeEventException;
 
@@ -62,7 +63,10 @@ public class ChangeEventSequenceFactory {
    * from shadow tables.
    */
   public static ChangeEventSequence createChangeEventSequenceFromShadowTable(
-      final TransactionContext transactionContext, final ChangeEventContext changeEventContext)
+      final TransactionContext transactionContext,
+      final ChangeEventContext changeEventContext,
+      Ddl shadowDdl,
+      boolean useSqlStatements)
       throws ChangeEventSequenceCreationException, InvalidChangeEventException {
 
     String sourceType = getSourceType(changeEventContext.getChangeEvent());
@@ -71,17 +75,23 @@ public class ChangeEventSequenceFactory {
       return MySqlChangeEventSequence.createFromShadowTable(
           transactionContext,
           changeEventContext.getShadowTable(),
-          changeEventContext.getPrimaryKey());
+          shadowDdl,
+          changeEventContext.getPrimaryKey(),
+          useSqlStatements);
     } else if (DatastreamConstants.ORACLE_SOURCE_TYPE.equals(sourceType)) {
       return OracleChangeEventSequence.createFromShadowTable(
           transactionContext,
           changeEventContext.getShadowTable(),
-          changeEventContext.getPrimaryKey());
+          shadowDdl,
+          changeEventContext.getPrimaryKey(),
+          useSqlStatements);
     } else if (DatastreamConstants.POSTGRES_SOURCE_TYPE.equals(sourceType)) {
       return PostgresChangeEventSequence.createFromShadowTable(
           transactionContext,
           changeEventContext.getShadowTable(),
-          changeEventContext.getPrimaryKey());
+          shadowDdl,
+          changeEventContext.getPrimaryKey(),
+          useSqlStatements);
     }
     throw new InvalidChangeEventException("Unsupported source database: " + sourceType);
   }

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventSequenceFactory.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventSequenceFactory.java
@@ -30,7 +30,7 @@ public class ChangeEventSequenceFactory {
 
   private ChangeEventSequenceFactory() {}
 
-  private static String getSourceType(JsonNode changeEvent) throws InvalidChangeEventException {
+  static String getSourceType(JsonNode changeEvent) throws InvalidChangeEventException {
     try {
       return changeEvent.get(DatastreamConstants.EVENT_SOURCE_TYPE_KEY).asText();
     } catch (Exception e) {

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MySqlChangeEventContext.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MySqlChangeEventContext.java
@@ -30,13 +30,14 @@ import com.google.cloud.teleport.v2.spanner.migrations.exceptions.InvalidChangeE
  */
 class MySqlChangeEventContext extends ChangeEventContext {
 
-  public MySqlChangeEventContext(JsonNode changeEvent, Ddl ddl, String shadowTablePrefix)
+  public MySqlChangeEventContext(
+      JsonNode changeEvent, Ddl ddl, Ddl shadowTableDdl, String shadowTablePrefix)
       throws ChangeEventConvertorException, InvalidChangeEventException, DroppedTableException {
     this.changeEvent = changeEvent;
     this.shadowTablePrefix = shadowTablePrefix;
     this.dataTable = changeEvent.get(DatastreamConstants.EVENT_TABLE_NAME_KEY).asText();
     this.shadowTable = shadowTablePrefix + this.dataTable;
-    convertChangeEventToMutation(ddl);
+    convertChangeEventToMutation(ddl, shadowTableDdl);
   }
 
   /*

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MySqlChangeEventSequence.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MySqlChangeEventSequence.java
@@ -16,8 +16,11 @@
 package com.google.cloud.teleport.v2.templates.datastream;
 
 import com.google.cloud.spanner.Key;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.TransactionContext;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.migrations.convertors.ChangeEventTypeConvertor;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.ChangeEventConvertorException;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.InvalidChangeEventException;
@@ -90,9 +93,17 @@ class MySqlChangeEventSequence extends ChangeEventSequence {
 
   /*
    * Creates a MySqlChangeEventSequence by reading from a shadow table.
+   * @param transactionContext The transaction context to use for reading from the shadow table
+   * @param shadowTable The name of the shadow table to read from
+   * @param primaryKey The primary key to look up in the shadow table
+   * @param useSqlStatements If true, performs shadow table read using SQL statement with exclusive lock on row
    */
   public static MySqlChangeEventSequence createFromShadowTable(
-      final TransactionContext transactionContext, String shadowTable, Key primaryKey)
+      final TransactionContext transactionContext,
+      String shadowTable,
+      Ddl shadowTableDdl,
+      Key primaryKey,
+      boolean useSqlStatements)
       throws ChangeEventSequenceCreationException {
 
     try {
@@ -101,13 +112,26 @@ class MySqlChangeEventSequence extends ChangeEventSequence {
           DatastreamConstants.MYSQL_SORT_ORDER.values().stream()
               .map(p -> p.getLeft())
               .collect(Collectors.toList());
-      Struct row = transactionContext.readRow(shadowTable, primaryKey, readColumnList);
-
+      Struct row;
+      // TODO: After beam release, use the latest client lib version which supports setting lock
+      // hints via the read api. SQL string generation should be removed.
+      if (useSqlStatements) {
+        Statement sql =
+            ShadowTableReadUtils.generateShadowTableReadSQL(
+                shadowTable, readColumnList, primaryKey, shadowTableDdl);
+        ResultSet resultSet = transactionContext.executeQuery(sql);
+        if (!resultSet.next()) {
+          return null;
+        }
+        row = resultSet.getCurrentRowAsStruct();
+      } else {
+        // Use direct row read
+        row = transactionContext.readRow(shadowTable, primaryKey, readColumnList);
+      }
       // This is the first event for the primary key and hence the latest event.
       if (row == null) {
         return null;
       }
-
       return new MySqlChangeEventSequence(
           row.getLong(readColumnList.get(0)),
           row.getString(readColumnList.get(1)),

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/OracleChangeEventContext.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/OracleChangeEventContext.java
@@ -30,13 +30,14 @@ import com.google.cloud.teleport.v2.spanner.migrations.exceptions.InvalidChangeE
  */
 class OracleChangeEventContext extends ChangeEventContext {
 
-  public OracleChangeEventContext(JsonNode changeEvent, Ddl ddl, String shadowTablePrefix)
+  public OracleChangeEventContext(
+      JsonNode changeEvent, Ddl ddl, Ddl shadowTableDdl, String shadowTablePrefix)
       throws ChangeEventConvertorException, InvalidChangeEventException, DroppedTableException {
     this.changeEvent = changeEvent;
     this.shadowTablePrefix = shadowTablePrefix;
     this.dataTable = changeEvent.get(DatastreamConstants.EVENT_TABLE_NAME_KEY).asText();
     this.shadowTable = shadowTablePrefix + this.dataTable;
-    convertChangeEventToMutation(ddl);
+    convertChangeEventToMutation(ddl, shadowTableDdl);
   }
 
   /*

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/OracleChangeEventSequence.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/OracleChangeEventSequence.java
@@ -16,8 +16,11 @@
 package com.google.cloud.teleport.v2.templates.datastream;
 
 import com.google.cloud.spanner.Key;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.TransactionContext;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.migrations.convertors.ChangeEventTypeConvertor;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.ChangeEventConvertorException;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.InvalidChangeEventException;
@@ -73,7 +76,11 @@ class OracleChangeEventSequence extends ChangeEventSequence {
    * Creates a OracleChangeEventSequence by reading from a shadow table.
    */
   public static OracleChangeEventSequence createFromShadowTable(
-      final TransactionContext transactionContext, String shadowTable, Key primaryKey)
+      final TransactionContext transactionContext,
+      String shadowTable,
+      Ddl shadowTableDdl,
+      Key primaryKey,
+      boolean useSqlStatements)
       throws ChangeEventSequenceCreationException {
 
     try {
@@ -82,7 +89,22 @@ class OracleChangeEventSequence extends ChangeEventSequence {
           DatastreamConstants.ORACLE_SORT_ORDER.values().stream()
               .map(p -> p.getLeft())
               .collect(Collectors.toList());
-      Struct row = transactionContext.readRow(shadowTable, primaryKey, readColumnList);
+      Struct row;
+      // TODO: After beam release, use the latest client lib version which supports setting lock
+      // hints via the read api. SQL string generation should be removed.
+      if (useSqlStatements) {
+        Statement sql =
+            ShadowTableReadUtils.generateShadowTableReadSQL(
+                shadowTable, readColumnList, primaryKey, shadowTableDdl);
+        ResultSet resultSet = transactionContext.executeQuery(sql);
+        if (!resultSet.next()) {
+          return null;
+        }
+        row = resultSet.getCurrentRowAsStruct();
+      } else {
+        // Use direct row read
+        row = transactionContext.readRow(shadowTable, primaryKey, readColumnList);
+      }
 
       // This is the first event for the primary key and hence the latest event.
       if (row == null) {

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/PostgresChangeEventContext.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/PostgresChangeEventContext.java
@@ -30,13 +30,14 @@ import com.google.cloud.teleport.v2.spanner.migrations.exceptions.InvalidChangeE
  */
 class PostgresChangeEventContext extends ChangeEventContext {
 
-  public PostgresChangeEventContext(JsonNode changeEvent, Ddl ddl, String shadowTablePrefix)
+  public PostgresChangeEventContext(
+      JsonNode changeEvent, Ddl ddl, Ddl shadowTableDdl, String shadowTablePrefix)
       throws ChangeEventConvertorException, InvalidChangeEventException, DroppedTableException {
     this.changeEvent = changeEvent;
     this.shadowTablePrefix = shadowTablePrefix;
     this.dataTable = changeEvent.get(DatastreamConstants.EVENT_TABLE_NAME_KEY).asText();
     this.shadowTable = shadowTablePrefix + this.dataTable;
-    convertChangeEventToMutation(ddl);
+    convertChangeEventToMutation(ddl, shadowTableDdl);
   }
 
   /*

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/PostgresChangeEventSequence.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/PostgresChangeEventSequence.java
@@ -16,8 +16,11 @@
 package com.google.cloud.teleport.v2.templates.datastream;
 
 import com.google.cloud.spanner.Key;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.TransactionContext;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.migrations.convertors.ChangeEventTypeConvertor;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.ChangeEventConvertorException;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.InvalidChangeEventException;
@@ -73,7 +76,11 @@ class PostgresChangeEventSequence extends ChangeEventSequence {
    * Creates a PostgresChangeEventSequence by reading from a shadow table.
    */
   public static PostgresChangeEventSequence createFromShadowTable(
-      final TransactionContext transactionContext, String shadowTable, Key primaryKey)
+      final TransactionContext transactionContext,
+      String shadowTable,
+      Ddl shadowTableDdl,
+      Key primaryKey,
+      boolean useSqlStatements)
       throws ChangeEventSequenceCreationException {
 
     try {
@@ -82,8 +89,22 @@ class PostgresChangeEventSequence extends ChangeEventSequence {
           DatastreamConstants.POSTGRES_SORT_ORDER.values().stream()
               .map(p -> p.getLeft())
               .collect(Collectors.toList());
-      Struct row = transactionContext.readRow(shadowTable, primaryKey, readColumnList);
-
+      Struct row;
+      // TODO: After beam release, use the latest client lib version which supports setting lock
+      // hints via the read api. SQL string generation should be removed.
+      if (useSqlStatements) {
+        Statement sql =
+            ShadowTableReadUtils.generateShadowTableReadSQL(
+                shadowTable, readColumnList, primaryKey, shadowTableDdl);
+        ResultSet resultSet = transactionContext.executeQuery(sql);
+        if (!resultSet.next()) {
+          return null;
+        }
+        row = resultSet.getCurrentRowAsStruct();
+      } else {
+        // Use direct row read
+        row = transactionContext.readRow(shadowTable, primaryKey, readColumnList);
+      }
       // This is the first event for the primary key and hence the latest event.
       if (row == null) {
         return null;

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ShadowTableReadUtils.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ShadowTableReadUtils.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.datastream;
+
+import com.google.cloud.ByteArray;
+import com.google.cloud.Date;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Key;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.teleport.v2.spanner.ddl.Column;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.Table;
+import com.google.cloud.teleport.v2.spanner.type.Type;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ShadowTableReadUtils {
+  // TODO: After beam release, use the latest client lib version which supports setting lock
+  // hints via the read api. SQL string generation should be removed.
+  public static Statement generateShadowTableReadSQL(
+      String shadowTable, List<String> readColumnList, Key primaryKey, Ddl shadowTableDdl) {
+    String columnNames = String.join(", ", readColumnList);
+    // TODO: Handle json type as PKs.
+    String whereClause =
+        String.join(
+            " AND ",
+            shadowTableDdl.table(shadowTable).primaryKeys().stream()
+                .map(col -> col.name() + "=@" + col.name())
+                .collect(Collectors.toList()));
+    String sql =
+        "@{LOCK_SCANNED_RANGES=exclusive} SELECT "
+            + columnNames
+            + " FROM "
+            + shadowTable
+            + " WHERE "
+            + whereClause;
+
+    Statement.Builder stmtBuilder = Statement.newBuilder(sql);
+    int i = 0;
+    for (Object value : primaryKey.getParts()) {
+      Table table = shadowTableDdl.table(shadowTable);
+      String colName = table.primaryKeys().get(i).name();
+      Column key = table.column(colName);
+      Type keyColType = key.type();
+
+      switch (keyColType.getCode()) {
+        case BOOL:
+        case PG_BOOL:
+          stmtBuilder.bind(colName).to((Boolean) value);
+          break;
+        case INT64:
+        case PG_INT8:
+          stmtBuilder.bind(colName).to((Long) value);
+          break;
+        case FLOAT64:
+        case PG_FLOAT8:
+          stmtBuilder.bind(colName).to((Double) value);
+          break;
+        case STRING:
+        case PG_VARCHAR:
+        case PG_TEXT:
+        case JSON:
+        case PG_JSONB:
+          stmtBuilder.bind(colName).to((String) value);
+          break;
+        case NUMERIC:
+        case PG_NUMERIC:
+          stmtBuilder.bind(colName).to((BigDecimal) value);
+          break;
+        case BYTES:
+        case PG_BYTEA:
+          stmtBuilder.bind(colName).to((ByteArray) value);
+          break;
+        case TIMESTAMP:
+        case PG_COMMIT_TIMESTAMP:
+        case PG_TIMESTAMPTZ:
+          stmtBuilder.bind(colName).to((Timestamp) value);
+          break;
+        case DATE:
+        case PG_DATE:
+          stmtBuilder.bind(colName).to((Date) value);
+          break;
+        default:
+          throw new IllegalArgumentException("Unsupported type: " + keyColType);
+      }
+      i++;
+    }
+    return stmtBuilder.build();
+  }
+}

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/spanner/ProcessInformationSchema.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/spanner/ProcessInformationSchema.java
@@ -38,47 +38,58 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PBegin;
-import org.apache.beam.sdk.values.PCollection;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.TupleTagList;
 
 /**
- * Beam transform which 1) Reads information schema using {@link InformationSchemaScanner}. 2)
- * Create shadow tables in the destination Cloud Spanner database. 3) Outputs the updated
- * information schema.
+ * Beam transform which 1) Reads information schema from both main and shadow table database. 2)
+ * Create shadow tables in the shadow table database 3) Outputs both DDL schemas
+ *
+ * <p>The shadow table database housing the shadow tables can be the same as the main database.
  */
-public class ProcessInformationSchema extends PTransform<PBegin, PCollection<Ddl>> {
-  private static final Logger LOG = LoggerFactory.getLogger(ProcessInformationSchema.class);
+public class ProcessInformationSchema extends PTransform<PBegin, PCollectionTuple> {
+  public static final TupleTag<Ddl> MAIN_DDL_TAG = new TupleTag<>() {};
+  public static final TupleTag<Ddl> SHADOW_TABLE_DDL_TAG = new TupleTag<>() {};
   private final SpannerConfig spannerConfig;
+  private final SpannerConfig shadowTableSpannerConfig;
   private final Boolean shouldCreateShadowTables;
   private final String shadowTablePrefix;
   private final String sourceType;
 
   public ProcessInformationSchema(
       SpannerConfig spannerConfig,
+      SpannerConfig shadowTableSpannerConfig,
       Boolean shouldCreateShadowTables,
       String shadowTablePrefix,
       String sourceType) {
     this.spannerConfig = spannerConfig;
+    this.shadowTableSpannerConfig = shadowTableSpannerConfig;
     this.shouldCreateShadowTables = shouldCreateShadowTables;
     this.shadowTablePrefix = shadowTablePrefix;
     this.sourceType = sourceType;
   }
 
   @Override
-  public PCollection<Ddl> expand(PBegin p) {
+  public PCollectionTuple expand(PBegin p) {
     return p.apply("Create empty", Create.of((Void) null))
         .apply(
-            "Create Shadow tables and return Information Schema",
+            "Create Shadow tables and return Information Schemas",
             ParDo.of(
-                new ProcessInformationSchemaFn(
-                    spannerConfig, shouldCreateShadowTables,
-                    shadowTablePrefix, sourceType)));
+                    new ProcessInformationSchemaFn(
+                        spannerConfig,
+                        shadowTableSpannerConfig,
+                        shouldCreateShadowTables,
+                        shadowTablePrefix,
+                        sourceType))
+                .withOutputTags(MAIN_DDL_TAG, TupleTagList.of(SHADOW_TABLE_DDL_TAG)));
   }
 
   static class ProcessInformationSchemaFn extends DoFn<Void, Ddl> {
     private final SpannerConfig spannerConfig;
+    private final SpannerConfig shadowTableSpannerConfig;
     private transient SpannerAccessor spannerAccessor;
+    private transient SpannerAccessor shadowTableSpannerAccessor;
     private transient Dialect dialect;
     private final Boolean shouldCreateShadowTables;
     private final String shadowTablePrefix;
@@ -89,10 +100,12 @@ public class ProcessInformationSchema extends PTransform<PBegin, PCollection<Ddl
 
     public ProcessInformationSchemaFn(
         SpannerConfig spannerConfig,
+        SpannerConfig shadowTableSpannerConfig,
         Boolean shouldCreateShadowTables,
         String shadowTablePrefix,
         String sourceType) {
       this.spannerConfig = spannerConfig;
+      this.shadowTableSpannerConfig = shadowTableSpannerConfig;
       this.shouldCreateShadowTables = shouldCreateShadowTables;
       this.shadowTablePrefix =
           (shadowTablePrefix.endsWith("_")) ? shadowTablePrefix : shadowTablePrefix + "_";
@@ -102,6 +115,7 @@ public class ProcessInformationSchema extends PTransform<PBegin, PCollection<Ddl
     @Setup
     public void setup() throws Exception {
       spannerAccessor = SpannerAccessor.getOrCreate(spannerConfig);
+      shadowTableSpannerAccessor = SpannerAccessor.getOrCreate(shadowTableSpannerConfig);
       DatabaseAdminClient databaseAdminClient = spannerAccessor.getDatabaseAdminClient();
       dialect =
           databaseAdminClient
@@ -112,34 +126,70 @@ public class ProcessInformationSchema extends PTransform<PBegin, PCollection<Ddl
     @Teardown
     public void teardown() throws Exception {
       spannerAccessor.close();
+      shadowTableSpannerAccessor.close();
     }
 
     @ProcessElement
     public void processElement(ProcessContext c) {
+      // TODO: Add pgsql support/ cross dialect support.
+      Ddl mainDdl = getInformationSchemaAsDdl(spannerAccessor);
+      Ddl shadowTableDdl = getInformationSchemaAsDdl(shadowTableSpannerAccessor);
+
       if (shouldCreateShadowTables) {
-        createShadowTablesInSpanner(getInformationSchemaAsDdl());
+        createShadowTablesInSpanner(mainDdl, shadowTableDdl);
+        // Refresh shadow table DDL after creating new shadow tables
+        shadowTableDdl = getInformationSchemaAsDdl(shadowTableSpannerAccessor);
       }
-      c.output(getInformationSchemaAsDdl());
+      // Clean up DDLs to ensure proper separation of main and shadow tables. Note that this is only
+      // for data hygiene, the downstream methods using these can handle Ddl with excess tables as
+      // well.
+      mainDdl = cleanupDdl(mainDdl, shadowTablePrefix, /* isMainDdl= */ true);
+      shadowTableDdl = cleanupDdl(shadowTableDdl, shadowTablePrefix, /* isMainDdl= */ false);
+      c.output(MAIN_DDL_TAG, mainDdl);
+      c.output(SHADOW_TABLE_DDL_TAG, shadowTableDdl);
     }
 
-    Ddl getInformationSchemaAsDdl() {
-      BatchClient batchClient = spannerAccessor.getBatchClient();
+    Ddl cleanupDdl(Ddl originalDdl, String shadowPrefix, boolean isMainDdl) {
+      // Create a new DDL builder with the same dialect as the original
+      Ddl.Builder cleanedDdlBuilder = Ddl.builder(dialect);
+
+      // Filter tables based on whether we're cleaning main DDL or shadow DDL
+      List<Table> filteredTables =
+          originalDdl.allTables().stream()
+              .filter(
+                  table -> {
+                    boolean isTableShadow = table.name().startsWith(shadowPrefix);
+                    // For main DDL, keep tables that are NOT shadow tables
+                    // For shadow DDL, keep tables that ARE shadow tables
+                    return isMainDdl ? !isTableShadow : isTableShadow;
+                  })
+              .collect(Collectors.toList());
+
+      // Add all filtered tables to the new DDL builder
+      filteredTables.forEach(cleanedDdlBuilder::addTable);
+
+      // Build and return the cleaned DDL
+      return cleanedDdlBuilder.build();
+    }
+
+    Ddl getInformationSchemaAsDdl(SpannerAccessor accessor) {
+      BatchClient batchClient = accessor.getBatchClient();
       BatchReadOnlyTransaction context =
           batchClient.batchReadOnlyTransaction(TimestampBound.strong());
       InformationSchemaScanner scanner = new InformationSchemaScanner(context, dialect);
       return scanner.scan();
     }
 
-    void createShadowTablesInSpanner(Ddl informationSchema) {
+    void createShadowTablesInSpanner(Ddl mainDdl, Ddl shadowTableDdl) {
       List<String> dataTablesWithoutShadowTables =
-          getDataTablesWithNoShadowTables(informationSchema);
+          getDataTablesWithNoShadowTables(mainDdl, shadowTableDdl);
 
       Ddl.Builder shadowTableBuilder = Ddl.builder(dialect);
       ShadowTableCreator shadowTableCreator =
           new ShadowTableCreator(sourceType, shadowTablePrefix, dialect);
       for (String dataTableName : dataTablesWithoutShadowTables) {
         Table shadowTable =
-            shadowTableCreator.constructShadowTable(informationSchema, dataTableName, dialect);
+            shadowTableCreator.constructShadowTable(mainDdl, dataTableName, dialect);
         shadowTableBuilder.addTable(shadowTable);
       }
       List<String> createShadowTableStatements = shadowTableBuilder.build().createTableStatements();
@@ -148,12 +198,12 @@ public class ProcessInformationSchema extends PTransform<PBegin, PCollection<Ddl
         return;
       }
 
-      DatabaseAdminClient databaseAdminClient = spannerAccessor.getDatabaseAdminClient();
+      DatabaseAdminClient databaseAdminClient = shadowTableSpannerAccessor.getDatabaseAdminClient();
 
       OperationFuture<Void, UpdateDatabaseDdlMetadata> op =
           databaseAdminClient.updateDatabaseDdl(
-              spannerConfig.getInstanceId().get(),
-              spannerConfig.getDatabaseId().get(),
+              shadowTableSpannerConfig.getInstanceId().get(),
+              shadowTableSpannerConfig.getDatabaseId().get(),
               createShadowTableStatements,
               null);
 
@@ -162,7 +212,6 @@ public class ProcessInformationSchema extends PTransform<PBegin, PCollection<Ddl
       } catch (InterruptedException | ExecutionException | TimeoutException e) {
         throw new RuntimeException(e);
       }
-      return;
     }
 
     /*
@@ -180,22 +229,22 @@ public class ProcessInformationSchema extends PTransform<PBegin, PCollection<Ddl
     }
 
     /*
-     * Returns the list of data table names that don't have a corresponding shadow table.
+     * Returns the list of data table names from main DB that don't have a corresponding shadow table.
+     * Shadow table db could be the same as main db or a separate database. Both of these cases get handled by this method.
      */
-    List<String> getDataTablesWithNoShadowTables(Ddl ddl) {
-      // Get the list of shadow tables in the information schema based on the prefix.
-      Set<String> existingShadowTables = getShadowTablesInDdl(ddl);
+    List<String> getDataTablesWithNoShadowTables(Ddl mainDdl, Ddl shadowTableDdl) {
+      // Get the list of shadow tables in the shadow table db based on the prefix
+      Set<String> existingShadowTables = getShadowTablesInDdl(shadowTableDdl);
 
-      List<String> allTables =
-          ddl.allTables().stream().map(t -> t.name()).collect(Collectors.toList());
-      /*
-       * Filter out the following from the list of all table names to get the list of
-       * data tables which do not have corresponding shadow tables:
-       * (1) Existing shadow tables
-       * (2) Data tables which have corresponding shadow tables.
-       */
-      return allTables.stream()
-          .filter(f -> !f.startsWith(shadowTablePrefix))
+      // Get all non-shadow tables from main DB
+      List<String> mainTables =
+          mainDdl.allTables().stream()
+              .map(t -> t.name())
+              .filter(f -> !f.startsWith(shadowTablePrefix))
+              .collect(Collectors.toList());
+
+      // Return tables that don't have corresponding shadow tables
+      return mainTables.stream()
           .filter(f -> !existingShadowTables.contains(shadowTablePrefix + f))
           .collect(Collectors.toList());
     }
@@ -212,6 +261,13 @@ public class ProcessInformationSchema extends PTransform<PBegin, PCollection<Ddl
     */
     public void setSpannerAccessor(SpannerAccessor spannerAccessor) {
       this.spannerAccessor = spannerAccessor;
+    }
+
+    /*
+      Added for the purpose of unit testing
+    */
+    public void setshadowTableSpannerAccessor(SpannerAccessor shadowTableSpannerAccessor) {
+      this.shadowTableSpannerAccessor = shadowTableSpannerAccessor;
     }
   }
 }

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SpannerStreamingWriteIntegrationTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SpannerStreamingWriteIntegrationTest.java
@@ -41,6 +41,7 @@ import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.json.JSONObject;
 import org.junit.After;
@@ -141,16 +142,34 @@ public class SpannerStreamingWriteIntegrationTest {
   private void constructAndRunPipeline(PCollection<FailsafeElement<String, String>> jsonRecords) {
     String shadowTablePrefix = "shadow";
     SpannerConfig spannerConfig = spannerServer.getSpannerConfig(testDb);
-    PCollection<Ddl> ddl =
+
+    PCollectionTuple ddlTuple =
         testPipeline.apply(
             "Process Information Schema",
-            new ProcessInformationSchema(spannerConfig, true, shadowTablePrefix, "oracle"));
-    PCollectionView<Ddl> ddlView = ddl.apply("Cloud Spanner DDL as view", View.asSingleton());
+            new ProcessInformationSchema(
+                spannerConfig, spannerConfig, true, shadowTablePrefix, "oracle"));
+    PCollectionView<Ddl> ddlView =
+        ddlTuple
+            .get(ProcessInformationSchema.MAIN_DDL_TAG)
+            .apply("Cloud Spanner Main DDL as view", View.asSingleton());
+
+    PCollectionView<Ddl> shadowTableDdlView =
+        ddlTuple
+            .get(ProcessInformationSchema.SHADOW_TABLE_DDL_TAG)
+            .apply("Cloud Spanner shadow tables DDL as view", View.asSingleton());
+
     Schema schema = new Schema();
 
     jsonRecords.apply(
         "Write events to Cloud Spanner",
-        new SpannerTransactionWriter(spannerConfig, ddlView, shadowTablePrefix, "oracle", true));
+        new SpannerTransactionWriter(
+            spannerConfig,
+            spannerConfig,
+            ddlView,
+            shadowTableDdlView,
+            shadowTablePrefix,
+            "oracle",
+            true));
 
     PipelineResult testResult = testPipeline.run();
     testResult.waitUntilFinish();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventContextFactoryTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventContextFactoryTest.java
@@ -46,6 +46,7 @@ public class ChangeEventContextFactoryTest {
         ChangeEventContextFactory.createChangeEventContext(
             getJsonNode(changeEvent.toString()),
             ddl,
+            ddl,
             "shadow_",
             DatastreamConstants.MYSQL_SOURCE_TYPE);
   }
@@ -63,6 +64,7 @@ public class ChangeEventContextFactoryTest {
         ChangeEventContextFactory.createChangeEventContext(
             getJsonNode(changeEvent.toString()),
             ddl,
+            ddl,
             "shadow_",
             DatastreamConstants.MYSQL_SOURCE_TYPE);
   }
@@ -77,6 +79,6 @@ public class ChangeEventContextFactoryTest {
     Ddl ddl = ChangeEventConvertorTest.getTestDdl();
     ChangeEventContext changeEventContext =
         ChangeEventContextFactory.createChangeEventContext(
-            getJsonNode(changeEvent.toString()), ddl, "shadow_", "xyz");
+            getJsonNode(changeEvent.toString()), ddl, ddl, "shadow_", "xyz");
   }
 }

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventSequenceFactoryTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventSequenceFactoryTest.java
@@ -197,7 +197,7 @@ public final class ChangeEventSequenceFactoryTest {
 
     ChangeEventSequence changeEventSequence =
         ChangeEventSequenceFactory.createChangeEventSequenceFromShadowTable(
-            mockTransaction, mockContext);
+            mockTransaction, mockContext, null, false);
 
     assertThat(changeEventSequence, instanceOf(MySqlChangeEventSequence.class));
     MySqlChangeEventSequence mysqlChangeEventSequence =
@@ -225,7 +225,7 @@ public final class ChangeEventSequenceFactoryTest {
 
     ChangeEventSequence changeEventSequence =
         ChangeEventSequenceFactory.createChangeEventSequenceFromShadowTable(
-            mockTransaction, mockContext);
+            mockTransaction, mockContext, null, false);
 
     assertThat(changeEventSequence, instanceOf(MySqlChangeEventSequence.class));
     MySqlChangeEventSequence mysqlChangeEventSequence =
@@ -249,7 +249,7 @@ public final class ChangeEventSequenceFactoryTest {
 
     ChangeEventSequence mysqlChangeEventSequence =
         ChangeEventSequenceFactory.createChangeEventSequenceFromShadowTable(
-            mockTransaction, mockContext);
+            mockTransaction, mockContext, null, false);
 
     assertNull(mysqlChangeEventSequence);
   }
@@ -321,7 +321,7 @@ public final class ChangeEventSequenceFactoryTest {
 
     ChangeEventSequence changeEventSequence =
         ChangeEventSequenceFactory.createChangeEventSequenceFromShadowTable(
-            mockTransaction, mockContext);
+            mockTransaction, mockContext, null, false);
 
     assertThat(changeEventSequence, instanceOf(OracleChangeEventSequence.class));
     OracleChangeEventSequence oracleChangeEventSequence =
@@ -347,7 +347,7 @@ public final class ChangeEventSequenceFactoryTest {
 
     ChangeEventSequence changeEventSequence =
         ChangeEventSequenceFactory.createChangeEventSequenceFromShadowTable(
-            mockTransaction, mockContext);
+            mockTransaction, mockContext, null, false);
 
     assertThat(changeEventSequence, instanceOf(OracleChangeEventSequence.class));
     OracleChangeEventSequence oracleChangeEventSequence =
@@ -370,7 +370,7 @@ public final class ChangeEventSequenceFactoryTest {
 
     ChangeEventSequence oracleChangeEventSequence =
         ChangeEventSequenceFactory.createChangeEventSequenceFromShadowTable(
-            mockTransaction, mockContext);
+            mockTransaction, mockContext, null, false);
 
     assertNull(oracleChangeEventSequence);
   }
@@ -446,7 +446,7 @@ public final class ChangeEventSequenceFactoryTest {
 
     ChangeEventSequence changeEventSequence =
         ChangeEventSequenceFactory.createChangeEventSequenceFromShadowTable(
-            mockTransaction, mockContext);
+            mockTransaction, mockContext, null, false);
 
     assertThat(changeEventSequence, instanceOf(PostgresChangeEventSequence.class));
     PostgresChangeEventSequence postgresChangeEventSequence =
@@ -474,7 +474,7 @@ public final class ChangeEventSequenceFactoryTest {
 
     ChangeEventSequence changeEventSequence =
         ChangeEventSequenceFactory.createChangeEventSequenceFromShadowTable(
-            mockTransaction, mockContext);
+            mockTransaction, mockContext, null, false);
 
     assertThat(changeEventSequence, instanceOf(PostgresChangeEventSequence.class));
     PostgresChangeEventSequence postgresChangeEventSequence =
@@ -498,7 +498,7 @@ public final class ChangeEventSequenceFactoryTest {
 
     ChangeEventSequence postgresChangeEventSequence =
         ChangeEventSequenceFactory.createChangeEventSequenceFromShadowTable(
-            mockTransaction, mockContext);
+            mockTransaction, mockContext, null, false);
 
     assertNull(postgresChangeEventSequence);
   }

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/MySqlChangeEventContextTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/MySqlChangeEventContextTest.java
@@ -63,6 +63,7 @@ public final class MySqlChangeEventContextTest {
         ChangeEventContextFactory.createChangeEventContext(
             getJsonNode(changeEvent.toString()),
             ddl,
+            ddl,
             "shadow_",
             DatastreamConstants.MYSQL_SOURCE_TYPE);
     Mutation shadowMutation = changeEventContext.getShadowTableMutation();
@@ -105,6 +106,7 @@ public final class MySqlChangeEventContextTest {
         ChangeEventContextFactory.createChangeEventContext(
             getJsonNode(changeEvent.toString()),
             ddl,
+            ddl,
             "shadow_",
             DatastreamConstants.MYSQL_SOURCE_TYPE);
     Mutation shadowMutation = changeEventContext.getShadowTableMutation();
@@ -144,6 +146,7 @@ public final class MySqlChangeEventContextTest {
     ChangeEventContext changeEventContext =
         ChangeEventContextFactory.createChangeEventContext(
             getJsonNode(changeEvent.toString()),
+            ddl,
             ddl,
             "shadow_",
             DatastreamConstants.MYSQL_SOURCE_TYPE);

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/MySqlChangeEventSequenceTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/MySqlChangeEventSequenceTest.java
@@ -15,8 +15,19 @@
  */
 package com.google.cloud.teleport.v2.templates.datastream;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.google.cloud.spanner.Key;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.TransactionContext;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import org.junit.Test;
 
 /** Unit tests for testing change event comparison logic in MySql database. */
@@ -67,5 +78,57 @@ public final class MySqlChangeEventSequenceTest {
 
     assertTrue(dumpEvent.compareTo(cdcEvent) < 0);
     assertTrue(cdcEvent.compareTo(dumpEvent) > 0);
+  }
+
+  @Test
+  public void testCreateFromShadowTableWithUseSqlStatements() throws Exception {
+    // Arrange
+    TransactionContext transactionContext = mock(TransactionContext.class);
+    String shadowTable = "shadow_table1";
+    Ddl shadowTableDdl =
+        Ddl.builder()
+            .createTable("shadow_table1")
+            .column("id")
+            .int64()
+            .endColumn()
+            .column("timestamp")
+            .int64()
+            .endColumn()
+            .column("log_file")
+            .string()
+            .endColumn()
+            .column("log_position")
+            .int64()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .build();
+    Key primaryKey = Key.of(1L);
+    boolean useSqlStatements = true;
+
+    // Mock the behavior of the transaction context
+    Struct mockRow = mock(Struct.class);
+    when(mockRow.getLong("id")).thenReturn(1L);
+    when(mockRow.getLong("timestamp")).thenReturn(1615159728L); // Updated to match new column
+    when(mockRow.getString("log_file")).thenReturn("file1.log");
+    when(mockRow.getLong("log_position")).thenReturn(2L); // Updated to match new column
+
+    ResultSet mockResultSet = mock(ResultSet.class);
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getCurrentRowAsStruct()).thenReturn(mockRow);
+    when(transactionContext.executeQuery(any(Statement.class))).thenReturn(mockResultSet);
+
+    // Act
+    MySqlChangeEventSequence result =
+        MySqlChangeEventSequence.createFromShadowTable(
+            transactionContext, shadowTable, shadowTableDdl, primaryKey, useSqlStatements);
+
+    // Assert
+    assertNotNull(result);
+    assertEquals((Object) 1615159728L, result.getTimestamp()); // Updated to match new column
+    assertEquals("file1.log", result.getLogFile());
+    assertEquals((Object) 2L, result.getLogPosition());
   }
 }

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/OracleChangeEventContextTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/OracleChangeEventContextTest.java
@@ -62,6 +62,7 @@ public final class OracleChangeEventContextTest {
         ChangeEventContextFactory.createChangeEventContext(
             getJsonNode(changeEvent.toString()),
             ddl,
+            ddl,
             "shadow_",
             DatastreamConstants.ORACLE_SOURCE_TYPE);
     Mutation shadowMutation = changeEventContext.getShadowTableMutation();
@@ -99,6 +100,7 @@ public final class OracleChangeEventContextTest {
         ChangeEventContextFactory.createChangeEventContext(
             getJsonNode(changeEvent.toString()),
             ddl,
+            ddl,
             "shadow_",
             DatastreamConstants.ORACLE_SOURCE_TYPE);
     Mutation shadowMutation = changeEventContext.getShadowTableMutation();
@@ -134,6 +136,7 @@ public final class OracleChangeEventContextTest {
     ChangeEventContext changeEventContext =
         ChangeEventContextFactory.createChangeEventContext(
             getJsonNode(changeEvent.toString()),
+            ddl,
             ddl,
             "shadow_",
             DatastreamConstants.ORACLE_SOURCE_TYPE);

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/OracleChangeEventSequenceTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/OracleChangeEventSequenceTest.java
@@ -15,8 +15,19 @@
  */
 package com.google.cloud.teleport.v2.templates.datastream;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.google.cloud.spanner.Key;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.TransactionContext;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import org.junit.Test;
 
 /** Unit tests for testing change event comparison logic in Oracle database. */
@@ -51,5 +62,52 @@ public final class OracleChangeEventSequenceTest {
 
     assertTrue(dumpEvent.compareTo(cdcEvent) < 0);
     assertTrue(cdcEvent.compareTo(dumpEvent) > 0);
+  }
+
+  @Test
+  public void testCreateFromShadowTableWithUseSqlStatements_Oracle() throws Exception {
+    // Arrange
+    TransactionContext transactionContext = mock(TransactionContext.class);
+    String shadowTable = "shadow_table_oracle";
+    Ddl shadowTableDdl =
+        Ddl.builder()
+            .createTable("shadow_table_oracle")
+            .column("id")
+            .int64()
+            .endColumn()
+            .column("timestamp")
+            .int64()
+            .endColumn()
+            .column("scn")
+            .int64()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .build();
+    Key primaryKey = Key.of(1L);
+    boolean useSqlStatements = true;
+
+    // Mock the behavior of the transaction context
+    Struct mockRow = mock(Struct.class);
+    when(mockRow.getLong("id")).thenReturn(1L);
+    when(mockRow.getLong("timestamp")).thenReturn(1615159728L);
+    when(mockRow.getLong("scn")).thenReturn(100L);
+
+    ResultSet mockResultSet = mock(ResultSet.class);
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getCurrentRowAsStruct()).thenReturn(mockRow);
+    when(transactionContext.executeQuery(any(Statement.class))).thenReturn(mockResultSet);
+
+    // Act
+    OracleChangeEventSequence result =
+        OracleChangeEventSequence.createFromShadowTable(
+            transactionContext, shadowTable, shadowTableDdl, primaryKey, useSqlStatements);
+
+    // Assert
+    assertNotNull(result);
+    assertEquals((Object) 1615159728L, result.getTimestamp());
+    assertEquals((Object) 100L, result.getSCN());
   }
 }

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/PostgresChangeEventContextTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/PostgresChangeEventContextTest.java
@@ -62,6 +62,7 @@ public final class PostgresChangeEventContextTest {
         ChangeEventContextFactory.createChangeEventContext(
             getJsonNode(changeEvent.toString()),
             ddl,
+            ddl,
             "shadow_",
             DatastreamConstants.POSTGRES_SOURCE_TYPE);
     Mutation shadowMutation = changeEventContext.getShadowTableMutation();
@@ -99,6 +100,7 @@ public final class PostgresChangeEventContextTest {
         ChangeEventContextFactory.createChangeEventContext(
             getJsonNode(changeEvent.toString()),
             ddl,
+            ddl,
             "shadow_",
             DatastreamConstants.POSTGRES_SOURCE_TYPE);
     Mutation shadowMutation = changeEventContext.getShadowTableMutation();
@@ -134,6 +136,7 @@ public final class PostgresChangeEventContextTest {
     ChangeEventContext changeEventContext =
         ChangeEventContextFactory.createChangeEventContext(
             getJsonNode(changeEvent.toString()),
+            ddl,
             ddl,
             "shadow_",
             DatastreamConstants.POSTGRES_SOURCE_TYPE);

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/ShadowTableReadUtilsTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/ShadowTableReadUtilsTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.datastream;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.cloud.ByteArray;
+import com.google.cloud.Date;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Key;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.Value;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ShadowTableReadUtilsTest {
+  private Ddl ddl;
+  private static final String SHADOW_TABLE = "shadow_test_table";
+  private static final List<String> READ_COLUMNS =
+      Arrays.asList("bool_field", "string_field", "version");
+
+  @Before
+  public void setUp() {
+    ddl =
+        Ddl.builder()
+            .createTable("shadow_test_table")
+            // Primary key columns - one of each type
+            .column("bool_field")
+            .bool()
+            .endColumn()
+            .column("int64_field")
+            .int64()
+            .endColumn()
+            .column("float64_field")
+            .float64()
+            .endColumn()
+            .column("numeric_field")
+            .numeric()
+            .endColumn()
+            .column("string_field")
+            .string()
+            .max()
+            .endColumn()
+            .column("bytes_field")
+            .bytes()
+            .max()
+            .endColumn() // BYTES
+            .column("timestamp_field")
+            .timestamp()
+            .endColumn() // TIMESTAMP
+            .column("date_field")
+            .date()
+            .endColumn() // DATE
+            // Additional non-PK columns
+            .column("version")
+            .int64()
+            .endColumn()
+            .column("extra_field")
+            .string()
+            .max()
+            .endColumn()
+            .primaryKey()
+            .asc("bool_field")
+            .asc("int64_field")
+            .asc("float64_field")
+            .asc("numeric_field")
+            .asc("string_field")
+            .asc("bytes_field")
+            .asc("timestamp_field")
+            .asc("date_field")
+            .end()
+            .endTable()
+            .build();
+  }
+
+  @Test
+  public void testGenerateShadowTableReadSQL_AllTypes() {
+    boolean boolValue = true;
+    long int64Value = 123L;
+    double float64Value = 123.45;
+    BigDecimal numericValue = new BigDecimal("123.456");
+    String stringValue = "test_string";
+    ByteArray bytesValue = ByteArray.copyFrom("test_bytes");
+    Timestamp timestampValue = Timestamp.ofTimeMicroseconds(1234567);
+    Date dateValue = Date.fromYearMonthDay(2024, 1, 1);
+
+    Key primaryKey =
+        Key.of(
+            boolValue, // BOOL
+            int64Value, // INT64
+            float64Value, // FLOAT64
+            numericValue, // NUMERIC
+            stringValue, // STRING
+            bytesValue, // BYTES
+            timestampValue, // TIMESTAMP
+            dateValue // DATE
+            );
+
+    Statement stmt =
+        ShadowTableReadUtils.generateShadowTableReadSQL(
+            SHADOW_TABLE, READ_COLUMNS, primaryKey, ddl);
+
+    String expectedSql =
+        "@{LOCK_SCANNED_RANGES=exclusive} SELECT bool_field, string_field, version "
+            + "FROM shadow_test_table WHERE bool_field=@bool_field AND int64_field=@int64_field AND "
+            + "float64_field=@float64_field AND numeric_field=@numeric_field AND "
+            + "string_field=@string_field AND bytes_field=@bytes_field AND "
+            + "timestamp_field=@timestamp_field AND date_field=@date_field";
+
+    assertEquals(expectedSql, stmt.getSql());
+
+    Map<String, Value> params = stmt.getParameters();
+
+    assertEquals(Value.bool(boolValue), params.get("bool_field"));
+    assertEquals(Value.int64(int64Value), params.get("int64_field"));
+    assertEquals(Value.float64(float64Value), params.get("float64_field"));
+    assertEquals(Value.numeric(numericValue), params.get("numeric_field"));
+    assertEquals(Value.string(stringValue), params.get("string_field"));
+    assertEquals(Value.bytes(bytesValue), params.get("bytes_field"));
+    assertEquals(Value.timestamp(timestampValue), params.get("timestamp_field"));
+    assertEquals(Value.date(dateValue), params.get("date_field"));
+  }
+}

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/spanner/ProcessInformationSchemaIntegrationTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/spanner/ProcessInformationSchemaIntegrationTest.java
@@ -112,7 +112,7 @@ public class ProcessInformationSchemaIntegrationTest {
     testPipeline.apply(
         "Process Information Schema",
         new ProcessInformationSchema(
-            sourceConfig, /* shouldCreateShadowTables= */ true, "shadow", "oracle"));
+            sourceConfig, sourceConfig, /* shouldCreateShadowTables= */ true, "shadow", "oracle"));
     PipelineResult testResult = testPipeline.run();
     testResult.waitUntilFinish();
     Ddl finalDdl = readDdl(testDb);
@@ -142,7 +142,7 @@ public class ProcessInformationSchemaIntegrationTest {
     testPipeline.apply(
         "Read Information Schema",
         new ProcessInformationSchema(
-            sourceConfig, /* shouldCreateShadowTables= */ false, "shadow", "oracle"));
+            sourceConfig, sourceConfig, /* shouldCreateShadowTables= */ false, "shadow", "oracle"));
     PipelineResult testResult = testPipeline.run();
     testResult.waitUntilFinish();
     Ddl finalDdl = readDdl(testDb);
@@ -176,7 +176,7 @@ public class ProcessInformationSchemaIntegrationTest {
     testPipeline.apply(
         "Process Information Schema",
         new ProcessInformationSchema(
-            sourceConfig, /* shouldCreateShadowTables= */ true, "shadow", "oracle"));
+            sourceConfig, sourceConfig, /* shouldCreateShadowTables= */ true, "shadow", "oracle"));
     PipelineResult testResult = testPipeline.run();
     testResult.waitUntilFinish();
     Ddl finalDdl = readDdl(testDb);

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/spanner/ProcessInformationSchemaTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/spanner/ProcessInformationSchemaTest.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
 import org.apache.beam.sdk.options.ValueProvider;
@@ -371,7 +372,11 @@ public class ProcessInformationSchemaTest {
     SpannerConfig spannerConfig = mock(SpannerConfig.class);
     ProcessInformationSchema.ProcessInformationSchemaFn processInformationSchema =
         new ProcessInformationSchema.ProcessInformationSchemaFn(
-            spannerConfig, /* shouldCreateShadowTables= */ true, "shadow_", "oracle");
+            spannerConfig,
+            spannerConfig,
+            /* shouldCreateShadowTables= */ true,
+            "shadow_",
+            "oracle");
     Set<String> shadowTables =
         processInformationSchema.getShadowTablesInDdl(getTestDdlWithGSqlDialect());
     assertThat(shadowTables, is(new HashSet<String>(Arrays.asList("shadow_Users"))));
@@ -382,10 +387,32 @@ public class ProcessInformationSchemaTest {
     SpannerConfig spannerConfig = mock(SpannerConfig.class);
     ProcessInformationSchema.ProcessInformationSchemaFn processInformationSchema =
         new ProcessInformationSchema.ProcessInformationSchemaFn(
-            spannerConfig, /* shouldCreateShadowTables= */ true, "shadow_", "oracle");
+            spannerConfig,
+            spannerConfig,
+            /* shouldCreateShadowTables= */ true,
+            "shadow_",
+            "oracle");
     List<String> dataTablesWithNoShadowTables =
-        processInformationSchema.getDataTablesWithNoShadowTables(getTestDdlWithGSqlDialect());
+        processInformationSchema.getDataTablesWithNoShadowTables(
+            getTestDdlWithGSqlDialect(), getTestDdlWithGSqlDialect());
     assertThat(dataTablesWithNoShadowTables, is(Arrays.asList("Users_interleaved")));
+  }
+
+  @Test
+  public void canListDataTablesWithNoShadowTables_separateDatabase() {
+    SpannerConfig spannerConfig = mock(SpannerConfig.class);
+    ProcessInformationSchema.ProcessInformationSchemaFn processInformationSchema =
+        new ProcessInformationSchema.ProcessInformationSchemaFn(
+            spannerConfig,
+            spannerConfig,
+            /* shouldCreateShadowTables= */ true,
+            "shadow_",
+            "oracle");
+
+    List<String> dataTablesWithNoShadowTables =
+        processInformationSchema.getDataTablesWithNoShadowTables(
+            getMiniMainDdl(), getMiniShadowDdl());
+    assertThat(dataTablesWithNoShadowTables, is(Arrays.asList("table2")));
   }
 
   @Test
@@ -397,9 +424,9 @@ public class ProcessInformationSchemaTest {
 
     ProcessInformationSchema.ProcessInformationSchemaFn processInformationSchema =
         new ProcessInformationSchema.ProcessInformationSchemaFn(
-            spannerConfig, /* shouldCreateShadowTables= */ true, "shadow_", "mysql");
+            spannerConfig, spannerConfig, /* shouldCreateShadowTables= */ true, "shadow_", "mysql");
     processInformationSchema.setDialect(Dialect.GOOGLE_STANDARD_SQL);
-    processInformationSchema.setSpannerAccessor(spannerAccessor);
+    processInformationSchema.setshadowTableSpannerAccessor(spannerAccessor);
 
     // Mock method calls
     when(databaseAdminClient.updateDatabaseDdl(anyString(), anyString(), any(), any()))
@@ -411,7 +438,8 @@ public class ProcessInformationSchemaTest {
     when(spannerConfig.getInstanceId()).thenReturn(sampleValueProvider);
     when(spannerConfig.getDatabaseId()).thenReturn(sampleValueProvider);
 
-    processInformationSchema.createShadowTablesInSpanner(getTestDdlWithGSqlDialect());
+    processInformationSchema.createShadowTablesInSpanner(
+        getTestDdlWithGSqlDialect(), getTestDdlWithGSqlDialect());
 
     List<String> createShadowTableStatements =
         Collections.singletonList(
@@ -436,5 +464,207 @@ public class ProcessInformationSchemaTest {
         .updateDatabaseDdl(
             eq("sample-value"), eq("sample-value"), eq(createShadowTableStatements), eq(null));
     verify(operationFuture, times(1)).get(anyLong(), any());
+  }
+
+  @Test
+  public void canCreateShadowTablesInSpanner_separateDb() throws Exception {
+    SpannerConfig spannerConfig = mock(SpannerConfig.class);
+    SpannerConfig shadowSpannerConfig = mock(SpannerConfig.class);
+    SpannerAccessor shadowSpannerAccessor = mock(SpannerAccessor.class);
+    DatabaseAdminClient databaseAdminClient = mock(DatabaseAdminClient.class);
+    OperationFuture<Void, UpdateDatabaseDdlMetadata> operationFuture = mock(OperationFuture.class);
+
+    ProcessInformationSchema.ProcessInformationSchemaFn processInformationSchema =
+        new ProcessInformationSchema.ProcessInformationSchemaFn(
+            spannerConfig,
+            shadowSpannerConfig,
+            /* shouldCreateShadowTables= */ true,
+            "shadow_",
+            "mysql");
+    processInformationSchema.setDialect(Dialect.GOOGLE_STANDARD_SQL);
+    processInformationSchema.setshadowTableSpannerAccessor(shadowSpannerAccessor);
+
+    // Mock method calls
+    when(databaseAdminClient.updateDatabaseDdl(anyString(), anyString(), any(), any()))
+        .thenReturn(operationFuture);
+    when(shadowSpannerAccessor.getDatabaseAdminClient()).thenReturn(databaseAdminClient);
+    when(operationFuture.get(anyLong(), any())).thenReturn(null);
+    ValueProvider<String> sampleValueProvider =
+        ValueProvider.StaticValueProvider.of("sample-value");
+    when(shadowSpannerConfig.getInstanceId()).thenReturn(sampleValueProvider);
+    when(shadowSpannerConfig.getDatabaseId()).thenReturn(sampleValueProvider);
+
+    processInformationSchema.createShadowTablesInSpanner(getMiniMainDdl(), getMiniShadowDdl());
+
+    List<String> createShadowTableStatements =
+        Collections.singletonList(
+            "CREATE TABLE `shadow_table2` (\n"
+                + "\t`id`                                    INT64,\n"
+                + "\t`timestamp`                             INT64,\n"
+                + "\t`log_file`                              STRING(MAX),\n"
+                + "\t`log_position`                          INT64,\n"
+                + ") PRIMARY KEY (`id` ASC)");
+    // Verify method calls
+    verify(databaseAdminClient, times(1))
+        .updateDatabaseDdl(
+            eq("sample-value"), eq("sample-value"), eq(createShadowTableStatements), eq(null));
+    verify(operationFuture, times(1)).get(anyLong(), any());
+  }
+
+  private Ddl getMiniShadowDdl() {
+    // Create shadow DDL with 1 shadow table
+    return Ddl.builder()
+        .createTable("shadow_table1")
+        .column("id")
+        .int64()
+        .endColumn()
+        .primaryKey()
+        .asc("id")
+        .end()
+        .endTable()
+        .build();
+  }
+
+  private Ddl getMiniMainDdl() {
+    // Create main DDL with 2 tables
+    return Ddl.builder()
+        .createTable("table1")
+        .column("id")
+        .int64()
+        .endColumn()
+        .primaryKey()
+        .asc("id")
+        .end()
+        .endTable()
+        .createTable("table2")
+        .column("id")
+        .int64()
+        .endColumn()
+        .primaryKey()
+        .asc("id")
+        .end()
+        .endTable()
+        .build();
+  }
+
+  @Test
+  public void testCleanupDdl_sameDatabaseScenario() {
+    SpannerConfig spannerConfig = mock(SpannerConfig.class);
+    ProcessInformationSchema.ProcessInformationSchemaFn processInformationSchema =
+        new ProcessInformationSchema.ProcessInformationSchemaFn(
+            spannerConfig, spannerConfig, true, "shadow_", "mysql");
+    processInformationSchema.setDialect(Dialect.GOOGLE_STANDARD_SQL);
+
+    // Create test DDL with both main and shadow tables
+    Ddl testDdl =
+        Ddl.builder()
+            .createTable("users")
+            .column("id")
+            .int64()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .createTable("customers")
+            .column("id")
+            .int64()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .createTable("shadow_users")
+            .column("id")
+            .int64()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .createTable("shadow_customers")
+            .column("id")
+            .int64()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .build();
+
+    // Test cleanup for main DDL (should only keep non-shadow tables)
+    Ddl cleanedMainDdl = processInformationSchema.cleanupDdl(testDdl, "shadow_", true);
+    assertThat(
+        cleanedMainDdl.allTables().stream().map(t -> t.name()).collect(Collectors.toSet()),
+        is(new HashSet<>(Arrays.asList("users", "customers"))));
+
+    // Test cleanup for shadow DDL (should only keep shadow tables)
+    Ddl cleanedShadowDdl = processInformationSchema.cleanupDdl(testDdl, "shadow_", false);
+    assertThat(
+        cleanedShadowDdl.allTables().stream().map(t -> t.name()).collect(Collectors.toSet()),
+        is(new HashSet<>(Arrays.asList("shadow_users", "shadow_customers"))));
+  }
+
+  @Test
+  public void testCleanupDdl_differentDatabaseScenario() {
+    SpannerConfig spannerConfig = mock(SpannerConfig.class);
+    ProcessInformationSchema.ProcessInformationSchemaFn processInformationSchema =
+        new ProcessInformationSchema.ProcessInformationSchemaFn(
+            spannerConfig, spannerConfig, true, "shadow_", "mysql");
+    processInformationSchema.setDialect(Dialect.GOOGLE_STANDARD_SQL);
+
+    // Create main DDL with an extra shadow table that shouldn't be there
+    Ddl mainDdl =
+        Ddl.builder()
+            .createTable("users")
+            .column("id")
+            .int64()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .createTable("shadow_unexpected")
+            .column("id")
+            .int64()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .build();
+
+    // Create shadow DDL with an extra non-shadow table that shouldn't be there
+    Ddl shadowDdl =
+        Ddl.builder()
+            .createTable("shadow_users")
+            .column("id")
+            .int64()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .createTable("unexpected_table")
+            .column("id")
+            .int64()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .build();
+
+    // Test cleanup for main DDL (should remove the unexpected shadow table)
+    Ddl cleanedMainDdl = processInformationSchema.cleanupDdl(mainDdl, "shadow_", true);
+    assertThat(
+        cleanedMainDdl.allTables().stream().map(t -> t.name()).collect(Collectors.toSet()),
+        is(new HashSet<>(Collections.singletonList("users"))));
+
+    // Test cleanup for shadow DDL (should remove the unexpected non-shadow table)
+    Ddl cleanedShadowDdl = processInformationSchema.cleanupDdl(shadowDdl, "shadow_", false);
+    assertThat(
+        cleanedShadowDdl.allTables().stream().map(t -> t.name()).collect(Collectors.toSet()),
+        is(new HashSet<>(Collections.singletonList("shadow_users"))));
   }
 }


### PR DESCRIPTION
This change introduces support for shadow table in a separate database. The code changes aim to minimise the existing live flow changes as much as possible.

Summary of changes:

1. Introduced 2 new flags `shadowTableSpannerInstanceId` and `shadowTableSpanneDatabaseId`: if both are provided we use a separate shadow table database, if neither are provided, we use the target database as the shadow table db as per the existing flow.
2. ProcessInformationSchema: Earlier this used to return a single ddl object containing both main and shadow tables in a single ddl object. It now separates main table and shadow tables into 2 separate ddl objects that are passed around in the codebase.
3. TransactionWriterDoFn now uses the cross db transaction only if shadow table is in a separate db.
4. Shadow Table Sequence reader reads with an exclusive lock in case of a cross db transaction. This requires usin gsql statements for querying. For normal flows, we use the read api as is. 

Manual Tests done:

- INSERT/UPDATE/DELETE on table with primary key consisting of all datatypes possible (JSON we are not supporting in the interim soln).
- UPDATE primary key itself which generates DELETE and INSERT event by Datastream which is also handled.
- Unspecified shadowtable instance and db params, defaults to main db for shadow table.

Pending:
- Integration Tests: these will be taken in a follow up PR