### PR TITLE
add dependencies label for enforcement check

### DIFF
--- a/.github/workflows/release-notes-labels.yml
+++ b/.github/workflows/release-notes-labels.yml
@@ -14,9 +14,10 @@ jobs:
           mode: minimum
           count: 1
           labels: |
-            ignore-for-release
-            new-template
-            improvement
             bug-fix
+            dependencies
+            ignore-for-release
+            improvement
+            new-template
             package-upgrade
-          message: "This PR is being prevented from merging because you have not added any of the following labels: [ignore-for-release, new-template, improvement, bug-fix, package-upgrade]. You'll need to add one before this PR can be merged so that these can be used for release notes. For more information, see https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/contributor-docs/code-contributions.md#release-notes"
+          message: "This PR is being prevented from merging because you have not added any of the following labels: [bug-fix, dependencies, ignore-for-release, improvement, new-template, package-upgrade]. You'll need to add one before this PR can be merged so that these can be used for release notes. For more information, see https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/contributor-docs/code-contributions.md#release-notes"


### PR DESCRIPTION
1. Currently, dependabot PRs seem to always have a failure check for "Enforce labels for release notes / label (pull_request)".
2. Adding "dependencies" label as another valid label for enforcement so that this check passes in the future and a human doesn't need to do it manually.
3. Sorted the labels also.