### PR TITLE
Don't assert on datetime row because this could vary by timezone

### DIFF
--- a/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryReadWithPartitionsTest.java
+++ b/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryReadWithPartitionsTest.java
@@ -204,8 +204,7 @@ public class JdbcToBigQueryReadWithPartitionsTest {
             options, JdbcToBigQuery.writeToBQTransform(options).withTestServices(bigQueryServices))
         .waitUntilFinish();
 
-    List<javax.swing.text.TableView.TableRow> rows =
-        fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
+    List<TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
     // Filter out time to avoid timezone issues
     assertThat(rows.size()).isEqualTo(1);
     assertThat(rows.get(0).get("BOOK_ID")).isEqualTo(1);

--- a/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryReadWithPartitionsTest.java
+++ b/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryReadWithPartitionsTest.java
@@ -30,6 +30,8 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.List;
+
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices;
 import org.apache.beam.sdk.io.gcp.testing.FakeBigQueryServices;
 import org.apache.beam.sdk.io.gcp.testing.FakeDatasetService;
@@ -117,13 +119,19 @@ public class JdbcToBigQueryReadWithPartitionsTest {
             options, JdbcToBigQuery.writeToBQTransform(options).withTestServices(bigQueryServices))
         .waitUntilFinish();
 
-    assertThat(fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE))
+    List<TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
+    // Filter out time to avoid timezone issues
+    List<TableRow> rowsWithoutTime = new List<TableRow>();
+    for (TableRow row : rows) {
+        rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
+    }
+
+    assertThat(rowsWithoutTime)
         .isEqualTo(
             ImmutableList.of(
                 new TableRow()
                     .set("BOOK_ID", 1)
-                    .set("TITLE", "ABC")
-                    .set("SELL_TIME", "2024-12-24 06:00:00.000")));
+                    .set("TITLE", "ABC")));
   }
 
   @Test
@@ -134,13 +142,19 @@ public class JdbcToBigQueryReadWithPartitionsTest {
             options, JdbcToBigQuery.writeToBQTransform(options).withTestServices(bigQueryServices))
         .waitUntilFinish();
 
-    assertThat(fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE))
+    List<TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
+    // Filter out time to avoid timezone issues
+    List<TableRow> rowsWithoutTime = new List<TableRow>();
+    for (TableRow row : rows) {
+        rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
+    }
+    
+    assertThat(rowsWithoutTime)
         .isEqualTo(
             ImmutableList.of(
                 new TableRow()
                     .set("BOOK_ID", 1)
-                    .set("TITLE", "ABC")
-                    .set("SELL_TIME", "2024-12-24 06:00:00.000")));
+                    .set("TITLE", "ABC")));
   }
 
   @Test
@@ -155,13 +169,20 @@ public class JdbcToBigQueryReadWithPartitionsTest {
             options, JdbcToBigQuery.writeToBQTransform(options).withTestServices(bigQueryServices))
         .waitUntilFinish();
 
-    assertThat(fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE))
+
+    List<TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
+    // Filter out time to avoid timezone issues
+    List<TableRow> rowsWithoutTime = new List<TableRow>();
+    for (TableRow row : rows) {
+        rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
+    }
+    
+    assertThat(rowsWithoutTime)
         .isEqualTo(
             ImmutableList.of(
                 new TableRow()
                     .set("BOOK_ID", 1)
-                    .set("TITLE", "ABC")
-                    .set("SELL_TIME", "2024-12-24 06:00:00.000")));
+                    .set("TITLE", "ABC")));
   }
 
   @Test
@@ -190,13 +211,20 @@ public class JdbcToBigQueryReadWithPartitionsTest {
             options, JdbcToBigQuery.writeToBQTransform(options).withTestServices(bigQueryServices))
         .waitUntilFinish();
 
-    assertThat(fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE))
+    
+    List<TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
+    // Filter out time to avoid timezone issues
+    List<TableRow> rowsWithoutTime = new List<TableRow>();
+    for (TableRow row : rows) {
+        rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
+    }
+    
+    assertThat(rowsWithoutTime)
         .isEqualTo(
             ImmutableList.of(
                 new TableRow()
                     .set("BOOK_ID", 1)
-                    .set("TITLE", "ABC")
-                    .set("SELL_TIME", "2024-12-24 06:00:00.000")));
+                    .set("TITLE", "ABC")));
   }
 
   @Test
