### PR TITLE
Bulk schema overrides

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/SourceDbToSpannerOptions.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/SourceDbToSpannerOptions.java
@@ -313,7 +313,7 @@ public interface SourceDbToSpannerOptions extends CommonTemplateOptions {
       order = 25,
       optional = true,
       regexes =
-          "^\\[([[:space:]]*\\{[[:graph:]]+\\[[:graph:]]+[[:space:]]*,[[:space:]]*[[:graph:]]+\\[[:graph:]]+[[:space:]]*\\}[[:space:]]*(,[[:space:]]*)*)*\\]$",
+          "^\\[([[:space:]]*\\{[[:space:]]*[[:graph:]]+\\.[[:graph:]]+[[:space:]]*,[[:space:]]*[[:graph:]]+\\.[[:graph:]]+[[:space:]]*\\}[[:space:]]*(,[[:space:]]*)*)*\\]$",
       description = "Column name overrides from source to spanner",
       example = "[{Singers.SingerName, Singers.TalentName}, {Albums.AlbumName, Albums.RecordName}]",
       helpText =

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/SourceDbToSpannerOptions.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/SourceDbToSpannerOptions.java
@@ -292,4 +292,48 @@ public interface SourceDbToSpannerOptions extends CommonTemplateOptions {
   Options.RpcPriority getSpannerPriority();
 
   void setSpannerPriority(Options.RpcPriority value);
+
+  @TemplateParameter.Text(
+      order = 24,
+      optional = true,
+      description = "Table name overrides from source to spanner",
+      regexes =
+          "^\\[([[:space:]]*\\{[[:graph:]]+[[:space:]]*,[[:space:]]*[[:graph:]]+[[:space:]]*\\}[[:space:]]*(,[[:space:]]*)*)*\\]$",
+      example = "[{Singers, Vocalists}, {Albums, Records}]",
+      helpText =
+          "These are the table name overrides from source to spanner. They are written in the"
+              + "following format: [{SourceTableName1, SpannerTableName1}, {SourceTableName2, SpannerTableName2}]"
+              + "This example shows mapping Singers table to Vocalists and Albums table to Records.")
+  @Default.String("")
+  String getTableOverrides();
+
+  void setTableOverrides(String value);
+
+  @TemplateParameter.Text(
+      order = 25,
+      optional = true,
+      regexes =
+          "^\\[([[:space:]]*\\{[[:graph:]]+\\[[:graph:]]+[[:space:]]*,[[:space:]]*[[:graph:]]+\\[[:graph:]]+[[:space:]]*\\}[[:space:]]*(,[[:space:]]*)*)*\\]$",
+      description = "Column name overrides from source to spanner",
+      example = "[{Singers.SingerName, Singers.TalentName}, {Albums.AlbumName, Albums.RecordName}]",
+      helpText =
+          "These are the column name overrides from source to spanner. They are written in the"
+              + "following format: [{SourceTableName1.SourceColumnName1, SourceTableName1.SpannerColumnName1}, {SourceTableName2.SourceColumnName1, SourceTableName2.SpannerColumnName1}]"
+              + "Note that the SourceTableName should remain the same in both the source and spanner pair. To override table names, use tableOverrides."
+              + "The example shows mapping SingerName to TalentName and AlbumName to RecordName in Singers and Albums table respectively.")
+  @Default.String("")
+  String getColumnOverrides();
+
+  void setColumnOverrides(String value);
+
+  @TemplateParameter.Text(
+      order = 26,
+      optional = true,
+      description = "File based overrides from source to spanner",
+      helpText =
+          "A file which specifies the table and the column name overrides from source to spanner.")
+  @Default.String("")
+  String getSchemaOverridesFilePath();
+
+  void setSchemaOverridesFilePath(String value);
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/PipelineController.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/PipelineController.java
@@ -26,6 +26,8 @@ import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.SQLDi
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaMapper;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.IdentityMapper;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SchemaFileOverridesBasedMapper;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SchemaStringOverridesBasedMapper;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SessionBasedMapper;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
 import com.google.cloud.teleport.v2.spanner.migrations.spanner.SpannerSchema;
@@ -239,9 +241,47 @@ public class PipelineController {
 
   @VisibleForTesting
   static ISchemaMapper getSchemaMapper(SourceDbToSpannerOptions options, Ddl ddl) {
+    // Check if config types are specified
+    boolean hasSessionFile =
+        options.getSessionFilePath() != null && !options.getSessionFilePath().equals("");
+    boolean hasSchemaOverridesFile =
+        options.getSchemaOverridesFilePath() != null
+            && !options.getSchemaOverridesFilePath().equals("");
+    boolean hasStringOverrides =
+        (options.getTableOverrides() != null && !options.getTableOverrides().equals(""))
+            || (options.getColumnOverrides() != null && !options.getColumnOverrides().equals(""));
+
+    int overrideTypesCount = 0;
+    if (hasSessionFile) {
+      overrideTypesCount++;
+    }
+    if (hasSchemaOverridesFile) {
+      overrideTypesCount++;
+    }
+    if (hasStringOverrides) {
+      overrideTypesCount++;
+    }
+
+    if (overrideTypesCount > 1) {
+      throw new IllegalArgumentException(
+          "Only one type of schema override can be specified. Please use only one of: sessionFilePath, "
+              + "schemaOverridesFilePath, or tableOverrides/columnOverrides.");
+    }
+
     ISchemaMapper schemaMapper = new IdentityMapper(ddl);
-    if (options.getSessionFilePath() != null && !options.getSessionFilePath().equals("")) {
+    if (hasSessionFile) {
       schemaMapper = new SessionBasedMapper(options.getSessionFilePath(), ddl);
+    } else if (hasSchemaOverridesFile) {
+      schemaMapper = new SchemaFileOverridesBasedMapper(options.getSchemaOverridesFilePath(), ddl);
+    } else if (hasStringOverrides) {
+      Map<String, String> userOptionsOverrides = new HashMap<>();
+      if (!options.getTableOverrides().isEmpty()) {
+        userOptionsOverrides.put("tableOverrides", options.getTableOverrides());
+      }
+      if (!options.getColumnOverrides().isEmpty()) {
+        userOptionsOverrides.put("columnOverrides", options.getColumnOverrides());
+      }
+      schemaMapper = new SchemaStringOverridesBasedMapper(userOptionsOverrides, ddl);
     }
     return schemaMapper;
   }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLFileOverridesSchemaMapperIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLFileOverridesSchemaMapperIT.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates;
+
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import com.google.common.collect.ImmutableList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.it.common.PipelineLauncher;
+import org.apache.beam.it.common.PipelineOperator;
+import org.apache.beam.it.common.utils.ResourceManagerUtils;
+import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
+import org.apache.beam.it.gcp.spanner.matchers.SpannerAsserts;
+import org.apache.beam.it.gcp.storage.GcsResourceManager;
+import org.apache.beam.it.jdbc.MySQLResourceManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.shaded.com.google.common.io.Resources;
+
+/**
+ * An integration test for {@link SourceDbToSpanner} Flex template which tests schema mapping using
+ * a schema overrides file with a common schema.
+ */
+@Category({TemplateIntegrationTest.class, SkipDirectRunnerTest.class})
+@TemplateIntegrationTest(SourceDbToSpanner.class)
+@RunWith(JUnit4.class)
+public class MySQLFileOverridesSchemaMapperIT extends SourceDbToSpannerITBase {
+  private static final Logger LOG = LoggerFactory.getLogger(MySQLFileOverridesSchemaMapperIT.class);
+  private static final HashSet<MySQLFileOverridesSchemaMapperIT> testInstances = new HashSet<>();
+  private static PipelineLauncher.LaunchInfo jobInfo;
+
+  public static MySQLResourceManager mySQLResourceManager;
+  public static SpannerResourceManager spannerResourceManager;
+  public static GcsResourceManager gcsResourceManager;
+
+  // Common SQL and override file resources
+  private static final String MYSQL_DDL_RESOURCE = "SchemaMapperIT/mysql-overrides-src.sql";
+  private static final String SPANNER_DDL_RESOURCE = "SchemaMapperIT/spanner-overrides-target.sql";
+  private static final String SCHEMA_OVERRIDE_FILE_RESOURCE = "SchemaMapperIT/file-overrides.json";
+  private static final String SCHEMA_OVERRIDE_GCS_PREFIX = "MySQLFileOverridesCommonIT";
+
+  /**
+   * Setup resource managers and Launch dataflow job once during the execution of this test class.
+   */
+  @Before
+  public void setUp() throws Exception {
+    mySQLResourceManager = setUpMySQLResourceManager();
+    spannerResourceManager = setUpSpannerResourceManager();
+    gcsResourceManager = setUpSpannerITGcsResourceManager();
+
+    gcsResourceManager.uploadArtifact(
+        SCHEMA_OVERRIDE_GCS_PREFIX + "/file-overrides.json",
+        Resources.getResource(SCHEMA_OVERRIDE_FILE_RESOURCE).getPath());
+  }
+
+  /** Cleanup dataflow job and all the resources and resource managers. */
+  @After
+  public void cleanUp() {
+    ResourceManagerUtils.cleanResources(
+        spannerResourceManager, mySQLResourceManager, gcsResourceManager);
+  }
+
+  @Test
+  public void testMigrationWithFileOverridesAndCommonSchema() throws Exception {
+    loadSQLFileResource(mySQLResourceManager, MYSQL_DDL_RESOURCE);
+    createSpannerDDL(spannerResourceManager, SPANNER_DDL_RESOURCE);
+
+    Map<String, String> jobParameters = new HashMap<>();
+    jobParameters.put(
+        "schemaOverridesFilePath",
+        getGcsPath(SCHEMA_OVERRIDE_GCS_PREFIX + "/file-overrides.json", gcsResourceManager));
+
+    jobInfo =
+        launchDataflowJob(
+            getClass().getSimpleName(),
+            null, // No session file
+            null,
+            mySQLResourceManager,
+            spannerResourceManager,
+            jobParameters,
+            null);
+    PipelineOperator.Result result = pipelineOperator().waitUntilDone(createConfig(jobInfo));
+
+    // Assertions for source_table1 -> Target_Table_1
+    List<Map<String, Object>> sourceTable1Data =
+        mySQLResourceManager.runSQLQuery("SELECT id_col1, name_col1, data_col1 FROM source_table1");
+
+    // Prepare expected data for Spanner with overridden column names for comparison
+    List<Map<String, Object>> expectedSpannerTable1 = new java.util.ArrayList<>();
+    for (Map<String, Object> row : sourceTable1Data) {
+      Map<String, Object> newRow = new HashMap<>();
+      newRow.put("id_col1", row.get("id_col1"));
+      newRow.put("Target_Name_Col_1", row.get("name_col1")); // Overridden name
+      newRow.put("data_col1", row.get("data_col1"));
+      expectedSpannerTable1.add(newRow);
+    }
+
+    ImmutableList<Struct> spannerTable1 =
+        spannerResourceManager.readTableRecords(
+            "Target_Table_1", "id_col1", "Target_Name_Col_1", "data_col1");
+    SpannerAsserts.assertThatStructs(spannerTable1)
+        .hasRecordsUnorderedCaseInsensitiveColumns(expectedSpannerTable1);
+    SpannerAsserts.assertThatStructs(spannerTable1).hasRows(sourceTable1Data.size());
+
+    // Assertions for source_table2 (table not renamed, one column renamed)
+    List<Map<String, Object>> sourceTable2Data =
+        mySQLResourceManager.runSQLQuery(
+            "SELECT key_col2, category_col2, value_col2 FROM source_table2");
+
+    List<Map<String, Object>> expectedSpannerTable2 = new java.util.ArrayList<>();
+    for (Map<String, Object> row : sourceTable2Data) {
+      Map<String, Object> newRow = new HashMap<>();
+      newRow.put("key_col2", row.get("key_col2"));
+      newRow.put("Target_Category_Col_2", row.get("category_col2")); // Overridden name
+      newRow.put("value_col2", row.get("value_col2"));
+      expectedSpannerTable2.add(newRow);
+    }
+
+    ImmutableList<Struct> spannerTable2 =
+        spannerResourceManager.readTableRecords(
+            "source_table2", "key_col2", "Target_Category_Col_2", "value_col2");
+    SpannerAsserts.assertThatStructs(spannerTable2)
+        .hasRecordsUnorderedCaseInsensitiveColumns(expectedSpannerTable2);
+    SpannerAsserts.assertThatStructs(spannerTable2).hasRows(sourceTable2Data.size());
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLStringOverridesSchemaMapperIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLStringOverridesSchemaMapperIT.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates;
+
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import com.google.common.collect.ImmutableList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.it.common.PipelineLauncher;
+import org.apache.beam.it.common.PipelineOperator;
+import org.apache.beam.it.common.utils.ResourceManagerUtils;
+import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
+import org.apache.beam.it.gcp.spanner.matchers.SpannerAsserts;
+import org.apache.beam.it.jdbc.MySQLResourceManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An integration test for {@link SourceDbToSpanner} Flex template which tests schema mapping using
+ * string-based overrides with a common schema.
+ */
+@Category({TemplateIntegrationTest.class, SkipDirectRunnerTest.class})
+@TemplateIntegrationTest(SourceDbToSpanner.class)
+@RunWith(JUnit4.class)
+public class MySQLStringOverridesSchemaMapperIT extends SourceDbToSpannerITBase {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(MySQLStringOverridesSchemaMapperIT.class);
+  private static final HashSet<MySQLStringOverridesSchemaMapperIT> testInstances = new HashSet<>();
+  private static PipelineLauncher.LaunchInfo jobInfo;
+
+  public static MySQLResourceManager mySQLResourceManager;
+  public static SpannerResourceManager spannerResourceManager;
+
+  // Common SQL resource files
+  private static final String MYSQL_DDL_RESOURCE = "SchemaMapperIT/mysql-overrides-src.sql";
+  private static final String SPANNER_DDL_RESOURCE = "SchemaMapperIT/spanner-overrides-target.sql";
+
+  /**
+   * Setup resource managers and Launch dataflow job once during the execution of this test class.
+   */
+  @Before
+  public void setUp() {
+    mySQLResourceManager = setUpMySQLResourceManager();
+    spannerResourceManager = setUpSpannerResourceManager();
+  }
+
+  /** Cleanup dataflow job and all the resources and resource managers. */
+  @After
+  public void cleanUp() {
+    ResourceManagerUtils.cleanResources(spannerResourceManager, mySQLResourceManager);
+  }
+
+  @Test
+  public void testMigrationWithStringOverridesAndCommonSchema() throws Exception {
+    loadSQLFileResource(mySQLResourceManager, MYSQL_DDL_RESOURCE);
+    createSpannerDDL(spannerResourceManager, SPANNER_DDL_RESOURCE);
+
+    Map<String, String> jobParameters = new HashMap<>();
+    jobParameters.put("tableOverrides", "[{source_table1, Target_Table_1}]");
+    jobParameters.put(
+        "columnOverrides",
+        "[{source_table1.name_col1, source_table1.Target_Name_Col_1},"
+            + " {source_table2.category_col2, source_table2.Target_Category_Col_2}]");
+
+    jobInfo =
+        launchDataflowJob(
+            getClass().getSimpleName(),
+            null, // No session file
+            null,
+            mySQLResourceManager,
+            spannerResourceManager,
+            jobParameters,
+            null);
+    PipelineOperator.Result result = pipelineOperator().waitUntilDone(createConfig(jobInfo));
+
+    // Assertions for source_table1 -> Target_Table_1
+    List<Map<String, Object>> sourceTable1Data =
+        mySQLResourceManager.runSQLQuery("SELECT id_col1, name_col1, data_col1 FROM source_table1");
+
+    List<Map<String, Object>> expectedSpannerTable1 = new java.util.ArrayList<>();
+    for (Map<String, Object> row : sourceTable1Data) {
+      Map<String, Object> newRow = new HashMap<>();
+      newRow.put("id_col1", row.get("id_col1"));
+      newRow.put("Target_Name_Col_1", row.get("name_col1")); // Overridden name
+      newRow.put("data_col1", row.get("data_col1"));
+      expectedSpannerTable1.add(newRow);
+    }
+
+    ImmutableList<Struct> spannerTable1 =
+        spannerResourceManager.readTableRecords(
+            "Target_Table_1", "id_col1", "Target_Name_Col_1", "data_col1");
+    SpannerAsserts.assertThatStructs(spannerTable1)
+        .hasRecordsUnorderedCaseInsensitiveColumns(expectedSpannerTable1);
+    SpannerAsserts.assertThatStructs(spannerTable1).hasRows(sourceTable1Data.size());
+
+    // Assertions for source_table2 (table not renamed, one column renamed)
+    List<Map<String, Object>> sourceTable2Data =
+        mySQLResourceManager.runSQLQuery(
+            "SELECT key_col2, category_col2, value_col2 FROM source_table2");
+
+    List<Map<String, Object>> expectedSpannerTable2 = new java.util.ArrayList<>();
+    for (Map<String, Object> row : sourceTable2Data) {
+      Map<String, Object> newRow = new HashMap<>();
+      newRow.put("key_col2", row.get("key_col2"));
+      newRow.put("Target_Category_Col_2", row.get("category_col2")); // Overridden name
+      newRow.put("value_col2", row.get("value_col2"));
+      expectedSpannerTable2.add(newRow);
+    }
+
+    ImmutableList<Struct> spannerTable2 =
+        spannerResourceManager.readTableRecords(
+            "source_table2", "key_col2", "Target_Category_Col_2", "value_col2");
+    SpannerAsserts.assertThatStructs(spannerTable2)
+        .hasRecordsUnorderedCaseInsensitiveColumns(expectedSpannerTable2);
+    SpannerAsserts.assertThatStructs(spannerTable2).hasRows(sourceTable2Data.size());
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PipelineControllerTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PipelineControllerTest.java
@@ -156,6 +156,7 @@ public class PipelineControllerTest {
             + "}";
     try (BufferedWriter writer = Files.newBufferedWriter(schemaOverridesFile)) {
       writer.write(overridesJsonContent);
+      writer.flush();
     }
   }
 

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PipelineControllerTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PipelineControllerTest.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.templates;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -29,11 +30,17 @@ import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.SQLDi
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaMapper;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.IdentityMapper;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SchemaFileOverridesBasedMapper;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SchemaStringOverridesBasedMapper;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SessionBasedMapper;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
 import com.google.cloud.teleport.v2.templates.PipelineController.ShardedJdbcDbConfigContainer;
 import com.google.cloud.teleport.v2.templates.PipelineController.SingleInstanceJdbcDbConfigContainer;
 import com.google.common.io.Resources;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
@@ -48,6 +55,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -59,16 +67,17 @@ import org.mockito.quality.Strictness;
 public class PipelineControllerTest {
 
   @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+  @Rule public final transient TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   private Ddl spannerDdl;
-
   private Ddl shardedDdl;
+  private Path schemaOverridesFile;
 
   private MockedStatic<JdbcIoWrapper> mockedStaticJdbcIoWrapper;
   @Mock private JdbcIoWrapper mockJdbcIoWrapper;
 
   @Before
-  public void setup() {
+  public void setup() throws IOException {
     mockedStaticJdbcIoWrapper = Mockito.mockStatic(JdbcIoWrapper.class);
     spannerDdl =
         Ddl.builder()
@@ -136,29 +145,132 @@ public class PipelineControllerTest {
             .end()
             .endTable()
             .build();
+
+    // Create a dummy schema overrides file for tests that need it
+    schemaOverridesFile = temporaryFolder.newFile("schema_overrides.json").toPath();
+    String overridesJsonContent =
+        "{\n"
+            + "  \"renamedTables\": {\n"
+            + "    \"source_table\": \"spanner_table\"\n"
+            + "  }\n"
+            + "}";
+    try (BufferedWriter writer = Files.newBufferedWriter(schemaOverridesFile)) {
+      writer.write(overridesJsonContent);
+    }
   }
 
   @Test
   public void createIdentitySchemaMapper() {
-    SourceDbToSpannerOptions mockOptions = createOptionsHelper("", "");
+    SourceDbToSpannerOptions mockOptions = createOptionsHelper(null, null, null, null, null);
     ISchemaMapper schemaMapper = PipelineController.getSchemaMapper(mockOptions, spannerDdl);
     assertTrue(schemaMapper instanceof IdentityMapper);
   }
 
   @Test
   public void createSessionSchemaMapper() {
+    String sessionFilePath =
+        Paths.get(Resources.getResource("session-file-with-dropped-column.json").getPath())
+            .toString();
     SourceDbToSpannerOptions mockOptions =
-        createOptionsHelper(
-            Paths.get(Resources.getResource("session-file-with-dropped-column.json").getPath())
-                .toString(),
-            null);
+        createOptionsHelper(sessionFilePath, null, null, null, null);
     ISchemaMapper schemaMapper = PipelineController.getSchemaMapper(mockOptions, spannerDdl);
     assertTrue(schemaMapper instanceof SessionBasedMapper);
   }
 
+  @Test
+  public void createSchemaFileOverridesMapper() {
+    SourceDbToSpannerOptions mockOptions =
+        createOptionsHelper(null, schemaOverridesFile.toString(), null, null, null);
+    ISchemaMapper schemaMapper = PipelineController.getSchemaMapper(mockOptions, spannerDdl);
+    assertTrue(schemaMapper instanceof SchemaFileOverridesBasedMapper);
+  }
+
+  @Test
+  public void createStringOverridesMapper_tableOnly() {
+    SourceDbToSpannerOptions mockOptions =
+        createOptionsHelper(null, null, "[{src,dest}]", null, null);
+    ISchemaMapper schemaMapper = PipelineController.getSchemaMapper(mockOptions, spannerDdl);
+    assertTrue(schemaMapper instanceof SchemaStringOverridesBasedMapper);
+  }
+
+  @Test
+  public void createStringOverridesMapper_columnOnly() {
+    SourceDbToSpannerOptions mockOptions =
+        createOptionsHelper(null, null, null, "[{src.col,src.spCol}]", null);
+    ISchemaMapper schemaMapper = PipelineController.getSchemaMapper(mockOptions, spannerDdl);
+    assertTrue(schemaMapper instanceof SchemaStringOverridesBasedMapper);
+  }
+
+  @Test
+  public void createStringOverridesMapper_both() {
+    SourceDbToSpannerOptions mockOptions =
+        createOptionsHelper(null, null, "[{s,d}]", "[{s.c,s.sc}]", null);
+    ISchemaMapper schemaMapper = PipelineController.getSchemaMapper(mockOptions, spannerDdl);
+    assertTrue(schemaMapper instanceof SchemaStringOverridesBasedMapper);
+  }
+
+  @Test
+  public void createSchemaMapper_multipleOverrides_sessionAndFile_throwsException() {
+    String sessionFilePath =
+        Paths.get(Resources.getResource("session-file-with-dropped-column.json").getPath())
+            .toString();
+    SourceDbToSpannerOptions mockOptions =
+        createOptionsHelper(sessionFilePath, schemaOverridesFile.toString(), null, null, null);
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> PipelineController.getSchemaMapper(mockOptions, spannerDdl));
+    assertTrue(
+        exception.getMessage().contains("Only one type of schema override can be specified"));
+  }
+
+  @Test
+  public void createSchemaMapper_multipleOverrides_sessionAndString_throwsException() {
+    String sessionFilePath =
+        Paths.get(Resources.getResource("session-file-with-dropped-column.json").getPath())
+            .toString();
+    SourceDbToSpannerOptions mockOptions =
+        createOptionsHelper(sessionFilePath, null, "[{s,d}]", null, null);
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> PipelineController.getSchemaMapper(mockOptions, spannerDdl));
+    assertTrue(
+        exception.getMessage().contains("Only one type of schema override can be specified"));
+  }
+
+  @Test
+  public void createSchemaMapper_multipleOverrides_fileAndString_throwsException() {
+    SourceDbToSpannerOptions mockOptions =
+        createOptionsHelper(null, schemaOverridesFile.toString(), "[{s,d}]", null, null);
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> PipelineController.getSchemaMapper(mockOptions, spannerDdl));
+    assertTrue(
+        exception.getMessage().contains("Only one type of schema override can be specified"));
+  }
+
+  @Test
+  public void createSchemaMapper_multipleOverrides_all_throwsException() {
+    String sessionFilePath =
+        Paths.get(Resources.getResource("session-file-with-dropped-column.json").getPath())
+            .toString();
+    SourceDbToSpannerOptions mockOptions =
+        createOptionsHelper(
+            sessionFilePath, schemaOverridesFile.toString(), "[{s,d}]", "[{s.c,s.sc}]", null);
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> PipelineController.getSchemaMapper(mockOptions, spannerDdl));
+    assertTrue(
+        exception.getMessage().contains("Only one type of schema override can be specified"));
+  }
+
   @Test(expected = Exception.class)
   public void createInvalidSchemaMapper_withException() {
-    SourceDbToSpannerOptions mockOptions = createOptionsHelper("invalid-file", "");
+    SourceDbToSpannerOptions mockOptions =
+        createOptionsHelper("invalid-file", null, null, null, "");
     PipelineController.getSchemaMapper(mockOptions, spannerDdl);
   }
 
@@ -196,16 +308,23 @@ public class PipelineControllerTest {
         schemaMapper, "", List.of("cart")); // Only accepts spanner table names
   }
 
-  private SourceDbToSpannerOptions createOptionsHelper(String sessionFile, String tables) {
-    /*
-     * This mock is used in exception paths where all the stubs don't get used.
-     */
+  private SourceDbToSpannerOptions createOptionsHelper(
+      String sessionFile,
+      String schemaOverridesFile,
+      String tableOverrides,
+      String columnOverrides,
+      String tables) {
     SourceDbToSpannerOptions mockOptions =
         mock(
             SourceDbToSpannerOptions.class,
             Mockito.withSettings().serializable().strictness(Strictness.LENIENT));
-    when(mockOptions.getSessionFilePath()).thenReturn(sessionFile);
-    when(mockOptions.getTables()).thenReturn(tables);
+    when(mockOptions.getSessionFilePath()).thenReturn(sessionFile == null ? "" : sessionFile);
+    when(mockOptions.getSchemaOverridesFilePath())
+        .thenReturn(schemaOverridesFile == null ? "" : schemaOverridesFile);
+    when(mockOptions.getTableOverrides()).thenReturn(tableOverrides == null ? "" : tableOverrides);
+    when(mockOptions.getColumnOverrides())
+        .thenReturn(columnOverrides == null ? "" : columnOverrides);
+    when(mockOptions.getTables()).thenReturn(tables == null ? "" : tables);
     return mockOptions;
   }
 
@@ -230,7 +349,9 @@ public class PipelineControllerTest {
     String sessionFilePath =
         Paths.get(Resources.getResource("session-file-with-dropped-column.json").getPath())
             .toString();
-    ISchemaMapper schemaMapper = new SessionBasedMapper(sessionFilePath, spannerDdl);
+    sourceDbToSpannerOptions.setSessionFilePath(sessionFilePath); // Ensure session file is set
+    ISchemaMapper schemaMapper =
+        PipelineController.getSchemaMapper(sourceDbToSpannerOptions, spannerDdl);
     PCollection<Integer> dummyPCollection = pipeline.apply(Create.of(1));
     pipeline.run();
     SingleInstanceJdbcDbConfigContainer dbConfigContainer =
@@ -246,6 +367,10 @@ public class PipelineControllerTest {
     assertThat(config.dbAuth().getPassword().get()).isEqualTo(testPassword);
     assertThat(config.waitOn()).isNotNull();
     assertEquals(null, dbConfigContainer.getShardId());
+    // Since schemaMapper is now derived from options, it will have the session file context.
+    // The original test expected an empty map, but with a session file, it might not be.
+    // Let's verify based on the actual session file if it defines shard IDs for new_cart.
+    // The "session-file-with-dropped-column.json" does not define shard IDs.
     assertThat(dbConfigContainer.getSrcTableToShardIdColumnMap(schemaMapper, List.of("new_cart")))
         .isEqualTo(new HashMap<>());
   }
@@ -342,7 +467,9 @@ public class PipelineControllerTest {
 
   @After
   public void cleanup() {
-    mockedStaticJdbcIoWrapper.close();
-    mockedStaticJdbcIoWrapper = null;
+    if (mockedStaticJdbcIoWrapper != null) {
+      mockedStaticJdbcIoWrapper.close();
+      mockedStaticJdbcIoWrapper = null;
+    }
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/resources/SchemaMapperIT/file-overrides.json
+++ b/v2/sourcedb-to-spanner/src/test/resources/SchemaMapperIT/file-overrides.json
@@ -1,0 +1,13 @@
+{
+  "renamedTables": {
+    "source_table1": "Target_Table_1"
+  },
+  "renamedColumns": {
+    "source_table1": {
+      "name_col1": "Target_Name_Col_1"
+    },
+    "source_table2": {
+      "category_col2": "Target_Category_Col_2"
+    }
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/resources/SchemaMapperIT/mysql-overrides-src.sql
+++ b/v2/sourcedb-to-spanner/src/test/resources/SchemaMapperIT/mysql-overrides-src.sql
@@ -1,0 +1,19 @@
+CREATE TABLE source_table1 (
+    id_col1 INT PRIMARY KEY,
+    name_col1 VARCHAR(255),
+    data_col1 TEXT
+);
+
+CREATE TABLE source_table2 (
+    key_col2 VARCHAR(50) PRIMARY KEY,
+    category_col2 VARCHAR(100),
+    value_col2 TEXT
+);
+
+INSERT INTO source_table1 (id_col1, name_col1, data_col1) VALUES
+(1, 'Name One', 'Data for one'),
+(2, 'Name Two', 'Data for two');
+
+INSERT INTO source_table2 (key_col2, category_col2, value_col2) VALUES
+('K1', 'Category Alpha', 'Value Alpha'),
+('K2', 'Category Beta', 'Value Beta');

--- a/v2/sourcedb-to-spanner/src/test/resources/SchemaMapperIT/spanner-overrides-target.sql
+++ b/v2/sourcedb-to-spanner/src/test/resources/SchemaMapperIT/spanner-overrides-target.sql
@@ -1,0 +1,11 @@
+CREATE TABLE Target_Table_1 ( -- Renamed from source_table1
+    id_col1 INT64 NOT NULL, -- Not renamed
+    Target_Name_Col_1 STRING(255), -- Renamed from name_col1
+    data_col1 STRING(MAX) -- Not renamed
+) PRIMARY KEY (id_col1);
+
+CREATE TABLE source_table2 ( -- This table is not renamed
+    key_col2 STRING(50) NOT NULL, -- Not renamed
+    Target_Category_Col_2 STRING(100), -- Renamed from category_col2
+    value_col2 STRING(MAX) -- Not renamed
+) PRIMARY KEY (key_col2);

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertor.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertor.java
@@ -114,7 +114,7 @@ public class GenericRecordTypeConvertor {
     }
     String spannerTableName = schemaMapper.getSpannerTableName(namespace, srcTableName);
     List<String> spannerColNames = schemaMapper.getSpannerColumns(namespace, spannerTableName);
-    // This is null/blank for identity/non-sharded cases.
+    // This is null/blank for identity/override/non-sharded cases.
     String shardIdCol = schemaMapper.getShardIdColumnName(namespace, spannerTableName);
     for (String spannerColName : spannerColNames) {
       try {

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SchemaFileOverridesBasedMapper.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SchemaFileOverridesBasedMapper.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.migrations.schema;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.teleport.v2.spanner.ddl.Column;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.Table;
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraAnnotations;
+import com.google.cloud.teleport.v2.spanner.type.Type;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Schema mapper that uses a file based schema overrides parser. Assumes that if a table or column
+ * is not explicitly overridden, its name is the same in the source and Spanner.
+ */
+public class SchemaFileOverridesBasedMapper implements ISchemaMapper, Serializable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SchemaFileOverridesBasedMapper.class);
+  private final SchemaFileOverridesParser parser;
+  private final Ddl ddl;
+
+  /**
+   * Constructs a new SchemaFileOverridesBasedMapper.
+   *
+   * @param schemaOverridesFilePath Path to the schema overrides JSON file.
+   * @param ddl The DDL representation of the Spanner schema.
+   */
+  public SchemaFileOverridesBasedMapper(String schemaOverridesFilePath, Ddl ddl) {
+    this.parser = new SchemaFileOverridesParser(schemaOverridesFilePath);
+    this.ddl = ddl;
+  }
+
+  @Override
+  public Dialect getDialect() {
+    return ddl.dialect();
+  }
+
+  @Override
+  public List<String> getSourceTablesToMigrate(String namespace) {
+    // For each table in the Spanner DDL, find its corresponding source table name.
+    // Namespace is ignored.
+    return ddl.allTables().stream()
+        .map(spannerTableInDdl -> getSourceTableName(namespace, spannerTableInDdl.name()))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public String getSourceTableName(String namespace, String spTable) throws NoSuchElementException {
+    // Ensure Spanner table exists in DDL first.
+    // Namespace is ignored.
+    if (ddl.table(spTable) == null) {
+      throw new NoSuchElementException("Spanner table '" + spTable + "' not found in DDL.");
+    }
+
+    // Check if spTable is a target of a rename in the overrides.
+    if (parser.schemaFileOverride != null && parser.schemaFileOverride.getRenamedTables() != null) {
+      for (Map.Entry<String, String> entry :
+          parser.schemaFileOverride.getRenamedTables().entrySet()) {
+        // If the value (Spanner name in override) matches spTable, the key is the source name.
+        if (entry.getValue().equals(spTable)) {
+          return entry.getKey();
+        }
+      }
+    }
+    // If not found in overrides as a target, assume source name is the same as the Spanner name.
+    return spTable;
+  }
+
+  @Override
+  public String getSpannerTableName(String namespace, String srcTable)
+      throws NoSuchElementException {
+    String spannerTableNameCandidate = parser.getTableOverride(srcTable);
+
+    // Validate that the resolved Spanner table exists in the DDL.
+    if (ddl.table(spannerTableNameCandidate) == null) {
+      throw new NoSuchElementException(
+          String.format(
+              "Resolved Spanner table '%s' (from source table '%s') not found in DDL.",
+              spannerTableNameCandidate, srcTable));
+    }
+    return spannerTableNameCandidate;
+  }
+
+  @Override
+  public String getSpannerColumnName(String namespace, String srcTable, String srcColumn)
+      throws NoSuchElementException {
+
+    String spannerTableName = getSpannerTableName(namespace, srcTable);
+
+    // Get the candidate Spanner column name from overrides for the original srcTable and srcColumn.
+    String spannerColumnNameCandidate = parser.getColumnOverride(srcTable, srcColumn);
+
+    // Validate that the resolved Spanner column exists in the Spanner table in the DDL.
+    Table spTableInDdl = ddl.table(spannerTableName);
+    Column spColInDdl = spTableInDdl.column(spannerColumnNameCandidate);
+    if (spColInDdl == null) {
+      throw new NoSuchElementException(
+          String.format(
+              "Resolved Spanner column '%s' (from source column '%s.%s') not found in Spanner table '%s' in DDL.",
+              spannerColumnNameCandidate, srcTable, srcColumn, spannerTableName));
+    }
+    return spannerColumnNameCandidate;
+  }
+
+  @Override
+  public String getSourceColumnName(String namespace, String spannerTable, String spannerColumn)
+      throws NoSuchElementException {
+    // Ensure Spanner table and column exist in DDL first.
+    // Namespace is ignored.
+    Table table = ddl.table(spannerTable);
+    if (table == null) {
+      throw new NoSuchElementException("Spanner table '" + spannerTable + "' not found in DDL.");
+    }
+    if (table.column(spannerColumn) == null) {
+      throw new NoSuchElementException(
+          "Spanner column '"
+              + spannerColumn
+              + "' not found in Spanner table '"
+              + spannerTable
+              + "' in DDL.");
+    }
+
+    // Determine the original source table name for the given spannerTable.
+    String sourceTableNameForLookup = getSourceTableName(namespace, spannerTable);
+
+    // Check if spannerColumn is a target of a column rename within sourceTableNameForLookup.
+    if (parser.schemaFileOverride != null
+        && parser.schemaFileOverride.getRenamedColumnTupleMap() != null) {
+      Map<String, String> columnOverrides =
+          parser.schemaFileOverride.getRenamedColumnTupleMap().get(sourceTableNameForLookup);
+      if (columnOverrides != null) {
+        for (Map.Entry<String, String> entry : columnOverrides.entrySet()) {
+          // If the value (Spanner column name in override) matches spannerColumn, the key is the
+          // source column name.
+          if (entry.getValue().equals(spannerColumn)) {
+            return entry.getKey();
+          }
+        }
+      }
+    }
+    // If not found in overrides, assume source column name is the same as the Spanner column name.
+    return spannerColumn;
+  }
+
+  @Override
+  public Type getSpannerColumnType(String namespace, String spannerTable, String spannerColumn)
+      throws NoSuchElementException {
+    // Namespace is ignored.
+    Table table = ddl.table(spannerTable);
+    if (table == null) {
+      throw new NoSuchElementException("Spanner table '" + spannerTable + "' not found in DDL.");
+    }
+    Column column = table.column(spannerColumn);
+    if (column == null) {
+      throw new NoSuchElementException(
+          "Spanner column '"
+              + spannerColumn
+              + "' not found in Spanner table '"
+              + spannerTable
+              + "' in DDL.");
+    }
+    return column.type();
+  }
+
+  @Override
+  public CassandraAnnotations getSpannerColumnCassandraAnnotations(
+      String namespace, String spannerTable, String spannerColumn) throws NoSuchElementException {
+    // Namespace is ignored.
+    Table table = ddl.table(spannerTable);
+    if (table == null) {
+      throw new NoSuchElementException("Spanner table '" + spannerTable + "' not found in DDL.");
+    }
+    Column column = table.column(spannerColumn);
+    if (column == null) {
+      throw new NoSuchElementException(
+          "Spanner column '"
+              + spannerColumn
+              + "' not found in Spanner table '"
+              + spannerTable
+              + "' in DDL.");
+    }
+    return column.cassandraAnnotation();
+  }
+
+  @Override
+  public List<String> getSpannerColumns(String namespace, String spannerTable)
+      throws NoSuchElementException {
+    // Namespace is ignored.
+    Table table = ddl.table(spannerTable);
+    if (table == null) {
+      throw new NoSuchElementException("Spanner table '" + spannerTable + "' not found in DDL.");
+    }
+    return table.columns().stream().map(Column::name).collect(Collectors.toList());
+  }
+
+  @Override
+  public String getShardIdColumnName(String namespace, String spannerTableName) {
+    // For schema override based migrations, the shard id must be supplied via custom jar.
+    return null;
+  }
+
+  @Override
+  public String getSyntheticPrimaryKeyColName(String namespace, String spannerTableName) {
+    // Synthetic PK cols will soon be deprecated hence not adding support for them.
+    return null;
+  }
+
+  @Override
+  public boolean colExistsAtSource(String namespace, String spannerTable, String spannerColumn) {
+    // Namespace is ignored.
+    try {
+      // If getSourceColumnName succeeds, it implies the Spanner table/column exist in DDL
+      // and a mapping to a source column (even if default/same name) was found.
+      getSourceColumnName(namespace, spannerTable, spannerColumn);
+      return true;
+    } catch (NoSuchElementException e) {
+      // Thrown if Spanner table/column not in DDL, or mapping fails.
+      return false;
+    }
+  }
+}

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SchemaFileOverridesBasedMapper.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SchemaFileOverridesBasedMapper.java
@@ -215,13 +215,13 @@ public class SchemaFileOverridesBasedMapper implements ISchemaMapper, Serializab
 
   @Override
   public String getShardIdColumnName(String namespace, String spannerTableName) {
-    // For schema override based migrations, the shard id must be supplied via custom jar.
+    LOG.warn("For schema override based migrations, the shard id must be supplied via custom jar.");
     return null;
   }
 
   @Override
   public String getSyntheticPrimaryKeyColName(String namespace, String spannerTableName) {
-    // Synthetic PK cols will soon be deprecated hence not adding support for them.
+    LOG.warn("Synthetic PK are not supported for schema override based migrations.");
     return null;
   }
 

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SchemaStringOverridesBasedMapper.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SchemaStringOverridesBasedMapper.java
@@ -236,13 +236,13 @@ public class SchemaStringOverridesBasedMapper implements ISchemaMapper, Serializ
 
   @Override
   public String getShardIdColumnName(String namespace, String spannerTableName) {
-    // For schema override based migrations, the shard id must be supplied via custom jar.
+    LOG.warn("For schema override based migrations, the shard id must be supplied via custom jar.");
     return null;
   }
 
   @Override
   public String getSyntheticPrimaryKeyColName(String namespace, String spannerTableName) {
-    // Synthetic PK cols will soon be deprecated hence not adding support for them.
+    LOG.warn("Synthetic PK are not supported for schema override based migrations.");
     return null;
   }
 

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SchemaStringOverridesBasedMapper.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SchemaStringOverridesBasedMapper.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.migrations.schema;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.teleport.v2.spanner.ddl.Column;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.Table;
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraAnnotations;
+import com.google.cloud.teleport.v2.spanner.type.Type;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Schema mapper that uses a string-based schema overrides parser. Assumes that if a table or column
+ * is not explicitly overridden, its name is the same in the source and Spanner.
+ */
+public class SchemaStringOverridesBasedMapper implements ISchemaMapper, Serializable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SchemaStringOverridesBasedMapper.class);
+  private final SchemaStringOverridesParser parser;
+  private final Ddl ddl;
+
+  /**
+   * Constructs a new SchemaStringOverridesBasedMapper.
+   *
+   * @param userOptionOverrides A map containing string-based override configurations. Expected
+   *     keys: "tableOverrides", "columnOverrides".
+   * @param ddl The DDL representation of the Spanner schema.
+   */
+  public SchemaStringOverridesBasedMapper(Map<String, String> userOptionOverrides, Ddl ddl) {
+    this.parser = new SchemaStringOverridesParser(userOptionOverrides);
+    this.ddl = ddl;
+  }
+
+  @Override
+  public Dialect getDialect() {
+    return ddl.dialect();
+  }
+
+  @Override
+  public List<String> getSourceTablesToMigrate(String namespace) {
+    // For each table in the Spanner DDL, find its corresponding source table name.
+    // Namespace is ignored.
+    return ddl.allTables().stream()
+        .map(spannerTableInDdl -> getSourceTableName(namespace, spannerTableInDdl.name()))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public String getSourceTableName(String namespace, String spTable) throws NoSuchElementException {
+    // Ensure Spanner table exists in DDL first.
+    // Namespace is ignored.
+    if (ddl.table(spTable) == null) {
+      throw new NoSuchElementException("Spanner table '" + spTable + "' not found in DDL.");
+    }
+
+    // Check if spTable is a target of a rename in the table overrides.
+    // The parser's tableNameOverrides stores <Source, Spanner>
+    for (Map.Entry<String, String> entry : parser.tableNameOverrides.entrySet()) {
+      // If the value (Spanner name in override) matches spTable, the key is the source name.
+      if (entry.getValue().equals(spTable)) {
+        return entry.getKey();
+      }
+    }
+    // If not found in overrides as a target, assume source name is the same as the Spanner name.
+    return spTable;
+  }
+
+  @Override
+  public String getSpannerTableName(String namespace, String srcTable)
+      throws NoSuchElementException {
+    // Get the candidate Spanner table name from overrides, or srcTable if no override.
+    // Namespace is ignored.
+    String spannerTableNameCandidate = parser.getTableOverride(srcTable);
+
+    // Validate that the resolved Spanner table exists in the DDL.
+    if (ddl.table(spannerTableNameCandidate) == null) {
+      throw new NoSuchElementException(
+          String.format(
+              "Resolved Spanner table '%s' (from source table '%s') not found in DDL.",
+              spannerTableNameCandidate, srcTable));
+    }
+    return spannerTableNameCandidate;
+  }
+
+  @Override
+  public String getSpannerColumnName(String namespace, String srcTable, String srcColumn)
+      throws NoSuchElementException {
+    // Get the Spanner table name that srcTable maps to. This also validates its DDL existence.
+    // Namespace is ignored.
+    String spannerTableNameContext = getSpannerTableName(namespace, srcTable);
+
+    // Get the candidate Spanner column name from overrides for the original srcTable and srcColumn.
+    // SchemaStringOverridesParser.getColumnOverride returns the Spanner column name directly.
+    String spannerColumnNameCandidate = parser.getColumnOverride(srcTable, srcColumn);
+
+    // Validate that the resolved Spanner column exists in the context Spanner table in the DDL.
+    Table spTableInDdl = ddl.table(spannerTableNameContext);
+    if (spTableInDdl == null) { // Should not happen if getSpannerTableName worked
+      throw new NoSuchElementException(
+          String.format(
+              "Context Spanner table '%s' (from source table '%s') unexpectedly not found in DDL.",
+              spannerTableNameContext, srcTable));
+    }
+
+    Column spColInDdl = spTableInDdl.column(spannerColumnNameCandidate);
+    if (spColInDdl == null) {
+      throw new NoSuchElementException(
+          String.format(
+              "Resolved Spanner column '%s' (from source column '%s.%s') not found in Spanner table '%s' in DDL.",
+              spannerColumnNameCandidate, srcTable, srcColumn, spannerTableNameContext));
+    }
+    return spannerColumnNameCandidate;
+  }
+
+  @Override
+  public String getSourceColumnName(String namespace, String spannerTable, String spannerColumn)
+      throws NoSuchElementException {
+    // Ensure Spanner table and column exist in DDL first.
+    // Namespace is ignored.
+    Table table = ddl.table(spannerTable);
+    if (table == null) {
+      throw new NoSuchElementException("Spanner table '" + spannerTable + "' not found in DDL.");
+    }
+    if (table.column(spannerColumn) == null) {
+      throw new NoSuchElementException(
+          "Spanner column '"
+              + spannerColumn
+              + "' not found in Spanner table '"
+              + spannerTable
+              + "' in DDL.");
+    }
+
+    // Determine the original source table name for the given spannerTable.
+    String sourceTableNameForLookup = getSourceTableName(namespace, spannerTable);
+
+    // Check if spannerColumn is a target of a column rename within sourceTableNameForLookup.
+    // The parser's columnNameOverrides stores:
+    // Key: "SourceTableName.SourceColumnName"
+    // Value: Pair<DestinationTableNameInOverride, DestinationSpannerColumnName>
+    // As per parser's validateMapping, DestinationTableNameInOverride == SourceTableName from key.
+    for (Map.Entry<String, Pair<String, String>> entry : parser.columnNameOverrides.entrySet()) {
+      String fullSourceKey = entry.getKey(); // e.g., "SourceTable.SourceCol"
+      Pair<String, String> spannerPair =
+          entry.getValue(); // e.g., Pair<"SourceTable", "SpannerCol">
+
+      String sourceTableInKey = fullSourceKey.substring(0, fullSourceKey.lastIndexOf('.'));
+      String sourceColInKey = fullSourceKey.substring(fullSourceKey.lastIndexOf('.') + 1);
+
+      // We are looking for an override where:
+      // 1. The source table context of the override matches our `sourceTableNameForLookup`.
+      // 2. The target Spanner column name in the override matches the given `spannerColumn`.
+      // 3. The target Spanner table name in the column override also matches
+      // `sourceTableNameForLookup`
+      //    (this is enforced by SchemaStringOverridesParser.validateMapping).
+      if (sourceTableInKey.equals(sourceTableNameForLookup)
+          && spannerPair.getRight().equals(spannerColumn)
+          && spannerPair.getLeft().equals(sourceTableNameForLookup)) {
+        return sourceColInKey;
+      }
+    }
+    // If not found in overrides, assume source column name is the same as the Spanner column name.
+    return spannerColumn;
+  }
+
+  @Override
+  public Type getSpannerColumnType(String namespace, String spannerTable, String spannerColumn)
+      throws NoSuchElementException {
+    // Namespace is ignored.
+    Table table = ddl.table(spannerTable);
+    if (table == null) {
+      throw new NoSuchElementException("Spanner table '" + spannerTable + "' not found in DDL.");
+    }
+    Column column = table.column(spannerColumn);
+    if (column == null) {
+      throw new NoSuchElementException(
+          "Spanner column '"
+              + spannerColumn
+              + "' not found in Spanner table '"
+              + spannerTable
+              + "' in DDL.");
+    }
+    return column.type();
+  }
+
+  @Override
+  public CassandraAnnotations getSpannerColumnCassandraAnnotations(
+      String namespace, String spannerTable, String spannerColumn) throws NoSuchElementException {
+    // Namespace is ignored.
+    Table table = ddl.table(spannerTable);
+    if (table == null) {
+      throw new NoSuchElementException("Spanner table '" + spannerTable + "' not found in DDL.");
+    }
+    Column column = table.column(spannerColumn);
+    if (column == null) {
+      throw new NoSuchElementException(
+          "Spanner column '"
+              + spannerColumn
+              + "' not found in Spanner table '"
+              + spannerTable
+              + "' in DDL.");
+    }
+    return column.cassandraAnnotation();
+  }
+
+  @Override
+  public List<String> getSpannerColumns(String namespace, String spannerTable)
+      throws NoSuchElementException {
+    // Namespace is ignored.
+    Table table = ddl.table(spannerTable);
+    if (table == null) {
+      throw new NoSuchElementException("Spanner table '" + spannerTable + "' not found in DDL.");
+    }
+    return table.columns().stream().map(Column::name).collect(Collectors.toList());
+  }
+
+  @Override
+  public String getShardIdColumnName(String namespace, String spannerTableName) {
+    // For schema override based migrations, the shard id must be supplied via custom jar.
+    return null;
+  }
+
+  @Override
+  public String getSyntheticPrimaryKeyColName(String namespace, String spannerTableName) {
+    // Synthetic PK cols will soon be deprecated hence not adding support for them.
+    return null;
+  }
+
+  @Override
+  public boolean colExistsAtSource(String namespace, String spannerTable, String spannerColumn) {
+    // Namespace is ignored.
+    try {
+      // If getSourceColumnName succeeds, it implies the Spanner table/column exist in DDL
+      // and a mapping to a source column (even if default/same name) was found.
+      getSourceColumnName(namespace, spannerTable, spannerColumn);
+      return true;
+    } catch (NoSuchElementException e) {
+      // Thrown if Spanner table/column not in DDL, or mapping fails.
+      return false;
+    }
+  }
+}

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SchemaFileOverridesBasedMapperTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SchemaFileOverridesBasedMapperTest.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.migrations.schema;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraType;
+import com.google.cloud.teleport.v2.spanner.type.Type;
+import com.google.common.collect.ImmutableList;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class SchemaFileOverridesBasedMapperTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private SchemaFileOverridesBasedMapper mapper;
+  private Ddl ddl;
+  private Path schemaOverridesFile;
+
+  @Before
+  public void setup() throws IOException {
+    // Define the Spanner DDL (same as StringOverrides test for consistency)
+    ddl =
+        Ddl.builder(Dialect.GOOGLE_STANDARD_SQL)
+            .createTable("t_spanner_alpha")
+            .column("c_spanner_alpha_id")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("c_spanner_alpha_val")
+            .string()
+            .max()
+            .endColumn()
+            .column("c_alpha_data")
+            .bytes()
+            .max()
+            .endColumn()
+            .primaryKey()
+            .asc("c_spanner_alpha_id")
+            .end()
+            .endTable()
+            .createTable("t_source_beta")
+            .column("c_beta_id")
+            .string()
+            .size(36)
+            .notNull()
+            .endColumn()
+            .column("c_spanner_beta_val")
+            .string()
+            .max()
+            .endColumn()
+            .column("c_beta_notes")
+            .string()
+            .max()
+            .columnOptions(ImmutableList.of("CASSANDRA_TYPE=\"text\""))
+            .endColumn()
+            .primaryKey()
+            .asc("c_beta_id")
+            .end()
+            .endTable()
+            .createTable("t_spanner_gamma")
+            .column("c_gamma_id")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("c_spanner_gamma_desc")
+            .string()
+            .max()
+            .endColumn()
+            .primaryKey()
+            .asc("c_gamma_id")
+            .end()
+            .endTable()
+            .build();
+
+    // Create a temporary schema overrides file
+    schemaOverridesFile = temporaryFolder.newFile("schema_overrides.json").toPath();
+    String overridesJsonContent =
+        "{\n"
+            + "  \"renamedTables\": {\n"
+            + "    \"t_source_alpha\": \"t_spanner_alpha\",\n"
+            + "    \"t_source_gamma\": \"t_spanner_gamma\"\n"
+            + "  },\n"
+            + "  \"renamedColumns\": {\n"
+            + "    \"t_source_alpha\": {\n"
+            + "      \"c_alpha_id\": \"c_spanner_alpha_id\",\n"
+            + "      \"c_alpha_val\": \"c_spanner_alpha_val\"\n"
+            + "    },\n"
+            + "    \"t_source_beta\": {\n"
+            + "      \"c_beta_val\": \"c_spanner_beta_val\"\n"
+            + "    },\n"
+            + "    \"t_source_gamma\": {\n"
+            + "      \"c_gamma_desc\": \"c_spanner_gamma_desc\"\n"
+            + "    }\n"
+            + "  }\n"
+            + "}";
+
+    try (BufferedWriter writer = Files.newBufferedWriter(schemaOverridesFile)) {
+      writer.write(overridesJsonContent);
+    }
+
+    mapper = new SchemaFileOverridesBasedMapper(schemaOverridesFile.toString(), ddl);
+  }
+
+  @Test
+  public void testGetDialect() {
+    assertEquals(Dialect.GOOGLE_STANDARD_SQL, mapper.getDialect());
+  }
+
+  @Test
+  public void testGetSourceTablesToMigrate() {
+    List<String> expected = Arrays.asList("t_source_alpha", "t_source_beta", "t_source_gamma");
+    List<String> actual = mapper.getSourceTablesToMigrate("");
+    Collections.sort(expected);
+    Collections.sort(actual);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testGetSourceTableName() {
+    assertEquals("t_source_alpha", mapper.getSourceTableName("", "t_spanner_alpha"));
+    assertEquals("t_source_beta", mapper.getSourceTableName("", "t_source_beta"));
+    assertEquals("t_source_gamma", mapper.getSourceTableName("", "t_spanner_gamma"));
+
+    assertThrows(
+        NoSuchElementException.class, () -> mapper.getSourceTableName("", "non_existent_sp_table"));
+  }
+
+  @Test
+  public void testGetSpannerTableName() throws IOException {
+    assertEquals("t_spanner_alpha", mapper.getSpannerTableName("", "t_source_alpha"));
+    assertEquals("t_source_beta", mapper.getSpannerTableName("", "t_source_beta"));
+    assertEquals("t_spanner_gamma", mapper.getSpannerTableName("", "t_source_gamma"));
+
+    // Create a faulty mapper with an override to a non-existent Spanner table
+    String faultyOverridesContent =
+        "{\n"
+            + "  \"renamedTables\": {\n"
+            + "    \"t_faulty_source\": \"t_non_existent_sp\"\n"
+            + "  }\n"
+            + "}";
+    Path faultyFile = temporaryFolder.newFile("faulty_overrides.json").toPath();
+    try (BufferedWriter writer = Files.newBufferedWriter(faultyFile)) {
+      writer.write(faultyOverridesContent);
+    }
+    SchemaFileOverridesBasedMapper faultyMapper =
+        new SchemaFileOverridesBasedMapper(faultyFile.toString(), ddl);
+    assertThrows(
+        NoSuchElementException.class,
+        () -> faultyMapper.getSpannerTableName("", "t_faulty_source"));
+
+    assertThrows(
+        NoSuchElementException.class,
+        () -> mapper.getSpannerTableName("", "non_existent_src_table"));
+  }
+
+  @Test
+  public void testGetSpannerColumnName() throws IOException {
+    assertEquals(
+        "c_spanner_alpha_id",
+        mapper.getSpannerColumnName("", "t_source_alpha", "c_alpha_id")); // Renamed
+    assertEquals(
+        "c_alpha_data",
+        mapper.getSpannerColumnName("", "t_source_alpha", "c_alpha_data")); // Not renamed
+    assertEquals(
+        "c_spanner_beta_val",
+        mapper.getSpannerColumnName("", "t_source_beta", "c_beta_val")); // Renamed
+    assertEquals(
+        "c_beta_id", mapper.getSpannerColumnName("", "t_source_beta", "c_beta_id")); // Not renamed
+
+    // Faulty override: column override maps to a Spanner column not in DDL
+    String faultyColOverridesContent =
+        "{\n"
+            + "  \"renamedColumns\": {\n"
+            + "    \"t_source_beta\": {\n"
+            + "      \"c_beta_id\": \"c_non_existent_sp_col\"\n"
+            + "    }\n"
+            + "  }\n"
+            + "}";
+    Path faultyColFile = temporaryFolder.newFile("faulty_col_overrides.json").toPath();
+    try (BufferedWriter writer = Files.newBufferedWriter(faultyColFile)) {
+      writer.write(faultyColOverridesContent);
+    }
+    SchemaFileOverridesBasedMapper faultyMapper =
+        new SchemaFileOverridesBasedMapper(faultyColFile.toString(), ddl);
+    assertThrows(
+        NoSuchElementException.class,
+        () -> faultyMapper.getSpannerColumnName("", "t_source_beta", "c_beta_id"));
+
+    assertThrows(
+        NoSuchElementException.class,
+        () -> mapper.getSpannerColumnName("", "non_existent_src_table", "any_col"));
+    assertThrows(
+        NoSuchElementException.class,
+        () -> mapper.getSpannerColumnName("", "t_source_alpha", "non_existent_src_col"));
+  }
+
+  @Test
+  public void testGetSourceColumnName() {
+    assertEquals(
+        "c_alpha_id", mapper.getSourceColumnName("", "t_spanner_alpha", "c_spanner_alpha_id"));
+    assertEquals("c_alpha_data", mapper.getSourceColumnName("", "t_spanner_alpha", "c_alpha_data"));
+    assertEquals(
+        "c_beta_val", mapper.getSourceColumnName("", "t_source_beta", "c_spanner_beta_val"));
+    assertEquals("c_beta_id", mapper.getSourceColumnName("", "t_source_beta", "c_beta_id"));
+
+    assertThrows(
+        NoSuchElementException.class,
+        () -> mapper.getSourceColumnName("", "non_existent_sp_table", "any_col"));
+    assertThrows(
+        NoSuchElementException.class,
+        () -> mapper.getSourceColumnName("", "t_spanner_alpha", "non_existent_sp_col"));
+  }
+
+  @Test
+  public void testGetSpannerColumnType() {
+    assertEquals(
+        Type.int64(), mapper.getSpannerColumnType("", "t_spanner_alpha", "c_spanner_alpha_id"));
+    assertEquals(
+        Type.string(), mapper.getSpannerColumnType("", "t_source_beta", "c_spanner_beta_val"));
+    assertEquals(Type.bytes(), mapper.getSpannerColumnType("", "t_spanner_alpha", "c_alpha_data"));
+
+    assertThrows(
+        NoSuchElementException.class,
+        () -> mapper.getSpannerColumnType("", "t_spanner_alpha", "non_existent_col"));
+  }
+
+  @Test
+  public void testCassandraAnnotations() {
+    assertEquals(
+        mapper
+            .getSpannerColumnCassandraAnnotations("", "t_source_beta", "c_spanner_beta_val")
+            .cassandraType()
+            .getKind(),
+        CassandraType.Kind.NONE);
+    assertEquals(
+        mapper
+            .getSpannerColumnCassandraAnnotations("", "t_source_beta", "c_beta_notes")
+            .cassandraType()
+            .getKind(),
+        CassandraType.Kind.PRIMITIVE);
+  }
+
+  @Test
+  public void testGetSpannerColumns() {
+    List<String> expectedAlpha =
+        Arrays.asList("c_spanner_alpha_id", "c_spanner_alpha_val", "c_alpha_data");
+    List<String> actualAlpha = mapper.getSpannerColumns("", "t_spanner_alpha");
+    Collections.sort(expectedAlpha);
+    Collections.sort(actualAlpha);
+    assertEquals(expectedAlpha, actualAlpha);
+
+    assertThrows(
+        NoSuchElementException.class, () -> mapper.getSpannerColumns("", "non_existent_table"));
+  }
+
+  @Test
+  public void testGetShardIdColumnName() {
+    assertNull(mapper.getShardIdColumnName("", "t_spanner_alpha"));
+  }
+
+  @Test
+  public void testGetSyntheticPrimaryKeyColName() {
+    assertNull(mapper.getSyntheticPrimaryKeyColName("", "t_spanner_alpha"));
+  }
+
+  @Test
+  public void testColExistsAtSource() {
+    assertTrue(mapper.colExistsAtSource("", "t_spanner_alpha", "c_spanner_alpha_id"));
+    assertTrue(mapper.colExistsAtSource("", "t_spanner_alpha", "c_alpha_data"));
+    assertFalse(mapper.colExistsAtSource("", "t_spanner_alpha", "non_existent_sp_col"));
+    assertFalse(mapper.colExistsAtSource("", "non_existent_sp_table", "any_col"));
+  }
+
+  @Test
+  public void testEmptyOverridesFile() throws IOException {
+    Path emptyFile = temporaryFolder.newFile("empty_overrides.json").toPath();
+    String emptyJsonContent = "{}"; // Valid JSON, but no overrides
+    try (BufferedWriter writer = Files.newBufferedWriter(emptyFile)) {
+      writer.write(emptyJsonContent);
+    }
+    SchemaFileOverridesBasedMapper emptyMapper =
+        new SchemaFileOverridesBasedMapper(emptyFile.toString(), ddl);
+
+    // Should default to same names
+    assertEquals("t_spanner_alpha", emptyMapper.getSpannerTableName("", "t_spanner_alpha"));
+    assertEquals(
+        "c_spanner_alpha_id",
+        emptyMapper.getSpannerColumnName("", "t_spanner_alpha", "c_spanner_alpha_id"));
+    assertEquals("t_spanner_alpha", emptyMapper.getSourceTableName("", "t_spanner_alpha"));
+    assertEquals(
+        "c_spanner_alpha_id",
+        emptyMapper.getSourceColumnName("", "t_spanner_alpha", "c_spanner_alpha_id"));
+  }
+
+  @Test
+  public void testMalformedOverridesFile() throws IOException {
+    Path malformedFile = temporaryFolder.newFile("malformed_overrides.json").toPath();
+    String malformedJsonContent = "{malformed_json_content";
+    try (BufferedWriter writer = Files.newBufferedWriter(malformedFile)) {
+      writer.write(malformedJsonContent);
+    }
+    // SchemaFileOverridesParser constructor should throw IllegalArgumentException
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new SchemaFileOverridesBasedMapper(malformedFile.toString(), ddl));
+  }
+}

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SchemaStringOverridesBasedMapperTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/schema/SchemaStringOverridesBasedMapperTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.spanner.migrations.schema;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.annotations.cassandra.CassandraType.Kind;
+import com.google.cloud.teleport.v2.spanner.type.Type;
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SchemaStringOverridesBasedMapperTest {
+
+  private SchemaStringOverridesBasedMapper mapper;
+  private Ddl ddl;
+
+  @Before
+  public void setup() {
+    // Define the Spanner DDL
+    ddl =
+        Ddl.builder(Dialect.GOOGLE_STANDARD_SQL)
+            // Table 't_spanner_alpha' is renamed from 't_source_alpha'
+            .createTable("t_spanner_alpha")
+            .column("c_spanner_alpha_id")
+            .int64()
+            .notNull()
+            .endColumn() // Renamed from c_alpha_id
+            .column("c_spanner_alpha_val")
+            .string()
+            .max()
+            .endColumn() // Renamed from c_alpha_val
+            .column("c_alpha_data")
+            .bytes()
+            .max()
+            .endColumn() // Not renamed
+            .primaryKey()
+            .asc("c_spanner_alpha_id")
+            .end()
+            .endTable()
+            // Table 't_source_beta' is not renamed
+            .createTable("t_source_beta")
+            .column("c_beta_id")
+            .string()
+            .size(36)
+            .notNull()
+            .endColumn() // Not renamed
+            .column("c_spanner_beta_val")
+            .string()
+            .max()
+            .endColumn() // Renamed from c_beta_val
+            .column("c_beta_notes")
+            .string()
+            .max()
+            .columnOptions(ImmutableList.of("CASSANDRA_TYPE=\"text\""))
+            .endColumn() // Not renamed, has Cassandra annotation
+            .primaryKey()
+            .asc("c_beta_id")
+            .end()
+            .endTable()
+            // Table 't_spanner_gamma' is renamed from 't_source_gamma'
+            // but has a column that is NOT renamed in the DDL (c_gamma_id)
+            // and one that IS renamed (c_spanner_gamma_desc from c_gamma_desc)
+            .createTable("t_spanner_gamma")
+            .column("c_gamma_id")
+            .int64()
+            .notNull()
+            .endColumn() // Not renamed in DDL, but table is.
+            .column("c_spanner_gamma_desc")
+            .string()
+            .max()
+            .endColumn() // Renamed from c_gamma_desc
+            .primaryKey()
+            .asc("c_gamma_id")
+            .end()
+            .endTable()
+            .build();
+
+    Map<String, String> userOptionOverrides = new HashMap<>();
+    userOptionOverrides.put(
+        "tableOverrides", "[{t_source_alpha, t_spanner_alpha}, {t_source_gamma, t_spanner_gamma}]");
+    userOptionOverrides.put(
+        "columnOverrides",
+        "[{t_source_alpha.c_alpha_id, t_source_alpha.c_spanner_alpha_id},"
+            + " {t_source_alpha.c_alpha_val, t_source_alpha.c_spanner_alpha_val},"
+            + " {t_source_beta.c_beta_val, t_source_beta.c_spanner_beta_val},"
+            + " {t_source_gamma.c_gamma_desc, t_source_gamma.c_spanner_gamma_desc}]");
+
+    mapper = new SchemaStringOverridesBasedMapper(userOptionOverrides, ddl);
+  }
+
+  @Test
+  public void testGetDialect() {
+    assertEquals(Dialect.GOOGLE_STANDARD_SQL, mapper.getDialect());
+  }
+
+  @Test
+  public void testGetSourceTablesToMigrate() {
+    List<String> expected = Arrays.asList("t_source_alpha", "t_source_beta", "t_source_gamma");
+    List<String> actual = mapper.getSourceTablesToMigrate("");
+    Collections.sort(expected);
+    Collections.sort(actual);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testGetSourceTableName() {
+    assertEquals("t_source_alpha", mapper.getSourceTableName("", "t_spanner_alpha"));
+    assertEquals("t_source_beta", mapper.getSourceTableName("", "t_source_beta")); // No override
+    assertEquals("t_source_gamma", mapper.getSourceTableName("", "t_spanner_gamma"));
+
+    // Spanner table not in DDL
+    assertThrows(
+        NoSuchElementException.class, () -> mapper.getSourceTableName("", "non_existent_sp_table"));
+  }
+
+  @Test
+  public void testGetSpannerTableName() {
+    assertEquals("t_spanner_alpha", mapper.getSpannerTableName("", "t_source_alpha"));
+    assertEquals("t_source_beta", mapper.getSpannerTableName("", "t_source_beta")); // No override
+    assertEquals("t_spanner_gamma", mapper.getSpannerTableName("", "t_source_gamma"));
+
+    // Source table with override, but target Spanner table not in DDL
+    Map<String, String> faultyOverrides = new HashMap<>();
+    faultyOverrides.put("tableOverrides", "[{t_faulty, t_non_existent_sp}]");
+    SchemaStringOverridesBasedMapper faultyMapper =
+        new SchemaStringOverridesBasedMapper(faultyOverrides, ddl);
+    assertThrows(
+        NoSuchElementException.class, () -> faultyMapper.getSpannerTableName("", "t_faulty"));
+
+    // Source table with no override, and not in DDL
+    assertThrows(
+        NoSuchElementException.class,
+        () -> mapper.getSpannerTableName("", "non_existent_src_table"));
+  }
+
+  @Test
+  public void testGetSpannerColumnName() {
+    // Renamed table, renamed column
+    assertEquals(
+        "c_spanner_alpha_id", mapper.getSpannerColumnName("", "t_source_alpha", "c_alpha_id"));
+    // Renamed table, non-renamed column
+    assertEquals("c_alpha_data", mapper.getSpannerColumnName("", "t_source_alpha", "c_alpha_data"));
+    // Non-renamed table, renamed column
+    assertEquals(
+        "c_spanner_beta_val", mapper.getSpannerColumnName("", "t_source_beta", "c_beta_val"));
+    // Non-renamed table, non-renamed column
+    assertEquals("c_beta_id", mapper.getSpannerColumnName("", "t_source_beta", "c_beta_id"));
+
+    // Source column whose override maps to a Spanner column not in DDL for that table
+    Map<String, String> faultyColOverrides = new HashMap<>();
+    faultyColOverrides.put(
+        "columnOverrides", "[{t_source_beta.c_beta_id, t_source_beta.c_non_existent_sp_col}]");
+    SchemaStringOverridesBasedMapper faultyMapper =
+        new SchemaStringOverridesBasedMapper(faultyColOverrides, ddl);
+    assertThrows(
+        NoSuchElementException.class,
+        () -> faultyMapper.getSpannerColumnName("", "t_source_beta", "c_beta_id"));
+
+    // Source table not found (implicitly, as it won't map to a DDL table)
+    assertThrows(
+        NoSuchElementException.class,
+        () -> mapper.getSpannerColumnName("", "non_existent_src_table", "any_col"));
+    // Source column not found for existing table
+    assertThrows(
+        NoSuchElementException.class,
+        () -> mapper.getSpannerColumnName("", "t_source_alpha", "non_existent_src_col"));
+  }
+
+  @Test
+  public void testGetSourceColumnName() {
+    // Renamed table, renamed column
+    assertEquals(
+        "c_alpha_id", mapper.getSourceColumnName("", "t_spanner_alpha", "c_spanner_alpha_id"));
+    // Renamed table, non-renamed column (Spanner col name is same as source col name)
+    assertEquals("c_alpha_data", mapper.getSourceColumnName("", "t_spanner_alpha", "c_alpha_data"));
+    // Non-renamed table, renamed column
+    assertEquals(
+        "c_beta_val", mapper.getSourceColumnName("", "t_source_beta", "c_spanner_beta_val"));
+    // Non-renamed table, non-renamed column
+    assertEquals("c_beta_id", mapper.getSourceColumnName("", "t_source_beta", "c_beta_id"));
+
+    // Spanner table not in DDL
+    assertThrows(
+        NoSuchElementException.class,
+        () -> mapper.getSourceColumnName("", "non_existent_sp_table", "any_col"));
+    // Spanner column not in DDL for existing table
+    assertThrows(
+        NoSuchElementException.class,
+        () -> mapper.getSourceColumnName("", "t_spanner_alpha", "non_existent_sp_col"));
+  }
+
+  @Test
+  public void testGetSpannerColumnType() {
+    assertEquals(
+        Type.int64(), mapper.getSpannerColumnType("", "t_spanner_alpha", "c_spanner_alpha_id"));
+    assertEquals(
+        Type.string(), mapper.getSpannerColumnType("", "t_source_beta", "c_spanner_beta_val"));
+    assertEquals(Type.bytes(), mapper.getSpannerColumnType("", "t_spanner_alpha", "c_alpha_data"));
+
+    assertThrows(
+        NoSuchElementException.class,
+        () -> mapper.getSpannerColumnType("", "t_spanner_alpha", "non_existent_col"));
+    assertThrows(
+        NoSuchElementException.class,
+        () -> mapper.getSpannerColumnType("", "non_existent_table", "c_spanner_alpha_id"));
+  }
+
+  @Test
+  public void testCassandraAnnotations() {
+    assertEquals(
+        mapper
+            .getSpannerColumnCassandraAnnotations("", "t_source_beta", "c_spanner_beta_val")
+            .cassandraType()
+            .getKind(),
+        Kind.NONE);
+    assertEquals(
+        mapper
+            .getSpannerColumnCassandraAnnotations("", "t_source_beta", "c_beta_notes")
+            .cassandraType()
+            .getKind(),
+        Kind.PRIMITIVE);
+  }
+
+  @Test
+  public void testGetSpannerColumns() {
+    List<String> expectedAlpha =
+        Arrays.asList("c_spanner_alpha_id", "c_spanner_alpha_val", "c_alpha_data");
+    List<String> actualAlpha = mapper.getSpannerColumns("", "t_spanner_alpha");
+    Collections.sort(expectedAlpha);
+    Collections.sort(actualAlpha);
+    assertEquals(expectedAlpha, actualAlpha);
+
+    List<String> expectedBeta = Arrays.asList("c_beta_id", "c_spanner_beta_val", "c_beta_notes");
+    List<String> actualBeta = mapper.getSpannerColumns("", "t_source_beta");
+    Collections.sort(expectedBeta);
+    Collections.sort(actualBeta);
+    assertEquals(expectedBeta, actualBeta);
+
+    assertThrows(
+        NoSuchElementException.class, () -> mapper.getSpannerColumns("", "non_existent_table"));
+  }
+
+  @Test
+  public void testGetShardIdColumnName() {
+    assertNull(mapper.getShardIdColumnName("", "t_spanner_alpha"));
+    assertNull(mapper.getShardIdColumnName("", "t_source_beta"));
+  }
+
+  @Test
+  public void testGetSyntheticPrimaryKeyColName() {
+    assertNull(mapper.getSyntheticPrimaryKeyColName("", "t_spanner_alpha"));
+    assertNull(mapper.getSyntheticPrimaryKeyColName("", "t_source_beta"));
+  }
+
+  @Test
+  public void testColExistsAtSource() {
+    // Renamed table, renamed column -> source exists
+    assertTrue(mapper.colExistsAtSource("", "t_spanner_alpha", "c_spanner_alpha_id")); // c_alpha_id
+    // Renamed table, non-renamed Spanner column -> source exists
+    assertTrue(mapper.colExistsAtSource("", "t_spanner_alpha", "c_alpha_data")); // c_alpha_data
+    // Non-renamed table, renamed Spanner column -> source exists
+    assertTrue(mapper.colExistsAtSource("", "t_source_beta", "c_spanner_beta_val")); // c_beta_val
+    // Non-renamed table, non-renamed Spanner column -> source exists
+    assertTrue(mapper.colExistsAtSource("", "t_source_beta", "c_beta_id")); // c_beta_id
+
+    // Spanner column exists in DDL, but no corresponding source override and name doesn't match a
+    // conceptual source column
+    // This case is tricky: if "c_spanner_only_col" is in DDL for "t_spanner_alpha",
+    // getSourceColumnName would return "c_spanner_only_col".
+    // colExistsAtSource depends on whether this "c_spanner_only_col" is considered a source column.
+    // Given current logic (default to same name), it would be true if DDL has it.
+    // To test false, the Spanner column must not exist in DDL or not be mappable.
+    assertFalse(mapper.colExistsAtSource("", "t_spanner_alpha", "non_existent_sp_col"));
+    assertFalse(mapper.colExistsAtSource("", "non_existent_sp_table", "any_col"));
+  }
+}


### PR DESCRIPTION
This PR adds support for file and string based overrides for bulk. Users can now provide a simple file/parameter on how tables/columns are renamed reducing setup time and customer toil managing complex session files.

When working with overrides the following things should be kept in mind:
- Dropped columns on spanner are automatically ignored during processing
- SynthPKs are not supported going forward
- Extra columns on Spanner(not on source, including shard id) should be be populated via custom transformations.