### PR TITLE
Test: update dependency versions and jvm config

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -4,4 +4,7 @@
 --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
 --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
 --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens=java.base/java.lang=ALL-UNNAMED
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+--add-opens=java.base/java.util=ALL-UNNAMED
 -Djava.net.preferIPv4Stack=true

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
     <jacoco.version>0.8.13</jacoco.version>
 
     <!-- Beam and linked versions -->
-    <beam.version>2.67.0</beam.version>
-    <beam-python.version>2.67.0</beam-python.version>
+    <beam.version>2.69.0-SNAPSHOT</beam.version>
+    <beam-python.version>2.69.0-SNAPSHOT</beam-python.version>
     <beam-maven-repo></beam-maven-repo>
 
     <!-- Common dependency versions -->

--- a/v2/mongodb-to-googlecloud/pom.xml
+++ b/v2/mongodb-to-googlecloud/pom.xml
@@ -35,7 +35,7 @@
     </description>
 
     <properties>
-        <mongo-java-driver.version>3.12.11</mongo-java-driver.version>
+        <mongo-java-driver.version>3.12.14</mongo-java-driver.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
- Update mongo-java-driver from 3.12.11 to 3.12.14
- Update beam and beam-python versions to 2.69.0-SNAPSHOT
- Add additional JVM opens for reflection access