@@ -211,13 +239,20 @@ public class JdbcToBigQueryReadWithPartitionsTest {
             options, JdbcToBigQuery.writeToBQTransform(options).withTestServices(bigQueryServices))
         .waitUntilFinish();
 
-    assertThat(fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE))
+    
+    List<TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
+    // Filter out time to avoid timezone issues
+    List<TableRow> rowsWithoutTime = new List<TableRow>();
+    for (TableRow row : rows) {
+        rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
+    }
+    
+    assertThat(rowsWithoutTime)
         .isEqualTo(
             ImmutableList.of(
                 new TableRow()
                     .set("BOOK_ID", 1)
-                    .set("TITLE", "ABC")
-                    .set("SELL_TIME", "2024-12-24 06:00:00.000")));
+                    .set("TITLE", "ABC")));
   }
 
   @Test

--- a/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryReadWithPartitionsTest.java
+++ b/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryReadWithPartitionsTest.java
@@ -121,8 +121,8 @@ public class JdbcToBigQueryReadWithPartitionsTest {
     List<TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
     // Filter out time to avoid timezone issues
     assertThat(rows.size()).isEqualTo(1);
-    assertThat(rows.get(0)["BOOK_ID"]).isEqualTo(1);
-    assertThat(rows.get(0)["TITLE"]).isEqualTo("ABC");
+    assertThat(rows.get(0).get("BOOK_ID")).isEqualTo(1);
+    assertThat(rows.get(0).get("TITLE")).isEqualTo("ABC");
   }
 
   @Test
@@ -136,8 +136,8 @@ public class JdbcToBigQueryReadWithPartitionsTest {
     List<TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
     // Filter out time to avoid timezone issues
     assertThat(rows.size()).isEqualTo(1);
-    assertThat(rows.get(0)["BOOK_ID"]).isEqualTo(1);
-    assertThat(rows.get(0)["TITLE"]).isEqualTo("ABC");
+    assertThat(rows.get(0).get("BOOK_ID")).isEqualTo(1);
+    assertThat(rows.get(0).get("TITLE")).isEqualTo("ABC");
   }
 
   @Test
@@ -155,8 +155,8 @@ public class JdbcToBigQueryReadWithPartitionsTest {
     List<TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
     // Filter out time to avoid timezone issues
     assertThat(rows.size()).isEqualTo(1);
-    assertThat(rows.get(0)["BOOK_ID"]).isEqualTo(1);
-    assertThat(rows.get(0)["TITLE"]).isEqualTo("ABC");
+    assertThat(rows.get(0).get("BOOK_ID")).isEqualTo(1);
+    assertThat(rows.get(0).get("TITLE")).isEqualTo("ABC");
   }
 
   @Test
@@ -188,8 +188,8 @@ public class JdbcToBigQueryReadWithPartitionsTest {
     List<TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
     // Filter out time to avoid timezone issues
     assertThat(rows.size()).isEqualTo(1);
-    assertThat(rows.get(0)["BOOK_ID"]).isEqualTo(1);
-    assertThat(rows.get(0)["TITLE"]).isEqualTo("ABC");
+    assertThat(rows.get(0).get("BOOK_ID")).isEqualTo(1);
+    assertThat(rows.get(0).get("TITLE")).isEqualTo("ABC");
   }
 
   @Test
@@ -208,8 +208,8 @@ public class JdbcToBigQueryReadWithPartitionsTest {
         fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
     // Filter out time to avoid timezone issues
     assertThat(rows.size()).isEqualTo(1);
-    assertThat(rows.get(0)["BOOK_ID"]).isEqualTo(1);
-    assertThat(rows.get(0)["TITLE"]).isEqualTo("ABC");
+    assertThat(rows.get(0).get("BOOK_ID")).isEqualTo(1);
+    assertThat(rows.get(0).get("TITLE")).isEqualTo("ABC");
   }
 
   @Test

