### PR TITLE
Remove Okio META-INF files from the templates jars

### DIFF
--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -526,6 +526,12 @@
                                                 <exclude>META-INF/maven/**</exclude>
                                             </excludes>
                                         </filter>
+                                        <filter>
+                                            <artifact>*:*</artifact>
+                                            <excludes>
+                                                <exclude>META-INF/maven/com.squareup.okio/**</exclude>
+                                            </excludes>
+                                        </filter>
                                     </filters>
                                     <transformers>
                                         <transformer


### PR DESCRIPTION
We already upgraded Okio dependency past 1.17.5 in [1] due to CVE-2023-3635 but the META-INF of shaded templates jars seems to contain a reference to this resulting in a false positive for vulnerability trackers.

This PR prevents bundling the relavent META-INF files.

[1] https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/2663