### PR TITLE
exposed it-thread-count for IT

### DIFF
--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -171,7 +171,7 @@ jobs:
           --it-region="${{ env.IT_REGION }}" \
           --it-project="cloud-teleport-testing" \
           --it-integration-test-parallelism=6 \
-          --it-thread-count=8 \
+          --it-thread-count=6 \
           --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \
           --it-private-connectivity="datastream-private-connect-us-central1"
       - name: Upload Integration Tests Report

--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -171,6 +171,7 @@ jobs:
           --it-region="${{ env.IT_REGION }}" \
           --it-project="cloud-teleport-testing" \
           --it-integration-test-parallelism=6 \
+          --it-thread-count=8 \
           --it-artifact-bucket="cloud-teleport-testing-it-gitactions" \
           --it-private-connectivity="datastream-private-connect-us-central1"
       - name: Upload Integration Tests Report

--- a/cicd/cmd/run-it-tests/main.go
+++ b/cicd/cmd/run-it-tests/main.go
@@ -56,7 +56,7 @@ func main() {
 		mvnFlags.SkipJib(),
 		mvnFlags.SkipShade(),
 		mvnFlags.RunIntegrationTests(flags.UnifiedWorkerHarnessContainerImage() != ""),
-		mvnFlags.ThreadCount(4),
+		mvnFlags.ThreadCount(flags.ThreadCount()),
 		mvnFlags.IntegrationTestParallelism(flags.IntegrationTestParallelism()),
 		mvnFlags.StaticBigtableInstance("teleport"),
 		mvnFlags.StaticSpannerInstance("teleport"),

--- a/cicd/internal/flags/it-flags.go
+++ b/cicd/internal/flags/it-flags.go
@@ -41,6 +41,7 @@ var (
 	dCloudOracleSysPassword             string
 	dUnifiedWorkerHarnessContainerImage string
 	dIntegrationTestParallelism         string
+	dThreadCount                        string
 )
 
 // Registers all it flags. Must be called before flag.Parse().
@@ -62,6 +63,7 @@ func RegisterItFlags() {
 	flag.StringVar(&dCloudOracleSysPassword, "it-oracle-sys-password", "oracle", "sys password of static Oracle DB")
 	flag.StringVar(&dUnifiedWorkerHarnessContainerImage, "it-unified-worker-harness-container-image", "", "Runner harness image to run tests against")
 	flag.StringVar(&dIntegrationTestParallelism, "it-integration-test-parallelism", "3", "The level of parallelism for integration tests")
+	flag.StringVar(&dThreadCount, "it-thread-count", "4", "The IT thread count to use for maven, which is the number of threads per core")
 }
 
 func Region() string {
@@ -157,5 +159,11 @@ func UnifiedWorkerHarnessContainerImage() string {
 func IntegrationTestParallelism() int {
 	i := 3
 	fmt.Sscan(dIntegrationTestParallelism, &i)
+	return i
+}
+
+func ThreadCount() int {
+	i := 4
+	fmt.Sscan(dThreadCount, &i)
 	return i
 }

--- a/v1/src/test/java/com/google/cloud/teleport/templates/PubSubToSplunkIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/templates/PubSubToSplunkIT.java
@@ -162,7 +162,7 @@ public class PubSubToSplunkIT extends TemplateTestBase {
         "search source=\"" + source + "\" sourcetype=\"" + sourceType + "\" host=\"" + host + "\"";
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForConditionsAndFinish(
+            .waitForConditionAndCancel(
                 createConfig(info),
                 CustomSplunkEventsCheck.builder(splunkResourceManager)
                     .setQuery(query)

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/PubSubToBigQueryIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/PubSubToBigQueryIT.java
@@ -178,7 +178,7 @@ public class PubSubToBigQueryIT extends TemplateTestBase {
 
     Result result =
         pipelineOperator()
-            .waitForConditionsAndFinish(
+            .waitForConditionAndCancel(
                 createConfig(info),
                 BigQueryRowsCheck.builder(bigQueryResourceManager, table)
                     .setMinRows(MESSAGES_COUNT)
@@ -295,7 +295,7 @@ public class PubSubToBigQueryIT extends TemplateTestBase {
 
     Result reloadedResult =
         pipelineOperator()
-            .waitForConditionsAndFinish(
+            .waitForConditionAndCancel(
                 createConfig(info),
                 BigQueryRowsCheck.builder(bigQueryResourceManager, table)
                     .setMinRows(MESSAGES_COUNT * 2)
@@ -359,7 +359,7 @@ public class PubSubToBigQueryIT extends TemplateTestBase {
 
     Result result =
         pipelineOperator()
-            .waitForConditionsAndFinish(
+            .waitForConditionAndCancel(
                 createConfig(info),
                 BigQueryRowsCheck.builder(bigQueryResourceManager, table)
                     .setMinRows(MESSAGES_COUNT)
@@ -427,7 +427,7 @@ public class PubSubToBigQueryIT extends TemplateTestBase {
 
     Result result =
         pipelineOperator()
-            .waitForConditionsAndFinish(
+            .waitForConditionAndCancel(
                 createConfig(info),
                 BigQueryRowsCheck.builder(bigQueryResourceManager, table)
                     .setMinRows(MESSAGES_COUNT)


### PR DESCRIPTION
grep com.google.cloud.teleport.v2.templates.PubSubToBigQueryIT 5_Dataflow\ Templates\ Integration\ Tests.txt
```
2025-06-27T13:22:21.9465056Z [INFO] /home/runner/actions-runner/_work/DataflowTemplates/DataflowTemplates/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/PubSubToBigQueryIT.java: Some input files use unchecked or unsafe operations.
2025-06-27T13:22:21.9468025Z [INFO] /home/runner/actions-runner/_work/DataflowTemplates/DataflowTemplates/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/PubSubToBigQueryIT.java: Recompile with -Xlint:unchecked for details.
2025-06-27T13:52:40.5993783Z [INFO] Running com.google.cloud.teleport.v2.templates.PubSubToBigQueryIT
2025-06-27T13:52:40.5995314Z [pool-1-thread-59] INFO org.apache.beam.it.gcp.TemplateTestBase - Starting integration test com.google.cloud.teleport.v2.templates.PubSubToBigQueryIT.testPubsubToBigQueryWithStorageApi
2025-06-27T13:52:40.6418996Z [pool-1-thread-58] INFO org.apache.beam.it.gcp.TemplateTestBase - Starting integration test com.google.cloud.teleport.v2.templates.PubSubToBigQueryIT.testPubsubToBigQueryWithReload
2025-06-27T13:52:40.6693987Z [pool-1-thread-57] INFO org.apache.beam.it.gcp.TemplateTestBase - Starting integration test com.google.cloud.teleport.v2.templates.PubSubToBigQueryIT.testPubsubToBigQueryNoUdf
2025-06-27T13:52:40.6918498Z [pool-1-thread-56] INFO org.apache.beam.it.gcp.TemplateTestBase - Starting integration test com.google.cloud.teleport.v2.templates.PubSubToBigQueryIT.testPubsubToBigQueryWithPythonUdf
2025-06-27T13:52:40.7191965Z [INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1,817.633 s - in com.google.cloud.teleport.v2.templates.PubSubToBigQueryIT
```

Change the default thread to 8.
