### PR TITLE
Verify Flaky Test in CassandraRowMapperFnTest

### DIFF
--- a/.github/workflows/verify-flaky-test.yml
+++ b/.github/workflows/verify-flaky-test.yml
@@ -1,0 +1,60 @@
+name: Verify Flaky Test
+
+on:
+  push:
+    branches: [ add-nondex-ci ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          
+      - name: Build with Maven (Skip Tests)
+        run: mvn clean install -DskipTests
+        
+      - name: Run Test Normally (Expected to Pass)
+        run: |
+          echo "Running test without NonDex - should PASS"
+          mvn test -Dtest=com.google.cloud.teleport.bigtable.CassandraRowMapperFnTest#testListColumn
+          echo "Test passed without NonDex as expected"
+          
+      - name: Run Test with NonDex (Expected to Fail)
+        continue-on-error: true
+        id: nondex-run
+        run: |
+          echo "Running test with NonDex - should FAIL"
+          mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.google.cloud.teleport.bigtable.CassandraRowMapperFnTest#testListColumn
+          # Store the exit code
+          echo "::set-output name=nondex_exit_code::$?"
+          
+      - name: Display NonDex Results
+        run: |
+          echo "Checking NonDex results"
+          ls -la .nondex/ || echo "No .nondex directory found"
+          for dir in .nondex/*/; do
+            if [ -d "$dir" ]; then
+              echo "Contents of $dir:"
+              ls -la "$dir"
+              if [ -f "$dir/failure" ]; then
+                echo "Found failure file in $dir:"
+                cat "$dir/failure"
+              fi
+            fi
+          done
+          
+      - name: Verify Test Flakiness
+        run: |
+          if [ "${{ steps.nondex-run.outputs.nondex_exit_code }}" != "0" ]; then
+            echo "✅ Test is flaky: Passes without NonDex but fails with NonDex"
+          else
+            echo "❌ Test is not flaky: Passes both with and without NonDex"
+            exit 1
+          fi


### PR DESCRIPTION
# Verify Flaky Test in CassandraRowMapperFnTest

## What is the purpose of this PR?
This PR adds a GitHub Actions workflow to verify and demonstrate the flaky behavior of `com.google.cloud.teleport.bigtable.CassandraRowMapperFnTest.testListColumn`. The workflow shows that the test passes under normal execution but fails when run with NonDex shuffling, confirming its flaky nature. This helps document the flaky test for future reference and provides a repeatable way to verify the issue.

## Why is this test flaky?
The test is flaky because it makes assumptions about the deterministic implementation of underdetermined Java APIs. Specifically, it likely assumes a consistent iteration order over Java collections (such as HashSet or HashMap) where the Java specification does not guarantee any particular order. NonDex helps detect such assumptions by exploring different valid behaviors allowed by the Java API specifications.

## How to reproduce the test failure
The failure can be reproduced by running the test with NonDex as follows:

`mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.google.cloud.teleport.bigtable.CassandraRowMapperFnTest#testListColumn`

##The test passes when run normally
`mvn test -Dtest=com.google.cloud.teleport.bigtable.CassandraRowMapperFnTest#testListColumn
`
## CI Changes
This PR adds a GitHub Actions workflow that:

- Builds the project
- Runs the test normally (which passes)
- Runs the test with NonDex (which fails)
- Reports the results, confirming the flaky nature of the test

The workflow can be run manually through the Actions tab or automatically when changes are pushed to the add-nondex-ci branch.

##Benefits

- Provides clear documentation and evidence of the flaky test
- Establishes a repeatable process for verifying the flaky behavior
- Helps future contributors understand the issue when working on a fix


