### PR TITLE
Revert "Removing Spanner templates from the Datastream PR workflow"

### DIFF
--- a/cicd/internal/flags/common-flags.go
+++ b/cicd/internal/flags/common-flags.go
@@ -56,7 +56,12 @@ var (
 			"v2/bigtable-changestreams-to-hbase/",
 			"plugins/templates-maven-plugin",
 		},
-		DATASTREAM: {
+		DATASTREAM: {"v2/datastream-to-spanner/",
+			"v2/spanner-change-streams-to-sharded-file-sink/",
+			"v2/gcs-to-sourcedb/",
+			"v2/sourcedb-to-spanner/",
+			"v2/spanner-to-sourcedb/",
+			"v2/spanner-custom-shard/",
 			"plugins/templates-maven-plugin",
 			"v2/datastream-common/",
 			"v2/datastream-mongodb-to-firestore/",

--- a/cicd/internal/flags/common-flags_test.go
+++ b/cicd/internal/flags/common-flags_test.go
@@ -56,6 +56,12 @@ func TestModulesToBuild(t *testing.T) {
 		{
 			input: "DATASTREAM",
 			expected: []string{
+				"v2/datastream-to-spanner/",
+				"v2/spanner-change-streams-to-sharded-file-sink/",
+				"v2/gcs-to-sourcedb/",
+				"v2/sourcedb-to-spanner/",
+				"v2/spanner-to-sourcedb/",
+				"v2/spanner-custom-shard/",
 				"plugins/templates-maven-plugin",
 				"v2/datastream-common/",
 				"v2/datastream-mongodb-to-firestore/",


### PR DESCRIPTION
Reverts GoogleCloudPlatform/DataflowTemplates#2583

https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/workflows/datastream-pr.yml?query=branch%3Amain failing