### PR TITLE
Fix github action concurrency to cancel old commit on new push

### DIFF
--- a/.github/workflows/kafka-pr.yml
+++ b/.github/workflows/kafka-pr.yml
@@ -38,7 +38,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/spanner-pr.yml
+++ b/.github/workflows/spanner-pr.yml
@@ -42,7 +42,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
apply same fix of #1595 to the other two workflows