### PR TITLE
Fix the additional sequence kind options

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/spanner/AvroSchemaToDdlConverter.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/AvroSchemaToDdlConverter.java
@@ -469,7 +469,7 @@ public class AvroSchemaToDdlConverter {
     ImmutableList.Builder<String> sequenceOptions = ImmutableList.builder();
     for (int i = 0; schema.getProp(SPANNER_SEQUENCE_OPTION + i) != null; i++) {
       String prop = schema.getProp(SPANNER_SEQUENCE_OPTION + i);
-      if (prop.equals("sequence_kind=default")) {
+      if (prop.equals("sequence_kind=\"default\"")) {
         // Specify no sequence kind by using the default_sequence_kind database option.
         continue;
       }

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/AvroSchemaToDdlConverterTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/AvroSchemaToDdlConverterTest.java
@@ -988,7 +988,7 @@ public class AvroSchemaToDdlConverterTest {
             + "  \"namespace\" : \"spannertest\","
             + "  \"googleStorage\" : \"CloudSpanner\","
             + "  \"googleFormatVersion\" : \"booleans\","
-            + "  \"sequenceOption_0\" : \"sequence_kind=default\""
+            + "  \"sequenceOption_0\" : \"sequence_kind=\\\"default\\\"\""
             + "}";
     Collection<Schema> schemas = new ArrayList<>();
     Schema.Parser parser = new Schema.Parser();


### PR DESCRIPTION
This fixes two issues: 

- The sequence option `default` is not added correctly when exporting sequences.
- We should use `tableName` instead of `tableSchema` when calling `GET_TABLE_COLUMN_IDENTITY_STATE`.
