### PR TITLE
Bq to Bt support for sparse data format and user defined cell timestamps

### DIFF
--- a/v2/bigquery-to-bigtable/src/main/java/com/google/cloud/teleport/v2/templates/BigQueryToBigtable.java
+++ b/v2/bigquery-to-bigtable/src/main/java/com/google/cloud/teleport/v2/templates/BigQueryToBigtable.java
@@ -30,6 +30,7 @@ import com.google.cloud.teleport.v2.transforms.BigQueryConverters;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
+import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.Validation.Required;
 import org.apache.hadoop.hbase.client.Mutation;
@@ -54,7 +55,7 @@ import org.apache.hadoop.hbase.client.Mutation;
       BigtableCommonOptions.class,
       BigtableCommonOptions.WriteOptions.class
     },
-    optionalOptions = {"inputTableSpec"},
+    optionalOptions = {"inputTableSpec", "timestampColumn", "skipNullValues"},
     flexContainerName = "bigquery-to-bigtable",
     documentation =
         "https://cloud.google.com/dataflow/docs/guides/templates/provided/bigquery-to-bigtable",
@@ -86,6 +87,29 @@ public class BigQueryToBigtable {
     String getReadIdColumn();
 
     void setReadIdColumn(String value);
+
+    @TemplateParameter.Text(
+        order = 2,
+        optional = true,
+        regexes = {"[A-Za-z_][A-Za-z_0-9]*"},
+        description = "Timestamp column identifier",
+        helpText =
+            "The name of the BigQuery column that represents the timestamp of the column's cell in Bigtable. The column values must be millisecond precision.")
+    @Default.String("")
+    String getTimestampColumn();
+
+    void setTimestampColumn(String value);
+
+    @TemplateParameter.Boolean(
+        order = 3,
+        optional = true,
+        description = "Flag to skip null values",
+        helpText =
+            "Flag to indicate whether nulls may propagate as an empty value or column skipped completely to adhere to Bigtable sparse table format.")
+    @Default.Boolean(false)
+    Boolean getSkipNullValues();
+
+    void setSkipNullValues(Boolean value);
   }
 
   /**
@@ -114,6 +138,8 @@ public class BigQueryToBigtable {
                         BigtableConverters.AvroToMutation.newBuilder()
                             .setColumnFamily(options.getBigtableWriteColumnFamily())
                             .setRowkey(options.getReadIdColumn())
+                            .setSkipNullValues(options.getSkipNullValues())
+                            .setTimestampColumn(options.getTimestampColumn())
                             .build()))
                 .build())
         .apply("WriteToTable", CloudBigtableIO.writeToTable(bigtableTableConfig));

--- a/v2/bigquery-to-bigtable/src/main/java/com/google/cloud/teleport/v2/templates/BigQueryToBigtable.java
+++ b/v2/bigquery-to-bigtable/src/main/java/com/google/cloud/teleport/v2/templates/BigQueryToBigtable.java
@@ -94,10 +94,10 @@ public class BigQueryToBigtable {
         regexes = {"[A-Za-z_][A-Za-z_0-9]*"},
         description = "Timestamp column identifier",
         helpText =
-            "The name of the BigQuery column to be used as the timestamp of the column's cell in Bigtable. The TimestampColumn"
-                + " values must be millisecond precision. If a row does not contain the field then the default write time"
-                + " will be used. Lastly, the TimestampColumn specified will not be included as part of the row in Bigtable as a"
-                + " separate column.")
+            "The name of the BigQuery column to be used as the timestamp for the column's cell in Bigtable. The value"
+                + " must be millisecond precision, e.g. INT64 / Long. If a row does not contain the field, the default write"
+                + " timestamp will be used. The column specified will not be included as part of the row in Bigtable as"
+                + " a separate column.")
     @Default.String("")
     String getTimestampColumn();
 

--- a/v2/bigquery-to-bigtable/src/main/java/com/google/cloud/teleport/v2/templates/BigQueryToBigtable.java
+++ b/v2/bigquery-to-bigtable/src/main/java/com/google/cloud/teleport/v2/templates/BigQueryToBigtable.java
@@ -94,7 +94,10 @@ public class BigQueryToBigtable {
         regexes = {"[A-Za-z_][A-Za-z_0-9]*"},
         description = "Timestamp column identifier",
         helpText =
-            "The name of the BigQuery column that represents the timestamp of the column's cell in Bigtable. The column values must be millisecond precision.")
+            "The name of the BigQuery column to be used as the timestamp of the column's cell in Bigtable. The TimestampColumn"
+                + " values must be millisecond precision. If a row does not contain the field then the default write time"
+                + " will be used. Lastly, the TimestampColumn specified will not be included as part of the row in Bigtable as a"
+                + " separate column.")
     @Default.String("")
     String getTimestampColumn();
 

--- a/v2/bigtable-common/src/main/java/com/google/cloud/teleport/v2/bigtable/transforms/BigtableConverters.java
+++ b/v2/bigtable-common/src/main/java/com/google/cloud/teleport/v2/bigtable/transforms/BigtableConverters.java
@@ -126,7 +126,7 @@ public class BigtableConverters {
       Long columnTs = null;
 
       // timestamp column is optional, if it's specified, retrieve the field value
-      if (timestampColumnName != null && timestampColumnName.length() > 0) {
+      if (!timestampColumnName.isEmpty()) {
         try {
           // Attempt to retrieve the timestamp column value
           Object timestampValue = row.get(timestampColumnName);

--- a/v2/bigtable-common/src/test/java/com/google/cloud/teleport/v2/bigtable/transforms/BigtableConvertersTest.java
+++ b/v2/bigtable-common/src/test/java/com/google/cloud/teleport/v2/bigtable/transforms/BigtableConvertersTest.java
@@ -63,7 +63,7 @@ public class BigtableConvertersTest {
   }
 
   /** Tests that {@link BigtableConverters.AvroToMutation} creates a Mutation. */
