### PR TITLE
chore: Ignore Gemini configuration directory

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,50 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config for the Gemini Pull Request Review Bot.
+# https://github.com/marketplace/gemini-code-assist
+
+# Enables fun features such as a poem in the initial pull request summary.
+# Type: boolean, default: false.
+have_fun: false
+
+code_review:
+  # Disables Gemini from acting on PRs.
+  # Type: boolean, default: false.
+  disable: false
+
+  # Minimum severity of comments to post (LOW, MEDIUM, HIGH, CRITICAL).
+  # Type: string, default: MEDIUM.
+  comment_severity_threshold: MEDIUM
+
+  # Max number of review comments (-1 for unlimited).
+  # Type: integer, default: -1.
+  max_review_comments: -1
+
+  pull_request_opened:
+    # Post helpful instructions when PR is opened.
+    # Type: boolean, default: false.
+    help: false
+
+    # Post PR summary when opened.
+    # Type boolean, default: true.
+    summary: true
+
+    # Post code review on PR open.
+    # Type boolean, default: true.
+    code_review: false
+
+# List of glob patterns to ignore (files and directories).
+# Type: array of string, default: [].
+ignore_patterns: []


### PR DESCRIPTION
The `.gemini/` directory is generated by Google's Gemini tooling to store cache and local configuration.

Add this directory to `.gitignore` to prevent user-specific files from being committed to the repository.