### PR TITLE
fix(build): correct sed command to handle test time formats

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -454,7 +454,7 @@
                <executable>bash</executable>
                <arguments>
                  <argument>-c</argument>
-                 <argument>find . -name "TEST-*.xml" -path "*/target/surefire-reports/*" -exec sed -i.bak 's/time="\([0-9]*\),\([0-9]*\.[0-9]*\)"/time="\1\2"/g' {} \;</argument>
+                 <argument>find . -name "TEST-*.xml" -path "*/target/surefire-reports/*" -exec sed -i.bak -e 's/time="\([0-9]*\),\([0-9]*\)"/time="\1\2"/g' -e 's/time="\([0-9]*\),\([0-9]*\.[0-9]*\)"/time="\1\2"/g' {} \;</argument>
                </arguments>
              </configuration>
           </execution>


### PR DESCRIPTION
Tested the sed command with:
```
<testsuite name="com.google.cloud.teleport.v2.templates.MySQLDataTypesIT" time="5,234" tests="3" failures="0" errors="0" skipped="0">
  <testcase classname="com.google.cloud.teleport.v2.templates.MySQLDataTypesIT" name="testMethod1" time="1,111"/>
  <testcase classname="com.google.cloud.teleport.v2.templates.MySQLDataTypesIT" name="testMethod2" time="2,23.456"/>
  <testcase classname="com.google.cloud.teleport.v2.templates.MySQLDataTypesIT" name="testMethod3" time="1,899.789"/>

```
Output:
```
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="com.google.cloud.teleport.v2.templates.MySQLDataTypesIT" time="5234" tests="3" failures="0" errors="0" skipped="0">
  <testcase classname="com.google.cloud.teleport.v2.templates.MySQLDataTypesIT" name="testMethod1" time="1111"/>
  <testcase classname="com.google.cloud.teleport.v2.templates.MySQLDataTypesIT" name="testMethod2" time="223.456"/>
  <testcase classname="com.google.cloud.teleport.v2.templates.MySQLDataTypesIT" name="testMethod3" time="1899.789"/>
</testsuite>%                 
```