### PR TITLE
[yaml] - move syntax test verification to validate section

### DIFF
--- a/yaml/pom.xml
+++ b/yaml/pom.xml
@@ -81,44 +81,6 @@
     </resources>
 
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>${exec-maven-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>pip-install</id>
-            <phase>test-compile</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <executable>pip</executable>
-              <arguments>
-                <argument>install</argument>
-                <argument>-r</argument>
-                <argument>src/test/python/requirements-test.txt</argument>
-              </arguments>
-            </configuration>
-          </execution>
-          <execution>
-            <id>python-test</id>
-            <phase>test</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <executable>python</executable>
-              <workingDirectory>${project.basedir}</workingDirectory>
-              <arguments>
-                <argument>-m</argument>
-                <argument>unittest</argument>
-                <argument>src/test/python/yaml_syntax_test.py</argument>
-              </arguments>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 
@@ -139,6 +101,44 @@
                <goals>
                  <goal>validate</goal>
                </goals>
+             </execution>
+           </executions>
+         </plugin>
+         <plugin>
+           <groupId>org.codehaus.mojo</groupId>
+           <artifactId>exec-maven-plugin</artifactId>
+           <version>${exec-maven-plugin.version}</version>
+           <executions>
+             <execution>
+               <id>pip-install</id>
+               <phase>test-compile</phase>
+               <goals>
+                 <goal>exec</goal>
+               </goals>
+               <configuration>
+                 <executable>pip</executable>
+                 <arguments>
+                   <argument>install</argument>
+                   <argument>-r</argument>
+                   <argument>src/test/python/requirements-test.txt</argument>
+                 </arguments>
+               </configuration>
+             </execution>
+             <execution>
+               <id>python-test</id>
+               <phase>test</phase>
+               <goals>
+                 <goal>exec</goal>
+               </goals>
+               <configuration>
+                 <executable>python</executable>
+                 <workingDirectory>${project.basedir}</workingDirectory>
+                 <arguments>
+                   <argument>-m</argument>
+                   <argument>unittest</argument>
+                   <argument>src/test/python/yaml_syntax_test.py</argument>
+                 </arguments>
+               </configuration>
              </execution>
            </executions>
          </plugin>


### PR DESCRIPTION
1. Current code breaks dataflow kokoro release process due to test running during stage process when it shouldn't.
2. Move test for now to templateValidate profile.
3. FYI, when more blueprints get linked to the yaml location, then this test may go away since everything will be tested in Beam repo.
4. mvn clean install -PtemplatesValidate -pl yaml -am