### PR TITLE
Add the support of default_time_zone database option.

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/DatabaseOptionAllowlist.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/DatabaseOptionAllowlist.java
@@ -28,5 +28,8 @@ public class DatabaseOptionAllowlist {
   // export/import pipelines.
   public static final ImmutableList<String> DATABASE_OPTION_ALLOWLIST =
       ImmutableList.of(
-          "version_retention_period", "opt_in_dataplacement_preview", "default_sequence_kind");
+          "version_retention_period",
+          "opt_in_dataplacement_preview",
+          "default_sequence_kind",
+          "default_time_zone");
 }

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ExportPipelineIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ExportPipelineIT.java
@@ -199,6 +199,8 @@ public class ExportPipelineIT extends SpannerTemplateITBase {
           paramsAdder)
       throws IOException {
     // Arrange
+    String setDefaultTimeZoneStatement =
+        "ALTER DATABASE db SET OPTIONS (default_time_zone = 'UTC')";
     String createEmptyTableStatement =
         String.format(
             "CREATE TABLE `%s_EmptyTable` (\n" + "  id INT64 NOT NULL,\n" + ") PRIMARY KEY(id)",
@@ -248,6 +250,9 @@ public class ExportPipelineIT extends SpannerTemplateITBase {
                 + " OPTIONS (sort_order_sharding=TRUE)",
             testName, testName);
 
+    // Setting default time zone needs to be the first statement because it requires
+    // an empty database without any tables.
+    spannerResourceManager.executeDdlStatement(setDefaultTimeZoneStatement);
     spannerResourceManager.executeDdlStatement(createEmptyTableStatement);
     spannerResourceManager.executeDdlStatement(createRootTableStatement);
     spannerResourceManager.executeDdlStatement(setDefaultSequenceKindStatement);
@@ -337,6 +342,7 @@ public class ExportPipelineIT extends SpannerTemplateITBase {
           paramsAdder)
       throws IOException {
     // Arrange
+    String setDefaultTimeZoneStatement = "ALTER DATABASE db SET spanner.default_time_zone = 'UTC'";
     String createEmptyTableStatement =
         String.format(
             "CREATE TABLE \"%s_EmptyTable\" (\n" + "  id bigint NOT NULL,\nPRIMARY KEY(id)\n" + ")",
@@ -378,6 +384,9 @@ public class ExportPipelineIT extends SpannerTemplateITBase {
                 + " WITH (sort_order_sharding=TRUE, disable_automatic_uid_column=TRUE)",
             testName, testName);
 
+    // Setting default time zone needs to be the first statement because it requires
+    // an empty database without any tables.
+    spannerResourceManager.executeDdlStatement(setDefaultTimeZoneStatement);
     spannerResourceManager.executeDdlStatement(createEmptyTableStatement);
     spannerResourceManager.executeDdlStatement(createRootTableStatement);
     spannerResourceManager.executeDdlStatement(createSingersTableStatement);

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ImportPipelineIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ImportPipelineIT.java
@@ -188,6 +188,9 @@ public class ImportPipelineIT extends SpannerTemplateITBase {
       throws IOException {
     // Arrange
     uploadImportPipelineArtifacts("googlesql");
+    String setDefaultTimeZoneStatement =
+        "ALTER DATABASE db SET OPTIONS (default_time_zone = 'UTC')";
+    spannerResourceManager.executeDdlStatement(setDefaultTimeZoneStatement);
     String createEmptyTableStatement =
         "CREATE TABLE EmptyTable (\n" + "  id INT64 NOT NULL,\n" + ") PRIMARY KEY(id)";
     spannerResourceManager.executeDdlStatement(createEmptyTableStatement);
@@ -261,6 +264,8 @@ public class ImportPipelineIT extends SpannerTemplateITBase {
       throws IOException {
     // Arrange
     uploadImportPipelineArtifacts("postgres");
+    String setDefaultTimeZoneStatement = "ALTER DATABASE db SET spanner.default_time_zone = 'UTC'";
+    spannerResourceManager.executeDdlStatement(setDefaultTimeZoneStatement);
     String createEmptyTableStatement =
         "CREATE TABLE \"EmptyTable\" (\n" + "  id bigint NOT NULL,\nPRIMARY KEY(id)\n" + ")";
     spannerResourceManager.executeDdlStatement(createEmptyTableStatement);

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
@@ -1359,4 +1359,27 @@ public class InformationSchemaScannerIT {
     statements.set(0, statements.get(0).replace(dbId, "%db_name%"));
     assertThat(ddl.prettyPrint(), equalToCompressingWhiteSpace(String.join("", statements)));
   }
+
+  @Test
+  public void defaultTimeZone() throws Exception {
+    List<String> statements =
+        Arrays.asList(
+            "ALTER DATABASE `" + dbId + "` SET OPTIONS ( default_time_zone = \"UTC\" )\n\n");
+
+    SPANNER_SERVER.createDatabase(dbId, statements);
+    Ddl ddl = getDatabaseDdl();
+    statements.set(0, statements.get(0).replace(dbId, "%db_name%"));
+    assertThat(ddl.prettyPrint(), equalToCompressingWhiteSpace(String.join("", statements)));
+  }
+
+  @Test
+  public void pgDefaultTimeZone() throws Exception {
+    List<String> statements =
+        Arrays.asList("ALTER DATABASE \"" + dbId + "\" SET spanner.default_time_zone = 'UTC'\n");
+
+    SPANNER_SERVER.createDatabase(dbId, statements);
+    Ddl ddl = getDatabaseDdl();
+    statements.set(0, statements.get(0).replace(dbId, "%db_name%"));
+    assertThat(ddl.prettyPrint(), equalToCompressingWhiteSpace(String.join("", statements)));
+  }
 }

--- a/v1/src/test/resources/ImportPipelineIT/googlesql/spanner-export.json
+++ b/v1/src/test/resources/ImportPipelineIT/googlesql/spanner-export.json
@@ -16,6 +16,10 @@
     "manifestFile": "ModelStruct-manifest.json"
   }],
   "databaseOptions": [{
+    "optionName": "default_time_zone",
+    "optionType": "STRING",
+    "optionValue": "UTC"
+  }, {
     "optionName": "default_sequence_kind",
     "optionType": "STRING",
     "optionValue": "bit_reversed_positive"

--- a/v1/src/test/resources/ImportPipelineIT/postgres/spanner-export.json
+++ b/v1/src/test/resources/ImportPipelineIT/postgres/spanner-export.json
@@ -13,6 +13,10 @@
     "manifestFile": "Identity-manifest.json"
   }],
   "databaseOptions": [{
+    "optionName": "default_time_zone",
+    "optionType": "character varying",
+    "optionValue": "UTC"
+  }, {
     "optionName": "default_sequence_kind",
     "optionType": "character varying",
     "optionValue": "bit_reversed_positive"


### PR DESCRIPTION
The `default_time_zone` database option allows to specify a time zone in date/timestamp functions in queries when a time zone is unspecified. Currently, the default time zone is always `America/Los_Angeles`. With this support, we allow users to set other time zones, e.g., UTC. 