### PR TITLE
Add support for Elasticsearch 9.0

### DIFF
--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/utils/ElasticsearchIO.java
@@ -1666,10 +1666,11 @@ public class ElasticsearchIO {
               || backendVersion == 5
               || backendVersion == 6
               || backendVersion == 7
-              || backendVersion == 8),
+              || backendVersion == 8
+              || backendVersion == 9),
           "The Elasticsearch version to connect to is %s.x. "
               + "This version of the ElasticsearchIO is only compatible with "
-              + "Elasticsearch v8.x, v7.x, v6.x, v5.x and v2.x",
+              + "Elasticsearch v9.x, v8.x, v7.x, v6.x, v5.x and v2.x",
           backendVersion);
       return backendVersion;
 


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/2324

Reading though changelog I didn't spot any changes that should affect the client
https://www.elastic.co/guide/en/elastic-stack/9.0/release-notes-elasticsearch-9.0.0.html#breaking-changes-9.0-beta1
https://www.elastic.co/guide/en/elastic-stack/9.0/release-notes-elasticsearch-9.0.0.html

I did a smoke test by spinning up a dataflow job writing some data to an ES 9.0 cluster, and it works well. I didn't try it as a source though.