### PR TITLE
optimized the run schedules

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -11,7 +11,7 @@ permissions: read-all
 jobs:
   load_tests:
     name: Dataflow Templates Load tests
-    timeout-minutes: 2880 # 2 days
+    timeout-minutes: 4320 # 3 days
     # Run on any runner that matches all the specified runs-on values.
     runs-on: [ self-hosted, perf ]
     steps:

--- a/.github/workflows/spanner-load-tests.yml
+++ b/.github/workflows/spanner-load-tests.yml
@@ -18,8 +18,8 @@ name: Spanner Load Tests
 
 on:
   schedule:
-  # at 02:00 weekly on every Monday.
-  - cron: '0 2 * * 1'
+  # at 02:00 weekly on every Friday.
+  - cron: '0 2 * * 5'
   workflow_dispatch:
 
 permissions: write-all


### PR DESCRIPTION
Load tests can run for more than 2 days. To avoid overlapping with the spanner load tests, move spanner tests to Friday.