### PR TITLE
fix: ensure that default spanner API is batch-spanner.googleapis.com

### DIFF
--- a/v2/googlecloud-to-googlecloud/README_Spanner_Change_Streams_to_Google_Cloud_Storage.md
+++ b/v2/googlecloud-to-googlecloud/README_Spanner_Change_Streams_to_Google_Cloud_Storage.md
@@ -56,7 +56,7 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 * **spannerMetadataTableName**: The Spanner change streams connector metadata table name to use. If not provided, a Spanner change streams metadata table is automatically created during pipeline execution. You must provide a value for this parameter when updating an existing pipeline. Otherwise, don't use this parameter.
 * **startTimestamp**: The starting DateTime, inclusive, to use for reading change streams, in the format `Ex-2021-10-12T07:20:50.52Z`. Defaults to the timestamp when the pipeline starts, that is, the current time.
 * **endTimestamp**: The ending DateTime, inclusive, to use for reading change streams. For example, `Ex-2021-10-12T07:20:50.52Z`. Defaults to an infinite time in the future.
-* **spannerHost**: The Cloud Spanner endpoint to call in the template. Only used for testing. For example, `https://spanner.googleapis.com`. Defaults to: https://spanner.googleapis.com.
+* **spannerHost**: The Cloud Spanner endpoint to call in the template. Only used for testing. For example, `https://batch-spanner.googleapis.com`. Defaults to: https://batch-spanner.googleapis.com.
 * **outputFileFormat**: The format of the output Cloud Storage file. Allowed formats are `TEXT` and `AVRO`. Defaults to `AVRO`.
 * **windowDuration**: The window duration is the interval in which data is written to the output directory. Configure the duration based on the pipeline's throughput. For example, a higher throughput might require smaller window sizes so that the data fits into memory. Defaults to 5m (five minutes), with a minimum of 1s (one second). Allowed formats are: [int]s (for seconds, example: 5s), [int]m (for minutes, example: 12m), [int]h (for hours, example: 2h). For example, `5m`.
 * **rpcPriority**: The request priority for Spanner calls. The value must be `HIGH`, `MEDIUM`, or `LOW`. Defaults to `HIGH`.
@@ -153,7 +153,7 @@ export SPANNER_DATABASE_ROLE=<spannerDatabaseRole>
 export SPANNER_METADATA_TABLE_NAME=<spannerMetadataTableName>
 export START_TIMESTAMP=""
 export END_TIMESTAMP=""
-export SPANNER_HOST=https://spanner.googleapis.com
+export SPANNER_HOST=https://batch-spanner.googleapis.com
 export OUTPUT_FILE_FORMAT=AVRO
 export WINDOW_DURATION=5m
 export RPC_PRIORITY=HIGH
@@ -212,7 +212,7 @@ export SPANNER_DATABASE_ROLE=<spannerDatabaseRole>
 export SPANNER_METADATA_TABLE_NAME=<spannerMetadataTableName>
 export START_TIMESTAMP=""
 export END_TIMESTAMP=""
-export SPANNER_HOST=https://spanner.googleapis.com
+export SPANNER_HOST=https://batch-spanner.googleapis.com
 export OUTPUT_FILE_FORMAT=AVRO
 export WINDOW_DURATION=5m
 export RPC_PRIORITY=HIGH
@@ -282,7 +282,7 @@ resource "google_dataflow_flex_template_job" "spanner_change_streams_to_google_c
     # spannerMetadataTableName = "<spannerMetadataTableName>"
     # startTimestamp = ""
     # endTimestamp = ""
-    # spannerHost = "https://spanner.googleapis.com"
+    # spannerHost = "https://batch-spanner.googleapis.com"
     # outputFileFormat = "AVRO"
     # windowDuration = "5m"
     # rpcPriority = "HIGH"

