### PR TITLE
Test adjustments

### DIFF
--- a/.github/workflows/kafka-pr.yml
+++ b/.github/workflows/kafka-pr.yml
@@ -22,6 +22,7 @@ on:
     - 'main'
     paths:
       # Template wide common modules
+      - 'pom.xml'
       - 'v2/common/**'
       - 'v2/datastream-common/**'
       - 'it/google-cloud-platform/**'

--- a/.github/workflows/spanner-pr.yml
+++ b/.github/workflows/spanner-pr.yml
@@ -22,6 +22,7 @@ on:
     - 'main'
     paths:
       # Template wide common modules
+      - 'pom.xml'
       - 'v2/common/**'
       - 'v2/datastream-common/**'
       - 'it/google-cloud-platform/**'

--- a/v1/src/test/java/com/google/cloud/teleport/bigtable/CassandraToBigtableIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/bigtable/CassandraToBigtableIT.java
@@ -44,6 +44,7 @@ import org.apache.beam.it.gcp.storage.GcsResourceManager;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -55,6 +56,7 @@ import org.slf4j.LoggerFactory;
 @Category(TemplateIntegrationTest.class)
 @TemplateIntegrationTest(CassandraToBigtable.class)
 @RunWith(JUnit4.class)
+@Ignore("https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/2288 test permared")
 public class CassandraToBigtableIT extends TemplateTestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(CassandraToBigtableIT.class);

--- a/v2/datastream-to-sql/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSQLIT.java
+++ b/v2/datastream-to-sql/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSQLIT.java
@@ -60,6 +60,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -70,6 +71,7 @@ import org.junit.runners.JUnit4;
 @Category({TemplateIntegrationTest.class, SkipDirectRunnerTest.class, SkipRunnerV2Test.class})
 @TemplateIntegrationTest(DataStreamToSQL.class)
 @RunWith(JUnit4.class)
+@Ignore("https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/2289 test permared")
 public class DataStreamToSQLIT extends TemplateTestBase {
 
   enum JDBCType {
@@ -78,7 +80,7 @@ public class DataStreamToSQLIT extends TemplateTestBase {
     POSTGRES
   }
 
-  @Rule public Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
+  @Rule public Timeout timeout = new Timeout(15, TimeUnit.MINUTES);
   private static final int NUM_EVENTS = 10;
 
   private static final String ROW_ID = "row_id";


### PR DESCRIPTION
Disable test failures due to #2288 #2289 . Otherwise lack of green signal causes more test failures spawning 

* spanner and kafka pr will run on main pom.xml change

* ~Bump DatastreamToSQL test timeout and consolidate test scenario~

hopefully this could fix tests currently failing on main without introducing more overhead

when there are n feature flags, we cannot afford to setup O(2**n) integration tests. Do O(n) tests with each covers one feature flag instead