### PR TITLE
build: update jetty dependencies to 12.0.12 to fix CVE-2024-6763

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
     <mssql-jdbc.version>12.2.0.jre11</mssql-jdbc.version>
     <neo4j-driver.version>4.4.18</neo4j-driver.version>
     <okio.version>1.17.6</okio.version>
+    <jetty.version>12.0.12</jetty.version>
     <!-- Socket factory JARs for Cloud SQL -->
     <mysql-socket-factory.version>1.15.2</mysql-socket-factory.version>
     <postgres-socket-factory.version>1.25.3</postgres-socket-factory.version>
@@ -245,6 +246,82 @@
         <artifactId>okio</artifactId>
         <version>${okio.version}</version>
       </dependency>
+
+      <!-- Enforce non-vulnerable version of Jetty HTTP (CVE-2024-6763) -->
+      <!-- Using Jetty 12 EE8 artifacts for compatibility with Hadoop -->
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-http</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-client</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-io</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-util</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-security</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-util-ajax</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-xml</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-alpn-client</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <!-- EE8 specific artifacts for compatibility with Hadoop -->
+      <dependency>
+        <groupId>org.eclipse.jetty.ee8</groupId>
+        <artifactId>jetty-ee8-servlet</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee8</groupId>
+        <artifactId>jetty-ee8-webapp</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <!-- WebSocket artifacts with correct Jetty 12 coordinates -->
+      <dependency>
+        <groupId>org.eclipse.jetty.websocket</groupId>
+        <artifactId>jetty-websocket-jetty-api</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.websocket</groupId>
+        <artifactId>jetty-websocket-jetty-client</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.websocket</groupId>
+        <artifactId>jetty-websocket-jetty-common</artifactId>
+        <version>${jetty.version}</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Use Jetty 12 EE8 artifacts for compatibility with Hadoop while addressing the security vulnerability

At version 12.0.12 (Security Fixed):

- jetty-client
- jetty-alpn-client
- jetty-server
- jetty-http ← This is the critical one for CVE-2024-6763
- jetty-io
- jetty-util
- jetty-security
- jetty-util-ajax
- jetty-xml
⚠️ Still at version 9.4.57.v20241219:

- websocket-client
- websocket-common
- websocket-api
- jetty-servlet
- jetty-webapp

```
 mvn dependency:tree -pl v2/astradb-to-bigquery | grep -i jetty

[INFO] |  |  |  +- org.eclipse.jetty.websocket:websocket-client:jar:9.4.57.v20241219:compile
[INFO] |  |  |  |  +- org.eclipse.jetty:jetty-client:jar:12.0.12:compile
[INFO] |  |  |  |  |  \- org.eclipse.jetty:jetty-alpn-client:jar:12.0.12:compile
[INFO] |  |  |  |  \- org.eclipse.jetty.websocket:websocket-common:jar:9.4.57.v20241219:compile
[INFO] |  |  |  |     \- org.eclipse.jetty.websocket:websocket-api:jar:9.4.57.v20241219:compile
[INFO] |  |  +- org.eclipse.jetty:jetty-server:jar:12.0.12:compile
[INFO] |  |  |  +- org.eclipse.jetty:jetty-http:jar:12.0.12:compile
[INFO] |  |  |  \- org.eclipse.jetty:jetty-io:jar:12.0.12:compile
[INFO] |  |  +- org.eclipse.jetty:jetty-util:jar:12.0.12:compile
[INFO] |  |  +- org.eclipse.jetty:jetty-servlet:jar:9.4.57.v20241219:compile
[INFO] |  |  |  +- org.eclipse.jetty:jetty-security:jar:12.0.12:compile
[INFO] |  |  |  \- org.eclipse.jetty:jetty-util-ajax:jar:12.0.12:compile
[INFO] |  |  +- org.eclipse.jetty:jetty-webapp:jar:9.4.57.v20241219:compile
[INFO] |  |  |  \- org.eclipse.jetty:jetty-xml:jar:12.0.12:compile
```