### PR TITLE
fix(maven-plugin): Validate container image existence after staging

### DIFF
--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
@@ -1139,14 +1139,11 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
             cloudBuildLogs);
 
     int retval = stageProcess.waitFor();
+    // Ideally this should raise an exception, but this sometimes return NZE even for successful
+    // runs.
     if (retval != 0) {
-      LOG.warn(
-          "Building YAML image nonzero return code {}. This does not necessarily mean an error. "
-              + "Check logs for details. {}",
-          retval,
-          cloudBuildLogs);
+      validateImageExists(imagePathTag, buildProjectId);
     }
-    validateImageExists(imagePathTag, buildProjectId);
   }
 
   private void stagePythonUsingDockerfile(
@@ -1216,13 +1213,8 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
     // Ideally this should raise an exception, but this sometimes return NZE even for successful
     // runs.
     if (retval != 0) {
-      LOG.warn(
-          "Building Python image nonzero return code {}. This does not necessarily mean an error. "
-              + "Check logs for details. {}",
-          retval,
-          cloudBuildLogs);
+      validateImageExists(imagePathTag, buildProjectId);
     }
-    validateImageExists(imagePathTag, buildProjectId);
   }
 
   /** generate image path (not including tag). */
@@ -1299,13 +1291,8 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
     // Ideally this should raise an exception, but this sometimes return NZE even for successful
     // runs.
     if (retval != 0) {
-      LOG.warn(
-          "Build Flex image nonzero return code {}.  This does not necessarily mean an error. "
-              + "Check logs for details. {}",
-          retval,
-          cloudBuildLogs);
+      validateImageExists(imagePathTag, buildProjectId);
     }
-    validateImageExists(imagePathTag, buildProjectId);
   }
 
   private void stageXlangUsingDockerfile(
@@ -1379,13 +1366,8 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
     // Ideally this should raise an exception, but this sometimes return NZE even for successful
     // runs.
     if (retval != 0) {
-      LOG.warn(
-          "Building Xlang image nonzero return code {}. This does not necessarily mean an error. "
-              + "Check logs for details. {}",
-          retval,
-          cloudBuildLogs);
+      validateImageExists(imagePathTag, buildProjectId);
     }
-    validateImageExists(imagePathTag, buildProjectId);
   }
 
   private static void copyJavaArtifacts(
@@ -1484,14 +1466,11 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
     // Ideally this should raise an exception, but this sometimes return NZE even for successful
     // runs.
     if (retval != 0) {
-      LOG.warn(
-          "Scanning container nonzero return code {}. This does not necessarily mean an error. Check logs for details. {}",
-          retval,
-          cloudBuildLogs);
+      validateImageExists(imagePathTag, buildProjectId);
     }
   }
 
-  private void validateImageExists(String imagePathTag, String buildProjectId)
+  private static void validateImageExists(String imagePathTag, String buildProjectId)
       throws IOException, InterruptedException {
     LOG.info("Validating that image {} was created...", imagePathTag);
 


### PR DESCRIPTION
The `gcloud builds submit` command can occasionally return a non-zero exit code even when the container image is built and pushed successfully. This was causing the template staging process to fail unnecessarily.

This change introduces a new validation step that runs after the build process completes. It uses `gcloud artifacts docker images describe` to explicitly verify that the expected image exists in the Artifact Registry.

This makes the staging process more robust by failing only if the final image artifact is confirmed to be missing, rather than relying solely on the build process's exit code. The error handling for the build process has also been relaxed to a warning for classic templates to accommodate this.

Fixes https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/2784