### PR TITLE
Fixing unnecessary mock errors which appear only on IDE runs

### DIFF
--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -204,7 +205,8 @@ public class JdbcIoWrapperTest {
                         .setIsUnique(true)
                         .setOrdinalPosition(2)
                         .build())));
-    when(mockDialectAdapter.discoverTableSchema(any(), (SourceSchemaReference) any(), any()))
+    lenient()
+        .when(mockDialectAdapter.discoverTableSchema(any(), (SourceSchemaReference) any(), any()))
         .thenReturn(ImmutableMap.of("testTable", ImmutableMap.of(testCol, testColType)));
 
     assertThrows(
@@ -298,7 +300,8 @@ public class JdbcIoWrapperTest {
     SourceColumnType testColType = new SourceColumnType("INTEGER", new Long[] {}, null);
     when(mockDialectAdapter.discoverTables(any(), (SourceSchemaReference) any()))
         .thenReturn(ImmutableList.of("testTable"));
-    when(mockDialectAdapter.discoverTableIndexes(any(), (SourceSchemaReference) any(), any()))
+    lenient()
+        .when(mockDialectAdapter.discoverTableIndexes(any(), (SourceSchemaReference) any(), any()))
         .thenReturn(
             ImmutableMap.of(
                 "testTable",
@@ -312,7 +315,8 @@ public class JdbcIoWrapperTest {
                         .setIsUnique(true)
                         .setOrdinalPosition(1)
                         .build())));
-    when(mockDialectAdapter.discoverTableSchema(any(), (SourceSchemaReference) any(), any()))
+    lenient()
+        .when(mockDialectAdapter.discoverTableSchema(any(), (SourceSchemaReference) any(), any()))
         .thenReturn(ImmutableMap.of("testTable", ImmutableMap.of(testCol, testColType)));
     JdbcIoWrapper jdbcIoWrapper =
         JdbcIoWrapper.of(

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryExtractorFactoryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryExtractorFactoryTest.java
@@ -268,9 +268,8 @@ public class BoundaryExtractorFactoryTest {
         PartitionColumn.builder().setColumnName("col1").setColumnClass(Timestamp.class).build();
     BoundaryExtractor<Timestamp> extractor = BoundaryExtractorFactory.create(Timestamp.class);
     when(mockResultSet.next()).thenReturn(true);
-    when(mockResultSet.getBigDecimal(1)).thenReturn(null);
-    // BigInt Unsigned Max in MySQL
-    when(mockResultSet.getBigDecimal(2)).thenReturn(null);
+    when(mockResultSet.getTimestamp(eq(1), any())).thenReturn(null);
+    when(mockResultSet.getTimestamp(eq(2), any())).thenReturn(null);
     Boundary<Timestamp> boundary = extractor.getBoundary(partitionColumn, mockResultSet, null);
 
     assertThat(boundary.start()).isNull();

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaDiscoveryImplTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaDiscoveryImplTest.java
@@ -54,7 +54,6 @@ public class SchemaDiscoveryImplTest {
   public void testSchemaDiscoveryImpl() throws RetriableSchemaDiscoveryException {
     final int testRetryCount = 2;
     final int expectedCallsCount = testRetryCount + 1;
-    when(mockDataSource.jdbc()).thenReturn(mockJdbcDataSource);
     when(mockRetriableSchemaDiscovery.discoverTableSchema(
             mockDataSource, mockSourceSchemaReference, ImmutableList.of()))
         .thenThrow(new RetriableSchemaDiscoveryException(new SQLTransientConnectionException()))
@@ -82,7 +81,6 @@ public class SchemaDiscoveryImplTest {
 
     when(mockFluentBackoff.backoff()).thenReturn(mockBackoff);
     when(mockBackoff.nextBackOffMillis()).thenThrow(new RuntimeException("test"));
-    when(mockDataSource.jdbc()).thenReturn(mockJdbcDataSource);
     when(mockRetriableSchemaDiscovery.discoverTableSchema(
             mockDataSource, mockSourceSchemaReference, ImmutableList.of()))
         .thenThrow(new RetriableSchemaDiscoveryException(new SQLTransientConnectionException()));
@@ -103,7 +101,6 @@ public class SchemaDiscoveryImplTest {
 
     final int testRetryCount = 2;
     final int expectedCallsCount = testRetryCount + 1;
-    when(mockDataSource.jdbc()).thenReturn(mockJdbcDataSource);
     when(mockRetriableSchemaDiscovery.discoverTableSchema(
             mockDataSource, mockSourceSchemaReference, ImmutableList.of()))
         .thenThrow(new RetriableSchemaDiscoveryException(new SQLTransientConnectionException()));
@@ -128,7 +125,6 @@ public class SchemaDiscoveryImplTest {
     final int testRetryCount = 2;
     final int expectedCallsCount = testRetryCount + 1;
     final ImmutableList<String> testTables = ImmutableList.of("testTable1", "testTable2");
-    when(mockDataSource.jdbc()).thenReturn(mockJdbcDataSource);
     when(mockRetriableSchemaDiscovery.discoverTables(mockDataSource, mockSourceSchemaReference))
         .thenThrow(new RetriableSchemaDiscoveryException(new SQLTransientConnectionException()))
         .thenThrow(new RetriableSchemaDiscoveryException(new SQLTransientConnectionException()))
@@ -162,7 +158,7 @@ public class SchemaDiscoveryImplTest {
                     .setOrdinalPosition(1)
                     .setIndexType(IndexType.NUMERIC)
                     .build()));
-    when(mockDataSource.jdbc()).thenReturn(mockJdbcDataSource);
+
     when(mockRetriableSchemaDiscovery.discoverTableIndexes(
             mockDataSource, mockSourceSchemaReference, ImmutableList.of("testTable1")))
         .thenThrow(new RetriableSchemaDiscoveryException(new SQLTransientConnectionException()))


### PR DESCRIPTION
# Fix: Resolve Mockito UnnecessaryStubbingExceptions in Reader Module Tests

## Overview

This change resolves a series of `UnnecessaryStubbingException` errors from Mockito that occurred during local test runs but were not caught in the Git Actions CI environment. These errors stemmed from a conflict between Mockito's `STRICT_STUBS` policy and conditional logic within the code under test, where some mock stubs were necessary for certain test cases but not for others.

The discrepancy between local and CI environments happens because local IDEs often run test classes in isolation, immediately flagging unused stubs. In contrast, the CI's Maven Surefire plugin runs the entire test suite, where other tests might call the stubbed methods, thus masking the issue.

The fix involves three key strategies:
1.  **Using `lenient()`:** For stubs that are conditionally used, `lenient()` is applied. This tells Mockito not to throw an error if the stub isn't used, while still providing the mocked response when it is. This maintains test coverage for all code paths without conflict.
2.  **Correcting Flawed Tests:** In one case, a test was fundamentally incorrect, stubbing the wrong method (`getBigDecimal` instead of `getTimestamp`). This latent bug was corrected.
3.  **Removing Redundant Mocks:** In another class, mock stubs were removed entirely as the code path they covered was never executed.

## Detailed Overview of Changes

### 1. `JdbcIoWrapperTest.java` - Use of `lenient()` for Conditional Logic

-   **Change:** The `discoverTableSchema` and `discoverTableIndexes` stubs marked as `lenient()`.
-   **Justification:** This is the core of the fix. These stubs are essential for the "happy path" tests like `testJdbcIoWrapperBasic`, which proceed to discover the full schema. However, they are *not* called in tests that verify early-exit error conditions, such as `testJdbcIoWrapperNoPrimaryKeyExistsOnTable` or `testJdbcIoWrapperDifferentTables`. These error-path tests are designed to throw an exception before the schema discovery methods are ever invoked.


### 2. `BoundaryExtractorFactoryTest.java` - Correction of a Flawed Test

-   **Change:** In the `testFromTimestampsEmptyTable` test, the mock `ResultSet` was incorrectly stubbed to expect a call to `getBigDecimal`. This has been corrected to `getTimestamp`.
-   **Justification:** This was a latent bug in the test itself. The code under test, when handling a `Timestamp` column, correctly calls `getTimestamp`. The test was mocking the wrong method. It passed in the past due to the fact that it was checking for a null output. The fix aligns the mock's expectation with the actual code's behavior, making the test accurate and reliable.

### 3. `SchemaDiscoveryImplTest.java` - Removal of Redundant Mocks

-   **Change:** Removed several `when(mockDataSource.jdbc()).thenReturn(...)` stubs from multiple test methods.
-   **Justification:** This is a straightforward cleanup. The code being tested in `SchemaDiscoveryImpl` does not invoke the `.jdbc()` method on the `DataSource` object. Therefore, these stubs were entirely unnecessary and were correctly flagged by Mockito as unused code. Removing them simplifies the tests with no impact on coverage.
