### PR TITLE
Fix codecov upload failure

### DIFF
--- a/.github/workflows/bigtable-pr.yml
+++ b/.github/workflows/bigtable-pr.yml
@@ -119,8 +119,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: GoogleCloudPlatform/DataflowTemplates
           files: 'target/site/jacoco-aggregate/jacoco.xml'
-          # Temp fix for https://github.com/codecov/codecov-action/issues/1487
-          version: v0.6.0
       - name: Cleanup Java Environment
         uses: ./.github/actions/cleanup-java-env
   java_integration_smoke_tests_templates:

--- a/.github/workflows/datastream-pr.yml
+++ b/.github/workflows/datastream-pr.yml
@@ -123,8 +123,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: GoogleCloudPlatform/DataflowTemplates
           files: 'target/site/jacoco-aggregate/jacoco.xml'
-          # Temp fix for https://github.com/codecov/codecov-action/issues/1487
-          version: v0.6.0
       - name: Cleanup Java Environment
         uses: ./.github/actions/cleanup-java-env
   java_integration_smoke_tests_templates:

--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -117,8 +117,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: GoogleCloudPlatform/DataflowTemplates
           files: 'target/site/jacoco-aggregate/jacoco.xml'
-          # Temp fix for https://github.com/codecov/codecov-action/issues/1487
-          version: v0.6.0
       - name: Cleanup Java Environment
         uses: ./.github/actions/cleanup-java-env
         if: always()

--- a/.github/workflows/kafka-pr.yml
+++ b/.github/workflows/kafka-pr.yml
@@ -121,8 +121,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: GoogleCloudPlatform/DataflowTemplates
           files: 'target/site/jacoco-aggregate/jacoco.xml'
-          # Temp fix for https://github.com/codecov/codecov-action/issues/1487
-          version: v0.6.0
       - name: Cleanup Java Environment
         uses: ./.github/actions/cleanup-java-env
   java_integration_smoke_tests_templates:

--- a/.github/workflows/spanner-pr.yml
+++ b/.github/workflows/spanner-pr.yml
@@ -124,8 +124,6 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: GoogleCloudPlatform/DataflowTemplates
         files: 'target/site/jacoco-aggregate/jacoco.xml'
-        # Temp fix for https://github.com/codecov/codecov-action/issues/1487
-        version: v0.6.0
     - name: Cleanup Java Environment
       uses: ./.github/actions/cleanup-java-env
   java_integration_smoke_tests_templates:


### PR DESCRIPTION
Uploading coverage report to codecov step was failing with the following error - 

```
==> Running upload-coverage
      ./codecov  upload-coverage --git-service github --sha 4d248b71a1d5224123e19d3a9c2e91858adfa54d --slug GoogleCloudPlatform/DataflowTemplates --branch VardhanThigle:rr-delete-pkey-change --file target/site/jacoco-aggregate/jacoco.xml --gcov-executable gcov
Usage: codecov [OPTIONS] COMMAND [ARGS]...
Try 'codecov --help' for help.

Error: No such command 'upload-coverage'.
==> Failed to run upload-coverage
```

Example: https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/runs/16249730088/job/45877716956

Fixing it by removing the hardcoded version of codecov-cli

The upload is successful in the workflow runs of this PR. Example -- https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/runs/16260033606/job/45903250451?pr=2552