### PR TITLE
fix: simplify sed command in surefire report time format conversion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -454,7 +454,7 @@
                <executable>bash</executable>
                <arguments>
                  <argument>-c</argument>
-                 <argument>find . -name "TEST-*.xml" -path "*/target/surefire-reports/*" -exec sed -i.bak -e 's/time="\([0-9]*\),\([0-9]*\)"/time="\1\2"/g' -e 's/time="\([0-9]*\),\([0-9]*\.[0-9]*\)"/time="\1\2"/g' {} \;</argument>
+                 <argument>find . -name "TEST-*.xml" -path "*/target/surefire-reports/*" -exec sed -i.bak 's/time="\([0-9]*\),\([0-9]*\.*[0-9]*\)"/time="\1\2"/g' {} \;</argument>
                </arguments>
              </configuration>
           </execution>


### PR DESCRIPTION
Tested:

```
echo -e 'time="1,315.109"\ntime="1,315"\ntime="315.109"\ntime="0,
001"\ntime="12,345.678"' | sed 's/time="\([0-9]*\),\([0-9]*\.*[0-9]*\)"/time="\1\2"/g'
```

Results:
```
time="1315.109"
time="1315"
time="315.109"
time="0001"
time="12345.678"
```