### PR TITLE
Reduce IT Times In Kafka Templates

### DIFF
--- a/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryAvroIT.java
+++ b/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryAvroIT.java
@@ -101,25 +101,6 @@ public final class KafkaToBigQueryAvroIT extends TemplateTestBase {
   }
 
   @Test
-  public void testKafkaToBigQueryAvroWithExistingDLQ() throws IOException, RestClientException {
-    TableId deadletterTableId =
-        bigQueryClient.createTable(testName + "_dlq", getDeadletterSchema());
-
-    baseKafkaToBigQueryAvro(
-        b -> b.addParameter("outputDeadletterTable", toTableSpecLegacy(deadletterTableId)), null);
-  }
-
-  @Test
-  public void testKafkaToBigQueryAvroWithStorageApi() throws IOException, RestClientException {
-    baseKafkaToBigQueryAvro(
-        b ->
-            b.addParameter("useStorageWriteApi", "true")
-                .addParameter("numStorageWriteApiStreams", "3")
-                .addParameter("storageWriteApiTriggeringFrequencySec", "3"),
-        null);
-  }
-
-  @Test
   public void testKafkaToBigQueryAvroWithStorageApiExistingDLQ()
       throws IOException, RestClientException {
     TableId deadletterTableId =


### PR DESCRIPTION
Remove duplicate tests and combine isolated tests to reduce test times on the largest IT classes in this subproject. The times of these tests can cause the build to fail occasionally.