### PR TITLE
Disable Spanner staging test

### DIFF
--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/spanner/SpannerTemplateITBase.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/spanner/SpannerTemplateITBase.java
@@ -1,13 +1,18 @@
 package org.apache.beam.it.gcp.spanner;
 
+import static org.junit.Assume.assumeTrue;
+
+import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.beam.it.gcp.TemplateTestBase;
 import org.apache.beam.it.gcp.spanner.matchers.SpannerAsserts;
+import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -30,6 +35,20 @@ public abstract class SpannerTemplateITBase extends TemplateTestBase {
 
   @Parameterized.Parameter(1)
   public String spannerHostName;
+
+  protected Set<String> stagingEnabledTests() {
+    // staging endpoint test disabled in base class. To enable it for certain test,
+    // override this in derived test class.
+    return ImmutableSet.of();
+  }
+
+  @Before
+  public void setupSpannerBase() {
+    if ("Staging".equals(spannerHostName)) {
+      // Only executes allow-listed staging test
+      assumeTrue(stagingEnabledTests().contains(testName));
+    }
+  }
 
   // Because of parameterization, the test names will have subscripts. For example:
   // testSpannerToGCSAvroBase[Staging]

--- a/v1/src/test/java/com/google/cloud/teleport/templates/TextImportPipelineIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/TextImportPipelineIT.java
@@ -27,6 +27,7 @@ import com.google.cloud.teleport.metadata.SpannerStagingTest;
 import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
 import com.google.cloud.teleport.spanner.TextImportPipeline;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
@@ -34,6 +35,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
 import org.apache.beam.it.common.PipelineLauncher.LaunchInfo;
@@ -590,5 +592,11 @@ public final class TextImportPipelineIT extends SpannerTemplateITBase {
         birthDate,
         "LastModified",
         lastModified);
+  }
+
+  @Override
+  protected Set<String> stagingEnabledTests() {
+    // TODO(#2325): re-enable staging tests when there are fixed
+    return ImmutableSet.of();
   }
 }


### PR DESCRIPTION
Mitigate #2325

Currently Java PR run two set of spanner test for v1 spanner templates. This makes Java PR more noisy. In particular, TextImportPipelineIT staging test has been red for a week.

Disable spanner staging test altogether at once and re-enable them as needed.

CC: @darshan-sj