### PR TITLE
Update Dockerfile-template-yaml

### DIFF
--- a/plugins/core-plugin/src/main/resources/Dockerfile-template-yaml
+++ b/plugins/core-plugin/src/main/resources/Dockerfile-template-yaml
@@ -28,7 +28,10 @@ RUN python -m venv /venv \
     && mv /venv/lib/python$PY_VERSION/site-packages /usr/local/lib/python$PY_VERSION/
 
 # Cache provider environments for faster startup and expansion time
-RUN python -m apache_beam.utils.subprocess_server
+RUN mkdir -p /root/.apache_beam/cache/jars/
+RUN wget -O /root/.apache_beam/cache/jars/beam-sdks-java-io-expansion-service-${beamVersion}.jar https://repo1.maven.org/maven2/org/apache/beam/beam-sdks-java-io-expansion-service/${beamVersion}/beam-sdks-java-io-expansion-service-${beamVersion}.jar
+RUN wget -O /root/.apache_beam/cache/jars/beam-sdks-java-extensions-schemaio-expansion-service-${beamVersion}.jar https://repo1.maven.org/maven2/org/apache/beam/beam-sdks-java-extensions-schemaio-expansion-service/${beamVersion}/beam-sdks-java-extensions-schemaio-expansion-service-${beamVersion}.jar
+RUN wget -O /root/.apache_beam/cache/jars/beam-sdks-java-io-google-cloud-platform-expansion-service-${beamVersion}.jar https://repo1.maven.org/maven2/org/apache/beam/beam-sdks-java-io-google-cloud-platform-expansion-service/${beamVersion}/beam-sdks-java-io-google-cloud-platform-expansion-service-${beamVersion}.jar
 RUN python -m apache_beam.yaml.cache_provider_artifacts
 
 #============================================================#

--- a/plugins/core-plugin/src/main/resources/Dockerfile-template-yaml
+++ b/plugins/core-plugin/src/main/resources/Dockerfile-template-yaml
@@ -28,6 +28,7 @@ RUN python -m venv /venv \
     && mv /venv/lib/python$PY_VERSION/site-packages /usr/local/lib/python$PY_VERSION/
 
 # Cache provider environments for faster startup and expansion time
+RUN python -m apache_beam.utils.subprocess_server
 RUN python -m apache_beam.yaml.cache_provider_artifacts
 
 #============================================================#

--- a/plugins/core-plugin/src/main/resources/Dockerfile-template-yaml
+++ b/plugins/core-plugin/src/main/resources/Dockerfile-template-yaml
@@ -29,9 +29,9 @@ RUN python -m venv /venv \
 
 # Cache provider environments for faster startup and expansion time
 RUN mkdir -p ~/.apache_beam/cache/jars
-RUN wget -O ~/.apache_beam/cache/jars/beam-sdks-java-io-expansion-service-2.63.0.jar https://repo1.maven.org/maven2/org/apache/beam/beam-sdks-java-io-expansion-service/2.63.0/beam-sdks-java-io-expansion-service-2.63.0.jar
-RUN wget -O ~/.apache_beam/cache/jars/beam-sdks-java-extensions-schemaio-expansion-service-2.63.0.jar https://repo1.maven.org/maven2/org/apache/beam/beam-sdks-java-extensions-schemaio-expansion-service/2.63.0/beam-sdks-java-extensions-schemaio-expansion-service-2.63.0.jar
-RUN wget -O ~/.apache_beam/cache/jars/beam-sdks-java-io-google-cloud-platform-expansion-service-2.63.0.jar https://repo1.maven.org/maven2/org/apache/beam/beam-sdks-java-io-google-cloud-platform-expansion-service/2.63.0/beam-sdks-java-io-google-cloud-platform-expansion-service-2.63.0.jar
+RUN wget -O ~/.apache_beam/cache/jars/beam-sdks-java-io-expansion-service-${beamVersion}.jar https://repo1.maven.org/maven2/org/apache/beam/beam-sdks-java-io-expansion-service/${beamVersion}/beam-sdks-java-io-expansion-service-${beamVersion}.jar
+RUN wget -O ~/.apache_beam/cache/jars/beam-sdks-java-extensions-schemaio-expansion-service-${beamVersion}.jar https://repo1.maven.org/maven2/org/apache/beam/beam-sdks-java-extensions-schemaio-expansion-service/${beamVersion}/beam-sdks-java-extensions-schemaio-expansion-service-${beamVersion}.jar
+RUN wget -O ~/.apache_beam/cache/jars/beam-sdks-java-io-google-cloud-platform-expansion-service-${beamVersion}.jar https://repo1.maven.org/maven2/org/apache/beam/beam-sdks-java-io-google-cloud-platform-expansion-service/${beamVersion}/beam-sdks-java-io-google-cloud-platform-expansion-service-${beamVersion}.jar
 RUN python -m apache_beam.yaml.cache_provider_artifacts
 
 #============================================================#

