### PR TITLE
add dependabot label workflow for ignore-for-release

### DIFF
--- a/.github/workflows/label-dependabot-prs.yml.
+++ b/.github/workflows/label-dependabot-prs.yml.
@@ -1,0 +1,32 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow appends additional labels to dependabot PRs. The idea was
+# considered about adding these labels to the dependabot.yml file, but that
+# would override the defaults that dependabot provides.
+
+name: Label Dependabot PRs
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  label-dependabot-pr:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          add-labels: "ignore-for-release"


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/2881 could possibly go away, since including "ignore-for-release" would cover the enforcement check.