### PR TITLE
Skip reading schema if the value capture mode is NEW_ROW_AND_OLD_VALUES.

### DIFF
--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SchemaUpdateUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/SchemaUpdateUtils.java
@@ -116,7 +116,8 @@ public class SchemaUpdateUtils {
       RpcPriority rpcPriority) {
     if (!spannerTableByName.containsKey(mod.getTableName())
         || SchemaUpdateUtils.detectDiffColumnInMod(mod, spannerTableByName)) {
-      if (mod.getValueCaptureType() != ValueCaptureType.NEW_ROW) {
+      if (mod.getValueCaptureType() != ValueCaptureType.NEW_ROW
+          && mod.getValueCaptureType() != ValueCaptureType.NEW_ROW_AND_OLD_VALUES) {
         com.google.cloud.Timestamp spannerCommitTimestamp =
             com.google.cloud.Timestamp.ofTimeSecondsAndNanos(
                 mod.getCommitTimestampSeconds(), mod.getCommitTimestampNanos());


### PR DESCRIPTION
When value capture mode is NEW_ROW_AND_OLD_VALUES, the new values will contain all columns of tracked table. Similar to value capture mode NEW_ROW, we don't need to read the information schema to get the new schema.