--- a/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryReadWithPartitionsTest.java
+++ b/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryReadWithPartitionsTest.java
@@ -64,7 +64,7 @@ public class JdbcToBigQueryReadWithPartitionsTest {
         Statement statement = conn.createStatement()) {
       statement.execute(
           "CREATE TABLE book (BOOK_ID bigint primary key, TITLE varchar(128), SELL_TIME timestamp)");
-      statement.execute("INSERT INTO book VALUES (1, 'ABC', '2024-12-24 06:00:00.000000Z')");
+      statement.execute("INSERT INTO book VALUES (1, 'ABC', '2024-12-24 06:00:00.000')");
     }
 
     // setup BQ
@@ -123,7 +123,7 @@ public class JdbcToBigQueryReadWithPartitionsTest {
                 new TableRow()
                     .set("BOOK_ID", 1)
                     .set("TITLE", "ABC")
-                    .set("SELL_TIME", "2024-12-24 06:00:00.000000Z")));
+                    .set("SELL_TIME", "2024-12-24 06:00:00.000")));
   }
 
   @Test
@@ -140,7 +140,7 @@ public class JdbcToBigQueryReadWithPartitionsTest {
                 new TableRow()
                     .set("BOOK_ID", 1)
                     .set("TITLE", "ABC")
-                    .set("SELL_TIME", "2024-12-24 06:00:00.000000Z")));
+                    .set("SELL_TIME", "2024-12-24 06:00:00.000")));
   }
 
   @Test
@@ -161,7 +161,7 @@ public class JdbcToBigQueryReadWithPartitionsTest {
                 new TableRow()
                     .set("BOOK_ID", 1)
                     .set("TITLE", "ABC")
-                    .set("SELL_TIME", "2024-12-24 06:00:00.000000Z")));
+                    .set("SELL_TIME", "2024-12-24 06:00:00.000")));
   }
 
   @Test
@@ -196,7 +196,7 @@ public class JdbcToBigQueryReadWithPartitionsTest {
                 new TableRow()
                     .set("BOOK_ID", 1)
                     .set("TITLE", "ABC")
-                    .set("SELL_TIME", "2024-12-24 06:00:00.000000Z")));
+                    .set("SELL_TIME", "2024-12-24 06:00:00.000")));
   }
 
   @Test
@@ -217,7 +217,7 @@ public class JdbcToBigQueryReadWithPartitionsTest {
                 new TableRow()
                     .set("BOOK_ID", 1)
                     .set("TITLE", "ABC")
-                    .set("SELL_TIME", "2024-12-24 06:00:00.000000Z")));
+                    .set("SELL_TIME", "2024-12-24 06:00:00.000")));
   }
 
   @Test

--- a/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryReadWithPartitionsTest.java
+++ b/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryReadWithPartitionsTest.java
@@ -64,7 +64,7 @@ public class JdbcToBigQueryReadWithPartitionsTest {
         Statement statement = conn.createStatement()) {
       statement.execute(
           "CREATE TABLE book (BOOK_ID bigint primary key, TITLE varchar(128), SELL_TIME timestamp)");
-      statement.execute("INSERT INTO book VALUES (1, 'ABC', '2024-12-24 06:00:00.000')");
+      statement.execute("INSERT INTO book VALUES (1, 'ABC', '2024-12-24 06:00:00.000000Z')");
     }
 
     // setup BQ

--- a/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryReadWithPartitionsTest.java
+++ b/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryReadWithPartitionsTest.java
@@ -30,6 +30,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices;
 import org.apache.beam.sdk.io.gcp.testing.FakeBigQueryServices;
@@ -120,13 +121,9 @@ public class JdbcToBigQueryReadWithPartitionsTest {
 
     List<TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
     // Filter out time to avoid timezone issues
-    List<TableRow> rowsWithoutTime = new List<TableRow>();
-    for (TableRow row : rows) {
-      rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
-    }
-
-    assertThat(rowsWithoutTime)
-        .isEqualTo(ImmutableList.of(new TableRow().set("BOOK_ID", 1).set("TITLE", "ABC")));
+    assertThat(rows.size()).isEqualTo(1);
+    assertThat(rows.get(0)["BOOK_ID"]).isEqualTo(1);
+    assertThat(rows.get(0)["TITLE"]).isEqualTo("ABC");
   }
 
   @Test
