### PR TITLE
build: update org.apache.commons:commons-configuration to resolve CVE-2024-29131

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <commons-codec.version>1.17.0</commons-codec.version>
     <commons-io.version>2.16.1</commons-io.version>
     <commons-lang3.version>3.14.0</commons-lang3.version>
+    <commons-configuration2.version>2.10.1</commons-configuration2.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <derby.version>10.14.2.0</derby.version>
     <failsafe.version>3.3.0</failsafe.version>

--- a/v2/cdc-parent/cdc-embedded-connector/pom.xml
+++ b/v2/cdc-parent/cdc-embedded-connector/pom.xml
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-configuration2</artifactId>
-      <version>2.8.0</version>
+      <version>${commons-configuration2.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
File locations: [/template/cdc-agg/classpath/cdc-change-applier-1.0-SNAPSHOT.jar/META-INF/maven/org.apache.commons/commons-configuration2/pom.properties] 
Vulnerability is fixed at version 2.10.1 of package org.apache.commons:commons-configuration2