### PR TITLE
Update pom.xml to version bump parquet to 1.15.1 to cover CVE-2025-30065

### DIFF
--- a/it/google-cloud-platform/pom.xml
+++ b/it/google-cloud-platform/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>it-google-cloud-platform</artifactId>
 
     <properties>
-        <parquet-avro.version>1.13.1</parquet-avro.version>
+        <parquet-avro.version>1.15.1</parquet-avro.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Version bump parquet-avro.version from 1.13.1 to 1.15.1 to address CVE-2025-30065