### PR TITLE
Turned Datastream template parameters as optional

### DIFF
--- a/v2/datastream-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToBigQuery.java
+++ b/v2/datastream-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToBigQuery.java
@@ -146,6 +146,7 @@ public class DataStreamToBigQuery {
 
     @TemplateParameter.GcsReadFile(
         order = 1,
+        optional = true,
         groupName = "Source",
         description = "File location for Datastream file output in Cloud Storage.",
         helpText =
@@ -167,6 +168,7 @@ public class DataStreamToBigQuery {
 
     @TemplateParameter.PubsubSubscription(
         order = 3,
+        optional = true,
         description = "The Pub/Sub subscription on the Cloud Storage bucket.",
         helpText =
             "The Pub/Sub subscription used by Cloud Storage to notify Dataflow of new files available for processing, in the format: `projects/<PROJECT_ID>/subscriptions/<SUBSCRIPTION_NAME>`.")

--- a/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToSQL.java
+++ b/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToSQL.java
@@ -99,6 +99,7 @@ public class DataStreamToSQL {
   public interface Options extends PipelineOptions, StreamingOptions {
     @TemplateParameter.GcsReadFile(
         order = 1,
+        optional = true,
         groupName = "Source",
         description = "File location for Datastream file input in Cloud Storage.",
         helpText =


### PR DESCRIPTION
Datastream templates require either gcsPubSubSubscription or inputFilePattern to run. Currently both parameters are mandatory, making users to pass both the parameters when only one is required.

Turned the parameters as optional to improve user experience. If both of them are not specified, we throw exception here - https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/sources/DataStreamIO.java#L275