### PR TITLE
Datastream To SQL - Added Default Casing Parameter Functionality

### DIFF
--- a/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToSQL.java
+++ b/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToSQL.java
@@ -226,8 +226,21 @@ public class DataStreamToSQL {
 
     void setDatabaseName(String value);
 
-    @TemplateParameter.Text(
+    @TemplateParameter.Enum(
         order = 13,
+        optional = true,
+        enumOptions = {@TemplateEnumOption("DEFAULT"), @TemplateEnumOption("UPPERCASED"), @TemplateEnumOption("CAPITALIZED")},
+        description = "Toggle for Table Casing",
+        helpText =
+            "A Toggle for table casing behavior. For example,(ie."
+                + "DEFAULT = table1 -> table1, Capitalized = table1 -> Table1")
+    @Default.String("DEFAULT")
+    String getDefaultCasing();
+
+    void setDefaultCasing(String value);
+
+    @TemplateParameter.Text(
+        order = 14,
         optional = true,
         description = "A map of key/values used to dictate schema name changes",
         helpText =
@@ -239,7 +252,7 @@ public class DataStreamToSQL {
     void setSchemaMap(String value);
 
     @TemplateParameter.Text(
-        order = 14,
+        order = 15,
         groupName = "Target",
         optional = true,
         description = "Custom connection string.",
@@ -251,7 +264,7 @@ public class DataStreamToSQL {
     void setCustomConnectionString(String value);
 
     @TemplateParameter.Integer(
-        order = 15,
+        order = 16,
         optional = true,
         description = "Number of threads to use for Format to DML step.",
         helpText =
@@ -262,7 +275,7 @@ public class DataStreamToSQL {
     void setNumThreads(int value);
 
     @TemplateParameter.Integer(
-        order = 16,
+        order = 17,
         groupName = "Target",
         optional = true,
         description = "Database login timeout in seconds.",
@@ -273,7 +286,7 @@ public class DataStreamToSQL {
     void setDatabaseLoginTimeout(Integer value);
 
     @TemplateParameter.Boolean(
-        order = 17,
+        order = 18,
         optional = true,
         description =
             "Order by configurations for data should include prioritizing data which is not deleted.",
@@ -300,6 +313,8 @@ public class DataStreamToSQL {
     options.setStreaming(true);
     run(options);
   }
+
+
 
   /**
    * Build the DataSourceConfiguration for the target SQL database. Using the pipeline options,
@@ -444,6 +459,7 @@ public class DataStreamToSQL {
             .apply(
                 "Format to DML",
                 CreateDml.of(dataSourceConfiguration)
+                    .withDefaultCasing(options.getDefaultCasing())
                     .withSchemaMap(schemaMap)
                     .withTableNameMap(tableNameMap)
                     .withOrderByIncludesIsDeleted(options.getOrderByIncludesIsDeleted())

--- a/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/transforms/CreateDml.java
+++ b/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/transforms/CreateDml.java
@@ -43,6 +43,7 @@ public class CreateDml
   private static final String WINDOW_DURATION = "1s";
   private static Integer numThreads = Integer.valueOf(100);
   private static DataSourceConfiguration dataSourceConfiguration;
+  private static String defaultCasing = "DEFAULT";
   private static Map<String, String> schemaMap = new HashMap<String, String>();
   private static Map<String, String> tableNameMap = new HashMap<String, String>();
   private static Boolean orderByIncludesIsDeleted = false;
@@ -53,6 +54,11 @@ public class CreateDml
 
   public static CreateDml of(DataSourceConfiguration dataSourceConfiguration) {
     return new CreateDml(dataSourceConfiguration);
+  }
+
+  public CreateDml withDefaultCasing(String casing) {
+    CreateDml.defaultCasing = casing;
+    return this;
   }
 
   public CreateDml withSchemaMap(Map<String, String> schemaMap) {
@@ -75,6 +81,7 @@ public class CreateDml
     return this;
   }
 
+
   public DatastreamToDML getDatastreamToDML() {
     DatastreamToDML datastreamToDML;
     String driverName = this.dataSourceConfiguration.getDriverClassName().get();
@@ -91,6 +98,7 @@ public class CreateDml
     }
 
     return datastreamToDML
+        .withDefaultCasing(defaultCasing)
         .withSchemaMap(this.schemaMap)
         .withTableNameMap(this.tableNameMap)
         .withOrderByIncludesIsDeleted(orderByIncludesIsDeleted);

--- a/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/utils/DatastreamToDML.java
+++ b/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/utils/DatastreamToDML.java
@@ -55,6 +55,7 @@ public abstract class DatastreamToDML
   private CdcJdbcIO.DataSourceConfiguration dataSourceConfiguration;
   private DataSource dataSource;
   public String quoteCharacter;
+  protected String defaultCasing = "DEFAULT";
   protected Map<String, String> schemaMappings = new HashMap<>();
   protected Map<String, String> tableMappings = new HashMap<>();
   protected Boolean orderByIncludesIsDeleted = false;
@@ -86,6 +87,29 @@ public abstract class DatastreamToDML
   public DatastreamToDML withQuoteCharacter(String quoteChar) {
     this.quoteCharacter = quoteChar;
     return this;
+  }
+
+  public DatastreamToDML withDefaultCasing(String casing) {
+    if (casing != null) {
+      this.defaultCasing = casing;
+    }
+    return this;
+  }
+
+  protected String applyCasing(String name) {
+    if (name == null) {
+      return null;
+    }
+
+    switch (this.defaultCasing.toUpperCase()) {
+      case "UPPERCASED":
+        return name.toUpperCase();
+      case "CAPITALIZED":
+        return StringUtils.capitalize(name.toLowerCase());
+      case "DEFAULT":
+      default:
+        return name.toLowerCase();
+    }
   }
 
   public DatastreamToDML withSchemaMap(Map<String, String> combinedMap) {
@@ -182,7 +206,7 @@ public abstract class DatastreamToDML
       return tableMappings.get(fullSourceTableName).split("\\.")[1];
     }
     // No other rules apply, just default to lowercase.
-    return row.getTableName().toLowerCase();
+    return applyCasing(row.getTableName());
   }
 
   public List<String> getPrimaryKeys(

--- a/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/utils/DatastreamToMySQLDML.java
+++ b/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/utils/DatastreamToMySQLDML.java
@@ -63,7 +63,7 @@ public class DatastreamToMySQLDML extends DatastreamToDML {
       return tableMappings.get(fullSourceTableName).split("\\.")[0];
     }
     // Fall back to a schema-level rule or the original name (lowercased).
-    return schemaMappings.getOrDefault(row.getSchemaName(), row.getSchemaName().toLowerCase());
+    return schemaMappings.getOrDefault(row.getSchemaName(), applyCasing(row.getSchemaName()));
   }
 
   @Override

--- a/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/utils/DatastreamToPostgresDML.java
+++ b/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/utils/DatastreamToPostgresDML.java
@@ -75,7 +75,7 @@ public class DatastreamToPostgresDML extends DatastreamToDML {
       return tableMappings.get(fullSourceTableName).split("\\.")[0];
     }
     // Fall back to a schema-level rule or the original name (lowercased).
-    return schemaMappings.getOrDefault(row.getSchemaName(), row.getSchemaName().toLowerCase());
+    return schemaMappings.getOrDefault(row.getSchemaName(), applyCasing(row.getSchemaName()));
   }
 
   @Override


### PR DESCRIPTION
This PR introduces a new, optional template parameter, defaultCasing, that allows users to control the casing for target table and schema names.

The parameter accepts the following values:

DEFAULT: Converts names to lowercase (e.g., MyTable → mytable).

UPPERCASED: Converts names to uppercase (e.g., MyTable → MYTABLE).

CAPITALIZED: Capitalizes the first letter and lowercases the rest (e.g., MyTable → Mytable).

