### PR TITLE
Updates AvroConverters schema documentation

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/AvroConverters.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/AvroConverters.java
@@ -57,7 +57,8 @@ public class AvroConverters {
 
     @TemplateParameter.GcsReadFile(
         order = 3,
-        description = "Path of the Avro schema file used for the conversion.",
+        description =
+            "Path of the Avro schema file used for the conversion (used by Avro and Parquet file formats).",
         helpText = "Cloud storage path to the avro schema file.",
         example = "gs://your-bucket/your-path/schema.avsc")
     String getSchema();


### PR DESCRIPTION
Updates the documentation to clarify that the provided schema may be used by both Avro and Parquet formats.