### PR TITLE
[Infra] Do not generate shaded jar for common modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <extra.enforcer.rules.version>1.8.0</extra.enforcer.rules.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <maven-javadoc-plugin.version>3.0.0-M1</maven-javadoc-plugin.version>
-    <maven-shade-plugin.version>3.0.0</maven-shade-plugin.version>
+    <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
     <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
     <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
     <jacoco.version>0.8.8</jacoco.version>

--- a/v2/bigtable-common/pom.xml
+++ b/v2/bigtable-common/pom.xml
@@ -27,6 +27,7 @@
 
     <properties>
         <bigtable.version>2.11.0</bigtable.version>
+        <skipShade>true</skipShade>
     </properties>
 
     <dependencies>

--- a/v2/cdc-parent/cdc-agg/pom.xml
+++ b/v2/cdc-parent/cdc-agg/pom.xml
@@ -23,6 +23,9 @@
     <version>1.0-SNAPSHOT</version>
   </parent>
   <artifactId>cdc-agg</artifactId>
+  <properties>
+    <skipShade>true</skipShade>
+  </properties>
   <inceptionYear>2019</inceptionYear>
   <licenses>
     <license>

--- a/v2/cdc-parent/cdc-common/pom.xml
+++ b/v2/cdc-parent/cdc-common/pom.xml
@@ -23,6 +23,9 @@
     <version>1.0-SNAPSHOT</version>
   </parent>
   <artifactId>cdc-common</artifactId>
+  <properties>
+    <skipShade>true</skipShade>
+  </properties>
   <packaging>jar</packaging>
   <inceptionYear>2019</inceptionYear>
   <licenses>

--- a/v2/common/pom.xml
+++ b/v2/common/pom.xml
@@ -31,6 +31,7 @@
         <commons-text.version>1.10.0</commons-text.version>
         <nashorn.version>15.4</nashorn.version>
         <truth-proto-extension.version>1.0.1</truth-proto-extension.version>
+        <skipShade>true</skipShade>
     </properties>
 
     <dependencies>

--- a/v2/datastream-common/pom.xml
+++ b/v2/datastream-common/pom.xml
@@ -26,6 +26,7 @@
     <artifactId>datastream-common</artifactId>
 
     <properties>
+        <skipShade>true</skipShade>
     </properties>
 
     <dependencies>

--- a/v2/jdbc-common/pom.xml
+++ b/v2/jdbc-common/pom.xml
@@ -27,6 +27,9 @@
   </parent>
 
   <artifactId>jdbc-common</artifactId>
+  <properties>
+    <skipShade>true</skipShade>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/v2/kafka-common/pom.xml
+++ b/v2/kafka-common/pom.xml
@@ -22,6 +22,9 @@
     <version>1.0-SNAPSHOT</version>
   </parent>
   <artifactId>kafka-common</artifactId>
+  <properties>
+    <skipShade>true</skipShade>
+  </properties>
   <modelVersion>4.0.0</modelVersion>
 
   <dependencies>

--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -490,13 +490,13 @@
                                     <goal>shade</goal>
                                 </goals>
                                 <configuration>
+                                    <skip>${skipShade}</skip>
                                     <extraDirectories>
                                         <paths>
                                             <path>${project.build.directory}/extra_libs</path>
                                         </paths>
                                     </extraDirectories>
                                     <createDependencyReducedPom>false</createDependencyReducedPom>
-                                    <shadeTestJar>true</shadeTestJar>
                                     <artifactSet>
                                         <excludes>
                                             <exclude>org.conscrypt:conscrypt-openjdk-uber</exclude>

--- a/v2/spanner-custom-shard/pom.xml
+++ b/v2/spanner-custom-shard/pom.xml
@@ -26,6 +26,9 @@
     </parent>
 
     <artifactId>spanner-custom-shard</artifactId>
+    <properties>
+        <skipShade>true</skipShade>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>com.google.cloud.teleport.v2</groupId>

--- a/v2/spanner-migrations-sdk/pom.xml
+++ b/v2/spanner-migrations-sdk/pom.xml
@@ -26,6 +26,9 @@
     </parent>
 
     <artifactId>spanner-migrations-sdk</artifactId>
+    <properties>
+        <skipShade>true</skipShade>
+    </properties>
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Fix #2158

skipped shaded jar for common modules that do not contain any `@Template`