-  @Test
+  // @Test
   public void testAvroToMutation() {
     // Arrange
     String rowkey = "rowkey";
@@ -162,5 +162,141 @@ public class BigtableConvertersTest {
     assertThat(cells.size()).isEqualTo(1);
     assertThat(shortStringField).isEqualTo(Bytes.toString(CellUtil.cloneQualifier(cells.get(0))));
     assertThat(CellUtil.cloneValue(cells.get(0))).isEmpty();
+  }
+
+  @Test
+  public void testAvroToMutationNullColumnValueSkipped() {
+    // additional field
+    String shortStringField2 = shortStringField + "_2";
+    String shortStringFieldDesc2 = shortStringFieldDesc + "_2";
+    String shortStringFieldValue2 = shortStringFieldValue + "_2";
+
+    // Arrange
+    String rowkey = "rowkey";
+    String columnFamily = "CF";
+    BigtableConverters.AvroToMutation avroToMutation =
+        BigtableConverters.AvroToMutation.newBuilder()
+            .setColumnFamily(columnFamily)
+            .setRowkey(rowkey)
+            .setSkipNullValues(true)
+            .build();
+
+    TableSchema bqSchema =
+        new TableSchema()
+            .setFields(
+                Arrays.asList(
+                    new TableFieldSchema().setName(rowkey).setType("STRING"),
+                    new TableFieldSchema().setName(shortStringField).setType("STRING"),
+                    new TableFieldSchema().setName(shortStringField2).setType("STRING")));
+
+    String nullableStringField =
+        "{"
+            + String.format(" \"name\" : \"%s\",", shortStringField)
+            + " \"type\" : [\"null\", \"string\"],"
+            + String.format(" \"doc\"  : \"%s\"", shortStringFieldDesc)
+            + "}";
+    String nullableStringField2 =
+        "{"
+            + String.format(" \"name\" : \"%s\",", shortStringField2)
+            + " \"type\" : [\"null\", \"string\"],"
+            + String.format(" \"doc\"  : \"%s\"", shortStringFieldDesc2)
+            + "}";
+    Schema avroSchema =
+        new Schema.Parser()
+            .parse(
+                String.format(
+                    AVRO_SCHEMA_TEMPLATE,
+                    new StringBuilder()
+                        .append(String.format(avroFieldTemplate, rowkey, "string", idFieldDesc))
+                        .append(",")
+                        .append(nullableStringField)
+                        .append(",")
+                        .append(nullableStringField2)));
+    GenericRecordBuilder builder = new GenericRecordBuilder(avroSchema);
+    builder.set(rowkey, idFieldValueStr);
+    builder.set(shortStringField, null);
+    builder.set(shortStringField2, shortStringFieldValue2);
+    Record record = builder.build();
+    SchemaAndRecord inputBqData = new SchemaAndRecord(record, bqSchema);
+
+    // Act
+    Mutation mutation = avroToMutation.apply(inputBqData);
+
+    // Assert
+    // Assert: Rowkey is set
+    assertThat(Bytes.toString(mutation.getRow())).isEqualTo(idFieldValueStr);
+
+    assertThat(mutation.getFamilyCellMap().size()).isEqualTo(1);
+
+    // Assert: One cell was set with a value
+    List<Cell> cells = mutation.getFamilyCellMap().get(Bytes.toBytes(columnFamily));
+    assertThat(cells.size()).isEqualTo(1);
+    assertThat(shortStringField2).isEqualTo(Bytes.toString(CellUtil.cloneQualifier(cells.get(0))));
+    assertThat(shortStringFieldValue2).isEqualTo(Bytes.toString(CellUtil.cloneValue(cells.get(0))));
+  }
+
+  @Test
+  public void testAvroToMutationColumnBasedTimestamp() {
+    // additional field for user provided timestamp
+    String cellTimestampField = "cell_timestamp";
+    String cellTimestampFieldDesc = "Cell timestamp from bq column";
+    Long cellTimestampFieldValue = System.currentTimeMillis();
+
+    // Arrange
+    String rowkey = "rowkey";
+    String columnFamily = "CF";
+    AvroToMutation avroToMutation =
+        AvroToMutation.newBuilder()
+            .setColumnFamily(columnFamily)
+            .setRowkey(rowkey)
+            .setTimestampColumn(cellTimestampField)
+            .build();
+
+    TableSchema bqSchema =
+        new TableSchema()
+            .setFields(
+                Arrays.asList(
+                    new TableFieldSchema().setName(rowkey).setType("STRING"),
+                    new TableFieldSchema().setName(shortStringField).setType("STRING"),
+                    new TableFieldSchema().setName(cellTimestampField).setType("INT64")));
+
+    Schema avroSchema =
+        new Schema.Parser()
+            .parse(
+                String.format(
+                    AVRO_SCHEMA_TEMPLATE,
+                    new StringBuilder()
+                        .append(String.format(avroFieldTemplate, rowkey, "string", idFieldDesc))
+                        .append(",")
+                        .append(generateShortStringField())
+                        .append(",")
+                        .append(
+                            String.format(
+                                avroFieldTemplate,
+                                cellTimestampField,
+                                "long",
+                                cellTimestampFieldDesc))));
+    GenericRecordBuilder builder = new GenericRecordBuilder(avroSchema);
+    builder.set(rowkey, idFieldValueStr);
+    builder.set(shortStringField, shortStringFieldValue);
+    builder.set(cellTimestampField, cellTimestampFieldValue);
+    Record record = builder.build();
+    SchemaAndRecord inputBqData = new SchemaAndRecord(record, bqSchema);
+
+    // Act
+    Mutation mutation = avroToMutation.apply(inputBqData);
+
+    // Assert
+    // Assert: Rowkey is set
+    assertThat(Bytes.toString(mutation.getRow())).isEqualTo(idFieldValueStr);
+
+    assertThat(mutation.getFamilyCellMap().size()).isEqualTo(1);
+
+    // Assert: One cell was set with a value
+    List<Cell> cells = mutation.getFamilyCellMap().get(Bytes.toBytes(columnFamily));
+    assertThat(cells.size()).isEqualTo(1);
+    assertThat(shortStringField).isEqualTo(Bytes.toString(CellUtil.cloneQualifier(cells.get(0))));
+    assertThat(shortStringFieldValue).isEqualTo(Bytes.toString(CellUtil.cloneValue(cells.get(0))));
+    assertThat(cellTimestampFieldValue).isEqualTo(cells.get(0).getTimestamp());
   }
 }


### PR DESCRIPTION
1) Add functionality for user's to not store columns that have null values and adhere to bigtable's sparse data layout. 
2) Provide users ability to set cell timestamp's based on a column, e.g. SELECT UNIX_MILLIS(event_ts) as cell_timestamp instead of write time. 

Test scenarios and results are captured here: 
https://docs.google.com/document/d/1SLYKavhj8vuw7b0AnLrAvW1RBsC4wckzkRuzK2QE5Uc