### PR TITLE
Adding python flex template to convert raw text/image objects to ArrayRecord

### DIFF
--- a/python/src/main/java/com/google/cloud/teleport/templates/python/ArrayRecordConverter.java
+++ b/python/src/main/java/com/google/cloud/teleport/templates/python/ArrayRecordConverter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.templates.python;
+
+import com.google.cloud.teleport.metadata.Template;
+import com.google.cloud.teleport.metadata.TemplateCategory;
+import com.google.cloud.teleport.metadata.TemplateParameter;
+
+/** template class for YAMLTemplate in Python. */
+@Template(
+    name = "ArrayRecord_Converter",
+    category = TemplateCategory.STREAMING,
+    type = Template.TemplateType.PYTHON,
+    displayName = "ArrayRecord Converter Job",
+    description =
+        "The ArrayRecord_Converter Template is used to convert bulk text/image dataset in GCS into ArrayRecord Datasets in GCS"
+            + "An input GCS path can be passed in and resulting data will be uploaded to the `output_path`",
+    flexContainerName = "arrayrecord-converter",
+    contactInformation = "https://cloud.google.com/support",
+    )
+public interface ArrayRecordConverter {
+  @TemplateParameter.GcsReadFile(
+      order = 1,
+      name = "input_path",
+      optional = false,
+      description = "Input GCS path to match all files(e.g., gcs://example/*.txt)",
+      helpText = "An input path in the form of a GCS path.")
+  String getInputPath();
+
+  @TemplateParameter.Text(
+      order = 2,
+      name = "input_format",
+      optional = false,
+      description = "Input format of the data, can be either text or image",
+      helpText = "The format of the input, which can be either text or image. This job does not support other values.")
+  String getInputFormat();
+
+  @TemplateParameter.GcsWriteFolder(
+      order = 3,
+      name = "output_path",
+      optional = false,
+      description = "Output GCS path where files are generated",
+      helpText =
+          "Output path in the form of a GCS path where files will be uploaded.")
+  String getOutputPath();
+}

--- a/python/src/main/python/arrayrecord-converter/main.py
+++ b/python/src/main/python/arrayrecord-converter/main.py
@@ -1,0 +1,138 @@
+#
+# Copyright (C) 2025 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+"""A template workflow to convert raw objects(text, images) into ArrayRecord files."""
+
+import argparse
+import logging
+import os
+import urllib
+
+import apache_beam as beam
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.options.pipeline_options import SetupOptions
+from array_record.python.array_record_module import ArrayRecordWriter
+from google.cloud import storage
+
+
+class ConvertToArrayRecordGCS(beam.DoFn):
+  """Write a tuple consisting of a filename and records to GCS ArrayRecords."""
+
+  _WRITE_DIR = '/tmp/'
+
+  def process(
+      self,
+      element,
+      path,
+      write_dir=_WRITE_DIR,
+      file_path_suffix='.arrayrecord',
+      overwrite_extension=False,
+  ):
+
+    ## Upload to GCS
+    def upload_to_gcs(
+        bucket_name, filename, prefix='', source_dir=self._WRITE_DIR
+    ):
+      source_filename = os.path.join(source_dir, filename)
+      blob_name = os.path.join(prefix, filename)
+      storage_client = storage.Client()
+      bucket = storage_client.get_bucket(bucket_name)
+      blob = bucket.blob(blob_name)
+      blob.upload_from_filename(source_filename)
+
+    ## Simple logic for stripping a file extension and replacing it
+    def fix_filename(filename):
+      base_name = os.path.splitext(filename)[0]
+      new_filename = base_name + file_path_suffix
+      return new_filename
+
+    parsed_gcs_path = urllib.parse.urlparse(path)
+    bucket_name = parsed_gcs_path.hostname
+    gcs_prefix = parsed_gcs_path.path.lstrip('/')
+
+    if overwrite_extension:
+      filename = fix_filename(os.path.basename(element[0]))
+    else:
+      filename = '{}{}'.format(os.path.basename(element[0]), file_path_suffix)
+
+    write_path = os.path.join(write_dir, filename)
+    writer = ArrayRecordWriter(write_path, 'group_size:1')
+
+    for item in element[1]:
+      writer.write(bytes(item, 'utf-8'))
+
+    writer.close()
+
+    upload_to_gcs(bucket_name, filename, prefix=gcs_prefix)
+    os.remove(os.path.join(write_dir, filename))
+
+
+def run(argv=None, save_main_session=True):
+  """Main entry point; defines and runs the wordcount pipeline."""
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '--input_path',
+      dest='input_path',
+      default=(
+          'gs://converter-datasets/input-datasets/google-top-terms/csv/1k/*.csv'
+      ),
+      help='Input file to process.',
+  )
+  parser.add_argument(
+      '--input_format',
+      dest='input_format',
+      default='text|images',
+      help='Input file format.',
+  )
+  parser.add_argument(
+      '--output_destination',
+      dest='output_destination',
+      required=True,
+      help='Output destination to write results to.',
+  )
+  known_args, pipeline_args = parser.parse_known_args(argv)
+
+  # We use the save_main_session option because one or more DoFn's in this
+  # workflow rely on global context (e.g., a module imported at module level).
+  pipeline_options = PipelineOptions(pipeline_args)
+  pipeline_options.view_as(SetupOptions).save_main_session = save_main_session
+
+  # The pipeline will be run on exiting the with block.
+  with beam.Pipeline(options=pipeline_options) as p:
+    # TODO(iamphani): Move this out to array_record/beam/pipelines.py once it is
+    # updated to support raw text.
+    initial_files = p | 'Start' >> beam.Create([known_args.input_path])
+    if known_args.input_format == 'text':
+      parsed_files = initial_files | 'Read' >> beam.io.ReadAllFromText(
+          with_filename=True
+      )
+    else:
+      raise ValueError('Unsupported input format: %s' % known_args.input_format)
+    _ = (
+        parsed_files
+        | 'Group' >> beam.GroupByKey()
+        | 'Write to ArrayRecord in GCS'
+        >> beam.ParDo(
+            ConvertToArrayRecordGCS(),
+            known_args.output_destination,
+            file_path_suffix='.arrayrecord',
+            overwrite_extension=False,
+        )
+    )
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  run()

