### PR TITLE
feat(datastream): add source type override for datastream cdc data

### DIFF
--- a/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/sources/DataStreamIO.java
+++ b/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/sources/DataStreamIO.java
@@ -115,6 +115,7 @@ public class DataStreamIO extends PTransform<PBegin, PCollection<FailsafeElement
   private Boolean hashRowId = false;
   private Duration directoryWatchDuration = Duration.standardMinutes(10);
   PCollection<String> directories = null;
+  private String datastreamSourceType;
 
   private Boolean applyReshuffle = true;
 
@@ -188,6 +189,11 @@ public class DataStreamIO extends PTransform<PBegin, PCollection<FailsafeElement
     return this;
   }
 
+  public DataStreamIO withDatastreamSourceType(String datastreamSourceType) {
+    this.datastreamSourceType = datastreamSourceType;
+    return this;
+  }
+
   @Override
   public PCollection<FailsafeElement<String, String>> expand(PBegin input) {
     PCollection<ReadableFile> datastreamFiles =
@@ -219,7 +225,8 @@ public class DataStreamIO extends PTransform<PBegin, PCollection<FailsafeElement
                               .withStreamName(this.streamName)
                               .withRenameColumnValues(this.renameColumns)
                               .withHashRowId(this.hashRowId)
-                              .withLowercaseSourceColumns(this.lowercaseSourceColumns)))
+                              .withLowercaseSourceColumns(this.lowercaseSourceColumns)
+                              .withDatastreamSourceType(this.datastreamSourceType)))
               .setCoder(coder);
     } else {
       SerializableFunction<GenericRecord, FailsafeElement<String, String>> parseFn =
@@ -227,7 +234,8 @@ public class DataStreamIO extends PTransform<PBegin, PCollection<FailsafeElement
               .withStreamName(this.streamName)
               .withRenameColumnValues(this.renameColumns)
               .withHashRowId(this.hashRowId)
-              .withLowercaseSourceColumns(this.lowercaseSourceColumns);
+              .withLowercaseSourceColumns(this.lowercaseSourceColumns)
+              .withDatastreamSourceType(this.datastreamSourceType);
       datastreamRecords =
           datastreamFiles
               .apply("ReshuffleFiles", Reshuffle.<ReadableFile>viaRandomKey())

--- a/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamJsonToJson.java
+++ b/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamJsonToJson.java
@@ -146,6 +146,11 @@ public final class FormatDatastreamJsonToJson
   }
 
   private String getSourceType(JsonNode record) {
+    // If datastreamSourceType is provided, use it as override
+    if (this.datastreamSourceType != null && !this.datastreamSourceType.isEmpty()) {
+      return this.datastreamSourceType;
+    }
+
     String sourceType = record.get("read_method").textValue().split("-")[0];
     // TODO: consider validating the value is mysql or oracle
     if (sourceType == "postgres" || sourceType == "postgresql") {

--- a/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamRecord.java
+++ b/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamRecord.java
@@ -33,6 +33,7 @@ public abstract class FormatDatastreamRecord<InputT, OutputT> extends DoFn<Input
   protected boolean lowercaseSourceColumns = false;
   protected Map<String, String> renameColumns = new HashMap<String, String>();
   protected boolean hashRowId = false;
+  protected String datastreamSourceType;
 
   static final String ROW_ID_CHARSET =
       "+/0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -64,6 +65,12 @@ public abstract class FormatDatastreamRecord<InputT, OutputT> extends DoFn<Input
   /** Set the reader to hash Oracle ROWID values into int. */
   public FormatDatastreamRecord withHashRowId(Boolean hashRowId) {
     this.hashRowId = hashRowId;
+    return this;
+  }
+
+  /** Set the Datastream source type override. */
+  public FormatDatastreamRecord withDatastreamSourceType(String datastreamSourceType) {
+    this.datastreamSourceType = datastreamSourceType;
     return this;
   }
 

--- a/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamRecordToJson.java
+++ b/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamRecordToJson.java
@@ -75,6 +75,7 @@ public class FormatDatastreamRecordToJson
   private String rowIdColumnName;
   private Map<String, String> renameColumns = new HashMap<String, String>();
   private boolean hashRowId = false;
+  private String datastreamSourceType;
 
   private static final Long DATETIME_POSITIVE_INFINITY = 9223372036825200000L;
   private static final Long DATETIME_NEGATIVE_INFINITY = -9223372036832400000L;
@@ -108,6 +109,12 @@ public class FormatDatastreamRecordToJson
   /** Set the reader to hash Oracle ROWID values into int. */
   public FormatDatastreamRecordToJson withHashRowId(Boolean hashRowId) {
     this.hashRowId = hashRowId;
+    return this;
+  }
+
+  /** Set the Datastream source type override. */
+  public FormatDatastreamRecordToJson withDatastreamSourceType(String datastreamSourceType) {
+    this.datastreamSourceType = datastreamSourceType;
     return this;
   }
 
@@ -208,6 +215,11 @@ public class FormatDatastreamRecordToJson
   }
 
   private String getSourceType(GenericRecord record) {
+    // If datastreamSourceType is provided, use it as override
+    if (this.datastreamSourceType != null && !this.datastreamSourceType.isEmpty()) {
+      return this.datastreamSourceType;
+    }
+
     String sourceType = record.get("read_method").toString().split("-")[0];
     // TODO: consider validating the value is mysql or oracle
     return sourceType;

--- a/v2/datastream-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToBigQuery.java
+++ b/v2/datastream-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToBigQuery.java
@@ -371,6 +371,16 @@ public class DataStreamToBigQuery {
     Boolean getUseStorageWriteApiAtLeastOnce();
 
     void setUseStorageWriteApiAtLeastOnce(Boolean value);
+
+    @TemplateParameter.Text(
+        order = 21,
+        optional = true,
+        description = "Datastream source type override",
+        helpText =
+            "Override the source type detection for Datastream CDC data. When specified, this value will be used instead of deriving the source type from the read_method field. Valid values include 'mysql', 'postgresql', 'oracle', etc. This parameter is useful when the read_method field contains 'cdc' and the actual source type cannot be determined automatically.")
+    String getDatastreamSourceType();
+
+    void setDatastreamSourceType(String value);
   }
 
   /**
@@ -465,7 +475,8 @@ public class DataStreamToBigQuery {
                     options.getInputFileFormat(),
                     options.getGcsPubSubSubscription(),
                     options.getRfcStartDateTime())
-                .withFileReadConcurrency(options.getFileReadConcurrency()));
+                .withFileReadConcurrency(options.getFileReadConcurrency())
+                .withDatastreamSourceType(options.getDatastreamSourceType()));
 
     // Elements sent to the Dead Letter Queue are to be reconsumed.
     // A DLQManager is to be created using PipelineOptions, and it is in charge

--- a/v2/datastream-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToMongoDB.java
+++ b/v2/datastream-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToMongoDB.java
@@ -177,6 +177,16 @@ public class DataStreamToMongoDB {
     String getCollection();
 
     void setCollection(String value);
+
+    @TemplateParameter.Text(
+        order = 10,
+        optional = true,
+        description = "Datastream source type override",
+        helpText =
+            "Override the source type detection for Datastream CDC data. When specified, this value will be used instead of deriving the source type from the read_method field. Valid values include 'mysql', 'postgresql', 'oracle', etc. This parameter is useful when the read_method field contains 'cdc' and the actual source type cannot be determined automatically.")
+    String getDatastreamSourceType();
+
+    void setDatastreamSourceType(String value);
   }
 
   /**
@@ -233,7 +243,8 @@ public class DataStreamToMongoDB {
                     options.getInputFileFormat(),
                     options.getInputSubscription(),
                     options.getRfcStartDateTime())
-                .withFileReadConcurrency(options.getFileReadConcurrency()));
+                .withFileReadConcurrency(options.getFileReadConcurrency())
+                .withDatastreamSourceType(options.getDatastreamSourceType()));
 
     PCollection<FailsafeElement<String, String>> jsonRecords =
         PCollectionList.of(datastreamJsonRecords).apply(Flatten.pCollections());

--- a/v2/datastream-to-postgres/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToPostgres.java
+++ b/v2/datastream-to-postgres/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToPostgres.java
@@ -183,6 +183,16 @@ public class DataStreamToPostgres {
     String getDatabaseName();
 
     void setDatabaseName(String value);
+
+    @TemplateParameter.Text(
+        order = 13,
+        optional = true,
+        description = "Datastream source type override",
+        helpText =
+            "Override the source type detection for Datastream CDC data. When specified, this value will be used instead of deriving the source type from the read_method field. Valid values include 'mysql', 'postgresql', 'oracle', etc. This parameter is useful when the read_method field contains 'cdc' and the actual source type cannot be determined automatically.")
+    String getDatastreamSourceType();
+
+    void setDatastreamSourceType(String value);
   }
 
   /**
@@ -264,7 +274,8 @@ public class DataStreamToPostgres {
                     options.getRfcStartDateTime())
                 .withLowercaseSourceColumns()
                 .withRenameColumnValue("_metadata_row_id", "rowid")
-                .withHashRowId());
+                .withHashRowId()
+                .withDatastreamSourceType(options.getDatastreamSourceType()));
 
     /*
      * Stage 2: Write JSON Strings to Postgres Insert Strings

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToSpanner.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToSpanner.java
@@ -742,7 +742,8 @@ public class DataStreamToSpanner {
                   .withFileReadConcurrency(options.getFileReadConcurrency())
                   .withoutDatastreamRecordsReshuffle()
                   .withDirectoryWatchDuration(
-                      Duration.standardMinutes(options.getDirectoryWatchDurationInMinutes())));
+                      Duration.standardMinutes(options.getDirectoryWatchDurationInMinutes()))
+                  .withDatastreamSourceType(options.getDatastreamSourceType()));
       int maxNumWorkers = options.getMaxNumWorkers() != 0 ? options.getMaxNumWorkers() : 1;
       jsonRecords =
           PCollectionList.of(datastreamJsonRecords)

--- a/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToSQL.java
+++ b/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToSQL.java
@@ -283,6 +283,16 @@ public class DataStreamToSQL {
     Boolean getOrderByIncludesIsDeleted();
 
     void setOrderByIncludesIsDeleted(Boolean value);
+
+    @TemplateParameter.Text(
+        order = 18,
+        optional = true,
+        description = "Datastream source type override",
+        helpText =
+            "Override the source type detection for Datastream CDC data. When specified, this value will be used instead of deriving the source type from the read_method field. Valid values include 'mysql', 'postgresql', 'oracle', etc. This parameter is useful when the read_method field contains 'cdc' and the actual source type cannot be determined automatically.")
+    String getDatastreamSourceType();
+
+    void setDatastreamSourceType(String value);
   }
 
   /**
@@ -432,7 +442,8 @@ public class DataStreamToSQL {
                     options.getRfcStartDateTime())
                 .withLowercaseSourceColumns()
                 .withRenameColumnValue("_metadata_row_id", "rowid")
-                .withHashRowId());
+                .withHashRowId()
+                .withDatastreamSourceType(options.getDatastreamSourceType()));
 
     /*
      * Stage 2: Write JSON Strings to SQL Insert Strings


### PR DESCRIPTION
Add support for overriding the source type detection in Datastream CDC data processing. This allows specifying the source type directly when automatic detection from read_method field is not reliable, particularly when the field contains 'cdc'.

Fixes https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/2688

We probably cannot change what `read_method` could contain without any breaking changes. I am wondering whether we can add this optional parameter `datastreamSourceType` to override the source type.