### PR TITLE
Bugfix - Delete with Primary Keys

### DIFF
--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/dml/CassandraDMLGenerator.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/dml/CassandraDMLGenerator.java
@@ -177,8 +177,7 @@ public class CassandraDMLGenerator implements IDMLGenerator {
     return switch (modType) {
       case "INSERT", "UPDATE" -> getUpsertStatementCQL(
           sourceTable.getName(), timestamp, allColumnNamesAndValues);
-      case "DELETE" -> getDeleteStatementCQL(
-          sourceTable.getName(), timestamp, allColumnNamesAndValues);
+      case "DELETE" -> getDeleteStatementCQL(sourceTable.getName(), timestamp, pkColumnNameValues);
       default -> {
         LOG.error("Unsupported modType: {} for table {}", modType, spannerTable.getName());
         yield new DMLGeneratorResponse("");


### PR DESCRIPTION
- The current DELETE DML statement includes both primary and non-key columns in the WHERE clause. However, since each row is uniquely identified by the primary keys, the WHERE clause should include only the key columns, excluding any non-key columns.