### PR TITLE
fix: update httpclient to fix CVE-2020-13956 vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,9 @@
     <mysql-socket-factory.version>1.15.2</mysql-socket-factory.version>
     <postgres-socket-factory.version>1.15.2</postgres-socket-factory.version>
 
+    <!-- Security vulnerability fixes -->
+    <httpclient.version>4.5.13</httpclient.version>
+
     <!-- Test categories -->
     <integration.tests>com.google.cloud.teleport.metadata.TemplateIntegrationTest</integration.tests>
     <load.tests>com.google.cloud.teleport.metadata.TemplateLoadTest</load.tests>
@@ -202,6 +205,13 @@
         <groupId>org.json</groupId>
         <artifactId>json</artifactId>
         <version>${json.version}</version>
+      </dependency>
+
+      <!-- Enforce non-vulnerable version of httpclient to fix CVE-2020-13956 -->
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${httpclient.version}</version>
       </dependency>
 
       <!-- TODO(https://github.com/apache/beam/issues/30700): Remove once Beam gets the latest version of gax. -->


### PR DESCRIPTION
Enforce non-vulnerable version of httpclient (4.5.13) to address security issue

```
mvn dependency:tree -pl v2/googlecloud-to-neo4j | grep org.apache.httpcomponents
```
```
[INFO] |  |  |  +- org.apache.httpcomponents.client5:httpclient5:jar:5.3.1:runtime
[INFO] |  |  |  |  +- org.apache.httpcomponents.core5:httpcore5:jar:5.2.4:runtime
[INFO] |  |  |  |  \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.2.4:runtime
[INFO] |  +- org.apache.httpcomponents:httpclient:jar:4.5.13:compile
[INFO] |  +- org.apache.httpcomponents:httpcore:jar:4.4.16:compile
```