### PR TITLE
Bump Beam version in datastream-mongodb-to-firestore

### DIFF
--- a/v2/datastream-mongodb-to-firestore/pom.xml
+++ b/v2/datastream-mongodb-to-firestore/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-runners-direct-java</artifactId>
-            <version>2.69.0</version>
+            <version>${beam.version}</version>
             <scope>runtime</scope>
         </dependency>
         <!-- Add dnsjava for MongoDB SRV record resolution -->


### PR DESCRIPTION
Increment the Beam version to address a potential mismatch in submission environment dependencies vs runtime dependencies.