### PR TITLE
Exclude META-INF/maven from hbase-shaded-client

### DIFF
--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -520,6 +520,12 @@
                                                 <exclude>META-INF/*.RSA</exclude>
                                             </excludes>
                                         </filter>
+                                        <filter>
+                                            <artifact>org.apache.hbase:hbase-shaded-client</artifact>
+                                            <excludes>
+                                                <exclude>META-INF/maven/**</exclude>
+                                            </excludes>
+                                        </filter>
                                     </filters>
                                     <transformers>
                                         <transformer


### PR DESCRIPTION
protobuf 2.x vulnerability detected by AR vul scan is false positive due to

- hbase-shaded-client included META-INFT/maven that contains old protobuf pom properties
- newer protobuf-java jar no longer contains META-INFT/maven

thus the file isn't get overriden in shaded jar. Exclude `META-INF/maven` dir of this particular dependency at once since most false positive came from it

Also checked the assembled shaded jar still contains `META-INF/maven` with many files (dep still publish its pom properties in jar)