### PR TITLE
Cassandra Bulk - List and Set - Avro Mapping.

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/mappings/CassandraMappings.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/mappings/CassandraMappings.java
@@ -17,11 +17,13 @@ package com.google.cloud.teleport.v2.source.reader.io.cassandra.mappings;
 
 import com.google.auto.value.AutoValue;
 import com.google.cloud.teleport.v2.source.reader.io.cassandra.rowmapper.CassandraFieldMapper;
+import com.google.cloud.teleport.v2.source.reader.io.cassandra.rowmapper.CassandraRowValueArrayMapper;
 import com.google.cloud.teleport.v2.source.reader.io.cassandra.rowmapper.CassandraRowValueExtractor;
 import com.google.cloud.teleport.v2.source.reader.io.cassandra.rowmapper.CassandraRowValueMapper;
 import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedTypeMapping;
 import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified.UnifiedMappingProvider;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
 
 /** Represent Unified type mapping, value extractor and value mappings for Cassandra. */
 @AutoValue
@@ -40,18 +42,70 @@ public abstract class CassandraMappings {
 
     abstract ImmutableMap.Builder<String, CassandraFieldMapper<?>> fieldMappingBuilder();
 
+    /**
+     * Maintain mappings for a given type, as primitive as well as part of collections.
+     *
+     * @param cassandraType - name of the cassandra type, as discovered by the schema discovery.
+     * @param type - Unified mapping type.
+     * @param rowValueExtractor - {@link CassandraRowValueExtractor} to extract value from {@link
+     *     com.datastax.driver.core.Row Cassandra Row}
+     * @param rowValueMapper - {@link CassandraRowValueMapper} to map value to {@link
+     *     com.google.cloud.teleport.v2.source.reader.io.row.SourceRow}
+     * @param typeClass - Class of the extracted value. Generally return type of the
+     *     rowValueExtractor.
+     * @return Builder
+     */
     public <T> Builder put(
         String cassandraType,
         UnifiedMappingProvider.Type type,
         CassandraRowValueExtractor<T> rowValueExtractor,
-        CassandraRowValueMapper<T> rowValueMapper) {
+        CassandraRowValueMapper<T> rowValueMapper,
+        Class<T> typeClass) {
       this.typeMappingBuilder()
           .put(cassandraType.toUpperCase(), UnifiedMappingProvider.getMapping(type));
       this.fieldMappingBuilder()
           .put(
               cassandraType.toUpperCase(),
               CassandraFieldMapper.create(rowValueExtractor, rowValueMapper));
+      if (!type.equals(UnifiedMappingProvider.Type.UNSUPPORTED)) {
+        putList(cassandraType, type, rowValueExtractor, rowValueMapper, typeClass);
+        putSet(cassandraType, type, rowValueExtractor, rowValueMapper, typeClass);
+      }
       return this;
+    }
+
+    private <T> void putList(
+        String cassandraType,
+        UnifiedMappingProvider.Type type,
+        CassandraRowValueExtractor<T> rowValueExtractor,
+        CassandraRowValueMapper<T> rowValueMapper,
+        Class<T> typeClass) {
+      String listType = "LIST<" + cassandraType.toUpperCase() + ">";
+      this.typeMappingBuilder().put(listType, UnifiedMappingProvider.getArrayMapping(type));
+      TypeToken<T> typeToken = TypeToken.of(typeClass);
+      this.fieldMappingBuilder()
+          .put(
+              listType,
+              CassandraFieldMapper.create(
+                  (row, name) -> row.getList(name, typeToken),
+                  CassandraRowValueArrayMapper.create(rowValueMapper)));
+    }
+
+    private <T> void putSet(
+        String cassandraType,
+        UnifiedMappingProvider.Type type,
+        CassandraRowValueExtractor<T> rowValueExtractor,
+        CassandraRowValueMapper<T> rowValueMapper,
+        Class<T> typeClass) {
+      String setType = "SET<" + cassandraType.toUpperCase() + ">";
+      TypeToken<T> typeToken = TypeToken.of(typeClass);
+      this.typeMappingBuilder().put(setType, UnifiedMappingProvider.getArrayMapping(type));
+      this.fieldMappingBuilder()
+          .put(
+              setType,
+              CassandraFieldMapper.create(
+                  (row, name) -> row.getSet(name, typeToken),
+                  CassandraRowValueArrayMapper.create(rowValueMapper)));
     }
 
     public abstract CassandraMappings build();

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/mappings/CassandraMappingsProvider.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/mappings/CassandraMappingsProvider.java
@@ -26,8 +26,12 @@ import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedT
 import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified.CustomSchema.IntervalNano;
 import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified.UnifiedMappingProvider;
 import com.google.common.collect.ImmutableMap;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.Date;
+import java.util.UUID;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.commons.codec.binary.Hex;
@@ -40,7 +44,11 @@ public class CassandraMappingsProvider {
   private static final CassandraRowValueMapper toString = (value, schema) -> value.toString();
 
   /** Pass the value as an integer to avro. */
-  private static final CassandraRowValueMapper<Number> toInt = (value, schema) -> value.intValue();
+  private static final CassandraRowValueMapper<Byte> byteToInt =
+      (value, schema) -> value.intValue();
+
+  private static final CassandraRowValueMapper<Short> shortToInt =
+      (value, schema) -> value.intValue();
 
   /** Map {@link ByteBuffer} to a Hex encoded String. */
   private static final CassandraRowValueMapper<ByteBuffer> ByteBufferToHexString =
@@ -84,38 +92,121 @@ public class CassandraMappingsProvider {
 
   private static final CassandraMappings CASSANDRA_MAPPINGS =
       CassandraMappings.builder()
-          .put("ASCII", UnifiedMappingProvider.Type.STRING, Row::getString, valuePassThrough)
-          .put("BIGINT", UnifiedMappingProvider.Type.LONG, Row::getLong, valuePassThrough)
-          .put("BLOB", UnifiedMappingProvider.Type.STRING, Row::getBytes, ByteBufferToHexString)
-          .put("BOOLEAN", UnifiedMappingProvider.Type.BOOLEAN, Row::getBool, valuePassThrough)
-          .put("COUNTER", UnifiedMappingProvider.Type.LONG, Row::getLong, valuePassThrough)
-          .put("DATE", UnifiedMappingProvider.Type.DATE, Row::getDate, localDateToAvroLogicalDate)
+          .put(
+              "ASCII",
+              UnifiedMappingProvider.Type.STRING,
+              Row::getString,
+              valuePassThrough,
+              String.class)
+          .put(
+              "BIGINT",
+              UnifiedMappingProvider.Type.LONG,
+              Row::getLong,
+              valuePassThrough,
+              Long.class)
+          .put(
+              "BLOB",
+              UnifiedMappingProvider.Type.STRING,
+              Row::getBytes,
+              ByteBufferToHexString,
+              ByteBuffer.class)
+          .put(
+              "BOOLEAN",
+              UnifiedMappingProvider.Type.BOOLEAN,
+              Row::getBool,
+              valuePassThrough,
+              Boolean.class)
+          .put(
+              "COUNTER",
+              UnifiedMappingProvider.Type.LONG,
+              Row::getLong,
+              valuePassThrough,
+              Long.class)
+          .put(
+              "DATE",
+              UnifiedMappingProvider.Type.DATE,
+              Row::getDate,
+              localDateToAvroLogicalDate,
+              LocalDate.class)
           // The Cassandra decimal does not have precision and scale fixed in the
           // schema which would be needed if we want to map it to Avro Decimal.
-          .put("DECIMAL", UnifiedMappingProvider.Type.STRING, Row::getDecimal, toString)
-          .put("DOUBLE", UnifiedMappingProvider.Type.DOUBLE, Row::getDouble, valuePassThrough)
-          .put("DURATION", UnifiedMappingProvider.Type.INTERVAL_NANO, getDuration, durationToAvro)
-          .put("FLOAT", UnifiedMappingProvider.Type.FLOAT, Row::getFloat, valuePassThrough)
-          .put("INET", UnifiedMappingProvider.Type.STRING, Row::getInet, toString)
-          .put("INT", UnifiedMappingProvider.Type.INTEGER, Row::getInt, valuePassThrough)
-          .put("SMALLINT", UnifiedMappingProvider.Type.INTEGER, Row::getShort, toInt)
-          .put("TEXT", UnifiedMappingProvider.Type.STRING, Row::getString, valuePassThrough)
+          .put(
+              "DECIMAL",
+              UnifiedMappingProvider.Type.STRING,
+              Row::getDecimal,
+              toString,
+              BigDecimal.class)
+          .put(
+              "DOUBLE",
+              UnifiedMappingProvider.Type.DOUBLE,
+              Row::getDouble,
+              valuePassThrough,
+              Double.class)
+          .put(
+              "DURATION",
+              UnifiedMappingProvider.Type.INTERVAL_NANO,
+              getDuration,
+              durationToAvro,
+              Duration.class)
+          .put(
+              "FLOAT",
+              UnifiedMappingProvider.Type.FLOAT,
+              Row::getFloat,
+              valuePassThrough,
+              Float.class)
+          .put(
+              "INET", UnifiedMappingProvider.Type.STRING, Row::getInet, toString, InetAddress.class)
+          .put(
+              "INT",
+              UnifiedMappingProvider.Type.INTEGER,
+              Row::getInt,
+              valuePassThrough,
+              Integer.class)
+          .put(
+              "SMALLINT",
+              UnifiedMappingProvider.Type.INTEGER,
+              Row::getShort,
+              shortToInt,
+              Short.class)
+          .put(
+              "TEXT",
+              UnifiedMappingProvider.Type.STRING,
+              Row::getString,
+              valuePassThrough,
+              String.class)
           .put(
               "TIME",
               UnifiedMappingProvider.Type.INTERVAL_NANO,
               Row::getTime,
-              cassandraTimeToIntervalNano)
-          .put("TIMESTAMP", UnifiedMappingProvider.Type.TIMESTAMP, Row::getTimestamp, dateToAvro)
-          .put("TIMEUUID", UnifiedMappingProvider.Type.STRING, Row::getUUID, toString)
-          .put("TINYINT", UnifiedMappingProvider.Type.INTEGER, Row::getByte, toInt)
-          .put("UUID", UnifiedMappingProvider.Type.STRING, Row::getUUID, toString)
-          .put("VARCHAR", UnifiedMappingProvider.Type.STRING, Row::getString, valuePassThrough)
-          .put("VARINT", UnifiedMappingProvider.Type.NUMBER, Row::getVarint, toString)
+              cassandraTimeToIntervalNano,
+              Long.class)
+          .put(
+              "TIMESTAMP",
+              UnifiedMappingProvider.Type.TIMESTAMP,
+              Row::getTimestamp,
+              dateToAvro,
+              Date.class)
+          .put("TIMEUUID", UnifiedMappingProvider.Type.STRING, Row::getUUID, toString, UUID.class)
+          .put("TINYINT", UnifiedMappingProvider.Type.INTEGER, Row::getByte, byteToInt, Byte.class)
+          .put("UUID", UnifiedMappingProvider.Type.STRING, Row::getUUID, toString, UUID.class)
+          .put(
+              "VARCHAR",
+              UnifiedMappingProvider.Type.STRING,
+              Row::getString,
+              valuePassThrough,
+              String.class)
+          .put(
+              "VARINT",
+              UnifiedMappingProvider.Type.NUMBER,
+              Row::getVarint,
+              toString,
+              BigInteger.class)
           .put(
               "UNSUPPORTED",
               UnifiedMappingProvider.Type.UNSUPPORTED,
               (row, name) -> null,
-              (value, schema) -> null)
+              (value, schema) -> null,
+              null)
           .build();
 
   private CassandraMappingsProvider() {}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/rowmapper/CassandraRowMapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/rowmapper/CassandraRowMapper.java
@@ -36,6 +36,9 @@ abstract class CassandraRowMapper implements Transformer<Row, SourceRow>, Serial
   public static final ImmutableMap<String, CassandraFieldMapper<?>> MAPPINGS =
       CassandraMappingsProvider.getFieldMapping();
 
+  /*
+   * TODO(vardhanvthigle): support nested collections.
+   */
   public static CassandraRowMapper create(
       SourceSchemaReference sourceSchemaReference, SourceTableSchema sourceTableSchema) {
     return new AutoValue_CassandraRowMapper(sourceSchemaReference, sourceTableSchema);

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/rowmapper/CassandraRowValueArrayMapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/rowmapper/CassandraRowValueArrayMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.cassandra.rowmapper;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+@AutoValue
+public abstract class CassandraRowValueArrayMapper<T>
+    implements CassandraRowValueMapper<Iterable<T>> {
+
+  public static <T> CassandraRowValueArrayMapper<T> create(
+      CassandraRowValueMapper<T> rowValueMapper) {
+    return new AutoValue_CassandraRowValueArrayMapper<>(rowValueMapper);
+  }
+
+  abstract CassandraRowValueMapper<T> rowValueMapper();
+
+  /**
+   * Map the extracted value to an object accepted by {@link GenericRecordBuilder#set(Field,
+   * Object)} as per the schema of the field.
+   *
+   * @param values extracted value collection.
+   * @param schema Avro Schema.
+   * @return mapped object.
+   */
+  @Override
+  public Object map(@NonNull Iterable<T> values, Schema schema) {
+    return ImmutableList.builder().addAll(values).build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/rowmapper/CassandraRowValueExtractor.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/rowmapper/CassandraRowValueExtractor.java
@@ -20,7 +20,7 @@ import com.datastax.oss.driver.api.core.cql.ResultSet;
 import java.io.Serializable;
 import javax.annotation.Nullable;
 
-public interface CassandraRowValueExtractor<T extends Object> extends Serializable {
+public interface CassandraRowValueExtractor<T> extends Serializable {
 
   /**
    * Extract the requested field from the result set.

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/schema/CassandraSchemaDiscovery.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/schema/CassandraSchemaDiscovery.java
@@ -162,7 +162,17 @@ public final class CassandraSchemaDiscovery implements RetriableSchemaDiscovery 
     for (ColumnMetadata columnMetadata : metadata.getTable(table).get().getColumns().values()) {
       String name = columnMetadata.getName().toString();
       SourceColumnType sourceColumnType =
-          new SourceColumnType(columnMetadata.getType().toString(), new Long[] {}, new Long[] {});
+          new SourceColumnType(
+              /*
+               * Get the name of the type as represented in CSql Language, using the driver's `asCql` wrapper.
+               * here we exclude the frozen keyword, as a type being frozen or not does not matter to the read pipeline.
+               */
+              columnMetadata
+                  .getType()
+                  .asCql(false /*includeFrozen*/, true /*prettyPrint*/)
+                  .toUpperCase(),
+              new Long[] {},
+              new Long[] {});
       tableSchemaBuilder.put(name, sourceColumnType);
     }
     return tableSchemaBuilder.build();

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/UnifiedTypeMapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/UnifiedTypeMapper.java
@@ -88,6 +88,9 @@ public final class UnifiedTypeMapper {
         : SchemaBuilder.builder().unionOf().nullType().and().type(schema).endUnion();
   }
 
+  /*
+   * TODO(vardhanvthigle): Handle Nested collections.
+   */
   private Schema getBasicSchema(SourceColumnType columnType) {
     return mappers
         .get(this.mapperType)

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/UnifiedTypeMapping.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/UnifiedTypeMapping.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping;
 
+import java.io.Serializable;
 import javax.annotation.Nullable;
 import org.apache.avro.Schema;
 
@@ -24,7 +25,7 @@ import org.apache.avro.Schema;
  * com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.MysqlMappingProvider
  * MysqlMappingProvider}.
  */
-public interface UnifiedTypeMapping {
+public interface UnifiedTypeMapping extends Serializable {
 
   /**
    * Convert the Source Schema.

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/Array.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/Array.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.provider.unified;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedTypeMapping;
+import java.io.Serializable;
+import javax.annotation.Nullable;
+import org.apache.avro.Schema;
+
+/**
+ * Generates a <a href=https://avro.apache.org/docs/1.8.2/spec.html#Decimal>Decimal</a> Avro Type.
+ */
+@AutoValue
+abstract class Array implements UnifiedTypeMapping, Serializable {
+
+  public static Array create(UnifiedTypeMapping mapping) {
+    return new AutoValue_Array(mapping);
+  }
+
+  abstract UnifiedTypeMapping mapping();
+
+  @Override
+  public Schema getSchema(@Nullable Long[] mods, @Nullable Long[] arrayBounds) {
+    return Schema.createArray(mapping().getSchema(mods, arrayBounds));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/UnifiedMappingProvider.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/UnifiedMappingProvider.java
@@ -116,6 +116,31 @@ public final class UnifiedMappingProvider {
     return MAPPING.getOrDefault(type, new Unsupported());
   }
 
+  /**
+   * Returns the {@link UnifiedTypeMapping} for an array of unified type mapping.
+   *
+   * @param type reference to the unified type to which an avro schema mapping for an array is
+   *     requested.
+   * @return mapping implementation. Default is {@link Unsupported} for unrecognized type.
+   */
+  public static UnifiedTypeMapping getArrayMapping(Type type) {
+    return getArrayMapping(MAPPING.getOrDefault(type, new Unsupported()));
+  }
+
+  /**
+   * Returns the {@link UnifiedTypeMapping} for an array of unified type mapping.
+   *
+   * @param mapping reference to the unified type mapping to which an avro schema mapping for an
+   *     array is requested.
+   * @return mapping implementation. Default is {@link Unsupported} for unrecognized type.
+   */
+  public static UnifiedTypeMapping getArrayMapping(UnifiedTypeMapping mapping) {
+    if (mapping instanceof Unsupported) {
+      return mapping;
+    }
+    return Array.create(mapping);
+  }
+
   /** Static final class. * */
   private UnifiedMappingProvider() {}
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperHelperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperHelperTest.java
@@ -35,6 +35,7 @@ import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.
 import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.TEST_CONFIG;
 import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.TEST_CQLSH;
 import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.TEST_KEYSPACE;
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.TEST_TABLES;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -138,7 +139,7 @@ public class CassandraIOWrapperHelperTest {
                 dataSource,
                 CassandraIOWrapperHelper.buildSchemaDiscovery(),
                 cassandraSchemaReference))
-        .isEqualTo(List.of(BASIC_TEST_TABLE, PRIMITIVE_TYPES_TABLE));
+        .isEqualTo(TEST_TABLES);
     assertThat(
             CassandraIOWrapperHelper.getTablesToRead(
                 List.of(BASIC_TEST_TABLE),

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/rowmapper/CassandraSourceRowMapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/rowmapper/CassandraSourceRowMapperTest.java
@@ -15,8 +15,12 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.cassandra.rowmapper;
 
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.LIST_TYPES_TABLE;
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.LIST_TYPES_TABLE_AVRO_ROWS;
 import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.PRIMITIVE_TYPES_TABLE;
 import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.PRIMITIVE_TYPES_TABLE_AVRO_ROWS;
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.SET_TYPES_TABLE;
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.SET_TYPES_TABLE_AVRO_ROWS;
 import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.TEST_CONFIG;
 import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.TEST_CQLSH;
 import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.TEST_KEYSPACE;
@@ -44,6 +48,7 @@ import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedT
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.util.List;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -74,6 +79,21 @@ public class CassandraSourceRowMapperTest {
 
   @Test
   public void testCassandraSourceRowMapperBasic() throws RetriableSchemaDiscoveryException {
+    cassandraSourceRowMapperTestHelper(PRIMITIVE_TYPES_TABLE, PRIMITIVE_TYPES_TABLE_AVRO_ROWS);
+  }
+
+  @Test
+  public void testCassandraSourceRowMapperList() throws RetriableSchemaDiscoveryException {
+    cassandraSourceRowMapperTestHelper(LIST_TYPES_TABLE, LIST_TYPES_TABLE_AVRO_ROWS);
+  }
+
+  @Test
+  public void testCassandraSourceRowMapperSet() throws RetriableSchemaDiscoveryException {
+    cassandraSourceRowMapperTestHelper(SET_TYPES_TABLE, SET_TYPES_TABLE_AVRO_ROWS);
+  }
+
+  private void cassandraSourceRowMapperTestHelper(String tableName, List<String> expectedRows)
+      throws RetriableSchemaDiscoveryException {
 
     SourceSchemaReference sourceSchemaReference =
         SourceSchemaReference.ofCassandra(
@@ -89,11 +109,10 @@ public class CassandraSourceRowMapperTest {
                 .build());
 
     SourceTableSchema.Builder sourceTableSchemaBuilder =
-        SourceTableSchema.builder(MapperType.CASSANDRA).setTableName(PRIMITIVE_TYPES_TABLE);
+        SourceTableSchema.builder(MapperType.CASSANDRA).setTableName(tableName);
     new CassandraSchemaDiscovery()
-        .discoverTableSchema(
-            dataSource, sourceSchemaReference, ImmutableList.of(PRIMITIVE_TYPES_TABLE))
-        .get(PRIMITIVE_TYPES_TABLE)
+        .discoverTableSchema(dataSource, sourceSchemaReference, ImmutableList.of(tableName))
+        .get(tableName)
         .forEach(sourceTableSchemaBuilder::addSourceColumnNameToSourceColumnType);
 
     CassandraSourceRowMapper cassandraSourceRowMapper =
@@ -103,7 +122,7 @@ public class CassandraSourceRowMapperTest {
             .build();
 
     ResultSet resultSet;
-    String query = "SELECT * FROM " + PRIMITIVE_TYPES_TABLE;
+    String query = "SELECT * FROM " + tableName;
     com.datastax.oss.driver.api.core.cql.SimpleStatement statement =
         SimpleStatement.newInstance(query);
     Cluster cluster =
@@ -123,26 +142,23 @@ public class CassandraSourceRowMapperTest {
       cassandraSourceRowMapper.map(resultSet).forEachRemaining(row -> readRowsBuilder.add(row));
       ImmutableList<SourceRow> readRows = readRowsBuilder.build();
 
-      readRows.forEach(r -> assertThat(r.tableName() == PRIMITIVE_TYPES_TABLE));
+      readRows.forEach(r -> assertThat(r.tableName() == tableName));
       readRows.forEach(r -> assertThat(r.sourceSchemaReference() == sourceSchemaReference));
       assertThat(
               readRows.stream()
                   .map(r -> r.getPayload().toString())
                   .sorted()
                   .collect(ImmutableList.toImmutableList()))
-          .isEqualTo(
-              PRIMITIVE_TYPES_TABLE_AVRO_ROWS.stream()
-                  .sorted()
-                  .collect(ImmutableList.toImmutableList()));
+          .isEqualTo(expectedRows.stream().sorted().collect(ImmutableList.toImmutableList()));
 
       // Since we will use CassandraIO only for reads, we don't need to support the `deleteAsync`
       // and `saveAsync` functions of the CassandraIO mapper interface.
       assertThrows(
           UnsupportedOperationException.class,
-          () -> cassandraSourceRowMapper.deleteAsync(readRows.get(1)));
+          () -> cassandraSourceRowMapper.deleteAsync(readRows.get(0)));
       assertThrows(
           UnsupportedOperationException.class,
-          () -> cassandraSourceRowMapper.saveAsync(readRows.get(1)));
+          () -> cassandraSourceRowMapper.saveAsync(readRows.get(0)));
     }
   }
 

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/schema/CassandraSchemaDiscoveryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/schema/CassandraSchemaDiscoveryTest.java
@@ -16,6 +16,8 @@
 package com.google.cloud.teleport.v2.source.reader.io.cassandra.schema;
 
 import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.BASIC_TEST_TABLE_SCHEMA;
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.LIST_TEST_TABLE_SCHEMA;
+import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.SET_TEST_TABLE_SCHEMA;
 import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.TEST_CONFIG;
 import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.TEST_CQLSH;
 import static com.google.cloud.teleport.v2.source.reader.io.cassandra.testutils.BasicTestSchema.TEST_KEYSPACE;
@@ -126,6 +128,22 @@ public class CassandraSchemaDiscoveryTest {
 
   @Test
   public void testDiscoverTableSchemaBasic() throws IOException, RetriableSchemaDiscoveryException {
+    discoverTableSchemaTestHelper(BASIC_TEST_TABLE_SCHEMA);
+  }
+
+  @Test
+  public void testDiscoverTableSchemaList() throws IOException, RetriableSchemaDiscoveryException {
+    discoverTableSchemaTestHelper(LIST_TEST_TABLE_SCHEMA);
+  }
+
+  @Test
+  public void testDiscoverTableSchemaSet() throws IOException, RetriableSchemaDiscoveryException {
+    discoverTableSchemaTestHelper(SET_TEST_TABLE_SCHEMA);
+  }
+
+  private void discoverTableSchemaTestHelper(
+      ImmutableMap<String, ImmutableMap<String, SourceColumnType>> expecedSchema)
+      throws IOException, RetriableSchemaDiscoveryException {
 
     SourceSchemaReference cassandraSchemaReference =
         SourceSchemaReference.ofCassandra(
@@ -142,10 +160,8 @@ public class CassandraSchemaDiscoveryTest {
     CassandraSchemaDiscovery cassandraSchemaDiscovery = new CassandraSchemaDiscovery();
     ImmutableMap<String, ImmutableMap<String, SourceColumnType>> schema =
         cassandraSchemaDiscovery.discoverTableSchema(
-            cassandraDataSource,
-            cassandraSchemaReference,
-            BASIC_TEST_TABLE_SCHEMA.keySet().asList());
-    assertThat(schema).isEqualTo(BASIC_TEST_TABLE_SCHEMA);
+            cassandraDataSource, cassandraSchemaReference, expecedSchema.keySet().asList());
+    assertThat(schema).isEqualTo(expecedSchema);
   }
 
   @Test

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/testutils/BasicTestSchema.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/testutils/BasicTestSchema.java
@@ -31,6 +31,8 @@ public class BasicTestSchema {
   public static final String TEST_CQLSH = TEST_RESOURCE_ROOT + "basicTest.cql";
   public static final String BASIC_TEST_TABLE = "basic_test_table";
   public static final String PRIMITIVE_TYPES_TABLE = "primitive_types_table";
+  public static final String LIST_TYPES_TABLE = "list_types_table";
+  public static final String SET_TYPES_TABLE = "set_types_table";
   public static final Long PRIMITIVE_TYPES_TABLE_ROW_COUNT = 6L;
   public static final ImmutableMap<String, ImmutableMap<String, SourceColumnType>>
       BASIC_TEST_TABLE_SCHEMA =
@@ -40,7 +42,7 @@ public class BasicTestSchema {
                   "id", new SourceColumnType("TEXT", new Long[] {}, new Long[] {}),
                   "name", new SourceColumnType("TEXT", new Long[] {}, new Long[] {})));
   public static final ImmutableList<String> TEST_TABLES =
-      ImmutableList.of(BASIC_TEST_TABLE, PRIMITIVE_TYPES_TABLE);
+      ImmutableList.of(BASIC_TEST_TABLE, LIST_TYPES_TABLE, PRIMITIVE_TYPES_TABLE, SET_TYPES_TABLE);
 
   public static final ImmutableList<String> PRIMITIVE_TYPES_TABLE_AVRO_ROWS =
       ImmutableList.of(
@@ -50,6 +52,13 @@ public class BasicTestSchema {
           "{\"primary_key\": \"e6bc8562-2575-420f-9344-9fedc4945f61\", \"ascii_col\": null, \"bigint_col\": 0, \"blob_col\": null, \"boolean_col\": false, \"date_col\": null, \"decimal_col\": null, \"double_col\": 0.0, \"duration_col\": null, \"float_col\": 0.0, \"inet_col\": null, \"int_col\": 0, \"smallint_col\": 0, \"text_col\": null, \"time_col\": {\"years\": 0, \"months\": 0, \"days\": 0, \"hours\": 0, \"minutes\": 0, \"seconds\": 0, \"nanos\": 0}, \"timestamp_col\": null, \"timeuuid_col\": null, \"tinyint_col\": 0, \"uuid_col\": null, \"varchar_col\": null, \"varint_col\": null}",
           "{\"primary_key\": \"a389de30-f01f-4395-a0c6-c407bfbe81d0\", \"ascii_col\": \"zzzzzzzzzz\", \"bigint_col\": 9223372036854775807, \"blob_col\": \"ffffffff\", \"boolean_col\": true, \"date_col\": 2932896, \"decimal_col\": \"10000000000000000000000000000000000000\", \"double_col\": 1.7976931348623157E308, \"duration_col\": {\"years\": 0, \"months\": 0, \"days\": 0, \"hours\": 0, \"minutes\": 0, \"seconds\": 0, \"nanos\": 320949000000000}, \"float_col\": 3.4028235E38, \"inet_col\": \"/255.255.255.255\", \"int_col\": 2147483647, \"smallint_col\": 32767, \"text_col\": \"abcdef\", \"time_col\": {\"years\": 0, \"months\": 0, \"days\": 0, \"hours\": 0, \"minutes\": 0, \"seconds\": 0, \"nanos\": 86399999000000}, \"timestamp_col\": -1000, \"timeuuid_col\": null, \"tinyint_col\": 127, \"uuid_col\": \"00e4afef-52f8-4e1f-9afa-0632c8ccf790\", \"varchar_col\": \"abcdef\", \"varint_col\": \"9223372036854775807\"}",
           "{\"primary_key\": \"29e38561-6376-4b45-b1a0-1709e11cfc8c\", \"ascii_col\": \"\", \"bigint_col\": -9223372036854775808, \"blob_col\": \"00\", \"boolean_col\": false, \"date_col\": -354285, \"decimal_col\": \"-10000000000000000000000000000000000000\", \"double_col\": -1.7976931348623157E308, \"duration_col\": {\"years\": 0, \"months\": 0, \"days\": 0, \"hours\": 0, \"minutes\": 0, \"seconds\": 0, \"nanos\": 320949000000000}, \"float_col\": -3.4028235E38, \"inet_col\": \"/0.0.0.0\", \"int_col\": -2147483648, \"smallint_col\": -32768, \"text_col\": \"\", \"time_col\": {\"years\": 0, \"months\": 0, \"days\": 0, \"hours\": 0, \"minutes\": 0, \"seconds\": 0, \"nanos\": 0}, \"timestamp_col\": 0, \"timeuuid_col\": null, \"tinyint_col\": -128, \"uuid_col\": \"fff6d876-560f-48bc-8088-90c69e5a0c40\", \"varchar_col\": \"\", \"varint_col\": \"-9223372036854775808\"}");
+  public static final ImmutableList<String> LIST_TYPES_TABLE_AVRO_ROWS =
+      ImmutableList.of(
+          "{\"primary_key\": \"a389de30-f01f-4395-a0c6-c407bfbe81d0\", \"ascii_list\": [\"a\", \"b\", \"c\"], \"bigint_list\": [1, 2, 3], \"blob_list\": [\"Hello\"], \"boolean_list\": [true, false], \"date_list\": [2024-10-27, 2024-10-28], \"decimal_list\": [123.45, 678.90], \"double_list\": [1.23, 4.56], \"duration_list\": [1y2mo3d4h5m6s, 2y2mo3d4h5m6s], \"float_list\": [1.23, 4.56], \"frozen_ascii_list\": [\"d\", \"e\", \"f\"], \"inet_list\": [/192.168.1.1, /10.0.0.1], \"int_list\": [10, 20, 30], \"smallint_list\": [100, 200, 300], \"text_list\": [\"hello\", \"world\"], \"time_list\": [36000000000000, 43200000000000], \"timestamp_list\": [Sun Oct 27 10:00:00 UTC 2024, Mon Oct 28 12:00:00 UTC 2024], \"timeuuid_list\": [\"9b9419da-b210-11ef-890e-9d9a41af9e54\"], \"tinyint_list\": [1, 2, 3], \"uuid_list\": [\"f0e1d922-06b5-4f07-a7a6-ec0c9f23e172\"], \"varchar_list\": [\"varchar1\", \"varchar2\"], \"varint_list\": [1234567890, 9876543210]}");
+
+  public static final ImmutableList<String> SET_TYPES_TABLE_AVRO_ROWS =
+      ImmutableList.of(
+          "{\"primary_key\": \"a389de30-f01f-4395-a0c6-c407bfbe81d0\", \"ascii_set\": [\"a\", \"b\", \"c\"], \"bigint_set\": [1, 2, 3], \"blob_set\": [\"Hello\"], \"boolean_set\": [false, true], \"date_set\": [2024-10-27, 2024-10-28], \"decimal_set\": [123.45, 678.90], \"double_set\": [1.23, 4.56], \"float_set\": [1.23, 4.56], \"frozen_ascii_set\": [\"d\", \"e\", \"f\"], \"inet_set\": [/10.0.0.1, /192.168.1.1], \"int_set\": [10, 20, 30], \"smallint_set\": [100, 200, 300], \"text_set\": [\"hello\", \"world\"], \"time_set\": [36000000000000, 43200000000000], \"timestamp_set\": [Sun Oct 27 10:00:00 UTC 2024, Mon Oct 28 12:00:00 UTC 2024], \"timeuuid_set\": [\"9b9419da-b210-11ef-890e-9d9a41af9e54\"], \"tinyint_set\": [1, 2, 3], \"uuid_set\": [\"f0e1d922-06b5-4f07-a7a6-ec0c9f23e172\"], \"varchar_set\": [\"varchar1\", \"varchar2\"], \"varint_set\": [1234567890, 9876543210]}");
 
   private BasicTestSchema() {}
   ;

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/testutils/BasicTestSchema.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/testutils/BasicTestSchema.java
@@ -41,6 +41,120 @@ public class BasicTestSchema {
               ImmutableMap.of(
                   "id", new SourceColumnType("TEXT", new Long[] {}, new Long[] {}),
                   "name", new SourceColumnType("TEXT", new Long[] {}, new Long[] {})));
+  public static final ImmutableMap<String, ImmutableMap<String, SourceColumnType>>
+      LIST_TEST_TABLE_SCHEMA =
+          ImmutableMap.of(
+              LIST_TYPES_TABLE,
+              ImmutableMap.<String, SourceColumnType>builder()
+                  .put("primary_key", new SourceColumnType("UUID", new Long[] {}, new Long[] {}))
+                  .put(
+                      "ascii_list",
+                      new SourceColumnType("LIST<ASCII>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "frozen_ascii_list",
+                      new SourceColumnType("LIST<ASCII>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "bigint_list",
+                      new SourceColumnType("LIST<BIGINT>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "blob_list", new SourceColumnType("LIST<BLOB>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "boolean_list",
+                      new SourceColumnType("LIST<BOOLEAN>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "date_list", new SourceColumnType("LIST<DATE>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "decimal_list",
+                      new SourceColumnType("LIST<DECIMAL>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "double_list",
+                      new SourceColumnType("LIST<DOUBLE>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "duration_list",
+                      new SourceColumnType("LIST<DURATION>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "float_list",
+                      new SourceColumnType("LIST<FLOAT>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "inet_list", new SourceColumnType("LIST<INET>", new Long[] {}, new Long[] {}))
+                  .put("int_list", new SourceColumnType("LIST<INT>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "smallint_list",
+                      new SourceColumnType("LIST<SMALLINT>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "text_list", new SourceColumnType("LIST<TEXT>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "time_list", new SourceColumnType("LIST<TIME>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "timestamp_list",
+                      new SourceColumnType("LIST<TIMESTAMP>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "timeuuid_list",
+                      new SourceColumnType("LIST<TIMEUUID>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "tinyint_list",
+                      new SourceColumnType("LIST<TINYINT>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "uuid_list", new SourceColumnType("LIST<UUID>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "varchar_list",
+                      new SourceColumnType("LIST<TEXT>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "varint_list",
+                      new SourceColumnType("LIST<VARINT>", new Long[] {}, new Long[] {}))
+                  .build());
+  public static final ImmutableMap<String, ImmutableMap<String, SourceColumnType>>
+      SET_TEST_TABLE_SCHEMA =
+          ImmutableMap.of(
+              SET_TYPES_TABLE,
+              ImmutableMap.<String, SourceColumnType>builder()
+                  .put("primary_key", new SourceColumnType("UUID", new Long[] {}, new Long[] {}))
+                  .put(
+                      "ascii_set", new SourceColumnType("SET<ASCII>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "frozen_ascii_set",
+                      new SourceColumnType("SET<ASCII>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "bigint_set",
+                      new SourceColumnType("SET<BIGINT>", new Long[] {}, new Long[] {}))
+                  .put("blob_set", new SourceColumnType("SET<BLOB>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "boolean_set",
+                      new SourceColumnType("SET<BOOLEAN>", new Long[] {}, new Long[] {}))
+                  .put("date_set", new SourceColumnType("SET<DATE>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "decimal_set",
+                      new SourceColumnType("SET<DECIMAL>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "double_set",
+                      new SourceColumnType("SET<DOUBLE>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "float_set", new SourceColumnType("SET<FLOAT>", new Long[] {}, new Long[] {}))
+                  .put("inet_set", new SourceColumnType("SET<INET>", new Long[] {}, new Long[] {}))
+                  .put("int_set", new SourceColumnType("SET<INT>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "smallint_set",
+                      new SourceColumnType("SET<SMALLINT>", new Long[] {}, new Long[] {}))
+                  .put("text_set", new SourceColumnType("SET<TEXT>", new Long[] {}, new Long[] {}))
+                  .put("time_set", new SourceColumnType("SET<TIME>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "timestamp_set",
+                      new SourceColumnType("SET<TIMESTAMP>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "timeuuid_set",
+                      new SourceColumnType("SET<TIMEUUID>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "tinyint_set",
+                      new SourceColumnType("SET<TINYINT>", new Long[] {}, new Long[] {}))
+                  .put("uuid_set", new SourceColumnType("SET<UUID>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "varchar_set",
+                      new SourceColumnType("SET<TEXT>", new Long[] {}, new Long[] {}))
+                  .put(
+                      "varint_set",
+                      new SourceColumnType("SET<VARINT>", new Long[] {}, new Long[] {}))
+                  .build());
+
   public static final ImmutableList<String> TEST_TABLES =
       ImmutableList.of(BASIC_TEST_TABLE, LIST_TYPES_TABLE, PRIMITIVE_TYPES_TABLE, SET_TYPES_TABLE);
 

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/UnifiedMappingProviderTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/unified/UnifiedMappingProviderTest.java
@@ -55,6 +55,17 @@ public class UnifiedMappingProviderTest {
                 .getSchema(varCharMods, null)
                 .toString())
         .isEqualTo("{\"type\":\"string\",\"logicalType\":\"varchar\",\"length\":10}");
+    assertThat(
+            UnifiedMappingProvider.getArrayMapping(UnifiedMappingProvider.Type.VARCHAR)
+                .getSchema(varCharMods, null)
+                .toString())
+        .isEqualTo(
+            "{\"type\":\"array\",\"items\":{\"type\":\"string\",\"logicalType\":\"varchar\",\"length\":10}}");
+    assertThat(
+            UnifiedMappingProvider.getArrayMapping(UnifiedMappingProvider.Type.UNSUPPORTED)
+                .getSchema(varCharMods, null)
+                .toString())
+        .isEqualTo("{\"type\":\"null\",\"logicalType\":\"unsupported\"}");
   }
 
   private ImmutableList<UnifiedMappingProvider.Type> simpleTypes() {

--- a/v2/sourcedb-to-spanner/src/test/resources/CassandraUT/basicTest.cql
+++ b/v2/sourcedb-to-spanner/src/test/resources/CassandraUT/basicTest.cql
@@ -35,7 +35,55 @@ CREATE TABLE primitive_types_table (
                                  uuid_col UUID,
                                  varchar_col VARCHAR,
                                  varint_col VARINT);
+CREATE TABLE list_types_table (
+                                  primary_key UUID PRIMARY KEY,
+                                  ascii_list LIST<ASCII>,
+                                  frozen_ascii_list FROZEN<LIST<ASCII>>,
+                                  bigint_list LIST<BIGINT>,
+                                  blob_list LIST<BLOB>,
+                                  boolean_list LIST<BOOLEAN>,
+                                  date_list LIST<DATE>,
+                                  decimal_list LIST<DECIMAL>,
+                                  double_list LIST<DOUBLE>,
+                                  duration_list LIST<DURATION>,
+                                  float_list LIST<FLOAT>,
+                                  inet_list LIST<INET>,
+                                  int_list LIST<INT>,
+                                  smallint_list LIST<SMALLINT>,
+                                  text_list LIST<TEXT>,
+                                  time_list LIST<TIME>,
+                                  timestamp_list LIST<TIMESTAMP>,
+                                  timeuuid_list LIST<TIMEUUID>,
+                                  tinyint_list LIST<TINYINT>,
+                                  uuid_list LIST<UUID>,
+                                  varchar_list LIST<VARCHAR>,
+                                  varint_list LIST<VARINT>
+);
 
+CREATE TABLE set_types_table (
+                                 primary_key UUID PRIMARY KEY,
+                                 ascii_set SET<ASCII>,
+                                 frozen_ascii_set FROZEN<SET<ASCII>>,
+                                 bigint_set SET<BIGINT>,
+                                 blob_set SET<BLOB>,
+                                 boolean_set SET<BOOLEAN>,
+                                 date_set SET<DATE>,
+                                 decimal_set SET<DECIMAL>,
+                                 double_set SET<DOUBLE>,
+                                 -- duration can not be added as a type set in cassandra.
+                                 float_set SET<FLOAT>,
+                                 inet_set SET<INET>,
+                                 int_set SET<INT>,
+                                 smallint_set SET<SMALLINT>,
+                                 text_set SET<TEXT>,
+                                 time_set SET<TIME>,
+                                 timestamp_set SET<TIMESTAMP>,
+                                 timeuuid_set SET<TIMEUUID>,
+                                 tinyint_set SET<TINYINT>,
+                                 uuid_set SET<UUID>,
+                                 varchar_set SET<VARCHAR>,
+                                 varint_set SET<VARINT>
+);
 -- Inserting 3 Randomly generated rows.
 INSERT INTO primitive_types_table (primary_key, ascii_col, bigint_col, blob_col, boolean_col, date_col, decimal_col, double_col, duration_col, float_col, inet_col, int_col, smallint_col, text_col, time_col, timestamp_col, timeuuid_col, tinyint_col, uuid_col, varchar_col, varint_col)
 VALUES (
@@ -165,4 +213,60 @@ VALUES (
           00e4afef-52f8-4e1f-9afa-0632c8ccf790,
            'abcdef',
            9223372036854775807  -- Maximum VARINT
+       );
+-- Inserts for list_types_table
+-- Cassandra does not support null inside of collection values.
+INSERT INTO list_types_table (primary_key, ascii_list, frozen_ascii_list, bigint_list, blob_list, boolean_list, date_list, decimal_list, double_list, duration_list, float_list, inet_list, int_list, smallint_list, text_list, time_list, timestamp_list, timeuuid_list, tinyint_list, uuid_list, varchar_list, varint_list)
+VALUES (
+           a389de30-f01f-4395-a0c6-c407bfbe81d0, -- primary_key
+           ['a', 'b', 'c'], -- ascii_list
+           ['d', 'e', 'f'], -- frozen_ascii_list
+           [1, 2, 3], -- bigint_list
+           [0x48656C6C6F], -- blob_list (Hex representation of "Hello")
+           [true, false], -- boolean_list
+           ['2024-10-27', '2024-10-28'], -- date_list
+           [123.45, 678.90], -- decimal_list
+           [1.23, 4.56], -- double_list
+           [1y2mo3d4h5m6s, 2y2mo3d4h5m6s], -- duration_list
+           [1.23, 4.56],  -- float_list
+           ['192.168.1.1', '10.0.0.1'], -- inet_list
+           [10, 20, 30], -- int_list
+           [100, 200, 300], -- smallint_list
+           ['hello', 'world'], -- text_list
+           ['10:00:00', '12:00:00'], -- time_list
+           ['2024-10-27T10:00:00', '2024-10-28T12:00:00'], -- timestamp_list
+           [9b9419da-b210-11ef-890e-9d9a41af9e54], -- timeuuid_list
+           [1, 2, 3],  -- tinyint_list
+           [f0e1d922-06b5-4f07-a7a6-ec0c9f23e172], -- uuid_list
+           ['varchar1', 'varchar2'], -- varchar_list
+           [1234567890, 9876543210] -- varint_list
+       );
+
+
+
+-- Inserts for set_types_table
+-- Cassandra does not support null inside of collection values.
+INSERT INTO set_types_table (primary_key, ascii_set, frozen_ascii_set, bigint_set, blob_set, boolean_set, date_set, decimal_set, double_set, float_set, inet_set, int_set, smallint_set, text_set, time_set, timestamp_set, timeuuid_set, tinyint_set, uuid_set, varchar_set, varint_set)
+VALUES (
+           a389de30-f01f-4395-a0c6-c407bfbe81d0, -- primary_key
+           {'a', 'b', 'c'}, -- ascii_set
+           {'d', 'e', 'f'}, -- frozen_ascii_set
+           {1, 2, 3}, -- bigint_set
+           {0x48656C6C6F}, -- blob_set (Hex representation of "Hello")
+           {true, false}, -- boolean_set
+           {'2024-10-27', '2024-10-28'}, -- date_set
+           {123.45, 678.90}, -- decimal_set
+           {1.23, 4.56}, -- double_set
+           {1.23, 4.56},  -- float_set
+           {'192.168.1.1', '10.0.0.1'}, -- inet_set
+           {10, 20, 30}, -- int_set
+           {100, 200, 300}, -- smallint_set
+           {'hello', 'world'}, -- text_set
+           {'10:00:00', '12:00:00'}, -- time_set
+           {'2024-10-27T10:00:00', '2024-10-28T12:00:00'}, -- timestamp_set
+           {9b9419da-b210-11ef-890e-9d9a41af9e54}, -- timeuuid_set
+           {1, 2, 3},  -- tinyint_set
+           {f0e1d922-06b5-4f07-a7a6-ec0c9f23e172}, -- uuid_set
+           {'varchar1', 'varchar2'}, -- varchar_set
+           {1234567890, 9876543210} -- varint_set
        );


### PR DESCRIPTION
# Cassandra Bulk - List and Set - Avro Mapping.
## Overview
In bulk migration pipeline, the source rows are mapped to Avro following the [unified type mapping](https://cloud.google.com/datastream/docs/unified-types) (this has been extended by bulk template for Cassandra). The Avro objects are further written to spanner.

 This change Discovers and Extracts **non-nested** `List` and `Set` Collections from Cassandra and map them to Avro Array.
 Nested list and set collections will unsupported and hence mapped to `null` as of now.
## TODO (In future PRs)
1. Spanner Writer for Avro Array
2. Handle Map types
## TODO (post MVP)
3. Handling nested collections