### PR TITLE
feat: Add support for property graph on view

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/spanner/DdlToAvroSchemaConverter.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/DdlToAvroSchemaConverter.java
@@ -303,6 +303,20 @@ public class DdlToAvroSchemaConverter {
       schemas.add(schema);
     }
 
+    for (View view : ddl.views()) {
+      LOG.info("DdlToAvo view {}", view.name());
+      SchemaBuilder.RecordBuilder<Schema> recordBuilder =
+          SchemaBuilder.record(generateAvroSchemaName(view.name())).namespace(this.namespace);
+      recordBuilder.prop(SPANNER_NAME, view.name());
+      recordBuilder.prop(GOOGLE_FORMAT_VERSION, version);
+      recordBuilder.prop(GOOGLE_STORAGE, "CloudSpanner");
+      recordBuilder.prop(SPANNER_VIEW_QUERY, view.query());
+      if (view.security() != null) {
+        recordBuilder.prop(SPANNER_VIEW_SECURITY, view.security().toString());
+      }
+      schemas.add(recordBuilder.fields().endRecord());
+    }
+
     for (PropertyGraph propertyGraph : ddl.propertyGraphs()) {
       LOG.info("DdlToAvro PropertyGraph {}", propertyGraph.name());
       SchemaBuilder.RecordBuilder<Schema> recordBuilder =
@@ -332,20 +346,6 @@ public class DdlToAvroSchemaConverter {
 
       Schema schema = recordBuilder.fields().endRecord();
       schemas.add(schema);
-    }
-
-    for (View view : ddl.views()) {
-      LOG.info("DdlToAvo view {}", view.name());
-      SchemaBuilder.RecordBuilder<Schema> recordBuilder =
-          SchemaBuilder.record(generateAvroSchemaName(view.name())).namespace(this.namespace);
-      recordBuilder.prop(SPANNER_NAME, view.name());
-      recordBuilder.prop(GOOGLE_FORMAT_VERSION, version);
-      recordBuilder.prop(GOOGLE_STORAGE, "CloudSpanner");
-      recordBuilder.prop(SPANNER_VIEW_QUERY, view.query());
-      if (view.security() != null) {
-        recordBuilder.prop(SPANNER_VIEW_SECURITY, view.security().toString());
-      }
-      schemas.add(recordBuilder.fields().endRecord());
     }
 
     for (ChangeStream changeStream : ddl.changeStreams()) {

--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/Ddl.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/Ddl.java
@@ -277,14 +277,14 @@ public class Ddl implements Serializable {
       model.prettyPrint(appendable);
     }
 
-    for (PropertyGraph graph : propertyGraphs()) {
-      appendable.append("\n");
-      graph.prettyPrint(appendable);
-    }
-
     for (View view : views()) {
       appendable.append("\n");
       view.prettyPrint(appendable);
+    }
+
+    for (PropertyGraph graph : propertyGraphs()) {
+      appendable.append("\n");
+      graph.prettyPrint(appendable);
     }
 
     for (Udf udf : udfs()) {
@@ -317,8 +317,8 @@ public class Ddl implements Serializable {
         .addAll(createIndexStatements())
         .addAll(addForeignKeyStatements())
         .addAll(createModelStatements())
-        .addAll(createPropertyGraphStatements())
         .addAll(createViewStatements())
+        .addAll(createPropertyGraphStatements())
         .addAll(createUdfStatements())
         .addAll(createChangeStreamStatements())
         .addAll(createPlacementStatements())

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/AvroSchemaToDdlConverterTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/AvroSchemaToDdlConverterTest.java
@@ -1854,4 +1854,63 @@ public class AvroSchemaToDdlConverterTest {
             + ")";
     assertThat(ddl.prettyPrint(), equalToCompressingWhiteSpace(expectedPg));
   }
+
+  @Test
+  public void propertyGraphOnViewWithNamedSchema() {
+    String avroString =
+        "{\n"
+            + "  \"type\": \"record\",\n"
+            + "  \"name\": \"aml\",\n"
+            + "  \"namespace\": \"spannertest\",\n"
+            + "  \"fields\": [],\n"
+            + "  \"spannerName\": \"aml\",\n"
+            + "  \"spannerEntity\": \"PropertyGraph\",\n"
+            + "  \"googleStorage\": \"CloudSpanner\",\n"
+            + "  \"googleFormatVersion\": \"booleans\",\n"
+            + "  \"spannerGraphNodeTable_0_BASE_TABLE_NAME\": \"V0\",\n"
+            + "  \"spannerGraphNodeTable_0_NAME\": \"V0\",\n"
+            + "  \"spannerGraphNodeTable_0_KEY_COLUMNS\": \"AccountID\",\n"
+            + "  \"spannerGraphNodeTable_0_LABEL_0_NAME\": \"V0\",\n"
+            + "  \"spannerGraphNodeTable_0_LABEL_0_PROPERTY_0_NAME\": \"AccountID\",\n"
+            + "  \"spannerGraphNodeTable_0_LABEL_0_PROPERTY_0_VALUE\": \"AccountID\",\n"
+            + "  \"spannerGraphNodeTable_0_LABEL_0_PROPERTY_1_NAME\": \"Money\",\n"
+            + "  \"spannerGraphNodeTable_0_LABEL_0_PROPERTY_1_VALUE\": \"Money\",\n"
+            + "  \"spannerGraphNodeTable_1_BASE_TABLE_NAME\": \"Sch1.V1\",\n"
+            + "  \"spannerGraphNodeTable_1_NAME\": \"Sch1.V1\",\n"
+            + "  \"spannerGraphNodeTable_1_KEY_COLUMNS\": \"AccountID\",\n"
+            + "  \"spannerGraphNodeTable_1_LABEL_0_NAME\": \"Sch1.V1\",\n"
+            + "  \"spannerGraphNodeTable_1_LABEL_0_PROPERTY_0_NAME\": \"AccountID\",\n"
+            + "  \"spannerGraphNodeTable_1_LABEL_0_PROPERTY_0_VALUE\": \"AccountID\",\n"
+            + "  \"spannerGraphNodeTable_1_LABEL_0_PROPERTY_1_NAME\": \"Money\",\n"
+            + "  \"spannerGraphNodeTable_1_LABEL_0_PROPERTY_1_VALUE\": \"Money\",\n"
+            + "  \"spannerGraphNodeTable_2_BASE_TABLE_NAME\": \"Sch2.V2\",\n"
+            + "  \"spannerGraphNodeTable_2_NAME\": \"Sch2.V2\",\n"
+            + "  \"spannerGraphNodeTable_2_KEY_COLUMNS\": \"AccountID\",\n"
+            + "  \"spannerGraphNodeTable_2_LABEL_0_NAME\": \"Sch2.V2\",\n"
+            + "  \"spannerGraphNodeTable_2_LABEL_0_PROPERTY_0_NAME\": \"AccountID\",\n"
+            + "  \"spannerGraphNodeTable_2_LABEL_0_PROPERTY_0_VALUE\": \"AccountID\",\n"
+            + "  \"spannerGraphNodeTable_2_LABEL_0_PROPERTY_1_NAME\": \"Money\",\n"
+            + "  \"spannerGraphNodeTable_2_LABEL_0_PROPERTY_1_VALUE\": \"Money\"\n"
+            + "}";
+
+    Schema schema = new Schema.Parser().parse(avroString);
+
+    AvroSchemaToDdlConverter converter = new AvroSchemaToDdlConverter();
+    Ddl ddl = converter.toDdl(Collections.singleton(schema));
+    assertThat(ddl.propertyGraphs(), hasSize(1));
+
+    String expectedPg =
+        "CREATE PROPERTY GRAPH aml\n"
+            + "NODE TABLES(\n"
+            + "V0 AS V0\n"
+            + " KEY (AccountID)\n"
+            + "LABEL V0 PROPERTIES(AccountID, Money), "
+            + "Sch1.V1 AS Sch1.V1\n"
+            + " KEY (AccountID)\n"
+            + "LABEL Sch1.V1 PROPERTIES(AccountID, Money), "
+            + "Sch2.V2 AS Sch2.V2\n"
+            + " KEY (AccountID)\n"
+            + "LABEL Sch2.V2 PROPERTIES(AccountID, Money))";
+    assertThat(ddl.prettyPrint(), equalToCompressingWhiteSpace(expectedPg));
+  }
 }

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/AvroSchemaToDdlConverterTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/AvroSchemaToDdlConverterTest.java
@@ -1732,6 +1732,7 @@ public class AvroSchemaToDdlConverterTest {
             + "  \"spannerEntity\": \"PropertyGraph\",\n"
             + "  \"googleStorage\": \"CloudSpanner\",\n"
             + "  \"googleFormatVersion\": \"booleans\",\n"
+            + "  \"spannerGraphNodeTable_0_NAME\": \"V_GroupByPerson\",\n"
             + "  \"spannerGraphNodeTable_0_BASE_TABLE_NAME\": \"V_GroupByPerson\",\n"
             + "  \"spannerGraphNodeTable_0_KEY_COLUMNS\": \"loc_id,pid\",\n"
             + "  \"spannerGraphNodeTable_0_LABEL_0_NAME\": \"V_GroupByPerson\",\n"
@@ -1741,6 +1742,7 @@ public class AvroSchemaToDdlConverterTest {
             + "  \"spannerGraphNodeTable_0_LABEL_0_PROPERTY_1_VALUE\": \"pid\",\n"
             + "  \"spannerGraphNodeTable_0_LABEL_0_PROPERTY_2_NAME\": \"cnt\",\n"
             + "  \"spannerGraphNodeTable_0_LABEL_0_PROPERTY_2_VALUE\": \"cnt\",\n"
+            + "  \"spannerGraphNodeTable_1_NAME\": \"V_FilteredPerson\",\n"
             + "  \"spannerGraphNodeTable_1_BASE_TABLE_NAME\": \"V_FilteredPerson\",\n"
             + "  \"spannerGraphNodeTable_1_KEY_COLUMNS\": \"loc_id,pid\",\n"
             + "  \"spannerGraphNodeTable_1_LABEL_0_NAME\": \"V_FilteredPerson\",\n"
@@ -1748,6 +1750,7 @@ public class AvroSchemaToDdlConverterTest {
             + "  \"spannerGraphNodeTable_1_LABEL_0_PROPERTY_0_VALUE\": \"loc_id\",\n"
             + "  \"spannerGraphNodeTable_1_LABEL_0_PROPERTY_1_NAME\": \"pid\",\n"
             + "  \"spannerGraphNodeTable_1_LABEL_0_PROPERTY_1_VALUE\": \"pid\",\n"
+            + "  \"spannerGraphNodeTable_2_NAME\": \"GraphTableAccount\",\n"
             + "  \"spannerGraphNodeTable_2_BASE_TABLE_NAME\": \"GraphTableAccount\",\n"
             + "  \"spannerGraphNodeTable_2_KEY_COLUMNS\": \"loc_id,aid\",\n"
             + "  \"spannerGraphNodeTable_2_LABEL_0_NAME\": \"GraphTableAccount\",\n"
@@ -1780,23 +1783,24 @@ public class AvroSchemaToDdlConverterTest {
     assertThat(ddl.propertyGraphs(), hasSize(1));
 
     String expectedPg =
-        "CREATE PROPERTY GRAPH `aml_view_complex`\n"
-            + "\tNODE TABLES (\n"
-            + "\t\t`V_GroupByPerson` KEY (`loc_id`, `pid`) LABEL `V_GroupByPerson`"
-            + " PROPERTIES (`loc_id`, `pid`, `cnt`),\n"
-            + "\t\t`V_FilteredPerson` KEY (`loc_id`, `pid`) LABEL `V_FilteredPerson`"
-            + " PROPERTIES (`loc_id`, `pid`),\n"
-            + "\t\t`GraphTableAccount` KEY (`loc_id`, `aid`) LABEL `GraphTableAccount`"
-            + " PROPERTIES (`loc_id`, `aid`)\n"
-            + "\t)\n"
-            + "\tEDGE TABLES (\n"
-            + "\t\t`GraphTableAccount` AS `Owns` KEY (`loc_id`, `aid`) SOURCE KEY (`loc_id`,"
-            + " `owner_id`) REFERENCES `V_FilteredPerson` (`loc_id`, `pid`) DESTINATION KEY"
-            + " (`loc_id`, `aid`) REFERENCES `GraphTableAccount` (`loc_id`, `aid`) LABEL `Owns`"
-            + " PROPERTIES (`loc_id`, `aid`, `owner_id`)\n"
-            + "\t)";
-    // TODO(b/348395193) Add full property list to the expected DDL, and fix the converter.
-    // assertThat(ddl.prettyPrint(), equalToCompressingWhiteSpace(expectedPg));
+        "CREATE PROPERTY GRAPH aml_view_complex\n"
+            + "NODE TABLES(\n"
+            + "V_GroupByPerson AS V_GroupByPerson\n"
+            + " KEY (loc_id, pid)\n"
+            + "LABEL V_GroupByPerson PROPERTIES(loc_id, pid, cnt), "
+            + "V_FilteredPerson AS V_FilteredPerson\n"
+            + " KEY (loc_id, pid)\n"
+            + "LABEL V_FilteredPerson PROPERTIES(loc_id, pid), "
+            + "GraphTableAccount AS GraphTableAccount\n"
+            + " KEY (loc_id, aid)\n"
+            + "LABEL GraphTableAccount PROPERTIES(loc_id, aid))\n"
+            + "EDGE TABLES(\n"
+            + "GraphTableAccount AS Owns\n"
+            + " KEY (loc_id, aid)\n"
+            + "SOURCE KEY(loc_id, owner_id) REFERENCES V_FilteredPerson(loc_id,pid) DESTINATION"
+            + " KEY(loc_id, aid) REFERENCES GraphTableAccount(loc_id,aid)\n"
+            + "LABEL Owns PROPERTIES(loc_id, aid, owner_id))";
+    assertThat(ddl.prettyPrint(), equalToCompressingWhiteSpace(expectedPg));
   }
 
   @Test

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/DdlToAvroSchemaConverterTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/DdlToAvroSchemaConverterTest.java
@@ -1562,9 +1562,7 @@ public class DdlToAvroSchemaConverterTest {
                     .keyColumns(ImmutableList.of("part_id", "supplier_id"))
                     .sourceNodeTable(
                         new GraphNodeTableReference(
-                            "PartView",
-                            ImmutableList.of("part_id"),
-                            ImmutableList.of("part_id")))
+                            "PartView", ImmutableList.of("part_id"), ImmutableList.of("part_id")))
                     .targetNodeTable(
                         new GraphNodeTableReference(
                             "SupplierView",
@@ -1595,12 +1593,9 @@ public class DdlToAvroSchemaConverterTest {
 
     assertEquals(
         "PartSuppliersView", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_BASE_TABLE_NAME"));
-    assertEquals(
-        "part_id, supplier_id", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_KEY_COLUMNS"));
-    assertEquals(
-        "PartView", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_SOURCE_NODE_TABLE_NAME"));
-    assertEquals(
-        "part_id", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_SOURCE_NODE_KEY_COLUMNS"));
+    assertEquals("part_id, supplier_id", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_KEY_COLUMNS"));
+    assertEquals("PartView", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_SOURCE_NODE_TABLE_NAME"));
+    assertEquals("part_id", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_SOURCE_NODE_KEY_COLUMNS"));
     assertEquals("part_id", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_SOURCE_EDGE_KEY_COLUMNS"));
     assertEquals(
         "SupplierView", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_TARGET_NODE_TABLE_NAME"));
@@ -2603,14 +2598,14 @@ public class DdlToAvroSchemaConverterTest {
 
     // Asserting properties related to Node table
     assertEquals("V_GroupByPerson", avroSchema.getProp(SPANNER_NODE_TABLE + "_0_BASE_TABLE_NAME"));
-    assertEquals(
-        "V_FilteredPerson", avroSchema.getProp(SPANNER_NODE_TABLE + "_1_BASE_TABLE_NAME"));
+    assertEquals("V_FilteredPerson", avroSchema.getProp(SPANNER_NODE_TABLE + "_1_BASE_TABLE_NAME"));
     assertEquals(
         "GraphTableAccount", avroSchema.getProp(SPANNER_NODE_TABLE + "_2_BASE_TABLE_NAME"));
 
     // Asserting properties related to Edge table
     assertEquals("Owns", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_NAME"));
-    assertEquals("GraphTableAccount", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_BASE_TABLE_NAME"));
+    assertEquals(
+        "GraphTableAccount", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_BASE_TABLE_NAME"));
     assertEquals(
         "V_FilteredPerson", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_SOURCE_NODE_TABLE_NAME"));
     assertEquals(
@@ -2703,10 +2698,7 @@ public class DdlToAvroSchemaConverterTest {
     Collection<Schema> result = converter.convert(ddl);
     assertThat(result, hasSize(7)); // 1 table, 2 schemas, 3 views, 1 property graph
     Schema avroSchema =
-        result.stream()
-            .filter(s -> s.getName().equals("aml"))
-            .findFirst()
-            .orElse(null);
+        result.stream().filter(s -> s.getName().equals("aml")).findFirst().orElse(null);
 
     assertThat(avroSchema, notNullValue());
     assertThat(avroSchema.getName(), equalTo("aml"));

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/DdlToAvroSchemaConverterTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/DdlToAvroSchemaConverterTest.java
@@ -1489,6 +1489,128 @@ public class DdlToAvroSchemaConverterTest {
   }
 
   @Test
+  public void propertyGraphOnViewMixedOrder() {
+    DdlToAvroSchemaConverter converter =
+        new DdlToAvroSchemaConverter("spannertest", "booleans", true);
+    Ddl ddl =
+        Ddl.builder()
+            .createTable("Parts")
+            .column("part_id")
+            .int64()
+            .endColumn()
+            .column("part_name")
+            .string()
+            .max()
+            .endColumn()
+            .primaryKey()
+            .asc("part_id")
+            .end()
+            .endTable()
+            .createView("PartView")
+            .query("SELECT part_id, part_name FROM Parts")
+            .security(View.SqlSecurity.INVOKER)
+            .endView()
+            .createTable("Suppliers")
+            .column("supplier_id")
+            .int64()
+            .endColumn()
+            .column("supplier_name")
+            .string()
+            .max()
+            .endColumn()
+            .primaryKey()
+            .asc("supplier_id")
+            .end()
+            .endTable()
+            .createView("SupplierView")
+            .query("SELECT supplier_id, supplier_name FROM Suppliers")
+            .security(View.SqlSecurity.INVOKER)
+            .endView()
+            .createTable("PartSuppliers")
+            .column("part_id")
+            .int64()
+            .endColumn()
+            .column("supplier_id")
+            .int64()
+            .endColumn()
+            .primaryKey()
+            .asc("part_id")
+            .asc("supplier_id")
+            .end()
+            .endTable()
+            .createView("PartSuppliersView")
+            .query("SELECT part_id, supplier_id FROM PartSuppliers")
+            .security(View.SqlSecurity.INVOKER)
+            .endView()
+            .createPropertyGraph("SupplyChainGraph")
+            .addNodeTable(
+                GraphElementTable.builder()
+                    .baseTableName("PartView")
+                    .name("PartView")
+                    .keyColumns(ImmutableList.of("part_id"))
+                    .autoBuild())
+            .addNodeTable(
+                GraphElementTable.builder()
+                    .baseTableName("SupplierView")
+                    .name("SupplierView")
+                    .keyColumns(ImmutableList.of("supplier_id"))
+                    .autoBuild())
+            .addEdgeTable(
+                GraphElementTable.builder()
+                    .baseTableName("PartSuppliersView")
+                    .name("PartSuppliersView")
+                    .keyColumns(ImmutableList.of("part_id", "supplier_id"))
+                    .sourceNodeTable(
+                        new GraphNodeTableReference(
+                            "PartView",
+                            ImmutableList.of("part_id"),
+                            ImmutableList.of("part_id")))
+                    .targetNodeTable(
+                        new GraphNodeTableReference(
+                            "SupplierView",
+                            ImmutableList.of("supplier_id"),
+                            ImmutableList.of("supplier_id")))
+                    .autoBuild())
+            .endPropertyGraph()
+            .build();
+
+    Collection<Schema> result = converter.convert(ddl);
+    assertThat(result, hasSize(7)); // 3 tables, 3 views, 1 property graph
+    Schema avroSchema = null;
+    for (Schema s : result) {
+      if (s.getName().equals("SupplyChainGraph")) {
+        avroSchema = s;
+        break;
+      }
+    }
+    assertThat(avroSchema, notNullValue());
+
+    assertEquals("SupplyChainGraph", avroSchema.getName());
+    assertEquals(SPANNER_ENTITY_PROPERTY_GRAPH, avroSchema.getProp(SPANNER_ENTITY));
+
+    assertEquals("PartView", avroSchema.getProp(SPANNER_NODE_TABLE + "_0_BASE_TABLE_NAME"));
+    assertEquals("part_id", avroSchema.getProp(SPANNER_NODE_TABLE + "_0_KEY_COLUMNS"));
+    assertEquals("SupplierView", avroSchema.getProp(SPANNER_NODE_TABLE + "_1_BASE_TABLE_NAME"));
+    assertEquals("supplier_id", avroSchema.getProp(SPANNER_NODE_TABLE + "_1_KEY_COLUMNS"));
+
+    assertEquals(
+        "PartSuppliersView", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_BASE_TABLE_NAME"));
+    assertEquals(
+        "part_id, supplier_id", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_KEY_COLUMNS"));
+    assertEquals(
+        "PartView", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_SOURCE_NODE_TABLE_NAME"));
+    assertEquals(
+        "part_id", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_SOURCE_NODE_KEY_COLUMNS"));
+    assertEquals("part_id", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_SOURCE_EDGE_KEY_COLUMNS"));
+    assertEquals(
+        "SupplierView", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_TARGET_NODE_TABLE_NAME"));
+    assertEquals(
+        "supplier_id", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_TARGET_NODE_KEY_COLUMNS"));
+    assertEquals(
+        "supplier_id", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_TARGET_EDGE_KEY_COLUMNS"));
+  }
+
+  @Test
   public void propertyGraphDynamic() {
     DdlToAvroSchemaConverter converter =
         new DdlToAvroSchemaConverter("spannertest", "booleans", true);
@@ -2322,5 +2444,176 @@ public class DdlToAvroSchemaConverterTest {
         Schema.create(Schema.Type.NULL),
         LogicalTypes.decimal(NumericUtils.PG_MAX_PRECISION, NumericUtils.PG_MAX_SCALE)
             .addToSchema(Schema.create(Schema.Type.BYTES)));
+  }
+
+  @Test
+  public void propertyGraphOnView() {
+    DdlToAvroSchemaConverter converter =
+        new DdlToAvroSchemaConverter("spannertest", "booleans", true);
+    Ddl ddl =
+        Ddl.builder()
+            .createTable("GraphTablePerson")
+            .column("loc_id")
+            .int64()
+            .endColumn()
+            .column("pid")
+            .int64()
+            .endColumn()
+            .primaryKey()
+            .asc("loc_id")
+            .asc("pid")
+            .end()
+            .endTable()
+            .createTable("GraphTableAccount")
+            .column("loc_id")
+            .int64()
+            .endColumn()
+            .column("aid")
+            .int64()
+            .endColumn()
+            .column("owner_id")
+            .int64()
+            .endColumn()
+            .column("name")
+            .string()
+            .max()
+            .endColumn()
+            .column("account_kind")
+            .int64()
+            .endColumn()
+            .column("ProtoColumn")
+            .bytes()
+            .max()
+            .endColumn()
+            .column("generated_enum_field")
+            .int64()
+            .endColumn()
+            .column("another_enum_field")
+            .int64()
+            .endColumn()
+            .primaryKey()
+            .asc("loc_id")
+            .asc("aid")
+            .end()
+            .endTable()
+            .createView("V_GroupByPerson")
+            .query(
+                "SELECT t.loc_id, t.pid, COUNT(*) AS cnt FROM GraphTablePerson AS t GROUP BY"
+                    + " t.loc_id, t.pid ORDER BY cnt DESC")
+            .security(View.SqlSecurity.INVOKER)
+            .endView()
+            .createView("V_FilteredPerson")
+            .query("SELECT t.loc_id, t.pid FROM GraphTablePerson AS t WHERE t.loc_id = 1")
+            .security(View.SqlSecurity.INVOKER)
+            .endView()
+            .createPropertyGraph("aml_view_complex")
+            .addNodeTable(
+                GraphElementTable.builder()
+                    .baseTableName("V_GroupByPerson")
+                    .name("V_GroupByPerson")
+                    .kind(GraphElementTable.Kind.NODE)
+                    .keyColumns(ImmutableList.of("loc_id", "pid"))
+                    .labelToPropertyDefinitions(
+                        ImmutableList.of(
+                            new LabelToPropertyDefinitions(
+                                "V_GroupByPerson",
+                                ImmutableList.of(
+                                    new PropertyDefinition("loc_id", "loc_id"),
+                                    new PropertyDefinition("pid", "pid"),
+                                    new PropertyDefinition("cnt", "cnt")))))
+                    .autoBuild())
+            .addNodeTable(
+                GraphElementTable.builder()
+                    .baseTableName("V_FilteredPerson")
+                    .name("V_FilteredPerson")
+                    .kind(GraphElementTable.Kind.NODE)
+                    .keyColumns(ImmutableList.of("loc_id", "pid"))
+                    .labelToPropertyDefinitions(
+                        ImmutableList.of(
+                            new LabelToPropertyDefinitions(
+                                "V_FilteredPerson",
+                                ImmutableList.of(
+                                    new PropertyDefinition("loc_id", "loc_id"),
+                                    new PropertyDefinition("pid", "pid")))))
+                    .autoBuild())
+            .addNodeTable(
+                GraphElementTable.builder()
+                    .baseTableName("GraphTableAccount")
+                    .name("GraphTableAccount")
+                    .kind(GraphElementTable.Kind.NODE)
+                    .keyColumns(ImmutableList.of("loc_id", "aid"))
+                    .labelToPropertyDefinitions(
+                        ImmutableList.of(
+                            new LabelToPropertyDefinitions(
+                                "GraphTableAccount",
+                                ImmutableList.of(
+                                    new PropertyDefinition("loc_id", "loc_id"),
+                                    new PropertyDefinition("aid", "aid"),
+                                    new PropertyDefinition("owner_id", "owner_id"),
+                                    new PropertyDefinition("name", "name"),
+                                    new PropertyDefinition("account_kind", "account_kind"),
+                                    new PropertyDefinition("ProtoColumn", "ProtoColumn"),
+                                    new PropertyDefinition(
+                                        "generated_enum_field", "generated_enum_field"),
+                                    new PropertyDefinition(
+                                        "another_enum_field", "another_enum_field")))))
+                    .autoBuild())
+            .addEdgeTable(
+                GraphElementTable.builder()
+                    .baseTableName("GraphTableAccount")
+                    .name("Owns")
+                    .kind(GraphElementTable.Kind.EDGE)
+                    .keyColumns(ImmutableList.of("loc_id", "aid"))
+                    .sourceNodeTable(
+                        new GraphNodeTableReference(
+                            "V_FilteredPerson",
+                            ImmutableList.of("loc_id", "pid"),
+                            ImmutableList.of("loc_id", "owner_id")))
+                    .targetNodeTable(
+                        new GraphNodeTableReference(
+                            "GraphTableAccount",
+                            ImmutableList.of("loc_id", "aid"),
+                            ImmutableList.of("loc_id", "aid")))
+                    .labelToPropertyDefinitions(
+                        ImmutableList.of(
+                            new LabelToPropertyDefinitions(
+                                "Owns",
+                                ImmutableList.of(
+                                    new PropertyDefinition("loc_id", "loc_id"),
+                                    new PropertyDefinition("aid", "aid"),
+                                    new PropertyDefinition("owner_id", "owner_id")))))
+                    .autoBuild())
+            .endPropertyGraph()
+            .build();
+
+    Collection<Schema> result = converter.convert(ddl);
+    assertThat(result, hasSize(5));
+    Schema avroSchema =
+        result.stream()
+            .filter(s -> s.getName().equals("aml_view_complex"))
+            .findFirst()
+            .orElse(null);
+
+    assertThat(avroSchema, notNullValue());
+    assertThat(avroSchema.getName(), equalTo("aml_view_complex"));
+    assertThat(avroSchema.getNamespace(), equalTo("spannertest"));
+    assertThat(avroSchema.getProp(GOOGLE_FORMAT_VERSION), equalTo("booleans"));
+    assertThat(avroSchema.getProp(GOOGLE_STORAGE), equalTo("CloudSpanner"));
+    assertThat(avroSchema.getProp(SPANNER_ENTITY), equalTo(SPANNER_ENTITY_PROPERTY_GRAPH));
+
+    // Asserting properties related to Node table
+    assertEquals("V_GroupByPerson", avroSchema.getProp(SPANNER_NODE_TABLE + "_0_BASE_TABLE_NAME"));
+    assertEquals(
+        "V_FilteredPerson", avroSchema.getProp(SPANNER_NODE_TABLE + "_1_BASE_TABLE_NAME"));
+    assertEquals(
+        "GraphTableAccount", avroSchema.getProp(SPANNER_NODE_TABLE + "_2_BASE_TABLE_NAME"));
+
+    // Asserting properties related to Edge table
+    assertEquals("Owns", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_NAME"));
+    assertEquals("GraphTableAccount", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_BASE_TABLE_NAME"));
+    assertEquals(
+        "V_FilteredPerson", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_SOURCE_NODE_TABLE_NAME"));
+    assertEquals(
+        "GraphTableAccount", avroSchema.getProp(SPANNER_EDGE_TABLE + "_0_TARGET_NODE_TABLE_NAME"));
   }
 }

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/DdlTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/DdlTest.java
@@ -1881,9 +1881,7 @@ public class DdlTest {
                     .keyColumns(ImmutableList.of("part_id", "supplier_id"))
                     .sourceNodeTable(
                         new GraphNodeTableReference(
-                            "PartView",
-                            ImmutableList.of("part_id"),
-                            ImmutableList.of("part_id")))
+                            "PartView", ImmutableList.of("part_id"), ImmutableList.of("part_id")))
                     .targetNodeTable(
                         new GraphNodeTableReference(
                             "SupplierView",
@@ -2001,9 +1999,7 @@ public class DdlTest {
                     .keyColumns(ImmutableList.of("part_id", "supplier_id"))
                     .sourceNodeTable(
                         new GraphNodeTableReference(
-                            "PartView2",
-                            ImmutableList.of("part_id"),
-                            ImmutableList.of("part_id")))
+                            "PartView2", ImmutableList.of("part_id"), ImmutableList.of("part_id")))
                     .targetNodeTable(
                         new GraphNodeTableReference(
                             "SupplierView2",

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/DdlTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/DdlTest.java
@@ -1628,4 +1628,423 @@ public class DdlTest {
     assertEquals("schema", namedSchema.name());
     assertEquals("CREATE SCHEMA `schema`", namedSchema.prettyPrint());
   }
+
+  @Test
+  public void testPropertyGraphOnView() {
+    Ddl ddl =
+        Ddl.builder()
+            .createTable("GraphTableAccount")
+            .column("loc_id")
+            .int64()
+            .endColumn()
+            .column("aid")
+            .int64()
+            .endColumn()
+            .column("owner_id")
+            .int64()
+            .endColumn()
+            .column("name")
+            .string()
+            .max()
+            .endColumn()
+            .column("account_kind")
+            .int64()
+            .endColumn()
+            .column("ProtoColumn")
+            .bytes()
+            .max()
+            .endColumn()
+            .column("generated_enum_field")
+            .int64()
+            .endColumn()
+            .column("another_enum_field")
+            .int64()
+            .endColumn()
+            .primaryKey()
+            .asc("loc_id")
+            .asc("aid")
+            .end()
+            .endTable()
+            .createTable("GraphTablePerson")
+            .column("loc_id")
+            .int64()
+            .endColumn()
+            .column("pid")
+            .int64()
+            .endColumn()
+            .primaryKey()
+            .asc("loc_id")
+            .asc("pid")
+            .end()
+            .endTable()
+            .createView("V_FilteredPerson")
+            .query("SELECT t.loc_id, t.pid FROM GraphTablePerson AS t WHERE t.loc_id = 1")
+            .security(View.SqlSecurity.INVOKER)
+            .endView()
+            .createView("V_GroupByPerson")
+            .query(
+                "SELECT t.loc_id, t.pid, COUNT(*) AS cnt FROM GraphTablePerson AS t GROUP BY"
+                    + " t.loc_id, t.pid ORDER BY cnt DESC")
+            .security(View.SqlSecurity.INVOKER)
+            .endView()
+            .createPropertyGraph("aml_view_complex")
+            .addNodeTable(
+                GraphElementTable.builder()
+                    .baseTableName("V_GroupByPerson")
+                    .name("V_GroupByPerson")
+                    .kind(GraphElementTable.Kind.NODE)
+                    .keyColumns(ImmutableList.of("loc_id", "pid"))
+                    .labelToPropertyDefinitions(
+                        ImmutableList.of(
+                            new LabelToPropertyDefinitions(
+                                "V_GroupByPerson",
+                                ImmutableList.of(
+                                    new PropertyDefinition("loc_id", "loc_id"),
+                                    new PropertyDefinition("pid", "pid"),
+                                    new PropertyDefinition("cnt", "cnt")))))
+                    .autoBuild())
+            .addNodeTable(
+                GraphElementTable.builder()
+                    .baseTableName("V_FilteredPerson")
+                    .name("V_FilteredPerson")
+                    .kind(GraphElementTable.Kind.NODE)
+                    .keyColumns(ImmutableList.of("loc_id", "pid"))
+                    .labelToPropertyDefinitions(
+                        ImmutableList.of(
+                            new LabelToPropertyDefinitions(
+                                "V_FilteredPerson",
+                                ImmutableList.of(
+                                    new PropertyDefinition("loc_id", "loc_id"),
+                                    new PropertyDefinition("pid", "pid")))))
+                    .autoBuild())
+            .addNodeTable(
+                GraphElementTable.builder()
+                    .baseTableName("GraphTableAccount")
+                    .name("GraphTableAccount")
+                    .kind(GraphElementTable.Kind.NODE)
+                    .keyColumns(ImmutableList.of("loc_id", "aid"))
+                    .labelToPropertyDefinitions(
+                        ImmutableList.of(
+                            new LabelToPropertyDefinitions(
+                                "GraphTableAccount",
+                                ImmutableList.of(
+                                    new PropertyDefinition("loc_id", "loc_id"),
+                                    new PropertyDefinition("aid", "aid"),
+                                    new PropertyDefinition("owner_id", "owner_id"),
+                                    new PropertyDefinition("name", "name"),
+                                    new PropertyDefinition("account_kind", "account_kind"),
+                                    new PropertyDefinition("ProtoColumn", "ProtoColumn"),
+                                    new PropertyDefinition(
+                                        "generated_enum_field", "generated_enum_field"),
+                                    new PropertyDefinition(
+                                        "another_enum_field", "another_enum_field")))))
+                    .autoBuild())
+            .addEdgeTable(
+                GraphElementTable.builder()
+                    .baseTableName("GraphTableAccount")
+                    .name("Owns")
+                    .kind(GraphElementTable.Kind.EDGE)
+                    .keyColumns(ImmutableList.of("loc_id", "aid"))
+                    .sourceNodeTable(
+                        new GraphNodeTableReference(
+                            "V_FilteredPerson",
+                            ImmutableList.of("loc_id", "pid"),
+                            ImmutableList.of("loc_id", "owner_id")))
+                    .targetNodeTable(
+                        new GraphNodeTableReference(
+                            "GraphTableAccount",
+                            ImmutableList.of("loc_id", "aid"),
+                            ImmutableList.of("loc_id", "aid")))
+                    .labelToPropertyDefinitions(
+                        ImmutableList.of(
+                            new LabelToPropertyDefinitions(
+                                "Owns",
+                                ImmutableList.of(
+                                    new PropertyDefinition("loc_id", "loc_id"),
+                                    new PropertyDefinition("aid", "aid"),
+                                    new PropertyDefinition("owner_id", "owner_id")))))
+                    .autoBuild())
+            .endPropertyGraph()
+            .build();
+
+    String expectedDdl =
+        "CREATE TABLE `GraphTableAccount` (\n"
+            + "\t`loc_id`                                INT64,\n"
+            + "\t`aid`                                   INT64,\n"
+            + "\t`owner_id`                              INT64,\n"
+            + "\t`name`                                  STRING(MAX),\n"
+            + "\t`account_kind`                          INT64,\n"
+            + "\t`ProtoColumn`                           BYTES(MAX),\n"
+            + "\t`generated_enum_field`                  INT64,\n"
+            + "\t`another_enum_field`                    INT64,\n"
+            + ") PRIMARY KEY (`loc_id` ASC, `aid` ASC)\n"
+            + "CREATE TABLE `GraphTablePerson` (\n"
+            + "\t`loc_id`                                INT64,\n"
+            + "\t`pid`                                   INT64,\n"
+            + ") PRIMARY KEY (`loc_id` ASC, `pid` ASC)\n"
+            + "CREATE VIEW `V_FilteredPerson` SQL SECURITY INVOKER AS SELECT t.loc_id, t.pid FROM"
+            + " GraphTablePerson AS t WHERE t.loc_id = 1\n"
+            + "CREATE VIEW `V_GroupByPerson` SQL SECURITY INVOKER AS SELECT t.loc_id, t.pid,"
+            + " COUNT(*) AS cnt FROM GraphTablePerson AS t GROUP BY t.loc_id, t.pid ORDER BY cnt"
+            + " DESC\n"
+            + "CREATE PROPERTY GRAPH aml_view_complex\n"
+            + "NODE TABLES(\n"
+            + "V_GroupByPerson AS V_GroupByPerson\n"
+            + " KEY (loc_id, pid)\n"
+            + "LABEL V_GroupByPerson PROPERTIES(loc_id, pid, cnt), V_FilteredPerson AS"
+            + " V_FilteredPerson\n"
+            + " KEY (loc_id, pid)\n"
+            + "LABEL V_FilteredPerson PROPERTIES(loc_id, pid), GraphTableAccount AS"
+            + " GraphTableAccount\n"
+            + " KEY (loc_id, aid)\n"
+            + "LABEL GraphTableAccount PROPERTIES(loc_id, aid, owner_id, name, account_kind,"
+            + " ProtoColumn, generated_enum_field, another_enum_field))\n"
+            + "EDGE TABLES(\n"
+            + "GraphTableAccount AS Owns\n"
+            + " KEY (loc_id, aid)\n"
+            + "SOURCE KEY(loc_id, owner_id) REFERENCES V_FilteredPerson(loc_id,pid) DESTINATION"
+            + " KEY(loc_id, aid) REFERENCES GraphTableAccount(loc_id,aid)\n"
+            + "LABEL Owns PROPERTIES(loc_id, aid, owner_id))";
+    assertThat(ddl.prettyPrint(), equalToCompressingWhiteSpace(expectedDdl));
+  }
+
+  @Test
+  public void testPropertyGraphOnViewMixedOrder() {
+    Ddl ddl =
+        Ddl.builder()
+            .createTable("Parts")
+            .column("part_id")
+            .int64()
+            .endColumn()
+            .column("part_name")
+            .string()
+            .max()
+            .endColumn()
+            .primaryKey()
+            .asc("part_id")
+            .end()
+            .endTable()
+            .createView("PartView")
+            .query("SELECT part_id, part_name FROM Parts")
+            .security(View.SqlSecurity.INVOKER)
+            .endView()
+            .createTable("Suppliers")
+            .column("supplier_id")
+            .int64()
+            .endColumn()
+            .column("supplier_name")
+            .string()
+            .max()
+            .endColumn()
+            .primaryKey()
+            .asc("supplier_id")
+            .end()
+            .endTable()
+            .createView("SupplierView")
+            .query("SELECT supplier_id, supplier_name FROM Suppliers")
+            .security(View.SqlSecurity.INVOKER)
+            .endView()
+            .createTable("PartSuppliers")
+            .column("part_id")
+            .int64()
+            .endColumn()
+            .column("supplier_id")
+            .int64()
+            .endColumn()
+            .primaryKey()
+            .asc("part_id")
+            .asc("supplier_id")
+            .end()
+            .endTable()
+            .createView("PartSuppliersView")
+            .query("SELECT part_id, supplier_id FROM PartSuppliers")
+            .security(View.SqlSecurity.INVOKER)
+            .endView()
+            .createPropertyGraph("SupplyChainGraph")
+            .addNodeTable(
+                GraphElementTable.builder()
+                    .baseTableName("PartView")
+                    .name("PartView")
+                    .keyColumns(ImmutableList.of("part_id"))
+                    .autoBuild())
+            .addNodeTable(
+                GraphElementTable.builder()
+                    .baseTableName("SupplierView")
+                    .name("SupplierView")
+                    .keyColumns(ImmutableList.of("supplier_id"))
+                    .autoBuild())
+            .addEdgeTable(
+                GraphElementTable.builder()
+                    .baseTableName("PartSuppliersView")
+                    .name("PartSuppliersView")
+                    .kind(GraphElementTable.Kind.EDGE)
+                    .keyColumns(ImmutableList.of("part_id", "supplier_id"))
+                    .sourceNodeTable(
+                        new GraphNodeTableReference(
+                            "PartView",
+                            ImmutableList.of("part_id"),
+                            ImmutableList.of("part_id")))
+                    .targetNodeTable(
+                        new GraphNodeTableReference(
+                            "SupplierView",
+                            ImmutableList.of("supplier_id"),
+                            ImmutableList.of("supplier_id")))
+                    .autoBuild())
+            .endPropertyGraph()
+            .build();
+
+    String expectedDdl =
+        "CREATE TABLE `Parts` (\n"
+            + "\t`part_id`                               INT64,\n"
+            + "\t`part_name`                             STRING(MAX),\n"
+            + ") PRIMARY KEY (`part_id` ASC)\n\n\n"
+            + "CREATE TABLE `PartSuppliers` (\n"
+            + "\t`part_id`                               INT64,\n"
+            + "\t`supplier_id`                           INT64,\n"
+            + ") PRIMARY KEY (`part_id` ASC, `supplier_id` ASC)\n\n\n"
+            + "CREATE TABLE `Suppliers` (\n"
+            + "\t`supplier_id`                           INT64,\n"
+            + "\t`supplier_name`                         STRING(MAX),\n"
+            + ") PRIMARY KEY (`supplier_id` ASC)\n\n\n"
+            + "CREATE VIEW `PartSuppliersView` SQL SECURITY INVOKER AS SELECT part_id, supplier_id"
+            + " FROM PartSuppliers\n"
+            + "CREATE VIEW `PartView` SQL SECURITY INVOKER AS SELECT part_id, part_name FROM"
+            + " Parts\n"
+            + "CREATE VIEW `SupplierView` SQL SECURITY INVOKER AS SELECT supplier_id, supplier_name"
+            + " FROM Suppliers\n"
+            + "CREATE PROPERTY GRAPH SupplyChainGraph\n"
+            + "NODE TABLES(\n"
+            + "PartView AS PartView\n"
+            + " KEY (part_id)\n"
+            + ", SupplierView AS SupplierView\n"
+            + " KEY (supplier_id)\n"
+            + ")\n"
+            + "EDGE TABLES(\n"
+            + "PartSuppliersView AS PartSuppliersView\n"
+            + " KEY (part_id, supplier_id)\n"
+            + "SOURCE KEY(part_id) REFERENCES PartView(part_id) DESTINATION"
+            + " KEY(supplier_id) REFERENCES SupplierView(supplier_id)\n"
+            + ")";
+    assertThat(ddl.prettyPrint(), equalToCompressingWhiteSpace(expectedDdl));
+  }
+
+  @Test
+  public void testPropertyGraphOnViewTablesFirst() {
+    Ddl ddl =
+        Ddl.builder()
+            .createTable("Parts2")
+            .column("part_id")
+            .int64()
+            .endColumn()
+            .column("part_name")
+            .string()
+            .max()
+            .endColumn()
+            .primaryKey()
+            .asc("part_id")
+            .end()
+            .endTable()
+            .createTable("Suppliers2")
+            .column("supplier_id")
+            .int64()
+            .endColumn()
+            .column("supplier_name")
+            .string()
+            .max()
+            .endColumn()
+            .primaryKey()
+            .asc("supplier_id")
+            .end()
+            .endTable()
+            .createTable("PartSuppliers2")
+            .column("part_id")
+            .int64()
+            .endColumn()
+            .column("supplier_id")
+            .int64()
+            .endColumn()
+            .primaryKey()
+            .asc("part_id")
+            .asc("supplier_id")
+            .end()
+            .endTable()
+            .createView("PartView2")
+            .query("SELECT part_id, part_name FROM Parts2")
+            .security(View.SqlSecurity.INVOKER)
+            .endView()
+            .createView("SupplierView2")
+            .query("SELECT supplier_id, supplier_name FROM Suppliers2")
+            .security(View.SqlSecurity.INVOKER)
+            .endView()
+            .createView("PartSuppliersView2")
+            .query("SELECT part_id, supplier_id FROM PartSuppliers2")
+            .security(View.SqlSecurity.INVOKER)
+            .endView()
+            .createPropertyGraph("SupplyChainGraph2")
+            .addNodeTable(
+                GraphElementTable.builder()
+                    .baseTableName("PartView2")
+                    .name("PartView2")
+                    .keyColumns(ImmutableList.of("part_id"))
+                    .autoBuild())
+            .addNodeTable(
+                GraphElementTable.builder()
+                    .baseTableName("SupplierView2")
+                    .name("SupplierView2")
+                    .keyColumns(ImmutableList.of("supplier_id"))
+                    .autoBuild())
+            .addEdgeTable(
+                GraphElementTable.builder()
+                    .baseTableName("PartSuppliersView2")
+                    .name("PartSuppliersView2")
+                    .kind(GraphElementTable.Kind.EDGE)
+                    .keyColumns(ImmutableList.of("part_id", "supplier_id"))
+                    .sourceNodeTable(
+                        new GraphNodeTableReference(
+                            "PartView2",
+                            ImmutableList.of("part_id"),
+                            ImmutableList.of("part_id")))
+                    .targetNodeTable(
+                        new GraphNodeTableReference(
+                            "SupplierView2",
+                            ImmutableList.of("supplier_id"),
+                            ImmutableList.of("supplier_id")))
+                    .autoBuild())
+            .endPropertyGraph()
+            .build();
+
+    String expectedDdl =
+        "CREATE TABLE `Parts2` (\n"
+            + "\t`part_id`                               INT64,\n"
+            + "\t`part_name`                             STRING(MAX),\n"
+            + ") PRIMARY KEY (`part_id` ASC)\n\n\n"
+            + "CREATE TABLE `PartSuppliers2` (\n"
+            + "\t`part_id`                               INT64,\n"
+            + "\t`supplier_id`                           INT64,\n"
+            + ") PRIMARY KEY (`part_id` ASC, `supplier_id` ASC)\n\n\n"
+            + "CREATE TABLE `Suppliers2` (\n"
+            + "\t`supplier_id`                           INT64,\n"
+            + "\t`supplier_name`                         STRING(MAX),\n"
+            + ") PRIMARY KEY (`supplier_id` ASC)\n\n\n"
+            + "CREATE VIEW `PartSuppliersView2` SQL SECURITY INVOKER AS SELECT part_id,"
+            + " supplier_id FROM PartSuppliers2\n"
+            + "CREATE VIEW `PartView2` SQL SECURITY INVOKER AS SELECT part_id, part_name FROM"
+            + " Parts2\n"
+            + "CREATE VIEW `SupplierView2` SQL SECURITY INVOKER AS SELECT supplier_id,"
+            + " supplier_name FROM Suppliers2\n"
+            + "CREATE PROPERTY GRAPH SupplyChainGraph2\n"
+            + "NODE TABLES(\n"
+            + "PartView2 AS PartView2\n"
+            + " KEY (part_id)\n"
+            + ", SupplierView2 AS SupplierView2\n"
+            + " KEY (supplier_id)\n"
+            + ")\n"
+            + "EDGE TABLES(\n"
+            + "PartSuppliersView2 AS PartSuppliersView2\n"
+            + " KEY (part_id, supplier_id)\n"
+            + "SOURCE KEY(part_id) REFERENCES PartView2(part_id) DESTINATION"
+            + " KEY(supplier_id) REFERENCES SupplierView2(supplier_id)\n"
+            + ")";
+    assertThat(ddl.prettyPrint(), equalToCompressingWhiteSpace(expectedDdl));
+  }
 }

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
@@ -85,6 +85,12 @@ public class InformationSchemaScannerIT {
 
   @BeforeClass
   public static void setupInstancePartition() throws Exception {
+    // To avoid failure due to already existing instance partition
+    try {
+      SPANNER_SERVER.deleteInstancePartition(INSTANCE_PARTITION_ID);
+    } catch (Exception e) {
+      // Ignore exception if instance partition does not exist.
+    }
     SPANNER_SERVER.createInstancePartition(INSTANCE_PARTITION_ID, "nam3");
   }
 
@@ -1547,5 +1553,233 @@ public class InformationSchemaScannerIT {
     Ddl ddl = getDatabaseDdl();
     statements.set(0, statements.get(0).replace(dbId, "%db_name%"));
     assertThat(ddl.prettyPrint(), equalToCompressingWhiteSpace(String.join("", statements)));
+  }
+
+  @Test
+  public void propertyGraphOnViewGroupBy() throws Exception {
+    List<String> statements =
+        Arrays.asList(
+            "CREATE TABLE GraphTablePerson(loc_id INT64, pid INT64) PRIMARY KEY(loc_id, pid)",
+            "CREATE TABLE GraphTableAccount(loc_id INT64, aid INT64, owner_id INT64, name"
+                + " STRING(MAX), account_kind INT64, ProtoColumn BYTES(MAX), generated_enum_field"
+                + " INT64, another_enum_field INT64) PRIMARY KEY(loc_id, aid)",
+            "CREATE VIEW V_GroupByPerson SQL SECURITY INVOKER AS SELECT t.loc_id, t.pid, COUNT(*)"
+                + " AS cnt FROM GraphTablePerson AS t GROUP BY t.loc_id, t.pid ORDER BY cnt DESC",
+            "CREATE VIEW V_FilteredPerson SQL SECURITY INVOKER AS SELECT t.loc_id, t.pid FROM"
+                + " GraphTablePerson AS t WHERE t.loc_id = 1",
+            "CREATE PROPERTY GRAPH aml_view_complex\n"
+                + "  NODE TABLES (\n"
+                + "    V_GroupByPerson KEY (loc_id, pid) PROPERTIES(loc_id, pid, cnt),\n"
+                + "    V_FilteredPerson KEY (loc_id, pid) PROPERTIES(loc_id, pid),\n"
+                + "    GraphTableAccount KEY(loc_id, aid) PROPERTIES(loc_id, aid, owner_id, name,"
+                + " account_kind, ProtoColumn, generated_enum_field, another_enum_field)\n"
+                + "  )\n"
+                + "  EDGE TABLES (\n"
+                + "    GraphTableAccount AS Owns KEY(loc_id, aid)\n"
+                + "      SOURCE KEY(loc_id, owner_id) REFERENCES V_FilteredPerson(loc_id, pid)\n"
+                + "      DESTINATION KEY(loc_id, aid) REFERENCES GraphTableAccount(loc_id, aid)"
+                + " PROPERTIES(loc_id, aid, owner_id)\n"
+                + "  )");
+
+    SPANNER_SERVER.createDatabase(dbId, statements);
+    Ddl ddl = getDatabaseDdl();
+    String expectedDdl =
+        "CREATE TABLE `GraphTableAccount` (\n"
+            + "\t`loc_id`                                INT64,\n"
+            + "\t`aid`                                   INT64,\n"
+            + "\t`owner_id`                              INT64,\n"
+            + "\t`name`                                  STRING(MAX),\n"
+            + "\t`account_kind`                          INT64,\n"
+            + "\t`ProtoColumn`                           BYTES(MAX),\n"
+            + "\t`generated_enum_field`                  INT64,\n"
+            + "\t`another_enum_field`                    INT64,\n"
+            + ") PRIMARY KEY (`loc_id` ASC, `aid` ASC)\n\n\n"
+            + "CREATE TABLE `GraphTablePerson` (\n"
+            + "\t`loc_id`                                INT64,\n"
+            + "\t`pid`                                   INT64,\n"
+            + ") PRIMARY KEY (`loc_id` ASC, `pid` ASC)\n\n\n"
+            + "CREATE VIEW `V_FilteredPerson` SQL SECURITY INVOKER AS SELECT t.loc_id, t.pid FROM"
+            + " GraphTablePerson AS t WHERE t.loc_id = 1\n"
+            + "CREATE VIEW `V_GroupByPerson` SQL SECURITY INVOKER AS SELECT t.loc_id,"
+            + " t.pid, COUNT(*) AS cnt FROM GraphTablePerson AS t GROUP BY t.loc_id, t.pid ORDER"
+            + " BY cnt DESC\n"
+            + "CREATE PROPERTY GRAPH aml_view_complex\n"
+            + "NODE TABLES(\n"
+            + "GraphTableAccount AS GraphTableAccount\n"
+            + " KEY (loc_id, aid)\n"
+            + "LABEL GraphTableAccount PROPERTIES(account_kind, aid, another_enum_field,"
+            + " generated_enum_field, loc_id, name, owner_id, ProtoColumn), V_FilteredPerson AS"
+            + " V_FilteredPerson\n"
+            + " KEY (loc_id, pid)\n"
+            + "LABEL V_FilteredPerson PROPERTIES(loc_id, pid), V_GroupByPerson AS V_GroupByPerson\n"
+            + " KEY (loc_id, pid)\n"
+            + "LABEL V_GroupByPerson PROPERTIES(cnt, loc_id, pid))\n"
+            + "EDGE TABLES(\n"
+            + "GraphTableAccount AS Owns\n"
+            + " KEY (loc_id, aid)\n"
+            + "SOURCE KEY(loc_id, owner_id) REFERENCES V_FilteredPerson(loc_id,pid) DESTINATION"
+            + " KEY(aid, loc_id) REFERENCES GraphTableAccount(aid,loc_id)\n"
+            + "LABEL Owns PROPERTIES(aid, loc_id, owner_id))";
+    assertThat(ddl.prettyPrint(), equalToCompressingWhiteSpace(expectedDdl));
+  }
+
+  @Test
+  public void propertyGraphOnViewSimple() throws Exception {
+    List<String> statements =
+        Arrays.asList(
+            "CREATE TABLE TableA(id INT64) PRIMARY KEY(id)",
+            "CREATE VIEW ViewA SQL SECURITY INVOKER AS SELECT TableA.id FROM TableA",
+            "CREATE TABLE TableB(id INT64) PRIMARY KEY(id)",
+            "CREATE VIEW ViewB SQL SECURITY INVOKER AS SELECT TableB.id FROM TableB",
+            "CREATE PROPERTY GRAPH aml_view_complex\n"
+                + "  NODE TABLES (\n"
+                + "    ViewA KEY (id),\n"
+                + "    ViewB KEY (id)\n"
+                + "  )\n");
+
+    SPANNER_SERVER.createDatabase(dbId, statements);
+    Ddl ddl = getDatabaseDdl();
+    String expectedDdl =
+        "CREATE TABLE `TableA` (\n"
+            + "\t`id`                                    INT64,\n"
+            + ") PRIMARY KEY (`id` ASC)\n\n\n"
+            + "CREATE TABLE `TableB` (\n"
+            + "\t`id`                                    INT64,\n"
+            + ") PRIMARY KEY (`id` ASC)\n\n\n"
+            + "CREATE VIEW `ViewA` SQL SECURITY INVOKER AS SELECT TableA.id FROM TableA\n"
+            + "CREATE VIEW `ViewB` SQL SECURITY INVOKER AS SELECT TableB.id FROM TableB\n"
+            + "CREATE PROPERTY GRAPH aml_view_complex\n"
+            + "NODE TABLES(\n"
+            + "ViewA AS ViewA\n"
+            + " KEY (id)\n"
+            + "LABEL ViewA PROPERTIES(id), ViewB AS ViewB\n"
+            + " KEY (id)\n"
+            + "LABEL ViewB PROPERTIES(id))";
+    assertThat(ddl.prettyPrint(), equalToCompressingWhiteSpace(expectedDdl));
+  }
+
+  @Test
+  public void propertyGraphOnViewMixedOrder() throws Exception {
+    List<String> statements =
+        Arrays.asList(
+            "CREATE TABLE Parts(part_id INT64, part_name STRING(MAX)) PRIMARY KEY(part_id)",
+            "CREATE VIEW PartView SQL SECURITY INVOKER AS SELECT Parts.part_id, Parts.part_name FROM Parts",
+            "CREATE TABLE Suppliers(supplier_id INT64, supplier_name STRING(MAX)) PRIMARY"
+                + " KEY(supplier_id)",
+            "CREATE VIEW SupplierView SQL SECURITY INVOKER AS SELECT Suppliers.supplier_id, Suppliers.supplier_name"
+                + " FROM Suppliers",
+            "CREATE TABLE PartSuppliers(part_id INT64, supplier_id INT64) PRIMARY KEY(part_id,"
+                + " supplier_id)",
+            "CREATE VIEW PartSuppliersView SQL SECURITY INVOKER AS SELECT PartSuppliers.part_id, PartSuppliers.supplier_id"
+                + " FROM PartSuppliers",
+            "CREATE PROPERTY GRAPH SupplyChainGraph\n"
+                + "  NODE TABLES (\n"
+                + "    PartView KEY (part_id),\n"
+                + "    SupplierView KEY (supplier_id)\n"
+                + "  )\n"
+                + "  EDGE TABLES (\n"
+                + "    PartSuppliersView KEY (part_id, supplier_id)\n"
+                + "      SOURCE KEY (part_id) REFERENCES PartView(part_id)\n"
+                + "      DESTINATION KEY (supplier_id) REFERENCES SupplierView(supplier_id)\n"
+                + "  )");
+
+    SPANNER_SERVER.createDatabase(dbId, statements);
+    Ddl ddl = getDatabaseDdl();
+    String expectedDdl =
+        "CREATE TABLE `Parts` (\n"
+            + "\t`part_id`                               INT64,\n"
+            + "\t`part_name`                             STRING(MAX),\n"
+            + ") PRIMARY KEY (`part_id` ASC)\n\n\n"
+            + "CREATE TABLE `PartSuppliers` (\n"
+            + "\t`part_id`                               INT64,\n"
+            + "\t`supplier_id`                           INT64,\n"
+            + ") PRIMARY KEY (`part_id` ASC, `supplier_id` ASC)\n\n\n"
+            + "CREATE TABLE `Suppliers` (\n"
+            + "\t`supplier_id`                           INT64,\n"
+            + "\t`supplier_name`                         STRING(MAX),\n"
+            + ") PRIMARY KEY (`supplier_id` ASC)\n\n\n"
+            + "CREATE VIEW `PartSuppliersView` SQL SECURITY INVOKER AS SELECT PartSuppliers.part_id,"
+            + " PartSuppliers.supplier_id FROM PartSuppliers\n"
+            + "CREATE VIEW `PartView` SQL SECURITY INVOKER AS SELECT Parts.part_id, Parts.part_name"
+            + " FROM Parts\n"
+            + "CREATE VIEW `SupplierView` SQL SECURITY INVOKER AS SELECT Suppliers.supplier_id,"
+            + " Suppliers.supplier_name FROM Suppliers\n"
+            + "CREATE PROPERTY GRAPH SupplyChainGraph\n"
+            + "NODE TABLES(\n"
+            + "PartView AS PartView\n"
+            + " KEY (part_id)\n"
+            + "LABEL PartView PROPERTIES(part_id, part_name), SupplierView AS SupplierView\n"
+            + " KEY (supplier_id)\n"
+            + "LABEL SupplierView PROPERTIES(supplier_id, supplier_name))\n"
+            + "EDGE TABLES(\n"
+            + "PartSuppliersView AS PartSuppliersView\n"
+            + " KEY (part_id, supplier_id)\n"
+            + "SOURCE KEY(part_id) REFERENCES PartView(part_id)\n"
+            + "DESTINATION KEY(supplier_id) REFERENCES SupplierView(supplier_id)\n"
+            + "LABEL PartSuppliersView PROPERTIES(part_id, supplier_id))";
+    assertThat(ddl.prettyPrint(), equalToCompressingWhiteSpace(expectedDdl));
+  }
+
+  @Test
+  public void propertyGraphOnViewTablesFirst() throws Exception {
+    List<String> statements =
+        Arrays.asList(
+            "CREATE TABLE Parts2(part_id INT64, part_name STRING(MAX)) PRIMARY KEY(part_id)",
+            "CREATE TABLE Suppliers2(supplier_id INT64, supplier_name STRING(MAX)) PRIMARY"
+                + " KEY(supplier_id)",
+            "CREATE TABLE PartSuppliers2(part_id INT64, supplier_id INT64) PRIMARY KEY(part_id,"
+                + " supplier_id)",
+            "CREATE VIEW PartView2 SQL SECURITY INVOKER AS SELECT Parts2.part_id, Parts2.part_name FROM"
+                + " Parts2",
+            "CREATE VIEW SupplierView2 SQL SECURITY INVOKER AS SELECT Suppliers2.supplier_id, Suppliers2.supplier_name"
+                + " FROM Suppliers2",
+            "CREATE VIEW PartSuppliersView2 SQL SECURITY INVOKER AS SELECT PartSuppliers2.part_id, PartSuppliers2.supplier_id"
+                + " FROM PartSuppliers2",
+            "CREATE PROPERTY GRAPH SupplyChainGraph2\n"
+                + "  NODE TABLES (\n"
+                + "    PartView2 KEY (part_id),\n"
+                + "    SupplierView2 KEY (supplier_id)\n"
+                + "  )\n"
+                + "  EDGE TABLES (\n"
+                + "    PartSuppliersView2 KEY (part_id, supplier_id)\n"
+                + "      SOURCE KEY (part_id) REFERENCES PartView2(part_id)\n"
+                + "      DESTINATION KEY (supplier_id) REFERENCES SupplierView2(supplier_id)\n"
+                + "  )");
+
+    SPANNER_SERVER.createDatabase(dbId, statements);
+    Ddl ddl = getDatabaseDdl();
+    String expectedDdl =
+        "CREATE TABLE `Parts2` (\n"
+            + "\t`part_id`                               INT64,\n"
+            + "\t`part_name`                             STRING(MAX),\n"
+            + ") PRIMARY KEY (`part_id` ASC)\n\n\n"
+            + "CREATE TABLE `PartSuppliers2` (\n"
+            + "\t`part_id`                               INT64,\n"
+            + "\t`supplier_id`                           INT64,\n"
+            + ") PRIMARY KEY (`part_id` ASC, `supplier_id` ASC)\n\n\n"
+            + "CREATE TABLE `Suppliers2` (\n"
+            + "\t`supplier_id`                           INT64,\n"
+            + "\t`supplier_name`                         STRING(MAX),\n"
+            + ") PRIMARY KEY (`supplier_id` ASC)\n\n\n"
+            + "CREATE VIEW `PartSuppliersView2` SQL SECURITY INVOKER AS SELECT"
+            + " PartSuppliers2.part_id, PartSuppliers2.supplier_id FROM PartSuppliers2\n"
+            + "CREATE VIEW `PartView2` SQL SECURITY INVOKER AS SELECT Parts2.part_id,"
+            + " Parts2.part_name FROM Parts2\n"
+            + "CREATE VIEW `SupplierView2` SQL SECURITY INVOKER AS SELECT"
+            + " Suppliers2.supplier_id, Suppliers2.supplier_name FROM Suppliers2\n"
+            + "CREATE PROPERTY GRAPH SupplyChainGraph2\n"
+            + "NODE TABLES(\n"
+            + "PartView2 AS PartView2\n"
+            + " KEY (part_id)\n"
+            + "LABEL PartView2 PROPERTIES(part_id, part_name), SupplierView2 AS SupplierView2\n"
+            + " KEY (supplier_id)\n"
+            + "LABEL SupplierView2 PROPERTIES(supplier_id, supplier_name))\n"
+            + "EDGE TABLES(\n"
+            + "PartSuppliersView2 AS PartSuppliersView2\n"
+            + " KEY (part_id, supplier_id)\n"
+            + "SOURCE KEY(part_id) REFERENCES PartView2(part_id)\n"
+            + "DESTINATION KEY(supplier_id) REFERENCES SupplierView2(supplier_id)\n"
+            + "LABEL PartSuppliersView2 PROPERTIES(part_id, supplier_id))";
+    assertThat(ddl.prettyPrint(), equalToCompressingWhiteSpace(expectedDdl));
   }
 }


### PR DESCRIPTION
This commit adds support for creating property graphs on top of views in Spanner importing / exporting.

The changes include:
- Updating the DDL to Avro schema converter and the DDL generation to ensure views are created before property graphs that use them.
- Adding comprehensive tests to validate the creation and conversion of property graphs on views.