### PR TITLE
Adding InsertOnly Mode for Bulk.

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/SourceDbToSpannerOptions.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/SourceDbToSpannerOptions.java
@@ -252,4 +252,15 @@ public interface SourceDbToSpannerOptions extends CommonTemplateOptions {
   String getNamespace();
 
   void setNamespace(String value);
+
+  @TemplateParameter.Text(
+      order = 21,
+      optional = true,
+      description = "Use Inserts instead of Upserts for spanner mutations.",
+      helpText =
+          "By default the pipeline uses Upserts to write rows to spanner. Which means existing rows would get overwritten. If InsertOnly mode is enabled, inserts would be used instead of upserts and existing rows won't be overwritten.")
+  @Default.Boolean(false)
+  Boolean getInsertOnlyModeForSpannerMutations();
+
+  void setInsertOnlyModeForSpannerMutations(Boolean value);
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/MigrateTableTransform.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/MigrateTableTransform.java
@@ -89,7 +89,8 @@ public class MigrateTableTransform extends PTransform<PBegin, PCollection<Void>>
 
     // Transform source data to Spanner Compatible Data
     SourceRowToMutationDoFn transformDoFn =
-        SourceRowToMutationDoFn.create(schemaMapper, customTransformation);
+        SourceRowToMutationDoFn.create(
+            schemaMapper, customTransformation, options.getInsertOnlyModeForSpannerMutations());
     PCollectionTuple transformationResult =
         sourceRows.apply(
             "Transform",


### PR DESCRIPTION
# Adding InsertOnly Mode for Bulk.
1. This will help the user run Bulk in parallel with dual writes.
2. Added integration test changes for testing inserts vs upserts in end to end migration.

Note that MigrateTableTransform does not have a UT wired as yet. This PR is adding a small one line change in the same file.
