### PR TITLE
Bump hbase-shaded-client to 2.6.3-hadoop3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <guava.version>32.0.1-jre</guava.version>
     <hadoop.version>3.4.1</hadoop.version>
     <hamcrest.version>2.1</hamcrest.version>
-    <hbase.client.version>2.5.3-hadoop3</hbase.client.version>
+    <hbase.client.version>2.6.3-hadoop3</hbase.client.version>
     <mockito.version>4.11.0</mockito.version>
     <log4j-2.version>2.24.3</log4j-2.version>
     <jackson.version>2.15.4</jackson.version>


### PR DESCRIPTION
Fixes a few CVEs like [CVE-2023-44981](https://github.com/advisories/GHSA-7286-pgfv-vxvh)