### PR TITLE
update maven version in pom.xml

### DIFF
--- a/plugins/templates-maven-plugin/pom.xml
+++ b/plugins/templates-maven-plugin/pom.xml
@@ -38,7 +38,7 @@
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <maven.version>3.6.3</maven.version>
+    <maven.version>3.9.9</maven.version>
     <dataflow.api.version>0.7.6</dataflow.api.version>
     <mojo.executor.version>2.4.1</mojo.executor.version>
     <maven-plugin.version>3.15.1</maven-plugin.version>


### PR DESCRIPTION
bump version of maven packages from 3.6.3 to 3.9.9 to address https://nvd.nist.gov/vuln/detail/CVE-2021-26291 vulnerability

[package-upgrade]