### PR TITLE
Add Option to run Incremental Export From Bigtable (Timestamp Filtering)

### DIFF
--- a/v1/README_Cloud_Bigtable_to_GCS_Avro.md
+++ b/v1/README_Cloud_Bigtable_to_GCS_Avro.md
@@ -152,6 +152,8 @@ export FILENAME_PREFIX=part
 
 ### Optional
 export BIGTABLE_APP_PROFILE_ID=default
+export START_TIMESTAMP=<start-timestamp-utc>
+export END_TIMESTAMP=<end-timestamp-utc>
 
 mvn clean package -PtemplatesRun \
 -DskipTests \
@@ -160,7 +162,7 @@ mvn clean package -PtemplatesRun \
 -Dregion="$REGION" \
 -DjobName="cloud-bigtable-to-gcs-avro-job" \
 -DtemplateName="Cloud_Bigtable_to_GCS_Avro" \
--Dparameters="bigtableProjectId=$BIGTABLE_PROJECT_ID,bigtableInstanceId=$BIGTABLE_INSTANCE_ID,bigtableTableId=$BIGTABLE_TABLE_ID,outputDirectory=$OUTPUT_DIRECTORY,filenamePrefix=$FILENAME_PREFIX,bigtableAppProfileId=$BIGTABLE_APP_PROFILE_ID" \
+-Dparameters="bigtableProjectId=$BIGTABLE_PROJECT_ID,bigtableInstanceId=$BIGTABLE_INSTANCE_ID,bigtableTableId=$BIGTABLE_TABLE_ID,outputDirectory=$OUTPUT_DIRECTORY,filenamePrefix=$FILENAME_PREFIX,bigtableAppProfileId=$BIGTABLE_APP_PROFILE_ID,startTimestamp=$START_TIMESTAMP,endTimestamp=$END_TIMESTAMP" \
 -f v1
 ```
 

--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -852,7 +852,7 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>0.6.1</version>
         <configuration>
-         <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
           <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.gen.version}:exe:${os.detected.classifier}</pluginArtifact>
         </configuration>

--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -852,9 +852,11 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>0.6.1</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+<!--          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>-->
+          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:osx-x86_64</protocArtifact>
           <pluginId>grpc-java</pluginId>
-          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.gen.version}:exe:${os.detected.classifier}</pluginArtifact>
+          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.gen.version}:exe:osx-x86_64</pluginArtifact>
+<!--          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.gen.version}:exe:${os.detected.classifier}</pluginArtifact>-->
         </configuration>
         <executions>
           <execution>

--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -852,11 +852,9 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>0.6.1</version>
         <configuration>
-<!--          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>-->
-          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:osx-x86_64</protocArtifact>
+         <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
-          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.gen.version}:exe:osx-x86_64</pluginArtifact>
-<!--          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.gen.version}:exe:${os.detected.classifier}</pluginArtifact>-->
+          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.gen.version}:exe:${os.detected.classifier}</pluginArtifact>
         </configuration>
         <executions>
           <execution>

--- a/v1/src/main/java/com/google/cloud/teleport/bigtable/BigtableToAvro.java
+++ b/v1/src/main/java/com/google/cloud/teleport/bigtable/BigtableToAvro.java
@@ -51,6 +51,12 @@ import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
+<<<<<<< HEAD
+=======
+
+
+
+>>>>>>> 382231bde (Adding changes for Bigtable incremental export for Bigtable to Avro)
 
 /**
  * Dataflow pipeline that exports data from a Cloud Bigtable table to Avro files in GCS. 
@@ -61,6 +67,7 @@ import org.joda.time.format.ISODateTimeFormat;
  * for instructions on how to use or modify this template.
  */
 @Template(
+<<<<<<< HEAD
     name = "Cloud_Bigtable_to_GCS_Avro",
     category = TemplateCategory.BATCH,
     displayName = "Cloud Bigtable to Avro Files in Cloud Storage",
@@ -295,57 +302,313 @@ public class BigtableToAvro {
             ByteBuffer value = ByteBuffer.wrap(toByteArray(cell.getValue()));
             cells.add(new BigtableCell(familyName, qualifier, timestamp, value));
           }
+=======
+        name = "Cloud_Bigtable_to_GCS_Avro",
+        category = TemplateCategory.BATCH,
+        displayName = "Cloud Bigtable to Avro Files in Cloud Storage",
+        description =
+                "The Bigtable to Cloud Storage Avro template is a pipeline that reads data from a Bigtable table and writes it to a Cloud Storage bucket in Avro format. "
+                        + "You can use the template to move data from Bigtable to Cloud Storage.",
+        optionsClass = Options.class,
+        documentation =
+                "https://cloud.google.com/dataflow/docs/guides/templates/provided/bigtable-to-avro",
+        contactInformation = "https://cloud.google.com/support",
+        requirements = {
+                "The Bigtable table must exist.",
+                "The output Cloud Storage bucket must exist before running the pipeline."
+        })
+
+
+public class BigtableToAvro {
+
+    /**
+     * Options for the export pipeline.
+     */
+
+    public interface Options extends PipelineOptions {
+        @TemplateParameter.ProjectId(
+                order = 1,
+                groupName = "Source",
+                description = "Project ID",
+                helpText =
+                        "The ID of the Google Cloud project that contains the Bigtable instance that you want to read data from.")
+        ValueProvider<String> getBigtableProjectId();
+
+        @SuppressWarnings("unused")
+        void setBigtableProjectId(ValueProvider<String> projectId);
+
+        @TemplateParameter.Text(
+                order = 2,
+                groupName = "Source",
+                regexes = {"[a-z][a-z0-9\\-]+[a-z0-9]"},
+                description = "Instance ID",
+                helpText = "The ID of the Bigtable instance that contains the table.")
+        ValueProvider<String> getBigtableInstanceId();
+
+        @SuppressWarnings("unused")
+        void setBigtableInstanceId(ValueProvider<String> instanceId);
+
+        @TemplateParameter.Text(
+                order = 3,
+                groupName = "Source",
+                regexes = {"[_a-zA-Z0-9][-_.a-zA-Z0-9]*"},
+                description = "Table ID",
+                helpText = "The ID of the Bigtable table to export.")
+        ValueProvider<String> getBigtableTableId();
+
+        @SuppressWarnings("unused")
+        void setBigtableTableId(ValueProvider<String> tableId);
+
+        @TemplateParameter.GcsWriteFolder(
+                order = 4,
+                groupName = "Target",
+                description = "Output file directory in Cloud Storage",
+                helpText = "The Cloud Storage path where data is written.",
+                example = "gs://mybucket/somefolder")
+        ValueProvider<String> getOutputDirectory();
+
+        @SuppressWarnings("unused")
+        void setOutputDirectory(ValueProvider<String> outputDirectory);
+
+        @TemplateParameter.Text(
+                order = 5,
+                groupName = "Target",
+                description = "Avro file prefix",
+                helpText = "The prefix of the Avro filename. For example, `output-`.")
+        @Default.String("part")
+        ValueProvider<String> getFilenamePrefix();
+
+        @SuppressWarnings("unused")
+        void setFilenamePrefix(ValueProvider<String> filenamePrefix);
+
+        @TemplateParameter.Text(
+                order = 6,
+                groupName = "Source",
+                optional = true,
+                regexes = {"[_a-zA-Z0-9][-_.a-zA-Z0-9]*"},
+                description = "Application profile ID",
+                helpText =
+                        "The ID of the Bigtable application profile to use for the export. If you don't specify an app profile, Bigtable uses the instance's default app profile: https://cloud.google.com/bigtable/docs/app-profiles#default-app-profile.")
+        @Default.String("default")
+        ValueProvider<String> getBigtableAppProfileId();
+
+        @SuppressWarnings("unused")
+        void setBigtableAppProfileId(ValueProvider<String> appProfileId);
+
+
+        @TemplateParameter.Text(
+                order = 7,
+                groupName = "Source",
+                optional = true,
+                regexes = {"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z"},
+                description = "Start Timestamp in UTC Format (YYYY-MM-DDTHH:MM:SSZ) for exporting ",
+                helpText = "The start timestamp (inclusive) for exporting data. Data with timestamps greater than or equal to this timestamp will be exported. Example UTC timestamp: 2024-10-27T10:15:30.00Z"
+        )
+        ValueProvider<String> getStartTimestamp();
+
+        @SuppressWarnings("unused")
+        void setStartTimestamp(ValueProvider<String> startTimestamp);
+
+        @TemplateParameter.Text(
+                order = 8,
+                groupName = "Source",
+                optional = true,
+                regexes = {"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z"},
+                description = "End Timestamp in UTC Format (YYYY-MM-DDTHH:MM:SSZ)",
+                helpText = " Example UTC timestamp 2024-10-27T10:15:30.00Z"
+        )
+        ValueProvider<String> getEndTimestamp();
+
+        @SuppressWarnings("unused")
+        void setEndTimestamp(ValueProvider<String> endTimestamp);
+    }
+
+    /**
+     * Runs a pipeline to export data from a Cloud Bigtable table to Avro files in GCS.
+     *
+     * @param args arguments to the pipeline
+     */
+    public static void main(String[] args) {
+        Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+
+        PipelineResult result = run(options);
+
+        // Wait for pipeline to finish only if it is not constructing a template.
+        if (options.as(DataflowPipelineOptions.class).getTemplateLocation() == null) {
+            result.waitUntilFinish();
+>>>>>>> 382231bde (Adding changes for Bigtable incremental export for Bigtable to Avro)
         }
-      }
-      return new BigtableRow(key, cells);
-    }
-  }
-
-  /**
-   * Extracts the byte array from the given {@link ByteString} without copy.
-   *
-   * @param byteString A {@link ByteString} from which to extract the array.
-   * @return an array of byte.
-   */
-  protected static byte[] toByteArray(final ByteString byteString) {
-    try {
-      ZeroCopyByteOutput byteOutput = new ZeroCopyByteOutput();
-      UnsafeByteOperations.unsafeWriteTo(byteString, byteOutput);
-      return byteOutput.bytes;
-    } catch (IOException e) {
-      return byteString.toByteArray();
-    }
-  }
-
-  private static final class ZeroCopyByteOutput extends ByteOutput {
-    private byte[] bytes;
-
-    @Override
-    public void writeLazy(byte[] value, int offset, int length) {
-      if (offset != 0 || length != value.length) {
-        throw new UnsupportedOperationException();
-      }
-      bytes = value;
     }
 
-    @Override
-    public void write(byte value) {
-      throw new UnsupportedOperationException();
+    /**
+     * @noinspection checkstyle:Indentation, checkstyle:Indentation
+     */
+    public static PipelineResult run(Options options) {
+
+        Pipeline pipeline = Pipeline.create(PipelineUtils.tweakPipelineOptions(options));
+
+        // Create a function to build the RowFilter based on the timestamps
+        SerializableFunction<String, Long> timestampConverter = utcTimestamp -> {
+            if (utcTimestamp == null || utcTimestamp.isEmpty()) {
+                return null;
+            }
+            DateTimeFormatter parser = ISODateTimeFormat.dateTimeParser();
+            return parser.parseDateTime(utcTimestamp).getMillis() * 1000;
+        };
+
+        // Runtime validation for timestamp parameters
+        ValueProvider<RowFilter> filterProvider = new DualInputNestedValueProvider<>(
+                options.getStartTimestamp(),
+                options.getEndTimestamp(),
+                (TranslatorInput<String, String> input) -> {
+                    String startTimestamp = input.getX();
+                    String endTimestamp = input.getY();
+
+                    boolean hasStart = startTimestamp != null && !startTimestamp.isEmpty();
+                    boolean hasEnd = endTimestamp != null && !endTimestamp.isEmpty();
+
+                    // Check if exactly one timestamp is provided (which is invalid)
+                    if ((hasStart && !hasEnd) || (!hasStart && hasEnd)) {
+                        throw new IllegalArgumentException(
+                                "Both startTimestamp and endTimestamp must be provided together, or neither should be provided.");
+                    }
+
+                    // If neither timestamp is provided, return null (no filter)
+                    if (!hasStart && !hasEnd) {
+                        return null;
+                    }
+
+                    // Convert timestamps to microseconds
+                    Long startMicros = timestampConverter.apply(startTimestamp);
+                    Long endMicros = timestampConverter.apply(endTimestamp);
+
+                    // Build the timestamp filter
+                    com.google.cloud.bigtable.data.v2.models.Filters.TimestampRangeFilter filterBuilder =
+                            FILTERS.timestamp().range();
+
+                    if (startMicros != null) {
+                        filterBuilder.startClosed(startMicros);
+                    }
+                    if (endMicros != null) {
+                        filterBuilder.endOpen(endMicros);
+                    }
+
+                    return filterBuilder.toProto();
+                });
+
+        // Create basic BigtableIO.Read
+        BigtableIO.Read read =
+                BigtableIO.read()
+                        .withProjectId(options.getBigtableProjectId())
+                        .withInstanceId(options.getBigtableInstanceId())
+                        .withAppProfileId(options.getBigtableAppProfileId())
+                        .withTableId(options.getBigtableTableId());
+
+
+        read = read.withRowFilter(filterProvider);
+
+        // Do not validate input fields if it is running as a template.
+        if (options.as(DataflowPipelineOptions.class).getTemplateLocation() != null) {
+            read = read.withoutValidation();
+        }
+
+        ValueProvider<String> filePathPrefix =
+                DualInputNestedValueProvider.of(
+                        options.getOutputDirectory(),
+                        options.getFilenamePrefix(),
+                        new SerializableFunction<TranslatorInput<String, String>, String>() {
+                            @Override
+                            public String apply(TranslatorInput<String, String> input) {
+                                return FileSystems.matchNewResource(input.getX(), true)
+                                        .resolve(input.getY(), StandardResolveOptions.RESOLVE_FILE)
+                                        .toString();
+                            }
+            });
+
+        pipeline
+                .apply("Read from Bigtable", read)
+                .apply("Transform to Avro", MapElements.via(new BigtableToAvroFn()))
+                .apply(
+                        "Write to Avro in GCS",
+                        AvroIO.write(BigtableRow.class).to(filePathPrefix).withSuffix(".avro"));
+
+        return pipeline.run();
     }
 
-    @Override
-    public void write(byte[] value, int offset, int length) {
-      throw new UnsupportedOperationException();
+
+    /**
+     * Translates Bigtable {@link Row} to Avro {@link BigtableRow}.
+     */
+    static class BigtableToAvroFn extends SimpleFunction<Row, BigtableRow> {
+        @Override
+        public BigtableRow apply(Row row) {
+            ByteBuffer key = ByteBuffer.wrap(toByteArray(row.getKey()));
+            List<BigtableCell> cells = new ArrayList<>();
+            for (Family family : row.getFamiliesList()) {
+                String familyName = family.getName();
+                for (Column column : family.getColumnsList()) {
+                    ByteBuffer qualifier = ByteBuffer.wrap(toByteArray(column.getQualifier()));
+                    for (Cell cell : column.getCellsList()) {
+                        long timestamp = cell.getTimestampMicros();
+                        ByteBuffer value = ByteBuffer.wrap(toByteArray(cell.getValue()));
+                        cells.add(new BigtableCell(familyName, qualifier, timestamp, value));
+                    }
+                }
+            }
+            return new BigtableRow(key, cells);
+        }
     }
 
-    @Override
-    public void write(ByteBuffer value) {
-      throw new UnsupportedOperationException();
+    /**
+     * Extracts the byte array from the given {@link ByteString} without copy.
+     *
+     * @param byteString A {@link ByteString} from which to extract the array.
+     * @return an array of byte.
+     */
+    protected static byte[] toByteArray(final ByteString byteString) {
+        try {
+            ZeroCopyByteOutput byteOutput = new ZeroCopyByteOutput();
+            UnsafeByteOperations.unsafeWriteTo(byteString, byteOutput);
+            return byteOutput.bytes;
+        } catch (IOException e) {
+            return byteString.toByteArray();
+        }
     }
 
-    @Override
-    public void writeLazy(ByteBuffer value) {
-      throw new UnsupportedOperationException();
+    private static final class ZeroCopyByteOutput extends ByteOutput {
+        private byte[] bytes;
+
+        @Override
+        public void writeLazy(byte[] value, int offset, int length) {
+            if (offset != 0 || length != value.length) {
+                throw new UnsupportedOperationException();
+            }
+            bytes = value;
+        }
+
+        @Override
+        public void write(byte value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void write(byte[] value, int offset, int length) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void write(ByteBuffer value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void writeLazy(ByteBuffer value) {
+            throw new UnsupportedOperationException();
+        }
     }
+<<<<<<< HEAD
   }
 }
+=======
+}
+>>>>>>> 382231bde (Adding changes for Bigtable incremental export for Bigtable to Avro)

--- a/v1/src/main/java/com/google/cloud/teleport/bigtable/BigtableToAvro.java
+++ b/v1/src/main/java/com/google/cloud/teleport/bigtable/BigtableToAvro.java
@@ -17,12 +17,11 @@ package com.google.cloud.teleport.bigtable;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
-import com.google.bigtable.v2.Column;
 import com.google.bigtable.v2.Cell;
+import com.google.bigtable.v2.Column;
 import com.google.bigtable.v2.Family;
 import com.google.bigtable.v2.Row;
 import com.google.bigtable.v2.RowFilter;
-import com.google.bigtable.v2.TimestampRange;
 import com.google.cloud.teleport.bigtable.BigtableToAvro.Options;
 import com.google.cloud.teleport.metadata.Template;
 import com.google.cloud.teleport.metadata.TemplateCategory;
@@ -34,7 +33,6 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.UnsafeByteOperations;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.time.*;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
@@ -44,14 +42,16 @@ import org.apache.beam.sdk.extensions.avro.io.AvroIO;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.io.gcp.bigtable.BigtableIO;
-import org.apache.beam.sdk.options.*;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 
 
 
@@ -64,391 +64,306 @@ import org.slf4j.LoggerFactory;
  * for instructions on how to use or modify this template.
  */
 @Template(
-    name = "Cloud_Bigtable_to_GCS_Avro",
-    category = TemplateCategory.BATCH,
-    displayName = "Cloud Bigtable to Avro Files in Cloud Storage",
-    description =
-        "The Bigtable to Cloud Storage Avro template is a pipeline that reads data from a Bigtable table and writes it to a Cloud Storage bucket in Avro format. "
-            + "You can use the template to move data from Bigtable to Cloud Storage.",
-    optionsClass = Options.class,
-    documentation =
-        "https://cloud.google.com/dataflow/docs/guides/templates/provided/bigtable-to-avro",
-    contactInformation = "https://cloud.google.com/support",
-    requirements = {
-      "The Bigtable table must exist.",
-      "The output Cloud Storage bucket must exist before running the pipeline."
-    })
-
+        name = "Cloud_Bigtable_to_GCS_Avro",
+        category = TemplateCategory.BATCH,
+        displayName = "Cloud Bigtable to Avro Files in Cloud Storage",
+        description =
+                "The Bigtable to Cloud Storage Avro template is a pipeline that reads data from a Bigtable table and writes it to a Cloud Storage bucket in Avro format. "
+                        + "You can use the template to move data from Bigtable to Cloud Storage.",
+        optionsClass = Options.class,
+        documentation =
+                "https://cloud.google.com/dataflow/docs/guides/templates/provided/bigtable-to-avro",
+        contactInformation = "https://cloud.google.com/support",
+        requirements = {
+                "The Bigtable table must exist.",
+                "The output Cloud Storage bucket must exist before running the pipeline."
+        })
 
 
 public class BigtableToAvro {
 
-  private static final Logger LOG = LoggerFactory.getLogger(BigtableToAvro.class);
+    /**
+     * Options for the export pipeline.
+     */
+
+    public interface Options extends PipelineOptions {
+        @TemplateParameter.ProjectId(
+                order = 1,
+                groupName = "Source",
+                description = "Project ID",
+                helpText =
+                        "The ID of the Google Cloud project that contains the Bigtable instance that you want to read data from.")
+        ValueProvider<String> getBigtableProjectId();
+
+        @SuppressWarnings("unused")
+        void setBigtableProjectId(ValueProvider<String> projectId);
+
+        @TemplateParameter.Text(
+                order = 2,
+                groupName = "Source",
+                regexes = {"[a-z][a-z0-9\\-]+[a-z0-9]"},
+                description = "Instance ID",
+                helpText = "The ID of the Bigtable instance that contains the table.")
+        ValueProvider<String> getBigtableInstanceId();
+
+        @SuppressWarnings("unused")
+        void setBigtableInstanceId(ValueProvider<String> instanceId);
+
+        @TemplateParameter.Text(
+                order = 3,
+                groupName = "Source",
+                regexes = {"[_a-zA-Z0-9][-_.a-zA-Z0-9]*"},
+                description = "Table ID",
+                helpText = "The ID of the Bigtable table to export.")
+        ValueProvider<String> getBigtableTableId();
+
+        @SuppressWarnings("unused")
+        void setBigtableTableId(ValueProvider<String> tableId);
+
+        @TemplateParameter.GcsWriteFolder(
+                order = 4,
+                groupName = "Target",
+                description = "Output file directory in Cloud Storage",
+                helpText = "The Cloud Storage path where data is written.",
+                example = "gs://mybucket/somefolder")
+        ValueProvider<String> getOutputDirectory();
+
+        @SuppressWarnings("unused")
+        void setOutputDirectory(ValueProvider<String> outputDirectory);
+
+        @TemplateParameter.Text(
+                order = 5,
+                groupName = "Target",
+                description = "Avro file prefix",
+                helpText = "The prefix of the Avro filename. For example, `output-`.")
+        @Default.String("part")
+        ValueProvider<String> getFilenamePrefix();
+
+        @SuppressWarnings("unused")
+        void setFilenamePrefix(ValueProvider<String> filenamePrefix);
+
+        @TemplateParameter.Text(
+                order = 6,
+                groupName = "Source",
+                optional = true,
+                regexes = {"[_a-zA-Z0-9][-_.a-zA-Z0-9]*"},
+                description = "Application profile ID",
+                helpText =
+                        "The ID of the Bigtable application profile to use for the export. If you don't specify an app profile, Bigtable uses the instance's default app profile: https://cloud.google.com/bigtable/docs/app-profiles#default-app-profile.")
+        @Default.String("default")
+        ValueProvider<String> getBigtableAppProfileId();
+
+        @SuppressWarnings("unused")
+        void setBigtableAppProfileId(ValueProvider<String> appProfileId);
 
 
-  /** Options for the export pipeline. */
+        @TemplateParameter.Text(
+                order = 7,
+                groupName = "Source",
+                optional = true,
+                regexes = {"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z"},
+                description = "Start Timestamp in UTC Format (YYYY-MM-DDTHH:MM:SSZ) for exporting ",
+                helpText = "The start timestamp (inclusive) for exporting data. Data with timestamps greater than or equal to this timestamp will be exported. Example UTC timestamp: 2024-10-27T10:15:30.00Z"
+        )
+        ValueProvider<String> getStartTimestamp();
 
+        @SuppressWarnings("unused")
+        void setStartTimestamp(ValueProvider<String> startTimestamp);
 
-  public interface Options extends PipelineOptions {
-    @TemplateParameter.ProjectId(
-        order = 1,
-        groupName = "Source",
-        description = "Project ID",
-        helpText =
-            "The ID of the Google Cloud project that contains the Bigtable instance that you want to read data from.")
-    ValueProvider<String> getBigtableProjectId();
+        @TemplateParameter.Text(
+                order = 8,
+                groupName = "Source",
+                optional = true,
+                regexes = {"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z"},
+                description = "End Timestamp in UTC Format (YYYY-MM-DDTHH:MM:SSZ)",
+                helpText = " Example UTC timestamp 2024-10-27T10:15:30.00Z"
+        )
+        ValueProvider<String> getEndTimestamp();
 
-    @SuppressWarnings("unused")
-    void setBigtableProjectId(ValueProvider<String> projectId);
-
-    @TemplateParameter.Text(
-        order = 2,
-        groupName = "Source",
-        regexes = {"[a-z][a-z0-9\\-]+[a-z0-9]"},
-        description = "Instance ID",
-        helpText = "The ID of the Bigtable instance that contains the table.")
-    ValueProvider<String> getBigtableInstanceId();
-
-    @SuppressWarnings("unused")
-    void setBigtableInstanceId(ValueProvider<String> instanceId);
-
-    @TemplateParameter.Text(
-        order = 3,
-        groupName = "Source",
-        regexes = {"[_a-zA-Z0-9][-_.a-zA-Z0-9]*"},
-        description = "Table ID",
-        helpText = "The ID of the Bigtable table to export.")
-    ValueProvider<String> getBigtableTableId();
-
-    @SuppressWarnings("unused")
-    void setBigtableTableId(ValueProvider<String> tableId);
-
-    @TemplateParameter.GcsWriteFolder(
-        order = 4,
-        groupName = "Target",
-        description = "Output file directory in Cloud Storage",
-        helpText = "The Cloud Storage path where data is written.",
-        example = "gs://mybucket/somefolder")
-    ValueProvider<String> getOutputDirectory();
-
-    @SuppressWarnings("unused")
-    void setOutputDirectory(ValueProvider<String> outputDirectory);
-
-    @TemplateParameter.Text(
-        order = 5,
-        groupName = "Target",
-        description = "Avro file prefix",
-        helpText = "The prefix of the Avro filename. For example, `output-`.")
-    @Default.String("part")
-    ValueProvider<String> getFilenamePrefix();
-
-    @SuppressWarnings("unused")
-    void setFilenamePrefix(ValueProvider<String> filenamePrefix);
-
-    @TemplateParameter.Text(
-        order = 6,
-        groupName = "Source",
-        optional = true,
-        regexes = {"[_a-zA-Z0-9][-_.a-zA-Z0-9]*"},
-        description = "Application profile ID",
-        helpText =
-            "The ID of the Bigtable application profile to use for the export. If you don't specify an app profile, Bigtable uses the instance's default app profile: https://cloud.google.com/bigtable/docs/app-profiles#default-app-profile.")
-    @Default.String("default")
-    ValueProvider<String> getBigtableAppProfileId();
-
-    @SuppressWarnings("unused")
-    void setBigtableAppProfileId(ValueProvider<String> appProfileId);
-
-
-    @TemplateParameter.Text(
-            order = 7,
-            groupName = "Source",
-            description = "Start Timestamp in UTC Format (YYYY-MM-DDTHH:MM:SSZ)",
-            helpText = " Example UTC timestamp 2024-10-27T10:15:30.00Z"
-    )
-    ValueProvider<String> getStartTimestamp();
-    @SuppressWarnings("unused")
-    void setStartTimestamp(ValueProvider<String> startTimestamp);
-
-
-    @TemplateParameter.Text(
-            order = 8,
-            groupName = "Source",
-            description = "End Timestamp in UTC Format (YYYY-MM-DDTHH:MM:SSZ)",
-            helpText = " Example UTC timestamp 2024-10-27T10:15:30.00Z"
-    )
-    ValueProvider<String> getEndTimestamp();
-    @SuppressWarnings("unused")
-    void setEndTimestamp(ValueProvider<String> endTimestamp);
-
-//    @TemplateParameter.Text(
-//            order = 7,
-//            groupName = "Source",
-//            description = "Start Timestamp in UTC Format (YYYY-MM-DDTHH:MM:SSZ)",
-//            helpText = " Example UTC timestamp 2024-10-27T10:15:30.00Z"
-//    )
-//    @Description("Start Timestamp in UTC Format (YYYY-MM-DDTHH:MM:SSZ)")
-//    @Default.String("") // Provide a default value or leave it empty
-//    String getStartTimestamp();
-//
-//    void setStartTimestamp(String startTimestamp1);
-//
-//
-//    @TemplateParameter.Text(
-//            order = 8,
-//            groupName = "Source",
-//            description = "End Timestamp in UTC Format (YYYY-MM-DDTHH:MM:SSZ)",
-//            helpText = " Example UTC timestamp 2024-10-27T10:15:30.00Z"
-//    )
-//    @Description("End Timestamp in UTC Format (YYYY-MM-DDTHH:MM:SSZ)")
-//    @Default.String("")
-//    String getEndTimestamp();
-//
-//    void setEndTimestamp(String endTimestamp1);
-
-  }
-
-  /**
-   * Runs a pipeline to export data from a Cloud Bigtable table to Avro files in GCS.
-   *
-   * @param args arguments to the pipeline
-   */
-  public static void main(String[] args) {
-    Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
-
-    SdkHarnessOptions loggingOptions = options.as(SdkHarnessOptions.class);
-    loggingOptions.setDefaultSdkHarnessLogLevel(SdkHarnessOptions.LogLevel.TRACE);
-
-    PipelineResult result = run(options);
-
-
-    // Wait for pipeline to finish only if it is not constructing a template.
-    if (options.as(DataflowPipelineOptions.class).getTemplateLocation() == null) {
-      result.waitUntilFinish();
-    }
-  }
-
-  public static long convertUtcToMicros(String utcTimestamp) {
-    DateTimeFormatter parser = ISODateTimeFormat.dateTimeParser();
-    long microsTimestamp = parser.parseDateTime(utcTimestamp).getMillis() * 1000;
-    LOG.debug("Converting UTC timestamp {} to microseconds: {}", utcTimestamp, microsTimestamp);
-    return microsTimestamp;
-  }
-
-  public static PipelineResult run(Options options) {
-    Pipeline pipeline = Pipeline.create(PipelineUtils.tweakPipelineOptions(options));
-
-    // Create a function to build the RowFilter based on the timestamps
-    SerializableFunction<String, Long> timestampConverter = utcTimestamp -> {
-      if (utcTimestamp == null || utcTimestamp.isEmpty()) {
-        return null;
-      }
-      DateTimeFormatter parser = ISODateTimeFormat.dateTimeParser();
-      return parser.parseDateTime(utcTimestamp).getMillis() * 1000;
-    };
-
-    ValueProvider<RowFilter> filterProvider = new DualInputNestedValueProvider<>(
-            options.getStartTimestamp(),
-            options.getEndTimestamp(),
-            (TranslatorInput<String, String> input) -> {
-              Long startMicros = timestampConverter.apply(input.getX());
-              Long endMicros = timestampConverter.apply(input.getY());
-
-              if (startMicros == null && endMicros == null) {
-                return null;
-              }
-
-              com.google.cloud.bigtable.data.v2.models.Filters.TimestampRangeFilter filterBuilder =
-                      FILTERS.timestamp().range();
-
-              if (startMicros != null) {
-                filterBuilder.startClosed(startMicros);
-              }
-              if (endMicros != null) {
-                filterBuilder.endOpen(endMicros);
-              }
-
-              return filterBuilder.toProto();
-            });
-
-    BigtableIO.Read read =
-            BigtableIO.read()
-                    .withProjectId(options.getBigtableProjectId())
-                    .withInstanceId(options.getBigtableInstanceId())
-                    .withAppProfileId(options.getBigtableAppProfileId())
-                    .withTableId(options.getBigtableTableId());
-
-    // Only add filter if timestamps are provided
-    if (options.getStartTimestamp() != null || options.getEndTimestamp() != null) {
-      read = read.withRowFilter(filterProvider);
+        @SuppressWarnings("unused")
+        void setEndTimestamp(ValueProvider<String> endTimestamp);
     }
 
-    // Do not validate input fields if it is running as a template.
-    if (options.as(DataflowPipelineOptions.class).getTemplateLocation() != null) {
-      read = read.withoutValidation();
-    }
-//    String startTimestamp = options.getStartTimestamp();
-////    String endTimestamp = options.getEndTimestamp();
-////
-////    long startMicros = 0;
-////    long endMicros = 0;
-////
-////    long epochMillis1 = Long.parseLong(startTimestamp);
-////    long epochMillis2 = Long.parseLong(endTimestamp);
-//
-//
-//    if (startTimestamp != null && !startTimestamp.isEmpty()) {
-//      startMicros = convertUtcToMicros(startTimestamp);
-//      LOG.info("Start timestamp microseconds: {}", startMicros);
-//    }
-//
-//    if (endTimestamp != null && !endTimestamp.isEmpty()) {
-//      endMicros = convertUtcToMicros(endTimestamp);
-//      LOG.info("End timestamp microseconds: {}", endMicros);
-//    }
-//
-//    RowFilter actualFilter =
-//            FILTERS.timestamp().range().startClosed(epochMillis1).endOpen(epochMillis2).toProto();
+    /**
+     * Runs a pipeline to export data from a Cloud Bigtable table to Avro files in GCS.
+     *
+     * @param args arguments to the pipeline
+     */
+    public static void main(String[] args) {
+        Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
 
-//    long startMicros =0;
-//    RowFilter.Builder filterBuilder = RowFilter.newBuilder();
-//    TimestampRange.Builder timestampRangeBuilder = TimestampRange.newBuilder();
-//    if (options.getStartTimestamp() != null && options.getStartTimestamp().isAccessible()) {
-//      String startTimestamp = options.getStartTimestamp().get();
-//      LOG.info("Processing start timestamp: {}", startTimestamp);
-//      if (startTimestamp != null && !startTimestamp.isEmpty()) {
-//         startMicros = convertUtcToMicros(startTimestamp);
-//        timestampRangeBuilder.setStartTimestampMicros(startMicros);
-//        LOG.info("Set start timestamp filter to {} microseconds", startMicros);
-//      }
-//    }
-//
-//    long endMicros=0;
-//
-//    if (options.getEndTimestamp() != null && options.getEndTimestamp().isAccessible()) {
-//      String endTimestamp = options.getEndTimestamp().get();
-//      LOG.info("Processing end timestamp: {}", endTimestamp);
-//      if (endTimestamp != null && !endTimestamp.isEmpty()) {
-//         endMicros = convertUtcToMicros(endTimestamp);
-//        timestampRangeBuilder.setEndTimestampMicros(endMicros);
-//        LOG.info("Set end timestamp filter to {} microseconds", endMicros);
-//      }
-//    }
-//
-//    TimestampRange timestampRange = timestampRangeBuilder.build();
-//    RowFilter filter = filterBuilder
-//            .setTimestampRangeFilter(timestampRange)
-//            .build();
-//
-//    LOG.info("Created row filter with timestamp range: {}", filter);
-//
-//    RowFilter actualFilter =
-//            FILTERS.timestamp().range().startClosed(startMicros).endOpen(endMicros).toProto();
+        PipelineResult result = run(options);
 
-//    BigtableIO.Read read =
-//        BigtableIO.read()
-//            .withProjectId(options.getBigtableProjectId())
-//            .withInstanceId(options.getBigtableInstanceId())
-//            .withAppProfileId(options.getBigtableAppProfileId())
-//            .withTableId(options.getBigtableTableId())
-//             .withRowFilter(actualFilter);
-
-
-
-    // Do not validate input fields if it is running as a template.
-    if (options.as(DataflowPipelineOptions.class).getTemplateLocation() != null) {
-      read = read.withoutValidation();
-    }
-
-    ValueProvider<String> filePathPrefix =
-        DualInputNestedValueProvider.of(
-            options.getOutputDirectory(),
-            options.getFilenamePrefix(),
-            new SerializableFunction<TranslatorInput<String, String>, String>() {
-              @Override
-              public String apply(TranslatorInput<String, String> input) {
-                return FileSystems.matchNewResource(input.getX(), true)
-                    .resolve(input.getY(), StandardResolveOptions.RESOLVE_FILE)
-                    .toString();
-              }
-            });
-
-    pipeline
-        .apply("Read from Bigtable", read)
-        .apply("Transform to Avro", MapElements.via(new BigtableToAvroFn()))
-        .apply(
-            "Write to Avro in GCS",
-            AvroIO.write(BigtableRow.class).to(filePathPrefix).withSuffix(".avro"));
-
-    return pipeline.run();
-  }
-
-  /** Translates Bigtable {@link Row} to Avro {@link BigtableRow}. */
-  static class BigtableToAvroFn extends SimpleFunction<Row, BigtableRow> {
-    @Override
-    public BigtableRow apply(Row row) {
-      ByteBuffer key = ByteBuffer.wrap(toByteArray(row.getKey()));
-      List<BigtableCell> cells = new ArrayList<>();
-      for (Family family : row.getFamiliesList()) {
-        String familyName = family.getName();
-        for (Column column : family.getColumnsList()) {
-          ByteBuffer qualifier = ByteBuffer.wrap(toByteArray(column.getQualifier()));
-          for (Cell cell : column.getCellsList()) {
-            long timestamp = cell.getTimestampMicros();
-            ByteBuffer value = ByteBuffer.wrap(toByteArray(cell.getValue()));
-            cells.add(new BigtableCell(familyName, qualifier, timestamp, value));
-          }
+        // Wait for pipeline to finish only if it is not constructing a template.
+        if (options.as(DataflowPipelineOptions.class).getTemplateLocation() == null) {
+            result.waitUntilFinish();
         }
-      }
-      return new BigtableRow(key, cells);
-    }
-  }
-
-  /**
-   * Extracts the byte array from the given {@link ByteString} without copy.
-   *
-   * @param byteString A {@link ByteString} from which to extract the array.
-   * @return an array of byte.
-   */
-  protected static byte[] toByteArray(final ByteString byteString) {
-    try {
-      ZeroCopyByteOutput byteOutput = new ZeroCopyByteOutput();
-      UnsafeByteOperations.unsafeWriteTo(byteString, byteOutput);
-      return byteOutput.bytes;
-    } catch (IOException e) {
-      return byteString.toByteArray();
-    }
-  }
-
-  private static final class ZeroCopyByteOutput extends ByteOutput {
-    private byte[] bytes;
-
-    @Override
-    public void writeLazy(byte[] value, int offset, int length) {
-      if (offset != 0 || length != value.length) {
-        throw new UnsupportedOperationException();
-      }
-      bytes = value;
     }
 
-    @Override
-    public void write(byte value) {
-      throw new UnsupportedOperationException();
+    /**
+     * @noinspection checkstyle:Indentation, checkstyle:Indentation
+     */
+    public static PipelineResult run(Options options) {
+
+        Pipeline pipeline = Pipeline.create(PipelineUtils.tweakPipelineOptions(options));
+
+        // Create a function to build the RowFilter based on the timestamps
+        SerializableFunction<String, Long> timestampConverter = utcTimestamp -> {
+            if (utcTimestamp == null || utcTimestamp.isEmpty()) {
+                return null;
+            }
+            DateTimeFormatter parser = ISODateTimeFormat.dateTimeParser();
+            return parser.parseDateTime(utcTimestamp).getMillis() * 1000;
+        };
+
+        // Runtime validation for timestamp parameters
+        ValueProvider<RowFilter> filterProvider = new DualInputNestedValueProvider<>(
+                options.getStartTimestamp(),
+                options.getEndTimestamp(),
+                (TranslatorInput<String, String> input) -> {
+                    String startTimestamp = input.getX();
+                    String endTimestamp = input.getY();
+
+                    boolean hasStart = startTimestamp != null && !startTimestamp.isEmpty();
+                    boolean hasEnd = endTimestamp != null && !endTimestamp.isEmpty();
+
+                    // Check if exactly one timestamp is provided (which is invalid)
+                    if ((hasStart && !hasEnd) || (!hasStart && hasEnd)) {
+                        throw new IllegalArgumentException(
+                                "Both startTimestamp and endTimestamp must be provided together, or neither should be provided.");
+                    }
+
+                    // If neither timestamp is provided, return null (no filter)
+                    if (!hasStart && !hasEnd) {
+                        return null;
+                    }
+
+                    // Convert timestamps to microseconds
+                    Long startMicros = timestampConverter.apply(startTimestamp);
+                    Long endMicros = timestampConverter.apply(endTimestamp);
+
+                    // Build the timestamp filter
+                    com.google.cloud.bigtable.data.v2.models.Filters.TimestampRangeFilter filterBuilder =
+                            FILTERS.timestamp().range();
+
+                    if (startMicros != null) {
+                        filterBuilder.startClosed(startMicros);
+                    }
+                    if (endMicros != null) {
+                        filterBuilder.endOpen(endMicros);
+                    }
+
+                    return filterBuilder.toProto();
+                });
+
+        // Create basic BigtableIO.Read
+        BigtableIO.Read read =
+                BigtableIO.read()
+                        .withProjectId(options.getBigtableProjectId())
+                        .withInstanceId(options.getBigtableInstanceId())
+                        .withAppProfileId(options.getBigtableAppProfileId())
+                        .withTableId(options.getBigtableTableId());
+
+
+        read = read.withRowFilter(filterProvider);
+
+        // Do not validate input fields if it is running as a template.
+        if (options.as(DataflowPipelineOptions.class).getTemplateLocation() != null) {
+            read = read.withoutValidation();
+        }
+
+        ValueProvider<String> filePathPrefix =
+                DualInputNestedValueProvider.of(
+                        options.getOutputDirectory(),
+                        options.getFilenamePrefix(),
+                        new SerializableFunction<TranslatorInput<String, String>, String>() {
+                            @Override
+                            public String apply(TranslatorInput<String, String> input) {
+                                return FileSystems.matchNewResource(input.getX(), true)
+                                        .resolve(input.getY(), StandardResolveOptions.RESOLVE_FILE)
+                                        .toString();
+                            }
+            });
+
+        pipeline
+                .apply("Read from Bigtable", read)
+                .apply("Transform to Avro", MapElements.via(new BigtableToAvroFn()))
+                .apply(
+                        "Write to Avro in GCS",
+                        AvroIO.write(BigtableRow.class).to(filePathPrefix).withSuffix(".avro"));
+
+        return pipeline.run();
     }
 
-    @Override
-    public void write(byte[] value, int offset, int length) {
-      throw new UnsupportedOperationException();
+
+    /**
+     * Translates Bigtable {@link Row} to Avro {@link BigtableRow}.
+     */
+    static class BigtableToAvroFn extends SimpleFunction<Row, BigtableRow> {
+        @Override
+        public BigtableRow apply(Row row) {
+            ByteBuffer key = ByteBuffer.wrap(toByteArray(row.getKey()));
+            List<BigtableCell> cells = new ArrayList<>();
+            for (Family family : row.getFamiliesList()) {
+                String familyName = family.getName();
+                for (Column column : family.getColumnsList()) {
+                    ByteBuffer qualifier = ByteBuffer.wrap(toByteArray(column.getQualifier()));
+                    for (Cell cell : column.getCellsList()) {
+                        long timestamp = cell.getTimestampMicros();
+                        ByteBuffer value = ByteBuffer.wrap(toByteArray(cell.getValue()));
+                        cells.add(new BigtableCell(familyName, qualifier, timestamp, value));
+                    }
+                }
+            }
+            return new BigtableRow(key, cells);
+        }
     }
 
-    @Override
-    public void write(ByteBuffer value) {
-      throw new UnsupportedOperationException();
+    /**
+     * Extracts the byte array from the given {@link ByteString} without copy.
+     *
+     * @param byteString A {@link ByteString} from which to extract the array.
+     * @return an array of byte.
+     */
+    protected static byte[] toByteArray(final ByteString byteString) {
+        try {
+            ZeroCopyByteOutput byteOutput = new ZeroCopyByteOutput();
+            UnsafeByteOperations.unsafeWriteTo(byteString, byteOutput);
+            return byteOutput.bytes;
+        } catch (IOException e) {
+            return byteString.toByteArray();
+        }
     }
 
-    @Override
-    public void writeLazy(ByteBuffer value) {
-      throw new UnsupportedOperationException();
+    private static final class ZeroCopyByteOutput extends ByteOutput {
+        private byte[] bytes;
+
+        @Override
+        public void writeLazy(byte[] value, int offset, int length) {
+            if (offset != 0 || length != value.length) {
+                throw new UnsupportedOperationException();
+            }
+            bytes = value;
+        }
+
+        @Override
+        public void write(byte value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void write(byte[] value, int offset, int length) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void write(ByteBuffer value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void writeLazy(ByteBuffer value) {
+            throw new UnsupportedOperationException();
+        }
     }
-  }
 }

--- a/v1/src/main/java/com/google/cloud/teleport/bigtable/BigtableToAvro.java
+++ b/v1/src/main/java/com/google/cloud/teleport/bigtable/BigtableToAvro.java
@@ -54,7 +54,7 @@ import org.joda.time.format.ISODateTimeFormat;
 
 /**
  * Dataflow pipeline that exports data from a Cloud Bigtable table to Avro files in GCS.
- * 
+ *
  *
  * <p>Check out <a
  * href="https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v1/README_Cloud_Bigtable_to_GCS_Avro.md">README</a>

--- a/v1/src/main/java/com/google/cloud/teleport/bigtable/BigtableToAvro.java
+++ b/v1/src/main/java/com/google/cloud/teleport/bigtable/BigtableToAvro.java
@@ -54,7 +54,7 @@ import org.joda.time.format.ISODateTimeFormat;
 
 /**
  * Dataflow pipeline that exports data from a Cloud Bigtable table to Avro files in GCS.
- * 2/25 Add filtering rows based on timestamp.
+ * 
  *
  * <p>Check out <a
  * href="https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v1/README_Cloud_Bigtable_to_GCS_Avro.md">README</a>

--- a/v1/src/main/java/com/google/cloud/teleport/bigtable/BigtableToAvro.java
+++ b/v1/src/main/java/com/google/cloud/teleport/bigtable/BigtableToAvro.java
@@ -15,10 +15,13 @@
  */
 package com.google.cloud.teleport.bigtable;
 
+import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
+
 import com.google.bigtable.v2.Cell;
 import com.google.bigtable.v2.Column;
 import com.google.bigtable.v2.Family;
 import com.google.bigtable.v2.Row;
+import com.google.bigtable.v2.RowFilter;
 import com.google.cloud.teleport.bigtable.BigtableToAvro.Options;
 import com.google.cloud.teleport.metadata.Template;
 import com.google.cloud.teleport.metadata.TemplateCategory;
@@ -46,10 +49,12 @@ import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
 
 /**
- * Dataflow pipeline that exports data from a Cloud Bigtable table to Avro files in GCS. Currently,
- * filtering on Cloud Bigtable table is not supported.
+ * Dataflow pipeline that exports data from a Cloud Bigtable table to Avro files in GCS.
+ * 2/25 Add filtering rows based on timestamp.
  *
  * <p>Check out <a
  * href="https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v1/README_Cloud_Bigtable_to_GCS_Avro.md">README</a>
@@ -142,6 +147,31 @@ public class BigtableToAvro {
 
     @SuppressWarnings("unused")
     void setBigtableAppProfileId(ValueProvider<String> appProfileId);
+    @TemplateParameter.Text(
+        order = 7,
+        groupName = "Source",
+        optional = true,
+        regexes = {"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z"},
+        description = "Start Timestamp in UTC Format (YYYY-MM-DDTHH:MM:SSZ) for exporting ",
+        helpText = "The start timestamp (inclusive) for exporting data. Data with timestamps greater than or equal to this timestamp will be exported. Example UTC timestamp: 2024-10-27T10:15:30.00Z"
+    )
+    ValueProvider<String> getStartTimestamp();
+
+    @SuppressWarnings("unused")
+    void setStartTimestamp(ValueProvider<String> startTimestamp);
+
+    @TemplateParameter.Text(
+        order = 8,
+        groupName = "Source",
+        optional = true,
+        regexes = {"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z"},
+        description = "End Timestamp in UTC Format (YYYY-MM-DDTHH:MM:SSZ)",
+        helpText = " Example UTC timestamp 2024-10-27T10:15:30.00Z"
+    )
+    ValueProvider<String> getEndTimestamp();
+
+    @SuppressWarnings("unused")
+    void setEndTimestamp(ValueProvider<String> endTimestamp);
   }
 
   /**
@@ -163,12 +193,66 @@ public class BigtableToAvro {
   public static PipelineResult run(Options options) {
     Pipeline pipeline = Pipeline.create(PipelineUtils.tweakPipelineOptions(options));
 
+    // Create a function to build the RowFilter based on the timestamps
+    SerializableFunction<String, Long> timestampConverter = utcTimestamp -> {
+      if (utcTimestamp == null || utcTimestamp.isEmpty()) {
+        return null;
+      }
+      DateTimeFormatter parser = ISODateTimeFormat.dateTimeParser();
+      return parser.parseDateTime(utcTimestamp).getMillis() * 1000;
+    };
+
+    // Runtime validation for timestamp parameters
+    ValueProvider<RowFilter> filterProvider = new DualInputNestedValueProvider<>(
+        options.getStartTimestamp(),
+        options.getEndTimestamp(),
+        (TranslatorInput<String, String> input) -> {
+          String startTimestamp = input.getX();
+          String endTimestamp = input.getY();
+
+          boolean hasStart = startTimestamp != null && !startTimestamp.isEmpty();
+          boolean hasEnd = endTimestamp != null && !endTimestamp.isEmpty();
+
+          // Check if exactly one timestamp is provided (which is invalid)
+          if ((hasStart && !hasEnd) || (!hasStart && hasEnd)) {
+            throw new IllegalArgumentException(
+                    "Both startTimestamp and endTimestamp must be provided together, or neither should be provided.");
+          }
+
+          // If neither timestamp is provided, return null (no filter)
+          if (!hasStart && !hasEnd) {
+            return null;
+          }
+
+          // Convert timestamps to microseconds
+          Long startMicros = timestampConverter.apply(startTimestamp);
+          Long endMicros = timestampConverter.apply(endTimestamp);
+
+          // Build the timestamp filter
+          com.google.cloud.bigtable.data.v2.models.Filters.TimestampRangeFilter filterBuilder =
+                  FILTERS.timestamp().range();
+
+          if (startMicros != null) {
+            filterBuilder.startClosed(startMicros);
+          }
+          if (endMicros != null) {
+            filterBuilder.endOpen(endMicros);
+          }
+
+          return filterBuilder.toProto();
+        });
+
     BigtableIO.Read read =
         BigtableIO.read()
             .withProjectId(options.getBigtableProjectId())
             .withInstanceId(options.getBigtableInstanceId())
             .withAppProfileId(options.getBigtableAppProfileId())
             .withTableId(options.getBigtableTableId());
+
+
+    //If start and end timestamps are provided. Rows will be filtered  based on cell timestamp.
+    // IF none of the timestamps are provided, the filter will remain empty.
+    read = read.withRowFilter(filterProvider);
 
     // Do not validate input fields if it is running as a template.
     if (options.as(DataflowPipelineOptions.class).getTemplateLocation() != null) {

--- a/v1/src/main/java/com/google/cloud/teleport/bigtable/BigtableToAvro.java
+++ b/v1/src/main/java/com/google/cloud/teleport/bigtable/BigtableToAvro.java
@@ -15,13 +15,10 @@
  */
 package com.google.cloud.teleport.bigtable;
 
-import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
-
 import com.google.bigtable.v2.Cell;
 import com.google.bigtable.v2.Column;
 import com.google.bigtable.v2.Family;
 import com.google.bigtable.v2.Row;
-import com.google.bigtable.v2.RowFilter;
 import com.google.cloud.teleport.bigtable.BigtableToAvro.Options;
 import com.google.cloud.teleport.metadata.Template;
 import com.google.cloud.teleport.metadata.TemplateCategory;
@@ -49,25 +46,16 @@ import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.SimpleFunction;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
-<<<<<<< HEAD
-=======
-
-
-
->>>>>>> 382231bde (Adding changes for Bigtable incremental export for Bigtable to Avro)
 
 /**
- * Dataflow pipeline that exports data from a Cloud Bigtable table to Avro files in GCS. 
- * 25/02 Added support for filtering on Cloud Bigtable table .
+ * Dataflow pipeline that exports data from a Cloud Bigtable table to Avro files in GCS. Currently,
+ * filtering on Cloud Bigtable table is not supported.
  *
  * <p>Check out <a
  * href="https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v1/README_Cloud_Bigtable_to_GCS_Avro.md">README</a>
  * for instructions on how to use or modify this template.
  */
 @Template(
-<<<<<<< HEAD
     name = "Cloud_Bigtable_to_GCS_Avro",
     category = TemplateCategory.BATCH,
     displayName = "Cloud Bigtable to Avro Files in Cloud Storage",
@@ -154,32 +142,6 @@ public class BigtableToAvro {
 
     @SuppressWarnings("unused")
     void setBigtableAppProfileId(ValueProvider<String> appProfileId);
-
-    @TemplateParameter.Text(
-        order = 7,
-        groupName = "Source",
-        optional = true,
-        regexes = {"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z"},
-        description = "Start Timestamp in UTC Format (YYYY-MM-DDTHH:MM:SSZ) for exporting ",
-        helpText = "The start timestamp (inclusive) for exporting data. Data with timestamps greater than or equal to this timestamp will be exported. Example UTC timestamp: 2024-10-27T10:15:30.00Z"
-    )
-    ValueProvider<String> getStartTimestamp();
-
-    @SuppressWarnings("unused")
-    void setStartTimestamp(ValueProvider<String> startTimestamp);
-
-    @TemplateParameter.Text(
-        order = 8,
-        groupName = "Source",
-        optional = true,
-        regexes = {"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z"},
-        description = "End Timestamp in UTC Format (YYYY-MM-DDTHH:MM:SSZ)",
-        helpText = " Example UTC timestamp 2024-10-27T10:15:30.00Z"
-    )
-    ValueProvider<String> getEndTimestamp();
-
-    @SuppressWarnings("unused")
-    void setEndTimestamp(ValueProvider<String> endTimestamp);
   }
 
   /**
@@ -201,63 +163,12 @@ public class BigtableToAvro {
   public static PipelineResult run(Options options) {
     Pipeline pipeline = Pipeline.create(PipelineUtils.tweakPipelineOptions(options));
 
-            // Create a function to build the RowFilter based on the timestamps
-    SerializableFunction<String, Long> timestampConverter = utcTimestamp -> {
-        if (utcTimestamp == null || utcTimestamp.isEmpty()) {
-            return null;
-        }
-        DateTimeFormatter parser = ISODateTimeFormat.dateTimeParser();
-        return parser.parseDateTime(utcTimestamp).getMillis() * 1000;
-    };
-
-    // Runtime validation for timestamp parameters
-    ValueProvider<RowFilter> filterProvider = new DualInputNestedValueProvider<>(
-            options.getStartTimestamp(),
-            options.getEndTimestamp(),
-            (TranslatorInput<String, String> input) -> {
-                String startTimestamp = input.getX();
-                String endTimestamp = input.getY();
-
-                boolean hasStart = startTimestamp != null && !startTimestamp.isEmpty();
-                boolean hasEnd = endTimestamp != null && !endTimestamp.isEmpty();
-
-                // Check if exactly one timestamp is provided (which is invalid)
-                if ((hasStart && !hasEnd) || (!hasStart && hasEnd)) {
-                    throw new IllegalArgumentException(
-                            "Both startTimestamp and endTimestamp must be provided together, or neither should be provided.");
-                }
-
-                // If neither timestamp is provided, return null (no filter)
-                if (!hasStart && !hasEnd) {
-                    return null;
-                }
-
-                // Convert timestamps to microseconds
-                Long startMicros = timestampConverter.apply(startTimestamp);
-                Long endMicros = timestampConverter.apply(endTimestamp);
-
-                // Build the timestamp filter
-                com.google.cloud.bigtable.data.v2.models.Filters.TimestampRangeFilter filterBuilder =
-                        FILTERS.timestamp().range();
-
-                if (startMicros != null) {
-                    filterBuilder.startClosed(startMicros);
-                }
-                if (endMicros != null) {
-                    filterBuilder.endOpen(endMicros);
-                }
-
-                return filterBuilder.toProto();
-            });
-
     BigtableIO.Read read =
         BigtableIO.read()
             .withProjectId(options.getBigtableProjectId())
             .withInstanceId(options.getBigtableInstanceId())
             .withAppProfileId(options.getBigtableAppProfileId())
             .withTableId(options.getBigtableTableId());
-
-    read = read.withRowFilter(filterProvider);
 
     // Do not validate input fields if it is running as a template.
     if (options.as(DataflowPipelineOptions.class).getTemplateLocation() != null) {
@@ -302,313 +213,57 @@ public class BigtableToAvro {
             ByteBuffer value = ByteBuffer.wrap(toByteArray(cell.getValue()));
             cells.add(new BigtableCell(familyName, qualifier, timestamp, value));
           }
-=======
-        name = "Cloud_Bigtable_to_GCS_Avro",
-        category = TemplateCategory.BATCH,
-        displayName = "Cloud Bigtable to Avro Files in Cloud Storage",
-        description =
-                "The Bigtable to Cloud Storage Avro template is a pipeline that reads data from a Bigtable table and writes it to a Cloud Storage bucket in Avro format. "
-                        + "You can use the template to move data from Bigtable to Cloud Storage.",
-        optionsClass = Options.class,
-        documentation =
-                "https://cloud.google.com/dataflow/docs/guides/templates/provided/bigtable-to-avro",
-        contactInformation = "https://cloud.google.com/support",
-        requirements = {
-                "The Bigtable table must exist.",
-                "The output Cloud Storage bucket must exist before running the pipeline."
-        })
+        }
+      }
+      return new BigtableRow(key, cells);
+    }
+  }
 
+  /**
+   * Extracts the byte array from the given {@link ByteString} without copy.
+   *
+   * @param byteString A {@link ByteString} from which to extract the array.
+   * @return an array of byte.
+   */
+  protected static byte[] toByteArray(final ByteString byteString) {
+    try {
+      ZeroCopyByteOutput byteOutput = new ZeroCopyByteOutput();
+      UnsafeByteOperations.unsafeWriteTo(byteString, byteOutput);
+      return byteOutput.bytes;
+    } catch (IOException e) {
+      return byteString.toByteArray();
+    }
+  }
 
-public class BigtableToAvro {
+  private static final class ZeroCopyByteOutput extends ByteOutput {
+    private byte[] bytes;
 
-    /**
-     * Options for the export pipeline.
-     */
-
-    public interface Options extends PipelineOptions {
-        @TemplateParameter.ProjectId(
-                order = 1,
-                groupName = "Source",
-                description = "Project ID",
-                helpText =
-                        "The ID of the Google Cloud project that contains the Bigtable instance that you want to read data from.")
-        ValueProvider<String> getBigtableProjectId();
-
-        @SuppressWarnings("unused")
-        void setBigtableProjectId(ValueProvider<String> projectId);
-
-        @TemplateParameter.Text(
-                order = 2,
-                groupName = "Source",
-                regexes = {"[a-z][a-z0-9\\-]+[a-z0-9]"},
-                description = "Instance ID",
-                helpText = "The ID of the Bigtable instance that contains the table.")
-        ValueProvider<String> getBigtableInstanceId();
-
-        @SuppressWarnings("unused")
-        void setBigtableInstanceId(ValueProvider<String> instanceId);
-
-        @TemplateParameter.Text(
-                order = 3,
-                groupName = "Source",
-                regexes = {"[_a-zA-Z0-9][-_.a-zA-Z0-9]*"},
-                description = "Table ID",
-                helpText = "The ID of the Bigtable table to export.")
-        ValueProvider<String> getBigtableTableId();
-
-        @SuppressWarnings("unused")
-        void setBigtableTableId(ValueProvider<String> tableId);
-
-        @TemplateParameter.GcsWriteFolder(
-                order = 4,
-                groupName = "Target",
-                description = "Output file directory in Cloud Storage",
-                helpText = "The Cloud Storage path where data is written.",
-                example = "gs://mybucket/somefolder")
-        ValueProvider<String> getOutputDirectory();
-
-        @SuppressWarnings("unused")
-        void setOutputDirectory(ValueProvider<String> outputDirectory);
-
-        @TemplateParameter.Text(
-                order = 5,
-                groupName = "Target",
-                description = "Avro file prefix",
-                helpText = "The prefix of the Avro filename. For example, `output-`.")
-        @Default.String("part")
-        ValueProvider<String> getFilenamePrefix();
-
-        @SuppressWarnings("unused")
-        void setFilenamePrefix(ValueProvider<String> filenamePrefix);
-
-        @TemplateParameter.Text(
-                order = 6,
-                groupName = "Source",
-                optional = true,
-                regexes = {"[_a-zA-Z0-9][-_.a-zA-Z0-9]*"},
-                description = "Application profile ID",
-                helpText =
-                        "The ID of the Bigtable application profile to use for the export. If you don't specify an app profile, Bigtable uses the instance's default app profile: https://cloud.google.com/bigtable/docs/app-profiles#default-app-profile.")
-        @Default.String("default")
-        ValueProvider<String> getBigtableAppProfileId();
-
-        @SuppressWarnings("unused")
-        void setBigtableAppProfileId(ValueProvider<String> appProfileId);
-
-
-        @TemplateParameter.Text(
-                order = 7,
-                groupName = "Source",
-                optional = true,
-                regexes = {"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z"},
-                description = "Start Timestamp in UTC Format (YYYY-MM-DDTHH:MM:SSZ) for exporting ",
-                helpText = "The start timestamp (inclusive) for exporting data. Data with timestamps greater than or equal to this timestamp will be exported. Example UTC timestamp: 2024-10-27T10:15:30.00Z"
-        )
-        ValueProvider<String> getStartTimestamp();
-
-        @SuppressWarnings("unused")
-        void setStartTimestamp(ValueProvider<String> startTimestamp);
-
-        @TemplateParameter.Text(
-                order = 8,
-                groupName = "Source",
-                optional = true,
-                regexes = {"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z"},
-                description = "End Timestamp in UTC Format (YYYY-MM-DDTHH:MM:SSZ)",
-                helpText = " Example UTC timestamp 2024-10-27T10:15:30.00Z"
-        )
-        ValueProvider<String> getEndTimestamp();
-
-        @SuppressWarnings("unused")
-        void setEndTimestamp(ValueProvider<String> endTimestamp);
+    @Override
+    public void writeLazy(byte[] value, int offset, int length) {
+      if (offset != 0 || length != value.length) {
+        throw new UnsupportedOperationException();
+      }
+      bytes = value;
     }
 
-    /**
-     * Runs a pipeline to export data from a Cloud Bigtable table to Avro files in GCS.
-     *
-     * @param args arguments to the pipeline
-     */
-    public static void main(String[] args) {
-        Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
-
-        PipelineResult result = run(options);
-
-        // Wait for pipeline to finish only if it is not constructing a template.
-        if (options.as(DataflowPipelineOptions.class).getTemplateLocation() == null) {
-            result.waitUntilFinish();
->>>>>>> 382231bde (Adding changes for Bigtable incremental export for Bigtable to Avro)
-        }
+    @Override
+    public void write(byte value) {
+      throw new UnsupportedOperationException();
     }
 
-    /**
-     * @noinspection checkstyle:Indentation, checkstyle:Indentation
-     */
-    public static PipelineResult run(Options options) {
-
-        Pipeline pipeline = Pipeline.create(PipelineUtils.tweakPipelineOptions(options));
-
-        // Create a function to build the RowFilter based on the timestamps
-        SerializableFunction<String, Long> timestampConverter = utcTimestamp -> {
-            if (utcTimestamp == null || utcTimestamp.isEmpty()) {
-                return null;
-            }
-            DateTimeFormatter parser = ISODateTimeFormat.dateTimeParser();
-            return parser.parseDateTime(utcTimestamp).getMillis() * 1000;
-        };
-
-        // Runtime validation for timestamp parameters
-        ValueProvider<RowFilter> filterProvider = new DualInputNestedValueProvider<>(
-                options.getStartTimestamp(),
-                options.getEndTimestamp(),
-                (TranslatorInput<String, String> input) -> {
-                    String startTimestamp = input.getX();
-                    String endTimestamp = input.getY();
-
-                    boolean hasStart = startTimestamp != null && !startTimestamp.isEmpty();
-                    boolean hasEnd = endTimestamp != null && !endTimestamp.isEmpty();
-
-                    // Check if exactly one timestamp is provided (which is invalid)
-                    if ((hasStart && !hasEnd) || (!hasStart && hasEnd)) {
-                        throw new IllegalArgumentException(
-                                "Both startTimestamp and endTimestamp must be provided together, or neither should be provided.");
-                    }
-
-                    // If neither timestamp is provided, return null (no filter)
-                    if (!hasStart && !hasEnd) {
-                        return null;
-                    }
-
-                    // Convert timestamps to microseconds
-                    Long startMicros = timestampConverter.apply(startTimestamp);
-                    Long endMicros = timestampConverter.apply(endTimestamp);
-
-                    // Build the timestamp filter
-                    com.google.cloud.bigtable.data.v2.models.Filters.TimestampRangeFilter filterBuilder =
-                            FILTERS.timestamp().range();
-
-                    if (startMicros != null) {
-                        filterBuilder.startClosed(startMicros);
-                    }
-                    if (endMicros != null) {
-                        filterBuilder.endOpen(endMicros);
-                    }
-
-                    return filterBuilder.toProto();
-                });
-
-        // Create basic BigtableIO.Read
-        BigtableIO.Read read =
-                BigtableIO.read()
-                        .withProjectId(options.getBigtableProjectId())
-                        .withInstanceId(options.getBigtableInstanceId())
-                        .withAppProfileId(options.getBigtableAppProfileId())
-                        .withTableId(options.getBigtableTableId());
-
-
-        read = read.withRowFilter(filterProvider);
-
-        // Do not validate input fields if it is running as a template.
-        if (options.as(DataflowPipelineOptions.class).getTemplateLocation() != null) {
-            read = read.withoutValidation();
-        }
-
-        ValueProvider<String> filePathPrefix =
-                DualInputNestedValueProvider.of(
-                        options.getOutputDirectory(),
-                        options.getFilenamePrefix(),
-                        new SerializableFunction<TranslatorInput<String, String>, String>() {
-                            @Override
-                            public String apply(TranslatorInput<String, String> input) {
-                                return FileSystems.matchNewResource(input.getX(), true)
-                                        .resolve(input.getY(), StandardResolveOptions.RESOLVE_FILE)
-                                        .toString();
-                            }
-            });
-
-        pipeline
-                .apply("Read from Bigtable", read)
-                .apply("Transform to Avro", MapElements.via(new BigtableToAvroFn()))
-                .apply(
-                        "Write to Avro in GCS",
-                        AvroIO.write(BigtableRow.class).to(filePathPrefix).withSuffix(".avro"));
-
-        return pipeline.run();
+    @Override
+    public void write(byte[] value, int offset, int length) {
+      throw new UnsupportedOperationException();
     }
 
-
-    /**
-     * Translates Bigtable {@link Row} to Avro {@link BigtableRow}.
-     */
-    static class BigtableToAvroFn extends SimpleFunction<Row, BigtableRow> {
-        @Override
-        public BigtableRow apply(Row row) {
-            ByteBuffer key = ByteBuffer.wrap(toByteArray(row.getKey()));
-            List<BigtableCell> cells = new ArrayList<>();
-            for (Family family : row.getFamiliesList()) {
-                String familyName = family.getName();
-                for (Column column : family.getColumnsList()) {
-                    ByteBuffer qualifier = ByteBuffer.wrap(toByteArray(column.getQualifier()));
-                    for (Cell cell : column.getCellsList()) {
-                        long timestamp = cell.getTimestampMicros();
-                        ByteBuffer value = ByteBuffer.wrap(toByteArray(cell.getValue()));
-                        cells.add(new BigtableCell(familyName, qualifier, timestamp, value));
-                    }
-                }
-            }
-            return new BigtableRow(key, cells);
-        }
+    @Override
+    public void write(ByteBuffer value) {
+      throw new UnsupportedOperationException();
     }
 
-    /**
-     * Extracts the byte array from the given {@link ByteString} without copy.
-     *
-     * @param byteString A {@link ByteString} from which to extract the array.
-     * @return an array of byte.
-     */
-    protected static byte[] toByteArray(final ByteString byteString) {
-        try {
-            ZeroCopyByteOutput byteOutput = new ZeroCopyByteOutput();
-            UnsafeByteOperations.unsafeWriteTo(byteString, byteOutput);
-            return byteOutput.bytes;
-        } catch (IOException e) {
-            return byteString.toByteArray();
-        }
+    @Override
+    public void writeLazy(ByteBuffer value) {
+      throw new UnsupportedOperationException();
     }
-
-    private static final class ZeroCopyByteOutput extends ByteOutput {
-        private byte[] bytes;
-
-        @Override
-        public void writeLazy(byte[] value, int offset, int length) {
-            if (offset != 0 || length != value.length) {
-                throw new UnsupportedOperationException();
-            }
-            bytes = value;
-        }
-
-        @Override
-        public void write(byte value) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void write(byte[] value, int offset, int length) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void write(ByteBuffer value) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void writeLazy(ByteBuffer value) {
-            throw new UnsupportedOperationException();
-        }
-    }
-<<<<<<< HEAD
   }
 }
-=======
-}
->>>>>>> 382231bde (Adding changes for Bigtable incremental export for Bigtable to Avro)

--- a/v1/src/test/java/com/google/cloud/teleport/bigtable/BigtableToAvroTimestampTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/bigtable/BigtableToAvroTimestampTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.bigtable;
+
+import static com.google.cloud.teleport.bigtable.BigtableToAvro.BigtableToAvroFn;
+import static com.google.cloud.teleport.bigtable.TestUtils.addAvroCell;
+import static com.google.cloud.teleport.bigtable.TestUtils.createAvroRow;
+import static com.google.cloud.teleport.bigtable.TestUtils.createBigtableRow;
+import static com.google.cloud.teleport.bigtable.TestUtils.upsertBigtableCell;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.bigtable.v2.Row;
+import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.teleport.bigtable.BigtableToAvro.Options;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.Filter;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.PCollection;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for BigtableToAvro with timestamp filtering.
+ */
+@RunWith(JUnit4.class)
+public final class BigtableToAvroTimestampTest {
+
+    @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+
+    // Column family and qualifier used in test data
+    private static final String COLUMN_FAMILY = "family1";
+    private static final String COLUMN_QUALIFIER = "column1";
+
+    // Timestamps for data (in microseconds)
+    private static final long EARLY_TS = new DateTime(2024, 10, 20, 10, 0, 0, DateTimeZone.UTC).getMillis() * 1000;
+    private static final long MID_TS = new DateTime(2024, 10, 25, 10, 0, 0, DateTimeZone.UTC).getMillis() * 1000;
+    private static final long LATE_TS = new DateTime(2024, 10, 30, 10, 0, 0, DateTimeZone.UTC).getMillis() * 1000;
+
+    // Filter timestamp range
+    private static final String START_TIMESTAMP = "2024-10-23T00:00:00.00Z";
+    private static final String END_TIMESTAMP = "2024-10-27T00:00:00.00Z";
+
+    private static final long START_TS_MICROS =
+            new DateTime(2024, 10, 23, 0, 0, 0, DateTimeZone.UTC).getMillis() * 1000;
+    private static final long END_TS_MICROS =
+            new DateTime(2024, 10, 27, 0, 0, 0, DateTimeZone.UTC).getMillis() * 1000;
+
+    private Options options;
+    private ValueProvider<String> emptyValueProvider;
+
+    @Before
+    public void setUp() {
+        options = mock(Options.class);
+        emptyValueProvider = StaticValueProvider.of("");
+
+        // Set up filter
+        when(options.getStartTimestamp()).thenReturn(StaticValueProvider.of(START_TIMESTAMP));
+        when(options.getEndTimestamp()).thenReturn(StaticValueProvider.of(END_TIMESTAMP));
+    }
+
+    @Test
+    public void testBigtableToAvroWithTimestampFilter() {
+        // Create test data with different timestamps
+        Row earlyRow = createBigtableRow("row1");
+        earlyRow = upsertBigtableCell(earlyRow, COLUMN_FAMILY, COLUMN_QUALIFIER, EARLY_TS, "early-value");
+
+        Row midRow = createBigtableRow("row2");
+        midRow = upsertBigtableCell(midRow, COLUMN_FAMILY, COLUMN_QUALIFIER, MID_TS, "mid-value");
+
+        Row lateRow = createBigtableRow("row3");
+        lateRow = upsertBigtableCell(lateRow, COLUMN_FAMILY, COLUMN_QUALIFIER, LATE_TS, "late-value");
+
+        final List<Row> bigtableRows = ImmutableList.of(earlyRow, midRow, lateRow);
+
+        // Create expected output (only the row with timestamp in range)
+        BigtableRow expectedAvroRow = createAvroRow("row2");
+        addAvroCell(expectedAvroRow, COLUMN_FAMILY, COLUMN_QUALIFIER, MID_TS, "mid-value");
+        final List<BigtableRow> expectedAvroRows = ImmutableList.of(expectedAvroRow);
+
+        // Simulate the filter by applying TimestampFilterPredicate
+        PCollection<Row> filteredRows =
+                pipeline
+                        .apply("Create", Create.of(bigtableRows))
+                        .apply("Apply Timestamp Filter", Filter.by(new TimestampFilterPredicate()));
+
+        // Convert filtered rows to Avro format
+        PCollection<BigtableRow> avroRows =
+                filteredRows.apply("Transform to Avro", MapElements.via(new BigtableToAvroFn()));
+
+        // Assert that only the row with timestamp in range is present
+        PAssert.that(avroRows).containsInAnyOrder(expectedAvroRows);
+
+        pipeline.run();
+    }
+
+    /**
+     * Test utility to simulate the timestamp filter behavior.
+     */
+    private static class TimestampFilterPredicate implements SerializableFunction<Row, Boolean> {
+        private static final long START_TS_MICROS =
+                new DateTime(2024, 10, 23, 0, 0, 0, DateTimeZone.UTC).getMillis() * 1000;
+        private static final long END_TS_MICROS =
+                new DateTime(2024, 10, 27, 0, 0, 0, DateTimeZone.UTC).getMillis() * 1000;
+
+        @Override
+        public Boolean apply(Row row) {
+            // Check each cell's timestamp to determine if the row should be included
+            for (com.google.bigtable.v2.Family family : row.getFamiliesList()) {
+                for (com.google.bigtable.v2.Column column : family.getColumnsList()) {
+                    for (com.google.bigtable.v2.Cell cell : column.getCellsList()) {
+                        long timestamp = cell.getTimestampMicros();
+                        if (timestamp >= START_TS_MICROS && timestamp < END_TS_MICROS) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Tests timestamp filter creation with valid start and end timestamps.
+     */
+    @Test
+    public void testFilterCreation_BothTimestamps() {
+        // Setup
+        ValueProvider<String> startTimestamp = StaticValueProvider.of("2024-10-27T10:15:10.00Z");
+        ValueProvider<String> endTimestamp = StaticValueProvider.of("2024-10-27T10:15:30.00Z");
+
+        when(options.getStartTimestamp()).thenReturn(startTimestamp);
+        when(options.getEndTimestamp()).thenReturn(endTimestamp);
+
+        // Calculate expected microseconds
+        DateTime startDateTime = new DateTime(2024, 10, 27, 10, 15, 10, DateTimeZone.UTC);
+        DateTime endDateTime = new DateTime(2024, 10, 27, 10, 15, 30, DateTimeZone.UTC);
+        long expectedStartMicros = startDateTime.getMillis() * 1000;
+        long expectedEndMicros = endDateTime.getMillis() * 1000;
+
+        // Use the new method to create the filterProvider
+        ValueProvider<RowFilter> filterProvider = BigtableToAvro.createRowFilterProvider(options);
+        RowFilter filter = filterProvider.get();
+
+        // Verify filter content
+        String filterString = filter.toString();
+        assertTrue(filterString.contains("timestamp_range_filter"));
+        assertTrue(filterString.contains("start_timestamp_micros: " + expectedStartMicros));
+        assertTrue(filterString.contains("end_timestamp_micros: " + expectedEndMicros));
+    }
+
+    /**
+     * Tests filter creation when no timestamps are provided.
+     */
+    @Test
+    public void testFilterCreation_NoTimestamps() {
+        // Setup
+        when(options.getStartTimestamp()).thenReturn(emptyValueProvider);
+        when(options.getEndTimestamp()).thenReturn(emptyValueProvider);
+
+        // Use the new method to create the filterProvider
+        ValueProvider<RowFilter> filterProvider = BigtableToAvro.createRowFilterProvider(options);
+
+        // Verify that no filter is created when no timestamps are provided
+        assertNull(filterProvider.get());
+    }
+
+    /**
+     * Tests that an exception is thrown when only start timestamp is provided.
+     */
+    @Test
+    public void testFilterCreation_OnlyStartTimestamp() {
+        // Setup
+        ValueProvider<String> startTimestamp = StaticValueProvider.of("2024-10-27T10:15:10.00Z");
+
+        when(options.getStartTimestamp()).thenReturn(startTimestamp);
+        when(options.getEndTimestamp()).thenReturn(emptyValueProvider);
+
+        // Use the new method to create the filterProvider
+        ValueProvider<RowFilter> filterProvider = BigtableToAvro.createRowFilterProvider(options);
+
+        // Verify that an exception is thrown when only start timestamp is provided
+        IllegalArgumentException exception =
+                assertThrows(IllegalArgumentException.class, () -> filterProvider.get());
+
+        assertEquals(
+                "Both startTimestamp and endTimestamp must be provided together, or neither should be provided.",
+                exception.getMessage());
+    }
+
+    /**
+     * Tests that an exception is thrown when only end timestamp is provided.
+     */
+    @Test
+    public void testFilterCreation_OnlyEndTimestamp() {
+        // Setup
+        ValueProvider<String> endTimestamp = StaticValueProvider.of("2024-10-27T10:15:30.00Z");
+
+        when(options.getStartTimestamp()).thenReturn(emptyValueProvider);
+        when(options.getEndTimestamp()).thenReturn(endTimestamp);
+
+        // Use the new method to create the filterProvider
+        ValueProvider<RowFilter> filterProvider = BigtableToAvro.createRowFilterProvider(options);
+
+        // Verify that an exception is thrown when only end timestamp is provided
+        IllegalArgumentException exception =
+                assertThrows(IllegalArgumentException.class, () -> filterProvider.get());
+
+        assertEquals(
+                "Both startTimestamp and endTimestamp must be provided together, or neither should be provided.",
+                exception.getMessage());
+    }
+
+    /**
+     * Tests that an exception is thrown when an invalid timestamp format is provided.
+     */
+    @Test
+    public void testFilterCreation_InvalidTimestampFormat() {
+        // Setup for invalid date format
+        ValueProvider<String> invalidStartTimestamp = StaticValueProvider.of("2024/10/27 10:15:10");
+        ValueProvider<String> validEndTimestamp = StaticValueProvider.of("2024-10-27T10:15:30.00Z");
+
+        when(options.getStartTimestamp()).thenReturn(invalidStartTimestamp);
+        when(options.getEndTimestamp()).thenReturn(validEndTimestamp);
+
+        // Use the new method to create the filterProvider
+        ValueProvider<RowFilter> filterProvider = BigtableToAvro.createRowFilterProvider(options);
+
+        // Verify that an exception is thrown for invalid date format
+        assertThrows(IllegalArgumentException.class, () -> filterProvider.get());
+    }
+}


### PR DESCRIPTION
**Description:**

This pull request introduces a new feature to enable incremental data exports from Google Cloud Bigtable based on timestamp filtering. This addresses a specific customer requirement for efficiently extracting daily data subsets for transfer to a non-production Bigtable instance.

**Problem:**

The customer needs to export data from their production Bigtable database on a daily basis, filtering it based on a timestamp criterion. Currently, the existing export functionality lacks the ability to perform incremental exports based on timestamps, forcing them to perform full table scans or implement complex custom solutions.

**Solution:**

This PR implements the following changes to enable incremental exports based on timestamps:

* **Introduce Timestamp Filtering Mechanism:**
    * Adds two new command-line options: `--startTimestamp` and `--endTimestamp`.
    * These options allow users to specify a time range in UTC format (YYYY-MM-DDTHH:MM:SSZ) to filter the data during export.
    * The export process will then only retrieve and export rows that fall within the specified time range.
* **Leverage Bigtable Timestamp Filtering Capabilities:**
    * Utilizes Bigtable's `TimestampRangeFilter` to efficiently retrieve only the required data.
    * This ensures that only the data within the specified time range is scanned and exported, minimizing resource consumption and export time.
* **Implementation Details:**
    * The `BigtableToAvro.Options` interface has been extended to include `getStartTimestamp()` and `getEndTimestamp()` methods.
    * A `timestampConverter` function is implemented to convert the provided UTC timestamp strings into microseconds.
    * A `filterProvider` `ValueProvider` is used to construct the `RowFilter` based on the provided start and end timestamps.
    * The `BigtableIO.Read` operation now includes a `withRowFilter(filterProvider)` call to apply the timestamp filter.
    * Validation is added to make sure if one time stamp is provided, the other one must be provided as well.
* **Code Snippet (RowFilter Construction):**

```java
ValueProvider<RowFilter> filterProvider = new DualInputNestedValueProvider<>(
        options.getStartTimestamp(),
        options.getEndTimestamp(),
        (TranslatorInput<String, String> input) -> {
            String startTimestamp = input.getX();
            String endTimestamp = input.getY();

            boolean hasStart = startTimestamp != null && !startTimestamp.isEmpty();
            boolean hasEnd = endTimestamp != null && !endTimestamp.isEmpty();

            // Check if exactly one timestamp is provided (which is invalid)
            if ((hasStart && !hasEnd) || (!hasStart && hasEnd)) {
                throw new IllegalArgumentException(
                        "Both startTimestamp and endTimestamp must be provided together, or neither should be provided.");
            }

            // If neither timestamp is provided, return null (no filter)
            if (!hasStart && !hasEnd) {
                return null;
            }

            // Convert timestamps to microseconds
            Long startMicros = timestampConverter.apply(startTimestamp);
            Long endMicros = timestampConverter.apply(endTimestamp);

            // Build the timestamp filter
            com.google.cloud.bigtable.data.v2.models.Filters.TimestampRangeFilter filterBuilder =
                    FILTERS.timestamp().range();

            if (startMicros != null) {
                filterBuilder.startClosed(startMicros);
            }
            if (endMicros != null) {
                filterBuilder.endOpen(endMicros);
            }

            return filterBuilder.toProto();
        });

read = read.withRowFilter(filterProvider);