### PR TITLE
chore: remove redundant jsonschema dependencies from requirements

### DIFF
--- a/python/default_base_python_requirements.txt
+++ b/python/default_base_python_requirements.txt
@@ -1,4 +1,2 @@
 apache-beam[gcp]==2.69.0
-jsonschema==4.25.1 # TODO: remove when correct version could come from beam
-jsonschema-specifications==2025.4.1 # TODO: remove when correct version could come from beam
 setuptools

--- a/python/default_base_yaml_requirements.txt
+++ b/python/default_base_yaml_requirements.txt
@@ -1,4 +1,2 @@
 apache-beam[dataframe,gcp,test,yaml]==2.69.0
-jsonschema==4.25.1 # TODO: remove when correct version could come from beam
-jsonschema-specifications==2025.4.1 # TODO: remove when correct version could come from beam
 setuptools

--- a/python/src/main/python/streaming-llm/base_requirements.txt
+++ b/python/src/main/python/streaming-llm/base_requirements.txt
@@ -1,6 +1,4 @@
 apache-beam[gcp]==2.69.0
-jsonschema==4.25.1 # TODO: remove when correct version could come from beam
-jsonschema-specifications==2025.4.1 # TODO: remove when correct version could come from beam
 torch
 transformers
 torchvision


### PR DESCRIPTION
Not needed any more since this is caused by the cloud build cache issue.

Will run the python update workflow once this is merged.

Addresses: https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/2962