### PR TITLE
Consuming severe errors in regular mode using rerouting logic

### DIFF
--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SevereRetryRecoveryFn.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SevereRetryRecoveryFn.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.cloud.teleport.v2.templates.constants.DatastreamToSpannerConstants;
+import com.google.cloud.teleport.v2.values.FailsafeElement;
+import java.io.IOException;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link DoFn} that checks if a severe (permanent) error should be retried. It intercepts
+ * permanent errors, checks the `_metadata_severe_retries` field, and routes them to either the
+ * RETRYABLE bucket (if retries remain) or the PERMANENT bucket (if exhausted).
+ */
+public class SevereRetryRecoveryFn
+    extends DoFn<FailsafeElement<String, String>, FailsafeElement<String, String>> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SevereRetryRecoveryFn.class);
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private final int maxRetries;
+
+  public SevereRetryRecoveryFn(int maxRetries) {
+    this.maxRetries = maxRetries;
+  }
+
+  @ProcessElement
+  public void process(
+      @Element FailsafeElement<String, String> element, MultiOutputReceiver output) {
+    // If maxRetries is 0 (infinite), everything should have gone to RETRYABLE
+    // anyway.
+    // But if we are here, it means we are in Regular mode (maxRetries > 0)
+    // or handling edge cases.
+    try {
+      if (element.getOriginalPayload() == null) {
+        LOG.warn(
+            "Original payload is null. Cannot check for recovery. Routing to PERMANENT_ERROR_TAG.");
+        output.get(DatastreamToSpannerConstants.PERMANENT_ERROR_TAG).output(element);
+        return;
+      }
+      JsonNode jsonDLQElement = mapper.readTree(element.getOriginalPayload());
+
+      // Check if this is a "Fresh" severe error vs a "Manual Retry"
+      if (!jsonDLQElement.has("_metadata_severe_retries")) {
+        // Initialize metadata for future manual retries
+        ((ObjectNode) jsonDLQElement).put("_metadata_severe_retries", 0);
+
+        FailsafeElement<String, String> permanentElement =
+            FailsafeElement.of(jsonDLQElement.toString(), jsonDLQElement.toString());
+        permanentElement.setErrorMessage(element.getErrorMessage());
+        permanentElement.setStacktrace(element.getStacktrace());
+
+        output.get(DatastreamToSpannerConstants.PERMANENT_ERROR_TAG).output(permanentElement);
+        return;
+      }
+
+      // intended for manual retries
+      int severeRetryCount = jsonDLQElement.get("_metadata_severe_retries").asInt();
+
+      if (severeRetryCount < maxRetries) {
+        LOG.info(
+            "Rescuing Error! Incrementing severe_retry_count to {}. Routing to RETRYABLE_ERROR_TAG.",
+            severeRetryCount + 1);
+
+        // Allow retry, increment severe retry count
+        ((ObjectNode) jsonDLQElement).put("_metadata_severe_retries", severeRetryCount + 1);
+        FailsafeElement<String, String> updatedElement =
+            FailsafeElement.of(jsonDLQElement.toString(), jsonDLQElement.toString());
+
+        updatedElement.setErrorMessage(element.getErrorMessage());
+        updatedElement.setStacktrace(element.getStacktrace());
+
+        output.get(DatastreamToSpannerConstants.RETRYABLE_ERROR_TAG).output(updatedElement);
+        return;
+      }
+
+      // Both counts maxed out - truly permanent failure
+      LOG.info(
+          "Severe retry count exhausted ({} >= {}). Routing to PERMANENT_ERROR_TAG (Active Severe Bucket).",
+          severeRetryCount,
+          maxRetries);
+
+      // Reset severe retry count to 0 for potential future manual retries
+      ((ObjectNode) jsonDLQElement).put("_metadata_severe_retries", 0);
+
+      FailsafeElement<String, String> permanentElement =
+          FailsafeElement.of(jsonDLQElement.toString(), jsonDLQElement.toString());
+      permanentElement.setErrorMessage(element.getErrorMessage());
+      permanentElement.setStacktrace(element.getStacktrace());
+      output.get(DatastreamToSpannerConstants.PERMANENT_ERROR_TAG).output(permanentElement);
+    } catch (IOException e) {
+      LOG.error("Issue parsing JSON record in RecoveryFn. Unable to continue.", e);
+      output.get(DatastreamToSpannerConstants.PERMANENT_ERROR_TAG).output(element);
+    }
+  }
+}

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
@@ -655,27 +655,22 @@ public class SpannerToSourceDb {
                 ? debugOptions.getNumberOfWorkerHarnessThreads()
                 : Constants.DEFAULT_WORKER_HARNESS_THREAD_COUNT);
 