--- a/python/src/main/python/arrayrecord-converter/metadata.json
+++ b/python/src/main/python/arrayrecord-converter/metadata.json
@@ -1,0 +1,30 @@
+{
+  "name": "ArrayRecord Conversion",
+  "description": "Converts a GCS object[CSV, JSON, Avro, Parquet] to ArrayRecord format.",
+  "parameters": [
+    {
+      "name": "input_path",
+      "label": "Input destination",
+      "helpText": "The path and filename prefix for reading input files. Example: gs://your-bucket/your-path",
+      "regexes": [
+        "^gs:\\/\\/[^\\n\\r]+$"
+      ]
+    },
+    {
+      "name": "input_format",
+      "label": "Input format",
+      "helpText": "The format of the input files. Supported formats: text, images",
+      "regexes": [
+        "text|image"
+      ]
+    },
+    {
+      "name": "output_destination",
+      "label": "Output destination",
+      "helpText": "The path and filename prefix for writing output files. Example: gs://your-bucket/your-path",
+      "regexes": [
+        "^gs:\\/\\/[^\\n\\r]+$"
+      ]
+    }
+  ]
+}

--- a/python/src/main/python/arrayrecord-converter/requirements.txt
+++ b/python/src/main/python/arrayrecord-converter/requirements.txt
@@ -1,0 +1,5 @@
+apache-beam[gcp]
+pandas
+pyarrow
+google-cloud-storage
+array-record[beam]

--- a/python/src/test/java/com/google/cloud/teleport/templates/python/ArrayRecordConverterIT.java
+++ b/python/src/test/java/com/google/cloud/teleport/templates/python/ArrayRecordConverterIT.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.templates.python;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
+
+import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
+import org.apache.beam.it.common.PipelineLauncher.LaunchInfo;
+import org.apache.beam.it.common.PipelineOperator.Result;
+import org.apache.beam.it.gcp.TemplateTestBase;
+import org.apache.beam.it.gcp.artifacts.Artifact;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Integration test for {@link ArrayRecordConverter}. */
+// SkipDirectRunnerTest: Python templates are not supported through DirectRunner yet.
+@Category({TemplateIntegrationTest.class, SkipDirectRunnerTest.class})
+@TemplateIntegrationTest(ArrayRecordConverter.class)
+@RunWith(JUnit4.class)
+public final class ArrayRecordConverterIT extends TemplateTestBase {
+
+  @Before
+  public void setup() throws IOException, URISyntaxException {
+    gcsClient.uploadArtifact(
+        "input/the_sonnets.txt", Resources.getResource("the_sonnets.txt").getPath());
+  }
+
+  @Test
+  public void testConvertRawText() throws IOException {
+    // Arrange
+    LaunchConfig.Builder options =
+        LaunchConfig.builder(testName, specPath)
+            .addParameter("input_path", getGcsPath("input") + "/*.txt")
+            .addParameter("input_format", "text")
+            .addParameter("output_path", getGcsPath("output/wc"));
+
+    // Act
+    LaunchInfo info = launchTemplate(options);
+    assertThatPipeline(info).isRunning();
+
+    Result result = pipelineOperator().waitUntilDone(createConfig(info));
+
+    // Assert
+    assertThatResult(result).isLaunchFinished();
+
+    List<Artifact> artifacts = gcsClient.listArtifacts("output/", Pattern.compile(".*"));
+
+    // Validate that the new file exists.
+    assertThat(artifacts).hasSize(1);
+  }
+}


### PR DESCRIPTION
Adding python flex template to convert raw text/image GCS objects in bulk to ArrayRecord format. This allows ML researchers to take advantage of Grain pipelines.

- Allows passing in `input_path`, `input_format`, and `output_path`.