### PR TITLE
fix: enforce non-vulnerable version of okio to address

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
     <ojdbc8.version>23.2.0.0</ojdbc8.version>
     <mssql-jdbc.version>12.2.0.jre11</mssql-jdbc.version>
     <neo4j-driver.version>4.4.18</neo4j-driver.version>
+    <okio.version>1.17.6</okio.version>
     <!-- Socket factory JARs for Cloud SQL -->
     <mysql-socket-factory.version>1.15.2</mysql-socket-factory.version>
     <postgres-socket-factory.version>1.15.2</postgres-socket-factory.version>
@@ -220,7 +221,7 @@
       <dependency>
         <groupId>com.squareup.okio</groupId>
         <artifactId>okio</artifactId>
-        <version>1.17.6</version>
+        <version>${okio.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Fix CVE-2023-3635

```
mvn dependency:tree -pl v2/googlecloud-to-clickhouse -am | grep okio                               
```

```
[INFO] |  |  |  +- com.squareup.okio:okio-jvm:jar:3.6.0:compile
[INFO] |  |     |  +- com.squareup.okio:okio:jar:1.17.6:runtime
[INFO] |  |     \- com.squareup.okio:okio-fakefilesystem:jar:3.4.0:compile
[INFO] |  |        \- com.squareup.okio:okio-fakefilesystem-jvm:jar:3.4.0:compile
[INFO] |  |  |  +- com.squareup.okio:okio-jvm:jar:3.6.0:compile
[INFO] |  |     |  +- com.squareup.okio:okio:jar:1.17.6:runtime
[INFO] |  |     \- com.squareup.okio:okio-fakefilesystem:jar:3.4.0:compile
[INFO] |  |        \- com.squareup.okio:okio-fakefilesystem-jvm:jar:3.4.0:compile
[INFO] |  |  |  +- com.squareup.okio:okio-jvm:jar:3.6.0:compile
[INFO] |  |     |  +- com.squareup.okio:okio:jar:1.17.6:runtime
[INFO] |  |     \- com.squareup.okio:okio-fakefilesystem:jar:3.4.0:compile
[INFO] |  |        \- com.squareup.okio:okio-fakefilesystem-jvm:jar:3.4.0:compile
[INFO] |  |  |  +- com.squareup.okio:okio-jvm:jar:3.6.0:compile
[INFO] |  |     |  +- com.squareup.okio:okio:jar:1.17.6:runtime
[INFO] |  |     \- com.squareup.okio:okio-fakefilesystem:jar:3.4.0:compile
[INFO] |  |        \- com.squareup.okio:okio-fakefilesystem-jvm:jar:3.4.0:compile
[INFO] |  |  |  +- com.squareup.okio:okio-jvm:jar:3.6.0:compile
[INFO] |  |     |  +- com.squareup.okio:okio:jar:1.17.6:runtime
[INFO] |  |     \- com.squareup.okio:okio-fakefilesystem:jar:3.4.0:compile
[INFO] |  |        \- com.squareup.okio:okio-fakefilesystem-jvm:jar:3.4.0:compile
```