### PR TITLE
Cassandra Bulk dlq Testing

### DIFF
--- a/v2/sourcedb-to-spanner/README.md
+++ b/v2/sourcedb-to-spanner/README.md
@@ -99,11 +99,13 @@ gcloud  dataflow flex-template run <jobname> \
 --region=<the region where the dataflow job must run> \
 --template-file-gcs-location=gs://dataflow-templates/latest/flex/Cloud_Datastream_to_Spanner \
 --additional-experiments=use_runner_v2 \
---parameters inputFilePattern=<GCS location of the input file pattern>,streamName="ignore", \
---datastreamSourceType=<source_type for example mysql/oracle. This needs to be set in the absence of an actual datastream.>\
-instanceId=<Spanner Instance Id>,databaseId=<Spanner Database Id>,sessionFilePath=<GCS path to session file>, \
+--parameters inputFilePattern=<GCS location of the input file pattern>,streamName="ignore",\
+datastreamSourceType=<source_type for example mysql/oracle. This needs to be set in the absence of an actual datastream.>,\
+instanceId=<Spanner Instance Id>,databaseId=<Spanner Database Id>,sessionFilePath=<GCS path to session file>,\
 deadLetterQueueDirectory=<outputDirectory/dlq>,runMode="retryDLQ"
 ```
+For DLQ Replay for Cassandra source, set the `datastreamSourceType` as `mysql`.
+
 ##### Checking if all DLQ entries are applied.
 To check if all DLQ entries have been applied to spanner, you could count the DLQ files in GCS and wait for it to go to 0.
 ```bash

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/rowmapper/CassandraRowMapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/rowmapper/CassandraRowMapper.java
@@ -60,7 +60,7 @@ abstract class CassandraRowMapper implements Transformer<Row, SourceRow>, Serial
     long time = getCurrentTimeMicros();
 
     SourceRow.Builder sourceRowBuilder =
-        SourceRow.builder(sourceSchemaReference(), sourceTableSchema(), "", time);
+        SourceRow.builder(sourceSchemaReference(), sourceTableSchema(), null, time);
 
     sourceTableSchema()
         .sourceColumnNameToSourceColumnType()

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/MigrateTableTransform.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/MigrateTableTransform.java
@@ -121,7 +121,8 @@ public class MigrateTableTransform extends PTransform<PBegin, PCollection<Void>>
     String dlqDirectory = outputDirectory + "dlq/severe/" + shardId;
     LOG.info("DLQ directory: {}", dlqDirectory);
     DeadLetterQueue dlq =
