### PR TITLE
feat(dataflow): replace cancelJob with forceCancelJob

### DIFF
--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
@@ -769,11 +769,12 @@ public abstract class TemplateTestBase {
       }
       try {
         Job cancelled =
-            pipelineLauncher.cancelJob(
+            pipelineLauncher.forceCancelJob(
                 launchInfo.projectId(), launchInfo.region(), launchInfo.jobId());
         LOG.warn("Job {} was shutdown by the hook to prevent resources leak.", cancelled.getId());
       } catch (Exception e) {
-        // expected that the cancel fails if the test works as intended, so logging as debug only.
+        // expected that the force cancel fails if the test works as intended, so logging as debug
+        // only.
         LOG.debug("Error shutting down job {}: {}", launchInfo.jobId(), e.getMessage());
       }
     }

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/dataflow/AbstractPipelineLauncher.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/dataflow/AbstractPipelineLauncher.java
@@ -342,10 +342,10 @@ public abstract class AbstractPipelineLauncher implements PipelineLauncher {
       try {
         JobState state = getJobStatus(TestProperties.project(), TestProperties.region(), jobId);
         if (ACTIVE_STATES.contains(state) || PENDING_STATES.contains(state)) {
-          cancelJob(TestProperties.project(), TestProperties.region(), jobId);
+          forceCancelJob(TestProperties.project(), TestProperties.region(), jobId);
         }
       } catch (Exception e) {
-        LOG.warn("Unable to cancel {}. Encountered error.", jobId, e);
+        LOG.warn("Unable to force cancel {}. Encountered error.", jobId, e);
       }
     }
     LOG.info("Dataflow jobs successfully cleaned up.");


### PR DESCRIPTION
Add forceCancelJob method to ensure jobs are terminated during cleanup Add tests for forceCancelJob functionality
Update logging messages to reflect force cancel operation

This should speed up the job canceling time.