--- a/v2/googlecloud-to-googlecloud/README_Spanner_Change_Streams_to_PubSub.md
+++ b/v2/googlecloud-to-googlecloud/README_Spanner_Change_Streams_to_PubSub.md
@@ -47,7 +47,7 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 * **spannerMetadataTableName**: The Spanner change streams connector metadata table name to use. If not provided, Spanner automatically creates the streams connector metadata table during the pipeline flow change. You must provide this parameter when updating an existing pipeline. Don't use this parameter for other cases.
 * **startTimestamp**: The starting DateTime (https://tools.ietf.org/html/rfc3339), inclusive, to use for reading change streams. For example, ex- 2021-10-12T07:20:50.52Z. Defaults to the timestamp when the pipeline starts, that is, the current time.
 * **endTimestamp**: The ending DateTime (https://tools.ietf.org/html/rfc3339), inclusive, to use for reading change streams. For example, ex- 2021-10-12T07:20:50.52Z. Defaults to an infinite time in the future.
-* **spannerHost**: The Cloud Spanner endpoint to call in the template. Only used for testing. For example, `https://spanner.googleapis.com`. Defaults to: https://spanner.googleapis.com.
+* **spannerHost**: The Cloud Spanner endpoint to call in the template. Only used for testing. For example, `https://batch-spanner.googleapis.com`. Defaults to: https://batch-spanner.googleapis.com.
 * **outputDataFormat**: The format of the output. Output is wrapped in many PubsubMessages and sent to a Pub/Sub topic. Allowed formats are JSON and AVRO. Default is JSON.
 * **pubsubAPI**: The Pub/Sub API used to implement the pipeline. Allowed APIs are `pubsubio` and `native_client`. For a small number of queries per second (QPS), `native_client` has less latency. For a large number of QPS, `pubsubio` provides better and more stable performance. The default is `pubsubio`.
 * **pubsubProjectId**: Project of Pub/Sub topic. The default for this parameter is the project where the Dataflow pipeline is running.
@@ -145,7 +145,7 @@ export SPANNER_DATABASE_ROLE=<spannerDatabaseRole>
 export SPANNER_METADATA_TABLE_NAME=<spannerMetadataTableName>
 export START_TIMESTAMP=""
 export END_TIMESTAMP=""
-export SPANNER_HOST=https://spanner.googleapis.com
+export SPANNER_HOST=https://batch-spanner.googleapis.com
 export OUTPUT_DATA_FORMAT=JSON
 export PUBSUB_API=pubsubio
 export PUBSUB_PROJECT_ID=""
@@ -206,7 +206,7 @@ export SPANNER_DATABASE_ROLE=<spannerDatabaseRole>
 export SPANNER_METADATA_TABLE_NAME=<spannerMetadataTableName>
 export START_TIMESTAMP=""
 export END_TIMESTAMP=""
-export SPANNER_HOST=https://spanner.googleapis.com
+export SPANNER_HOST=https://batch-spanner.googleapis.com
 export OUTPUT_DATA_FORMAT=JSON
 export PUBSUB_API=pubsubio
 export PUBSUB_PROJECT_ID=""
@@ -277,7 +277,7 @@ resource "google_dataflow_flex_template_job" "spanner_change_streams_to_pubsub" 
     # spannerMetadataTableName = "<spannerMetadataTableName>"
     # startTimestamp = ""
     # endTimestamp = ""
-    # spannerHost = "https://spanner.googleapis.com"
+    # spannerHost = "https://batch-spanner.googleapis.com"
     # outputDataFormat = "JSON"
     # pubsubAPI = "pubsubio"
     # pubsubProjectId = ""

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerChangeStreamsToGcsOptions.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerChangeStreamsToGcsOptions.java
@@ -141,8 +141,8 @@ public interface SpannerChangeStreamsToGcsOptions
       optional = true,
       description = "Cloud Spanner Endpoint to call",
       helpText = "The Cloud Spanner endpoint to call in the template. Only used for testing.",
-      example = "https://spanner.googleapis.com")
-  @Default.String("https://spanner.googleapis.com")
+      example = "https://batch-spanner.googleapis.com")
+  @Default.String("https://batch-spanner.googleapis.com")
   String getSpannerHost();
 
   void setSpannerHost(String value);

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerChangeStreamsToPubSubOptions.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerChangeStreamsToPubSubOptions.java
@@ -145,8 +145,8 @@ public interface SpannerChangeStreamsToPubSubOptions extends DataflowPipelineOpt
       optional = true,
       description = "Cloud Spanner Endpoint to call",
       helpText = "The Cloud Spanner endpoint to call in the template. Only used for testing.",
-      example = "https://spanner.googleapis.com")
-  @Default.String("https://spanner.googleapis.com")
+      example = "https://batch-spanner.googleapis.com")
+  @Default.String("https://batch-spanner.googleapis.com")
   String getSpannerHost();
 
   void setSpannerHost(String value);

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/TestUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/TestUtils.java
@@ -32,7 +32,6 @@ class TestUtils {
   static final String TEST_PROJECT = "span-cloud-testing";
   static final String TEST_SPANNER_INSTANCE = "changestream";
   static final String TEST_SPANNER_DATABASE_PREFIX = "testdbchangestreams";
-  static final String TEST_SPANNER_HOST = "https://spanner.googleapis.com";
   static final String TEST_SPANNER_TABLE = "AllTypes";
   static final String TEST_SPANNER_CHANGE_STREAM = "AllTypesStream";
   static final String TEST_BIG_QUERY_DATESET = "dataset";

--- a/v2/googlecloud-to-googlecloud/terraform/Spanner_Change_Streams_to_Google_Cloud_Storage/dataflow_job.tf
+++ b/v2/googlecloud-to-googlecloud/terraform/Spanner_Change_Streams_to_Google_Cloud_Storage/dataflow_job.tf
@@ -95,7 +95,7 @@ variable "endTimestamp" {
 
 variable "spannerHost" {
   type        = string
-  description = "The Cloud Spanner endpoint to call in the template. Only used for testing. (Example: https://spanner.googleapis.com). Defaults to: https://spanner.googleapis.com."
+  description = "The Cloud Spanner endpoint to call in the template. Only used for testing. (Example: https://batch-spanner.googleapis.com). Defaults to: https://batch-spanner.googleapis.com."
   default     = null
 }
 

--- a/v2/googlecloud-to-googlecloud/terraform/Spanner_Change_Streams_to_PubSub/dataflow_job.tf
+++ b/v2/googlecloud-to-googlecloud/terraform/Spanner_Change_Streams_to_PubSub/dataflow_job.tf
@@ -95,7 +95,7 @@ variable "endTimestamp" {
 
 variable "spannerHost" {
   type        = string
-  description = "The Cloud Spanner endpoint to call in the template. Only used for testing. (Example: https://spanner.googleapis.com). Defaults to: https://spanner.googleapis.com."
+  description = "The Cloud Spanner endpoint to call in the template. Only used for testing. (Example: https://batch-spanner.googleapis.com). Defaults to: https://batch-spanner.googleapis.com."
   default     = null
 }
 


### PR DESCRIPTION
Some of the dataflow templates use the incorrect endpoint for batch spanner actions.

This PR renames the defaults from spanner.googleapis.com to batch-spanner.googleapis.com to match the default host in Beam SpannerIO

Fixes #2304