### PR TITLE
fix readme outputs for python and yaml modules

### DIFF
--- a/contributor-docs/code-contributions.md
+++ b/contributor-docs/code-contributions.md
@@ -439,6 +439,28 @@ mvn clean prepare-package \
   -PtemplatesSpec
 ```
 
+To generate the documentation for a specific template, the following command can be used:
+
+```shell
+mvn clean prepare-package \
+  -DskipTests \
+  -PtemplatesSpec \
+  -pl python \
+  -DtemplateName="Yaml_Template" \
+  -am
+```
+
+`pl` argument can be any plugin module such as:
+```shell
+v1
+v2/bigquery-to-bigtable
+python
+yaml
+```
+
+REMINDER: Run `mvn clean install -pl plugins/templates-maven-plugin -am` command
+after making any changes and before running `mvn clean prepare-package` command here.
+
 ## Python Dependency Management
 
 See [maintainers-guide](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/contributor-docs/maintainers-guide.md#validating-and-upgrading-beam-versions) for more information.

--- a/contributor-docs/code-contributions.md
+++ b/contributor-docs/code-contributions.md
@@ -458,9 +458,6 @@ python
 yaml
 ```
 
-REMINDER: Run `mvn clean install -pl plugins/templates-maven-plugin -am` command
-after making any changes and before running `mvn clean prepare-package` command here.
-
 ## Python Dependency Management
 
 See [maintainers-guide](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/contributor-docs/maintainers-guide.md#validating-and-upgrading-beam-versions) for more information.

--- a/plugins/core-plugin/src/main/resources/README-template.md
+++ b/plugins/core-plugin/src/main/resources/README-template.md
@@ -95,7 +95,7 @@ mvn clean package -PtemplatesStage  \
 -DbucketName="$BUCKET_NAME" \
 -DstagePrefix="templates" \
 -DtemplateName="${spec.metadata.internalName}" \
-<#if language == 'PYTHON'>
+<#if language == 'PYTHON' || spec.metadata.module! == 'python'>
 -f python
 <#elseif language == 'YAML'>
 -f yaml
@@ -198,8 +198,10 @@ mvn clean package -PtemplatesRun \
 -DjobName="${spec.metadata.internalName?lower_case?replace("_", "-")}-job" \
 -DtemplateName="${spec.metadata.internalName}" \
 -Dparameters="<#list spec.metadata.parameters as parameter>${parameter.name}=$${parameter.name?replace('([a-z])([A-Z])', '$1_$2', 'r')?upper_case?replace("-", "_")}<#sep>,</#sep></#list>" \
-<#if language == 'PYTHON' || language == 'YAML'>
+<#if language == 'PYTHON' || spec.metadata.module! == 'python'>
 -f python
+<#elseif language == 'YAML'>
+-f yaml
 <#elseif flex>
 -f v2/${spec.metadata.module!}
 <#else>

--- a/python/README_Yaml_Template.md
+++ b/python/README_Yaml_Template.md
@@ -75,7 +75,7 @@ mvn clean package -PtemplatesStage  \
 -DbucketName="$BUCKET_NAME" \
 -DstagePrefix="templates" \
 -DtemplateName="Yaml_Template" \
--f yaml
+-f python
 ```
 
 

--- a/yaml/README_Kafka_to_BigQuery_Yaml.md
+++ b/yaml/README_Kafka_to_BigQuery_Yaml.md
@@ -170,7 +170,7 @@ mvn clean package -PtemplatesRun \
 -DjobName="kafka-to-bigquery-yaml-job" \
 -DtemplateName="Kafka_to_BigQuery_Yaml" \
 -Dparameters="readBootstrapServers=$READ_BOOTSTRAP_SERVERS,kafkaReadTopics=$KAFKA_READ_TOPICS,outputTableSpec=$OUTPUT_TABLE_SPEC,outputDeadletterTable=$OUTPUT_DEADLETTER_TABLE,messageFormat=$MESSAGE_FORMAT,schema=$SCHEMA,numStorageWriteApiStreams=$NUM_STORAGE_WRITE_API_STREAMS,storageWriteApiTriggeringFrequencySec=$STORAGE_WRITE_API_TRIGGERING_FREQUENCY_SEC" \
--f python
+-f yaml
 ```
 
 ## Terraform


### PR DESCRIPTION
1. By chance saw #2695 and noticed that the Yaml-template instructions changed to yaml instead of being python. For Yaml-template it should be python since in python module.
1. This was caused by my logic I added in #2668. 
1. This PR fixes it now to where Yaml-template reverts back to python module. 
1. I also missed another mvn command conditional for python/yaml further down in the Readme-template.md, so that is fixed too in this PR.
1. Added more instructions on individual template documentation changes. 

Ran:
mvn clean install -pl plugins/templates-maven-plugin -am
mvn clean prepare-package -DskipTests -PtemplatesSpec -pl python -DtemplateName="Yaml_Template" -am 
mvn clean prepare-package -DskipTests -PtemplatesSpec -pl yaml -DtemplateName="Kafka_to_BigQuery_Yaml" -am