### PR TITLE
Bump hivemq-mqtt-client to 1.3.7

### DIFF
--- a/v2/mqtt-to-pubsub/pom.xml
+++ b/v2/mqtt-to-pubsub/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.hivemq</groupId>
             <artifactId>hivemq-mqtt-client</artifactId>
-            <version>1.3.0</version>
+            <version>1.3.7</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Fixes 
- [CVE-2021-37136](https://github.com/advisories/GHSA-grg4-wf29-r9vv)
- [CVE-2021-37137](https://github.com/advisories/GHSA-9vjp-v76f-g363)
- [CVE-2021-20193](https://github.com/advisories/GHSA-mwq4-jmcc-2cx4)
- [CVE-2023-34462](https://github.com/advisories/GHSA-6mjq-h674-j845)