### PR TITLE
Adding DDL parsing for Cassandra annotations

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/PipelineController.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/PipelineController.java
@@ -64,11 +64,6 @@ public class PipelineController {
       SpannerConfig spannerConfig,
       DbConfigContainer dbConfigContainer) {
     Ddl ddl = SpannerSchema.getInformationSchemaAsDdl(spannerConfig);
-
-    LOG.info(
-        "Spanner tables = {}, ddl = {}",
-        ddl.allTables().stream().map(t -> t.name()).collect(Collectors.toList()),
-        ddl);
     ISchemaMapper schemaMapper = PipelineController.getSchemaMapper(options, ddl);
     TableSelector tableSelector = new TableSelector(options.getTables(), ddl, schemaMapper);
 
@@ -110,6 +105,9 @@ public class PipelineController {
 
     SQLDialect sqlDialect = SQLDialect.valueOf(options.getSourceDbDialect());
 
+    LOG.info(
+        "running migration for shards: {}",
+        shards.stream().map(Shard::getHost).collect(Collectors.toList()));
     for (Shard shard : shards) {
       for (Map.Entry<String, String> entry : shard.getDbNameToLogicalShardIdMap().entrySet()) {
         // Read data from source

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/PipelineController.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/PipelineController.java
@@ -64,6 +64,11 @@ public class PipelineController {
       SpannerConfig spannerConfig,
       DbConfigContainer dbConfigContainer) {
     Ddl ddl = SpannerSchema.getInformationSchemaAsDdl(spannerConfig);
+
+    LOG.info(
+        "Spanner tables = {}, ddl = {}",
+        ddl.allTables().stream().map(t -> t.name()).collect(Collectors.toList()),
+        ddl);
     ISchemaMapper schemaMapper = PipelineController.getSchemaMapper(options, ddl);
     TableSelector tableSelector = new TableSelector(options.getTables(), ddl, schemaMapper);
 
@@ -105,9 +110,6 @@ public class PipelineController {
 
     SQLDialect sqlDialect = SQLDialect.valueOf(options.getSourceDbDialect());
 
-    LOG.info(
-        "running migration for shards: {}",
-        shards.stream().map(Shard::getHost).collect(Collectors.toList()));
     for (Shard shard : shards) {
       for (Map.Entry<String, String> entry : shard.getDbNameToLogicalShardIdMap().entrySet()) {
         // Read data from source

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/CassandraAllDataTypesIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/CassandraAllDataTypesIT.java
@@ -325,7 +325,7 @@ public class CassandraAllDataTypesIT extends SourceDbToSpannerITBase {
             "[-99999999999999999999999999999.999999999,0,99999999999999999999999999999.999999999]")
         .put(
             "date_double_map_col",
-            "{\"0\":\"NaN\",\"304\":\"3.14\",\"365\":\"Infinity\",\"365243\":\"0.0\",\"7305\":\"-Infinity\"}")
+            "{\"1970-01-01\":\"NaN\",\"1970-11-01\":\"3.14\",\"1971-01-01\":\"Infinity\",\"1990-01-01\":\"-Infinity\",\"2970-01-01\":\"0.0\"}")
         .put(
             "uuid_ascii_map_col",
             "{\"00000000-0000-1000-9000-000000000000\":\"abc\",\"ffffffff-ffff-1fff-9fff-ffffffffffff\":\"def\"}")
@@ -383,7 +383,7 @@ public class CassandraAllDataTypesIT extends SourceDbToSpannerITBase {
         .put(
             "varchar_bigint_map_col",
             "{\"abcd\":\"-9223372036854775808\",\"efgh\":\"9223372036854775807\"}")
-        .put("blob_int_map_col", "{\"0000000000000001\":\"1\",\"000000000000002a\":\"42\"}")
+        .put("blob_int_map_col", "{\"AAAAAAAAAAE=\":\"1\",\"AAAAAAAAACo=\":\"42\"}")
         .put("smallint_col", "32767")
         .put(
             "varint_blob_map_col",
@@ -394,7 +394,9 @@ public class CassandraAllDataTypesIT extends SourceDbToSpannerITBase {
         .put("varint_list_col", "[-9223372036854775808,0,9223372036854775808]")
         .put("text_col", "NULL")
         .put("float_smallint_map_col", "{\"3.14\":\"32767\",\"Infinity\":\"-32768\"}")
-        .put("smallint_timestamp_map_col", "{\"-128\":\"0\",\"127\":\"-1000\"}")
+        .put(
+            "smallint_timestamp_map_col",
+            "{\"-128\":\"1970-01-01T00:00:00Z\",\"127\":\"1969-12-31T23:59:59.999Z\"}")
         .put(
             "text_timeuuid_map_col",
             "{\"a\":\"00000000-0000-1000-9000-000000000000\",\"~\":\"ffffffff-ffff-1fff-9fff-ffffffffffff\"}")
@@ -417,7 +419,7 @@ public class CassandraAllDataTypesIT extends SourceDbToSpannerITBase {
         .put("tinyint_list_col", "[-128,0,127]")
         .put(
             "timestamp_uuid_map_col",
-            "{\"-1000\":\"ffffffff-ffff-1fff-9fff-ffffffffffff\",\"0\":\"00000000-0000-1000-9000-000000000000\"}")
+            "{\"1969-12-31T23:59:59.999Z\":\"ffffffff-ffff-1fff-9fff-ffffffffffff\",\"1970-01-01T00:00:00Z\":\"00000000-0000-1000-9000-000000000000\"}")
         .put(
             "decimal_duration_map_col",
             "{\"12.34\":\"{\\\"years\\\": 0, \\\"months\\\": 0, \\\"days\\\": -10675199, \\\"hours\\\": 0, \\\"minutes\\\": 0, \\\"seconds\\\": 0, \\\"nanos\\\": -10085000000000}\",\"34.45\":\"{\\\"years\\\": 0, \\\"months\\\": 0, \\\"days\\\": 10675199, \\\"hours\\\": 0, \\\"minutes\\\": 0, \\\"seconds\\\": 0, \\\"nanos\\\": 10085000000000}\"}")

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/Column.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/Column.java
@@ -16,7 +16,9 @@
 package com.google.cloud.teleport.v2.spanner.ddl;
 
 import com.google.auto.value.AutoValue;
+import com.google.auto.value.extension.memoized.Memoized;
 import com.google.cloud.spanner.Dialect;
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraAnnotations;
 import com.google.cloud.teleport.v2.spanner.type.Type;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
@@ -34,6 +36,11 @@ public abstract class Column implements Serializable {
   public abstract Type type();
 
   public abstract ImmutableList<String> columnOptions();
+
+  @Memoized
+  public CassandraAnnotations cassandraAnnotation() {
+    return CassandraAnnotations.fromColumnOptions(columnOptions(), name());
+  }
 
   @Nullable
   public abstract Integer size();

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/annotations/cassandra/CassandraAnnotations.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/annotations/cassandra/CassandraAnnotations.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Represents the Cassandra Adapter Annotations specified in Options. */
+@AutoValue
+public abstract class CassandraAnnotations implements Serializable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CassandraAnnotations.class);
+
+  /**
+   * Cassandra Type. Passed as `Options (cassandra_type=type)` Empty string if cassandra_type is not
+   * set.
+   */
+  public abstract CassandraType cassandraType();
+
+  /*
+   * TODO(Add backing table once supported).
+   */
+
+  public static Builder builder() {
+    return new AutoValue_CassandraAnnotations.Builder();
+  }
+
+  public static CassandraAnnotations fromColumnOptions(
+      List<String> columnOptions, String columnName) {
+    ImmutableList<String> cassandraTypes =
+        columnOptions.stream()
+            .map(o -> o.toUpperCase().replaceAll("\\s+", ""))
+            .filter(o -> o.contains("CASSANDRA_TYPE="))
+            .map(o -> o.replaceAll("CASSANDRA_TYPE=", ""))
+            .map(o -> o.replaceAll("['\"]", ""))
+            .collect(ImmutableList.toImmutableList());
+    String typeName = (cassandraTypes.isEmpty()) ? "" : cassandraTypes.get(0);
+    CassandraAnnotations annotation =
+        CassandraAnnotations.builder()
+            .setCassandraType(CassandraType.fromAnnotation(typeName))
+            .build();
+    LOG.info(
+        "Cassandra Type for column {} is {}, Annotation is {}",
+        columnName,
+        cassandraTypes,
+        annotation);
+    return annotation;
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    abstract Builder setCassandraType(CassandraType cassandraType);
+
+    public abstract CassandraAnnotations build();
+  }
+}

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/annotations/cassandra/CassandraList.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/annotations/cassandra/CassandraList.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra;
+
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+
+@AutoValue
+public abstract class CassandraList implements Serializable {
+  public abstract String elementType();
+
+  public static Builder builder() {
+    return new AutoValue_CassandraList.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setElementType(String value);
+
+    public abstract CassandraList build();
+  }
+}

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/annotations/cassandra/CassandraMap.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/annotations/cassandra/CassandraMap.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class CassandraMap {
+  public abstract String keyType();
+
+  public abstract String valueType();
+
+  public static Builder builder() {
+    return new AutoValue_CassandraMap.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setKeyType(String value);
+
+    public abstract Builder setValueType(String value);
+
+    public abstract CassandraMap build();
+  }
+}

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/annotations/cassandra/CassandraSet.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/annotations/cassandra/CassandraSet.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra;
+
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+
+@AutoValue
+public abstract class CassandraSet implements Serializable {
+  public abstract String elementType();
+
+  public static Builder builder() {
+    return new AutoValue_CassandraSet.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setElementType(String value);
+
+    public abstract CassandraSet build();
+  }
+}

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/annotations/cassandra/CassandraType.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/annotations/cassandra/CassandraType.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra;
+
+import com.google.auto.value.AutoOneOf;
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraType.Kind;
+import com.google.re2j.Matcher;
+import com.google.re2j.Pattern;
+import org.apache.commons.lang3.StringUtils;
+
+@AutoOneOf(Kind.class)
+public abstract class CassandraType {
+  public abstract Kind getKind();
+
+  public abstract CassandraList list();
+
+  public abstract CassandraMap map();
+
+  public abstract String primitive();
+
+  public abstract CassandraSet set();
+
+  public abstract void none();
+
+  private static Pattern listPattern = Pattern.compile("LIST<(.*?)>");
+  private static Pattern mapPattern = Pattern.compile("MAP<(.*?),(.*?)>");
+  private static Pattern setPattern = Pattern.compile("SET<(.*?)>");
+
+  public static CassandraType fromAnnotation(String type) {
+    String normalizedType = type.toUpperCase().replaceAll("\\s+", "");
+    Matcher listMatcher = listPattern.matcher(normalizedType);
+    Matcher mapMatcher = mapPattern.matcher(normalizedType);
+    Matcher setMatcher = setPattern.matcher(normalizedType);
+    if (StringUtils.isBlank(type)) {
+      return AutoOneOf_CassandraType.none();
+    }
+    if (listMatcher.matches()) {
+      return AutoOneOf_CassandraType.list(
+          CassandraList.builder().setElementType(listMatcher.group(1)).build());
+    } else if (mapMatcher.matches()) {
+      return AutoOneOf_CassandraType.map(
+          CassandraMap.builder()
+              .setKeyType(mapMatcher.group(1))
+              .setValueType(mapMatcher.group(2))
+              .build());
+    } else if (setMatcher.matches()) {
+      return AutoOneOf_CassandraType.set(
+          CassandraSet.builder().setElementType(setMatcher.group(1)).build());
+    } else {
+      return AutoOneOf_CassandraType.primitive(normalizedType);
+    }
+  }
+
+  public enum Kind {
+    NONE, /* No Cassandra Anotation */
+    LIST,
+    MAP,
+    PRIMITIVE,
+    SET
+  };
+}

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/annotations/cassandra/package-info.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/annotations/cassandra/package-info.java
@@ -1,0 +1,1 @@
+package com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra;

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/annotations/package-info.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/ddl/annotations/package-info.java
@@ -1,0 +1,1 @@
+package com.google.cloud.teleport.v2.spanner.ddl.annotations;

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroJsonToCassandraMapConvertor.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroJsonToCassandraMapConvertor.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.migrations.avro;
+
+import static java.lang.Math.multiplyExact;
+
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraAnnotations;
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraType.Kind;
+import com.google.cloud.teleport.v2.spanner.migrations.exceptions.AvroTypeConvertorException;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import java.time.Instant;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import org.apache.avro.Schema;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*
+ * Convert AvroJson To CassandraMap based on the Spanner Annotations.
+ * Note that this mapping will not be needed when spanner supports Cassandra maps as interleaved tables.
+ *
+ */
+public class AvroJsonToCassandraMapConvertor {
+  private static final Logger LOG = LoggerFactory.getLogger(AvroJsonToCassandraMapConvertor.class);
+  private static final String NULL_REPRESENTATION = "NULL";
+
+  /**
+   * Handle A cassandra map represented as Avro Json.
+   *
+   * @param recordValue - input
+   * @param cassandraAnnotations - Annotation for Cassandra type, if not map, input is same as
+   *     output.
+   * @param fieldName - name of the field. Used for logging purpose only.
+   * @param fieldSchema - avro schema of the filed. Used for logging purpose only.
+   * @return
+   */
+  static String handleJsonToMap(
+      Object recordValue,
+      CassandraAnnotations cassandraAnnotations,
+      String fieldName,
+      Schema fieldSchema) {
+    if (recordValue == null) {
+      LOG.debug(
+          "Handling Json as map fieldName {}, recordValue {}, fieldSchema {}, cassandraAnnotations {}, ret {}",
+          fieldName,
+          recordValue,
+          fieldSchema,
+          cassandraAnnotations,
+          NULL_REPRESENTATION);
+      return NULL_REPRESENTATION;
+    }
+    if (!cassandraAnnotations.cassandraType().getKind().equals(Kind.MAP)) {
+      LOG.debug(
+          "Handling Json as map fieldName {}, recordValue {}, fieldSchema {}, cassandraAnnotations {}, ret {}",
+          fieldName,
+          recordValue,
+          fieldSchema,
+          cassandraAnnotations,
+          recordValue.toString());
+      return recordValue.toString();
+    }
+
+    String keyType = cassandraAnnotations.cassandraType().map().keyType();
+    String valueType = cassandraAnnotations.cassandraType().map().valueType();
+
+    JsonObject element = JsonParser.parseString(recordValue.toString()).getAsJsonObject();
+    JsonObject mappedJson = new JsonObject();
+
+    element
+        .asMap()
+        .forEach(
+            (k, v) -> {
+              String mappedKey = mapKeyOrValue(k, keyType);
+              String mappedValue = mapKeyOrValue(v, valueType);
+              mappedJson.add(mappedKey, new JsonPrimitive(mappedValue));
+            });
+
+    LOG.debug(
+        "Handling Json as map fieldName {}, recordValue {}, fieldSchema {}, cassandraAnnotations {}, ret {}",
+        fieldName,
+        recordValue,
+        fieldSchema,
+        cassandraAnnotations,
+        mappedJson);
+    return mappedJson.toString();
+  }
+
+  @VisibleForTesting
+  static String mapKeyOrValue(Object input, String type) {
+    if (input instanceof JsonPrimitive) {
+      input = ((JsonPrimitive) input).getAsString();
+    }
+    if (input == null) {
+      return NULL_REPRESENTATION;
+    }
+    MapValue mapper = CASSANDRA_ADAPTER_MAPPERS.getOrDefault(type, toString);
+    return mapper.map(input);
+  }
+
+  private static final MapValue toString = (value) -> value.toString();
+  private static final MapValue toStringLowerCase = (value) -> value.toString().toLowerCase();
+
+  private static final MapValue hexStringToBase64 = (value) -> hexStringToBase64(value);
+
+  private static MapValue daysSinceEpochToYYMMDD = (value) -> daysSinceEpochToYYMMDD(value);
+  private static MapValue timestampMicrosecondsToISO8601UTC =
+      (value) -> timestampMicrosecondsToISO8601UTC(value);
+  private static MapValue durationToString = (value) -> durationToString(value);
+
+  /**
+   * Mappers for types that need special handling while representing as a map. Default for all other
+   * types is to just stringify the input.
+   */
+  private static final ImmutableMap<String, MapValue> CASSANDRA_ADAPTER_MAPPERS =
+      ImmutableMap.<String, MapValue>builder()
+          .put("BOOLEAN", toStringLowerCase)
+          .put("BLOB", hexStringToBase64)
+          .put("DATE", daysSinceEpochToYYMMDD)
+          .put("DURATION", durationToString)
+          .put("TIMESTAMP", timestampMicrosecondsToISO8601UTC)
+          .put("UUID", toStringLowerCase)
+          .put("TIMEUUID", toStringLowerCase)
+          .build();
+
+  private interface MapValue {
+    String map(Object input);
+  }
+
+  private static String durationToString(Object input) {
+    JsonObject element = JsonParser.parseString(input.toString()).getAsJsonObject();
+    Period period =
+        Period.ZERO
+            .plusYears(((Number) getOrDefault(element, "years", 0L)).longValue())
+            .plusMonths(((Number) getOrDefault(element, "months", 0L)).longValue())
+            .plusDays(((Number) getOrDefault(element, "days", 0L)).longValue());
+    /*
+     * Convert the period to a ISO-8601 period formatted String, such as P6Y3M1D.
+     * A zero period will be represented as zero days, 'P0D'.
+     * Refer to javadoc for Period#toString.
+     */
+    String periodIso8061 = period.toString();
+    java.time.Duration duration =
+        java.time.Duration.ZERO
+            .plusHours(((Number) getOrDefault(element, "hours", 0L)).longValue())
+            .plusMinutes(((Number) getOrDefault(element, "minutes", 0L)).longValue())
+            .plusSeconds(((Number) getOrDefault(element, "seconds", 0L)).longValue())
+            .plusNanos(((Number) getOrDefault(element, "nanos", 0L)).longValue());
+    /*
+     * Convert the duration to a ISO-8601 period formatted String, such as  PT8H6M12.345S
+     * refer to javadoc for Duration#toString.
+     */
+    String durationIso8610 = duration.toString();
+    // Convert to ISO-8601 period format.
+    if (duration.isZero()) {
+      return periodIso8061.toUpperCase();
+    } else {
+      return (periodIso8061 + StringUtils.removeStartIgnoreCase(durationIso8610, "P"))
+          .toUpperCase();
+    }
+  }
+
+  private static String hexStringToBase64(Object input) {
+    // For string avro type, expect hex encoded string.
+    String s = input.toString();
+    if (s.length() % 2 == 1) {
+      s = "0" + s;
+    }
+    try {
+      return Base64.encodeBase64String(Hex.decodeHex(s));
+    } catch (DecoderException e) {
+      throw new AvroTypeConvertorException(
+          "Unable to convert Json Value "
+              + input
+              + " to Bytes."
+              + ", Exception: "
+              + e.getMessage());
+    }
+  }
+
+  private static String daysSinceEpochToYYMMDD(Object input) {
+    long daysSinceEpoch = Long.parseLong(input.toString());
+    // Calculate the number of seconds from days.
+    long secondsSinceEpoch = multiplyExact(daysSinceEpoch, (24 * 60 * 60));
+
+    // Create an Instant from the seconds.
+    Instant instant = Instant.ofEpochSecond(secondsSinceEpoch);
+
+    // Format the Instant into the desired date string in UTC.
+    DateTimeFormatter formatter =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.from(ZoneOffset.UTC));
+    return formatter.format(instant);
+  }
+
+  private static String timestampMicrosecondsToISO8601UTC(Object input) {
+    long microseconds = Long.parseLong(input.toString());
+    long seconds = microseconds / 1_000_000;
+    long nanos = (microseconds % 1_000_000) * 1000; // Convert remaining microseconds to nanoseconds
+
+    Instant instant = Instant.ofEpochSecond(seconds, nanos);
+    return DateTimeFormatter.ISO_INSTANT.withZone(ZoneId.of("UTC")).format(instant);
+  }
+
+  private static Long getOrDefault(JsonObject element, String name, Long def) {
+    if (element.get(name).isJsonNull()) {
+      return def;
+    }
+    return element.get(name).getAsLong();
+  }
+
+  private AvroJsonToCassandraMapConvertor() {}
+}

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertor.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertor.java
@@ -17,6 +17,8 @@ package com.google.cloud.teleport.v2.spanner.migrations.avro;
 
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Value;
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraAnnotations;
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraType.Kind;
 import com.google.cloud.teleport.v2.spanner.exceptions.InvalidTransformationException;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaMapper;
 import com.google.cloud.teleport.v2.spanner.type.Type;
@@ -155,6 +157,10 @@ public class GenericRecordTypeConvertor {
             schemaMapper.getSourceColumnName(namespace, spannerTableName, spannerColName);
         Type spannerColumnType =
             schemaMapper.getSpannerColumnType(namespace, spannerTableName, spannerColName);
+
+        final CassandraAnnotations cassandraAnnotations =
+            schemaMapper.getSpannerColumnCassandraAnnotations(
+                namespace, spannerTableName, spannerColName);
         LOG.debug(
             "Transformer processing srcCol: {} spannerColumnType:{}",
             srcColName,
@@ -165,7 +171,8 @@ public class GenericRecordTypeConvertor {
                 record.get(srcColName),
                 record.getSchema().getField(srcColName).schema(),
                 srcColName,
-                spannerColumnType);
+                spannerColumnType,
+                cassandraAnnotations);
         result.put(spannerColName, value);
       } catch (NullPointerException e) {
         throw e;
@@ -210,7 +217,7 @@ public class GenericRecordTypeConvertor {
     String spannerTableName = schemaMapper.getSpannerTableName(namespace, srcTableName);
     // TODO: verify if direct to object (Current) works the same as Object -> JsonNode-> Object
     // (Live).
-    Map<String, Object> sourceRowMap = genericRecordToMap(record);
+    Map<String, Object> sourceRowMap = genericRecordToMap(record, srcTableName);
     MigrationTransformationResponse migrationTransformationResponse =
         getCustomTransformationResponse(sourceRowMap, srcTableName, shardId);
     if (migrationTransformationResponse.isEventFiltered()) {
@@ -233,7 +240,7 @@ public class GenericRecordTypeConvertor {
   }
 
   /** Converts a generic record to a Map. */
-  private Map<String, Object> genericRecordToMap(GenericRecord record) {
+  private Map<String, Object> genericRecordToMap(GenericRecord record, String srcTableName) {
     Map<String, Object> map = new HashMap<>();
     Schema schema = record.getSchema();
 
@@ -246,7 +253,13 @@ public class GenericRecordTypeConvertor {
       }
       Schema fieldSchema = filterNullSchema(field.schema(), fieldName, fieldValue);
       // Handle logical/record types.
-      fieldValue = handleNonPrimitiveAvroTypes(fieldValue, fieldSchema, fieldName);
+      final CassandraAnnotations cassandraAnnotations =
+          schemaMapper.getSpannerColumnCassandraAnnotations(
+              namespace,
+              schemaMapper.getSpannerTableName(namespace, srcTableName),
+              schemaMapper.getSpannerColumnName(namespace, srcTableName, fieldName));
+      fieldValue =
+          handleNonPrimitiveAvroTypes(fieldValue, fieldSchema, fieldName, cassandraAnnotations);
       // Standardizing the types for custom jar input.
       if (fieldSchema.getProp(LOGICAL_TYPE) != null
           || fieldSchema.getType() == Schema.Type.RECORD) {
@@ -254,7 +267,9 @@ public class GenericRecordTypeConvertor {
         continue;
       }
       if (fieldSchema.getType().equals(Schema.Type.ARRAY)) {
-        fieldValue = getObjectMapValueForArrayFieldValue(fieldValue, fieldSchema, fieldName);
+        fieldValue =
+            getObjectMapValueForArrayFieldValue(
+                fieldValue, fieldSchema, fieldName, cassandraAnnotations);
         map.put(fieldName, fieldValue);
         continue;
       }
@@ -277,7 +292,10 @@ public class GenericRecordTypeConvertor {
    *     primitives are handled in both the code flows.
    */
   static Object getObjectMapValueForArrayFieldValue(
-      Object fieldValue, Schema fieldSchema, String fieldName) {
+      Object fieldValue,
+      Schema fieldSchema,
+      String fieldName,
+      CassandraAnnotations cassandraAnnotations) {
 
     if (fieldValue instanceof List) {
       fieldValue = ((List<Object>) fieldValue).toArray();
@@ -292,7 +310,8 @@ public class GenericRecordTypeConvertor {
     for (int i = 0; i < Array.getLength(fieldValue); i++) {
 
       Object curValue = Array.get(fieldValue, i);
-      curValue = handleNonPrimitiveAvroTypes(curValue, elementSchema, fieldName);
+      curValue =
+          handleNonPrimitiveAvroTypes(curValue, elementSchema, fieldName, cassandraAnnotations);
       // Standardizing the types for custom jar input.
       if (elementSchema.getProp(LOGICAL_TYPE) != null
           || elementSchema.getType() == Schema.Type.RECORD) {
@@ -367,7 +386,11 @@ public class GenericRecordTypeConvertor {
 
   /** Extract the field value from Generic Record and try to convert it to @spannerType. */
   public Value getSpannerValue(
-      Object recordValue, Schema fieldSchema, String recordColName, Type spannerType) {
+      Object recordValue,
+      Schema fieldSchema,
+      String recordColName,
+      Type spannerType,
+      CassandraAnnotations cassandraAnnotations) {
     // Logical and record types should be converted to string.
     LOG.debug(
         "gettingSpannerValue for recordValue: {}, fieldSchema: {}, recordColName: {}, spannerType: {}",
@@ -376,7 +399,9 @@ public class GenericRecordTypeConvertor {
         fieldSchema,
         spannerType);
     fieldSchema = filterNullSchema(fieldSchema, recordColName, recordValue);
-    recordValue = handleNonPrimitiveAvroTypes(recordValue, fieldSchema, recordColName);
+
+    recordValue =
+        handleNonPrimitiveAvroTypes(recordValue, fieldSchema, recordColName, cassandraAnnotations);
     return getSpannerValueFromObject(recordValue, fieldSchema, recordColName, spannerType);
   }
 
@@ -419,15 +444,20 @@ public class GenericRecordTypeConvertor {
    *     type.
    */
   private static Object handleNonPrimitiveAvroTypes(
-      Object recordValue, Schema fieldSchema, String recordColName) {
+      Object recordValue,
+      Schema fieldSchema,
+      String recordColName,
+      CassandraAnnotations cassandraAnnotations) {
     if (fieldSchema.getLogicalType() != null || fieldSchema.getProp(LOGICAL_TYPE) != null) {
-      recordValue = handleLogicalFieldType(recordColName, recordValue, fieldSchema);
+      recordValue =
+          handleLogicalFieldType(recordColName, recordValue, fieldSchema, cassandraAnnotations);
     } else if (fieldSchema.getType().equals(Schema.Type.RECORD)) {
       // Get the avro field of type record from the whole record.
       recordValue = handleRecordFieldType(recordColName, (GenericRecord) recordValue, fieldSchema);
     } else if (fieldSchema.getType().equals(Schema.Type.ARRAY)) {
       // Get the avro field of type record from the Array.
-      recordValue = handleArrayAvroTypes(recordValue, fieldSchema, recordColName);
+      recordValue =
+          handleArrayAvroTypes(recordValue, fieldSchema, recordColName, cassandraAnnotations);
     }
     LOG.debug("Updated record value is {} for recordColName {}", recordValue, recordColName);
     return recordValue;
@@ -442,7 +472,11 @@ public class GenericRecordTypeConvertor {
    * @return The processed value of the field, potentially transformed according to its complex
    *     type.
    */
-  static Object handleArrayAvroTypes(Object recordValue, Schema fieldSchema, String recordColName) {
+  static Object handleArrayAvroTypes(
+      Object recordValue,
+      Schema fieldSchema,
+      String recordColName,
+      CassandraAnnotations cassandraAnnotations) {
     if (recordValue instanceof List) {
       recordValue = ((List<Object>) recordValue).toArray();
     }
@@ -458,7 +492,8 @@ public class GenericRecordTypeConvertor {
     Schema elementSchema = fieldSchema.getElementType();
     for (int i = 0; i < Array.getLength(recordValue); i++) {
       Object curValue = Array.get(recordValue, i);
-      curValue = handleNonPrimitiveAvroTypes(curValue, elementSchema, recordColName);
+      curValue =
+          handleNonPrimitiveAvroTypes(curValue, elementSchema, recordColName, cassandraAnnotations);
       // Standardizing the types for custom jar input.
       if (elementSchema.getProp(LOGICAL_TYPE) != null
           || elementSchema.getType() == Schema.Type.RECORD) {
@@ -504,7 +539,11 @@ public class GenericRecordTypeConvertor {
   }
 
   /** Avro logical types are converted to an equivalent string type. */
-  static String handleLogicalFieldType(String fieldName, Object recordValue, Schema fieldSchema) {
+  static String handleLogicalFieldType(
+      String fieldName,
+      Object recordValue,
+      Schema fieldSchema,
+      CassandraAnnotations cassandraAnnotations) {
     LOG.debug("found logical type for col {} with schema {}", fieldName, fieldSchema);
     if (recordValue == null) {
       return null;
@@ -540,7 +579,12 @@ public class GenericRecordTypeConvertor {
       return timestamp.atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
     } else if (fieldSchema.getProp(LOGICAL_TYPE) != null
         && fieldSchema.getProp(LOGICAL_TYPE).equals(CustomAvroTypes.JSON)) {
-      return recordValue.toString();
+      if (cassandraAnnotations.cassandraType().getKind().equals(Kind.MAP)) {
+        /* TODO Add handler to marshal Map Types as needed by Cassandra Adapter. */
+        return recordValue.toString();
+      } else {
+        return recordValue.toString();
+      }
     } else if (fieldSchema.getProp(LOGICAL_TYPE) != null
         && fieldSchema.getProp(LOGICAL_TYPE).equals(CustomAvroTypes.NUMBER)) {
       return recordValue.toString();

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertor.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertor.java
@@ -580,8 +580,8 @@ public class GenericRecordTypeConvertor {
     } else if (fieldSchema.getProp(LOGICAL_TYPE) != null
         && fieldSchema.getProp(LOGICAL_TYPE).equals(CustomAvroTypes.JSON)) {
       if (cassandraAnnotations.cassandraType().getKind().equals(Kind.MAP)) {
-        /* TODO Add handler to marshal Map Types as needed by Cassandra Adapter. */
-        return recordValue.toString();
+        return AvroJsonToCassandraMapConvertor.handleJsonToMap(
+            recordValue, cassandraAnnotations, fieldName, fieldSchema);
       } else {
         return recordValue.toString();
       }

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/ISchemaMapper.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/ISchemaMapper.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.spanner.migrations.schema;
 
 import com.google.cloud.spanner.Dialect;
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraAnnotations;
 import com.google.cloud.teleport.v2.spanner.type.Type;
 import java.io.Serializable;
 import java.util.List;
@@ -70,6 +71,14 @@ public interface ISchemaMapper extends Serializable {
    */
   Type getSpannerColumnType(String namespace, String spannerTable, String spannerColumn)
       throws NoSuchElementException;
+
+  /**
+   * Retrieves the Spanner column's Cassandra annotation given a spanner table and spanner column.
+   *
+   * @param namespace is currently not operational.
+   */
+  CassandraAnnotations getSpannerColumnCassandraAnnotations(
+      String namespace, String spannerTable, String spannerColumn) throws NoSuchElementException;
 
   /**
    * Retrieves a list of all column names within a Spanner table.

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/IdentityMapper.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/IdentityMapper.java
@@ -19,6 +19,7 @@ import com.google.cloud.spanner.Dialect;
 import com.google.cloud.teleport.v2.spanner.ddl.Column;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.ddl.Table;
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraAnnotations;
 import com.google.cloud.teleport.v2.spanner.type.Type;
 import java.io.Serializable;
 import java.util.List;
@@ -88,6 +89,29 @@ public class IdentityMapper implements ISchemaMapper, Serializable {
   @Override
   public Type getSpannerColumnType(String namespace, String spannerTable, String spannerColumn)
       throws NoSuchElementException {
+    Column col = getCol(namespace, spannerTable, spannerColumn);
+    return col.type();
+  }
+
+  /**
+   * Retrieves the Spanner column's Cassandra annotations given a spanner table and spanner column.
+   *
+   * @param namespace is currently not operational.
+   */
+  @Override
+  public CassandraAnnotations getSpannerColumnCassandraAnnotations(
+      String namespace, String spannerTable, String spannerColumn) throws NoSuchElementException {
+    Column col = getCol(namespace, spannerTable, spannerColumn);
+    return col.cassandraAnnotation();
+  }
+
+  /**
+   * private helper to extract spannerColumn form nameSpace spannerTable, and spannerColumn.
+   *
+   * @param namespace is currently not operational.
+   */
+  private Column getCol(String namespace, String spannerTable, String spannerColumn)
+      throws NoSuchElementException {
     Table spTable = ddl.table(spannerTable);
     if (spTable == null) {
       throw new NoSuchElementException(String.format("Spanner table '%s' not found", spannerTable));
@@ -97,7 +121,7 @@ public class IdentityMapper implements ISchemaMapper, Serializable {
       throw new NoSuchElementException(
           String.format("Spanner column '%s' not found", spannerColumn));
     }
-    return col.type();
+    return col;
   }
 
   @Override

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SessionBasedMapper.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SessionBasedMapper.java
@@ -19,6 +19,7 @@ import com.google.cloud.spanner.Dialect;
 import com.google.cloud.teleport.v2.spanner.ddl.Column;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.ddl.Table;
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraAnnotations;
 import com.google.cloud.teleport.v2.spanner.migrations.utils.SessionFileReader;
 import com.google.cloud.teleport.v2.spanner.type.Type;
 import java.io.Serializable;
@@ -182,6 +183,35 @@ public class SessionBasedMapper implements ISchemaMapper, Serializable {
   @Override
   public Type getSpannerColumnType(String namespace, String spannerTable, String spannerColumn)
       throws NoSuchElementException {
+    Column col = getCol(namespace, spannerTable, spannerColumn);
+    return col.type();
+  }
+
+  /**
+   * Retrieves the Spanner column's Cassandra type given a spanner table and spanner column.
+   *
+   * @param namespace is currently not operational.
+   */
+  @Override
+  public CassandraAnnotations getSpannerColumnCassandraAnnotations(
+      String namespace, String spannerTable, String spannerColumn) throws NoSuchElementException {
+    Column col = getCol(namespace, spannerTable, spannerColumn);
+    return col.cassandraAnnotation();
+  }
+
+  @Override
+  public List<String> getSpannerColumns(String namespace, String spannerTable)
+      throws NoSuchElementException {
+    return schema.getSpannerColumnNames(spannerTable);
+  }
+
+  /**
+   * private helper to extract spannerColumn form nameSpace spannerTable, and spannerColumn.
+   *
+   * @param namespace is currently not operational.
+   */
+  private Column getCol(String namespace, String spannerTable, String spannerColumn)
+      throws NoSuchElementException {
     Table spTable = ddl.table(spannerTable);
     if (spTable == null) {
       throw new NoSuchElementException(String.format("Spanner table '%s' not found", spannerTable));
@@ -191,13 +221,7 @@ public class SessionBasedMapper implements ISchemaMapper, Serializable {
       throw new NoSuchElementException(
           String.format("Spanner column '%s' not found", spannerColumn));
     }
-    return col.type();
-  }
-
-  @Override
-  public List<String> getSpannerColumns(String namespace, String spannerTable)
-      throws NoSuchElementException {
-    return schema.getSpannerColumnNames(spannerTable);
+    return col;
   }
 
   @Override

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/ddl/DdlTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/ddl/DdlTest.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.spanner.Dialect;
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraType;
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraType.Kind;
 import com.google.cloud.teleport.v2.spanner.type.Type;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -137,6 +139,35 @@ public class DdlTest {
     assertNotNull(ddl.hashCode());
     assertTrue(ddl.tablesReferenced("Users").contains("AllowedNames"));
     assertTrue(ddl.tablesReferenced("Users").size() == 1);
+  }
+
+  @Test
+  public void testDdlCassandraOptions() {
+
+    Ddl.Builder builder = Ddl.builder();
+
+    builder
+        .createTable("Users")
+        .column("id")
+        .int64()
+        .notNull()
+        .columnOptions(ImmutableList.of("CASSANDRA_TYPE=\"int\"", "SOME_UNKNOWN_OPTION"))
+        .endColumn()
+        .column("first_name")
+        .string()
+        .size(10)
+        .endColumn()
+        .primaryKey()
+        .asc("id")
+        .end()
+        .endTable();
+    Ddl ddl = builder.build();
+    assertEquals(
+        ddl.table("Users").column("id").cassandraAnnotation().cassandraType(),
+        CassandraType.fromAnnotation("int"));
+    assertEquals(
+        ddl.table("Users").column("first_name").cassandraAnnotation().cassandraType().getKind(),
+        Kind.NONE);
   }
 
   @Test

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/ddl/annotations/cassandra/CassandraAnnotationsTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/ddl/annotations/cassandra/CassandraAnnotationsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraType.Kind;
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CassandraAnnotationsTest {
+
+  @Test
+  public void testCassandraAnnotationsBasic() {
+    assertThat(
+            CassandraAnnotations.fromColumnOptions(ImmutableList.of(), "testCol")
+                .cassandraType()
+                .getKind())
+        .isEqualTo(Kind.NONE);
+
+    assertThat(
+            CassandraAnnotations.fromColumnOptions(
+                    ImmutableList.of("cassandra_type='ascii'"), "testCol")
+                .cassandraType()
+                .getKind())
+        .isEqualTo(Kind.PRIMITIVE);
+
+    assertThat(
+            CassandraAnnotations.fromColumnOptions(
+                    ImmutableList.of("cassandra_type=\"list<time>\""), "testCol")
+                .cassandraType()
+                .getKind())
+        .isEqualTo(Kind.LIST);
+
+    assertThat(
+            CassandraAnnotations.fromColumnOptions(
+                    ImmutableList.of("cassandra_type='set<time>'"), "testCol")
+                .cassandraType()
+                .getKind())
+        .isEqualTo(Kind.SET);
+
+    assertThat(
+            CassandraAnnotations.fromColumnOptions(
+                    ImmutableList.of("cassandra_type='map<time, time>'"), "testCol")
+                .cassandraType()
+                .getKind())
+        .isEqualTo(Kind.MAP);
+  }
+}

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/ddl/annotations/cassandra/CassandraTypeTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/ddl/annotations/cassandra/CassandraTypeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraType.Kind;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CassandraTypeTest {
+  @Test
+  public void testCassandraTypeBasic() {
+    CassandraType primitiveType = CassandraType.fromAnnotation("int");
+    CassandraType listType = CassandraType.fromAnnotation("list<int>");
+    CassandraType setType = CassandraType.fromAnnotation("set<int>");
+    CassandraType mapType = CassandraType.fromAnnotation("map<int, time>");
+    CassandraType nonType = CassandraType.fromAnnotation("");
+
+    assertThat(primitiveType.getKind()).isEqualTo(Kind.PRIMITIVE);
+    assertThat(primitiveType.primitive()).isEqualTo("INT");
+    assertThat(listType.getKind()).isEqualTo(Kind.LIST);
+    assertThat(listType.list().elementType()).isEqualTo("INT");
+    assertThat(setType.getKind()).isEqualTo(Kind.SET);
+    assertThat(setType.set().elementType()).isEqualTo("INT");
+    assertThat(mapType.getKind()).isEqualTo(Kind.MAP);
+    assertThat(mapType.map().keyType()).isEqualTo("INT");
+    assertThat(mapType.map().valueType()).isEqualTo("TIME");
+    assertThat(nonType.getKind()).isEqualTo(Kind.NONE);
+    // Check that void method does not cause an exception, there's nothing more to assert.
+    nonType.none();
+  }
+}

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroJsonToCassandraMapConvertorTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroJsonToCassandraMapConvertorTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.migrations.avro;
+
+import static com.google.cloud.teleport.v2.spanner.migrations.avro.AvroTestingHelper.createIntervalNanosRecord;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraAnnotations;
+import com.google.cloud.teleport.v2.spanner.migrations.exceptions.AvroTypeConvertorException;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import java.util.List;
+import org.apache.avro.LogicalType;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.kerby.util.Hex;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AvroJsonToCassandraMapConvertorTest {
+
+  private static final Schema JSON_TYPE =
+      new LogicalType(GenericRecordTypeConvertor.CustomAvroTypes.JSON)
+          .addToSchema(SchemaBuilder.builder().stringType());
+
+  Object getMapJson(Object key, Object value) {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.add(
+        (key == null) ? "null" : key.toString(),
+        new JsonPrimitive((value == null) ? "null" : value.toString()));
+
+    Schema payloadSchema =
+        SchemaBuilder.record("payload")
+            .fields()
+            .name("mapCol")
+            .type(JSON_TYPE)
+            .noDefault()
+            .endRecord();
+
+    GenericRecord payload =
+        new GenericRecordBuilder(payloadSchema).set("mapCol", jsonObject.toString()).build();
+    return payload.get("mapCol");
+  }
+
+  @Test
+  public void testHandleJsonToMapBasic() {
+    assertThat(
+            AvroJsonToCassandraMapConvertor.handleJsonToMap(
+                getMapJson(42, 42),
+                CassandraAnnotations.fromColumnOptions(
+                    List.of("cassandra_type='map<int, int>'"), "testCol"),
+                "testCol",
+                JSON_TYPE))
+        .isEqualTo("{\"42\":\"42\"}");
+
+    /* Nulls */
+    assertThat(
+            AvroJsonToCassandraMapConvertor.handleJsonToMap(
+                null,
+                CassandraAnnotations.fromColumnOptions(
+                    List.of("cassandra_type='map<int, int>'"), "testCol"),
+                "testCol",
+                JSON_TYPE))
+        .isEqualTo("NULL");
+    assertThat(
+            AvroJsonToCassandraMapConvertor.handleJsonToMap(
+                getMapJson(null, null),
+                CassandraAnnotations.fromColumnOptions(
+                    List.of("cassandra_type='map<sting, string>'"), "testCol"),
+                "testCol",
+                JSON_TYPE))
+        .isEqualTo("{\"null\":\"null\"}");
+
+    /* Pass through for not maps */
+    assertThat(
+            AvroJsonToCassandraMapConvertor.handleJsonToMap(
+                42,
+                CassandraAnnotations.fromColumnOptions(List.of("cassandra_type='int'"), "testCol"),
+                "testCol",
+                JSON_TYPE))
+        .isEqualTo("42");
+  }
+
+  @Test
+  public void testTypeMappings() {
+    /* Null */
+    assertThat(AvroJsonToCassandraMapConvertor.mapKeyOrValue(null, "BOOLEAN")).isEqualTo("NULL");
+    /* Boolean */
+    assertThat(AvroJsonToCassandraMapConvertor.mapKeyOrValue(true, "BOOLEAN")).isEqualTo("true");
+    /* Case mixed-up on purpose for test */
+    assertThat(AvroJsonToCassandraMapConvertor.mapKeyOrValue("FaLSE", "BOOLEAN"))
+        .isEqualTo("false");
+    /* Blob */
+    assertThat(
+            AvroJsonToCassandraMapConvertor.mapKeyOrValue(Hex.encode("Google".getBytes()), "BLOB"))
+        .isEqualTo("R29vZ2xl");
+    /* Float, Double */
+    assertThat(AvroJsonToCassandraMapConvertor.mapKeyOrValue(3.14, "FLOAT")).isEqualTo("3.14");
+    assertThat(AvroJsonToCassandraMapConvertor.mapKeyOrValue(Float.NaN, "FLOAT")).isEqualTo("NaN");
+    assertThat(AvroJsonToCassandraMapConvertor.mapKeyOrValue(Float.POSITIVE_INFINITY, "FLOAT"))
+        .isEqualTo("Infinity");
+    assertThat(AvroJsonToCassandraMapConvertor.mapKeyOrValue(Float.NEGATIVE_INFINITY, "FLOAT"))
+        .isEqualTo("-Infinity");
+    assertThat(AvroJsonToCassandraMapConvertor.mapKeyOrValue(4.28, "DOUBLE")).isEqualTo("4.28");
+    /* Date */
+    assertThat(AvroJsonToCassandraMapConvertor.mapKeyOrValue(10, "DATE")).isEqualTo("1970-01-11");
+    assertThat(AvroJsonToCassandraMapConvertor.mapKeyOrValue(-10, "DATE")).isEqualTo("1969-12-22");
+    /* Time */
+    assertThat(AvroJsonToCassandraMapConvertor.mapKeyOrValue(68400000000000L, "TIME"))
+        .isEqualTo("68400000000000");
+    /* Timestamp */
+    assertThat(AvroJsonToCassandraMapConvertor.mapKeyOrValue(1742372396581000L, "TIMESTAMP"))
+        .isEqualTo("2025-03-19T08:19:56.581Z");
+
+    /* Duration */
+    assertThat(
+            AvroJsonToCassandraMapConvertor.mapKeyOrValue(
+                createIntervalNanosRecord(1L, 2L, 3L, 4L, 5L, 6L, 789000000L).toString(),
+                "DURATION"))
+        .isEqualTo("P1Y2M3DT4H5M6.789S");
+    assertThat(
+            AvroJsonToCassandraMapConvertor.mapKeyOrValue(
+                createIntervalNanosRecord(0L, 0L, 0L, 0L, 0L, 0L, 0L).toString(), "DURATION"))
+        .isEqualTo("P0D");
+    assertThat(
+            AvroJsonToCassandraMapConvertor.mapKeyOrValue(
+                createIntervalNanosRecord(null, 0L, 0L, 0L, 0L, 0L, 0L).toString(), "DURATION"))
+        .isEqualTo("P0D");
+    /* UUID */
+    /* Case of input mixed-up for the purpose of test */
+    assertThat(
+            AvroJsonToCassandraMapConvertor.mapKeyOrValue(
+                "B430e5b6-4f06-4dd9-85f7-df10b77fc382", "UUID"))
+        .isEqualTo("b430e5b6-4f06-4dd9-85f7-df10b77fc382");
+    /* Inet */
+    assertThat(AvroJsonToCassandraMapConvertor.mapKeyOrValue("10.37.41.15", "inet"))
+        .isEqualTo("10.37.41.15");
+
+    assertThrows(
+        AvroTypeConvertorException.class,
+        () -> {
+          assertThat(AvroJsonToCassandraMapConvertor.mapKeyOrValue("XYZ", "BLOB"))
+              .isEqualTo("R29vZ2xl");
+        });
+  }
+}

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroTestingHelper.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroTestingHelper.java
@@ -20,7 +20,10 @@ import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class AvroTestingHelper {
   public static final Schema TIMESTAMPTZ_SCHEMA =
       SchemaBuilder.record("timestampTz")

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroToValueMapperTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroToValueMapperTest.java
@@ -45,7 +45,10 @@ import org.apache.avro.generic.GenericRecordBuilder;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class AvroToValueMapperTest {
 
   @Test

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertorTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertorTest.java
@@ -190,7 +190,7 @@ public class GenericRecordTypeConvertorTest {
     genericRecord.put("time_millis_col", 48035000);
     genericRecord.put("timestamp_micros_col", 1602599400056483L);
     genericRecord.put("timestamp_millis_col", 1602599400056L);
-    genericRecord.put("json_col", "{\"k1\":\"v1\"}");
+    genericRecord.put("json_col", "{\"k1\":\"476F6F676C65\"}");
     genericRecord.put("number_col", "289452");
     genericRecord.put("varchar_col", "Hellogcds");
     genericRecord.put("time_interval_col", -3020398999999L);
@@ -257,7 +257,16 @@ public class GenericRecordTypeConvertorTest {
             genericRecord.get(col),
             genericRecord.getSchema().getField(col).schema(),
             getTestCassandraAnnotationNone());
-    assertEquals("Test json_col conversion: ", "{\"k1\":\"v1\"}", result);
+    assertEquals("Test json_col conversion: ", "{\"k1\":\"476F6F676C65\"}", result);
+
+    col = "json_col";
+    result =
+        GenericRecordTypeConvertor.handleLogicalFieldType(
+            col,
+            genericRecord.get(col),
+            genericRecord.getSchema().getField(col).schema(),
+            getTestCassandraAnnotation("cassandra_type='map<string,blob>'"));
+    assertEquals("Test json_col conversion with map annotation: ", "{\"k1\":\"R29vZ2xl\"}", result);
 
     col = "number_col";
     result =

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertorTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertorTest.java
@@ -29,6 +29,7 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraAnnotations;
 import com.google.cloud.teleport.v2.spanner.exceptions.InvalidTransformationException;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaMapper;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.IdentityMapper;
@@ -57,8 +58,11 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.commons.collections.map.HashedMap;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class GenericRecordTypeConvertorTest {
 
   public Schema getLogicalTypesSchema() {
@@ -195,67 +199,100 @@ public class GenericRecordTypeConvertorTest {
     String col = "date_col";
     String result =
         GenericRecordTypeConvertor.handleLogicalFieldType(
-            col, genericRecord.get(col), genericRecord.getSchema().getField(col).schema());
+            col,
+            genericRecord.get(col),
+            genericRecord.getSchema().getField(col).schema(),
+            getTestCassandraAnnotationNone());
     assertEquals("Test date_col conversion: ", "3993-04-16", result);
 
     col = "decimal_col";
     result =
         GenericRecordTypeConvertor.handleLogicalFieldType(
-            col, genericRecord.get(col), genericRecord.getSchema().getField(col).schema());
+            col,
+            genericRecord.get(col),
+            genericRecord.getSchema().getField(col).schema(),
+            getTestCassandraAnnotationNone());
     assertEquals("Test decimal_col conversion: ", "12.34", result);
 
     col = "time_micros_col";
     result =
         GenericRecordTypeConvertor.handleLogicalFieldType(
-            col, genericRecord.get(col), genericRecord.getSchema().getField(col).schema());
+            col,
+            genericRecord.get(col),
+            genericRecord.getSchema().getField(col).schema(),
+            getTestCassandraAnnotationNone());
     assertEquals("Test time_micros_col conversion: ", "13:20:35", result);
 
     col = "time_millis_col";
     result =
         GenericRecordTypeConvertor.handleLogicalFieldType(
-            col, genericRecord.get(col), genericRecord.getSchema().getField(col).schema());
+            col,
+            genericRecord.get(col),
+            genericRecord.getSchema().getField(col).schema(),
+            getTestCassandraAnnotationNone());
     assertEquals("Test time_millis_col conversion: ", "13:20:35", result);
 
     col = "timestamp_micros_col";
     result =
         GenericRecordTypeConvertor.handleLogicalFieldType(
-            col, genericRecord.get(col), genericRecord.getSchema().getField(col).schema());
+            col,
+            genericRecord.get(col),
+            genericRecord.getSchema().getField(col).schema(),
+            getTestCassandraAnnotationNone());
     assertEquals("Test timestamp_micros_col conversion: ", "2020-10-13T14:30:00.056483Z", result);
 
     col = "timestamp_millis_col";
     result =
         GenericRecordTypeConvertor.handleLogicalFieldType(
-            col, genericRecord.get(col), genericRecord.getSchema().getField(col).schema());
+            col,
+            genericRecord.get(col),
+            genericRecord.getSchema().getField(col).schema(),
+            getTestCassandraAnnotationNone());
     assertEquals("Test timestamp_millis_col conversion: ", "2020-10-13T14:30:00.056Z", result);
 
     col = "json_col";
     result =
         GenericRecordTypeConvertor.handleLogicalFieldType(
-            col, genericRecord.get(col), genericRecord.getSchema().getField(col).schema());
+            col,
+            genericRecord.get(col),
+            genericRecord.getSchema().getField(col).schema(),
+            getTestCassandraAnnotationNone());
     assertEquals("Test json_col conversion: ", "{\"k1\":\"v1\"}", result);
 
     col = "number_col";
     result =
         GenericRecordTypeConvertor.handleLogicalFieldType(
-            col, genericRecord.get(col), genericRecord.getSchema().getField(col).schema());
+            col,
+            genericRecord.get(col),
+            genericRecord.getSchema().getField(col).schema(),
+            getTestCassandraAnnotationNone());
     assertEquals("Test number_col conversion: ", "289452", result);
 
     col = "varchar_col";
     result =
         GenericRecordTypeConvertor.handleLogicalFieldType(
-            col, genericRecord.get(col), genericRecord.getSchema().getField(col).schema());
+            col,
+            genericRecord.get(col),
+            genericRecord.getSchema().getField(col).schema(),
+            getTestCassandraAnnotationNone());
     assertEquals("Test varchar_col conversion: ", "Hellogcds", result);
 
     col = "time_interval_col";
     result =
         GenericRecordTypeConvertor.handleLogicalFieldType(
-            col, genericRecord.get(col), genericRecord.getSchema().getField(col).schema());
+            col,
+            genericRecord.get(col),
+            genericRecord.getSchema().getField(col).schema(),
+            getTestCassandraAnnotationNone());
     assertEquals("Test time_interval_col conversion: ", "-838:59:58.999999", result);
 
     col = "unsupported_col";
     result =
         GenericRecordTypeConvertor.handleLogicalFieldType(
-            col, genericRecord.get(col), genericRecord.getSchema().getField(col).schema());
+            col,
+            genericRecord.get(col),
+            genericRecord.getSchema().getField(col).schema(),
+            getTestCassandraAnnotationNone());
     assertEquals("Test unsupported_col conversion: ", null, result);
   }
 
@@ -265,14 +302,16 @@ public class GenericRecordTypeConvertorTest {
             GenericRecordTypeConvertor.getObjectMapValueForArrayFieldValue(
                 null,
                 SchemaBuilder.array().items(SchemaBuilder.builder().booleanType()),
-                "testFiled"))
+                "testFiled",
+                getTestCassandraAnnotationNone()))
         .isEqualTo(null);
 
     assertThat(
             GenericRecordTypeConvertor.getObjectMapValueForArrayFieldValue(
                 new Boolean[] {true, false},
                 SchemaBuilder.array().items(SchemaBuilder.builder().booleanType()),
-                "testFiled"))
+                "testFiled",
+                getTestCassandraAnnotationNone()))
         .isEqualTo(new Boolean[] {true, false});
 
     assertThat(
@@ -282,7 +321,8 @@ public class GenericRecordTypeConvertorTest {
                     .items(
                         LogicalTypes.timestampMillis()
                             .addToSchema(Schema.create(Schema.Type.LONG))),
-                "testFiled"))
+                "testFiled",
+                getTestCassandraAnnotationNone()))
         .isEqualTo(new String[] {"2025-02-19T14:51:49.018Z"});
 
     assertThat(
@@ -292,7 +332,8 @@ public class GenericRecordTypeConvertorTest {
                     .items(
                         LogicalTypes.timestampMillis()
                             .addToSchema(Schema.create(Schema.Type.LONG))),
-                "testFiled"))
+                "testFiled",
+                getTestCassandraAnnotationNone()))
         .isEqualTo(new String[] {"2025-02-19T14:51:49.018Z"});
     assertThat(
             GenericRecordTypeConvertor.getObjectMapValueForArrayFieldValue(
@@ -300,7 +341,8 @@ public class GenericRecordTypeConvertorTest {
                   AvroTestingHelper.createTimestampTzRecord(1602599400056483L, 3600000), null
                 },
                 SchemaBuilder.array().items(AvroTestingHelper.TIMESTAMPTZ_SCHEMA),
-                "testFiled"))
+                "testFiled",
+                getTestCassandraAnnotationNone()))
         .isEqualTo(new String[] {"2020-10-13T14:30:00.056483Z", null});
   }
 
@@ -324,7 +366,8 @@ public class GenericRecordTypeConvertorTest {
           GenericRecordTypeConvertor.handleLogicalFieldType(
               "timestamp_micros_col",
               entry.getKey(),
-              LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG)));
+              LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG)),
+              getTestCassandraAnnotationNone());
       assertEquals("Test timestamp for epoch " + entry.getKey() + ": ", entry.getValue(), result);
     }
   }
@@ -333,13 +376,13 @@ public class GenericRecordTypeConvertorTest {
   public void testHandleLogicalFieldType_nullInput() {
     assertNull(
         GenericRecordTypeConvertor.handleLogicalFieldType(
-            "col", null, SchemaBuilder.builder().stringType()));
+            "col", null, SchemaBuilder.builder().stringType(), getTestCassandraAnnotationNone()));
   }
 
   @Test(expected = UnsupportedOperationException.class)
   public void testHandleLogicalFieldType_unsupportedLogicalType() {
     GenericRecordTypeConvertor.handleLogicalFieldType(
-        "col", "test", SchemaBuilder.builder().stringType());
+        "col", "test", SchemaBuilder.builder().stringType(), getTestCassandraAnnotationNone());
   }
 
   @Test
@@ -488,7 +531,8 @@ public class GenericRecordTypeConvertorTest {
                 payload.get("booleanCol"),
                 payloadSchema.getField("booleanCol").schema(),
                 "booleanCol",
-                Type.bool()))
+                Type.bool(),
+                getTestCassandraAnnotationNone()))
         .isEqualTo(Value.bool(true));
 
     assertThat(
@@ -496,7 +540,8 @@ public class GenericRecordTypeConvertorTest {
                 payload.get("intervalNanoCol"),
                 payloadSchema.getField("intervalNanoCol").schema(),
                 "intervalNanoCol",
-                Type.string()))
+                Type.string(),
+                getTestCassandraAnnotationNone()))
         .isEqualTo(Value.string("P1000Y1000M3890DT30H31M12.000000009S"));
 
     assertThat(
@@ -504,7 +549,8 @@ public class GenericRecordTypeConvertorTest {
                 payload.get("timeStampCol"),
                 payloadSchema.getField("timeStampCol").schema(),
                 "timeStampCol",
-                Type.timestamp()))
+                Type.timestamp(),
+                getTestCassandraAnnotationNone()))
         .isEqualTo(Value.timestamp(Timestamp.parseTimestamp("2020-10-13T14:30:00.056000000Z")));
 
     assertThat(
@@ -512,7 +558,8 @@ public class GenericRecordTypeConvertorTest {
                 payload.get("booleanArrayCol"),
                 payloadSchema.getField("booleanArrayCol").schema(),
                 "booleanArrayCol",
-                Type.array(Type.bool())))
+                Type.array(Type.bool()),
+                getTestCassandraAnnotationNone()))
         .isEqualTo(Value.boolArray(ImmutableList.of(true, false)));
 
     assertThat(
@@ -520,7 +567,8 @@ public class GenericRecordTypeConvertorTest {
                 payload.get("intervalNanoArrayCol"),
                 payloadSchema.getField("intervalNanoArrayCol").schema(),
                 "intervalNanoCol",
-                Type.array(Type.string())))
+                Type.array(Type.string()),
+                getTestCassandraAnnotationNone()))
         .isEqualTo(
             Value.stringArray(
                 ImmutableList.of(
@@ -533,13 +581,17 @@ public class GenericRecordTypeConvertorTest {
                 payload.get("timeStampArrayCol"),
                 payloadSchema.getField("timeStampArrayCol").schema(),
                 "timeStampCol",
-                Type.array(Type.timestamp())))
+                Type.array(Type.timestamp()),
+                getTestCassandraAnnotationNone()))
         .isEqualTo(Value.timestampArray(expectedTimeStampArray));
 
     /* Pass through for non-array types */
     assertThat(
             genericRecordTypeConvertor.handleArrayAvroTypes(
-                42L, SchemaBuilder.builder().longType(), "primitive"))
+                42L,
+                SchemaBuilder.builder().longType(),
+                "primitive",
+                getTestCassandraAnnotationNone()))
         .isEqualTo(42L);
 
     assertThat(genericRecordTypeConvertor.transformChangeEvent(payload, "few_types"))
@@ -863,7 +915,9 @@ public class GenericRecordTypeConvertorTest {
             .endUnion();
     assertThrows(
         IllegalArgumentException.class,
-        () -> genericRecordTypeConvertor.getSpannerValue(null, schema, "union_col", Type.string()));
+        () ->
+            genericRecordTypeConvertor.getSpannerValue(
+                null, schema, "union_col", Type.string(), getTestCassandraAnnotationNone()));
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -1232,5 +1286,13 @@ public class GenericRecordTypeConvertorTest {
         throws InvalidTransformationException {
       return null;
     }
+  }
+
+  private CassandraAnnotations getTestCassandraAnnotation(String annotation) {
+    return CassandraAnnotations.fromColumnOptions(ImmutableList.of(annotation), "testCol");
+  }
+
+  private CassandraAnnotations getTestCassandraAnnotationNone() {
+    return getTestCassandraAnnotation("");
   }
 }

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/schema/IdentityMapperTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/schema/IdentityMapperTest.java
@@ -20,7 +20,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraType.Kind;
 import com.google.cloud.teleport.v2.spanner.type.Type;
