### PR TITLE
Use a more recent version of cache action

### DIFF
--- a/.github/actions/setup-java-env/action.yml
+++ b/.github/actions/setup-java-env/action.yml
@@ -57,7 +57,7 @@ runs:
           echo "YESTERDAY=$KEY" >> $GITHUB_ENV
         fi
     - name: Setup Cache
-      uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
+      uses: actions/cache@v4
       id: setup-cache
       with:
         path: |


### PR DESCRIPTION
Right now this is causing the release workflow to fail - https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/runs/13386891020/job/37420600891