### PR TITLE
build: update astra-io dependency to 4.18.1

### DIFF
--- a/v2/astradb-to-bigquery/pom.xml
+++ b/v2/astradb-to-bigquery/pom.xml
@@ -30,7 +30,7 @@
     <description>Copy a Table hosted in DataStax AstraDb (Cassandra) to BigQuery</description>
 
     <properties>
-        <astra-io.version>4.16.3</astra-io.version>
+        <astra-io.version>4.18.1</astra-io.version>
         <astra-sdk.version>0.6.3</astra-sdk.version>
     </properties>
 

--- a/v2/astradb-to-bigquery/src/main/java/com/google/cloud/teleport/v2/astradb/transforms/AstraDbToBigQueryMappingFn.java
+++ b/v2/astradb-to-bigquery/src/main/java/com/google/cloud/teleport/v2/astradb/transforms/AstraDbToBigQueryMappingFn.java
@@ -20,7 +20,6 @@ import com.datastax.oss.driver.api.core.metadata.Metadata;
 import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
-import com.datastax.oss.driver.api.core.type.CqlVectorType;
 import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.driver.api.core.type.ListType;
 import com.datastax.oss.driver.api.core.type.SetType;
@@ -149,10 +148,12 @@ public class AstraDbToBigQueryMappingFn
         return StandardSQLTypeName.BOOL;
 
       case ProtocolConstants.DataType.CUSTOM:
-        if (type instanceof CqlVectorType) {
+        // Check if this is a vector type by examining the CQL representation
+        String cqlType = type.asCql(false, false);
+        if (cqlType.toLowerCase().startsWith("vector<")) {
           return StandardSQLTypeName.BYTES;
         } else {
-          throw new IllegalArgumentException("Invalid custom type " + type.asCql(false, false));
+          throw new IllegalArgumentException("Invalid custom type " + cqlType);
         }
       default:
         throw new IllegalArgumentException(


### PR DESCRIPTION
Tested:
```
mvn dependency:tree -pl v2/astradb-to-bigquery  -am > ~/tmp/deps.txt   
cat ~/tmp/deps.txt | grep ch.qos.logback
```

Now we get:
```
[INFO] +- ch.qos.logback:logback-classic:jar:1.5.13:compile
[INFO] +- ch.qos.logback:logback-core:jar:1.5.13:compile
[INFO] |  +- ch.qos.logback:logback-classic:jar:1.5.13:test
[INFO] |  \- ch.qos.logback:logback-core:jar:1.5.13:test
[INFO] |  +- ch.qos.logback:logback-classic:jar:1.5.13:compile
[INFO] |  \- ch.qos.logback:logback-core:jar:1.5.13:compile
[INFO] |  +- ch.qos.logback:logback-classic:jar:1.5.13:compile
[INFO] |  \- ch.qos.logback:logback-core:jar:1.5.13:compile
[INFO] |  +- ch.qos.logback:logback-classic:jar:1.5.11:compile
[INFO] |  \- ch.qos.logback:logback-core:jar:1.5.11:compile
```
This fixes CVE-2023-6378, CVE-2024-12801, CVE-2024-12798