### PR TITLE
CPU priority in reverse replication jobs

### DIFF
--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
@@ -508,9 +508,9 @@ public class SpannerToSourceDb {
     @TemplateParameter.Enum(
         order = 34,
         enumOptions = {
-            @TemplateEnumOption("LOW"),
-            @TemplateEnumOption("MEDIUM"),
-            @TemplateEnumOption("HIGH")
+          @TemplateEnumOption("LOW"),
+          @TemplateEnumOption("MEDIUM"),
+          @TemplateEnumOption("HIGH")
         },
         optional = true,
         description = "Priority for Spanner RPC invocations",


### PR DESCRIPTION
Taken CPU priority as a parameter.

This defaults to HIGH to ensure low latency