### PR TITLE
Remove preemptive cleanup

### DIFF
--- a/v2/datastream-to-sql/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToPostgresIT.java
+++ b/v2/datastream-to-sql/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToPostgresIT.java
@@ -150,9 +150,6 @@ public class DataStreamToPostgresIT extends TemplateTestBase {
     cloudSqlSourceResourceManager.runSQLUpdate(
         String.format("ALTER USER %s WITH REPLICATION;", user));
 
-    // Clean up any existing replication slots that might be left over from previous test runs
-    cleanupExistingReplicationSlots();
-
     // Try to create the replication slot, with retry logic if slots are full
     createReplicationSlotWithRetry(this.replicationSlot);
     cloudSqlSourceResourceManager.runSQLUpdate(


### PR DESCRIPTION
Remove cleanupExistingReplicationSlots() call in runTest, since it was creating IT test errors.
