### PR TITLE
Fix dependency conflict on beam-sdks-java-core in Datastream to Firestore

### DIFF
--- a/v2/datastream-mongodb-to-firestore/pom.xml
+++ b/v2/datastream-mongodb-to-firestore/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-runners-direct-java</artifactId>
-            <version>2.66.0</version>
+            <version>${beam.version}</version>
             <scope>runtime</scope>
         </dependency>
         <!-- Add dnsjava for MongoDB SRV record resolution -->


### PR DESCRIPTION

The hard-coded version `2.66.0` for `beam-runners-direct-java` makes `beam-sdks-java-core:2.66.0` included in the uber jar for the Flex template, while other beam libraries such as `beam-sdks-java-io-google-cloud-platform` are `2.69.0`

It triggers a dependency issue (b/461392575):
```
com.google.cloud.teleport.v2.common.UncaughtExceptionLogger - The template launch failed.
java.lang.NoSuchMethodError: 'com.fasterxml.jackson.core.JsonFactory org.apache.beam.sdk.util.RowJsonUtils.createJsonFactory(int)'
	at org.apache.beam.sdk.io.gcp.bigquery.TableRowJsonCoder.<clinit>(TableRowJsonCoder.java:79)
	at org.apache.beam.sdk.io.gcp.bigquery.BigQueryCoderProviderRegistrar.getCoderProviders(BigQueryCoderProviderRegistrar.java:35)
	at org.apache.beam.sdk.coders.CoderRegistry.<clinit>(CoderRegistry.java:177)
	at org.apache.beam.sdk.Pipeline.getCoderRegistry(Pipeline.java:338)
	at org.apache.beam.sdk.values.PCollection.finishSpecifyingOutput(PCollection.java:94)
	at org.apache.beam.sdk.runners.TransformHierarchy.setOutput(TransformHierarchy.java:173)
	at org.apache.beam.sdk.Pipeline.applyInternal(Pipeline.java:560)
	at org.apache.beam.sdk.Pipeline.applyTransform(Pipeline.java:490)
	at org.apache.beam.sdk.values.PBegin.apply(PBegin.java:44)
	at org.apache.beam.sdk.Pipeline.apply(Pipeline.java:180)
	at org.apache.beam.sdk.io.Read$Unbounded.expand(Read.java:224)
	at org.apache.beam.sdk.io.Read$Unbounded.expand(Read.java:182)
	at org.apache.beam.sdk.Pipeline.applyInternal(Pipeline.java:559)
	at org.apache.beam.sdk.Pipeline.applyTransform(Pipeline.java:490)
	at org.apache.beam.sdk.values.PBegin.apply(PBegin.java:44)
	at org.apache.beam.sdk.io.GenerateSequence.expand(GenerateSequence.java:242)
	at org.apache.beam.sdk.io.GenerateSequence.expand(GenerateSequence.java:73)
	at org.apache.beam.sdk.Pipeline.applyInternal(Pipeline.java:559)
	at org.apache.beam.sdk.Pipeline.applyTransform(Pipeline.java:507)
	at org.apache.beam.sdk.values.PBegin.apply(PBegin.java:56)
	at org.apache.beam.sdk.Pipeline.apply(Pipeline.java:195)
	at com.google.cloud.teleport.v2.cdc.dlq.FileBasedDeadLetterQueueReconsumer.expand(FileBasedDeadLetterQueueReconsumer.java:92)
	at com.google.cloud.teleport.v2.cdc.dlq.FileBasedDeadLetterQueueReconsumer.expand(FileBasedDeadLetterQueueReconsumer.java:60)
	at org.apache.beam.sdk.Pipeline.applyInternal(Pipeline.java:559)
	at org.apache.beam.sdk.Pipeline.applyTransform(Pipeline.java:507)
	at org.apache.beam.sdk.values.PBegin.apply(PBegin.java:56)
	at org.apache.beam.sdk.Pipeline.apply(Pipeline.java:195)
	at com.google.cloud.teleport.v2.templates.DataStreamMongoDBToFirestore.ingestAndNormalizeJson(DataStreamMongoDBToFirestore.java:809)
	at com.google.cloud.teleport.v2.templates.DataStreamMongoDBToFirestore.runWithBackfillFirst(DataStreamMongoDBToFirestore.java:505)
	at com.google.cloud.teleport.v2.templates.DataStreamMongoDBToFirestore.run(DataStreamMongoDBToFirestore.java:463)
	at com.google.cloud.teleport.v2.templates.DataStreamMongoDBToFirestore.main(DataStreamMongoDBToFirestore.java:400)
```