### PR TITLE
Re-enable Datastream-to-sql tests and consolidate expensive datastream integration tests

### DIFF
--- a/v2/datastream-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToBigQueryIT.java
+++ b/v2/datastream-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToBigQueryIT.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.apache.beam.it.common.PipelineLauncher;
 import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
@@ -66,8 +67,11 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -81,6 +85,8 @@ public class DataStreamToBigQueryIT extends TemplateTestBase {
     ORACLE
   }
 
+  // TODO: Decrease timeout. Currently need to wait for long to make sure results are propagated.
+  @Rule public Timeout timeout = new Timeout(40, TimeUnit.MINUTES);
   private static final int NUM_EVENTS = 10;
 
   private static final String ROW_ID = "ROW_ID";
@@ -145,6 +151,7 @@ public class DataStreamToBigQueryIT extends TemplateTestBase {
   }
 
   @Test
+  @Ignore("Consolidate feature matrix for expensive tests")
   public void testDataStreamOracleToBigQuery() throws IOException {
     // Run a simple IT
     simpleJdbcToBigQueryTest(
@@ -157,6 +164,7 @@ public class DataStreamToBigQueryIT extends TemplateTestBase {
   }
 
   @Test
+  @Ignore("Consolidate feature matrix for expensive tests")
   public void testDataStreamMySqlToBigQueryJson() throws IOException {
     // Run a simple IT
     simpleJdbcToBigQueryTest(

--- a/v2/datastream-to-sql/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSQLIT.java
+++ b/v2/datastream-to-sql/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSQLIT.java
@@ -71,7 +71,6 @@ import org.junit.runners.JUnit4;
 @Category({TemplateIntegrationTest.class, SkipDirectRunnerTest.class, SkipRunnerV2Test.class})
 @TemplateIntegrationTest(DataStreamToSQL.class)
 @RunWith(JUnit4.class)
-@Ignore("https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/2289 test permared")
 public class DataStreamToSQLIT extends TemplateTestBase {
 
   enum JDBCType {
@@ -80,7 +79,7 @@ public class DataStreamToSQLIT extends TemplateTestBase {
     POSTGRES
   }
 
-  @Rule public Timeout timeout = new Timeout(15, TimeUnit.MINUTES);
+  @Rule public Timeout timeout = new Timeout(30, TimeUnit.MINUTES);
   private static final int NUM_EVENTS = 10;
 
   private static final String ROW_ID = "row_id";
@@ -139,12 +138,14 @@ public class DataStreamToSQLIT extends TemplateTestBase {
   }
 
   @Test
+  @Ignore("Consolidate feature matrix for expensive tests")
   public void testDataStreamOracleToPostgresJson() throws IOException {
     // Run a simple IT
     simpleOracleToJdbcTest(JDBCType.POSTGRES, Function.identity());
   }
 
   @Test
+  @Ignore("Consolidate feature matrix for expensive tests")
   public void testDataStreamOracleToMySqlJsonGCSNotifications() throws IOException {
     // Set up pubsub notifications
     SubscriptionName subscriptionName = createGcsNotifications();


### PR DESCRIPTION
Fix #2289

These tests needs 25 minutes to run.

when there are n feature flags, we cannot afford to setup O(2**n) integration tests. Do O(n) tests with each covers one feature flag instead