### PR TITLE
Require hashes when downloading dependencies

### DIFF
--- a/python/src/main/python/word-count-python/Dockerfile
+++ b/python/src/main/python/word-count-python/Dockerfile
@@ -11,6 +11,6 @@ ENV FLEX_TEMPLATE_PYTHON_PY_FILE=main.py
 
 # Install dependencies to launch the pipeline
 RUN pip install -U --require-hashes -r $FLEX_TEMPLATE_PYTHON_REQUIREMENTS_FILE
-RUN pip download --no-cache-dir --dest /tmp/dataflow-requirements-cache -r $FLEX_TEMPLATE_PYTHON_REQUIREMENTS_FILE
+RUN pip download --no-cache-dir --require-hashes --dest /tmp/dataflow-requirements-cache -r $FLEX_TEMPLATE_PYTHON_REQUIREMENTS_FILE
 
 ENTRYPOINT ["/opt/google/dataflow/python_template_launcher"]


### PR DESCRIPTION
This is setting off compliance alarms