### PR TITLE
Add IncludeDependencies flag to Maven build process

### DIFF
--- a/cicd/cmd/run-build/main.go
+++ b/cicd/cmd/run-build/main.go
@@ -30,6 +30,7 @@ func main() {
 
 	mvnFlags := workflows.NewMavenFlags()
 	err := workflows.MvnCleanInstallAll().Run(
+		mvnFlags.IncludeDependencies(),
 		mvnFlags.SkipDependencyAnalysis(), // TODO(zhoufek): Fix our dependencies then remove this flag
 		mvnFlags.SkipJib(),
 		mvnFlags.SkipShade(),


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/runs/16521719052/job/46725074407
```
Error:  Failed to execute goal on project datastream-to-spanner: Could not collect dependencies for project com.google.cloud.teleport.v2:datastream-to-spanner:jar:1.0-SNAPSHOT
Error:  Failed to read artifact descriptor for com.google.cloud.teleport.v2:spanner-common:jar:1.0-SNAPSHOT
Error:  	Caused by: The following artifacts could not be resolved: com.google.cloud.teleport.v2:spanner-common:pom:1.0-SNAPSHOT (absent): Could not transfer artifact com.google.cloud.teleport.v2:spanner-common:pom:1.0-SNAPSHOT from/to splunk-artifactory (https://splunk.jfrog.io/splunk/ext-releases-local): status code: 409, reason phrase:  (409)
Error:  Failed to read artifact descriptor for com.google.cloud.teleport.v2:spanner-migrations-sdk:jar:1.0-SNAPSHOT
Error:  	Caused by: The following artifacts could not be resolved: com.google.cloud.teleport.v2:spanner-migrations-sdk:pom:1.0-SNAPSHOT (absent): Could not transfer artifact com.google.cloud.teleport.v2:spanner-migrations-sdk:pom:1.0-SNAPSHOT from/to splunk-artifactory (https://splunk.jfrog.io/splunk/ext-releases-local): status code: 409, reason phrase:  (409)
Error:  Failed to read artifact descriptor for com.google.cloud.teleport.v2:spanner-custom-shard:jar:1.0-SNAPSHOT
Error:  	Caused by: The following artifacts could not be resolved: com.google.cloud.teleport.v2:spanner-custom-shard:pom:1.0-SNAPSHOT (absent): Could not transfer artifact com.google.cloud.teleport.v2:spanner-custom-shard:pom:1.0-SNAPSHOT from/to splunk-artifactory (https://splunk.jfrog.io/splunk/ext-releases-local): status code: 409, reason phrase:  (409)
Error:  Failed to read artifact descriptor for com.google.cloud.teleport.v2:real-spanner-service:jar:1.0-SNAPSHOT
Error:  	Caused by: The following artifacts could not be resolved: com.google.cloud.teleport.v2:real-spanner-service:pom:1.0-SNAPSHOT (absent): Could not transfer artifact com.google.cloud.teleport.v2:real-spanner-service:pom:1.0-SNAPSHOT from/to splunk-artifactory (https://splunk.jfrog.io/splunk/ext-releases-local): status code: 409, reason phrase:  (409)
Error:  -> [Help 1]
```