### PR TITLE
chore: remove unused defaults to avoid future confusion

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/defaults/MySqlConfigDefaults.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/defaults/MySqlConfigDefaults.java
@@ -42,16 +42,6 @@ public class MySqlConfigDefaults {
   public static final JdbcValueMappingsProvider DEFAULT_MYSQL_VALUE_MAPPING_PROVIDER =
       new MysqlJdbcValueMappings();
 
-  public static final String DEFAULT_MYSQL_CONNECTION_PROPERTIES =
-      "maxTotal=160;maxpoolsize=160;maxIdle=160;minIdle=160"
-          + ";wait_timeout=57600"
-          + ";interactive_timeout=57600"
-          + ";idletimeout=3600"
-          + ";maxwaittime=600_000"
-          + ";maxWaitMillis=600_000"
-          + ";maxConnLifetimeMillis=600_000"
-          + ";testOnCreate=true;testOnBorrow=true;testOnReturn=true;testWhileIdle=true";
-
   public static final Long DEFAULT_MYSQL_MAX_CONNECTIONS = 160L;
 
   /**


### PR DESCRIPTION
fixes b/471747468
`DEFAULT_MYSQL_CONNECTION_PROPERTIES` is not being used anywhere and has values that don't match with the actual implementation. Hence removing for clarity.