### PR TITLE
Fix stagingArtifactRegistry support raw us.gcr.io artifact registry

### DIFF
--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
@@ -443,7 +443,7 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
     String imagePath =
         stageImageBeforePromote
             ? generateFlexTemplateImagePath(
-                containerName, null, null, stagingArtifactRegistry, stagePrefix)
+                containerName, projectId, null, stagingArtifactRegistry, stagePrefix)
             : imageSpec.getImage();
     String buildProjectId =
         stageImageBeforePromote

--- a/plugins/templates-maven-plugin/src/test/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojoTest.java
+++ b/plugins/templates-maven-plugin/src/test/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojoTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.plugin.maven;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TemplatesStageMojoTest {
+  @Test
+  public void testGenerateFlexTemplateImagePath() {
+    String containerName = "name";
+    String projectId = "some-project";
+    String stagePrefix = "some-prefix";
+    ImmutableMap<String, String> testCases =
+        ImmutableMap.<String, String>builder()
+            .put("", "gcr.io/some-project/some-prefix/name")
+            .put("gcr.io", "gcr.io/some-project/some-prefix/name")
+            .put("eu.gcr.io", "eu.gcr.io/some-project/some-prefix/name")
+            .put(
+                "us-docker.pkg.dev/other-project/other-repo",
+                "us-docker.pkg.dev/other-project/other-repo/some-prefix/name")
+            .build();
+    testCases.forEach(
+        (key, value) -> {
+          // workaround for null key we intended to test
+          if (Strings.isNullOrEmpty(key)) {
+            key = null;
+          }
+          assertEquals(
+              value,
+              TemplatesStageMojo.generateFlexTemplateImagePath(
+                  containerName, projectId, null, key, stagePrefix));
+        });
+  }
+
+  @Test
+  public void testGenerateFlexTemplateImagePathWithDomain() {
+    String containerName = "name";
+    String projectId = "google.com:project";
+    String stagePrefix = "some-prefix";
+    ImmutableMap<String, String> testCases =
+        ImmutableMap.<String, String>builder()
+            .put("", "gcr.io/google.com/project/some-prefix/name")
+            .put("gcr.io", "gcr.io/google.com/project/some-prefix/name")
+            .put("eu.gcr.io", "eu.gcr.io/google.com/project/some-prefix/name")
+            .put(
+                "us-docker.pkg.dev/other-project/other-repo",
+                "us-docker.pkg.dev/other-project/other-repo/some-prefix/name")
+            .build();
+    testCases.forEach(
+        (key, value) -> {
+          // workaround for null key we intended to test
+          if (Strings.isNullOrEmpty(key)) {
+            key = null;
+          }
+          assertEquals(
+              value,
+              TemplatesStageMojo.generateFlexTemplateImagePath(
+                  containerName, projectId, null, key, stagePrefix));
+        });
+  }
+}


### PR DESCRIPTION
Resolving https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/2227#discussion_r1985537269 accidentally removed support for raw "us.gcr.io" provided as stagingArtifactRegistry. This adds it back and created tests