### PR TITLE
RetryCount for Retry mode

### DIFF
--- a/v2/datastream-to-spanner/pom.xml
+++ b/v2/datastream-to-spanner/pom.xml
@@ -56,6 +56,12 @@
 
         <!-- Test dependencies -->
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.12.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.cloud.teleport</groupId>
             <artifactId>it-google-cloud-platform</artifactId>
             <version>${project.version}</version>

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/constants/DatastreamToSpannerConstants.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/constants/DatastreamToSpannerConstants.java
@@ -59,4 +59,10 @@ public class DatastreamToSpannerConstants {
 
   /* The counter name for Retryable errors */
   public static final String RETRYABLE_ERRORS_COUNTER_NAME = "Retryable errors";
+
+  /* Regular Mode */
+  public static final String RUN_MODE_REGULAR = "regular";
+  public static final String RUN_MODE_RETRY = "retryDLQ";
+  public static final Integer RUN_MODE_REGULAR_DEFAULT_RETRY_COUNT = 500;
+  public static final Integer RUN_MODE_RETRY_DEFAULT_RETRY_COUNT = 5;
 }

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerTest.java
@@ -15,22 +15,36 @@
  */
 package com.google.cloud.teleport.v2.templates;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.teleport.v2.cdc.dlq.DeadLetterQueueManager;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaOverridesParser;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.NoopSchemaOverridesParser;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SchemaFileOverridesParser;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.SchemaStringOverridesParser;
+import com.google.cloud.teleport.v2.templates.constants.DatastreamToSpannerConstants;
 import com.google.common.io.Resources;
