### PR TITLE
Removing Spanner templates from the Datastream PR workflow

### DIFF
--- a/cicd/cmd/run-it-smoke-tests/main.go
+++ b/cicd/cmd/run-it-smoke-tests/main.go
@@ -34,7 +34,6 @@ func main() {
 	mvnFlags := workflows.NewMavenFlags()
 	err := workflows.MvnCleanInstall().Run(
 		mvnFlags.IncludeDependencies(),
-		mvnFlags.IncludeDependents(),
 		mvnFlags.SkipDependencyAnalysis(),
 		mvnFlags.SkipCheckstyle(),
 		mvnFlags.SkipJib(),
@@ -51,7 +50,6 @@ func main() {
 	mvnFlags = workflows.NewMavenFlags()
 	err = workflows.MvnVerify().Run(
 		mvnFlags.IncludeDependencies(),
-		mvnFlags.IncludeDependents(),
 		mvnFlags.SkipDependencyAnalysis(),
 		mvnFlags.SkipCheckstyle(),
 		mvnFlags.SkipJib(),

--- a/cicd/cmd/run-it-tests/main.go
+++ b/cicd/cmd/run-it-tests/main.go
@@ -33,7 +33,6 @@ func main() {
 	mvnFlags := workflows.NewMavenFlags()
 	err := workflows.MvnCleanInstall().Run(
 		mvnFlags.IncludeDependencies(),
-		mvnFlags.IncludeDependents(),
 		mvnFlags.SkipDependencyAnalysis(),
 		mvnFlags.SkipCheckstyle(),
 		mvnFlags.SkipJib(),
@@ -50,7 +49,6 @@ func main() {
 	mvnFlags = workflows.NewMavenFlags()
 	err = workflows.MvnVerify().Run(
 		mvnFlags.IncludeDependencies(),
-		mvnFlags.IncludeDependents(),
 		mvnFlags.SkipDependencyAnalysis(),
 		mvnFlags.SkipCheckstyle(),
 		mvnFlags.SkipJib(),

--- a/cicd/internal/flags/common-flags.go
+++ b/cicd/internal/flags/common-flags.go
@@ -56,12 +56,7 @@ var (
 			"v2/bigtable-changestreams-to-hbase/",
 			"plugins/templates-maven-plugin",
 		},
-		DATASTREAM: {"v2/datastream-to-spanner/",
-			"v2/spanner-change-streams-to-sharded-file-sink/",
-			"v2/gcs-to-sourcedb/",
-			"v2/sourcedb-to-spanner/",
-			"v2/spanner-to-sourcedb/",
-			"v2/spanner-custom-shard/",
+		DATASTREAM: {
 			"plugins/templates-maven-plugin",
 			"v2/datastream-common/",
 			"v2/datastream-mongodb-to-firestore/",

--- a/cicd/internal/flags/common-flags_test.go
+++ b/cicd/internal/flags/common-flags_test.go
@@ -56,12 +56,6 @@ func TestModulesToBuild(t *testing.T) {
 		{
 			input: "DATASTREAM",
 			expected: []string{
-				"v2/datastream-to-spanner/",
-				"v2/spanner-change-streams-to-sharded-file-sink/",
-				"v2/gcs-to-sourcedb/",
-				"v2/sourcedb-to-spanner/",
-				"v2/spanner-to-sourcedb/",
-				"v2/spanner-custom-shard/",
 				"plugins/templates-maven-plugin",
 				"v2/datastream-common/",
 				"v2/datastream-mongodb-to-firestore/",

--- a/v2/datastream-common/pom.xml
+++ b/v2/datastream-common/pom.xml
@@ -69,3 +69,4 @@
         </plugins>
     </build>
 </project>
+


### PR DESCRIPTION
Removing the Spanner templates from the Datastream PR workflow.

The earlier attempt to accomplish this [failed](https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/runs/16568772856/job/46855451788) because `datastream-to-spanner` and `sourcedb-to-spanner` were still being run even after removing them from the list of modules to build. This was happening because of `-amd` flag which implies build dependents. `datastream-to-spanner` is dependent on ` datastream-common` and hence they were also being considered for build by the maven build reactor. Removed the `-amd` flag which was appended by IncludeDependents() function call to resolve this issue.

Tested: 
Datastream PR, Spanner PR, Java PR, Kafka PR and Bigtable PR workflows run as part of the PR check build.