-    List<String> filePathsToIgnore =
-        new ArrayList<>(
-            Arrays.asList(
-                "/tmp_retry",
-                "/tmp_severe/",
-                ".temp",
-                "/tmp_skip/",
-                "/" + options.getSkipDirectoryName()));
-    if (isRegularMode) {
-      filePathsToIgnore.add("/severe/");
-    } else {
-      filePathsToIgnore.add("/retry/");
-    }
-
-    if (!Strings.isNullOrEmpty(options.getDlqGcsPubSubSubscription())) {
+    if (isRegularMode && (!Strings.isNullOrEmpty(options.getDlqGcsPubSubSubscription()))) {
       reconsumedElements =
           dlqManager.getReconsumerDataTransformForFiles(
               pipeline.apply(
                   "Read retry from PubSub",
                   new PubSubNotifiedDlqIO(
-                      options.getDlqGcsPubSubSubscription(), filePathsToIgnore)));
+                      options.getDlqGcsPubSubSubscription(),
+                      // file paths to ignore when re-consuming for retry
+                      new ArrayList<String>(
+                          Arrays.asList(
+                              "/severe/",
+                              "/tmp_retry",
+                              "/tmp_severe/",
+                              ".temp",
+                              "/tmp_skip/",
+                              "/" + options.getSkipDirectoryName())))));
     } else {
       reconsumedElements =
           dlqManager.getReconsumerDataTransform(


### PR DESCRIPTION
Documentation Change: https://github.com/GoogleCloudPlatform/spanner-migration-tool/pull/1255 

# Implementation Details
## A. The Recovery Function (SevereRetryRecoveryFn)
Acts as a gatekeeper for all errors destined for the Severe bucket.
Input: FailsafeElement tagged as PERMANENT.

### Logic:
1. **Freshness Check:** If `_metadata_severe_retries` is missing, initialize it to 0.
- **Why:** By stamping it with 0 now, we ensure that if a user manually retries this file later, the pipeline knows it's a "candidate for severe retry" rather than a brand new error.

2. **Retry Check:** If `_metadata_severe_retries < maxRetries`:
- Increment _metadata_severe_retries.
- Output to `RETRYABLE` tag ("Rescued").
- Note: The increment happens before routing, so the item enters the retry queue with count 1.

3. **Exhaustion:** If `counter >= maxRetries`:
- Reset `_metadata_severe_retries` to 0.
- Why: Just like the freshness check, resetting to 0 allows the user to restart the manual retry cycle if they choose to do so again.
- Output to `PERMANENT` tag (Graveyard).

## B. Pipeline Graph Changes
Specific steps were added to intercept and process permanent errors from multiple sources.

### 1. FlattenProcessingFailures (Flatten)
- What: Merges two error streams:
  - spannerWriteResults.permanentErrors(): Failures from Spanner itself.
  - transformedRecords.get(PERMANENT_ERROR_TAG): Failures from the transformer.
- Why: Creates a single logical stream of "all failures" to apply the severe retry logic uniformly.

### 2. EvaluateProcessingFailureRetry (ParDo)
- What: Applies the `SevereRetryRecoveryFn` to the `processingFailures` stream.
- Why: This is the "Freshness Check". It ensures that every permanent error is checked for metadata. Fresh errors get tagged with 0 and sent to Severe, preventing them from bypassing the safety net.

### 3. EvaluateDlqRetry (ParDo)
- What: Applies the `SevereRetryRecoveryFn` to the `reconsumedElements` stream (errors coming from the DLQ).
- Why: Intercepts errors that were already in the DLQ and are being retried.

### 4. Flatten Retryable Errors (Flatten)
- What: Merges standard retryable errors with "Rescued" severe errors.
- Why: "Rescued" errors are merged into the main retry pipeline to be written to the 
`retry/` GCS bucket.


## Potential Regressions & Risks
1. Metrics discrepancy: Metrics and counters for "Rescued" errors are not fully accounted for yet.
2. Log noise: Every time a severe error is "rescued", it might log "A severe error occurred..." before being successfully rescued (i.e. its actually a retriable error at the time being), which could be confusing.
3. Metadata Overhead: The JSON payloads now carry an extra integer field _metadata_severe_retries.
4. Pipeline Graph Change: The DAG structure has changed (extra Flatten and ParDo steps).

**Important Callout**: The _metadata_retry_count keeps incrementing on each retry. So if a retriable error has gone through: retry -> severe -> retry -> severe, it's _metadata_retry_count = 11 if maxRetryCount was 5

## Design Decision: Template vs. Common Library
It was explicitly chosen NOT to implement this in the shared `DeadLetterQueueManager.java`

- **Reason:** `DeadLetterQueueManager` is a shared component used by multiple Dataflow templates (BigQuery, JDBC, MongoDB, etc.).
- **Risk:** Modifying the common retry logic to support "Severe Retries" could introduce unexpected behavior or regressions in other stable templates that do not require this feature.
- **Isolation**: By implementing this logic entirely within DataStreamToSpanner.java, we strictly gate this behavior to this specific template/use-case, ensuring zero impact on the broader ecosystem.

# Testing
## Scenario 1: Fresh Severe Error (Direct to Severe)
**Condition:** A unique constraint violation (ALREADY_EXISTS) occurs immediately. 
**Behavior:**
- Logic detects missing _metadata_severe_retries.
- Sets _metadata_severe_retries = 0.
- Routes DIRECTLY to Severe Bucket.

DLQ Entry:
```
{"message":{"ddrkey":14,"userId":400,"nucUserId":4000,"nucPersId":40000,"time":1679145600,"_metadata_stream":"projects/443856856628/locations/us-central1/streams/aastha-severe-retry3-shard1-mysql-stream","_metadata_timestamp":1767185793,"_metadata_read_timestamp":1767185794,"_metadata_dataflow_timestamp":1767185801,"_metadata_read_method":"mysql-cdc-binlog","_metadata_source_type":"mysql","_metadata_deleted":false,"_metadata_table":"ut_bidtokens","_metadata_change_type":"INSERT","_metadata_primary_keys":["ddrkey","userId"],"_metadata_uuid":"5ca45833-ebcb-4359-ba74-727168c353fa","_metadata_schema":"final_test00","_metadata_log_file":"mysql-bin.001884","_metadata_log_position":"16541","_metadata_source":{"table":"ut_bidtokens","database":"final_test00","primary_keys":["ddrkey","userId"],"log_file":"mysql-bin.001884","log_position":16541,"change_type":"INSERT","is_deleted":false},"_metadata_severe_retries":0},"error_message":"ALREADY_EXISTS: io.grpc.StatusRuntimeException: ALREADY_EXISTS: Unique index violation on index ut_bidtokens_userId at index key [400,4]. It conflicts with row [4,400] in table ut_bidtokens."}
```

## Scenario 2: Manual Retry Loop (Severe -> Retry -> Severe)
**Condition:** User manually moves the file from Scenario 1 into the retry/bucket. The error is NOT resolved. 
**Behavior:**
- Pipeline consumes file (_metadata_severe_retries=0).
- Validation: 0 < maxDlqRetries (e.g. 10).
- Action: Increments _metadata_severe_retries to 1. Routes to Retry Bucket ("Rescued").
- The above keeps repeating till maxDlqRetries is met and then the error is shifted back to severe bucket with _metadata_severe_retries reset to 0. 
- Note that _metadata_retry_count does get incremented with each retry (so becomes 11 in this case when its written back)

DLQ Entry (when it's written back to severe):
```
{"message":{"ddrkey":15,"userId":500,"nucUserId":5000,"nucPersId":50000,"time":1679232000,"_metadata_stream":"projects/443856856628/locations/us-central1/streams/aastha-severe-retry3-shard1-mysql-stream","_metadata_timestamp":1767185793,"_metadata_read_timestamp":1767185794,"_metadata_dataflow_timestamp":1767185801,"_metadata_read_method":"mysql-cdc-binlog","_metadata_source_type":"mysql","_metadata_deleted":false,"_metadata_table":"ut_bidtokens","_metadata_change_type":"INSERT","_metadata_primary_keys":["ddrkey","userId"],"_metadata_uuid":"4466cc0f-2384-4118-b21e-fcb36d542b71","_metadata_schema":"final_test00","_metadata_log_file":"mysql-bin.001884","_metadata_log_position":"16541","_metadata_source":{"table":"ut_bidtokens","database":"final_test00","primary_keys":["ddrkey","userId"],"log_file":"mysql-bin.001884","log_position":16541,"change_type":"INSERT","is_deleted":false},"_metadata_severe_retries":0,"_metadata_error":"ALREADY_EXISTS: io.grpc.StatusRuntimeException: ALREADY_EXISTS: Unique index violation on index ut_bidtokens_userId at index key [500,5]. It conflicts with row [5,500] in table ut_bidtokens.","_metadata_retry_count":11},"error_message":"ALREADY_EXISTS: io.grpc.StatusRuntimeException: ALREADY_EXISTS: Unique index violation on index ut_bidtokens_userId at index key [500,5]. It conflicts with row [5,500] in table ut_bidtokens."}
```

## Scenario 3: "Fresh" severe error is moved to retry bucket after resolving issue (Severe -> Retry)
**Condition:** User manually moves the file from Scenario 1 into the retry/bucket after the error is resolved. 
**Behavior:**
- Pipeline consumes file (_metadata_severe_retries=0).
- Validation: 0 < maxDlqRetries (e.g. 10).
- Action: Increments _metadata_severe_retries to 1. Routes to Retry Bucket ("Rescued").
- Since error was resolved, query is written to Spanner and error file is deleted. 



## Scenario 4: Retriable Error that got exhausted and moved to severe (Retry -> Severe)
**Condition:**  INTERLEAVE IN PARENT violation by orphan child - Error that is first written to retry bucket and is retried dlqMaxRetryCount (10 in this case) times but keeps failing
**Behavior:**
- Pipeline consumes file and retries maxDlqRetries times as _metadata_retry_count < maxDlqRetries
- File is moved to severe bucket when _metadata_severe_retries = 11
- _metadata_severe_retries is set to 0 before file is written in severe bucket

DLQ Entry (when it's written to severe):
```
{"message":{"ddrkey":555,"userId":789,"itemId":1001,"added_col_char":"test","_metadata_stream":"projects/443856856628/locations/us-central1/streams/aastha-severe-retry3-shard1-mysql-stream","_metadata_timestamp":1767183215,"_metadata_read_timestamp":1767183219,"_metadata_dataflow_timestamp":1767183232,"_metadata_read_method":"mysql-cdc-binlog","_metadata_source_type":"mysql","_metadata_deleted":false,"_metadata_table":"ut_academy_tradeable_player","_metadata_change_type":"INSERT","_metadata_primary_keys":["ddrkey","userId","itemId"],"_metadata_uuid":"ff97ce77-c834-4c86-acab-dd2d19418c85","_metadata_schema":"final_test00","_metadata_log_file":"mysql-bin.001884","_metadata_log_position":"15032","_metadata_source":{"table":"ut_academy_tradeable_player","database":"final_test00","primary_keys":["ddrkey","userId","itemId"],"log_file":"mysql-bin.001884","log_position":15032,"change_type":"INSERT","is_deleted":false},"_metadata_error":"NOT_FOUND: io.grpc.StatusRuntimeException: NOT_FOUND: Parent row for row [555,789,1001] in table ut_academy_tradeable_player is missing. Row cannot be written.","_metadata_retry_count":11,"_metadata_severe_retries":0},"error_message":"NOT_FOUND: io.grpc.StatusRuntimeException: NOT_FOUND: Parent row for row [555,789,1001] in table ut_academy_tradeable_player is missing. Row cannot be written."}
```


## Scenario 5: Cyclic Severe Exhaustion (Retry -> Severe -> Retry -> Severe)
**Condition:** User keeps moving the above file back to Retry, but error persists (5 times). 
**Behavior:**
- Error is retried on the basis of _metadata_severe_retries value now, which keeps retrying till its <= dlqMaxRetryCount or success. 
- Everytime its written back to severe bucket _metadata_severe_retries is reset but _metadata_severe_retries keeps increasing