### PR TITLE
added JDBC_DRIVER_CLASS_NAME

### DIFF
--- a/python/src/test/java/com/google/cloud/teleport/templates/python/JdbcToBigQueryYamlIT.java
+++ b/python/src/test/java/com/google/cloud/teleport/templates/python/JdbcToBigQueryYamlIT.java
@@ -113,6 +113,8 @@ public class JdbcToBigQueryYamlIT extends JDBCBaseIT {
     String password = postgresResourceManager.getPassword();
     String query = String.format("SELECT %s, %s, %s FROM %s", ROW_ID, NAME, AGE, JDBC_TABLE_NAME);
 
+    // TODO: when Beam 2.66.0 is released, JDBC_DRIVER_JARS and JDBC_DRIVER_CLASS_NAME can be
+    // removed
     String jinjaVars =
         String.format(
             "{"
@@ -120,15 +122,17 @@ public class JdbcToBigQueryYamlIT extends JDBCBaseIT {
                 + "\"JDBC_USERNAME\": \"%s\", "
                 + "\"JDBC_PASSWORD\": \"%s\", "
                 + "\"JDBC_QUERY\": \"%s\", "
-                + "\"BQ_TABLE_SPEC\": \"%s\","
-                + "\"JDBC_DRIVER_JARS\": \"%s\""
+                + "\"BQ_TABLE_SPEC\": \"%s\", "
+                + "\"JDBC_DRIVER_JARS\": \"%s\", "
+                + "\"JDBC_DRIVER_CLASS_NAME\": \"%s\""
                 + "}",
             jdbcUrl,
             username,
             password,
             query,
             toTableSpecStandard(table),
-            postgresDriverGCSPath());
+            postgresDriverGCSPath(),
+            POSTGRES_DRIVER);
 
     LaunchConfig.Builder options =
         LaunchConfig.builder(testName, specPath)

--- a/python/src/test/resources/JdbcToBigQueryYamlIT.yaml
+++ b/python/src/test/resources/JdbcToBigQueryYamlIT.yaml
@@ -8,6 +8,7 @@ pipeline:
         password: "{{ JDBC_PASSWORD }}"
         read_query: "{{ JDBC_QUERY }}"
         driver_jars: "{{ JDBC_DRIVER_JARS }}"
+        driver_class_name: "{{ JDBC_DRIVER_CLASS_NAME }}"
     - type: WriteToBigQuery
       config:
         table: "{{ BQ_TABLE_SPEC }}"


### PR DESCRIPTION
Fixed the broken test due to Beam 2.65.0 for YAML: https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/runs/15553996223/job/43790287468

This fails because we revert https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/2428