### PR TITLE
shuffle around mock version to centralized location to fix dependabot PR

### DIFF
--- a/it/datadog/pom.xml
+++ b/it/datadog/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-client-java</artifactId>
-            <version>5.14.0</version>
+            <version>${mock-server-netty.version}</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -71,12 +71,13 @@
     <hadoop.version>3.4.2</hadoop.version>
     <hamcrest.version>2.1</hamcrest.version>
     <hbase.client.version>2.6.3-hadoop3</hbase.client.version>
-    <mockito.version>4.11.0</mockito.version>
-    <log4j-2.version>2.24.3</log4j-2.version>
     <jackson.version>2.15.4</jackson.version>
     <jettison.version>1.5.4</jettison.version>
     <json.version>20250517</json.version>
     <junit.version>4.13.2</junit.version>
+    <log4j-2.version>2.24.3</log4j-2.version>
+    <mock-server-netty.version>5.15.0</mock-server-netty.version>
+    <mockito.version>4.11.0</mockito.version>
     <re2j.version>1.6</re2j.version>
     <slf4j.version>2.0.17</slf4j.version>
     <snakeyaml.version>2.4</snakeyaml.version>

--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -34,7 +34,6 @@
   </description>
 
   <properties>
-    <mock-server-netty.version>5.14.0</mock-server-netty.version>
     <open-census.version>0.31.1</open-census.version>
     <!-- TODO: check if this could be declared on a Beam BOM instead of here -->
     <bigtable-beam-import.version>2.14.2</bigtable-beam-import.version>


### PR DESCRIPTION
1. Fix dependabot PR - https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/2865 as it missed the mock server version in a different pom.
2. Move the mock server version to the parent pom and then reference that for both locations.
3. Also, fix a small alphabetical sorting issue for properties.