### PR TITLE
Surface error on cloud build

### DIFF
--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
@@ -999,8 +999,9 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
                       + imagePath
                       + "']\n"
                       + "options:\n"
+                      + "  logging: CLOUD_LOGGING_ONLY\n"
                       + "  requestedVerifyOption: VERIFIED"
-                  : ""));
+                  : "\noptions:\n" + "  logging: CLOUD_LOGGING_ONLY\n"));
     }
 
     LOG.info("Submitting Cloud Build job with config: " + cloudbuildFile.getAbsolutePath());
@@ -1023,12 +1024,12 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
             directory,
             cloudBuildLogs);
 
-    // Ideally this should raise an exception, but in GitHub Actions this returns NZE even for
-    // successful runs.
-    if (stageProcess.waitFor() != 0) {
-      LOG.warn(
-          "Possible error building container image using gcloud. Check logs for details. {}",
-          cloudBuildLogs);
+    int retval = stageProcess.waitFor();
+    if (retval != 0) {
+      throw new RuntimeException(
+          String.format(
+              "Error building yaml image using gcloud. Code %d. Check logs for details.\n%s",
+              retval, cloudBuildLogs));
     }
   }
 
@@ -1070,8 +1071,9 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
                       + imagePath
                       + "']\n"
                       + "options:\n"
+                      + "  logging: CLOUD_LOGGING_ONLY\n"
                       + "  requestedVerifyOption: VERIFIED"
-                  : ""));
+                  : "\noptions:\n" + "  logging: CLOUD_LOGGING_ONLY\n"));
     }
 
     LOG.info("Submitting Cloud Build job with config: " + cloudbuildFile.getAbsolutePath());
@@ -1094,12 +1096,12 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
             directory,
             cloudBuildLogs);
 
-    // Ideally this should raise an exception, but in GitHub Actions this returns NZE even for
-    // successful runs.
-    if (stageProcess.waitFor() != 0) {
-      LOG.warn(
-          "Possible error building container image using gcloud. Check logs for details. {}",
-          cloudBuildLogs);
+    int retval = stageProcess.waitFor();
+    if (retval != 0) {
+      throw new RuntimeException(
+          String.format(
+              "Error building Python image using gcloud. Code %d. Check logs for details. %s",
+              retval, cloudBuildLogs));
     }
   }
 
@@ -1169,6 +1171,7 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
               + imagePath
               + "']\n"
               + "options:\n"
+              + "  logging: CLOUD_LOGGING_ONLY\n"
               + "  requestedVerifyOption: VERIFIED");
     }
 
@@ -1188,12 +1191,12 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
             directory,
             cloudBuildLogs);
 
-    // Ideally this should raise an exception, but in GitHub Actions this returns NZE even for
-    // successful runs.
-    if (stageProcess.waitFor() != 0) {
-      LOG.warn(
-          "Possible error building container image using gcloud. Check logs for details. {}",
-          cloudBuildLogs);
+    int retval = stageProcess.waitFor();
+    if (retval != 0) {
+      throw new RuntimeException(
+          String.format(
+              "Possible error building Flex image using gcloud. Code %d. Check logs for details. %s",
+              retval, cloudBuildLogs));
     }
   }
 
@@ -1239,8 +1242,9 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
                       + imagePath
                       + "']\n"
                       + "options:\n"
+                      + "  logging: CLOUD_LOGGING_ONLY\n"
                       + "  requestedVerifyOption: VERIFIED"
-                  : ""));
+                  : "\noptions:\n" + "  logging: CLOUD_LOGGING_ONLY\n"));
     }
 
     LOG.info("Submitting Cloud Build job with config: " + cloudbuildFile.getAbsolutePath());
@@ -1263,12 +1267,12 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
             directory,
             cloudBuildLogs);
 
-    // Ideally this should raise an exception, but this returns NZE even for
-    // successful runs.
-    if (stageProcess.waitFor() != 0) {
-      LOG.warn(
-          "Possible error building container image using gcloud. Check logs for details. {}",
-          cloudBuildLogs);
+    int retval = stageProcess.waitFor();
+    if (retval != 0) {
+      throw new RuntimeException(
+          String.format(
+              "Possible error building Xlang image using gcloud. Code %d. Check logs for details. %s",
+              retval, cloudBuildLogs));
     }
   }
 


### PR DESCRIPTION
These errors were silenced to make release workflow pass. However, it also ignores real build errors and caused confusion in, e.g. #2278

The reason release workflow nonzero retval was the service account used on the production project has only limited permission, and error shown below:

```
[INFO] ERROR: (gcloud.builds.submit) 
[INFO] The build is running, and logs are being written to the default logs bucket.
[INFO] This tool can only stream logs if you are Viewer/Owner of the project and, if applicable, allowed by your VPC-SC security policy.
[INFO] 
[INFO] The default logs bucket is always outside any VPC-SC security perimeter.
[INFO] If you want your logs saved inside your VPC-SC perimeter, use your own bucket.
[INFO] See https://cloud.google.com/build/docs/securing-builds/store-manage-build-logs.
```

otherwise, the return value is zero here, for test workflow (ran in different gcp project and permission are granted)

Solution: https://github.com/google-github-actions/setup-gcloud/issues/281#issuecomment-1369620825