### PR TITLE
Change stage prefix to tag

### DIFF
--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/PromoteHelper.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/PromoteHelper.java
@@ -46,18 +46,19 @@ class PromoteHelper {
   /**
    * Promote the staged flex template image using MOSS promote API.
    *
-   * @param sourcePath - spec for source image.
-   * @param targetPath - spec for target image
+   * @param sourcePath - spec for source image without tag
+   * @param targetPath - spec for target image without tag
+   * @param imageTag - image tag
    * @param sourceDigest - source image digest, e.g. sha256:xxxxx
    */
-  public PromoteHelper(String sourcePath, String imageTag, String targetPath, String sourceDigest)
+  public PromoteHelper(String sourcePath, String targetPath, String imageTag, String sourceDigest)
       throws IOException, InterruptedException {
-    this(sourcePath, imageTag, targetPath, sourceDigest, accessToken());
+    this(sourcePath, targetPath, imageTag, sourceDigest, accessToken());
   }
 
   @VisibleForTesting
   PromoteHelper(
-      String sourcePath, String imageTag, String targetPath, String sourceDigest, String token) {
+      String sourcePath, String targetPath, String imageTag, String sourceDigest, String token) {
     this.sourceSpec = new ArtifactRegImageSpec(sourcePath);
     this.targetSpec = new ArtifactRegImageSpec(targetPath);
     this.imageTag = imageTag;

--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
@@ -452,7 +452,7 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
     String imagePath =
         stageImageBeforePromote
             ? generateFlexTemplateImagePath(containerName, projectId, null, stagingArtifactRegistry)
-            : imageSpec.getImage();
+            : targetImagePath;
     String imagePathTag = imagePath + ":" + stagePrefix;
     String buildProjectId =
         stageImageBeforePromote
@@ -547,7 +547,7 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
       if (stageImageBeforePromote) {
         // promote image
         PromoteHelper promoteHelper =
-            new PromoteHelper(imagePath, stagePrefix, imageSpec.getImage(), digest);
+            new PromoteHelper(imagePath, targetImagePath, stagePrefix, digest);
         promoteHelper.promote();
 
         if (!stageImageOnly) {

--- a/plugins/templates-maven-plugin/src/test/java/com/google/cloud/teleport/plugin/maven/PromoteHelperTest.java
+++ b/plugins/templates-maven-plugin/src/test/java/com/google/cloud/teleport/plugin/maven/PromoteHelperTest.java
@@ -30,7 +30,8 @@ public class PromoteHelperTest {
     PromoteHelper helper =
         new PromoteHelper(
             "us-docker.pkg.dev/source-project/source-repo",
-            "us-docker.pkg.dev/target-project/target-repo/2020_10_10_rc00/io_to_io",
+            "2020_10_10_rc00",
+            "us-docker.pkg.dev/target-project/target-repo/some-prefix/io_to_io",
             "sha256:123",
             "fake-token");
     String[] cmds = helper.getPromoteFlexTemplateImageCmd();
@@ -39,7 +40,7 @@ public class PromoteHelperTest {
         "wget -O- --content-on-error --header=Authorization: Bearer fake-token "
             + "--header=Content-Type: application/json "
             + "--post-data={\"source_repository\":\"projects/source-project/locations/us/repositories/source-repo\","
-            + "\"source_version\":\"projects/source-project/locations/us/repositories/source-repo/packages/2020_10_10_rc00%2Fio_to_io/"
+            + "\"source_version\":\"projects/source-project/locations/us/repositories/source-repo/packages/some-prefix%2Fio_to_io/"
             + "versions/sha256:123\",\"attachment_behavior\":\"EXCLUDE\"} https://artifactregistry.googleapis.com/v1/"
             + "projects/target-project/locations/us/repositories/target-repo:promoteArtifact",
         cmd);

--- a/plugins/templates-maven-plugin/src/test/java/com/google/cloud/teleport/plugin/maven/PromoteHelperTest.java
+++ b/plugins/templates-maven-plugin/src/test/java/com/google/cloud/teleport/plugin/maven/PromoteHelperTest.java
@@ -30,8 +30,8 @@ public class PromoteHelperTest {
     PromoteHelper helper =
         new PromoteHelper(
             "us-docker.pkg.dev/source-project/source-repo",
-            "2020_10_10_rc00",
             "us-docker.pkg.dev/target-project/target-repo/some-prefix/io_to_io",
+            "2020_10_10_rc00",
             "sha256:123",
             "fake-token");
     String[] cmds = helper.getPromoteFlexTemplateImageCmd();

--- a/plugins/templates-maven-plugin/src/test/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojoTest.java
+++ b/plugins/templates-maven-plugin/src/test/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojoTest.java
@@ -29,64 +29,6 @@ public class TemplatesStageMojoTest {
   public void testGenerateFlexTemplateImagePath() {
     String containerName = "name";
     String projectId = "some-project";
-    String stagePrefix = "some-prefix";
-    boolean skipStagingPart = false;
-    ImmutableMap<String, String> testCases =
-        ImmutableMap.<String, String>builder()
-            .put("", "gcr.io/some-project/some-prefix/name")
-            .put("gcr.io", "gcr.io/some-project/some-prefix/name")
-            .put("eu.gcr.io", "eu.gcr.io/some-project/some-prefix/name")
-            .put(
-                "us-docker.pkg.dev/other-project/other-repo",
-                "us-docker.pkg.dev/other-project/other-repo/some-prefix/name")
-            .build();
-    testCases.forEach(
-        (key, value) -> {
-          // workaround for null key we intended to test
-          if (Strings.isNullOrEmpty(key)) {
-            key = null;
-          }
-          assertEquals(
-              value,
-              TemplatesStageMojo.generateFlexTemplateImagePath(
-                  containerName, projectId, null, key, stagePrefix, skipStagingPart));
-        });
-  }
-
-  @Test
-  public void testGenerateFlexTemplateImagePathWithDomain() {
-    String containerName = "name";
-    String projectId = "google.com:project";
-    String stagePrefix = "some-prefix";
-    boolean skipStagingPart = false;
-    ImmutableMap<String, String> testCases =
-        ImmutableMap.<String, String>builder()
-            .put("", "gcr.io/google.com/project/some-prefix/name")
-            .put("gcr.io", "gcr.io/google.com/project/some-prefix/name")
-            .put("eu.gcr.io", "eu.gcr.io/google.com/project/some-prefix/name")
-            .put(
-                "us-docker.pkg.dev/other-project/other-repo",
-                "us-docker.pkg.dev/other-project/other-repo/some-prefix/name")
-            .build();
-    testCases.forEach(
-        (key, value) -> {
-          // workaround for null key we intended to test
-          if (Strings.isNullOrEmpty(key)) {
-            key = null;
-          }
-          assertEquals(
-              value,
-              TemplatesStageMojo.generateFlexTemplateImagePath(
-                  containerName, projectId, null, key, stagePrefix, skipStagingPart));
-        });
-  }
-
-  @Test
-  public void testGenerateFlexTemplateImagePathSkipStagingPart() {
-    String containerName = "name";
-    String projectId = "some-project";
-    String stagePrefix = "some-prefix";
-    boolean skipStagingPart = true;
     ImmutableMap<String, String> testCases =
         ImmutableMap.<String, String>builder()
             .put("", "gcr.io/some-project/name")
@@ -105,7 +47,33 @@ public class TemplatesStageMojoTest {
           assertEquals(
               value,
               TemplatesStageMojo.generateFlexTemplateImagePath(
-                  containerName, projectId, null, key, stagePrefix, skipStagingPart));
+                  containerName, projectId, null, key));
+        });
+  }
+
+  @Test
+  public void testGenerateFlexTemplateImagePathWithDomain() {
+    String containerName = "name";
+    String projectId = "google.com:project";
+    ImmutableMap<String, String> testCases =
+        ImmutableMap.<String, String>builder()
+            .put("", "gcr.io/google.com/project/name")
+            .put("gcr.io", "gcr.io/google.com/project/name")
+            .put("eu.gcr.io", "eu.gcr.io/google.com/project/name")
+            .put(
+                "us-docker.pkg.dev/other-project/other-repo",
+                "us-docker.pkg.dev/other-project/other-repo/name")
+            .build();
+    testCases.forEach(
+        (key, value) -> {
+          // workaround for null key we intended to test
+          if (Strings.isNullOrEmpty(key)) {
+            key = null;
+          }
+          assertEquals(
+              value,
+              TemplatesStageMojo.generateFlexTemplateImagePath(
+                  containerName, projectId, null, key));
         });
   }
 }


### PR DESCRIPTION
Change published image path of v2 templates from  `<registry>/<date-time>/<image-name>:latest` to `<registry>/<image-name>:<date-time>`. 

The gcs path for metadata are not changed. 

The gcr image path written in the gcs metadata is changed accordingly