### PR TITLE
Set maven version requirement to 3.6.3

### DIFF
--- a/plugins/templates-maven-plugin/pom.xml
+++ b/plugins/templates-maven-plugin/pom.xml
@@ -38,7 +38,7 @@
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <maven.version>3.9.9</maven.version>
+    <maven.version>3.6.3</maven.version>
     <dataflow.api.version>0.7.6</dataflow.api.version>
     <mojo.executor.version>2.4.0</mojo.executor.version>
     <maven-plugin.version>3.15.1</maven-plugin.version>


### PR DESCRIPTION
In alignment with https://github.com/apache/maven-plugin-tools/blob/maven-plugin-tools-3.15.1/maven-plugin-plugin/pom.xml#L38

as we bumped maven-plugin plugin to 3.15.1 in #2050