### PR TITLE
feat(import): add early index create threshold parameter

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ImportPipeline.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ImportPipeline.java
@@ -204,6 +204,17 @@ public class ImportPipeline {
     ValueProvider<RpcPriority> getSpannerPriority();
 
     void setSpannerPriority(ValueProvider<RpcPriority> value);
+
+    @TemplateParameter.Integer(
+        order = 12,
+        optional = true,
+        description = "Early Index Create Threshold",
+        helpText =
+            "The threshold for the number of indexes and foreign keys that determines whether to create indexes before data loading. If the total number of indexes and foreign keys is less than this threshold, they will be created before data import for better performance. The default value is 40.")
+    @Default.Integer(40)
+    ValueProvider<Integer> getEarlyIndexCreateThreshold();
+
+    void setEarlyIndexCreateThreshold(ValueProvider<Integer> value);
   }
 
   public static void main(String[] args) {
@@ -239,7 +250,8 @@ public class ImportPipeline {
             options.getWaitForChangeStreams(),
             options.getWaitForSequences(),
             options.getEarlyIndexCreateFlag(),
-            options.getDdlCreationTimeoutInMinutes()));
+            options.getDdlCreationTimeoutInMinutes(),
+            options.getEarlyIndexCreateThreshold()));
 
     PipelineResult result = p.run();
 

--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ImportPipeline.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ImportPipeline.java
@@ -210,7 +210,7 @@ public class ImportPipeline {
         optional = true,
         description = "Early Index Create Threshold",
         helpText =
-            "The threshold for the number of indexes and foreign keys that determines whether to create indexes before data loading. If the total number of indexes and foreign keys is less than this threshold, they will be created before data import for better performance. The default value is 40.")
+            "The threshold for the number of indexes and foreign keys that determines whether to create indexes before data loading. If the total number of indexes and foreign keys is larger than this threshold, they will be created before data import for better performance. The default value is 40.")
     @Default.Integer(40)
     ValueProvider<Integer> getEarlyIndexCreateThreshold();
 

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/CopyDbTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/CopyDbTest.java
@@ -1199,7 +1199,8 @@ public class CopyDbTest {
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
-            ValueProvider.StaticValueProvider.of(30)));
+            ValueProvider.StaticValueProvider.of(30),
+            ValueProvider.StaticValueProvider.of(40)));
     PipelineResult importResult = importPipeline.run();
     importResult.waitUntilFinish();
 

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ExportRelatedTablesCheckTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ExportRelatedTablesCheckTest.java
@@ -1045,7 +1045,8 @@ public final class ExportRelatedTablesCheckTest {
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
-            ValueProvider.StaticValueProvider.of(30)));
+            ValueProvider.StaticValueProvider.of(30),
+            ValueProvider.StaticValueProvider.of(40)));
     PipelineResult importResult = importPipeline.run();
     importResult.waitUntilFinish();
   }

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ExportTimestampTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ExportTimestampTest.java
@@ -460,7 +460,8 @@ public class ExportTimestampTest {
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
-            ValueProvider.StaticValueProvider.of(30)));
+            ValueProvider.StaticValueProvider.of(30),
+            ValueProvider.StaticValueProvider.of(40)));
     PipelineResult importResult = importPipeline.run();
     importResult.waitUntilFinish();
   }

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ImportFromAvroTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ImportFromAvroTest.java
@@ -1329,7 +1329,8 @@ public class ImportFromAvroTest {
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
-            ValueProvider.StaticValueProvider.of(30)));
+            ValueProvider.StaticValueProvider.of(30),
+            ValueProvider.StaticValueProvider.of(40)));
     PipelineResult importResult = importPipeline.run();
     importResult.waitUntilFinish();
 

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ImportFromAvroTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ImportFromAvroTest.java
@@ -1418,7 +1418,8 @@ public class ImportFromAvroTest {
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
-            ValueProvider.StaticValueProvider.of(30)));
+            ValueProvider.StaticValueProvider.of(30),
+            ValueProvider.StaticValueProvider.of(40)));
 
     PipelineResult importResult = importPipeline.run();
     importResult.waitUntilFinish();
