### PR TITLE
[SourceDbToSpanner] Fixing severe error file overwrite issue in Bulk migration template

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/DLQWriteTransform.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/DLQWriteTransform.java
@@ -42,7 +42,9 @@ public class DLQWriteTransform {
   public abstract static class WriteDLQ extends PTransform<PCollection<String>, PDone> {
 
     public static Builder newBuilder() {
-      return new AutoValue_DLQWriteTransform_WriteDLQ.Builder().setIncludePaneInfo(false);
+      return new AutoValue_DLQWriteTransform_WriteDLQ.Builder()
+          .setIncludePaneInfo(false)
+          .setFileNamePrefix("error");
     }
 
     public abstract String dlqDirectory();
@@ -50,6 +52,8 @@ public class DLQWriteTransform {
     public abstract String tmpDirectory();
 
     public abstract boolean includePaneInfo();
+
+    public abstract String fileNamePrefix();
 
     @Override
     public PDone expand(PCollection<String> input) {
@@ -80,7 +84,7 @@ public class DLQWriteTransform {
                   .to(
                       WindowedFilenamePolicy.writeWindowedFiles()
                           .withOutputDirectory(dlqDirectory())
-                          .withOutputFilenamePrefix("error")
+                          .withOutputFilenamePrefix(fileNamePrefix())
                           .withShardTemplate(getShardTemplate())
                           .withSuffix(".json"))
                   .withTempDirectory(
@@ -112,6 +116,10 @@ public class DLQWriteTransform {
       }
 
       public abstract Builder setIncludePaneInfo(boolean value);
+
+      public abstract Builder setFileNamePrefix(String value);
+
+      public abstract String fileNamePrefix();
 
       public abstract boolean includePaneInfo();
 

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/writer/DeadLetterQueue.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/writer/DeadLetterQueue.java
@@ -32,6 +32,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
@@ -122,6 +123,7 @@ public class DeadLetterQueue implements Serializable {
           .withDlqDirectory(dlqUri)
           .withTmpDirectory(dlqUri + "/tmp")
           .setIncludePaneInfo(true)
+          .setFileNamePrefix(UUID.randomUUID().toString())
           .build();
     }
   }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/writer/DeadLetterQueueTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/writer/DeadLetterQueueTest.java
@@ -99,6 +99,8 @@ public class DeadLetterQueueTest {
     assertTrue(dlq.getDlqTransform() instanceof WriteDLQ);
 
     assertTrue(((WriteDLQ) dlq.getDlqTransform()).dlqDirectory().endsWith("testDir/"));
+
+    assertNotNull(((WriteDLQ) dlq.getDlqTransform()).fileNamePrefix());
   }
 
   @Test


### PR DESCRIPTION
Fixing the severe error file overwrite issue in SourceDbToSpanner (Bulk migration) template. The template is supposed to write all the rows which had errors during migration into output GCS directory under output/dlq/severe folder. But when there are foreign keys, the template migrates the tables in stages. First the data of tables at level 0 will be migrated, then level 1 and so on. The errors files which get generated while migrating higher level tables (level 1 for example) were overwriting the error files of lower level tables (level 0). Fixing this issue by adding a random prefix to DLQWriteTransform at every level.

Tested:
Ran the MySQLBulkAndLiveSpannerFT.java failure injection test and manually verified that the severe error folder contains events for both parent table and child table. Also, verified that the live migration template in retryDLQ mode is able to consume all the files produced.