### PR TITLE
Configuring numPartitions for Cassandra and allowing Spanner Mutation BatchSize to be configurable

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/SourceDbToSpannerOptions.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/SourceDbToSpannerOptions.java
@@ -263,4 +263,15 @@ public interface SourceDbToSpannerOptions extends CommonTemplateOptions {
   Boolean getInsertOnlyModeForSpannerMutations();
 
   void setInsertOnlyModeForSpannerMutations(Boolean value);
+
+  @TemplateParameter.Text(
+      order = 22,
+      optional = true,
+      description = "BatchSize for Spanner Mutation.",
+      helpText =
+          "BatchSize in bytes for Spanner Mutations. if set less than 0, default of Apache Beam's SpannerIO is used, which is 1MB. Set this to 0 or 10, to disable batching mutations.")
+  @Default.Long(-1)
+  Long getBatchSizeForSpannerMutations();
+
+  void setBatchSizeForSpannerMutations(Long value);
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraDataSource.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraDataSource.java
@@ -41,6 +41,15 @@ public abstract class CassandraDataSource implements Serializable {
   @Nullable
   public abstract String clusterName();
 
+  /**
+   * Number of Partitions to read from Cassandra.
+   *
+   * <p>Defaults to Null, which causes CassandraIO to default the number of partitions to number of
+   * hosts. TODO(vardhanvthigle): Auto infer Number of partitions based on size estimates table.
+   */
+  @Nullable
+  public abstract Integer numPartitions();
+
   public DriverConfigLoader driverConfigLoader() {
     return CassandraDriverConfigLoader.fromOptionsMap(optionsMap());
   }
@@ -77,7 +86,7 @@ public abstract class CassandraDataSource implements Serializable {
   }
 
   public static Builder builder() {
-    return new AutoValue_CassandraDataSource.Builder();
+    return new AutoValue_CassandraDataSource.Builder().setNumPartitions(null);
   }
 
   public abstract Builder toBuilder();
@@ -88,6 +97,8 @@ public abstract class CassandraDataSource implements Serializable {
     public abstract Builder setOptionsMap(OptionsMap value);
 
     public abstract Builder setClusterName(@Nullable String value);
+
+    public abstract Builder setNumPartitions(@Nullable Integer value);
 
     abstract OptionsMap optionsMap();
 

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperHelper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperHelper.java
@@ -45,12 +45,15 @@ class CassandraIOWrapperHelper {
 
   private static final Logger LOG = LoggerFactory.getLogger(CassandraIOWrapperHelper.class);
 
-  static DataSource buildDataSource(String gcsPath) {
+  static DataSource buildDataSource(String gcsPath, Integer numPartitions) {
     DataSource dataSource;
     try {
       dataSource =
           DataSource.ofCassandra(
-              CassandraDataSource.builder().setOptionsMapFromGcsFile(gcsPath).build());
+              CassandraDataSource.builder()
+                  .setOptionsMapFromGcsFile(gcsPath)
+                  .setNumPartitions(numPartitions)
+                  .build());
     } catch (FileNotFoundException e) {
       LOG.error("Unable to find driver config file in {}. Cause ", gcsPath, e);
       throw (new SchemaDiscoveryException(e));

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIoWrapper.java
@@ -26,6 +26,7 @@ import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableReference
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
@@ -36,8 +37,9 @@ public final class CassandraIoWrapper implements IoWrapper {
   private ImmutableMap<SourceTableReference, PTransform<PBegin, PCollection<SourceRow>>>
       tableReaders;
 
-  public CassandraIoWrapper(String gcsPath, List<String> sourceTables) {
-    DataSource dataSource = CassandraIOWrapperHelper.buildDataSource(gcsPath);
+  public CassandraIoWrapper(
+      String gcsPath, List<String> sourceTables, @Nullable Integer numPartitions) {
+    DataSource dataSource = CassandraIOWrapperHelper.buildDataSource(gcsPath, numPartitions);
     SchemaDiscovery schemaDiscovery = CassandraIOWrapperHelper.buildSchemaDiscovery();
     SourceSchemaReference sourceSchemaReference =
         SourceSchemaReference.ofCassandra(

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/MigrateTableTransform.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/MigrateTableTransform.java
@@ -103,7 +103,8 @@ public class MigrateTableTransform extends PTransform<PBegin, PCollection<Void>>
                             SourceDbToSpannerConstants.FILTERED_EVENT_TAG))));
 
     // Write to Spanner
-    SpannerWriter writer = new SpannerWriter(spannerConfig);
+    SpannerWriter writer =
+        new SpannerWriter(spannerConfig, options.getBatchSizeForSpannerMutations());
     SpannerWriteResult spannerWriteResult =
         writer.writeToSpanner(
             transformationResult

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraDataSourceTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraDataSourceTest.java
@@ -66,6 +66,9 @@ public class CassandraDataSourceTest {
                 .getDefaultProfile()
                 .getString(TypedDriverOption.AUTH_PROVIDER_PASSWORD.getRawOption()))
         .isEqualTo("test");
+    assertThat(cassandraDataSource.numPartitions()).isNull();
+    assertThat(cassandraDataSource.toBuilder().setNumPartitions(42).build().numPartitions())
+        .isEqualTo(42);
   }
 
   @Test

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperFactoryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperFactoryTest.java
@@ -90,7 +90,8 @@ public class CassandraIOWrapperFactoryTest {
         mockTableReaders = ImmutableMap.of(mockSourceTableReference, mockTableReader);
 
     mockCassandraIoWrapperHelper
-        .when(() -> CassandraIOWrapperHelper.buildDataSource(TEST_BUCKET_CASSANDRA_CONFIG_CONF))
+        .when(
+            () -> CassandraIOWrapperHelper.buildDataSource(TEST_BUCKET_CASSANDRA_CONFIG_CONF, null))
         .thenReturn(dataSource);
     mockCassandraIoWrapperHelper
         .when(() -> CassandraIOWrapperHelper.buildSchemaDiscovery())
@@ -125,6 +126,7 @@ public class CassandraIOWrapperFactoryTest {
         mock(SourceDbToSpannerOptions.class, Mockito.withSettings().serializable());
     when(mockOptions.getSourceDbDialect()).thenReturn("CASSANDRA");
     when(mockOptions.getSourceConfigURL()).thenReturn(testConfigPath);
+    when(mockOptions.getNumPartitions()).thenReturn(null);
     CassandraIOWrapperFactory cassandraIOWrapperFactory =
         CassandraIOWrapperFactory.fromPipelineOptions(mockOptions);
     assertThat(cassandraIOWrapperFactory.gcsConfigPath()).isEqualTo(testConfigPath);

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperHelperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperHelperTest.java
@@ -104,15 +104,20 @@ public class CassandraIOWrapperHelperTest {
       mockFileReader
           .when(() -> JarFileReader.saveFilesLocally(testGcsPath))
           .thenReturn(new URL[] {testUrl})
+          .thenReturn(new URL[] {testUrl})
           /* Empty URL List to test FileNotFoundException handling. */
           .thenReturn(new URL[] {});
 
-      DataSource dataSource = CassandraIOWrapperHelper.buildDataSource(testGcsPath);
+      DataSource dataSource = CassandraIOWrapperHelper.buildDataSource(testGcsPath, null);
       assertThat(dataSource.cassandra().loggedKeySpace()).isEqualTo("test-keyspace");
       assertThat(dataSource.cassandra().localDataCenter()).isEqualTo("datacenter1");
+      assertThat(dataSource.cassandra().numPartitions()).isEqualTo(null);
+      assertThat(
+              CassandraIOWrapperHelper.buildDataSource(testGcsPath, 42).cassandra().numPartitions())
+          .isEqualTo(42);
       assertThrows(
           SchemaDiscoveryException.class,
-          () -> CassandraIOWrapperHelper.buildDataSource(testGcsPath));
+          () -> CassandraIOWrapperHelper.buildDataSource(testGcsPath, null));
     }
   }
 

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIoWrapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIoWrapperTest.java
@@ -79,7 +79,7 @@ public class CassandraIoWrapperTest {
 
     try (MockedStatic mockCassandraIoWrapperHelper = mockStatic(CassandraIOWrapperHelper.class)) {
       mockCassandraIoWrapperHelper
-          .when(() -> CassandraIOWrapperHelper.buildDataSource(testGcsPath))
+          .when(() -> CassandraIOWrapperHelper.buildDataSource(testGcsPath, null))
           .thenReturn(dataSource);
       mockCassandraIoWrapperHelper
           .when(() -> CassandraIOWrapperHelper.buildSchemaDiscovery())
@@ -100,7 +100,8 @@ public class CassandraIoWrapperTest {
           .when(() -> CassandraIOWrapperHelper.getTableReaders(dataSource, mockSourceSchema))
           .thenReturn(mockTableReaders);
 
-      CassandraIoWrapper cassandraIoWrapper = new CassandraIoWrapper(testGcsPath, tablesToRead);
+      CassandraIoWrapper cassandraIoWrapper =
+          new CassandraIoWrapper(testGcsPath, tablesToRead, null);
       assertThat(cassandraIoWrapper.discoverTableSchema()).isEqualTo(mockSourceSchema);
       assertThat(cassandraIoWrapper.getTableReaders()).isEqualTo(mockTableReaders);
     }


### PR DESCRIPTION
# Making Number of Partitions on CassandraIo configurable
## Overview
CassandraIO defaults to number of partitions equal to number of hosts on Cassandra cluster. This default behavior leads to many timeout errors when run at scale.
With this PR we are percolating the existing option of numPartitions to CassandraIO.
## TODOS
1. Post Cloud Next (Auto-Infer Cassandra numPartitions from size estimate tables).