### PR TITLE
added timestamp to logging

### DIFF
--- a/structured-logging/src/main/java/com/google/cloud/teleport/v2/logging/JsonAppender.java
+++ b/structured-logging/src/main/java/com/google/cloud/teleport/v2/logging/JsonAppender.java
@@ -20,6 +20,9 @@ import ch.qos.logback.classic.spi.ThrowableProxyUtil;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import com.google.gson.Gson;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 
 /**
  * A simple logging Appender that output logs in Json format. Inspired by
@@ -27,6 +30,8 @@ import com.google.gson.Gson;
  */
 public class JsonAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   private static final Gson gson = new Gson();
+  private static final DateTimeFormatter TIMESTAMP_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS'Z'").withZone(ZoneOffset.UTC);
 
   @Override
   protected void append(ILoggingEvent event) {
@@ -38,16 +43,23 @@ public class JsonAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
           .append(CoreConstants.LINE_SEPARATOR)
           .append(ThrowableProxyUtil.asString(event.getThrowableProxy()));
     }
-    System.err.println(gson.toJson(new JsonEntry(message, event.getLevel().toString())));
+    System.err.println(
+        gson.toJson(
+            new JsonEntry(
+                message,
+                event.getLevel().toString(),
+                TIMESTAMP_FORMATTER.format(Instant.ofEpochMilli(event.getTimeStamp())))));
   }
 
   private static final class JsonEntry {
     final CharSequence message;
     final CharSequence severity;
+    final CharSequence timestamp;
 
-    public JsonEntry(CharSequence message, CharSequence severity) {
+    public JsonEntry(CharSequence message, CharSequence severity, CharSequence timestamp) {
       this.message = message;
       this.severity = severity;
+      this.timestamp = timestamp;
     }
   }
 }


### PR DESCRIPTION
The below timestamp is not helpful. 
```
2025-06-19T15:28:32.8571119Z [pool-1-thread-6] INFO org.apache.beam.it.common.PipelineOperator - Condition was not met yet. Checking if job is finished.
2025-06-19T15:28:32.8573464Z [pool-1-thread-6] INFO org.apache.beam.it.common.PipelineOperator - Job 2025-06-19_08_14_13-1924383829825156948 is in state JOB_STATE_DRAINING
2025-06-19T15:28:32.8576530Z [pool-1-thread-6] INFO org.apache.beam.it.common.PipelineOperator - Job not finished and conditions not met. Will check again in 15 seconds (total wait: 256s of max 900s)
2025-06-19T15:28:32.8578104Z [pool-1-thread-6] INFO org.apache.beam.it.common.PipelineOperator - Condition was not met yet. Checking if job is finished.
2025-06-19T15:28:32.8580702Z [pool-1-thread-6] INFO org.apache.beam.it.common.PipelineOperator - Job 2025-06-19_08_14_13-1924383829825156948 is in state JOB_STATE_DRAINED
2025-06-19T15:28:32.8582712Z [pool-1-thread-6] INFO org.apache.beam.it.common.PipelineOperator - Detected that launch was finished, checking conditions once more.
2025-06-19T15:28:32.8584618Z [pool-1-thread-6] INFO org.apache.beam.it.common.PipelineOperator - Condition was not met yet. Checking if job is finished.
2025-06-19T15:28:32.8586221Z [pool-1-thread-6] INFO org.apache.beam.it.common.PipelineOperator - Launch was finished, stop checking.
```
Added the specific timestamp for structured-logging