### PR TITLE
chore(templates-maven-plugin): Add retry logic to template staging

### DIFF
--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
@@ -304,10 +304,14 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
   public String stageTemplate(
       TemplateDefinitions definition, ImageSpec imageSpec, BuildPluginManager pluginManager)
       throws MojoExecutionException, IOException, InterruptedException, TemplateException {
+    RetryPolicy<String> retryPolicy =
+        RetryPolicy.<String>builder().withDelay(Duration.ofSeconds(10)).withMaxRetries(3).build();
     if (definition.isClassic()) {
-      return stageClassicTemplate(definition, imageSpec, pluginManager);
+      return Failsafe.with(retryPolicy)
+          .get(() -> stageClassicTemplate(definition, imageSpec, pluginManager));
     } else {
-      return stageFlexTemplate(definition, imageSpec, pluginManager);
+      return Failsafe.with(retryPolicy)
+          .get(() -> stageFlexTemplate(definition, imageSpec, pluginManager));
     }
   }
 


### PR DESCRIPTION
The template staging process for both Classic and Flex templates can occasionally fail due to transient network issues or temporary service unavailability. This can lead to flaky and unreliable builds.

This change introduces a retry mechanism using the Failsafe library. The staging operation will now be retried up to 3 times with a 10-second delay between attempts, making the build process more resilient to these intermittent failures.

Fixes https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/2784