@@ -139,13 +136,9 @@ public class JdbcToBigQueryReadWithPartitionsTest {
 
     List<TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
     // Filter out time to avoid timezone issues
-    List<TableRow> rowsWithoutTime = new List<TableRow>();
-    for (TableRow row : rows) {
-      rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
-    }
-
-    assertThat(rowsWithoutTime)
-        .isEqualTo(ImmutableList.of(new TableRow().set("BOOK_ID", 1).set("TITLE", "ABC")));
+    assertThat(rows.size()).isEqualTo(1);
+    assertThat(rows.get(0)["BOOK_ID"]).isEqualTo(1);
+    assertThat(rows.get(0)["TITLE"]).isEqualTo("ABC");
   }
 
   @Test
@@ -162,13 +155,9 @@ public class JdbcToBigQueryReadWithPartitionsTest {
 
     List<TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
     // Filter out time to avoid timezone issues
-    List<TableRow> rowsWithoutTime = new List<TableRow>();
-    for (TableRow row : rows) {
-      rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
-    }
-
-    assertThat(rowsWithoutTime)
-        .isEqualTo(ImmutableList.of(new TableRow().set("BOOK_ID", 1).set("TITLE", "ABC")));
+    assertThat(rows.size()).isEqualTo(1);
+    assertThat(rows.get(0)["BOOK_ID"]).isEqualTo(1);
+    assertThat(rows.get(0)["TITLE"]).isEqualTo("ABC");
   }
 
   @Test
@@ -199,13 +188,9 @@ public class JdbcToBigQueryReadWithPartitionsTest {
 
     List<TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
     // Filter out time to avoid timezone issues
-    List<TableRow> rowsWithoutTime = new List<TableRow>();
-    for (TableRow row : rows) {
-      rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
-    }
-
-    assertThat(rowsWithoutTime)
-        .isEqualTo(ImmutableList.of(new TableRow().set("BOOK_ID", 1).set("TITLE", "ABC")));
+    assertThat(rows.size()).isEqualTo(1);
+    assertThat(rows.get(0)["BOOK_ID"]).isEqualTo(1);
+    assertThat(rows.get(0)["TITLE"]).isEqualTo("ABC");
   }
 
   @Test
@@ -220,15 +205,11 @@ public class JdbcToBigQueryReadWithPartitionsTest {
             options, JdbcToBigQuery.writeToBQTransform(options).withTestServices(bigQueryServices))
         .waitUntilFinish();
 
-    List<TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
+    List<javax.swing.text.TableView.TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
     // Filter out time to avoid timezone issues
-    List<TableRow> rowsWithoutTime = new List<TableRow>();
-    for (TableRow row : rows) {
-      rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
-    }
-
-    assertThat(rowsWithoutTime)
-        .isEqualTo(ImmutableList.of(new TableRow().set("BOOK_ID", 1).set("TITLE", "ABC")));
+    assertThat(rows.size()).isEqualTo(1);
+    assertThat(rows.get(0)["BOOK_ID"]).isEqualTo(1);
+    assertThat(rows.get(0)["TITLE"]).isEqualTo("ABC");
   }
 
   @Test

--- a/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryReadWithPartitionsTest.java
+++ b/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryReadWithPartitionsTest.java
@@ -31,7 +31,6 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
-
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices;
 import org.apache.beam.sdk.io.gcp.testing.FakeBigQueryServices;
 import org.apache.beam.sdk.io.gcp.testing.FakeDatasetService;
@@ -123,15 +122,11 @@ public class JdbcToBigQueryReadWithPartitionsTest {
     // Filter out time to avoid timezone issues
     List<TableRow> rowsWithoutTime = new List<TableRow>();
     for (TableRow row : rows) {
-        rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
+      rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
     }
 
     assertThat(rowsWithoutTime)
-        .isEqualTo(
-            ImmutableList.of(
-                new TableRow()
-                    .set("BOOK_ID", 1)
-                    .set("TITLE", "ABC")));
+        .isEqualTo(ImmutableList.of(new TableRow().set("BOOK_ID", 1).set("TITLE", "ABC")));
   }
 
   @Test
