### PR TITLE
Skip staging part of AR path for job-builder

### DIFF
--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
@@ -430,7 +430,12 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
     imageSpec.setAdditionalUserLabel("goog-dataflow-provided-template-version", version);
     imageSpec.setImage(
         generateFlexTemplateImagePath(
-            containerName, projectId, artifactRegion, artifactRegistry, stagePrefix, stageImageOnly));
+            containerName,
+            projectId,
+            artifactRegion,
+            artifactRegistry,
+            stagePrefix,
+            stageImageOnly));
 
     if (beamVersion == null || beamVersion.isEmpty()) {
       beamVersion = project.getProperties().getProperty("beam-python.version");
@@ -444,7 +449,12 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
     String imagePath =
         stageImageBeforePromote
             ? generateFlexTemplateImagePath(
-                containerName, projectId, null, stagingArtifactRegistry, stagePrefix, stageImageOnly)
+                containerName,
+                projectId,
+                null,
+                stagingArtifactRegistry,
+                stagePrefix,
+                stageImageOnly)
             : imageSpec.getImage();
     String buildProjectId =
         stageImageBeforePromote
@@ -1119,20 +1129,9 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
         .map(
             value ->
                 value.endsWith("gcr.io")
-                    ? value
-                        + "/"
-                        + projectIdUrl
-                        + "/"
-                        + stagingPart
-                        + containerName
+                    ? value + "/" + projectIdUrl + "/" + stagingPart + containerName
                     : value + "/" + stagePrefix.toLowerCase() + "/" + containerName)
-        .orElse(
-            prefix
-                + "gcr.io/"
-                + projectIdUrl
-                + "/"
-                + stagingPart
-                + containerName);
+        .orElse(prefix + "gcr.io/" + projectIdUrl + "/" + stagingPart + containerName);
   }
 
   private void gcsCopy(String fromPath, String toPath) throws InterruptedException, IOException {

--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
@@ -1130,7 +1130,7 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
             value ->
                 value.endsWith("gcr.io")
                     ? value + "/" + projectIdUrl + "/" + stagingPart + containerName
-                    : value + stagingPart + "/" + containerName)
+                    : value + "/" + stagingPart + containerName)
         .orElse(prefix + "gcr.io/" + projectIdUrl + "/" + stagingPart + containerName);
   }
 

--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
@@ -1130,7 +1130,7 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
             value ->
                 value.endsWith("gcr.io")
                     ? value + "/" + projectIdUrl + "/" + stagingPart + containerName
-                    : value + "/" + stagePrefix.toLowerCase() + "/" + containerName)
+                    : value + stagingPart + "/" + containerName)
         .orElse(prefix + "gcr.io/" + projectIdUrl + "/" + stagingPart + containerName);
   }
 

--- a/plugins/templates-maven-plugin/src/test/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojoTest.java
+++ b/plugins/templates-maven-plugin/src/test/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojoTest.java
@@ -30,6 +30,7 @@ public class TemplatesStageMojoTest {
     String containerName = "name";
     String projectId = "some-project";
     String stagePrefix = "some-prefix";
+    boolean skipStagingPart = false;
     ImmutableMap<String, String> testCases =
         ImmutableMap.<String, String>builder()
             .put("", "gcr.io/some-project/some-prefix/name")
@@ -48,7 +49,7 @@ public class TemplatesStageMojoTest {
           assertEquals(
               value,
               TemplatesStageMojo.generateFlexTemplateImagePath(
-                  containerName, projectId, null, key, stagePrefix));
+                  containerName, projectId, null, key, stagePrefix, skipStagingPart));
         });
   }
 
@@ -57,6 +58,7 @@ public class TemplatesStageMojoTest {
     String containerName = "name";
     String projectId = "google.com:project";
     String stagePrefix = "some-prefix";
+    boolean skipStagingPart = false;
     ImmutableMap<String, String> testCases =
         ImmutableMap.<String, String>builder()
             .put("", "gcr.io/google.com/project/some-prefix/name")
@@ -75,7 +77,37 @@ public class TemplatesStageMojoTest {
           assertEquals(
               value,
               TemplatesStageMojo.generateFlexTemplateImagePath(
-                  containerName, projectId, null, key, stagePrefix));
+                  containerName, projectId, null, key, stagePrefix, skipStagingPart));
         });
   }
