### PR TITLE
ci(release): add package-upgrade label to release notes configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,3 +12,6 @@ changelog:
     - title: Bug fixes
       labels:
         - bug-fix
+    - title: Package Upgrades
+      labels:
+        - package-upgrade

--- a/.github/workflows/release-notes-labels.yml
+++ b/.github/workflows/release-notes-labels.yml
@@ -18,4 +18,5 @@ jobs:
             new-template
             improvement
             bug-fix
-          message: "This PR is being prevented from merging because you have not added any of the following labels: [ignore-for-release, new-template, improvement, bug-fix]. You'll need to add one before this PR can be merged so that these can be used for release notes. For more information, see https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/contributor-docs/code-contributions.md#release-notes"
+            package-upgrade
+          message: "This PR is being prevented from merging because you have not added any of the following labels: [ignore-for-release, new-template, improvement, bug-fix, package-upgrade]. You'll need to add one before this PR can be merged so that these can be used for release notes. For more information, see https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/contributor-docs/code-contributions.md#release-notes"

--- a/.github/workflows/update-python-deps.yml
+++ b/.github/workflows/update-python-deps.yml
@@ -44,3 +44,4 @@ jobs:
             **Note:** If this PR does not trigger the template integration tests, please close the PR and reopen it. This should trigger all the tests.
           branch: chore/update-python-deps
           base: main
+          labels: package-upgrade

--- a/contributor-docs/code-contributions.md
+++ b/contributor-docs/code-contributions.md
@@ -473,4 +473,10 @@ To learn more about this process, or how you can stage your own changes, see [Re
 
 Release notes are [automatically generated](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)
 based on the PR labels defined in [release.yml](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/.github/release.yml).
-Before submitting your PR, a repo maintainer must add one of the following labels in order for all checks to pass: `ignore-for-release`, `new-template`, `improvement`, or `bug-fix`.
+Before submitting your PR, a repo maintainer must add one of the following labels in order for all checks to pass:
+
+- `ignore-for-release`: Changes that should not appear in release notes (e.g., documentation updates, internal refactoring)
+- `new-template`: Addition of new Dataflow templates
+- `improvement`: Enhancements to existing functionality or performance improvements
+- `bug-fix`: Fixes for bugs or issues in existing code
+- `package-upgrade`: Updates to dependencies, libraries, or package versions


### PR DESCRIPTION
Update release.yml and related files to include package-upgrade as a valid label for PRs This ensures dependency updates are properly categorized in release notes