### PR TITLE
Reverse Replication - Addition of missing datatypes to IT 

### DIFF
--- a/v2/spanner-to-sourcedb/src/test/resources/SpannerToCassandraSourceIT/cassandra-schema.sql
+++ b/v2/spanner-to-sourcedb/src/test/resources/SpannerToCassandraSourceIT/cassandra-schema.sql
@@ -49,7 +49,13 @@ CREATE TABLE AllDatatypeTransformation (
     frozen_map_text_to_set_column map<text, frozen<set<text>>>,
     frozen_set_of_maps_column set<frozen<map<text, int>>>,
     frozen_list_of_sets_column list<frozen<set<text>>>,
-    varint_column varint
+    varint_column varint,
+    inet_column INET,
+    timeuuid_column timeuuid,
+    duration_column duration,
+    uuid_column uuid,
+    ascii_column ascii,
+    bytes_column BLOB
 );
 
 CREATE TABLE AllDatatypeColumns (
@@ -94,7 +100,14 @@ CREATE TABLE AllDatatypeColumns (
     frozen_set_of_maps_column set<frozen<map<text, int>>>,
     frozen_list_of_sets_column list<frozen<set<text>>>,
     varint_column varint,
-    inet_column INET
+    inet_column INET,
+    timeuuid_column timeuuid,
+    duration_column duration,
+    uuid_column uuid,
+    ascii_column ascii
+    list_text_column_from_array list<text>,
+    set_text_column_from_array set<text>
+
 );
 
 CREATE TABLE BoundaryConversionTestTable (

--- a/v2/spanner-to-sourcedb/src/test/resources/SpannerToCassandraSourceIT/cassandra-schema.sql
+++ b/v2/spanner-to-sourcedb/src/test/resources/SpannerToCassandraSourceIT/cassandra-schema.sql
@@ -99,12 +99,11 @@ CREATE TABLE AllDatatypeColumns (
     frozen_map_text_to_set_column map<text, frozen<set<text>>>,
     frozen_set_of_maps_column set<frozen<map<text, int>>>,
     frozen_list_of_sets_column list<frozen<set<text>>>,
-    varint_column varint,
     inet_column INET,
     timeuuid_column timeuuid,
     duration_column duration,
     uuid_column uuid,
-    ascii_column ascii
+    ascii_column ascii,
     list_text_column_from_array list<text>,
     set_text_column_from_array set<text>
 

--- a/v2/spanner-to-sourcedb/src/test/resources/SpannerToCassandraSourceIT/spanner-schema.sql
+++ b/v2/spanner-to-sourcedb/src/test/resources/SpannerToCassandraSourceIT/spanner-schema.sql
@@ -56,6 +56,12 @@ CREATE TABLE IF NOT EXISTS alldatatypetransformation (
     frozen_set_of_maps_column JSON,
     frozen_list_of_sets_column JSON,
     varint_column STRING(MAX)
+    inet_column STRING(MAX),
+    timeuuid_column STRING(MAX),
+    duration_column STRING(MAX),
+    uuid_column STRING(MAX),
+    ascii_column STRING(MAX),
+    bytes_column STRING(MAX)
 ) PRIMARY KEY(varchar_column);
 
 DROP TABLE IF EXISTS alldatatypecolumns;
@@ -102,7 +108,13 @@ CREATE TABLE IF NOT EXISTS alldatatypecolumns (
     frozen_set_of_maps_column JSON,
     frozen_list_of_sets_column JSON,
     varint_column STRING(MAX),
-    inet_column STRING(MAX)
+    inet_column STRING(MAX),
+    timeuuid_column STRING(MAX),
+    duration_column STRING(MAX),
+    uuid_column STRING(MAX),
+    ascii_column STRING(MAX),
+    list_text_column_from_array ARRAY<STRING(MAX)>,
+    set_text_column_from_array ARRAY<STRING(MAX)>
 ) PRIMARY KEY(varchar_column);
 
 CREATE TABLE IF NOT EXISTS boundaryconversiontesttable (

--- a/v2/spanner-to-sourcedb/src/test/resources/SpannerToCassandraSourceIT/spanner-schema.sql
+++ b/v2/spanner-to-sourcedb/src/test/resources/SpannerToCassandraSourceIT/spanner-schema.sql
@@ -55,7 +55,7 @@ CREATE TABLE IF NOT EXISTS alldatatypetransformation (
     frozen_map_text_to_set_column JSON,
     frozen_set_of_maps_column JSON,
     frozen_list_of_sets_column JSON,
-    varint_column STRING(MAX)
+    varint_column STRING(MAX),
     inet_column STRING(MAX),
     timeuuid_column STRING(MAX),
     duration_column STRING(MAX),
@@ -116,6 +116,8 @@ CREATE TABLE IF NOT EXISTS alldatatypecolumns (
     list_text_column_from_array ARRAY<STRING(MAX)>,
     set_text_column_from_array ARRAY<STRING(MAX)>
 ) PRIMARY KEY(varchar_column);
+
+DROP TABLE IF EXISTS boundaryconversiontesttable;
 
 CREATE TABLE IF NOT EXISTS boundaryconversiontesttable (
     varchar_column STRING(20) NOT NULL,


### PR DESCRIPTION
1. Add uuid, timestampuuid, duration , inet column and other missing types in the updates test
2. Also test update and delete for a record in boundaryvalue table
3. Add missing type in string to datatype conversion test - example inet , etc