+
+  @RunWith(JUnit4.class)
+  public class TemplatesStageMojoTest {
+    @Test
+    public void testGenerateFlexTemplateImagePathSkipStagingPart() {
+      String containerName = "name";
+      String projectId = "some-project";
+      String stagePrefix = "some-prefix";
+      boolean skipStagingPart = true;
+      ImmutableMap<String, String> testCases =
+          ImmutableMap.<String, String>builder()
+              .put("", "gcr.io/some-project/name")
+              .put("gcr.io", "gcr.io/some-project/name")
+              .put("eu.gcr.io", "eu.gcr.io/some-project/name")
+              .put(
+                  "us-docker.pkg.dev/other-project/other-repo",
+                  "us-docker.pkg.dev/other-project/other-repo/name")
+              .build();
+      testCases.forEach(
+          (key, value) -> {
+            // workaround for null key we intended to test
+            if (Strings.isNullOrEmpty(key)) {
+              key = null;
+            }
+            assertEquals(
+                value,
+                TemplatesStageMojo.generateFlexTemplateImagePath(
+                    containerName, projectId, null, key, stagePrefix, skipStagingPart));
+          });
+    }
 }

--- a/plugins/templates-maven-plugin/src/test/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojoTest.java
+++ b/plugins/templates-maven-plugin/src/test/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojoTest.java
@@ -81,33 +81,31 @@ public class TemplatesStageMojoTest {
         });
   }
 
-  @RunWith(JUnit4.class)
-  public class TemplatesStageMojoTest {
-    @Test
-    public void testGenerateFlexTemplateImagePathSkipStagingPart() {
-      String containerName = "name";
-      String projectId = "some-project";
-      String stagePrefix = "some-prefix";
-      boolean skipStagingPart = true;
-      ImmutableMap<String, String> testCases =
-          ImmutableMap.<String, String>builder()
-              .put("", "gcr.io/some-project/name")
-              .put("gcr.io", "gcr.io/some-project/name")
-              .put("eu.gcr.io", "eu.gcr.io/some-project/name")
-              .put(
-                  "us-docker.pkg.dev/other-project/other-repo",
-                  "us-docker.pkg.dev/other-project/other-repo/name")
-              .build();
-      testCases.forEach(
-          (key, value) -> {
-            // workaround for null key we intended to test
-            if (Strings.isNullOrEmpty(key)) {
-              key = null;
-            }
-            assertEquals(
-                value,
-                TemplatesStageMojo.generateFlexTemplateImagePath(
-                    containerName, projectId, null, key, stagePrefix, skipStagingPart));
-          });
-    }
+  @Test
+  public void testGenerateFlexTemplateImagePathSkipStagingPart() {
+    String containerName = "name";
+    String projectId = "some-project";
+    String stagePrefix = "some-prefix";
+    boolean skipStagingPart = true;
+    ImmutableMap<String, String> testCases =
+        ImmutableMap.<String, String>builder()
+            .put("", "gcr.io/some-project/name")
+            .put("gcr.io", "gcr.io/some-project/name")
+            .put("eu.gcr.io", "eu.gcr.io/some-project/name")
+            .put(
+                "us-docker.pkg.dev/other-project/other-repo",
+                "us-docker.pkg.dev/other-project/other-repo/name")
+            .build();
+    testCases.forEach(
+        (key, value) -> {
+          // workaround for null key we intended to test
+          if (Strings.isNullOrEmpty(key)) {
+            key = null;
+          }
+          assertEquals(
+              value,
+              TemplatesStageMojo.generateFlexTemplateImagePath(
+                  containerName, projectId, null, key, stagePrefix, skipStagingPart));
+        });
+  }
 }


### PR DESCRIPTION
When we're only staging the image (job builder), having the postfix doesn't get us as much; right now this is all config driven from the UI side. This gives us the option of just pinning to latest for the image rather than needing to manually update every time, and we can still handle rollout safety by pinning to image shas if needed.