### PR TITLE
update docs and readme about template validation

### DIFF
--- a/contributor-docs/code-contributions.md
+++ b/contributor-docs/code-contributions.md
@@ -145,6 +145,14 @@ and prevent any future changes from being observed.  Please reissue:
 mvn clean install -pl plugins/templates-maven-plugin -am
 ```
 
+### Validating Templates
+
+Validating a template's code quality is as simple as this:
+
+```shell
+mvn clean install -PtemplatesValidate -DskipTests -pl <module> -am
+```
+
 ### Staging (Deploying) Templates
 
 To stage a Template, it is necessary to upload the images to Artifact

--- a/plugins/core-plugin/src/main/resources/README-template.md
+++ b/plugins/core-plugin/src/main/resources/README-template.md
@@ -61,7 +61,25 @@ for more information about how to create and test those functions.
 ### Templates Plugin
 
 This README provides instructions using
-the [Templates Plugin](https://github.com/GoogleCloudPlatform/DataflowTemplates#templates-plugin).
+the [Templates Plugin](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/contributor-docs/code-contributions.md#templates-plugin).
+
+#### Validating the Template
+
+This template has a validation command that is used to check code quality.
+
+```shell
+mvn clean install -PtemplatesValidate \
+-DskipTests -am \
+<#if language == 'PYTHON' || spec.metadata.module! == 'python'>
+-pl python
+<#elseif language == 'YAML'>
+-pl yaml
+<#elseif flex>
+-pl v2/${spec.metadata.module!}
+<#else>
+-pl v1
+</#if>
+```
 
 ### Building Template
 


### PR DESCRIPTION
1. Fixes template plugin incorrect link.
2. Adds documentation on template validation for both the code contributions doc and the README-template markdown.