### PR TITLE
upgrade go to 1.24 to fix cicd issue

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -40,7 +40,7 @@ inputs:
     type: string
     description: 'The version of Go to install'
     required: false
-    default: '1.21'
+    default: '1.24'
   python-version:
     type: string
     description: 'The version of Python to install'

--- a/.github/workflows/go-pr.yml
+++ b/.github/workflows/go-pr.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: Run Fmt
         run: |
           cd cicd
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       # By nature, this also makes sure that everything builds
       - name: Run Tests
         run: |

--- a/cicd/go.mod
+++ b/cicd/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/DataflowTemplates/cicd
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/3008 shows cicd failing, so upgrading everything to 1.24
