### PR TITLE
Use update-available for deprecated older images

### DIFF
--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
@@ -559,7 +559,7 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
         String trackTag = "public-image-latest";
         String dateSuffix =
             LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd-HH"));
-        String deprecatedTag = "no-new-use-public-image-newer-available-" + dateSuffix;
+        String deprecatedTag = "update-available-" + dateSuffix;
         if (metadata.isHidden()) {
           trackTag = "no-new-use-public-image-latest";
         } else if (metadata.getName().contains("[Deprecated]")) {


### PR DESCRIPTION
This tag is still compliant, but less alarming to users (internal link b/435162212#comment6)