### PR TITLE
build: Ignore Python __pycache__ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Python requirements build files
 **/__build__/**/*
+**/__pycache__/**/*
 
 # IntelliJ files
 **/.idea/**/*


### PR DESCRIPTION
The `__pycache__` directory is automatically generated by the Python interpreter to store compiled bytecode (`.pyc` files).

These files are build artifacts specific to the local environment and should not be tracked in version control. This change adds a rule to `.gitignore` to exclude these directories, keeping the repository clean.

Example doc PR that has `__pycache__`

https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/2934/files