### PR TITLE
Changed the grouping factor to 500 from the default 1000

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/writer/SpannerWriter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/writer/SpannerWriter.java
@@ -49,6 +49,8 @@ public class SpannerWriter implements Serializable {
             .withSpannerConfig(spannerConfig)
             .withFailureMode(FailureMode.REPORT_FAILURES)
             .withGroupingFactor(500));
+    // Reduced grouping factor from 1000 to 500 to reduce memory pressure. Tests show very little
+    // impact of throughput by this change.
   }
 
   protected Write setBatchSize(Write write) {


### PR DESCRIPTION
Reduced grouping factor from 1000 to 500 to reduce memory pressure.
Tests show very little impact of throughput by this change.