### PR TITLE
Apply GCP Application Default authentication when using a Managed Service for Apache Kafka cluster.

### DIFF
--- a/v2/streaming-data-generator/src/main/java/com/google/cloud/teleport/v2/transforms/StreamingDataGeneratorWriteToKafka.java
+++ b/v2/streaming-data-generator/src/main/java/com/google/cloud/teleport/v2/transforms/StreamingDataGeneratorWriteToKafka.java
@@ -50,7 +50,8 @@ import org.joda.time.Instant;
 /** A {@link PTransform} that converts generatedMessages to write to Spanner table. */
 public final class StreamingDataGeneratorWriteToKafka {
 
-  private static final Pattern ManagedKafkaRegex = Pattern.compile(".*managedkafka\\..*\\.goog.*");
+  private static final Pattern ManagedKafkaRegex =
+      Pattern.compile("bootstrap\\..*\\.managedkafka\\..*\\.cloud\\.goog.*");
 
   private StreamingDataGeneratorWriteToKafka() {}
 


### PR DESCRIPTION
This change allows the streaming data generator to be used in conjunction with Google's Managed Service for Apache Kafka. 

Due to the lack of ability to create UTs/ITs which create and utilize Managed Service resources and the existing flakiness of the kafka IT, this was tested manually. 4 tests were conducted:
1. JSON using local Kafka cluster
2. JSON using Managed Service cluster
3. Avro using local Kafka cluster
4. Avro using Managed Service cluster

These were conducted by modifying the existing Kafka Integration test to utilize these resources as necessary. These cases all pass, and I observed data moving through both kafka clusters. 