### PR TITLE
Set multi release manifest for classic template shadow jar

### DIFF
--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -1006,6 +1006,11 @@
                     </filter>
                   </filters>
                   <transformers>
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                      <manifestEntries>
+                        <Multi-Release>true</Multi-Release>
+                      </manifestEntries>
+                    </transformer>
                     <transformer
                         implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                   </transformers>


### PR DESCRIPTION
This fixes classic template running on Java 21, which causes same error as https://github.com/apache/beam/issues/33471