### PR TITLE
Do not set null Spanner Host in SpannerChangeStreamsToBigQuery Templates

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/spanner/spannerio/SpannerAccessor.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/spannerio/SpannerAccessor.java
@@ -223,7 +223,10 @@ public class SpannerAccessor implements AutoCloseable {
     }
     ValueProvider<String> host = spannerConfig.getHost();
     if (host != null) {
-      builder.setHost(host.get());
+      String hostValue = host.get();
+      if (hostValue != null && !hostValue.trim().isEmpty()) {
+        builder.setHost(hostValue);
+      }
     }
     ValueProvider<String> emulatorHost = spannerConfig.getEmulatorHost();
     if (emulatorHost != null) {

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SpannerChangeStreamsToBigQuery.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SpannerChangeStreamsToBigQuery.java
@@ -31,6 +31,7 @@ import com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.sch
 import com.google.cloud.teleport.v2.transforms.DLQWriteTransform;
 import com.google.cloud.teleport.v2.utils.BigQueryIOUtils;
 import com.google.cloud.teleport.v2.values.FailsafeElement;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -293,11 +294,14 @@ public final class SpannerChangeStreamsToBigQuery {
 
     SpannerConfig spannerConfig =
         SpannerConfig.create()
-            .withHost(ValueProvider.StaticValueProvider.of(options.getSpannerHost()))
             .withProjectId(spannerProjectId)
             .withInstanceId(options.getSpannerInstanceId())
             .withDatabaseId(options.getSpannerDatabase())
             .withRpcPriority(options.getRpcPriority());
+    if (!Strings.isNullOrEmpty(options.getSpannerHost())) {
+      spannerConfig =
+          spannerConfig.withHost(ValueProvider.StaticValueProvider.of(options.getSpannerHost()));
+    }
     // Propagate database role for fine-grained access control on change stream.
     if (options.getSpannerDatabaseRole() != null) {
       spannerConfig =


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/2278#discussion_r2021054220

only this template is affected because SpannerChangeStreamsToBigQueryOptions getSpannerHost defaults to null, while other templates they default to "https://spanner.googleapis.com"