--- a/plugins/core-plugin/src/main/resources/Dockerfile-template-yaml
+++ b/plugins/core-plugin/src/main/resources/Dockerfile-template-yaml
@@ -28,10 +28,10 @@ RUN python -m venv /venv \
     && mv /venv/lib/python$PY_VERSION/site-packages /usr/local/lib/python$PY_VERSION/
 
 # Cache provider environments for faster startup and expansion time
-RUN mkdir -p /root/.apache_beam/cache/jars/
-RUN wget -O /root/.apache_beam/cache/jars/beam-sdks-java-io-expansion-service-${beamVersion}.jar https://repo1.maven.org/maven2/org/apache/beam/beam-sdks-java-io-expansion-service/${beamVersion}/beam-sdks-java-io-expansion-service-${beamVersion}.jar
-RUN wget -O /root/.apache_beam/cache/jars/beam-sdks-java-extensions-schemaio-expansion-service-${beamVersion}.jar https://repo1.maven.org/maven2/org/apache/beam/beam-sdks-java-extensions-schemaio-expansion-service/${beamVersion}/beam-sdks-java-extensions-schemaio-expansion-service-${beamVersion}.jar
-RUN wget -O /root/.apache_beam/cache/jars/beam-sdks-java-io-google-cloud-platform-expansion-service-${beamVersion}.jar https://repo1.maven.org/maven2/org/apache/beam/beam-sdks-java-io-google-cloud-platform-expansion-service/${beamVersion}/beam-sdks-java-io-google-cloud-platform-expansion-service-${beamVersion}.jar
+RUN mkdir -p ~/.apache_beam/cache/jars
+RUN wget -O ~/.apache_beam/cache/jars/beam-sdks-java-io-expansion-service-2.63.0.jar https://repo1.maven.org/maven2/org/apache/beam/beam-sdks-java-io-expansion-service/2.63.0/beam-sdks-java-io-expansion-service-2.63.0.jar
+RUN wget -O ~/.apache_beam/cache/jars/beam-sdks-java-extensions-schemaio-expansion-service-2.63.0.jar https://repo1.maven.org/maven2/org/apache/beam/beam-sdks-java-extensions-schemaio-expansion-service/2.63.0/beam-sdks-java-extensions-schemaio-expansion-service-2.63.0.jar
+RUN wget -O ~/.apache_beam/cache/jars/beam-sdks-java-io-google-cloud-platform-expansion-service-2.63.0.jar https://repo1.maven.org/maven2/org/apache/beam/beam-sdks-java-io-google-cloud-platform-expansion-service/2.63.0/beam-sdks-java-io-google-cloud-platform-expansion-service-2.63.0.jar
 RUN python -m apache_beam.yaml.cache_provider_artifacts
 
 #============================================================#


### PR DESCRIPTION
This change adds JARs to the cache in the Dockerfile, so that a Dataflow pipeline doesn't need to access public maven during pipeline runtime.

Verified that the JARs are in the cache:

<img width="1062" alt="Screenshot 2025-03-04 at 9 04 08 PM" src="https://github.com/user-attachments/assets/7839d557-a35f-44c8-8b1a-e6a1dbdffbcc" />



Pipeline expanding `ReadFromKafka` from cache:


<img width="790" alt="Screenshot 2025-03-04 at 9 10 13 PM" src="https://github.com/user-attachments/assets/8da16a9b-c444-41d8-a1b1-601ffe53b1f4" />