@@ -146,15 +141,11 @@ public class JdbcToBigQueryReadWithPartitionsTest {
     // Filter out time to avoid timezone issues
     List<TableRow> rowsWithoutTime = new List<TableRow>();
     for (TableRow row : rows) {
-        rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
+      rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
     }
-    
+
     assertThat(rowsWithoutTime)
-        .isEqualTo(
-            ImmutableList.of(
-                new TableRow()
-                    .set("BOOK_ID", 1)
-                    .set("TITLE", "ABC")));
+        .isEqualTo(ImmutableList.of(new TableRow().set("BOOK_ID", 1).set("TITLE", "ABC")));
   }
 
   @Test
@@ -169,20 +160,15 @@ public class JdbcToBigQueryReadWithPartitionsTest {
             options, JdbcToBigQuery.writeToBQTransform(options).withTestServices(bigQueryServices))
         .waitUntilFinish();
 
-
     List<TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
     // Filter out time to avoid timezone issues
     List<TableRow> rowsWithoutTime = new List<TableRow>();
     for (TableRow row : rows) {
-        rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
+      rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
     }
-    
+
     assertThat(rowsWithoutTime)
-        .isEqualTo(
-            ImmutableList.of(
-                new TableRow()
-                    .set("BOOK_ID", 1)
-                    .set("TITLE", "ABC")));
+        .isEqualTo(ImmutableList.of(new TableRow().set("BOOK_ID", 1).set("TITLE", "ABC")));
   }
 
   @Test
@@ -211,20 +197,15 @@ public class JdbcToBigQueryReadWithPartitionsTest {
             options, JdbcToBigQuery.writeToBQTransform(options).withTestServices(bigQueryServices))
         .waitUntilFinish();
 
-    
     List<TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
     // Filter out time to avoid timezone issues
     List<TableRow> rowsWithoutTime = new List<TableRow>();
     for (TableRow row : rows) {
-        rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
+      rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
     }
-    
+
     assertThat(rowsWithoutTime)
-        .isEqualTo(
-            ImmutableList.of(
-                new TableRow()
-                    .set("BOOK_ID", 1)
-                    .set("TITLE", "ABC")));
+        .isEqualTo(ImmutableList.of(new TableRow().set("BOOK_ID", 1).set("TITLE", "ABC")));
   }
 
   @Test
@@ -239,20 +220,15 @@ public class JdbcToBigQueryReadWithPartitionsTest {
             options, JdbcToBigQuery.writeToBQTransform(options).withTestServices(bigQueryServices))
         .waitUntilFinish();
 
-    
     List<TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
     // Filter out time to avoid timezone issues
     List<TableRow> rowsWithoutTime = new List<TableRow>();
     for (TableRow row : rows) {
-        rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
+      rowsWithoutTime.add(new TableRow().set("BOOK_ID", row["BOOK_ID"]).set("TITLE", row["TITLE"]));
     }
-    
+
     assertThat(rowsWithoutTime)
-        .isEqualTo(
-            ImmutableList.of(
-                new TableRow()
-                    .set("BOOK_ID", 1)
-                    .set("TITLE", "ABC")));
+        .isEqualTo(ImmutableList.of(new TableRow().set("BOOK_ID", 1).set("TITLE", "ABC")));
   }
 
   @Test

--- a/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryReadWithPartitionsTest.java
+++ b/v2/jdbc-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/JdbcToBigQueryReadWithPartitionsTest.java
@@ -30,7 +30,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices;
 import org.apache.beam.sdk.io.gcp.testing.FakeBigQueryServices;
@@ -205,7 +204,8 @@ public class JdbcToBigQueryReadWithPartitionsTest {
             options, JdbcToBigQuery.writeToBQTransform(options).withTestServices(bigQueryServices))
         .waitUntilFinish();
 
-    List<javax.swing.text.TableView.TableRow> rows = fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
+    List<javax.swing.text.TableView.TableRow> rows =
+        fakeDatasetService.getAllRows(PROJECT, DATASET, TABLE);
     // Filter out time to avoid timezone issues
     assertThat(rows.size()).isEqualTo(1);
     assertThat(rows.get(0)["BOOK_ID"]).isEqualTo(1);


### PR DESCRIPTION
Right now, we're seeing failures in internal tests (internal cl/732015551) because of issues with timezones. I'm not actually sure where the disconnect is coming from, but it seems like we're assuming a certain timezone in these tests and are running into issues.

There's not really a reason for us to care about the datetime column in the output, so we can easily get rid of this to unblock these tests.