### PR TITLE
fix: update MongoDB container image tag in integration test setup

### DIFF
--- a/v2/mongodb-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQueryIT.java
+++ b/v2/mongodb-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQueryIT.java
@@ -110,7 +110,7 @@ public final class MongoDbToBigQueryIT extends TemplateTestBase {
 
   @Before
   public void setup() {
-    mongoDbClient = MongoDBResourceManager.builder(testName).build();
+    mongoDbClient = MongoDBResourceManager.builder(testName).setContainerImageTag("4.2").build();
     bigQueryClient = BigQueryResourceManager.builder(testName, PROJECT, credentials).build();
   }
 


### PR DESCRIPTION
Errors with using Beam SNAPSHOT:

2025-09-09T00:57:10.4186272Z Caused by: com.mongodb.MongoIncompatibleDriverException: Server at 10.128.0.105:57885 reports wire version 7, but this version of the driver requires at least 8 (MongoDB 4.2).
2025-09-09T00:57:10.4187820Z 	at com.mongodb.internal.connection.BaseCluster.createIncompatibleException(BaseCluster.java:415)
2025-09-09T00:57:10.4189085Z 	at com.mongodb.internal.connection.BaseCluster.logAndThrowIncompatibleException(BaseCluster.java:394)
2025-09-09T00:57:10.4190251Z 	at com.mongodb.internal.connection.BaseCluster.selectServer(BaseCluster.java:140)
2025-09-09T00:57:10.4191351Z 	at com.mongodb.internal.connection.SingleServerCluster.selectServer(SingleServerCluster.java:47)
2025-09-09T00:57:10.4192559Z 	at com.mongodb.internal.binding.ClusterBinding.getReadConnectionSource(ClusterBinding.java:82)
2025-09-09T00:57:10.4193863Z 	at com.mongodb.client.internal.ClientSessionBinding.getConnectionSource(ClientSessionBinding.java:108)
2025-09-09T00:57:10.4195180Z 	at com.mongodb.client.internal.ClientSessionBinding.getReadConnectionSource(ClientSessionBinding.java:88)
2025-09-09T00:57:10.4196548Z 	at com.mongodb.internal.operation.SyncOperationHelper.withSuppliedResource(SyncOperationHelper.java:148)
2025-09-09T00:57:10.4197908Z 	at com.mongodb.internal.operation.SyncOperationHelper.withSourceAndConnection(SyncOperationHelper.java:129)
2025-09-09T00:57:10.4199478Z 	at com.mongodb.internal.operation.ListCollectionsOperation.lambda$execute$2(ListCollectionsOperation.java:164)
2025-09-09T00:57:10.4200927Z 	at com.mongodb.internal.operation.SyncOperationHelper.lambda$decorateReadWithRetries$13(SyncOperationHelper.java:317)
2025-09-09T00:57:10.4202221Z 	at com.mongodb.internal.async.function.RetryingSyncSupplier.get(RetryingSyncSupplier.java:67)
2025-09-09T00:57:10.4203587Z 	at com.mongodb.internal.operation.ListCollectionsOperation.execute(ListCollectionsOperation.java:175)
2025-09-09T00:57:10.4204886Z 	at com.mongodb.internal.operation.ListCollectionsOperation.execute(ListCollectionsOperation.java:72)
2025-09-09T00:57:10.4206146Z 	at com.mongodb.client.internal.MongoClusterImpl$OperationExecutorImpl.execute(MongoClusterImpl.java:424)
2025-09-09T00:57:10.4207296Z 	at com.mongodb.client.internal.MongoIterableImpl.execute(MongoIterableImpl.java:156)
2025-09-09T00:57:10.4208318Z 	at com.mongodb.client.internal.MongoIterableImpl.iterator(MongoIterableImpl.java:116)
2025-09-09T00:57:10.4209330Z 	at com.mongodb.client.internal.MappingIterable.iterator(MappingIterable.java:42)
2025-09-09T00:57:10.4210560Z 	at com.mongodb.client.internal.ListCollectionNamesIterableImpl.iterator(ListCollectionNamesIterableImpl.java:83)
2025-09-09T00:57:10.4212013Z 	at com.mongodb.client.internal.ListCollectionNamesIterableImpl.iterator(ListCollectionNamesIterableImpl.java:35)
2025-09-09T00:57:10.4213426Z 	at org.apache.beam.it.mongodb.MongoDBResourceManager.collectionExists(MongoDBResourceManager.java:126)
2025-09-09T00:57:10.4214815Z 	at org.apache.beam.it.mongodb.MongoDBResourceManager.getMongoDBCollection(MongoDBResourceManager.java:176)
2025-09-09T00:57:10.4216174Z 	at org.apache.beam.it.mongodb.MongoDBResourceManager.insertDocuments(MongoDBResourceManager.java:216)
2025-09-09T00:57:10.4216976Z 	... 25 more
2025-09-09T00:57:10.4217150Z 
2025-09-09T00:57:15.2988783Z [INFO] 
2025-09-09T00:57:15.2989175Z [INFO] Results:
2025-09-09T00:57:15.2989481Z [INFO] 
2025-09-09T00:57:15.2989773Z [ERROR] Errors: 
2025-09-09T00:57:15.2991462Z [ERROR]   MongoDbToBigQueryIT.testMongoDbToBigQueryFlatten:124->mongoDbToBigQueryWithUdfBase:145->mongoDbToBigQueryBase:153 » MongoDBResourceManager
2025-09-09T00:57:15.2993208Z [ERROR]   MongoDbToBigQueryIT.testMongoDbToBigQueryWithFilters:141->mongoDbToBigQueryBase:153 » MongoDBResourceManager

