### PR TITLE
 feat: enforce cypher 5 for generated queries

### DIFF
--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/CypherGenerator.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/CypherGenerator.java
@@ -42,18 +42,22 @@ public class CypherGenerator {
    * target.
    *
    * @param importSpecification the whole import specification
-   * @param target              the node or relationship target
+   * @param target the node or relationship target
    * @return the batch import query
    */
   public static String getImportStatement(
-      ImportSpecification importSpecification, EntityTarget target, Neo4jCapabilities capabilities) {
+      ImportSpecification importSpecification,
+      EntityTarget target,
+      Neo4jCapabilities capabilities) {
     var type = target.getTargetType();
-    var generatedCypher = switch (type) {
-      case NODE -> unwindNodes((NodeTarget) target);
-      case RELATIONSHIP -> unwindRelationships(importSpecification, (RelationshipTarget) target);
-      default ->
-          throw new IllegalArgumentException(String.format("unexpected target type: %s", type));
-    };
+    var generatedCypher =
+        switch (type) {
+          case NODE -> unwindNodes((NodeTarget) target);
+          case RELATIONSHIP -> unwindRelationships(
+              importSpecification, (RelationshipTarget) target);
+          default -> throw new IllegalArgumentException(
+              String.format("unexpected target type: %s", type));
+        };
 
     if (capabilities.hasCypherVersionStatement()) {
       return "CYPHER 5 " + generatedCypher;
@@ -71,16 +75,18 @@ public class CypherGenerator {
   public static Set<String> getSchemaStatements(
       EntityTarget target, Neo4jCapabilities capabilities) {
     var type = target.getTargetType();
-    var generatedCyphers = switch (type) {
-      case NODE -> getNodeSchemaStatements((NodeTarget) target, capabilities);
-      case RELATIONSHIP ->
-          getRelationshipSchemaStatements((RelationshipTarget) target, capabilities);
-      default ->
-          throw new IllegalArgumentException(String.format("unexpected target type: %s", type));
-    };
+    var generatedCyphers =
+        switch (type) {
+          case NODE -> getNodeSchemaStatements((NodeTarget) target, capabilities);
+          case RELATIONSHIP -> getRelationshipSchemaStatements(
+              (RelationshipTarget) target, capabilities);
+          default -> throw new IllegalArgumentException(
+              String.format("unexpected target type: %s", type));
+        };
 
     if (capabilities.hasCypherVersionStatement()) {
-      generatedCyphers = generatedCyphers.stream().map(cypher -> "CYPHER 5 " + cypher).collect(Collectors.toSet());
+      generatedCyphers =
+          generatedCyphers.stream().map(cypher -> "CYPHER 5 " + cypher).collect(Collectors.toSet());
     }
 
     return generatedCyphers;

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/CypherGenerator.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/CypherGenerator.java
@@ -22,6 +22,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.neo4j.importer.v1.ImportSpecification;
 import org.neo4j.importer.v1.targets.EntityTarget;
 import org.neo4j.importer.v1.targets.NodeSchema;
@@ -41,20 +42,24 @@ public class CypherGenerator {
    * target.
    *
    * @param importSpecification the whole import specification
-   * @param target the node or relationship target
+   * @param target              the node or relationship target
    * @return the batch import query
    */
   public static String getImportStatement(
-      ImportSpecification importSpecification, EntityTarget target) {
+      ImportSpecification importSpecification, EntityTarget target, Neo4jCapabilities capabilities) {
     var type = target.getTargetType();
-    switch (type) {
-      case NODE:
-        return unwindNodes((NodeTarget) target);
-      case RELATIONSHIP:
-        return unwindRelationships(importSpecification, (RelationshipTarget) target);
-      default:
-        throw new IllegalArgumentException(String.format("unexpected target type: %s", type));
+    var generatedCypher = switch (type) {
+      case NODE -> unwindNodes((NodeTarget) target);
+      case RELATIONSHIP -> unwindRelationships(importSpecification, (RelationshipTarget) target);
+      default ->
+          throw new IllegalArgumentException(String.format("unexpected target type: %s", type));
+    };
+
+    if (capabilities.hasCypherVersionStatement()) {
+      return "CYPHER 5 " + generatedCypher;
     }
+
+    return generatedCypher;
   }
 
   /**
@@ -66,14 +71,19 @@ public class CypherGenerator {
   public static Set<String> getSchemaStatements(
       EntityTarget target, Neo4jCapabilities capabilities) {
     var type = target.getTargetType();
-    switch (type) {
-      case NODE:
-        return getNodeSchemaStatements((NodeTarget) target, capabilities);
-      case RELATIONSHIP:
-        return getRelationshipSchemaStatements((RelationshipTarget) target, capabilities);
-      default:
-        throw new IllegalArgumentException(String.format("unexpected target type: %s", type));
+    var generatedCyphers = switch (type) {
+      case NODE -> getNodeSchemaStatements((NodeTarget) target, capabilities);
+      case RELATIONSHIP ->
+          getRelationshipSchemaStatements((RelationshipTarget) target, capabilities);
+      default ->
+          throw new IllegalArgumentException(String.format("unexpected target type: %s", type));
+    };
+
+    if (capabilities.hasCypherVersionStatement()) {
+      generatedCyphers = generatedCyphers.stream().map(cypher -> "CYPHER 5 " + cypher).collect(Collectors.toSet());
     }
+
+    return generatedCyphers;
   }
 
   private static String unwindNodes(NodeTarget nodeTarget) {

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilities.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilities.java
@@ -35,6 +35,10 @@ public final class Neo4jCapabilities implements Serializable {
     return edition;
   }
 
+  public boolean hasCypherVersionStatement() {
+    return version.compareTo(Neo4jVersion.V2025_06) >= 0;
+  }
+
   public boolean hasVectorIndexes() {
     return edition != Neo4jEdition.COMMUNITY && version.compareTo(Neo4jVersion.V5_13_0) >= 0;
   }
@@ -99,6 +103,7 @@ public final class Neo4jCapabilities implements Serializable {
     public static final Neo4jVersion V5_7_0 = new Neo4jVersion(5, 7, 0);
     public static final Neo4jVersion V5_11_0 = new Neo4jVersion(5, 11, 0);
     public static final Neo4jVersion V5_13_0 = new Neo4jVersion(5, 13, 0);
+    public static final Neo4jVersion V2025_06 = new Neo4jVersion(2025, 6, 0);
 
     private final int major;
     private final int minor;

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilities.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilities.java
@@ -36,7 +36,7 @@ public final class Neo4jCapabilities implements Serializable {
   }
 
   public boolean hasCypherVersionStatement() {
-    return version.compareTo(Neo4jVersion.V2025_06) >= 0;
+    return version.compareTo(Neo4jVersion.V5_21_0) >= 0;
   }
 
   public boolean hasVectorIndexes() {
@@ -103,7 +103,7 @@ public final class Neo4jCapabilities implements Serializable {
     public static final Neo4jVersion V5_7_0 = new Neo4jVersion(5, 7, 0);
     public static final Neo4jVersion V5_11_0 = new Neo4jVersion(5, 11, 0);
     public static final Neo4jVersion V5_13_0 = new Neo4jVersion(5, 13, 0);
-    public static final Neo4jVersion V2025_06 = new Neo4jVersion(2025, 6, 0);
+    public static final Neo4jVersion V5_21_0 = new Neo4jVersion(5, 21, 0);
 
     private final int major;
     private final int minor;

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnection.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jConnection.java
@@ -70,12 +70,15 @@ public class Neo4jConnection implements AutoCloseable, Serializable {
     }
 
     try (var session = getSession()) {
-      var result = session.run(
-          "CALL dbms.components() YIELD name, versions, edition WHERE name = $kernel RETURN versions[0], edition",
-          Map.of("kernel", "Neo4j Kernel")
-      ).single();
+      var result =
+          session
+              .run(
+                  "CALL dbms.components() YIELD name, versions, edition WHERE name = $kernel RETURN versions[0], edition",
+                  Map.of("kernel", "Neo4j Kernel"))
+              .single();
 
-      this.capabilitiesCache = new Neo4jCapabilities(result.get(0).asString(), result.get(1).asString());
+      this.capabilitiesCache =
+          new Neo4jCapabilities(result.get(0).asString(), result.get(1).asString());
       return this.capabilitiesCache;
     }
   }

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/transforms/Neo4jRowWriterTransform.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/transforms/Neo4jRowWriterTransform.java
@@ -180,7 +180,9 @@ public class Neo4jRowWriterTransform extends PTransform<PCollection<Row>, PColle
     }
 
     var capabilities = connectionSupplier.get().capabilities();
-    var query = CypherGenerator.getImportStatement(importSpecification, (EntityTarget) target, capabilities);
+    var query =
+        CypherGenerator.getImportStatement(
+            importSpecification, (EntityTarget) target, capabilities);
     LOG.info("Unwind cypher query: {}", query);
     return query;
   }

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/transforms/Neo4jRowWriterTransform.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/transforms/Neo4jRowWriterTransform.java
@@ -172,12 +172,15 @@ public class Neo4jRowWriterTransform extends PTransform<PCollection<Row>, PColle
 
   private String getCypherQuery() {
     TargetType targetType = target.getTargetType();
+
     if (targetType == TargetType.QUERY) {
       var query = ((CustomQueryTarget) target).getQuery();
       LOG.info("Custom cypher query: {}", query);
       return query;
     }
-    var query = CypherGenerator.getImportStatement(importSpecification, (EntityTarget) target);
+
+    var capabilities = connectionSupplier.get().capabilities();
+    var query = CypherGenerator.getImportStatement(importSpecification, (EntityTarget) target, capabilities);
     LOG.info("Unwind cypher query: {}", query);
     return query;
   }

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/BaseCypherGeneratorTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/BaseCypherGeneratorTest.java
@@ -26,55 +26,55 @@ import org.neo4j.importer.v1.targets.EntityTarget;
 import org.neo4j.importer.v1.targets.TargetType;
 
 public abstract sealed class BaseCypherGeneratorTest permits CypherGeneratorTest {
-    protected static final String SPEC_PATH = "src/test/resources/testing-specs/cypher-generator-test/";
-    protected static final String MULTI_DISTINCT_KEYS_SINGLE_PASS =
-            "multi-distinct-keys-single-pass-import.json";
-    protected static final String MULTI_LABEL_SINGLE_PASS =
-            "multi-label-single-pass-import.json";
-    protected static final String SINGLE_TARGET_CREATE_RELS_MERGE_NODES =
-            "single-target-relation-import-create-rels-merge-nodes.json";
-    protected static final String SINGLE_TARGET_MERGE_ALL =
-            "single-target-relation-import-merge-all.json";
-    protected static final String SINGLE_TARGET_WITH_KEYS =
-            "single-target-relation-import-with-keys-spec.json";
-    protected static final String SINGLE_TARGET_WITHOUT_KEYS =
-            "single-target-relation-import-without-keys-spec.json";
+  protected static final String SPEC_PATH =
+      "src/test/resources/testing-specs/cypher-generator-test/";
+  protected static final String MULTI_DISTINCT_KEYS_SINGLE_PASS =
+      "multi-distinct-keys-single-pass-import.json";
+  protected static final String MULTI_LABEL_SINGLE_PASS = "multi-label-single-pass-import.json";
+  protected static final String SINGLE_TARGET_CREATE_RELS_MERGE_NODES =
+      "single-target-relation-import-create-rels-merge-nodes.json";
+  protected static final String SINGLE_TARGET_MERGE_ALL =
+      "single-target-relation-import-merge-all.json";
+  protected static final String SINGLE_TARGET_WITH_KEYS =
+      "single-target-relation-import-with-keys-spec.json";
+  protected static final String SINGLE_TARGET_WITHOUT_KEYS =
+      "single-target-relation-import-without-keys-spec.json";
 
-    protected static ImportSpecification importSpecificationOf(String specFile) {
-        return JobSpecMapper.parse(SPEC_PATH + specFile, new OptionsParams());
-    }
+  protected static ImportSpecification importSpecificationOf(String specFile) {
+    return JobSpecMapper.parse(SPEC_PATH + specFile, new OptionsParams());
+  }
 
-    protected void assertImportStatementOf(ImportSpecification spec, String expectedCypher) {
-        final Neo4jCapabilities preCypher25 = new Neo4jCapabilities("2025.05", "community");
-        var relationshipTarget = spec.getTargets().getRelationships().iterator().next();
-        var actualCypher = CypherGenerator.getImportStatement(spec, relationshipTarget, preCypher25);
-        assertThat(actualCypher).isEqualTo(expectedCypher);
-    }
+  protected void assertImportStatementOf(ImportSpecification spec, String expectedCypher) {
+    final Neo4jCapabilities preCypher25 = new Neo4jCapabilities("2025.05", "community");
+    var relationshipTarget = spec.getTargets().getRelationships().iterator().next();
+    var actualCypher = CypherGenerator.getImportStatement(spec, relationshipTarget, preCypher25);
+    assertThat(actualCypher).isEqualTo(expectedCypher);
+  }
 
-    protected void assertCypherPrefixOf(ImportSpecification spec, String expectedCypherPrefix) {
-        final Neo4jCapabilities postCypher25 = new Neo4jCapabilities("2025.06", "community");
-        var relationshipTarget = spec.getTargets().getRelationships().iterator().next();
-        var actualCypher = CypherGenerator.getImportStatement(spec, relationshipTarget, postCypher25);
-        assertThat(actualCypher).startsWith(expectedCypherPrefix);
-    }
+  protected void assertCypherPrefixOf(ImportSpecification spec, String expectedCypherPrefix) {
+    final Neo4jCapabilities postCypher25 = new Neo4jCapabilities("2025.06", "community");
+    var relationshipTarget = spec.getTargets().getRelationships().iterator().next();
+    var actualCypher = CypherGenerator.getImportStatement(spec, relationshipTarget, postCypher25);
+    assertThat(actualCypher).startsWith(expectedCypherPrefix);
+  }
 
-    protected void assertSchemaStatements(
-            ImportSpecification spec, Neo4jCapabilities capabilities, Set<String> expectedStatements) {
-        var statements =
-                spec.getTargets().getAll().stream()
-                        .filter(
-                                target ->
-                                        target.isActive()
-                                                && (target.getTargetType() == TargetType.NODE
-                                                || target.getTargetType() == TargetType.RELATIONSHIP))
-                        .map(target -> (EntityTarget) target)
-                        .flatMap(target -> CypherGenerator.getSchemaStatements(target, capabilities).stream())
-                        .collect(Collectors.toSet());
+  protected void assertSchemaStatements(
+      ImportSpecification spec, Neo4jCapabilities capabilities, Set<String> expectedStatements) {
+    var statements =
+        spec.getTargets().getAll().stream()
+            .filter(
+                target ->
+                    target.isActive()
+                        && (target.getTargetType() == TargetType.NODE
+                            || target.getTargetType() == TargetType.RELATIONSHIP))
+            .map(target -> (EntityTarget) target)
+            .flatMap(target -> CypherGenerator.getSchemaStatements(target, capabilities).stream())
+            .collect(Collectors.toSet());
 
-        assertThat(statements).isEqualTo(expectedStatements);
-    }
+    assertThat(statements).isEqualTo(expectedStatements);
+  }
 
-    protected Neo4jCapabilities capabilitiesFor(String neo4jVersion, String neo4jEdition) {
-        return new Neo4jCapabilities(neo4jVersion, neo4jEdition);
-    }
+  protected Neo4jCapabilities capabilitiesFor(String neo4jVersion, String neo4jEdition) {
+    return new Neo4jCapabilities(neo4jVersion, neo4jEdition);
+  }
 }

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/BaseCypherGeneratorTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/BaseCypherGeneratorTest.java
@@ -27,15 +27,35 @@ import org.neo4j.importer.v1.targets.TargetType;
 
 public abstract sealed class BaseCypherGeneratorTest permits CypherGeneratorTest {
     protected static final String SPEC_PATH = "src/test/resources/testing-specs/cypher-generator-test/";
+    protected static final String MULTI_DISTINCT_KEYS_SINGLE_PASS =
+            "multi-distinct-keys-single-pass-import.json";
+    protected static final String MULTI_LABEL_SINGLE_PASS =
+            "multi-label-single-pass-import.json";
+    protected static final String SINGLE_TARGET_CREATE_RELS_MERGE_NODES =
+            "single-target-relation-import-create-rels-merge-nodes.json";
+    protected static final String SINGLE_TARGET_MERGE_ALL =
+            "single-target-relation-import-merge-all.json";
+    protected static final String SINGLE_TARGET_WITH_KEYS =
+            "single-target-relation-import-with-keys-spec.json";
+    protected static final String SINGLE_TARGET_WITHOUT_KEYS =
+            "single-target-relation-import-without-keys-spec.json";
 
     protected static ImportSpecification importSpecificationOf(String specFile) {
         return JobSpecMapper.parse(SPEC_PATH + specFile, new OptionsParams());
     }
 
     protected void assertImportStatementOf(ImportSpecification spec, String expectedCypher) {
+        final Neo4jCapabilities preCypher25 = new Neo4jCapabilities("2025.05", "community");
         var relationshipTarget = spec.getTargets().getRelationships().iterator().next();
-        var actualCypher = CypherGenerator.getImportStatement(spec, relationshipTarget);
+        var actualCypher = CypherGenerator.getImportStatement(spec, relationshipTarget, preCypher25);
         assertThat(actualCypher).isEqualTo(expectedCypher);
+    }
+
+    protected void assertCypherPrefixOf(ImportSpecification spec, String expectedCypherPrefix) {
+        final Neo4jCapabilities postCypher25 = new Neo4jCapabilities("2025.06", "community");
+        var relationshipTarget = spec.getTargets().getRelationships().iterator().next();
+        var actualCypher = CypherGenerator.getImportStatement(spec, relationshipTarget, postCypher25);
+        assertThat(actualCypher).startsWith(expectedCypherPrefix);
     }
 
     protected void assertSchemaStatements(

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/BaseCypherGeneratorTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/BaseCypherGeneratorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.neo4j.database;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.teleport.v2.neo4j.model.helpers.JobSpecMapper;
+import com.google.cloud.teleport.v2.neo4j.model.job.OptionsParams;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.neo4j.importer.v1.ImportSpecification;
+import org.neo4j.importer.v1.targets.EntityTarget;
+import org.neo4j.importer.v1.targets.TargetType;
+
+public abstract sealed class BaseCypherGeneratorTest permits CypherGeneratorTest {
+    protected static final String SPEC_PATH = "src/test/resources/testing-specs/cypher-generator-test/";
+
+    protected static ImportSpecification importSpecificationOf(String specFile) {
+        return JobSpecMapper.parse(SPEC_PATH + specFile, new OptionsParams());
+    }
+
+    protected void assertImportStatementOf(ImportSpecification spec, String expectedCypher) {
+        var relationshipTarget = spec.getTargets().getRelationships().iterator().next();
+        var actualCypher = CypherGenerator.getImportStatement(spec, relationshipTarget);
+        assertThat(actualCypher).isEqualTo(expectedCypher);
+    }
+
+    protected void assertSchemaStatements(
+            ImportSpecification spec, Neo4jCapabilities capabilities, Set<String> expectedStatements) {
+        var statements =
+                spec.getTargets().getAll().stream()
+                        .filter(
+                                target ->
+                                        target.isActive()
+                                                && (target.getTargetType() == TargetType.NODE
+                                                || target.getTargetType() == TargetType.RELATIONSHIP))
+                        .map(target -> (EntityTarget) target)
+                        .flatMap(target -> CypherGenerator.getSchemaStatements(target, capabilities).stream())
+                        .collect(Collectors.toSet());
+
+        assertThat(statements).isEqualTo(expectedStatements);
+    }
+
+    protected Neo4jCapabilities capabilitiesFor(String neo4jVersion, String neo4jEdition) {
+        return new Neo4jCapabilities(neo4jVersion, neo4jEdition);
+    }
+}

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/BaseCypherGeneratorTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/BaseCypherGeneratorTest.java
@@ -45,16 +45,18 @@ public abstract sealed class BaseCypherGeneratorTest permits CypherGeneratorTest
   }
 
   protected void assertImportStatementOf(ImportSpecification spec, String expectedCypher) {
-    final Neo4jCapabilities preCypher25 = new Neo4jCapabilities("2025.05", "community");
+    final Neo4jCapabilities beforeCypher5Possibility = new Neo4jCapabilities("5.20", "community");
     var relationshipTarget = spec.getTargets().getRelationships().iterator().next();
-    var actualCypher = CypherGenerator.getImportStatement(spec, relationshipTarget, preCypher25);
+    var actualCypher =
+        CypherGenerator.getImportStatement(spec, relationshipTarget, beforeCypher5Possibility);
     assertThat(actualCypher).isEqualTo(expectedCypher);
   }
 
   protected void assertCypherPrefixOf(ImportSpecification spec, String expectedCypherPrefix) {
-    final Neo4jCapabilities postCypher25 = new Neo4jCapabilities("2025.06", "community");
+    final Neo4jCapabilities afterCypher5Possibility = new Neo4jCapabilities("5.21", "community");
     var relationshipTarget = spec.getTargets().getRelationships().iterator().next();
-    var actualCypher = CypherGenerator.getImportStatement(spec, relationshipTarget, postCypher25);
+    var actualCypher =
+        CypherGenerator.getImportStatement(spec, relationshipTarget, afterCypher5Possibility);
     assertThat(actualCypher).startsWith(expectedCypherPrefix);
   }
 

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/CypherGeneratorTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/CypherGeneratorTest.java
@@ -588,7 +588,7 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
       generates_correct_schema_statement_for_multi_label_node_key_constraints_when_merging_edge_nodes_on_neo4j_2025_06_plus() {
     assertSchemaStatements(
         importSpecificationOf(MULTI_LABEL_SINGLE_PASS),
-        capabilitiesFor("2025.06", "enterprise"),
+        capabilitiesFor("5.21", "enterprise"),
         Set.of(
             "CYPHER 5 CREATE CONSTRAINT `Edge import-source-Source1-node-single-key-for-src_id` IF NOT EXISTS FOR (n:`Source1`) REQUIRE (n.`src_id`) IS NODE KEY",
             "CYPHER 5 CREATE CONSTRAINT `Edge import-source-Source2-node-single-key-for-src_id` IF NOT EXISTS FOR (n:`Source2`) REQUIRE (n.`src_id`) IS NODE KEY",
@@ -671,7 +671,7 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
       generates_correct_schema_statement_for_multi_distinct_keys_node_key_constraints_when_merging_edge_nodes_on_neo4j_2025_06_plus() {
     assertSchemaStatements(
         importSpecificationOf(MULTI_DISTINCT_KEYS_SINGLE_PASS),
-        capabilitiesFor("2025.06", "enterprise"),
+        capabilitiesFor("5.21", "enterprise"),
         Set.of(
             "CYPHER 5 CREATE CONSTRAINT `Edge import-source-Source-node-key-for-src_id1` IF NOT EXISTS FOR (n:`Source`) REQUIRE (n.`src_id1`) IS NODE KEY",
             "CYPHER 5 CREATE CONSTRAINT `Edge import-source-Source-node-key-for-src_id2` IF NOT EXISTS FOR (n:`Source`) REQUIRE (n.`src_id2`) IS NODE KEY",
@@ -710,7 +710,7 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
       generates_correct_schema_statement_for_multi_distinct_keys_node_key_constraints_when_merging_edge_nodes_on_neo4j_2025_06_plus_community() {
     assertSchemaStatements(
         importSpecificationOf(MULTI_DISTINCT_KEYS_SINGLE_PASS),
-        capabilitiesFor("2025.06", "community"),
+        capabilitiesFor("5.21", "community"),
         Set.of());
   }
 

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/CypherGeneratorTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/CypherGeneratorTest.java
@@ -54,44 +54,49 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
 
   @Test
   public void specifies_keys_in_relationship_merge_pattern() {
-    var expectedCypher = "UNWIND $rows AS row "
-        + "MATCH (start:`Source` {`id`: row.`source`}) "
-        + "MATCH (end:`Target` {`id`: row.`target`}) "
-        + "MERGE (start)-[r:`LINKS` {`id1`: row.`rel_id_1`, `id2`: row.`rel_id_2`}]->(end) "
-        + "SET r.`ts` = row.`timestamp`";
+    var expectedCypher =
+        "UNWIND $rows AS row "
+            + "MATCH (start:`Source` {`id`: row.`source`}) "
+            + "MATCH (end:`Target` {`id`: row.`target`}) "
+            + "MERGE (start)-[r:`LINKS` {`id1`: row.`rel_id_1`, `id2`: row.`rel_id_2`}]->(end) "
+            + "SET r.`ts` = row.`timestamp`";
 
     assertImportStatementOf(importSpecificationOf(SINGLE_TARGET_WITH_KEYS), expectedCypher);
   }
 
   @Test
   public void specifies_only_type_in_keyless_relationship_merge_pattern() {
-    var expectedCypher = "UNWIND $rows AS row "
-        + "MATCH (start:`Source` {`id`: row.`source`}) "
-        + "MATCH (end:`Target` {`id`: row.`target`}) "
-        + "MERGE (start)-[r:`LINKS`]->(end) "
-        + "SET r.`ts` = row.`timestamp`";
+    var expectedCypher =
+        "UNWIND $rows AS row "
+            + "MATCH (start:`Source` {`id`: row.`source`}) "
+            + "MATCH (end:`Target` {`id`: row.`target`}) "
+            + "MERGE (start)-[r:`LINKS`]->(end) "
+            + "SET r.`ts` = row.`timestamp`";
 
     assertImportStatementOf(importSpecificationOf(SINGLE_TARGET_WITHOUT_KEYS), expectedCypher);
   }
 
   @Test
   public void merges_edges_as_well_as_their_start_and_end_nodes() {
-    var expectedCypher = "UNWIND $rows AS row "
-        + "MERGE (start:`Source` {`src_id`: row.`source`}) "
-        + "MERGE (end:`Target` {`tgt_id`: row.`target`}) "
-        + "MERGE (start)-[r:`LINKS`]->(end) SET r.`ts` = row.`timestamp`";
+    var expectedCypher =
+        "UNWIND $rows AS row "
+            + "MERGE (start:`Source` {`src_id`: row.`source`}) "
+            + "MERGE (end:`Target` {`tgt_id`: row.`target`}) "
+            + "MERGE (start)-[r:`LINKS`]->(end) SET r.`ts` = row.`timestamp`";
 
     assertImportStatementOf(importSpecificationOf(SINGLE_TARGET_MERGE_ALL), expectedCypher);
   }
 
   @Test
   public void creates_edges_and_merges_their_start_and_end_nodes() {
-    var expectedCypher = "UNWIND $rows AS row "
-        + "MERGE (start:`Source` {`src_id`: row.`source`}) "
-        + "MERGE (end:`Target` {`tgt_id`: row.`target`}) "
-        + "CREATE (start)-[r:`LINKS`]->(end) SET r.`ts` = row.`timestamp`";
+    var expectedCypher =
+        "UNWIND $rows AS row "
+            + "MERGE (start:`Source` {`src_id`: row.`source`}) "
+            + "MERGE (end:`Target` {`tgt_id`: row.`target`}) "
+            + "CREATE (start)-[r:`LINKS`]->(end) SET r.`ts` = row.`timestamp`";
 
-    assertImportStatementOf(importSpecificationOf(SINGLE_TARGET_CREATE_RELS_MERGE_NODES), expectedCypher);
+    assertImportStatementOf(
+        importSpecificationOf(SINGLE_TARGET_CREATE_RELS_MERGE_NODES), expectedCypher);
   }
 
   @Test
@@ -115,21 +120,22 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
   @Test
   public void creates_edges_and_merges_their_start_and_end_nodes_cypher_prefix() {
     var expectedCypherPrefix = "CYPHER 5 UNWIND $rows AS row";
-    assertCypherPrefixOf(importSpecificationOf(SINGLE_TARGET_CREATE_RELS_MERGE_NODES), expectedCypherPrefix);
+    assertCypherPrefixOf(
+        importSpecificationOf(SINGLE_TARGET_CREATE_RELS_MERGE_NODES), expectedCypherPrefix);
   }
 
   @Test
   public void does_not_generate_constraints_for_edge_without_schema() {
-    var relationshipTarget = importSpecificationOf(SINGLE_TARGET_MERGE_ALL)
-        .getTargets()
-        .getRelationships()
-        .iterator()
-        .next();
+    var relationshipTarget =
+        importSpecificationOf(SINGLE_TARGET_MERGE_ALL)
+            .getTargets()
+            .getRelationships()
+            .iterator()
+            .next();
 
-    var statements = CypherGenerator.getSchemaStatements(
-        relationshipTarget,
-        capabilitiesFor("5.20", "enterprise")
-    );
+    var statements =
+        CypherGenerator.getSchemaStatements(
+            relationshipTarget, capabilitiesFor("5.20", "enterprise"));
 
     assertThat(statements).isEmpty();
   }
@@ -164,9 +170,10 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
     Set<String> schemaStatements =
         CypherGenerator.getSchemaStatements(relationship, capabilitiesFor("5.20", "enterprise"));
 
-    assertThat(schemaStatements).isEqualTo(Set.of(
-        "CREATE CONSTRAINT `rel-key` IF NOT EXISTS FOR ()-[r:`SELF_LINKS_TO`]-() REQUIRE (r.`targetRelProperty`) IS RELATIONSHIP KEY")
-    );
+    assertThat(schemaStatements)
+        .isEqualTo(
+            Set.of(
+                "CREATE CONSTRAINT `rel-key` IF NOT EXISTS FOR ()-[r:`SELF_LINKS_TO`]-() REQUIRE (r.`targetRelProperty`) IS RELATIONSHIP KEY"));
   }
 
   @Test
@@ -247,10 +254,11 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
             new Targets(List.of(startNode, endNode), List.of(relationship), null),
             null);
 
-    var expectedCypher = "UNWIND $rows AS row "
-        + "MATCH (start:`StartNode` {`targetNodeProperty`: row.`source_node_field`}) "
-        + "MATCH (end:`EndNode` {`targetNodeProperty`: row.`source_node_field`}) "
-        + "MERGE (start)-[r:`LINKS_TO` {`targetRelProperty`: row.`source_field`}]->(end)";
+    var expectedCypher =
+        "UNWIND $rows AS row "
+            + "MATCH (start:`StartNode` {`targetNodeProperty`: row.`source_node_field`}) "
+            + "MATCH (end:`EndNode` {`targetNodeProperty`: row.`source_node_field`}) "
+            + "MERGE (start)-[r:`LINKS_TO` {`targetRelProperty`: row.`source_field`}]->(end)";
 
     assertImportStatementOf(importSpecification, expectedCypher);
   }
@@ -576,7 +584,8 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
   }
 
   @Test
-  public void generates_correct_schema_statement_for_multi_label_node_key_constraints_when_merging_edge_nodes_on_neo4j_2025_06_plus() {
+  public void
+      generates_correct_schema_statement_for_multi_label_node_key_constraints_when_merging_edge_nodes_on_neo4j_2025_06_plus() {
     assertSchemaStatements(
         importSpecificationOf(MULTI_LABEL_SINGLE_PASS),
         capabilitiesFor("2025.06", "enterprise"),
@@ -588,7 +597,8 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
   }
 
   @Test
-  public void generates_correct_schema_statement_for_multi_label_node_key_constraints_when_merging_edge_nodes_on_neo4j_5_enterprise() {
+  public void
+      generates_correct_schema_statement_for_multi_label_node_key_constraints_when_merging_edge_nodes_on_neo4j_5_enterprise() {
     assertSchemaStatements(
         importSpecificationOf(MULTI_LABEL_SINGLE_PASS),
         capabilitiesFor("5.1.0", "enterprise"),
@@ -600,7 +610,8 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
   }
 
   @Test
-  public void generates_correct_schema_statement_for_multi_label_node_key_constraints_when_merging_edge_nodes_on_neo4j_5_aura() {
+  public void
+      generates_correct_schema_statement_for_multi_label_node_key_constraints_when_merging_edge_nodes_on_neo4j_5_aura() {
     assertSchemaStatements(
         importSpecificationOf(MULTI_LABEL_SINGLE_PASS),
         capabilitiesFor("5.1-aura", "enterprise"),
@@ -612,13 +623,17 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
   }
 
   @Test
-  public void generates_correct_schema_statement_for_multi_label_node_key_constraints_when_merging_edge_nodes_on_neo4j_5_community() {
+  public void
+      generates_correct_schema_statement_for_multi_label_node_key_constraints_when_merging_edge_nodes_on_neo4j_5_community() {
     assertSchemaStatements(
-        importSpecificationOf(MULTI_LABEL_SINGLE_PASS), capabilitiesFor("5.1.6", "community"), Set.of());
+        importSpecificationOf(MULTI_LABEL_SINGLE_PASS),
+        capabilitiesFor("5.1.6", "community"),
+        Set.of());
   }
 
   @Test
-  public void generates_correct_schema_statement_for_multi_label_node_key_constraints_when_merging_edge_nodes_on_neo4j_44_enterprise() {
+  public void
+      generates_correct_schema_statement_for_multi_label_node_key_constraints_when_merging_edge_nodes_on_neo4j_44_enterprise() {
     assertSchemaStatements(
         importSpecificationOf(MULTI_LABEL_SINGLE_PASS),
         capabilitiesFor("4.4.25", "enterprise"),
@@ -630,7 +645,8 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
   }
 
   @Test
-  public void generates_correct_schema_statement_for_multi_label_node_key_constraints_when_merging_edge_nodes_on_neo4j_44_aura() {
+  public void
+      generates_correct_schema_statement_for_multi_label_node_key_constraints_when_merging_edge_nodes_on_neo4j_44_aura() {
     assertSchemaStatements(
         importSpecificationOf(MULTI_LABEL_SINGLE_PASS),
         capabilitiesFor("4.4-aura", "enterprise"),
@@ -642,13 +658,17 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
   }
 
   @Test
-  public void generates_correct_schema_statement_for_multi_label_node_key_constraints_when_merging_edge_nodes_on_neo4j_44_community() {
+  public void
+      generates_correct_schema_statement_for_multi_label_node_key_constraints_when_merging_edge_nodes_on_neo4j_44_community() {
     assertSchemaStatements(
-        importSpecificationOf(MULTI_LABEL_SINGLE_PASS), capabilitiesFor("4.4.25", "community"), Set.of());
+        importSpecificationOf(MULTI_LABEL_SINGLE_PASS),
+        capabilitiesFor("4.4.25", "community"),
+        Set.of());
   }
 
   @Test
-  public void generates_correct_schema_statement_for_multi_distinct_keys_node_key_constraints_when_merging_edge_nodes_on_neo4j_2025_06_plus() {
+  public void
+      generates_correct_schema_statement_for_multi_distinct_keys_node_key_constraints_when_merging_edge_nodes_on_neo4j_2025_06_plus() {
     assertSchemaStatements(
         importSpecificationOf(MULTI_DISTINCT_KEYS_SINGLE_PASS),
         capabilitiesFor("2025.06", "enterprise"),
@@ -660,7 +680,8 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
   }
 
   @Test
-  public void generates_correct_schema_statement_for_multi_distinct_keys_node_key_constraints_when_merging_edge_nodes_on_neo4j_5_enterprise() {
+  public void
+      generates_correct_schema_statement_for_multi_distinct_keys_node_key_constraints_when_merging_edge_nodes_on_neo4j_5_enterprise() {
     assertSchemaStatements(
         importSpecificationOf(MULTI_DISTINCT_KEYS_SINGLE_PASS),
         capabilitiesFor("5.1.0", "enterprise"),
@@ -672,7 +693,8 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
   }
 
   @Test
-  public void generates_correct_schema_statement_for_multi_distinct_keys_node_key_constraints_when_merging_edge_nodes_on_neo4j_5_aura() {
+  public void
+      generates_correct_schema_statement_for_multi_distinct_keys_node_key_constraints_when_merging_edge_nodes_on_neo4j_5_aura() {
     assertSchemaStatements(
         importSpecificationOf(MULTI_DISTINCT_KEYS_SINGLE_PASS),
         capabilitiesFor("5.1-aura", "enterprise"),
@@ -684,7 +706,8 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
   }
 
   @Test
-  public void generates_correct_schema_statement_for_multi_distinct_keys_node_key_constraints_when_merging_edge_nodes_on_neo4j_2025_06_plus_community() {
+  public void
+      generates_correct_schema_statement_for_multi_distinct_keys_node_key_constraints_when_merging_edge_nodes_on_neo4j_2025_06_plus_community() {
     assertSchemaStatements(
         importSpecificationOf(MULTI_DISTINCT_KEYS_SINGLE_PASS),
         capabilitiesFor("2025.06", "community"),
@@ -692,7 +715,8 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
   }
 
   @Test
-  public void generates_correct_schema_statement_for_multi_distinct_keys_node_key_constraints_when_merging_edge_nodes_on_neo4j_5_community() {
+  public void
+      generates_correct_schema_statement_for_multi_distinct_keys_node_key_constraints_when_merging_edge_nodes_on_neo4j_5_community() {
     assertSchemaStatements(
         importSpecificationOf(MULTI_DISTINCT_KEYS_SINGLE_PASS),
         capabilitiesFor("5.1.0", "community"),
@@ -700,7 +724,8 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
   }
 
   @Test
-  public void generates_correct_schema_statement_for_multi_distinct_keys_node_key_constraints_when_merging_edge_nodes_on_neo4j_44_enterprise() {
+  public void
+      generates_correct_schema_statement_for_multi_distinct_keys_node_key_constraints_when_merging_edge_nodes_on_neo4j_44_enterprise() {
     assertSchemaStatements(
         importSpecificationOf(MULTI_DISTINCT_KEYS_SINGLE_PASS),
         capabilitiesFor("4.4.25", "enterprise"),
@@ -712,7 +737,8 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
   }
 
   @Test
-  public void generates_correct_schema_statement_for_distinct_keys_node_key_constraints_when_merging_edge_nodes_on_neo4j_44_aura() {
+  public void
+      generates_correct_schema_statement_for_distinct_keys_node_key_constraints_when_merging_edge_nodes_on_neo4j_44_aura() {
     assertSchemaStatements(
         importSpecificationOf(MULTI_DISTINCT_KEYS_SINGLE_PASS),
         capabilitiesFor("4.4-aura", "enterprise"),
@@ -724,7 +750,8 @@ public final class CypherGeneratorTest extends BaseCypherGeneratorTest {
   }
 
   @Test
-  public void generates_correct_schema_statement_for_multi_distinct_keys_node_key_constraints_when_merging_edge_nodes_on_neo4j_44_community() {
+  public void
+      generates_correct_schema_statement_for_multi_distinct_keys_node_key_constraints_when_merging_edge_nodes_on_neo4j_44_community() {
     assertSchemaStatements(
         importSpecificationOf(MULTI_DISTINCT_KEYS_SINGLE_PASS),
         capabilitiesFor("4.4.25", "community"),

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilitiesTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilitiesTest.java
@@ -50,9 +50,9 @@ public class Neo4jCapabilitiesTest {
 
   @Test
   public void cypher_version_statement_availability() {
-    var before = new Neo4jCapabilities("2025.05.01", "community");
-    var first = new Neo4jCapabilities("2025.06.00", "community");
-    var after = new Neo4jCapabilities("2025.07.01", "community");
+    var before = new Neo4jCapabilities("5.20", "community");
+    var first = new Neo4jCapabilities("5.21", "community");
+    var after = new Neo4jCapabilities("5.26", "community");
 
     assertFalse("last version before cypher version statement", before.hasCypherVersionStatement());
     assertTrue("first version with cypher version statement", first.hasCypherVersionStatement());

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilitiesTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/database/Neo4jCapabilitiesTest.java
@@ -16,7 +16,9 @@
 package com.google.cloud.teleport.v2.neo4j.database;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.teleport.v2.neo4j.database.Neo4jCapabilities.Neo4jVersion;
 import org.junit.Test;
@@ -44,5 +46,16 @@ public class Neo4jCapabilitiesTest {
     assertThrows(NumberFormatException.class, () -> Neo4jVersion.of(".."));
     assertThrows(NumberFormatException.class, () -> Neo4jVersion.of("5..3"));
     assertThrows(NumberFormatException.class, () -> Neo4jVersion.of(".2025.6"));
+  }
+
+  @Test
+  public void cypher_version_statement_availability() {
+    var before = new Neo4jCapabilities("2025.05.01", "community");
+    var first = new Neo4jCapabilities("2025.06.00", "community");
+    var after = new Neo4jCapabilities("2025.07.01", "community");
+
+    assertFalse("last version before cypher version statement", before.hasCypherVersionStatement());
+    assertTrue("first version with cypher version statement", first.hasCypherVersionStatement());
+    assertTrue("some versions after cypher version statement", after.hasCypherVersionStatement());
   }
 }

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/templates/InlineDataToNeo4jIT.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/templates/InlineDataToNeo4jIT.java
@@ -78,19 +78,24 @@ public class InlineDataToNeo4jIT extends TemplateTestBase {
                 createConfig(info),
                 Neo4jQueryCheck.builder(neo4jClient)
                     .setQuery(
-                        "CALL db.schema.nodeTypeProperties() YIELD nodeLabels, propertyName, mandatory RETURN nodeLabels, collect(propertyName) AS propertyNames ORDER BY nodeLabels ASC")
+                        "CALL db.schema.nodeTypeProperties() "
+                            + "YIELD nodeLabels, propertyName, mandatory "
+                            + "WITH nodeLabels, propertyName "
+                            + "ORDER BY nodeLabels, propertyName "
+                            + "RETURN nodeLabels, collect(propertyName) AS propertyNames "
+                            + "ORDER BY nodeLabels ASC")
                     .setExpectedResult(
                         List.of(
                             Map.of(
                                 "nodeLabels",
                                 List.of("Customer"),
                                 "propertyNames",
-                                List.of("customerId", "contactName", "companyName")),
+                                List.of("companyName", "contactName", "customerId")),
                             Map.of(
                                 "nodeLabels",
                                 List.of("Product"),
                                 "propertyNames",
-                                List.of("productId", "productName", "amount", "quantity"))))
+                                List.of("amount", "productId", "productName", "quantity"))))
                     .build(),
                 Neo4jQueryCheck.builder(neo4jClient)
                     .setQuery(
@@ -102,14 +107,19 @@ public class InlineDataToNeo4jIT extends TemplateTestBase {
                     .build(),
                 Neo4jQueryCheck.builder(neo4jClient)
                     .setQuery(
-                        "CALL db.schema.relTypeProperties() YIELD relType, propertyName RETURN relType, collect(propertyName) AS propertyNames ORDER BY relType ASC")
+                        "CALL db.schema.relTypeProperties() "
+                            + "YIELD relType, propertyName "
+                            + "WITH relType, propertyName "
+                            + "ORDER BY relType, propertyName "
+                            + "RETURN relType, collect(propertyName) AS propertyNames "
+                            + "ORDER BY relType ASC")
                     .setExpectedResult(
                         List.of(
                             Map.of(
                                 "relType",
                                 ":`PURCHASES`",
                                 "propertyNames",
-                                List.of("orderId", "amount", "quantity"))))
+                                List.of("amount", "orderId", "quantity"))))
                     .build(),
                 Neo4jQueryCheck.builder(neo4jClient)
                     .setQuery(


### PR DESCRIPTION
Neo4j version 2025.06 introduces the possibility to specify if cypher version 5 or 25 should be
used. In order to maximise backwards compatibility and minimize regressions we want to use
cypher version 5 in case of generated queries when possible.

First possible version where "CYPHER 5" statement can be accepted is 5.21.

This change extends Neo4jCapabilities to properly flag for a version that ships with cypher
version statements.

Then also extends Neo4jRowWriterTransform to check if "CYPHER 5" can be safely prepended
