### PR TITLE
build: add json-smart dependency to fix CVE-2023-1370

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,8 @@
       </dependency>
 
       <!-- Enforce non-vulnerable version of json-smart (CVE-2023-1370) -->
+      <!-- Caused by beam-vendor-calcite-1_28_0-0.2.jar-->
+      <!-- TODO: Remove once Beam releases 2.68.0. -->
       <dependency>
         <groupId>net.minidev</groupId>
         <artifactId>json-smart</artifactId>


### PR DESCRIPTION
Enforce non-vulnerable version of json-smart to address security vulnerability

```
mvn dependency:tree | grep -i "json-smart\|net.minidev"
```

```
[INFO] |  |  |  \- net.minidev:json-smart:jar:2.4.9:compile
[INFO] |  |  |     \- net.minidev:accessors-smart:jar:2.4.9:compile
[INFO] |  |  |  \- net.minidev:json-smart:jar:2.4.9:test
[INFO] |  |  |     \- net.minidev:accessors-smart:jar:2.4.9:test
```