### PR TITLE
Add FirestoreMigrationTool team as code owner of v2/datastream-mongodb-to-firestore

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,9 @@ v2/datastream-to-postgres/ @GoogleCloudPlatform/datastream
 v2/datastream-to-mongodb/ @GoogleCloudPlatform/datastream
 v2/datastream-common/ @GoogleCloudPlatform/datastream @GoogleCloudPlatform/spanner-migrations-team
 
+# Datastream MongoDB To Firestore Templates
+v2/datastream-mongodb-to-firestore/ @GoogleCloudPlatform/FirestoreMigrationTool
+
 # Spanner Bulk migration template
 v2/sourcedb-to-spanner/ @GoogleCloudPlatform/spanner-migrations-team
 


### PR DESCRIPTION
Configure the code owner of the template Cloud_Datastream_MongoDB_to_Firestore added by [commit](https://github.com/GoogleCloudPlatform/DataflowTemplates/commit/660c5ee082126bbd1910387621261bc5f1d5feee).