### PR TITLE
Fix spanner change streams owners file paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,9 +11,9 @@ v1/src/test/java/com/google/cloud/teleport/templates/SpannerToTextTest.java @Goo
 v1/src/test/java/com/google/cloud/teleport/templates/common/SpannerConverterTest.java @GoogleCloudPlatform/spanner-migrations-team
 
 # Spanner Change Streams templates
-v2/templates/SpannerChangeStreamsToGcs.java @GoogleCloudPlatform/cloud-spanner-change-stream-rotation
-v2/templates/SpannerChangeStreamsToPubSub.java @GoogleCloudPlatform/cloud-spanner-change-stream-rotation
-v2/templates/spannerchangestreamstobigquery/ @GoogleCloudPlatform/cloud-spanner-change-stream-rotation
+v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToGcs.java @GoogleCloudPlatform/cloud-spanner-change-stream-rotation
+v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToPubSub.java @GoogleCloudPlatform/cloud-spanner-change-stream-rotation
+v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/ @GoogleCloudPlatform/cloud-spanner-change-stream-rotation
 
 # Datastream To spanner template
 v2/datastream-to-spanner/ @GoogleCloudPlatform/spanner-migrations-team


### PR DESCRIPTION
These didn't call out the full directory structure, so they were pointing to invalid paths

This is the desired directory: https://github.com/GoogleCloudPlatform/DataflowTemplates/tree/main/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates