### PR TITLE
build: add mongodb-driver-core dependency for Beam 2.68.0 compatibility

### DIFF
--- a/v2/datastream-mongodb-to-firestore/pom.xml
+++ b/v2/datastream-mongodb-to-firestore/pom.xml
@@ -70,6 +70,12 @@
             <artifactId>mongodb-driver-sync</artifactId>
             <version>5.3.0</version>
         </dependency>
+        <!-- Add MongoDB driver core explicitly for compatibility with Beam 2.68.0-SNAPSHOT -->
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-core</artifactId>
+            <version>5.3.0</version>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/runs/17389487808/job/49361843282 is failing with this error when running with `2.68.0-SNAPSHOT`:
```
025-09-02T00:37:03.6194106Z [ERROR] Tests run: 7, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 4.35 s <<< FAILURE! - in com.google.cloud.teleport.v2.templates.DataStreamMongoDBToFirestoreTest
2025-09-02T00:37:03.6198019Z [ERROR] inputArgs_inputFileFormat_invalid(com.google.cloud.teleport.v2.templates.DataStreamMongoDBToFirestoreTest)  Time elapsed: 4.312 s  <<< FAILURE!
2025-09-02T00:37:03.6201745Z java.lang.AssertionError: unexpected exception type thrown; expected:<java.lang.IllegalArgumentException> but was:<java.lang.NoSuchMethodError>
```

Explicitly add the  `mongodb-driver-core` dependency.

Tested:

```
mvn test -Psnapshot -Dbeam.version=2.68.0-SNAPSHOT -pl v2/datastream-mongodb-to-firestore -Dtest=DataStreamMongoDBToFirestoreTest
```

and

```
mvn test -pl v2/datastream-mongodb-to-firestore -Dtest=DataStreamMongoDBToFirestoreTest
```

Both run fines now.