### PR TITLE
Change visibility of template class to Public - CassandraToBigTable

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/bigtable/CassandraToBigtable.java
+++ b/v1/src/main/java/com/google/cloud/teleport/bigtable/CassandraToBigtable.java
@@ -65,7 +65,7 @@ import org.slf4j.LoggerFactory;
       "The target Bigtable table must exist before running the pipeline.",
       "Network connection between Dataflow workers and Apache Cassandra nodes."
     })
-final class CassandraToBigtable {
+public final class CassandraToBigtable {
 
   /** TODO - refactor to extend BigtableCommonOptions.WriteOptions. */
   public interface Options extends PipelineOptions {


### PR DESCRIPTION
Dependabot updated exec-maven-plugin from 1.6.0 to 3.5.1 which caused https://github.com/mojohaus/exec-maven-plugin/issues/336 . Fix is to change problematic class to public.