### PR TITLE
Bump parquet-avro version to 1.15.2

### DIFF
--- a/it/cassandra/pom.xml
+++ b/it/cassandra/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>it-cassandra</artifactId>
 
     <properties>
-        <parquet-avro.version>1.15.1</parquet-avro.version>
+        <parquet-avro.version>1.15.2</parquet-avro.version>
     </properties>
     <dependencies>
         <dependency>

--- a/it/google-cloud-platform/pom.xml
+++ b/it/google-cloud-platform/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>it-google-cloud-platform</artifactId>
 
     <properties>
-        <parquet-avro.version>1.15.1</parquet-avro.version>
+        <parquet-avro.version>1.15.2</parquet-avro.version>
     </properties>
     <dependencies>
         <dependency>

--- a/it/jdbc/pom.xml
+++ b/it/jdbc/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>it-jdbc</artifactId>
 
     <properties>
-        <parquet-avro.version>1.15.1</parquet-avro.version>
+        <parquet-avro.version>1.15.2</parquet-avro.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Bump parquet-avro to 1.15.2 to address [CVE-2025-46762](https://nvd.nist.gov/vuln/detail/cve-2025-46762)