### PR TITLE
update YAML instructions to be 1,2,3,4,5 rendered and update links

### DIFF
--- a/yaml/README.md
+++ b/yaml/README.md
@@ -8,7 +8,7 @@ More detailed instructions on how to run the template can be found in the associ
 1.  **Contribution Instructions:** Read the code contributions located [here](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/contributor-docs/code-contributions.md).
 
 1. **Add YAML Blueprint:** Create the YAML blueprint file that defines the template's structure and parameters.
-Place this file in [here](https://github.com/GoogleCloudPlatform/DataflowTemplates/yaml/src/main/yaml).
+Place this file in [here](https://github.com/GoogleCloudPlatform/DataflowTemplates/tree/main/yaml/src/main/yaml).
 
 1.  **Generate YAML Template (Optional):** If desired, create the YAML template using the generation script.
 
@@ -17,7 +17,7 @@ Place this file in [here](https://github.com/GoogleCloudPlatform/DataflowTemplat
     ```
 
 1.  **Create Integration Test:** Develop an integration test to validate the functionality of the new template.
-Place this file in [here](https://github.com/GoogleCloudPlatform/DataflowTemplates/yaml/src/test/java).
+Place this file in [here](https://github.com/GoogleCloudPlatform/DataflowTemplates/tree/main/yaml/src/test/java/com/google/cloud/teleport/templates/yaml).
 Additional instructions can be located [here](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/contributor-docs/add-integration-or-load-test.md).
 
 1.  **Generate Documentation:** Run the documentation generation script to create the official documentation for the template. You can find instructions on how to do this in the [contributor documentation](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/contributor-docs/code-contributions.md#generated-documentation).


### PR DESCRIPTION
1. Currently, the markdown renders as 1,2,3,1,1 due to indentation of the code block and it has some incorrect links.
2. This PR fixes it to be 1,2,3,4,5 and the link issues.