### PR TITLE
fix: revamp Neo4j kernel version sniffing

### DIFF
--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilities.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilities.java
@@ -129,18 +129,19 @@ public final class Neo4jCapabilities implements Serializable {
         } else if (minor == -1) {
           minor = parseMinor(buffer);
         } else {
-          // too many dots
           throw invalidVersion(version);
         }
         buffer = "";
       }
-      if (!buffer.isEmpty()) {
-        if (minor == -1) {
-          minor = parseMinor(buffer);
-        } else {
-          patch = Integer.parseInt(buffer, 10);
-        }
+      if (buffer.isEmpty()) {
+        throw invalidVersion(version);
       }
+      if (minor == -1) {
+        minor = parseMinor(buffer);
+      } else {
+        patch = Integer.parseInt(buffer, 10);
+      }
+
       if (major == -1 || minor == -1) {
         throw invalidVersion(version);
       }

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilities.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilities.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.neo4j.database;
 
 import java.io.Serializable;
 import java.util.Locale;
+import java.util.Objects;
 
 public final class Neo4jCapabilities implements Serializable {
 
@@ -30,44 +31,44 @@ public final class Neo4jCapabilities implements Serializable {
     this.versionString = String.format("Neo4j %s %s", version, edition);
   }
 
-  public boolean hasVectorIndexes() {
-    return version == Neo4jVersion.V5;
+  public Neo4jEdition edition() {
+    return edition;
   }
 
-  public boolean hasConstraints() {
-    return edition != Neo4jEdition.COMMUNITY;
+  public boolean hasVectorIndexes() {
+    return edition != Neo4jEdition.COMMUNITY && version.compareTo(Neo4jVersion.V5_13_0) >= 0;
   }
 
   public boolean hasNodeTypeConstraints() {
-    return hasConstraints() && version == Neo4jVersion.V5;
-  }
-
-  public boolean hasNodeKeyConstraints() {
-    return hasConstraints();
-  }
-
-  public boolean hasNodeUniqueConstraints() {
-    return hasConstraints();
+    return edition != Neo4jEdition.COMMUNITY && version.compareTo(Neo4jVersion.V5_11_0) >= 0;
   }
 
   public boolean hasRelationshipTypeConstraints() {
-    return hasConstraints() && version == Neo4jVersion.V5;
+    return edition != Neo4jEdition.COMMUNITY && version.compareTo(Neo4jVersion.V5_11_0) >= 0;
+  }
+
+  public boolean hasNodeKeyConstraints() {
+    return edition != Neo4jEdition.COMMUNITY;
   }
 
   public boolean hasRelationshipKeyConstraints() {
-    return hasConstraints() && version == Neo4jVersion.V5;
+    return edition != Neo4jEdition.COMMUNITY && version.compareTo(Neo4jVersion.V5_7_0) >= 0;
+  }
+
+  public boolean hasNodeUniqueConstraints() {
+    return true;
   }
 
   public boolean hasRelationshipUniqueConstraints() {
-    return hasRelationshipKeyConstraints();
+    return version.compareTo(Neo4jVersion.V5_7_0) >= 0;
   }
 
   public boolean hasNodeExistenceConstraints() {
-    return hasConstraints();
+    return edition != Neo4jEdition.COMMUNITY;
   }
 
   public boolean hasRelationshipExistenceConstraints() {
-    return hasConstraints();
+    return edition != Neo4jEdition.COMMUNITY;
   }
 
   public boolean hasCreateOrReplaceDatabase() {
@@ -93,19 +94,104 @@ public final class Neo4jCapabilities implements Serializable {
     }
   }
 
-  enum Neo4jVersion {
-    UNKNOWN,
-    V4_4,
-    V5;
+  static class Neo4jVersion implements Comparable<Neo4jVersion> {
+
+    public static final Neo4jVersion V5_7_0 = new Neo4jVersion(5, 7, 0);
+    public static final Neo4jVersion V5_11_0 = new Neo4jVersion(5, 11, 0);
+    public static final Neo4jVersion V5_13_0 = new Neo4jVersion(5, 13, 0);
+
+    private final int major;
+    private final int minor;
+    private final int patch;
+
+    Neo4jVersion(int major, int minor) {
+      this(major, minor, Integer.MAX_VALUE);
+    }
+
+    Neo4jVersion(int major, int minor, int patch) {
+      this.major = major;
+      this.minor = minor;
+      this.patch = patch;
+    }
 
     public static Neo4jVersion of(String version) {
-      if (version.startsWith("4.4")) {
-        return V4_4;
-      } else if (version.startsWith("5.")) {
-        return V5;
-      } else {
-        return UNKNOWN;
+      int major = -1;
+      int minor = -1;
+      int patch = -1;
+      String buffer = "";
+      for (char c : version.toCharArray()) {
+        if (c != '.') {
+          buffer += c;
+          continue;
+        }
+        if (major == -1) {
+          major = Integer.parseInt(buffer, 10);
+        } else if (minor == -1) {
+          minor = parseMinor(buffer);
+        } else {
+          // too many dots
+          throw invalidVersion(version);
+        }
+        buffer = "";
       }
+      if (!buffer.isEmpty()) {
+        if (minor == -1) {
+          minor = parseMinor(buffer);
+        } else {
+          patch = Integer.parseInt(buffer, 10);
+        }
+      }
+      if (major == -1 || minor == -1) {
+        throw invalidVersion(version);
+      }
+      if (patch == -1) {
+        return new Neo4jVersion(major, minor);
+      }
+      return new Neo4jVersion(major, minor, patch);
+    }
+
+    @Override
+    public int compareTo(Neo4jVersion other) {
+      if (major != other.major) {
+        return signum(major - other.major);
+      }
+      if (minor != other.minor) {
+        return signum(minor - other.minor);
+      }
+      return signum(patch - other.patch);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof Neo4jVersion that)) {
+        return false;
+      }
+      return major == that.major && minor == that.minor && patch == that.patch;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(major, minor, patch);
+    }
+
+    @Override
+    public String toString() {
+      if (patch == Integer.MAX_VALUE) {
+        return String.format("%d.%d", major, minor);
+      }
+      return String.format("%d.%d.%d", major, minor, patch);
+    }
+
+    private static int parseMinor(String buffer) {
+      return Integer.parseInt(buffer.replace("-aura", ""), 10);
+    }
+
+    private static int signum(int result) {
+      return (int) Math.signum(result);
+    }
+
+    private static IllegalArgumentException invalidVersion(String version) {
+      return new IllegalArgumentException(String.format("Invalid Neo4j version: %s", version));
     }
   }
 }

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnection.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnection.java
@@ -141,23 +141,21 @@ public class Neo4jConnection implements AutoCloseable, Serializable {
 
   private void dropSchema(Neo4jCapabilities capabilities) {
     try (var session = getSession()) {
-      if (capabilities.hasConstraints()) {
-        LOG.info("Dropping constraints");
-        var constraints =
-            session
-                .run(
-                    "SHOW CONSTRAINTS YIELD name",
-                    Map.of(),
-                    databaseResetMetadata("show-constraints"))
-                .list(r -> r.get(0).asString());
-        for (var constraint : constraints) {
-          LOG.info("Dropping constraint {}", constraint);
+      LOG.info("Dropping constraints");
+      var constraints =
+          session
+              .run(
+                  "SHOW CONSTRAINTS YIELD name",
+                  Map.of(),
+                  databaseResetMetadata("show-constraints"))
+              .list(r -> r.get(0).asString());
+      for (var constraint : constraints) {
+        LOG.info("Dropping constraint {}", constraint);
 
-          runAutocommit(
-              String.format("DROP CONSTRAINT %s", CypherPatterns.sanitize(constraint)),
-              Map.of(),
-              databaseResetMetadata("drop-constraint"));
-        }
+        runAutocommit(
+            String.format("DROP CONSTRAINT %s", CypherPatterns.sanitize(constraint)),
+            Map.of(),
+            databaseResetMetadata("drop-constraint"));
       }
 
       LOG.info("Dropping indexes");

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/CypherGeneratorTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/CypherGeneratorTest.java
@@ -419,6 +419,7 @@ public class CypherGeneratorTest {
     assertThat(statements)
         .isEqualTo(
             Set.of(
+                "CREATE CONSTRAINT `unique-constraint-1` IF NOT EXISTS FOR (n:`Placeholder`) REQUIRE (n.`prop3`) IS UNIQUE",
                 "CREATE INDEX `range-index-1` IF NOT EXISTS FOR (n:`Placeholder`) ON (n.`prop5`)",
                 "CREATE TEXT INDEX `text-index-1` IF NOT EXISTS FOR (n:`Placeholder`) ON (n.`prop6`) OPTIONS {`indexProvider`: 'text-2.0'}",
                 "CREATE POINT INDEX `point-index-1` IF NOT EXISTS FOR (n:`Placeholder`) ON (n.`prop7`) OPTIONS {`indexConfig`: {`spatial.cartesian.min`: [-100.0,100.0]}}",

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilitiesTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilitiesTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.neo4j.database;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.teleport.v2.neo4j.database.Neo4jCapabilities.Neo4jVersion;
+import org.junit.Test;
+
+public class Neo4jCapabilitiesTest {
+
+  @Test
+  public void parses_kernel_version() {
+    assertThat(Neo4jVersion.of("4.4")).isEqualTo(new Neo4jVersion(4, 4));
+    assertThat(Neo4jVersion.of("4.4-aura")).isEqualTo(new Neo4jVersion(4, 4));
+    assertThat(Neo4jVersion.of("4.4.13")).isEqualTo(new Neo4jVersion(4, 4, 13));
+    assertThat(Neo4jVersion.of("2025.01")).isEqualTo(new Neo4jVersion(2025, 1));
+    assertThat(Neo4jVersion.of("2025.01-aura")).isEqualTo(new Neo4jVersion(2025, 1));
+  }
+
+  @Test
+  public void rejects_invalid_kernel_version() {
+    assertThrows(IllegalArgumentException.class, () -> Neo4jVersion.of("5"));
+    assertThrows(IllegalArgumentException.class, () -> Neo4jVersion.of("5.5.3.1"));
+    assertThrows(NumberFormatException.class, () -> Neo4jVersion.of(".."));
+    assertThrows(NumberFormatException.class, () -> Neo4jVersion.of("5..3"));
+    assertThrows(NumberFormatException.class, () -> Neo4jVersion.of(".2025.6"));
+  }
+}

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilitiesTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilitiesTest.java
@@ -29,11 +29,13 @@ public class Neo4jCapabilitiesTest {
     assertThat(Neo4jVersion.of("4.4-aura")).isEqualTo(new Neo4jVersion(4, 4));
     assertThat(Neo4jVersion.of("4.4.13")).isEqualTo(new Neo4jVersion(4, 4, 13));
     assertThat(Neo4jVersion.of("2025.01")).isEqualTo(new Neo4jVersion(2025, 1));
+    assertThat(Neo4jVersion.of("2025.01.0")).isEqualTo(new Neo4jVersion(2025, 1, 0));
     assertThat(Neo4jVersion.of("2025.01-aura")).isEqualTo(new Neo4jVersion(2025, 1));
   }
 
   @Test
   public void rejects_invalid_kernel_version() {
+    assertThrows(IllegalArgumentException.class, () -> Neo4jVersion.of(""));
     assertThrows(IllegalArgumentException.class, () -> Neo4jVersion.of("5"));
     assertThrows(IllegalArgumentException.class, () -> Neo4jVersion.of("5.5.3.1"));
     assertThrows(NumberFormatException.class, () -> Neo4jVersion.of(".."));

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilitiesTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilitiesTest.java
@@ -37,6 +37,8 @@ public class Neo4jCapabilitiesTest {
   public void rejects_invalid_kernel_version() {
     assertThrows(IllegalArgumentException.class, () -> Neo4jVersion.of(""));
     assertThrows(IllegalArgumentException.class, () -> Neo4jVersion.of("5"));
+    assertThrows(IllegalArgumentException.class, () -> Neo4jVersion.of("5."));
+    assertThrows(IllegalArgumentException.class, () -> Neo4jVersion.of("2025.1."));
     assertThrows(IllegalArgumentException.class, () -> Neo4jVersion.of("5.5.3.1"));
     assertThrows(NumberFormatException.class, () -> Neo4jVersion.of(".."));
     assertThrows(NumberFormatException.class, () -> Neo4jVersion.of("5..3"));

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnectionTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnectionTest.java
@@ -117,6 +117,7 @@ public class Neo4jConnectionTest {
     inOrder
         .verify(session)
         .run(eq("MATCH (n) CALL { WITH n DETACH DELETE n } IN TRANSACTIONS"), eq(Map.of()), any());
+    inOrder.verify(session).run(eq("SHOW CONSTRAINTS YIELD name"), eq(Map.of()), any());
     inOrder
         .verify(session)
         .run(
@@ -125,8 +126,6 @@ public class Neo4jConnectionTest {
             any());
     inOrder.verify(session).run(eq("DROP INDEX `c`"), eq(Map.of()), any());
     inOrder.verify(session).run(eq("DROP INDEX `d`"), eq(Map.of()), any());
-
-    verify(session, never()).run(contains("CONSTRAINT"), anyMap(), any());
   }
 
   @Test


### PR DESCRIPTION
Neo4j switches to calver-versioning very soon, so trying to exactly match a version is not gonna work properly anymore.

This commit changes the version parsing logic, to make versions comparable (e.g.: Version(2025,1) > Version(5, 26, 0)).

This also fixes a bunch of inaccuracies of some of the capability checks.