### PR TITLE
Fix flaky test in MySQLSrcDataProviderTest caused by nondeterministic HashMap iteration

### DIFF
--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/testutils/failureinjectiontesting/MySQLSrcDataProviderTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/testutils/failureinjectiontesting/MySQLSrcDataProviderTest.java
@@ -69,16 +69,20 @@ public class MySQLSrcDataProviderTest {
       int authorIndex = tableNameCaptor.getAllValues().indexOf(AUTHORS_TABLE);
       assertThat(authorIndex).isNotEqualTo(-1);
       JDBCSchema authorSchema = schemaCaptor.getAllValues().get(authorIndex);
-      assertThat(authorSchema.toSqlStatement())
-          .isEqualTo("author_id INT NOT NULL, name VARCHAR(200), PRIMARY KEY ( author_id )");
+      String authorSql = authorSchema.toSqlStatement();
+      assertThat(authorSql).startsWith("author_id INT NOT NULL");
+      assertThat(authorSql).contains("name VARCHAR(200)");
+      assertThat(authorSql).endsWith("PRIMARY KEY ( author_id )");
 
       // Verify books table creation
       int bookIndex = tableNameCaptor.getAllValues().indexOf(BOOKS_TABLE);
       assertThat(bookIndex).isNotEqualTo(-1);
       JDBCSchema bookSchema = schemaCaptor.getAllValues().get(bookIndex);
-      assertThat(bookSchema.toSqlStatement())
-          .isEqualTo(
-              "book_id INT NOT NULL, name VARCHAR(200), author_id INT NOT NULL, PRIMARY KEY ( book_id )");
+      String bookSql = bookSchema.toSqlStatement();
+      assertThat(bookSql).startsWith("book_id INT NOT NULL");
+      assertThat(bookSql).contains("name VARCHAR(200)");
+      assertThat(bookSql).contains("author_id INT NOT NULL");
+      assertThat(bookSql).endsWith("PRIMARY KEY ( book_id )");
     }
   }
 


### PR DESCRIPTION
**Fix Issue:** https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/2897
Similar Fix before: https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/1176

## Root Cause
The flaky behavior was detected by NonDex when running
com.google.cloud.teleport.v2.spanner.testutils.failureinjectiontesting.MySQLSrcDataProviderTest.

This test originally asserted the full SQL statement string, assuming deterministic column ordering from JDBCSchema#toSqlStatement().

However, JDBCSchema internally uses a regular HashMap to store column definitions:
```
for (Map.Entry<String, String> entry : this.columns.entrySet()) {
    ...
}
```
Since HashMap iteration order depends on the JVM hash seed, it can vary across runs, Java versions, and environments.
This is not a NonDex-specific issue—it indicates that the test is order-sensitive by accident, not by design.

As a result, the serialized SQL string may differ between executions:
```
Run 1: book_id INT NOT NULL, name VARCHAR(200), author_id INT NOT NULL, PRIMARY KEY ( book_id )
Run 2: book_id INT NOT NULL, author_id INT NOT NULL, name VARCHAR(200), PRIMARY KEY ( book_id )
```

## Fix

Update the test to assert the structure deterministically:
- Verify the first column (primary key) position.
- Validate that the middle columns contain the expected values regardless of order.
- Verify the last clause ("PRIMARY KEY (...)") position.