### PR TITLE
handle retryable errors in AssignShardIdFn [reverse replication]

### DIFF
--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/constants/Constants.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/constants/Constants.java
@@ -82,6 +82,6 @@ public class Constants {
       "Filtered record from custom transformation in reverse replication";
 
   // Sentinel Shard IDs for error handling
-  public static final String RETRYABLE_SENTINEL_SHARD_ID = "retryable_error_shard";
-  public static final String SEVERE_SENTINEL_SHARD_ID = "severe_error_shard";
+  public static final String RETRYABLE_ERROR_SHARD_ID = "retryable_error_shard";
+  public static final String SEVERE_ERROR_SHARD_ID = "severe_error_shard";
 }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/AssignShardIdFn.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/AssignShardIdFn.java
@@ -261,10 +261,10 @@ public class AssignShardIdFn
     } catch (Exception e) {
       LOG.error("Error fetching shard Id column: {}", e);
       TupleTag<String> errorTag = SpannerToSourceDbExceptionClassifier.classify(e);
-      if (Constants.RETRYABLE_ERROR_TAG.equals(errorTag)) {
-        record.setShard(Constants.RETRYABLE_SENTINEL_SHARD_ID);
+      if (Constants.PERMANENT_ERROR_TAG.equals(errorTag)) {
+        record.setShard(Constants.SEVERE_ERROR_SHARD_ID);
       } else {
-        record.setShard(Constants.SEVERE_SENTINEL_SHARD_ID);
+        record.setShard(Constants.RETRYABLE_ERROR_SHARD_ID);
       }
       String finalKeyString = record.getTableName() + "_" + keysJsonStr + "_" + skipDirName;
       Long finalKey = finalKeyString.hashCode() % maxConnectionsAcrossAllShards;

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFn.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFn.java
@@ -199,16 +199,14 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
     KV<Long, TrimmedShardedDataChangeRecord> element = c.element();
     TrimmedShardedDataChangeRecord spannerRec = element.getValue();
     String shardId = spannerRec.getShard();
-    if (shardId == null) {
-      // no shard found, move to permanent error
+    if (shardId == null || shardId.equals(Constants.SEVERE_ERROR_SHARD_ID)) {
+      // if no shard or permanent error shard id found, move to permanent error
       outputWithTag(
           c, Constants.PERMANENT_ERROR_TAG, Constants.SHARD_NOT_PRESENT_ERROR_MESSAGE, spannerRec);
-    } else if (shardId.equals(Constants.RETRYABLE_SENTINEL_SHARD_ID)) {
+    } else if (shardId.equals(Constants.RETRYABLE_ERROR_SHARD_ID)) {
+      // if retryable error shard id found, move to retryable error
       outputWithTag(
           c, Constants.RETRYABLE_ERROR_TAG, Constants.SHARD_NOT_PRESENT_ERROR_MESSAGE, spannerRec);
-    } else if (shardId.equals(Constants.SEVERE_SENTINEL_SHARD_ID)) {
-      outputWithTag(
-          c, Constants.PERMANENT_ERROR_TAG, Constants.SHARD_NOT_PRESENT_ERROR_MESSAGE, spannerRec);
     } else if (shardId.equals(skipDirName)) {
       // the record is skipped
       skippedRecordCountMetric.inc();

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifier.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifier.java
@@ -39,8 +39,8 @@ public class SpannerToSourceDbExceptionClassifier {
           ErrorCode.FAILED_PRECONDITION,
           ErrorCode.PERMISSION_DENIED,
           ErrorCode.UNAUTHENTICATED,
-          ErrorCode.RESOURCE_EXHAUSTED,
-          ErrorCode.UNIMPLEMENTED);
+          ErrorCode.UNIMPLEMENTED,
+          ErrorCode.INTERNAL);
 
   public static TupleTag<String> classify(Exception exception) {
     if (exception instanceof SpannerException e) {

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/transforms/AssignShardIdFnTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/transforms/AssignShardIdFnTest.java
@@ -575,14 +575,14 @@ public class AssignShardIdFnTest {
             "");
     String keyStr = "tableName" + "_" + record.getMod().getKeysJson() + "_" + "skip";
     Long key = keyStr.hashCode() % 10000L;
-    record.setShard(Constants.SEVERE_SENTINEL_SHARD_ID);
+    record.setShard(Constants.SEVERE_ERROR_SHARD_ID);
 
     ObjectMapper mapper = new ObjectMapper();
     mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
     assignShardIdFn.setMapper(mapper);
     assignShardIdFn.processElement(processContext);
     verify(processContext, atLeast(1)).output(eq(KV.of(key, record)));
-    assertEquals(Constants.SEVERE_SENTINEL_SHARD_ID, record.getShard());
+    assertEquals(Constants.SEVERE_ERROR_SHARD_ID, record.getShard());
   }
 
   @Test
@@ -614,7 +614,7 @@ public class AssignShardIdFnTest {
             "",
             "");
 
-    record.setShard(Constants.SEVERE_SENTINEL_SHARD_ID);
+    record.setShard(Constants.SEVERE_ERROR_SHARD_ID);
     assignShardIdFn.setSpannerAccessor(spannerAccessor);
     ObjectMapper mapper = new ObjectMapper();
     mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
@@ -624,7 +624,7 @@ public class AssignShardIdFnTest {
     String keyStr = "tableName" + "_" + record.getMod().getKeysJson() + "_" + "skip";
     Long key = keyStr.hashCode() % 10000L;
     verify(processContext, atLeast(1)).output(eq(KV.of(key, record)));
-    assertEquals(Constants.SEVERE_SENTINEL_SHARD_ID, record.getShard());
+    assertEquals(Constants.SEVERE_ERROR_SHARD_ID, record.getShard());
   }
 
   @Test
@@ -660,7 +660,7 @@ public class AssignShardIdFnTest {
             "",
             "");
 
-    record.setShard(Constants.SEVERE_SENTINEL_SHARD_ID);
+    record.setShard(Constants.SEVERE_ERROR_SHARD_ID);
     assignShardIdFn.setSpannerAccessor(spannerAccessor);
     ObjectMapper mapper = new ObjectMapper();
     mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
@@ -671,7 +671,7 @@ public class AssignShardIdFnTest {
     Long key = keyStr.hashCode() % 10000L;
 
     verify(processContext, atLeast(1)).output(eq(KV.of(key, record)));
-    assertEquals(Constants.SEVERE_SENTINEL_SHARD_ID, record.getShard());
+    assertEquals(Constants.SEVERE_ERROR_SHARD_ID, record.getShard());
   }
 
   @Test
@@ -772,7 +772,7 @@ public class AssignShardIdFnTest {
             "",
             "",
             "");
-    record.setShard(Constants.RETRYABLE_SENTINEL_SHARD_ID);
+    record.setShard(Constants.RETRYABLE_ERROR_SHARD_ID);
     assignShardIdFn.setSpannerAccessor(spannerAccessor);
     ObjectMapper mapper = new ObjectMapper();
     mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
@@ -784,7 +784,7 @@ public class AssignShardIdFnTest {
     Long key = keyStr.hashCode() % 10000L;
 
     verify(processContext).output(eq(KV.of(key, record)));
-    assertEquals(Constants.RETRYABLE_SENTINEL_SHARD_ID, record.getShard());
+    assertEquals(Constants.RETRYABLE_ERROR_SHARD_ID, record.getShard());
   }
 
   @Test
@@ -822,7 +822,7 @@ public class AssignShardIdFnTest {
             "",
             "",
             "");
-    record.setShard(Constants.SEVERE_SENTINEL_SHARD_ID);
+    record.setShard(Constants.SEVERE_ERROR_SHARD_ID);
     assignShardIdFn.setSpannerAccessor(spannerAccessor);
     ObjectMapper mapper = new ObjectMapper();
     mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
@@ -834,7 +834,7 @@ public class AssignShardIdFnTest {
     Long key = keyStr.hashCode() % 10000L;
 
     verify(processContext).output(eq(KV.of(key, record)));
-    assertEquals(Constants.SEVERE_SENTINEL_SHARD_ID, record.getShard());
+    assertEquals(Constants.SEVERE_ERROR_SHARD_ID, record.getShard());
   }
 
   public TrimmedShardedDataChangeRecord getInsertTrimmedDataChangeRecord(String shardId) {

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFnTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFnTest.java
@@ -816,8 +816,8 @@ public class SourceWriterFnTest {
   @Test
   public void testRetryableSentinelShardId() throws Exception {
     TrimmedShardedDataChangeRecord record =
-        getParent1TrimmedDataChangeRecord(Constants.RETRYABLE_SENTINEL_SHARD_ID);
-    record.setShard(Constants.RETRYABLE_SENTINEL_SHARD_ID);
+        getParent1TrimmedDataChangeRecord(Constants.RETRYABLE_ERROR_SHARD_ID);
+    record.setShard(Constants.RETRYABLE_ERROR_SHARD_ID);
     when(processContext.element()).thenReturn(KV.of(1L, record));
 
     SourceWriterFn sourceWriterFn =
@@ -848,8 +848,8 @@ public class SourceWriterFnTest {
   @Test
   public void testSevereSentinelShardId() throws Exception {
     TrimmedShardedDataChangeRecord record =
-        getParent1TrimmedDataChangeRecord(Constants.SEVERE_SENTINEL_SHARD_ID);
-    record.setShard(Constants.SEVERE_SENTINEL_SHARD_ID);
+        getParent1TrimmedDataChangeRecord(Constants.SEVERE_ERROR_SHARD_ID);
+    record.setShard(Constants.SEVERE_ERROR_SHARD_ID);
     when(processContext.element()).thenReturn(KV.of(1L, record));
 
     SourceWriterFn sourceWriterFn =

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifierTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifierTest.java
@@ -46,8 +46,8 @@ public class SpannerToSourceDbExceptionClassifierTest {
       ErrorCode.FAILED_PRECONDITION,
       ErrorCode.PERMISSION_DENIED,
       ErrorCode.UNAUTHENTICATED,
-      ErrorCode.RESOURCE_EXHAUSTED,
-      ErrorCode.UNIMPLEMENTED
+      ErrorCode.UNIMPLEMENTED,
+      ErrorCode.INTERNAL,
     };
 
     for (ErrorCode code : permanentCodes) {
@@ -63,8 +63,9 @@ public class SpannerToSourceDbExceptionClassifierTest {
       ErrorCode.UNAVAILABLE,
       ErrorCode.ABORTED,
       ErrorCode.DEADLINE_EXCEEDED,
-      ErrorCode.INTERNAL,
-      ErrorCode.UNKNOWN
+      ErrorCode.UNKNOWN,
+      ErrorCode.RESOURCE_EXHAUSTED,
+      ErrorCode.CANCELLED,
     };
 
     for (ErrorCode code : retryableCodes) {


### PR DESCRIPTION
fixes b/460679219

Context:
- if the AssignShardIdFn cannot provide a shardId, then we consider it to be permanent error.
- to get the shardId we need the entire row (in multi-shard migration). However, in case of a DELETE, the ChangeStream doesnot provide the entire row. this requires a read from spanner.
- if we cannot read from spanner, we set the shardId as NULL which causes the template to consider it as a permanent error.

Solution:
Using a sentinel shard_id to identify that it was a retryable error or severe error in SourceWriterFn.

Changes:
- added constant shard ids to represent permanent and retryable errors.
- Added a spanner to sourcedb exception classifier to use it in assignshardidfn and sourcewriterfn

Extra:
- Chore: removed an unused import on AssignShardIdFn