### PR TITLE
removed log message

### DIFF
--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MySqlChangeEventSequence.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MySqlChangeEventSequence.java
@@ -189,15 +189,7 @@ class MySqlChangeEventSequence extends ChangeEventSequence {
       return logPositionComparisonResult;
     }
 
-    int timestampComparisonResult = this.timestamp.compareTo(other.getTimestamp());
-    if (timestampComparisonResult == 0) {
-      LOG.warn(
-          "encountered two events with same log file: {} and position: {} and timestamp:{}",
-          this.logFile,
-          this.logPosition,
-          this.timestamp);
-    }
-    return timestampComparisonResult;
+    return this.timestamp.compareTo(other.getTimestamp());
   }
 
   @Override


### PR DESCRIPTION
This log was added to call out scenarios where the previous event and current event have exactly the same log file, position and timestamp indicating some issue with the source data. There is no action item, but the idea was that it is something to watch out for is it happens often enough.

However there are a couple of scenarios where this may come up in the regular flows
1. In the multi db flow (with distributed transactions) - In the second check to ensure the row has not changed outside transaction, this will be logged for every event
2. In the single DB flow (without distributed transactions) If an event is retried due to write to 

This logging in the regular flows is leading to throttling, hence removing this logger.