### PR TITLE
Increasing maxConnection on MySqlResourceManager For AllDataTypesIT

### DIFF
--- a/v2/sourcedb-to-spanner/src/test/resources/DataTypesIT/mysql-data-types.sql
+++ b/v2/sourcedb-to-spanner/src/test/resources/DataTypesIT/mysql-data-types.sql
@@ -1,3 +1,5 @@
+SET GLOBAL max_connections = 300;
+
 CREATE TABLE `varchar_table` (
     `id` INT PRIMARY KEY,
     `varchar_col` VARCHAR(21000) CHARACTER SET utf8 DEFAULT NULL


### PR DESCRIPTION
**IT only Change** - Increasing maxConnection on Containarized MySqlResourceManager For AllDataTypesIT, this is to unblock #3046  which is adding more schema elements to AllDataTypesIT for cross Schema Testing thereby opening more connection to the container (active connections = O(tables)).

TODO: Waiting for IT run to check if this works.