### PR TITLE
build: add jsonschema-specifications dependency

### DIFF
--- a/python/default_base_python_requirements.txt
+++ b/python/default_base_python_requirements.txt
@@ -1,3 +1,4 @@
 apache-beam[gcp]==2.68.0
 jsonschema==4.25.1 # TODO: remove when correct version could come from beam
+jsonschema-specifications==2025.4.1 # TODO: remove when correct version could come from beam
 setuptools

--- a/python/default_base_yaml_requirements.txt
+++ b/python/default_base_yaml_requirements.txt
@@ -1,3 +1,4 @@
 apache-beam[dataframe,gcp,test,yaml]==2.68.0
 jsonschema==4.25.1 # TODO: remove when correct version could come from beam
+jsonschema-specifications==2025.4.1 # TODO: remove when correct version could come from beam
 setuptools

--- a/python/src/main/python/streaming-llm/base_requirements.txt
+++ b/python/src/main/python/streaming-llm/base_requirements.txt
@@ -1,5 +1,6 @@
 apache-beam[gcp]==2.68.0
 jsonschema==4.25.1 # TODO: remove when correct version could come from beam
+jsonschema-specifications==2025.4.1 # TODO: remove when correct version could come from beam
 torch
 transformers
 torchvision


### PR DESCRIPTION
Add jsonschema-specifications package to base requirements files as a temporary solution until the correct version can be provided by beam

We need to pin `jsonschema-specifications==2025.4.1` since `jsonschema==4.25.1` could resolve to use `jsonschema-specifications==2025.9.1`, which causes the strange error like https://github.com/python-jsonschema/jsonschema-specifications/issues/112#issuecomment-3347843568