-        DeadLetterQueue.create(dlqDirectory, ddl, srcTableToShardIdColumnMap, sqlDialect);
+        DeadLetterQueue.create(
+            dlqDirectory, ddl, srcTableToShardIdColumnMap, sqlDialect, this.schemaMapper);
     dlq.failedMutationsToDLQ(failedMutations);
     dlq.failedTransformsToDLQ(
         transformationResult
@@ -134,7 +135,8 @@ public class MigrateTableTransform extends PTransform<PBegin, PCollection<Void>>
     String filterEventsDirectory = outputDirectory + "filteredEvents/" + shardId;
     LOG.info("Filtered events directory: {}", filterEventsDirectory);
     DeadLetterQueue filteredEventsQueue =
-        DeadLetterQueue.create(filterEventsDirectory, ddl, srcTableToShardIdColumnMap, sqlDialect);
+        DeadLetterQueue.create(
+            filterEventsDirectory, ddl, srcTableToShardIdColumnMap, sqlDialect, this.schemaMapper);
     filteredEventsQueue.filteredEventsToDLQ(
         transformationResult
             .get(SourceDbToSpannerConstants.FILTERED_EVENT_TAG)

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/CassandraAllDataTypesIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/CassandraAllDataTypesIT.java
@@ -16,22 +16,41 @@
 package com.google.cloud.teleport.v2.templates;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
 
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Type;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
 import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import com.google.cloud.teleport.v2.spanner.migrations.transformation.CustomTransformation;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import org.apache.beam.it.cassandra.CassandraResourceManager;
 import org.apache.beam.it.common.PipelineLauncher;
+import org.apache.beam.it.common.PipelineLauncher.LaunchInfo;
 import org.apache.beam.it.common.PipelineOperator;
+import org.apache.beam.it.common.PipelineOperator.Result;
+import org.apache.beam.it.common.utils.PipelineUtils;
 import org.apache.beam.it.common.utils.ResourceManagerUtils;
+import org.apache.beam.it.conditions.ConditionCheck;
+import org.apache.beam.it.gcp.dataflow.FlexTemplateDataflowJobResourceManager;
 import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
+import org.checkerframework.checker.initialization.qual.Initialized;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
+import org.jetbrains.annotations.NotNull;
 import org.jline.utils.Log;
 import org.junit.After;
 import org.junit.Before;
@@ -53,15 +72,84 @@ import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 public class CassandraAllDataTypesIT extends SourceDbToSpannerITBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(MySQLDataTypesIT.class);
+  public static final String CUSTOM_TRANSFORMATION_ALL_DATA_TYPES_GCS_PREFIX =
+      "CustomTransformationAllDataTypes";
   private static PipelineLauncher.LaunchInfo jobInfo;
 
-  public static CassandraResourceManager cassandraResourceManager;
-  public static SpannerResourceManager spannerResourceManager;
+  private static CassandraResourceManager cassandraResourceManager;
+  private static SpannerResourceManager spannerResourceManager;
+  private static final List<FlexTemplateDataflowJobResourceManager>
+      dlqFlexTemplateDataflowJobResourceManagers = Collections.synchronizedList(new ArrayList<>());
 
   private static final String CASSANDRA_DUMP_FILE_RESOURCE =
       "DataTypesIT/cassandra-data-types.csql";
 
   private static final String SPANNER_DDL_RESOURCE = "DataTypesIT/cassandra-spanner-schema.sql";
+  private static final Integer DLQ_RETRY_MINUTES = 1;
+
+  private FlexTemplateDataflowJobResourceManager launchDlqReplay(LaunchInfo bulkJobInfo)
+      throws IOException, InterruptedException {
+    String dlqGcsPath = getDlqPath(bulkJobInfo);
+    String dlqJobName = PipelineUtils.createJobName("dlq-" + getClass().getSimpleName());
+    LOG.info(
+        "Bulk Job ID = {}, DLQ Job Name = {}, bulkInfo = {}",
+        bulkJobInfo.jobId(),
+        dlqJobName,
+        bulkJobInfo);
+
+    createAndUploadJarToGcs(CUSTOM_TRANSFORMATION_ALL_DATA_TYPES_GCS_PREFIX);
+    CustomTransformation customTransformation =
+        CustomTransformation.builder(
+                getCustomTransformPath(bulkJobInfo) + "/customTransformation.jar",
+                "com.custom.CustomTransformationForCassandraAllDataTypesIT")
+            .build();
+
+    // TODO(b/421826801): Add a Cassandra Source type in datastream-to-spanner.
+    FlexTemplateDataflowJobResourceManager flexTemplateDataflowJobResourceManager =
+        FlexTemplateDataflowJobResourceManager.builder(dlqJobName)
+            .withTemplateName("Cloud_Datastream_to_Spanner")
+            .withTemplateModulePath("v2/datastream-to-spanner")
+            .addParameter("instanceId", spannerResourceManager.getInstanceId())
+            .addParameter("databaseId", spannerResourceManager.getDatabaseId())
+            .addParameter("deadLetterQueueDirectory", dlqGcsPath)
+            .addParameter("streamName", "ignore")
+            .addParameter("runMode", "retryDLQ")
+            .addParameter("datastreamSourceType", "mysql")
+            .addParameter("transformationJarPath", customTransformation.jarPath())
+            .addParameter("transformationClassName", customTransformation.classPath())
+            .addParameter("dlqRetryMinutes", DLQ_RETRY_MINUTES.toString())
+            .addEnvironmentVariable(
+                "additionalExperiments", List.of("use_runner_v2", "enable_data_sampling"))
+            .build();
+
+    dlqFlexTemplateDataflowJobResourceManagers.add(flexTemplateDataflowJobResourceManager);
+    LaunchInfo dlqJobInfo = flexTemplateDataflowJobResourceManager.launchJob();
+    assertThatPipeline(dlqJobInfo).isRunning();
+    return flexTemplateDataflowJobResourceManager;
+  }
+
+  private static String getDlqPath(LaunchInfo bulkJobInfo) {
+    return bulkJobInfo.parameters().get("outputDirectory").replaceAll("/$", "") + "/dlq/";
+  }
+
+  private static String getDlqBucketName(LaunchInfo bulkJobInfo) {
+    return getBucketName(getDlqPath(bulkJobInfo));
+  }
+
+  private static String getBucketName(String path) {
+    return path.split("gs://")[1].split("/")[0];
+  }
+
+  private static String getObjectPath(String path) {
+    return path.replaceAll("gs://" + getBucketName(path) + "/", "");
+  }
+
+  private String getCustomTransformPath(LaunchInfo bulkJobInfo) {
+    return "gs://"
+        + gcsClient.getBucket()
+        + "/"
+        + gcsClient.getPathForArtifact(CUSTOM_TRANSFORMATION_ALL_DATA_TYPES_GCS_PREFIX);
+  }
 
   /**
    * Setup resource managers and Launch dataflow job once during the execution of this test class. \
@@ -75,7 +163,12 @@ public class CassandraAllDataTypesIT extends SourceDbToSpannerITBase {
   /** Cleanup dataflow job and all the resources and resource managers. */
   @After
   public void cleanUp() {
+    if (skipBaseCleanup) {
+      ResourceManagerUtils.cleanResources(cassandraResourceManager);
+      return;
+    }
     ResourceManagerUtils.cleanResources(spannerResourceManager, cassandraResourceManager);
+    dlqFlexTemplateDataflowJobResourceManagers.forEach(ResourceManagerUtils::cleanResources);
   }
 
   @Test
@@ -94,6 +187,48 @@ public class CassandraAllDataTypesIT extends SourceDbToSpannerITBase {
     PipelineOperator.Result result =
         pipelineOperator().waitUntilDone(createConfig(jobInfo, Duration.ofMinutes(35L)));
     assertThatResult(result).isLaunchFinished();
+    LOG.info(
+        "Listing DLQ Entries from output director {} , dlq path {}, bucket {} ",
+        jobInfo.parameters().get("outputDirectory"),
+        getDlqPath(jobInfo),
+        getDlqBucketName(jobInfo));
+    List<String> dlqFiles = getDlqFileList(jobInfo);
+    LOG.info("DLQ Entries from {} are {}", getDlqPath(jobInfo), dlqFiles);
+    assertThat(dlqFiles).isNotEmpty();
+    // DLQ Replay.
+    FlexTemplateDataflowJobResourceManager dlqResourceManager = launchDlqReplay(jobInfo);
+    LaunchInfo dlqJobInfo = dlqResourceManager.getJobInfo();
+    Result dlqResult =
+        pipelineOperator()
+            .waitForCondition(
+                createConfig(dlqJobInfo, Duration.ofMinutes(10)),
+                new ConditionCheck() {
+                  @Override
+                  protected @UnknownKeyFor @NonNull @Initialized String getDescription() {
+                    return "Check if DLQ directory is empty";
+                  }
+
+                  @Override
+                  protected @UnknownKeyFor @NonNull @Initialized CheckResult check() {
+                    if (getDlqFileList(jobInfo).isEmpty()) {
+                      try {
+                        Thread.sleep(60 * 1000);
+                      } catch (InterruptedException e) {
+                        return new CheckResult(false);
+                      }
+                      if (getDlqFileList(jobInfo).isEmpty()) {
+                        Long rowCount = spannerResourceManager.getRowCount("all_data_types");
+                        LOG.info(
+                            "dlq File List is {}, row count = {}",
+                            getDlqFileList(jobInfo),
+                            rowCount);
+                        return new CheckResult(rowCount > 3);
+                      }
+                    }
+                    return new CheckResult(false);
+                  }
+                });
+    assertThatResult(dlqResult).meetsConditions();
 
     // Validate supported data types.
     Map<String, List<Map<String, String>>> expectedData = getExpectedData();
@@ -124,6 +259,22 @@ public class CassandraAllDataTypesIT extends SourceDbToSpannerITBase {
     }
   }
 
+  @NotNull
+  private static List<String> getDlqFileList(LaunchInfo bulkJobInfo) {
+    Storage storage =
+        StorageOptions.newBuilder().setProjectId(bulkJobInfo.projectId()).build().getService();
+    String dlqGcsPath = getDlqPath(bulkJobInfo);
+    List<String> dlqFiles =
+        storage
+            .list(
+                getDlqBucketName(bulkJobInfo),
+                BlobListOption.prefix(dlqGcsPath.replaceFirst("^gs://[^/]+/?", "")))
+            .streamAll()
+            .map(BlobInfo::getName)
+            .collect(Collectors.toList());
+    return dlqFiles;
+  }
+
   private Map<String, List<Map<String, String>>> getExpectedData() {
     Map<String, List<Map<String, String>>> expectedData = new HashMap<>();
     expectedData.put("all_data_types", getAllDataTypeRows());
@@ -133,6 +284,20 @@ public class CassandraAllDataTypesIT extends SourceDbToSpannerITBase {
   private List<Map<String, String>> getAllDataTypeRows() {
     List<Map<String, String>> allDataTypeRows = new ArrayList<>();
     allDataTypeRows.add(getAllDataTypeNullRow());
+    allDataTypeRows.add(
+        getAllDataTypeDlqRow().entrySet().stream()
+            // TODO(b/422928714) : Remove this after Arrarys are supported in Live template.
+            .map(
+                e -> {
+                  if (e.getKey().contains("_set_col")) {
+                    return Map.entry(e.getKey(), "NULL");
+                  } else if (e.getKey().contains("_list_col")) {
+                    return Map.entry(e.getKey(), "NULL");
+                  } else {
+                    return e;
+                  }
+                })
+            .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue)));
     allDataTypeRows.add(getAllDataTypeMaxRow());
     allDataTypeRows.add(getAllDataTypeMinRow());
     return allDataTypeRows;
@@ -412,6 +577,132 @@ public class CassandraAllDataTypesIT extends SourceDbToSpannerITBase {
             "[00000000-0000-4000-9000-900000000000,88888888-8888-4888-9888-888888888888,ffffffff-ffff-4fff-9fff-ffffffffffff]")
         .put("boolean_decimal_map_col", "{\"false\":\"0.0\",\"true\":\"0.1\"}")
         .put("primary_key", "e6bc8562-2575-420f-9344-9fedc4945f61")
+        .put("blob_set_col", "[AAAAAAAAAAA=,////////]")
+        .put("varchar_col", "~~~~~~~")
+        .put("inet_text_map_col", "{\"/0.0.0.0\":\"test-text\"}")
+        .put("varint_set_col", "[-9223372036854775808,0,9223372036854775808]")
+        .put("tinyint_list_col", "[-128,0,127]")
+        .put(
+            "timestamp_uuid_map_col",
+            "{\"1969-12-31T23:59:59.999Z\":\"ffffffff-ffff-1fff-9fff-ffffffffffff\",\"1970-01-01T00:00:00Z\":\"00000000-0000-1000-9000-000000000000\"}")
+        .put(
+            "decimal_duration_map_col",
+            "{\"12.34\":\"{\\\"years\\\": 0, \\\"months\\\": 0, \\\"days\\\": -10675199, \\\"hours\\\": 0, \\\"minutes\\\": 0, \\\"seconds\\\": 0, \\\"nanos\\\": -10085000000000}\",\"34.45\":\"{\\\"years\\\": 0, \\\"months\\\": 0, \\\"days\\\": 10675199, \\\"hours\\\": 0, \\\"minutes\\\": 0, \\\"seconds\\\": 0, \\\"nanos\\\": 10085000000000}\"}")
+        .put("tinyint_col", "127")
+        .put(
+            "decimal_list_col",
+            "[-99999999999999999999999999999.999999999,0,99999999999999999999999999999.999999999]")
+        .put("inet_set_col", "[/0.0.0.0,/172.16.0.0,/255.255.255.255]")
+        .put(
+            "timeuuid_varchar_map_col",
+            "{\"00000000-0000-1000-9000-000000000000\":\"abc\",\"ffffffff-ffff-1fff-9fff-ffffffffffff\":\"def\"}")
+        .put("duration_list_col", "[P-10675199DT-2H-48M-5S,P0D,P10675199DT2H48M5S]")
+        .put("double_col", "1.7976931348623157E308")
+        .put("duration_col", "P10675199DT2H48M5S")
+        .put("frozen_ascii_set_col", "[a,b]")
+        .build();
+  }
+
+  private Map<String, String> getAllDataTypeDlqRow() {
+
+    return ImmutableMap.<String, String>builder()
+        .put("uuid_col", "ffffffff-ffff-4fff-9fff-ffffffffffff")
+        .put(
+            "double_float_map_col",
+            "{\"-Infinity\":\"0.0\",\"1.7976931348623157E308\":\"Infinity\",\"3.14\":\"-Infinity\",\"Infinity\":\"NaN\",\"NaN\":\"3.14\"}")
+        .put("int_col", "2147483647")
+        .put(
+            "decimal_set_col",
+            "[-99999999999999999999999999999.999999999,0,99999999999999999999999999999.999999999]")
+        .put(
+            "date_double_map_col",
+            "{\"1970-01-01\":\"NaN\",\"1970-11-01\":\"3.14\",\"1971-01-01\":\"Infinity\",\"1990-01-01\":\"-Infinity\",\"2970-01-01\":\"0.0\"}")
+        .put(
+            "uuid_ascii_map_col",
+            "{\"00000000-0000-1000-9000-000000000000\":\"abc\",\"ffffffff-ffff-1fff-9fff-ffffffffffff\":\"def\"}")
+        .put("ascii_text_map_col", "{\"a\":\"z\",\"z\":\"a\"}")
+        .put(
+            "timestamp_list_col",
+            "[1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,1969-12-31T23:59:59.999000000Z]")
+        .put("date_col", "2038-01-19")
+        .put("int_set_col", "[-2147483648,0,2147483647]")
+        .put("blob_col", "////////")
+        .put("smallint_set_col", "[-32768,0,32767]")
+        .put("varchar_list_col", "[a,~]")
+        .put("inet_list_col", "[/0.0.0.0,/172.16.0.0,/255.255.255.255]")
+        .put("bigint_list_col", "[-9223372036854775808,0,9223372036854775807]")
+        .put(
+            "tinyint_varint_map_col",
+            "{\"-128\":\"184467440000000000000\",\"127\":\"-184467440000000000000\"}")
+        .put("text_set_col", "[G,KNOWS,LEONARDO,LER,MATHEMATICIAN,O,OG]")
+        .put("double_set_col", "[-Infinity,-1.7976931348623157E308,0.0,3.1415926,Infinity,NaN]")
+        .put("time_list_col", "[0,86399999999999]")
+        .put("frozen_ascii_list_col", "[a,b]")
+        .put("int_list_col", "[-2147483648,0,2147483647]")
+        .put("ascii_list_col", "[a,~]")
+        .put("date_set_col", "[1901-12-13,1970-01-01,2038-01-19]")
+        .put("double_inet_map_col", "{\"3.14\":\"/255.255.255.255\",\"Infinity\":\"/0.0.0.0\"}")
+        .put(
+            "timestamp_set_col",
+            "[1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,1969-12-31T23:59:59.999000000Z]")
+        .put("ascii_col", "~~~~~~~")
+        .put("time_tinyint_map_col", "{\"0\":\"127\",\"86399999999999\":\"-128\"}")
+        .put("float_col", "3.4028235E38")
+        .put("bigint_set_col", "[-9223372036854775808,0,9223372036854775807]")
+        .put("varchar_set_col", "[a,~]")
+        .put("timestamp_col", "1969-12-31T23:59:59.999000000Z")
+        .put("tinyint_set_col", "[-128,0,127]")
+        .put("time_col", "86399999999999")
+        .put("bigint_boolean_map_col", "{\"42\":\"true\",\"84\":\"false\"}")
+        .put("text_list_col", "[G,O,OG,LER,KNOWS,LEONARDO,MATHEMATICIAN]")
+        .put("boolean_list_col", "[true,false]")
+        .put("blob_list_col", "[AAAAAAAAAAA=,////////]")
+        .put(
+            "timeuuid_set_col",
+            "[00000000-0000-1000-9000-000000000000,88888888-8888-1888-9888-888888888888,ffffffff-ffff-1fff-9fff-ffffffffffff]")
+        .put("int_time_map_col", "{\"1\":\"0\",\"42\":\"2400\"}")
+        .put("timeuuid_col", "ffffffff-ffff-1fff-9fff-ffffffffffff")
+        .put("time_set_col", "[0,86399999999999]")
+        .put("boolean_set_col", "[false,true]")
+        .put("bigint_col", "9223372036854775807")
+        .put("float_set_col", "[-Infinity,-3.4028235E38,0.0,3.4028235E38,Infinity,NaN]")
+        .put("boolean_col", "true")
+        .put("ascii_set_col", "[a,~]")
+        .put(
+            "uuid_list_col",
+            "[00000000-0000-4000-9000-900000000000,88888888-8888-4888-9888-888888888888,ffffffff-ffff-4fff-9fff-ffffffffffff]")
+        .put(
+            "varchar_bigint_map_col",
+            "{\"abcd\":\"-9223372036854775808\",\"efgh\":\"9223372036854775807\"}")
+        .put("blob_int_map_col", "{\"AAAAAAAAAAE=\":\"1\",\"AAAAAAAAACo=\":\"42\"}")
+        .put("smallint_col", "32767")
+        .put(
+            "varint_blob_map_col",
+            "{\"-184467440000000000000\":\"8000000000000000\",\"184467440000000000000\":\"7fffffffffffffff\"}")
+        .put("double_list_col", "[NaN,-Infinity,-1.7976931348623157E308,0.0,3.1415926,Infinity]")
+        .put("float_list_col", "[NaN,-Infinity,-3.4028235E38,0.0,3.4028235E38,Infinity]")
+        .put("smallint_list_col", "[-32768,0,32767]")
+        .put("varint_list_col", "[-9223372036854775808,0,9223372036854775808]")
+        .put("text_col", "NULL")
+        .put("float_smallint_map_col", "{\"3.14\":\"32767\",\"Infinity\":\"-32768\"}")
+        .put(
+            "smallint_timestamp_map_col",
+            "{\"-128\":\"1970-01-01T00:00:00Z\",\"127\":\"1969-12-31T23:59:59.999Z\"}")
+        .put(
+            "text_timeuuid_map_col",
+            "{\"a\":\"00000000-0000-1000-9000-000000000000\",\"~\":\"ffffffff-ffff-1fff-9fff-ffffffffffff\"}")
+        .put(
+            "timeuuid_list_col",
+            "[00000000-0000-1000-9000-000000000000,88888888-8888-1888-9888-888888888888,ffffffff-ffff-1fff-9fff-ffffffffffff]")
+        .put("decimal_col", "3.1416")
+        .put("inet_col", "/255.255.255.255")
+        .put("date_list_col", "[1901-12-13,1970-01-01,2038-01-19]")
+        .put("varint_col", "9223372036854775808")
+        .put(
+            "uuid_set_col",
+            "[00000000-0000-4000-9000-900000000000,88888888-8888-4888-9888-888888888888,ffffffff-ffff-4fff-9fff-ffffffffffff]")
+        .put("boolean_decimal_map_col", "{\"false\":\"0.0\",\"true\":\"0.1\"}")
+        .put("primary_key", "d19c8562-2575-420f-9344-9fedc4945f61")
         .put("blob_set_col", "[AAAAAAAAAAA=,////////]")
         .put("varchar_col", "~~~~~~~")
         .put("inet_text_map_col", "{\"/0.0.0.0\":\"test-text\"}")

--- a/v2/sourcedb-to-spanner/src/test/resources/DataTypesIT/cassandra-data-types.csql
+++ b/v2/sourcedb-to-spanner/src/test/resources/DataTypesIT/cassandra-data-types.csql
@@ -595,3 +595,174 @@ VALUES (
     {'abcd':-9223372036854775808,'efgh':9223372036854775807}, -- varchar_bigint_map_col
     {184467440000000000000:BigIntAsBlob(9223372036854775807), -184467440000000000000:BigintAsBlob(-9223372036854775808)} -- varint_blob_map_col
 );
+INSERT INTO all_data_types
+(
+    primary_key,
+    ascii_col,
+    bigint_col,
+    blob_col,
+    boolean_col,
+    date_col,
+    decimal_col,
+    double_col,
+    duration_col,
+    float_col,
+    inet_col,
+    int_col,
+    smallint_col,
+    text_col,
+    time_col,
+    timestamp_col,
+    timeuuid_col,
+    tinyint_col,
+    uuid_col,
+    varchar_col,
+    varint_col,
+    ascii_list_col,
+    frozen_ascii_list_col,
+    bigint_list_col,
+    blob_list_col,
+    boolean_list_col,
+    date_list_col,
+    decimal_list_col,
+    double_list_col,
+    duration_list_col,
+    float_list_col,
+    inet_list_col,
+    int_list_col,
+    smallint_list_col,
+    text_list_col,
+    time_list_col,
+    timestamp_list_col,
+    timeuuid_list_col,
+    tinyint_list_col,
+    uuid_list_col,
+    varchar_list_col,
+    varint_list_col,
+    ascii_set_col,
+    frozen_ascii_set_col,
+    bigint_set_col,
+    blob_set_col,
+    boolean_set_col,
+    date_set_col,
+    decimal_set_col,
+    double_set_col,
+    float_set_col,
+    inet_set_col,
+    int_set_col,
+    smallint_set_col,
+    text_set_col,
+    time_set_col,
+    timestamp_set_col,
+    timeuuid_set_col,
+    tinyint_set_col,
+    uuid_set_col,
+    varchar_set_col,
+    varint_set_col,
+    ascii_text_map_col,
+    bigint_boolean_map_col,
+    blob_int_map_col,
+    boolean_decimal_map_col,
+    date_double_map_col,
+    decimal_duration_map_col,
+    double_float_map_col,
+    double_inet_map_col,
+    float_smallint_map_col,
+    inet_text_map_col,
+    int_time_map_col,
+    smallint_timestamp_map_col,
+    text_timeuuid_map_col,
+    time_tinyint_map_col,
+    timestamp_uuid_map_col,
+    timeuuid_varchar_map_col,
+    tinyint_varint_map_col,
+    uuid_ascii_map_col,
+    varchar_bigint_map_col,
+    varint_blob_map_col
+)
+VALUES (
+    d19c8562-2575-420f-9344-9fedc4945f61, -- primary_key
+    '~~~~~~~', -- ascii_col with max ascii character.
+    9223372036854775807, -- max bigint_col
+    0xFFFFFFFFFFFF, -- max blob_col
+    true, -- max boolean_col
+    -- < 5.0, Cassandra has Y38 issue.
+    -- https://github.com/apache/cassandra/blob/trunk/NEWS.txt
+    '2038-01-19', -- max date_col
+    31415926535897932384626433832795028841971, -- pi*10^41, does not fit in spanner, should land in DLQ.
+    1.7976931348623157E308, -- max double_col
+    P10675199DT2H48M5S, -- max duration_col
+    3.4028235E38, -- max float_col
+    '255.255.255.255', -- max inet_col
+    2147483647, -- max int_col
+    32767, -- max smallint_col
+    null, -- max text_col
+    86399999999999, -- max time_col (nanos since mid night)
+    9223372036854775807, -- max timestamp_col
+    ffffffff-ffff-1fff-9fff-ffffffffffff, -- max timeuuid_col (version1)
+    127, -- max tinyint_col
+    ffffffff-ffff-4fff-9fff-ffffffffffff, -- max uuid_col
+    '~~~~~~~', -- varchar_col
+    9223372036854775808, -- large varint_col
+    ['a', '~'], -- ascii_list_col
+    ['a', 'b'], -- frozen_ascii_list_col
+    [-9223372036854775808, 0, 9223372036854775807], -- bigint_list_col
+    [BigintAsBlob(0), 0xFFFFFFFFFFFF], -- blob_list_col
+    [true, false], -- boolean_list_col
+    ['1901-12-13', '1970-01-01', '2038-01-19'], -- date_list_col
+    [-99999999999999999999999999999.999999999, 0.0, 99999999999999999999999999999.999999999], -- decimal_list_col
+    [NAN, -1 * INFINITY, -1.7976931348623157E308, 0.0, 3.1415926, INFINITY], -- double_list_col
+    [-P10675199DT2H48M5S, P0DT0S, P10675199DT2H48M5S], -- duration_list_col
+    [NAN, -1 * INFINITY, -3.4028235E38, 0.0, 3.4028235E38, INFINITY], -- float_list_col
+    ['0.0.0.0', '172.16.0.0', '255.255.255.255'], -- inet_list_col
+    [-2147483648,0,2147483647], -- int_list_col
+    [-32768, 0, 32767], -- smallint_list_col
+    ['G', 'O', 'OG', 'LER', 'KNOWS', 'LEONARDO', 'MATHEMATICIAN'], -- text_list_col
+    [0, 86399999999999], -- time_list_col
+    [-9223372036854775808, 0, 9223372036854775807], -- timestamp_list_col
+    [00000000-0000-1000-9000-000000000000, 88888888-8888-1888-9888-888888888888, ffffffff-ffff-1fff-9fff-ffffffffffff], -- timeuuid_list_col
+    [-128, 0, 127], -- tinyint_list_col
+    [00000000-0000-4000-9000-900000000000, 88888888-8888-4888-9888-888888888888 ,ffffffff-ffff-4fff-9fff-ffffffffffff], -- uuid_list_col
+    ['a', '~'], -- varchar_list_col
+    [-9223372036854775808, 0, 9223372036854775808], -- varint_list_col
+    {'a', '~'}, -- ascii_set_col
+    {'a', 'b'}, -- frozen_ascii_set_col
+    {-9223372036854775808, 0, 9223372036854775807}, -- bigint_set_col
+    {BigintAsBlob(0), 0xFFFFFFFFFFFF}, -- blob_set_col
+    {true, false}, -- boolean_set_col
+    {'1901-12-13', '1970-01-01', '2038-01-19'}, -- date_set_col
+    {-99999999999999999999999999999.999999999, 0.0, 99999999999999999999999999999.999999999}, -- decimal_set_col
+    {NAN, -1 * INFINITY, -1.7976931348623157E308, 0.0, 3.1415926, INFINITY}, -- double_set_col
+    {NAN, -1 * INFINITY, -3.4028235E38, 0.0, 3.4028235E38, INFINITY}, -- float_set_col
+    {'0.0.0.0', '172.16.0.0', '255.255.255.255'}, -- inet_set_col
+    {-2147483648,0,2147483647}, -- int_set_col
+    {-32768, 0, 32767}, -- smallint_set_col
+    {'G', 'O', 'OG', 'LER', 'KNOWS', 'LEONARDO', 'MATHEMATICIAN'}, -- text_set_col
+    {0, 86399999999999}, -- time_set_col
+    {-9223372036854775808, 0, 9223372036854775807}, -- timestamp_set_col
+    {00000000-0000-1000-9000-000000000000, 88888888-8888-1888-9888-888888888888, ffffffff-ffff-1fff-9fff-ffffffffffff}, -- timeuuid_set_col
+    {-128, 0, 127}, -- tinyint_set_col
+    {00000000-0000-4000-9000-900000000000, 88888888-8888-4888-9888-888888888888 ,ffffffff-ffff-4fff-9fff-ffffffffffff}, -- uuid_set_col
+    {'a', '~'}, -- varchar_set_col
+    {-9223372036854775808, 0, 9223372036854775808}, -- varint_set_col
+    {'a':'z', 'z':'a'}, -- ascii_text_map_col
+    {42:true, 84:false}, -- bigint_boolean_map_col
+    {BigintAsBlob(1):1, BigintAsBlob(42):42}, -- blob_int_map_col
+    {true:0.1, false:0.0}, -- boolean_decimal_map_col
+    {'1970-01-01':NAN, '1990-01-01':-INFINITY, '2970-01-01':0.0,'1970-11-01':3.14,'1971-01-01':INFINITY}, --  date_double_map_col
+    {12.34:-P10675199DT2H48M5S, 34.45:P10675199DT2H48M5S}, -- max decimal_duration_map_col
+    {INFINITY:NAN, 3.14:-INFINITY, -INFINITY:0.0,NAN:3.14, 1.7976931348623157E308:INFINITY}, --  double_float_map_col
+    {INFINITY:'0.0.0.0', 3.14:'255.255.255.255'}, --  double_inet_map_col
+    {INFINITY:-32768, 3.14:32767}, --  float_smallint_map_col
+    {'0.0.0.0':'test-text'}, -- inet_text_map_col
+    {1:0, 42:2400}, -- int_time_map_col
+    {-128:-9223372036854775808, 127:9223372036854775807}, -- smallint_timestamp_map_col
+    {'a':00000000-0000-1000-9000-000000000000, '~':ffffffff-ffff-1fff-9fff-ffffffffffff}, -- text_timeuuid_map_col
+    {86399999999999:-128, 0:127}, -- time_tinyint_map_col
+    {-9223372036854775808:00000000-0000-1000-9000-000000000000, 9223372036854775807:ffffffff-ffff-1fff-9fff-ffffffffffff}, -- timestamp_uuid_map_col
+    {00000000-0000-1000-9000-000000000000:'abc', ffffffff-ffff-1fff-9fff-ffffffffffff:'def'}, -- timeuuid_varchar_map_col
+    {-128:184467440000000000000,127:-184467440000000000000}, -- tinyint_varint_map_col
+    {00000000-0000-1000-9000-000000000000:'abc', ffffffff-ffff-1fff-9fff-ffffffffffff:'def'}, -- uuid_ascii_map_col
+    {'abcd':-9223372036854775808,'efgh':9223372036854775807}, -- varchar_bigint_map_col
+    {184467440000000000000:BigIntAsBlob(9223372036854775807), -184467440000000000000:BigintAsBlob(-9223372036854775808)} -- varint_blob_map_col
+);

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertor.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertor.java
@@ -40,8 +40,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.apache.arrow.util.VisibleForTesting;
 import org.apache.avro.Conversions;
 import org.apache.avro.LogicalType;
@@ -91,6 +93,34 @@ public class GenericRecordTypeConvertor {
     this.namespace = namespace;
     this.shardId = shardId;
     this.customTransformer = customTransformer;
+  }
+
+  public static Object getJsonNodeObjectFromGenericRecord(
+      @Nullable GenericRecord record,
+      Schema.Field f,
+      String srcTableName,
+      ISchemaMapper schemaMapper) {
+    String fieldName = f.name();
+    if (record == null) {
+      return null;
+    }
+    Object recordValue = record.get(fieldName);
+    if (recordValue == null) {
+      return null;
+    }
+    Schema fieldSchema = filterNullSchema(f.schema(), fieldName, recordValue);
+    CassandraAnnotations cassandraAnnotations = null;
+    try {
+      cassandraAnnotations =
+          schemaMapper.getSpannerColumnCassandraAnnotations(
+              "",
+              schemaMapper.getSpannerTableName("", srcTableName),
+              schemaMapper.getSpannerColumnName("", srcTableName, fieldName));
+    } catch (NoSuchElementException e) {
+      // For Non-Existant Columns or Tables, we initialize Cassandra Annotations to empty array.
+      cassandraAnnotations = CassandraAnnotations.fromColumnOptions(List.of(), fieldName);
+    }
+    return handleNonPrimitiveAvroTypes(recordValue, fieldSchema, fieldName, cassandraAnnotations);
   }
 
   /**
@@ -413,7 +443,8 @@ public class GenericRecordTypeConvertor {
    * not a union, or if it's a union with more than two types or a non-nullable type other than
    * NULL, an IllegalArgumentException is thrown.
    */
-  private Schema filterNullSchema(Schema fieldSchema, String recordColName, Object recordValue) {
+  private static Schema filterNullSchema(
+      Schema fieldSchema, String recordColName, Object recordValue) {
     if (fieldSchema.getType().equals(Schema.Type.UNION)) {
       List<Schema> types = fieldSchema.getTypes();
       LOG.debug("found union type: {}", types);

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/convertors/ChangeEventSpannerConvertor.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/convertors/ChangeEventSpannerConvertor.java
@@ -24,6 +24,7 @@ import com.google.cloud.teleport.v2.spanner.ddl.IndexColumn;
 import com.google.cloud.teleport.v2.spanner.ddl.Table;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.ChangeEventConvertorException;
 import com.google.cloud.teleport.v2.spanner.type.Type;
+import com.google.cloud.teleport.v2.spanner.type.Type.Code;
 import com.google.common.collect.ImmutableList;
 import java.util.HashSet;
 import java.util.List;
@@ -120,6 +121,10 @@ public class ChangeEventSpannerConvertor {
           columnValue =
               Value.date(ChangeEventTypeConvertor.toDate(changeEvent, colName, requiredField));
           break;
+        case ARRAY:
+          // TODO(b/422928714): Add support for Array types.
+          columnValue = null;
+          break;
           // TODO(b/179070999) - Add support for other data types.
         default:
           throw new IllegalArgumentException(
@@ -129,7 +134,10 @@ public class ChangeEventSpannerConvertor {
                   + columnType.getCode()
                   + ")");
       }
-      builder.set(columnName).to(columnValue);
+      // TODO(b/422928714): Add support for Array types.
+      if (columnType.getCode() != Code.ARRAY) {
+        builder.set(columnName).to(columnValue);
+      }
     }
     return builder;
   }

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/convertors/ChangeEventToMapConvertor.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/convertors/ChangeEventToMapConvertor.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import org.jline.utils.Log;
 import org.json.JSONObject;
 
 public class ChangeEventToMapConvertor {
@@ -82,6 +83,8 @@ public class ChangeEventToMapConvertor {
       } else if (columnValue instanceof String) {
         ((ObjectNode) changeEvent).put(columnName, (String) columnValue);
       } else {
+        Log.error(
+            "Column name(" + columnName + ") has unsupported column value(" + columnValue + ")");
         throw new InvalidTransformationException(
             "Column name(" + columnName + ") has unsupported column value(" + columnValue + ")");
       }

--- a/v2/spanner-custom-shard/pom.xml
+++ b/v2/spanner-custom-shard/pom.xml
@@ -49,6 +49,36 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <configuration>
+                    <excludes>
+                        <!-- Excluding exception classes -->
+                        <exclude>**/*Exception.*</exclude>
+                        <!-- Excluding auto-generated classes. -->
+                        <exclude>**/*AutoValue_*</exclude>
+                        <exclude>**/CustomTransformationForCassandraAllDataTypesIT.*</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/v2/spanner-custom-shard/src/main/java/com/custom/CustomTransformationForCassandraAllDataTypesIT.java
+++ b/v2/spanner-custom-shard/src/main/java/com/custom/CustomTransformationForCassandraAllDataTypesIT.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.custom;
+
+import com.google.cloud.teleport.v2.spanner.exceptions.InvalidTransformationException;
+import com.google.cloud.teleport.v2.spanner.utils.ISpannerMigrationTransformer;
+import com.google.cloud.teleport.v2.spanner.utils.MigrationTransformationRequest;
+import com.google.cloud.teleport.v2.spanner.utils.MigrationTransformationResponse;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Class used only for Integration test. Do not use for production. */
+public class CustomTransformationForCassandraAllDataTypesIT
+    implements ISpannerMigrationTransformer {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CustomTransformationForCassandraAllDataTypesIT.class);
+
+  @Override
+  public void init(String parameters) {
+    LOG.info("init called with {}", parameters);
+  }
+
+  @Override
+  public MigrationTransformationResponse toSpannerRow(MigrationTransformationRequest request)
+      throws InvalidTransformationException {
+    LOG.info(
+        "Got transformation request {}\ntableName = {}\nrow={}",
+        request,
+        request.getTableName(),
+        request.getRequestRow());
+    if (request.getTableName().toLowerCase().equals("all_data_types")) {
+      Map<String, Object> row = new HashMap<>(request.getRequestRow());
+      BigDecimal decimalCol = new BigDecimal(row.get("decimal_col").toString());
+      LOG.info("DecimalCol is {}\nrow is {}", decimalCol, row);
+      String newDecimalCol =
+          decimalCol
+              .divide((new BigDecimal(10)).pow(40))
+              .setScale(4, RoundingMode.HALF_DOWN)
+              .toString();
+      row.remove("decimal_col");
+      row.<String, String>put("decimal_col", newDecimalCol);
+      LOG.info("NewDecimalCol is {}\n new row is {}\n", newDecimalCol, row);
+      MigrationTransformationResponse response = new MigrationTransformationResponse(row, false);
+      return response;
+    }
+    LOG.error("Returning request without processing {}", request);
+    return new MigrationTransformationResponse(null, false);
+  }
+
+  @Override
+  public MigrationTransformationResponse toSourceRow(MigrationTransformationRequest request)
+      throws InvalidTransformationException {
+    throw new UnsupportedOperationException(
+        "This test custom transform is not intended for reverse replication.");
+  }
+}


### PR DESCRIPTION
## Overview

Adding End to End dlq handling  testfor All data types in Cassandra across Bullk and live templates.
TODO: 
1. b/421826801  - Implementing Cassandra as a source in Live template.
2. b/266041306 - Array support for Live template
## Note on
Unit testing - All lines are covered except - 
1. Logs added in `SpannerTransactionWriterDoFn` for debugability.
2. `MigrateTableTransform` - This class does not have a UT in bulk as of now as that involves wiring up entire pipeline. Adding that would be outside the scope of this PR