### PR TITLE
[PropertyGraph] Explicitly output node reference key columns

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/GraphElementTable.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/GraphElementTable.java
@@ -133,6 +133,7 @@ public abstract class GraphElementTable implements Serializable {
       sb.append("KEY(");
       sb.append(edgeKeyColumns.stream().collect(Collectors.joining(", ")));
       sb.append(") REFERENCES ").append(nodeTableName);
+      sb.append("(").append(nodeKeyColumns.stream().collect(Collectors.joining(","))).append(")");
       return sb.toString();
     }
   }

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/AvroSchemaToDdlConverterTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/AvroSchemaToDdlConverterTest.java
@@ -585,7 +585,7 @@ public class AvroSchemaToDdlConverterTest {
             + "EDGE TABLES(\n"
             + "edgeBaseTable AS edgeAlias\n"
             + " KEY (edgePrimaryKey)\n"
-            + "SOURCE KEY(sourceEdgeKey) REFERENCES baseTable DESTINATION KEY(destEdgeKey) REFERENCES baseTable\n"
+            + "SOURCE KEY(sourceEdgeKey) REFERENCES baseTable(nodeKey) DESTINATION KEY(destEdgeKey) REFERENCES baseTable(otherNodeKey)\n"
             + "LABEL dummyLabelName3 NO PROPERTIES)";
 
     assertThat(ddl.prettyPrint(), equalToCompressingWhiteSpace(expectedPg));

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/DdlTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/DdlTest.java
@@ -1009,7 +1009,7 @@ public class DdlTest {
                 + "EDGE TABLES(\n"
                 + "edge-base-table AS edge-alias\n"
                 + " KEY (edge-primary-key)\n"
-                + "SOURCE KEY(source-edge-key) REFERENCES base-table DESTINATION KEY(dest-edge-key) REFERENCES base-table\n"
+                + "SOURCE KEY(source-edge-key) REFERENCES base-table(node-key) DESTINATION KEY(dest-edge-key) REFERENCES base-table(other-node-key)\n"
                 + "LABEL dummy-label-name3 NO PROPERTIES"
                 + ")"));
   }

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/GraphElementTableTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/GraphElementTableTest.java
@@ -78,7 +78,7 @@ public class GraphElementTableTest {
     assertEquals(ImmutableList.of("nodeKey1", "nodeKey2"), graphNodeTableReference.nodeKeyColumns);
     assertEquals(ImmutableList.of("edgeKey"), graphNodeTableReference.edgeKeyColumns);
 
-    String expectedPrettyPrint = "KEY(edgeKey) REFERENCES nodeTable";
+    String expectedPrettyPrint = "KEY(edgeKey) REFERENCES nodeTable(nodeKey1,nodeKey2)";
     assertEquals(expectedPrettyPrint, graphNodeTableReference.prettyPrint());
   }
 
@@ -117,7 +117,7 @@ public class GraphElementTableTest {
     String expectedPrettyPrint =
         "baseEdgeTable AS edgeTable\n"
             + " KEY (edgeKey1, edgeKey2)\n"
-            + "SOURCE KEY(edgeKey1) REFERENCES sourceNodeTable DESTINATION KEY(edgeKey2) REFERENCES targetNodeTable\n"
+            + "SOURCE KEY(edgeKey1) REFERENCES sourceNodeTable(sourceNodeKey) DESTINATION KEY(edgeKey2) REFERENCES targetNodeTable(targetNodeKey)\n"
             + "LABEL label1 PROPERTIES(valueA AS propertyA)";
     assertEquals(expectedPrettyPrint, graphElementTable.prettyPrint());
 

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/PropertyGraphTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/PropertyGraphTest.java
@@ -117,7 +117,7 @@ public class PropertyGraphTest {
             + "EDGE TABLES(\n"
             + "baseEdgeTable AS edgeTable\n"
             + " KEY (edgeKey1, edgeKey2)\n"
-            + "SOURCE KEY(edgeKey1) REFERENCES nodeTable DESTINATION KEY(edgeKey2) REFERENCES nodeTable\n"
+            + "SOURCE KEY(edgeKey1) REFERENCES nodeTable(nodeKey) DESTINATION KEY(edgeKey2) REFERENCES nodeTable(nodeKey)\n"
             + "LABEL edgeLabel PROPERTIES(valueB AS propertyB)"
             + ")";
     assertEquals(expectedPrettyPrint, propertyGraph.prettyPrint());


### PR DESCRIPTION
In the general case, ommitted node key columns are filled in via the element table primary keys.
However, it is always better to explicitly call out the key columns to avoid ambiguity in reference key selection in edge cases.