### PR TITLE
Cancel previous PR workflow run on the same PR

### DIFF
--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -43,7 +43,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -134,7 +134,7 @@ jobs:
         id: setup-env
         uses: ./.github/actions/setup-env
       - name: Run Integration Smoke Tests
-        run: | 
+        run: |
           ./cicd/run-it-smoke-tests \
           --modules-to-build="DEFAULT" \
           --it-region="us-central1" \
@@ -164,7 +164,7 @@ jobs:
         id: setup-env
         uses: ./.github/actions/setup-env
       - name: Run Integration Tests
-        run: | 
+        run: |
           ./cicd/run-it-tests \
           --modules-to-build="DEFAULT" \
           --it-region="us-central1" \

--- a/.github/workflows/kafka-pr.yml
+++ b/.github/workflows/kafka-pr.yml
@@ -40,7 +40,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/spanner-pr.yml
+++ b/.github/workflows/spanner-pr.yml
@@ -43,7 +43,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
Fixes #2159

For Pull Request events, `github.event.pull_request.number` provides a stable identifier for the PR. This ensures all runs for the same PR belong to the same concurrency group.