+import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
+import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 
+@RunWith(JUnit4.class)
 public class DataStreamToSpannerTest {
 
   @Rule public ExpectedException expectedEx = ExpectedException.none();
@@ -203,5 +217,235 @@ public class DataStreamToSpannerTest {
     assertEquals("main-instance-id", spannerConfig.getInstanceId().get());
     assertEquals("main-database-id", spannerConfig.getDatabaseId().get());
     assertEquals("project-id", spannerConfig.getProjectId().get());
+  }
+
+  @Test
+  public void testBuildDlqManager_regularMode_defaultRetryCount_tempLocationWithSlash() {
+    DataStreamToSpanner.Options options = mock(DataStreamToSpanner.Options.class);
+    DataflowPipelineOptions dataflowOptions = mock(DataflowPipelineOptions.class);
+    when(options.as(DataflowPipelineOptions.class)).thenReturn(dataflowOptions);
+    when(dataflowOptions.getTempLocation()).thenReturn("gs://temp/");
+    when(options.getDeadLetterQueueDirectory()).thenReturn("");
+    when(options.getDlqMaxRetryCount()).thenReturn(-1);
+    when(options.getRunMode()).thenReturn(DatastreamToSpannerConstants.RUN_MODE_REGULAR);
+
+    try (MockedStatic<DeadLetterQueueManager> deadLetterQueueManagerMock =
+        mockStatic(DeadLetterQueueManager.class)) {
+      ArgumentCaptor<String> dlqDirectoryCaptor = ArgumentCaptor.forClass(String.class);
+      ArgumentCaptor<Integer> dlqRetryCountCaptor = ArgumentCaptor.forClass(Integer.class);
+
+      deadLetterQueueManagerMock
+          .when(() -> DeadLetterQueueManager.create(any(String.class), any(Integer.class)))
+          .thenReturn(null);
+
+      DataStreamToSpanner.buildDlqManager(options);
+
+      deadLetterQueueManagerMock.verify(
+          () ->
+              DeadLetterQueueManager.create(
+                  dlqDirectoryCaptor.capture(), dlqRetryCountCaptor.capture()));
+
+      assertThat(dlqDirectoryCaptor.getValue()).isEqualTo("gs://temp/dlq/");
+      assertThat(dlqRetryCountCaptor.getValue())
+          .isEqualTo(DatastreamToSpannerConstants.RUN_MODE_REGULAR_DEFAULT_RETRY_COUNT);
+    }
+  }
+
+  @Test
+  public void testBuildDlqManager_regularMode_defaultRetryCount_tempLocationWithoutSlash() {
+    DataStreamToSpanner.Options options = mock(DataStreamToSpanner.Options.class);
+    DataflowPipelineOptions dataflowOptions = mock(DataflowPipelineOptions.class);
+    when(options.as(DataflowPipelineOptions.class)).thenReturn(dataflowOptions);
+    when(dataflowOptions.getTempLocation()).thenReturn("gs://temp");
+    when(options.getDeadLetterQueueDirectory()).thenReturn("");
+    when(options.getDlqMaxRetryCount()).thenReturn(-1);
+    when(options.getRunMode()).thenReturn(DatastreamToSpannerConstants.RUN_MODE_REGULAR);
+
+    try (MockedStatic<DeadLetterQueueManager> deadLetterQueueManagerMock =
+        mockStatic(DeadLetterQueueManager.class)) {
+      ArgumentCaptor<String> dlqDirectoryCaptor = ArgumentCaptor.forClass(String.class);
+      ArgumentCaptor<Integer> dlqRetryCountCaptor = ArgumentCaptor.forClass(Integer.class);
+
+      deadLetterQueueManagerMock
+          .when(() -> DeadLetterQueueManager.create(any(String.class), any(Integer.class)))
+          .thenReturn(null);
+
+      DataStreamToSpanner.buildDlqManager(options);
+
+      deadLetterQueueManagerMock.verify(
+          () ->
+              DeadLetterQueueManager.create(
+                  dlqDirectoryCaptor.capture(), dlqRetryCountCaptor.capture()));
+
+      assertThat(dlqDirectoryCaptor.getValue()).isEqualTo("gs://temp/dlq/");
+      assertThat(dlqRetryCountCaptor.getValue())
+          .isEqualTo(DatastreamToSpannerConstants.RUN_MODE_REGULAR_DEFAULT_RETRY_COUNT);
+    }
+  }
+
+  @Test
+  public void testBuildDlqManager_regularMode_withDlqDirectory() {
+    DataStreamToSpanner.Options options = mock(DataStreamToSpanner.Options.class);
+    DataflowPipelineOptions dataflowOptions = mock(DataflowPipelineOptions.class);
+    when(options.as(DataflowPipelineOptions.class)).thenReturn(dataflowOptions);
+    when(dataflowOptions.getTempLocation()).thenReturn("gs://temp/");
+    when(options.getDeadLetterQueueDirectory()).thenReturn("gs://dlq/");
+    when(options.getDlqMaxRetryCount()).thenReturn(-1);
+    when(options.getRunMode()).thenReturn(DatastreamToSpannerConstants.RUN_MODE_REGULAR);
+
+    try (MockedStatic<DeadLetterQueueManager> deadLetterQueueManagerMock =
+        mockStatic(DeadLetterQueueManager.class)) {
+      ArgumentCaptor<String> dlqDirectoryCaptor = ArgumentCaptor.forClass(String.class);
+      ArgumentCaptor<Integer> dlqRetryCountCaptor = ArgumentCaptor.forClass(Integer.class);
+
+      deadLetterQueueManagerMock
+          .when(() -> DeadLetterQueueManager.create(any(String.class), any(Integer.class)))
+          .thenReturn(null);
+
+      DataStreamToSpanner.buildDlqManager(options);
+
+      deadLetterQueueManagerMock.verify(
+          () ->
+              DeadLetterQueueManager.create(
+                  dlqDirectoryCaptor.capture(), dlqRetryCountCaptor.capture()));
+
+      assertThat(dlqDirectoryCaptor.getValue()).isEqualTo("gs://dlq/");
+      assertThat(dlqRetryCountCaptor.getValue())
+          .isEqualTo(DatastreamToSpannerConstants.RUN_MODE_REGULAR_DEFAULT_RETRY_COUNT);
+    }
+  }
+
+  @Test
+  public void testBuildDlqManager_regularMode_withPositiveRetryCount() {
+    DataStreamToSpanner.Options options = mock(DataStreamToSpanner.Options.class);
+    DataflowPipelineOptions dataflowOptions = mock(DataflowPipelineOptions.class);
+    when(options.as(DataflowPipelineOptions.class)).thenReturn(dataflowOptions);
+    when(dataflowOptions.getTempLocation()).thenReturn("gs://temp/");
+    when(options.getDeadLetterQueueDirectory()).thenReturn("gs://dlq/");
+    when(options.getDlqMaxRetryCount()).thenReturn(10);
+    when(options.getRunMode()).thenReturn(DatastreamToSpannerConstants.RUN_MODE_REGULAR);
+
+    try (MockedStatic<DeadLetterQueueManager> deadLetterQueueManagerMock =
+        mockStatic(DeadLetterQueueManager.class)) {
+      ArgumentCaptor<String> dlqDirectoryCaptor = ArgumentCaptor.forClass(String.class);
+      ArgumentCaptor<Integer> dlqRetryCountCaptor = ArgumentCaptor.forClass(Integer.class);
+
+      deadLetterQueueManagerMock
+          .when(() -> DeadLetterQueueManager.create(any(String.class), any(Integer.class)))
+          .thenReturn(null);
+
+      DataStreamToSpanner.buildDlqManager(options);
+
+      deadLetterQueueManagerMock.verify(
+          () ->
+              DeadLetterQueueManager.create(
+                  dlqDirectoryCaptor.capture(), dlqRetryCountCaptor.capture()));
+
+      assertThat(dlqDirectoryCaptor.getValue()).isEqualTo("gs://dlq/");
+      assertThat(dlqRetryCountCaptor.getValue()).isEqualTo(10);
+    }
+  }
+
+  @Test
+  public void testBuildDlqManager_retryMode_defaultRetryCount() {
+    DataStreamToSpanner.Options options = mock(DataStreamToSpanner.Options.class);
+    DataflowPipelineOptions dataflowOptions = mock(DataflowPipelineOptions.class);
+    when(options.as(DataflowPipelineOptions.class)).thenReturn(dataflowOptions);
+    when(dataflowOptions.getTempLocation()).thenReturn("gs://temp/");
+    when(options.getDeadLetterQueueDirectory()).thenReturn("gs://dlq/");
+    when(options.getDlqMaxRetryCount()).thenReturn(-1);
+    when(options.getRunMode()).thenReturn(DatastreamToSpannerConstants.RUN_MODE_RETRY);
+
+    ResourceId dlqDirectoryResource = mock(ResourceId.class);
+    ResourceId severeDirectoryResource = mock(ResourceId.class);
+    when(severeDirectoryResource.toString()).thenReturn("gs://dlq/severe/");
+
+    try (MockedStatic<DeadLetterQueueManager> deadLetterQueueManagerMock =
+            mockStatic(DeadLetterQueueManager.class);
+        MockedStatic<FileSystems> fileSystemsMock = mockStatic(FileSystems.class)) {
+
+      fileSystemsMock
+          .when(() -> FileSystems.matchNewResource("gs://dlq/", true))
+          .thenReturn(dlqDirectoryResource);
+
+      when(dlqDirectoryResource.resolve("severe", StandardResolveOptions.RESOLVE_DIRECTORY))
+          .thenReturn(severeDirectoryResource);
+
+      ArgumentCaptor<String> dlqDirectoryCaptor = ArgumentCaptor.forClass(String.class);
+      ArgumentCaptor<String> retryDlqUriCaptor = ArgumentCaptor.forClass(String.class);
+      ArgumentCaptor<Integer> dlqRetryCountCaptor = ArgumentCaptor.forClass(Integer.class);
+
+      deadLetterQueueManagerMock
+          .when(
+              () ->
+                  DeadLetterQueueManager.create(
+                      any(String.class), any(String.class), any(Integer.class)))
+          .thenReturn(null);
+
+      DataStreamToSpanner.buildDlqManager(options);
+
+      deadLetterQueueManagerMock.verify(
+          () ->
+              DeadLetterQueueManager.create(
+                  dlqDirectoryCaptor.capture(),
+                  retryDlqUriCaptor.capture(),
+                  dlqRetryCountCaptor.capture()));
+
+      assertThat(dlqDirectoryCaptor.getValue()).isEqualTo("gs://dlq/");
+      assertThat(retryDlqUriCaptor.getValue()).isEqualTo("gs://dlq/severe/");
+      assertThat(dlqRetryCountCaptor.getValue())
+          .isEqualTo(DatastreamToSpannerConstants.RUN_MODE_RETRY_DEFAULT_RETRY_COUNT);
+    }
+  }
+
+  @Test
+  public void testBuildDlqManager_retryMode_withPositiveRetryCount() {
+    DataStreamToSpanner.Options options = mock(DataStreamToSpanner.Options.class);
+    DataflowPipelineOptions dataflowOptions = mock(DataflowPipelineOptions.class);
+    when(options.as(DataflowPipelineOptions.class)).thenReturn(dataflowOptions);
+    when(dataflowOptions.getTempLocation()).thenReturn("gs://temp/");
+    when(options.getDeadLetterQueueDirectory()).thenReturn("gs://dlq/");
+    when(options.getDlqMaxRetryCount()).thenReturn(20);
+    when(options.getRunMode()).thenReturn(DatastreamToSpannerConstants.RUN_MODE_RETRY);
+
+    ResourceId dlqDirectoryResource = mock(ResourceId.class);
+    ResourceId severeDirectoryResource = mock(ResourceId.class);
+    when(severeDirectoryResource.toString()).thenReturn("gs://dlq/severe/");
+
+    try (MockedStatic<DeadLetterQueueManager> deadLetterQueueManagerMock =
+            mockStatic(DeadLetterQueueManager.class);
+        MockedStatic<FileSystems> fileSystemsMock = mockStatic(FileSystems.class)) {
+
+      fileSystemsMock
+          .when(() -> FileSystems.matchNewResource("gs://dlq/", true))
+          .thenReturn(dlqDirectoryResource);
+
+      when(dlqDirectoryResource.resolve("severe", StandardResolveOptions.RESOLVE_DIRECTORY))
+          .thenReturn(severeDirectoryResource);
+
+      ArgumentCaptor<String> dlqDirectoryCaptor = ArgumentCaptor.forClass(String.class);
+      ArgumentCaptor<String> retryDlqUriCaptor = ArgumentCaptor.forClass(String.class);
+      ArgumentCaptor<Integer> dlqRetryCountCaptor = ArgumentCaptor.forClass(Integer.class);
+
+      deadLetterQueueManagerMock
+          .when(
+              () ->
+                  DeadLetterQueueManager.create(
+                      any(String.class), any(String.class), any(Integer.class)))
+          .thenReturn(null);
+
+      DataStreamToSpanner.buildDlqManager(options);
+
+      deadLetterQueueManagerMock.verify(
+          () ->
+              DeadLetterQueueManager.create(
+                  dlqDirectoryCaptor.capture(),
+                  retryDlqUriCaptor.capture(),
+                  dlqRetryCountCaptor.capture()));
+
+      assertThat(dlqDirectoryCaptor.getValue()).isEqualTo("gs://dlq/");
+      assertThat(retryDlqUriCaptor.getValue()).isEqualTo("gs://dlq/severe/");
+      assertThat(dlqRetryCountCaptor.getValue()).isEqualTo(20);
+    }
   }
 }


### PR DESCRIPTION
Fixes b/465412503. 
Allows DLQ retry count for severe retries to be configured by user while keeping the default low (`5`) as we would want the failing severe errors to not cause sever retry mode take long.

TODO:
Add a test case to check and fix if retries of retry actually happen