### PR TITLE
Fix JSON/JSONB datatypes in postgres-to-sql template

### DIFF
--- a/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/utils/DatastreamToPostgresDML.java
+++ b/v2/datastream-to-sql/src/main/java/com/google/cloud/teleport/v2/utils/DatastreamToPostgresDML.java
@@ -117,6 +117,16 @@ public class DatastreamToPostgresDML extends DatastreamToDML {
           return hstoreLiteral;
         }
         return hstoreLiteral + "::hstore";
+      case "JSON":
+      case "JSONB":
+        if (columnValue.equals("")
+            || columnValue.equals("''")
+            || columnValue.equalsIgnoreCase("'NULL'")
+            || columnValue.equalsIgnoreCase("NULL")) {
+          return getNullValueSql();
+        }
+        return "'" + cleanSql(unquote(columnValue)) + "'";
+
       case "LTREE":
         if (columnValue.equals("")
             || columnValue.equals("''")

--- a/v2/datastream-to-sql/src/test/java/com/google/cloud/teleport/v2/utils/DatastreamToDMLTest.java
+++ b/v2/datastream-to-sql/src/test/java/com/google/cloud/teleport/v2/utils/DatastreamToDMLTest.java
@@ -997,4 +997,28 @@ public class DatastreamToDMLTest {
     // Assert
     assertThat(lowerColumns).isEqualTo("\"mycolumn\",\"another_column\"");
   }
+
+  /**
+   * Test whether {@link DatastreamToPostgresDML#getValueSql(JsonNode, String, Map)} converts JSON
+   * and JSONB data into correct typed literal syntax.
+   */
+  @Test
+  public void testJsonAndJsonbTypeCoercion() {
+    String json =
+        "{\"json_column\": {\"a\": 1, \"b\": \"test\"},"
+            + "\"jsonb_column\": {\"c\": true, \"d\": [1, 2]}}";
+    JsonNode rowObj = getRowObj(json);
+    Map<String, String> tableSchema = new HashMap<>();
+    tableSchema.put("json_column", "JSON");
+    tableSchema.put("jsonb_column", "JSONB");
+    DatastreamToPostgresDML dml = DatastreamToPostgresDML.of(null);
+
+    String expectedJson = "'{\"a\":1,\"b\":\"test\"}'";
+    String actualJson = dml.getValueSql(rowObj, "json_column", tableSchema);
+    assertEquals(expectedJson, actualJson);
+
+    String expectedJsonb = "'{\"c\":true,\"d\":[1,2]}'";
+    String actualJsonb = dml.getValueSql(rowObj, "jsonb_column", tableSchema);
+    assertEquals(expectedJsonb, actualJsonb);
+  }
 }


### PR DESCRIPTION
Support JSON/JSONB datatype in datastream-to-sql templayte.

Test:
source: PG
Dest: PG

Source Table DDL:
CREATE TABLE "public".dummy_table1(
 id integer NOT NULL,
 your_array_column text[],
 your_json_column jsonb
);

Verify all rows were successfully inserted to the destination.