+import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -54,6 +56,7 @@ public class IdentityMapperTest {
             .endTable()
             .createTable("Account")
             .column("id")
+            .columnOptions(ImmutableList.of("CASSANDRA_TYPE=\"bigint\""))
             .int64()
             .notNull()
             .endColumn()
@@ -73,6 +76,16 @@ public class IdentityMapperTest {
             .endTable()
             .build();
     this.mapper = new IdentityMapper(ddl);
+  }
+
+  @Test
+  public void testCassandraAnnotations() {
+    assertEquals(
+        mapper.getSpannerColumnCassandraAnnotations("", "Users", "id").cassandraType().getKind(),
+        Kind.NONE);
+    assertEquals(
+        mapper.getSpannerColumnCassandraAnnotations("", "Account", "id").cassandraType().getKind(),
+        Kind.PRIMITIVE);
   }
 
   @Test

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SessionBasedMapperTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SessionBasedMapperTest.java
@@ -22,8 +22,10 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraType.Kind;
 import com.google.cloud.teleport.v2.spanner.migrations.utils.SessionFileReader;
 import com.google.cloud.teleport.v2.spanner.type.Type;
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -59,6 +61,7 @@ public class SessionBasedMapperTest {
             .column("new_user_id")
             .string()
             .size(10)
+            .columnOptions(ImmutableList.of("CASSANDRA_TYPE=\"ascii\""))
             .endColumn()
             .primaryKey()
             .asc("new_user_id")
@@ -94,6 +97,7 @@ public class SessionBasedMapperTest {
             .column("new_user_id")
             .string()
             .size(20)
+            .columnOptions(ImmutableList.of("CASSANDRA_TYPE=\"ascii\""))
             .endColumn()
             .primaryKey()
             .asc("new_user_id")
@@ -372,5 +376,15 @@ public class SessionBasedMapperTest {
   public void testColExistsAtSource() {
     assertTrue(mapper.colExistsAtSource("", "new_cart", "new_quantity"));
     assertFalse(mapper.colExistsAtSource("", "new_cart", "abc"));
+  }
+
+  @Test
+  public void testCassandraAnnotations() {
+    assertEquals(
+        mapper
+            .getSpannerColumnCassandraAnnotations("", "new_cart", "new_user_id")
+            .cassandraType()
+            .getKind(),
+        Kind.PRIMITIVE);
   }
 }


### PR DESCRIPTION
# Overview
1. Adding DDL Parsing logic for Cassandra Annotations
This will help current Adapter mappings for map to Json as well as any other strategies in future.
2. Marshalling Avro Json to Map to match adapter's current  mappings for `MAP<K, V>`.


ITs for Cassandra and Bulk are passing. Since this is a change in `spanner-common` many other ITs are triggered. Different modules are failing for current known issue of `ClassNotFound` in different re-runs.