### PR TITLE
Update ensurepip to avoid vulnerabilities in wheels

### DIFF
--- a/plugins/core-plugin/src/main/resources/Dockerfile-template-yaml
+++ b/plugins/core-plugin/src/main/resources/Dockerfile-template-yaml
@@ -25,7 +25,14 @@ RUN python -m venv /venv \
     && /venv/bin/pip install --require-hashes --no-deps --no-cache-dir -U -r $REQUIREMENTS_FILE \
     && /venv/bin/pip download --require-hashes --no-cache-dir --dest /tmp/dataflow-requirements-cache -r $REQUIREMENTS_FILE \
     && rm -rf /usr/local/lib/python$PY_VERSION/site-packages \
-    && mv /venv/lib/python$PY_VERSION/site-packages /usr/local/lib/python$PY_VERSION/
+    && mv /venv/lib/python$PY_VERSION/site-packages /usr/local/lib/python$PY_VERSION/ \
+    # Update ensurepip to use most recent versions of setuptools and pip. This avoids some vulnerabilities which won't be fixed on older versions of python.
+    && pip install upgrade_ensurepip; \
+    python3 -m upgrade_ensurepip; \
+    find /usr/local/lib/python$PY_VERSION/ensurepip/_bundled/setuptools-* -type f ! -name $(basename $(ls -v /usr/local/lib/python$PY_VERSION/ensurepip/_bundled/setuptools-*-py3-none-any.whl | tail -n 1)) -delete; \
+    find /usr/local/lib/python$PY_VERSION/ensurepip/_bundled/pip-* -type f ! -name $(basename $(ls -v /usr/local/lib/python$PY_VERSION/ensurepip/_bundled/pip-*-py3-none-any.whl | tail -n 1)) -delete; \
+    pip uninstall upgrade_ensurepip -y; \
+    python3 -m ensurepip;
 
 # Cache provider environments for faster startup and expansion time
 RUN mkdir -p ~/.apache_beam/cache/jars


### PR DESCRIPTION
Ensurepip is packaged with old wheels of setuptools and pip. This can cause issues with vulnerability tools; this fixes the problem by upgrading those wheels and manually removing the bad wheels.

Basically, this is the same change as https://github.com/apache/beam/pull/35856 and https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/2671. It is needed to handle the separate virtual environment