### PR TITLE
docs: Updates incorrect default value

### DIFF
--- a/v1/README_Cloud_PubSub_to_Datadog.md
+++ b/v1/README_Cloud_PubSub_to_Datadog.md
@@ -40,7 +40,7 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 ### Optional parameters
 
 * **apiKey**: The Datadog API key. You must provide this value if the `apiKeySource` is set to `PLAINTEXT` or `KMS`. For more information, see API and Application Keys (https://docs.datadoghq.com/account_management/api-app-keys/) in the Datadog documentation.
-* **batchCount**: The batch size for sending multiple events to Datadog. The default is `1` (no batching).
+* **batchCount**: The batch size for sending multiple events to Datadog. The default is `100`.
 * **parallelism**: The maximum number of parallel requests. The default is `1` (no parallelism).
 * **includePubsubMessage**: Whether to include the full Pub/Sub message in the payload. The default is `true` (all elements, including the data element, are included in the payload).
 * **apiKeyKMSEncryptionKey**: The Cloud KMS key to use to decrypt the API Key. You must provide this parameter if the `apiKeySource` is set to `KMS`. If the Cloud KMS key is provided, you must pass in an encrypted API Key. For example, `projects/your-project-id/locations/global/keyRings/your-keyring/cryptoKeys/your-key-name`.

--- a/v1/src/main/java/com/google/cloud/teleport/templates/common/DatadogConverters.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/common/DatadogConverters.java
@@ -112,8 +112,7 @@ public class DatadogConverters {
         order = 3,
         optional = true,
         description = "Batch size for sending multiple events to Datadog Logs API.",
-        helpText =
-            "The batch size for sending multiple events to Datadog. The default is `100`.")
+        helpText = "The batch size for sending multiple events to Datadog. The default is `100`.")
     ValueProvider<Integer> getBatchCount();
 
     void setBatchCount(ValueProvider<Integer> batchCount);

--- a/v1/src/main/java/com/google/cloud/teleport/templates/common/DatadogConverters.java
+++ b/v1/src/main/java/com/google/cloud/teleport/templates/common/DatadogConverters.java
@@ -113,7 +113,7 @@ public class DatadogConverters {
         optional = true,
         description = "Batch size for sending multiple events to Datadog Logs API.",
         helpText =
-            "The batch size for sending multiple events to Datadog. The default is `1` (no batching).")
+            "The batch size for sending multiple events to Datadog. The default is `100`.")
     ValueProvider<Integer> getBatchCount();
 
     void setBatchCount(ValueProvider<Integer> batchCount);


### PR DESCRIPTION
Technical Solutions Engineer reported an incorrect value that is surfaced in https://cloud.google.com/dataflow/docs/guides/templates/provided/pubsub-to-datadog#optional-parameters, which pulls from the `README`. Evidence they provided as to correct value (100):
* https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v1/src/main/java/com/google/cloud/teleport/datadog/DatadogEventWriter.java#L61
* https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/854\

More context: b/430467136