@@ -1521,7 +1522,8 @@ public class ImportFromAvroTest {
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
-            ValueProvider.StaticValueProvider.of(30)));
+            ValueProvider.StaticValueProvider.of(30),
+            ValueProvider.StaticValueProvider.of(40)));
     PipelineResult importResult = importPipeline.run();
     importResult.waitUntilFinish();
 
@@ -1632,7 +1634,8 @@ public class ImportFromAvroTest {
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
-            ValueProvider.StaticValueProvider.of(30)));
+            ValueProvider.StaticValueProvider.of(30),
+            ValueProvider.StaticValueProvider.of(40)));
     PipelineResult importResult = importPipeline.run();
     importResult.waitUntilFinish();
 
@@ -1724,7 +1727,8 @@ public class ImportFromAvroTest {
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
-            ValueProvider.StaticValueProvider.of(30)));
+            ValueProvider.StaticValueProvider.of(30),
+            ValueProvider.StaticValueProvider.of(40)));
     PipelineResult importResult = importPipeline.run();
     importResult.waitUntilFinish();
 
@@ -1814,7 +1818,8 @@ public class ImportFromAvroTest {
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
-            ValueProvider.StaticValueProvider.of(30)));
+            ValueProvider.StaticValueProvider.of(30),
+            ValueProvider.StaticValueProvider.of(40)));
     PipelineResult importResult = importPipeline.run();
     importResult.waitUntilFinish();
 
@@ -1914,7 +1919,8 @@ public class ImportFromAvroTest {
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
-            ValueProvider.StaticValueProvider.of(30)));
+            ValueProvider.StaticValueProvider.of(30),
+            ValueProvider.StaticValueProvider.of(40)));
     PipelineResult importResult = importPipeline.run();
     importResult.waitUntilFinish();
 
@@ -1990,7 +1996,8 @@ public class ImportFromAvroTest {
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
-            ValueProvider.StaticValueProvider.of(30)));
+            ValueProvider.StaticValueProvider.of(30),
+            ValueProvider.StaticValueProvider.of(40)));
     PipelineResult importResult = importPipeline.run();
     importResult.waitUntilFinish();
 
@@ -2070,7 +2077,8 @@ public class ImportFromAvroTest {
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
-            ValueProvider.StaticValueProvider.of(30)));
+            ValueProvider.StaticValueProvider.of(30),
+            ValueProvider.StaticValueProvider.of(40)));
     PipelineResult importResult = importPipeline.run();
     importResult.waitUntilFinish();
   }
@@ -2137,7 +2145,8 @@ public class ImportFromAvroTest {
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
-            ValueProvider.StaticValueProvider.of(30)));
+            ValueProvider.StaticValueProvider.of(30),
+            ValueProvider.StaticValueProvider.of(40)));
     PipelineResult importResult = importPipeline.run();
     importResult.waitUntilFinish();
 
@@ -2224,7 +2233,8 @@ public class ImportFromAvroTest {
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
-            ValueProvider.StaticValueProvider.of(30)));
+            ValueProvider.StaticValueProvider.of(30),
+            ValueProvider.StaticValueProvider.of(40)));
     PipelineResult importResult = importPipeline.run();
     importResult.waitUntilFinish();
 
@@ -2319,7 +2329,8 @@ public class ImportFromAvroTest {
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
             ValueProvider.StaticValueProvider.of(true),
-            ValueProvider.StaticValueProvider.of(30)));
+            ValueProvider.StaticValueProvider.of(30),
+            ValueProvider.StaticValueProvider.of(40)));
     PipelineResult importResult = importPipeline.run();
     importResult.waitUntilFinish();
 


### PR DESCRIPTION
Add configurable threshold for determining when to create indexes before data loading to optimize performance. Default value is set to 40.

internal bug: b/440945726