### PR TITLE
feat: enforce cypher 5 for generated queries

### DIFF
--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/CypherGenerator.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/CypherGenerator.java
@@ -22,6 +22,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.neo4j.importer.v1.ImportSpecification;
 import org.neo4j.importer.v1.targets.EntityTarget;
 import org.neo4j.importer.v1.targets.NodeSchema;
@@ -41,20 +42,24 @@ public class CypherGenerator {
    * target.
    *
    * @param importSpecification the whole import specification
-   * @param target the node or relationship target
+   * @param target              the node or relationship target
    * @return the batch import query
    */
   public static String getImportStatement(
-      ImportSpecification importSpecification, EntityTarget target) {
+      ImportSpecification importSpecification, EntityTarget target, Neo4jCapabilities capabilities) {
     var type = target.getTargetType();
-    switch (type) {
-      case NODE:
-        return unwindNodes((NodeTarget) target);
-      case RELATIONSHIP:
-        return unwindRelationships(importSpecification, (RelationshipTarget) target);
-      default:
-        throw new IllegalArgumentException(String.format("unexpected target type: %s", type));
+    var generatedCypher = switch (type) {
+      case NODE -> unwindNodes((NodeTarget) target);
+      case RELATIONSHIP -> unwindRelationships(importSpecification, (RelationshipTarget) target);
+      default ->
+          throw new IllegalArgumentException(String.format("unexpected target type: %s", type));
+    };
+
+    if (capabilities.hasCypherVersionStatement()) {
+      return "CYPHER 5 " + generatedCypher;
     }
+
+    return generatedCypher;
   }
 
   /**
@@ -66,14 +71,19 @@ public class CypherGenerator {
   public static Set<String> getSchemaStatements(
       EntityTarget target, Neo4jCapabilities capabilities) {
     var type = target.getTargetType();
-    switch (type) {
-      case NODE:
-        return getNodeSchemaStatements((NodeTarget) target, capabilities);
-      case RELATIONSHIP:
-        return getRelationshipSchemaStatements((RelationshipTarget) target, capabilities);
-      default:
-        throw new IllegalArgumentException(String.format("unexpected target type: %s", type));
+    var generatedCyphers = switch (type) {
+      case NODE -> getNodeSchemaStatements((NodeTarget) target, capabilities);
+      case RELATIONSHIP ->
+          getRelationshipSchemaStatements((RelationshipTarget) target, capabilities);
+      default ->
+          throw new IllegalArgumentException(String.format("unexpected target type: %s", type));
+    };
+
+    if (capabilities.hasCypherVersionStatement()) {
+      generatedCyphers = generatedCyphers.stream().map(cypher -> "CYPHER 5 " + cypher).collect(Collectors.toSet());
     }
+
+    return generatedCyphers;
   }
 
   private static String unwindNodes(NodeTarget nodeTarget) {

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilities.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilities.java
@@ -35,6 +35,10 @@ public final class Neo4jCapabilities implements Serializable {
     return edition;
   }
 
+  public boolean hasCypherVersionStatement() {
+    return version.compareTo(Neo4jVersion.V2025_06) >= 0;
+  }
+
   public boolean hasVectorIndexes() {
     return edition != Neo4jEdition.COMMUNITY && version.compareTo(Neo4jVersion.V5_13_0) >= 0;
   }
@@ -99,6 +103,7 @@ public final class Neo4jCapabilities implements Serializable {
     public static final Neo4jVersion V5_7_0 = new Neo4jVersion(5, 7, 0);
     public static final Neo4jVersion V5_11_0 = new Neo4jVersion(5, 11, 0);
     public static final Neo4jVersion V5_13_0 = new Neo4jVersion(5, 13, 0);
+    public static final Neo4jVersion V2025_06 = new Neo4jVersion(2025, 6, 0);
 
     private final int major;
     private final int minor;

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/transforms/Neo4jRowWriterTransform.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/transforms/Neo4jRowWriterTransform.java
@@ -172,12 +172,15 @@ public class Neo4jRowWriterTransform extends PTransform<PCollection<Row>, PColle
 
   private String getCypherQuery() {
     TargetType targetType = target.getTargetType();
+
     if (targetType == TargetType.QUERY) {
       var query = ((CustomQueryTarget) target).getQuery();
       LOG.info("Custom cypher query: {}", query);
       return query;
     }
-    var query = CypherGenerator.getImportStatement(importSpecification, (EntityTarget) target);
+
+    var capabilities = connectionSupplier.get().capabilities();
+    var query = CypherGenerator.getImportStatement(importSpecification, (EntityTarget) target, capabilities);
     LOG.info("Unwind cypher query: {}", query);
     return query;
   }

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/BaseCypherGeneratorTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/BaseCypherGeneratorTest.java
@@ -27,15 +27,35 @@ import org.neo4j.importer.v1.targets.TargetType;
 
 public abstract sealed class BaseCypherGeneratorTest permits CypherGeneratorTest {
     protected static final String SPEC_PATH = "src/test/resources/testing-specs/cypher-generator-test/";
+    protected static final String MULTI_DISTINCT_KEYS_SINGLE_PASS =
+            "multi-distinct-keys-single-pass-import.json";
+    protected static final String MULTI_LABEL_SINGLE_PASS =
+            "multi-label-single-pass-import.json";
+    protected static final String SINGLE_TARGET_CREATE_RELS_MERGE_NODES =
+            "single-target-relation-import-create-rels-merge-nodes.json";
+    protected static final String SINGLE_TARGET_MERGE_ALL =
+            "single-target-relation-import-merge-all.json";
+    protected static final String SINGLE_TARGET_WITH_KEYS =
+            "single-target-relation-import-with-keys-spec.json";
+    protected static final String SINGLE_TARGET_WITHOUT_KEYS =
+            "single-target-relation-import-without-keys-spec.json";
 
     protected static ImportSpecification importSpecificationOf(String specFile) {
         return JobSpecMapper.parse(SPEC_PATH + specFile, new OptionsParams());
     }
 
     protected void assertImportStatementOf(ImportSpecification spec, String expectedCypher) {
+        final Neo4jCapabilities preCypher25 = new Neo4jCapabilities("2025.05", "community");
         var relationshipTarget = spec.getTargets().getRelationships().iterator().next();
-        var actualCypher = CypherGenerator.getImportStatement(spec, relationshipTarget);
+        var actualCypher = CypherGenerator.getImportStatement(spec, relationshipTarget, preCypher25);
         assertThat(actualCypher).isEqualTo(expectedCypher);
+    }
+
+    protected void assertCypherPrefixOf(ImportSpecification spec, String expectedCypherPrefix) {
+        final Neo4jCapabilities postCypher25 = new Neo4jCapabilities("2025.06", "community");
+        var relationshipTarget = spec.getTargets().getRelationships().iterator().next();
+        var actualCypher = CypherGenerator.getImportStatement(spec, relationshipTarget, postCypher25);
+        assertThat(actualCypher).startsWith(expectedCypherPrefix);
     }
 
     protected void assertSchemaStatements(

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/BaseCypherGeneratorTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/BaseCypherGeneratorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.neo4j.database;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.teleport.v2.neo4j.model.helpers.JobSpecMapper;
+import com.google.cloud.teleport.v2.neo4j.model.job.OptionsParams;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.neo4j.importer.v1.ImportSpecification;
+import org.neo4j.importer.v1.targets.EntityTarget;
+import org.neo4j.importer.v1.targets.TargetType;
+
+public abstract sealed class BaseCypherGeneratorTest permits CypherGeneratorTest {
+    protected static final String SPEC_PATH = "src/test/resources/testing-specs/cypher-generator-test/";
+
+    protected static ImportSpecification importSpecificationOf(String specFile) {
+        return JobSpecMapper.parse(SPEC_PATH + specFile, new OptionsParams());
+    }
+
+    protected void assertImportStatementOf(ImportSpecification spec, String expectedCypher) {
+        var relationshipTarget = spec.getTargets().getRelationships().iterator().next();
+        var actualCypher = CypherGenerator.getImportStatement(spec, relationshipTarget);
+        assertThat(actualCypher).isEqualTo(expectedCypher);
+    }
+
+    protected void assertSchemaStatements(
+            ImportSpecification spec, Neo4jCapabilities capabilities, Set<String> expectedStatements) {
+        var statements =
+                spec.getTargets().getAll().stream()
+                        .filter(
+                                target ->
+                                        target.isActive()
+                                                && (target.getTargetType() == TargetType.NODE
+                                                || target.getTargetType() == TargetType.RELATIONSHIP))
+                        .map(target -> (EntityTarget) target)
+                        .flatMap(target -> CypherGenerator.getSchemaStatements(target, capabilities).stream())
+                        .collect(Collectors.toSet());
+
+        assertThat(statements).isEqualTo(expectedStatements);
+    }
+
+    protected Neo4jCapabilities capabilitiesFor(String neo4jVersion, String neo4jEdition) {
+        return new Neo4jCapabilities(neo4jVersion, neo4jEdition);
+    }
+}

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilitiesTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilitiesTest.java
@@ -16,7 +16,9 @@
 package com.google.cloud.teleport.v2.neo4j.database;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.teleport.v2.neo4j.database.Neo4jCapabilities.Neo4jVersion;
 import org.junit.Test;
@@ -44,5 +46,16 @@ public class Neo4jCapabilitiesTest {
     assertThrows(NumberFormatException.class, () -> Neo4jVersion.of(".."));
     assertThrows(NumberFormatException.class, () -> Neo4jVersion.of("5..3"));
     assertThrows(NumberFormatException.class, () -> Neo4jVersion.of(".2025.6"));
+  }
+
+  @Test
+  public void cypher_version_statement_availability() {
+    var before = new Neo4jCapabilities("2025.05.01", "community");
+    var first = new Neo4jCapabilities("2025.06.00", "community");
+    var after = new Neo4jCapabilities("2025.07.01", "community");
+
+    assertFalse("last version before cypher version statement", before.hasCypherVersionStatement());
+    assertTrue("first version with cypher version statement", first.hasCypherVersionStatement());
+    assertTrue("some versions after cypher version statement", after.hasCypherVersionStatement());
   }
 }


### PR DESCRIPTION
Neo4j version 2026.0 introduces the possibility to specify if cypher version 5 or 25 should be
used. In order to maximise backwards compatibility and minimize regressions we want to use
cypher version 5 in case of generated queries when possible.

This change extends Neo4jCapabilities to properly flag for a version that ships with cypher
version statements.

Then also extends Neo4jRowWriterTransform to check if "CYPHER 5" can be safely prepended.