### PR TITLE
Fix incorrect schema change detection in spanner cdc to bq template

### DIFF
--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SchemaUpdateUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SchemaUpdateUtils.java
@@ -42,10 +42,6 @@ public class SchemaUpdateUtils {
         mod.getNewValuesJson() == ""
             ? new JSONObject("{}").keySet()
             : new JSONObject(mod.getNewValuesJson()).keySet();
-    // At this mod's spannerCommitTimestamp, one column is added/dropped.
-    if (spannerTable.getNonPkColumns().size() != keySetOfNewValuesJsonObject.size()) {
-      return true;
-    }
     Set<String> nonPkColumnsNamesSet = spannerTable.getNonPkColumnsNamesSet();
     // Returns true if the stored schema doesn't contain a column in the mod
     return !nonPkColumnsNamesSet.containsAll(keySetOfNewValuesJsonObject);

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SchemaUpdateUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SchemaUpdateUtils.java
@@ -42,6 +42,10 @@ public class SchemaUpdateUtils {
         mod.getNewValuesJson() == ""
             ? new JSONObject("{}").keySet()
             : new JSONObject(mod.getNewValuesJson()).keySet();
+    // Return true iff there are more cols in new values json than existing record.
+    if (spannerTable.getNonPkColumns().size() < keySetOfNewValuesJsonObject.size()) {
+      return true;
+    }
     Set<String> nonPkColumnsNamesSet = spannerTable.getNonPkColumnsNamesSet();
     // Returns true if the stored schema doesn't contain a column in the mod
     return !nonPkColumnsNamesSet.containsAll(keySetOfNewValuesJsonObject);

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SchemaUpdateUtilsTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SchemaUpdateUtilsTest.java
@@ -101,6 +101,35 @@ public final class SchemaUpdateUtilsTest {
   }
 
   @Test
+  public void testDetectDiffColumnInModWithLessColsButWithoutDiff() {
+    ObjectNode pkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
+    pkColJsonNode.put("SingerId", 1);
+    ObjectNode nonPkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
+    nonPkColJsonNode.put("FirstName", "firstName");
+    List<ModColumnType> rowTypes = new ArrayList<>();
+    rowTypes.add(new ModColumnType("SingerId", new TypeCode("INT64"), true, 1));
+    rowTypes.add(new ModColumnType("FirstName", new TypeCode("STRING"), false, 2));
+    rowTypes.add(new ModColumnType("LastName", new TypeCode("STRING"), false, 3));
+
+    Mod mod =
+        new Mod(
+            pkColJsonNode.toString(),
+            nonPkColJsonNode.toString(),
+            Timestamp.ofTimeSecondsAndNanos(1650908264L, 925679000),
+            "1",
+            true,
+            "00000001",
+            "Singers",
+            rowTypes,
+            ModType.INSERT,
+            ValueCaptureType.OLD_AND_NEW_VALUES,
+            1L,
+            1L);
+    Map<String, TrackedSpannerTable> spannerTableByName = createSpannerTableByName();
+    assertThat(SchemaUpdateUtils.detectDiffColumnInMod(mod, spannerTableByName)).isEqualTo(false);
+  }
+
+  @Test
   public void testDetectDiffColumnInModWithColDiff() {
     ObjectNode pkColJsonNode = new ObjectNode(JsonNodeFactory.instance);
     pkColJsonNode.put("SingerId", 1);


### PR DESCRIPTION
We should only query information schema if the recorded tracked columns is less than the # of columns from a mod for `NEW_VALUES` and `OLD_AND_NEW_VALUES`. For these two val capture types, it is expected to have less columns in new values json compare to all tracking columns and this doesn't necessarily means there are schema updates.

 Basically `detectDiffColumnInMod` should return false if `keySetOfNewValuesJsonObject` is a subset of `spannerTable.getNonPkColumns()`.
 
 Before the fix the information schema columns query would trigger more often than needed, whenever there are less columns in new values json compare to all tracking columns for `NEW_VALUES` and `OLD_AND_NEW_VALUES`. This is more likely to occur if user has just add a new column and only try to only update that new column(where mod will only contain the new column).