### PR TITLE
Force timeout for DataStreamToSQLIT

### DIFF
--- a/.github/workflows/kafka-pr.yml
+++ b/.github/workflows/kafka-pr.yml
@@ -33,6 +33,7 @@ on:
       - 'v2/kafka-to-bigquery/**'
       - 'v2/kafka-to-gcs/**'
       - 'v2/kafka-to-kafka/**'
+      - 'v2/pubsub-to-kafka/**'
   schedule:
     - cron: "6 */12 * * *"
   workflow_dispatch:

--- a/cicd/internal/flags/common-flags.go
+++ b/cicd/internal/flags/common-flags.go
@@ -39,6 +39,7 @@ var (
 			"v2/kafka-to-gcs/",
 			"v2/kafka-to-kafka/",
 			"v2/kafka-to-pubsub/",
+			"v2/pubsub-to-kafka/",
 			"plugins/templates-maven-plugin",
 		},
 		SPANNER: {"v2/datastream-to-spanner/",

--- a/cicd/internal/flags/common-flags_test.go
+++ b/cicd/internal/flags/common-flags_test.go
@@ -43,7 +43,7 @@ func TestModulesToBuild(t *testing.T) {
 		},
 		{
 			input:    "KAFKA",
-			expected: []string{"v2/kafka-common/", "v2/kafka-to-bigquery/", "v2/kafka-to-gcs/", "v2/kafka-to-kafka/", "v2/kafka-to-pubsub/", "plugins/templates-maven-plugin"},
+			expected: []string{"v2/kafka-common/", "v2/kafka-to-bigquery/", "v2/kafka-to-gcs/", "v2/kafka-to-kafka/", "v2/kafka-to-pubsub/", "v2/pubsub-to-kafka/", "plugins/templates-maven-plugin"},
 		},
 		{
 			input:    "SPANNER",

--- a/v2/datastream-to-sql/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSQLIT.java
+++ b/v2/datastream-to-sql/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSQLIT.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.apache.beam.it.common.PipelineLauncher;
 import org.apache.beam.it.common.PipelineOperator;
@@ -58,8 +59,10 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -74,6 +77,7 @@ public class DataStreamToSQLIT extends TemplateTestBase {
     POSTGRES
   }
 
+  @Rule public Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
   private static final int NUM_EVENTS = 10;
 
   private static final String ROW_ID = "row_id";


### PR DESCRIPTION
Also move pubsub-to-kafka to correct PR workflow

It is found datastream-to-sql is the module that currently timing out in Dataflow integration test