### PR TITLE
DataStreamToSpanner - Adding main table read at the beginning of main transaction

### DIFF
--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SpannerTransactionWriterDoFn.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SpannerTransactionWriterDoFn.java
@@ -474,7 +474,8 @@ class SpannerTransactionWriterDoFn extends DoFn<FailsafeElement<String, String>,
                               mainTxn -> {
                                 // Read row from main table with lock scanned ranges to acquire
                                 // exclusive lock on the main table row.
-                                changeEventContext.readDataTableRowWithExclusiveLock(mainTxn, dataTableDdl);
+                                changeEventContext.readDataTableRowWithExclusiveLock(
+                                    mainTxn, dataTableDdl);
 
                                 // Validate the row still holds the exclusive lock. In case of
                                 // network

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SpannerTransactionWriterDoFn.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SpannerTransactionWriterDoFn.java
@@ -474,7 +474,7 @@ class SpannerTransactionWriterDoFn extends DoFn<FailsafeElement<String, String>,
                               mainTxn -> {
                                 // Read row from main table with lock scanned ranges to acquire
                                 // exclusive lock on the main table row.
-                                changeEventContext.readDataTable(mainTxn, dataTableDdl);
+                                changeEventContext.readDataTableRowWithExclusiveLock(mainTxn, dataTableDdl);
 
                                 // Validate the row still holds the exclusive lock. In case of
                                 // network

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventContext.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventContext.java
@@ -115,14 +115,17 @@ public abstract class ChangeEventContext {
 
   // Fires a read on Data table with lock scanned ranges. Used to acquire exclusive lock on Data row
   // at the beginning of a readWriteTransaction
-  public void readDataTableRowWithExclusiveLock(final TransactionContext transactionContext, Ddl dataTableDdl) {
+  public void readDataTableRowWithExclusiveLock(
+      final TransactionContext transactionContext, Ddl dataTableDdl) {
     // TODO: After beam release, use the latest client lib version which supports setting lock
     // hints via the read api. SQL string generation should be removed.
-    List<String> columnNames = dataTableDdl.table(dataTable).primaryKeys().stream()
-                .map(col -> col.name())
-                .collect(Collectors.toList());
+    List<String> columnNames =
+        dataTableDdl.table(dataTable).primaryKeys().stream()
+            .map(col -> col.name())
+            .collect(Collectors.toList());
     Statement sql =
-        ShadowTableReadUtils.generateReadSQLWithExclusiveLock(dataTable, columnNames, primaryKey, dataTableDdl);
+        ShadowTableReadUtils.generateReadSQLWithExclusiveLock(
+            dataTable, columnNames, primaryKey, dataTableDdl);
     ResultSet resultSet = transactionContext.executeQuery(sql);
     if (!resultSet.next()) {
       return;

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MySqlChangeEventSequence.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MySqlChangeEventSequence.java
@@ -117,7 +117,7 @@ class MySqlChangeEventSequence extends ChangeEventSequence {
       // hints via the read api. SQL string generation should be removed.
       if (useSqlStatements) {
         Statement sql =
-            ShadowTableReadUtils.generateShadowTableReadSQL(
+            ShadowTableReadUtils.generateReadSQLWithExclusiveLock(
                 shadowTable, readColumnList, primaryKey, shadowTableDdl);
         ResultSet resultSet = transactionContext.executeQuery(sql);
         if (!resultSet.next()) {

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/OracleChangeEventSequence.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/OracleChangeEventSequence.java
@@ -94,7 +94,7 @@ class OracleChangeEventSequence extends ChangeEventSequence {
       // hints via the read api. SQL string generation should be removed.
       if (useSqlStatements) {
         Statement sql =
-            ShadowTableReadUtils.generateShadowTableReadSQL(
+            ShadowTableReadUtils.generateReadSQLWithExclusiveLock(
                 shadowTable, readColumnList, primaryKey, shadowTableDdl);
         ResultSet resultSet = transactionContext.executeQuery(sql);
         if (!resultSet.next()) {

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/PostgresChangeEventSequence.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/PostgresChangeEventSequence.java
@@ -94,7 +94,7 @@ class PostgresChangeEventSequence extends ChangeEventSequence {
       // hints via the read api. SQL string generation should be removed.
       if (useSqlStatements) {
         Statement sql =
-            ShadowTableReadUtils.generateShadowTableReadSQL(
+            ShadowTableReadUtils.generateReadSQLWithExclusiveLock(
                 shadowTable, readColumnList, primaryKey, shadowTableDdl);
         ResultSet resultSet = transactionContext.executeQuery(sql);
         if (!resultSet.next()) {

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ShadowTableReadUtils.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/ShadowTableReadUtils.java
@@ -31,106 +31,28 @@ import java.util.stream.Collectors;
 public class ShadowTableReadUtils {
   // TODO: After beam release, use the latest client lib version which supports setting lock
   // hints via the read api. SQL string generation should be removed.
-  public static Statement generateShadowTableReadSQL(
-      String shadowTable, List<String> readColumnList, Key primaryKey, Ddl shadowTableDdl) {
+  public static Statement generateReadSQLWithExclusiveLock(
+      String tableName, List<String> readColumnList, Key primaryKey, Ddl ddl) {
     String columnNames = String.join(", ", readColumnList);
     // TODO: Handle json type as PKs.
     String whereClause =
         String.join(
             " AND ",
-            shadowTableDdl.table(shadowTable).primaryKeys().stream()
+            ddl.table(tableName).primaryKeys().stream()
                 .map(col -> col.name() + "=@" + col.name())
                 .collect(Collectors.toList()));
     String sql =
         "@{LOCK_SCANNED_RANGES=exclusive} SELECT "
             + columnNames
             + " FROM "
-            + shadowTable
+            + tableName
             + " WHERE "
             + whereClause;
 
     Statement.Builder stmtBuilder = Statement.newBuilder(sql);
     int i = 0;
     for (Object value : primaryKey.getParts()) {
-      Table table = shadowTableDdl.table(shadowTable);
-      String colName = table.primaryKeys().get(i).name();
-      Column key = table.column(colName);
-      Type keyColType = key.type();
-
-      switch (keyColType.getCode()) {
-        case BOOL:
-        case PG_BOOL:
-          stmtBuilder.bind(colName).to((Boolean) value);
-          break;
-        case INT64:
-        case PG_INT8:
-          stmtBuilder.bind(colName).to((Long) value);
-          break;
-        case FLOAT64:
-        case PG_FLOAT8:
-          stmtBuilder.bind(colName).to((Double) value);
-          break;
-        case STRING:
-        case PG_VARCHAR:
-        case PG_TEXT:
-        case JSON:
-        case PG_JSONB:
-          stmtBuilder.bind(colName).to((String) value);
-          break;
-        case NUMERIC:
-        case PG_NUMERIC:
-          stmtBuilder.bind(colName).to((BigDecimal) value);
-          break;
-        case BYTES:
-        case PG_BYTEA:
-          stmtBuilder.bind(colName).to((ByteArray) value);
-          break;
-        case TIMESTAMP:
-        case PG_COMMIT_TIMESTAMP:
-        case PG_TIMESTAMPTZ:
-          stmtBuilder.bind(colName).to((Timestamp) value);
-          break;
-        case DATE:
-        case PG_DATE:
-          stmtBuilder.bind(colName).to((Date) value);
-          break;
-        default:
-          throw new IllegalArgumentException("Unsupported type: " + keyColType);
-      }
-      i++;
-    }
-    return stmtBuilder.build();
-  }
-
-  // TODO: After beam release, use the latest client lib version which supports setting lock
-  // hints via the read api. SQL string generation should be removed.
-  public static Statement generateDataTableReadSQL(
-      String dataTable, Key primaryKey, Ddl dataTableDdl) {
-    String columnNames =
-        String.join(
-            ", ",
-            dataTableDdl.table(dataTable).primaryKeys().stream()
-                .map(col -> col.name())
-                .collect(Collectors.toList()));
-    // TODO: Handle json type as PKs.
-    String whereClause =
-        String.join(
-            " AND ",
-            dataTableDdl.table(dataTable).primaryKeys().stream()
-                .map(col -> col.name() + "=@" + col.name())
-                .collect(Collectors.toList()));
-    String sql =
-        "@{LOCK_SCANNED_RANGES=exclusive} SELECT "
-            + columnNames
-            + " FROM "
-            + dataTable
-            + " WHERE "
-            + whereClause;
-
-    Statement.Builder stmtBuilder = Statement.newBuilder(sql);
-    int i = 0;
-    for (Object value : primaryKey.getParts()) {
-      Table table = dataTableDdl.table(dataTable);
+      Table table = ddl.table(tableName);
       String colName = table.primaryKeys().get(i).name();
       Column key = table.column(colName);
       Type keyColType = key.type();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/MySqlChangeEventContextTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/MySqlChangeEventContextTest.java
@@ -203,7 +203,7 @@ public final class MySqlChangeEventContextTest {
     when(transactionContext.executeQuery(any(Statement.class))).thenReturn(resultSet);
     when(resultSet.next()).thenReturn(true);
 
-    context.readDataTable(transactionContext, ddl);
+    context.readDataTableRowWithExclusiveLock(transactionContext, ddl);
 
     ArgumentCaptor<Statement> statementCaptor = ArgumentCaptor.forClass(Statement.class);
     verify(transactionContext, times(1)).executeQuery(statementCaptor.capture());
@@ -223,7 +223,7 @@ public final class MySqlChangeEventContextTest {
     when(transactionContext.executeQuery(any(Statement.class))).thenReturn(resultSet);
     when(resultSet.next()).thenReturn(false);
 
-    context.readDataTable(transactionContext, ddl);
+    context.readDataTableRowWithExclusiveLock(transactionContext, ddl);
     verify(transactionContext, times(1)).executeQuery(any(Statement.class));
     verify(resultSet, times(1)).next();
     verify(resultSet, times(0)).getCurrentRowAsStruct();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/MySqlChangeEventContextTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/MySqlChangeEventContextTest.java
@@ -19,17 +19,27 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.TransactionContext;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import java.io.IOException;
 import java.util.Map;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 /**
  * Unit tests 1) ChangeEventContextFactory methods for mysql change events. 2) shadow table
@@ -167,5 +177,55 @@ public final class MySqlChangeEventContextTest {
     assertThat(actual, is(expected));
     assertEquals(shadowMutation.getTable(), "shadow_Users2");
     assertEquals(shadowMutation.getOperation(), Mutation.Op.INSERT_OR_UPDATE);
+  }
+
+  @Test
+  public void testReadDataTable() throws Exception {
+    long eventTimestamp = 1615159728L;
+    Ddl ddl = ChangeEventConvertorTest.getTestDdl();
+    JSONObject changeEvent = ChangeEventConvertorTest.getTestChangeEvent("Users");
+    changeEvent.put(DatastreamConstants.MYSQL_TIMESTAMP_KEY, eventTimestamp);
+    changeEvent.put(
+        DatastreamConstants.EVENT_SOURCE_TYPE_KEY, DatastreamConstants.MYSQL_SOURCE_TYPE);
+
+    ChangeEventContext context =
+        ChangeEventContextFactory.createChangeEventContext(
+            getJsonNode(changeEvent.toString()),
+            ddl,
+            ddl,
+            "shadow_",
+            DatastreamConstants.MYSQL_SOURCE_TYPE);
+
+    TransactionContext transactionContext = mock(TransactionContext.class);
+    ResultSet resultSet = mock(ResultSet.class);
+
+    // Test the case where the row is found.
+    when(transactionContext.executeQuery(any(Statement.class))).thenReturn(resultSet);
+    when(resultSet.next()).thenReturn(true);
+
+    context.readDataTable(transactionContext, ddl);
+
+    ArgumentCaptor<Statement> statementCaptor = ArgumentCaptor.forClass(Statement.class);
+    verify(transactionContext, times(1)).executeQuery(statementCaptor.capture());
+    verify(resultSet, times(1)).next();
+    verify(resultSet, times(1)).getCurrentRowAsStruct();
+
+    // Verify the generated SQL
+    String expectedSql =
+        "@{LOCK_SCANNED_RANGES=exclusive} SELECT first_name, last_name FROM Users WHERE first_name=@first_name AND last_name=@last_name";
+    Statement capturedStatement = statementCaptor.getValue();
+    assertEquals(expectedSql, capturedStatement.getSql());
+    assertEquals("A", capturedStatement.getParameters().get("first_name").getString());
+    assertEquals("B", capturedStatement.getParameters().get("last_name").getString());
+
+    // Test the case where the row is not found.
+    Mockito.reset(transactionContext, resultSet);
+    when(transactionContext.executeQuery(any(Statement.class))).thenReturn(resultSet);
+    when(resultSet.next()).thenReturn(false);
+
+    context.readDataTable(transactionContext, ddl);
+    verify(transactionContext, times(1)).executeQuery(any(Statement.class));
+    verify(resultSet, times(1)).next();
+    verify(resultSet, times(0)).getCurrentRowAsStruct();
   }
 }

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/ShadowTableReadUtilsTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/ShadowTableReadUtilsTest.java
@@ -115,7 +115,7 @@ public class ShadowTableReadUtilsTest {
             );
 
     Statement stmt =
-        ShadowTableReadUtils.generateShadowTableReadSQL(
+        ShadowTableReadUtils.generateReadSQLWithExclusiveLock(
             SHADOW_TABLE, READ_COLUMNS, primaryKey, ddl);
 
     String expectedSql =
@@ -137,54 +137,5 @@ public class ShadowTableReadUtilsTest {
     assertEquals(Value.bytes(bytesValue), params.get("bytes_field"));
     assertEquals(Value.timestamp(timestampValue), params.get("timestamp_field"));
     assertEquals(Value.date(dateValue), params.get("date_field"));
-  }
-
-  @Test
-  public void testGenerateDataTableReadSQL() {
-    Ddl ddl =
-        Ddl.builder()
-            .createTable("all_types")
-            .column("id")
-            .int64()
-            .notNull()
-            .endColumn()
-            .column("id2")
-            .string()
-            .size(10)
-            .notNull()
-            .endColumn()
-            .column("bytes_col")
-            .bytes()
-            .max()
-            .endColumn()
-            .column("bool_col")
-            .bool()
-            .endColumn()
-            .column("date_col")
-            .date()
-            .endColumn()
-            .column("float64_col")
-            .float64()
-            .endColumn()
-            .column("numeric_col")
-            .numeric()
-            .endColumn()
-            .column("timestamp_col")
-            .timestamp()
-            .endColumn()
-            .primaryKey()
-            .asc("id")
-            .asc("id2")
-            .end()
-            .endTable()
-            .build();
-
-    Key key = Key.newBuilder().append(123L).append("abc").build();
-    Statement statement = ShadowTableReadUtils.generateDataTableReadSQL("all_types", key, ddl);
-    String expectedSql =
-        "@{LOCK_SCANNED_RANGES=exclusive} SELECT id, id2 FROM all_types WHERE id=@id AND id2=@id2";
-    assertEquals(expectedSql, statement.getSql());
-    assertEquals(123L, statement.getParameters().get("id").getInt64());
-    assertEquals("abc", statement.getParameters().get("id2").getString());
   }
 }

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/ShadowTableReadUtilsTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/ShadowTableReadUtilsTest.java
@@ -138,4 +138,53 @@ public class ShadowTableReadUtilsTest {
     assertEquals(Value.timestamp(timestampValue), params.get("timestamp_field"));
     assertEquals(Value.date(dateValue), params.get("date_field"));
   }
+
+  @Test
+  public void testGenerateDataTableReadSQL() {
+    Ddl ddl =
+        Ddl.builder()
+            .createTable("all_types")
+            .column("id")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("id2")
+            .string()
+            .size(10)
+            .notNull()
+            .endColumn()
+            .column("bytes_col")
+            .bytes()
+            .max()
+            .endColumn()
+            .column("bool_col")
+            .bool()
+            .endColumn()
+            .column("date_col")
+            .date()
+            .endColumn()
+            .column("float64_col")
+            .float64()
+            .endColumn()
+            .column("numeric_col")
+            .numeric()
+            .endColumn()
+            .column("timestamp_col")
+            .timestamp()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .asc("id2")
+            .end()
+            .endTable()
+            .build();
+
+    Key key = Key.newBuilder().append(123L).append("abc").build();
+    Statement statement = ShadowTableReadUtils.generateDataTableReadSQL("all_types", key, ddl);
+    String expectedSql =
+        "@{LOCK_SCANNED_RANGES=exclusive} SELECT id, id2 FROM all_types WHERE id=@id AND id2=@id2";
+    assertEquals(expectedSql, statement.getSql());
+    assertEquals(123L, statement.getParameters().get("id").getInt64());
+    assertEquals("abc", statement.getParameters().get("id2").getString());
+  }
 }


### PR DESCRIPTION
Fixing commit consistency issue in in Separate shadow table database case, by adding a main table read at the beginning of main read write transaction. 