### PR TITLE
Add logic to skip runnerV2 for the ITs

### DIFF
--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
@@ -135,6 +135,7 @@ public abstract class TemplateTestBase {
   protected GcsResourceManager artifactClient;
 
   private boolean usingDirectRunner;
+  private boolean skipRunnerV2;
   protected PipelineLauncher pipelineLauncher;
   protected boolean skipBaseCleanup;
 
@@ -147,14 +148,16 @@ public abstract class TemplateTestBase {
     MultiTemplateIntegrationTest multiAnnotation =
         getClass().getAnnotation(MultiTemplateIntegrationTest.class);
     usingDirectRunner = System.getProperty("directRunnerTest") != null;
+    skipRunnerV2 = System.getProperty("skipRunnerV2Test") != null;
     try {
       Method testMethod = getClass().getMethod(testName);
       annotation = testMethod.getAnnotation(TemplateIntegrationTest.class);
       Category category = testMethod.getAnnotation(Category.class);
       if (category != null) {
         usingDirectRunner =
-            Arrays.asList(category.value()).contains(DirectRunnerTest.class) ||  Arrays.asList(category.value()).contains(
-            SkipRunnerV2Test.class) || usingDirectRunner;
+            Arrays.asList(category.value()).contains(DirectRunnerTest.class) || usingDirectRunner;
+        skipRunnerV2 = Arrays.asList(category.value()).contains(
+            SkipRunnerV2Test.class) && skipRunnerV2;
       }
     } catch (NoSuchMethodException e) {
       // ignore error
@@ -495,8 +498,9 @@ public abstract class TemplateTestBase {
     String unifiedWorkerHarnessContainerImage =
         System.getProperty("unifiedWorkerHarnessContainerImage");
     if (System.getProperty("unifiedWorker") != null || unifiedWorkerHarnessContainerImage != null) {
-      appendExperiment(options, "use_runner_v2");
-
+      if(!skipRunnerV2) {
+        appendExperiment(options, "use_runner_v2");
+      }
       if (System.getProperty("sdkContainerImage") != null) {
         options.addParameter("sdkContainerImage", System.getProperty("sdkContainerImage"));
       }

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
@@ -155,8 +155,7 @@ public abstract class TemplateTestBase {
       if (category != null) {
         usingDirectRunner =
             Arrays.asList(category.value()).contains(DirectRunnerTest.class) || usingDirectRunner;
-        skipRunnerV2 =
-            Arrays.asList(category.value()).contains(SkipRunnerV2Test.class);
+        skipRunnerV2 = Arrays.asList(category.value()).contains(SkipRunnerV2Test.class);
       }
     } catch (NoSuchMethodException e) {
       // ignore error
@@ -496,8 +495,10 @@ public abstract class TemplateTestBase {
     // Property allows testing with Runner v2 / Unified Worker
     String unifiedWorkerHarnessContainerImage =
         System.getProperty("unifiedWorkerHarnessContainerImage");
-    if (!skipRunnerV2 && (System.getProperty("unifiedWorker") != null || unifiedWorkerHarnessContainerImage != null)) {
-        appendExperiment(options, "use_runner_v2");
+    if (!skipRunnerV2
+        && (System.getProperty("unifiedWorker") != null
+            || unifiedWorkerHarnessContainerImage != null)) {
+      appendExperiment(options, "use_runner_v2");
       if (System.getProperty("sdkContainerImage") != null) {
         options.addParameter("sdkContainerImage", System.getProperty("sdkContainerImage"));
       }

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
@@ -24,6 +24,7 @@ import com.google.auth.Credentials;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.teleport.metadata.DirectRunnerTest;
 import com.google.cloud.teleport.metadata.MultiTemplateIntegrationTest;
+import com.google.cloud.teleport.metadata.SkipRunnerV2Test;
 import com.google.cloud.teleport.metadata.Template;
 import com.google.cloud.teleport.metadata.Template.TemplateType;
 import com.google.cloud.teleport.metadata.TemplateCreationParameter;
@@ -152,7 +153,8 @@ public abstract class TemplateTestBase {
       Category category = testMethod.getAnnotation(Category.class);
       if (category != null) {
         usingDirectRunner =
-            Arrays.asList(category.value()).contains(DirectRunnerTest.class) || usingDirectRunner;
+            Arrays.asList(category.value()).contains(DirectRunnerTest.class) ||  Arrays.asList(category.value()).contains(
+            SkipRunnerV2Test.class) || usingDirectRunner;
       }
     } catch (NoSuchMethodException e) {
       // ignore error

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
@@ -148,7 +148,6 @@ public abstract class TemplateTestBase {
     MultiTemplateIntegrationTest multiAnnotation =
         getClass().getAnnotation(MultiTemplateIntegrationTest.class);
     usingDirectRunner = System.getProperty("directRunnerTest") != null;
-    skipRunnerV2 = System.getProperty("skipRunnerV2Test") != null;
     try {
       Method testMethod = getClass().getMethod(testName);
       annotation = testMethod.getAnnotation(TemplateIntegrationTest.class);
@@ -156,8 +155,8 @@ public abstract class TemplateTestBase {
       if (category != null) {
         usingDirectRunner =
             Arrays.asList(category.value()).contains(DirectRunnerTest.class) || usingDirectRunner;
-        skipRunnerV2 = Arrays.asList(category.value()).contains(
-            SkipRunnerV2Test.class) && skipRunnerV2;
+        skipRunnerV2 =
+            Arrays.asList(category.value()).contains(SkipRunnerV2Test.class);
       }
     } catch (NoSuchMethodException e) {
       // ignore error
@@ -497,10 +496,8 @@ public abstract class TemplateTestBase {
     // Property allows testing with Runner v2 / Unified Worker
     String unifiedWorkerHarnessContainerImage =
         System.getProperty("unifiedWorkerHarnessContainerImage");
-    if (System.getProperty("unifiedWorker") != null || unifiedWorkerHarnessContainerImage != null) {
-      if(!skipRunnerV2) {
+    if (!skipRunnerV2 && (System.getProperty("unifiedWorker") != null || unifiedWorkerHarnessContainerImage != null)) {
         appendExperiment(options, "use_runner_v2");
-      }
       if (System.getProperty("sdkContainerImage") != null) {
         options.addParameter("sdkContainerImage", System.getProperty("sdkContainerImage"));
       }

--- a/pom.xml
+++ b/pom.xml
@@ -678,6 +678,10 @@
             <configuration combine.self="override">
               <systemProperties>
                 <property>
+                  <name>skipRunnerV2Tests</name>
+                  <value>true</value>
+                </property>
+                <property>
                   <name>beamPythonVersion</name>
                   <value>${beam-python.version}</value>
                 </property>

--- a/pom.xml
+++ b/pom.xml
@@ -678,7 +678,7 @@
             <configuration combine.self="override">
               <systemProperties>
                 <property>
-                  <name>skipRunnerV2Tests</name>
+                  <name>skipRunnerV2Test</name>
                   <value>true</value>
                 </property>
                 <property>

--- a/pom.xml
+++ b/pom.xml
@@ -678,10 +678,6 @@
             <configuration combine.self="override">
               <systemProperties>
                 <property>
-                  <name>skipRunnerV2Test</name>
-                  <value>true</value>
-                </property>
-                <property>
                   <name>beamPythonVersion</name>
                   <value>${beam-python.version}</value>
                 </property>


### PR DESCRIPTION
This code adds the logic for skipping runner V2 for the integration test methods that are annotated with SkipRunnerV2Test in the JUnit categories or using system property in the profile.