### PR TITLE
clean up some repeat properties in submodule poms

### DIFF
--- a/it/pom.xml
+++ b/it/pom.xml
@@ -30,9 +30,7 @@
   <properties>
     <awaitility.version>4.3.0</awaitility.version>
     <commons-math3.version>3.6.1</commons-math3.version>
-    <testcontainers.version>1.21.3</testcontainers.version>
     <dataflow-api.version>v1b3-rev20250519-2.0.0</dataflow-api.version>
-    <cassandra-java-driver-core.version>4.18.1</cassandra-java-driver-core.version>
   </properties>
 
   <dependencies>

--- a/plaintext-logging/pom.xml
+++ b/plaintext-logging/pom.xml
@@ -28,7 +28,6 @@
 
   <properties>
     <java.version>17</java.version>
-    <surefire.version>2.21.0</surefire.version>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -58,13 +58,16 @@
     <autovalue.service.version>1.0.2</autovalue.service.version>
     <avro.version>1.11.4</avro.version>
     <caffeine.version>3.2.2</caffeine.version>
+    <cassandra-java-driver-core.version>4.18.1</cassandra-java-driver-core.version>
     <checkstyle.version>12.3.0</checkstyle.version>
     <commons-codec.version>1.17.0</commons-codec.version>
     <commons-io.version>2.16.1</commons-io.version>
     <commons-lang3.version>3.18.0</commons-lang3.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
+    <commons-text.version>1.10.0</commons-text.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <derby.version>10.14.2.0</derby.version>
+    <dlp.version>3.85.0</dlp.version>
     <failsafe.version>3.3.0</failsafe.version>
     <grpc.gen.version>1.70.0</grpc.gen.version>
     <guava.version>32.0.1-jre</guava.version>
@@ -78,12 +81,14 @@
     <log4j-2.version>2.24.3</log4j-2.version>
     <mock-server-netty.version>5.15.0</mock-server-netty.version>
     <mockito.version>4.11.0</mockito.version>
+    <nashorn.version>15.4</nashorn.version>
     <re2j.version>1.8</re2j.version>
     <slf4j.version>2.0.17</slf4j.version>
     <snakeyaml.version>2.4</snakeyaml.version>
     <snappy.version>1.1.10.8</snappy.version>
     <spotless-maven-plugin.version>2.46.1</spotless-maven-plugin.version>
     <surefire.version>3.5.3</surefire.version>
+    <testcontainers.version>1.21.3</testcontainers.version>
     <truth.version>1.4.5</truth.version>
     <netty.version>4.1.125.Final</netty.version>
 

--- a/python/pom.xml
+++ b/python/pom.xml
@@ -36,7 +36,6 @@
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <postgresql.version>42.6.1</postgresql.version>
   </properties>
 
   <dependencies>

--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -38,21 +38,17 @@
     <!-- TODO: check if this could be declared on a Beam BOM instead of here -->
     <bigtable-beam-import.version>2.15.6</bigtable-beam-import.version>
     <protobuf.version>4.29.4</protobuf.version>
-    <nashorn.version>15.4</nashorn.version>
     <junit.jupiter.version>6.0.1</junit.jupiter.version>
     <codehaus-jackson.version>1.9.13</codehaus-jackson.version>
     <commons-csv.version>1.8</commons-csv.version>
-    <commons-text.version>1.10.0</commons-text.version>
     <kafka.clients.version>1.0.0</kafka.clients.version>
     <threetenbp.version>1.7.2</threetenbp.version>
     <spring.version>5.2.22.RELEASE</spring.version>
     <tensorflow.version>1.0.0</tensorflow.version>
-    <dlp.version>3.85.0</dlp.version>
     <hbase.version>2.5.3-hadoop3</hbase.version>
     <scassandra.version>1.1.2</scassandra.version>
     <cassandra.driver.version>3.6.0</cassandra.driver.version>
     <datastax.query.builder.version>4.17.0</datastax.query.builder.version>
-    <jacoco.version>0.8.13</jacoco.version>
     <excluded.spanner.tests>com.google.cloud.teleport.spanner.IntegrationTest</excluded.spanner.tests>
   </properties>
 

--- a/v2/common/pom.xml
+++ b/v2/common/pom.xml
@@ -28,8 +28,6 @@
 
     <properties>
         <commons.version>1.8</commons.version>
-        <commons-text.version>1.10.0</commons-text.version>
-        <nashorn.version>15.4</nashorn.version>
         <truth-proto-extension.version>1.4.5</truth-proto-extension.version>
         <skipShade>true</skipShade>
     </properties>

--- a/v2/dataplex/pom.xml
+++ b/v2/dataplex/pom.xml
@@ -30,7 +30,6 @@
 
   <properties>
     <dataplex.api.version>v1-rev20251113-2.0.0</dataplex.api.version>
-    <dlp.version>2.1.0</dlp.version>
   </properties>
 
   <dependencies>

--- a/v2/file-format-conversion/pom.xml
+++ b/v2/file-format-conversion/pom.xml
@@ -28,7 +28,6 @@
 
     <properties>
         <google-storage-api.version>v1-rev20200611-1.30.10</google-storage-api.version>
-        <commons-csv.version>1.8</commons-csv.version>
     </properties>
 
     <dependencies>

--- a/v2/googlecloud-to-googlecloud/pom.xml
+++ b/v2/googlecloud-to-googlecloud/pom.xml
@@ -30,7 +30,6 @@
 
   <properties>
     <dataplex.api.version>v1-rev20251113-2.0.0</dataplex.api.version>
-    <dlp.version>3.85.0</dlp.version>
   </properties>
 
   <build>

--- a/v2/jms-to-pubsub/pom.xml
+++ b/v2/jms-to-pubsub/pom.xml
@@ -29,7 +29,6 @@
         <!-- ActiveMQ uses JMS 1.1 until 5.17.6 -->
         <!-- This can only be upgraded after Beam moves to JMS 2.0 -->
         <activemq.version>5.17.7</activemq.version>
-        <testcontainers.version>1.17.5</testcontainers.version>
     </properties>
 
     <dependencies>

--- a/v2/managed-io-to-managed-io/pom.xml
+++ b/v2/managed-io-to-managed-io/pom.xml
@@ -30,7 +30,6 @@
 
   <properties>
     <activemq.version>5.17.7</activemq.version>
-    <testcontainers.version>1.17.5</testcontainers.version>
   </properties>
 
   <dependencies>

--- a/v2/mqtt-to-pubsub/pom.xml
+++ b/v2/mqtt-to-pubsub/pom.xml
@@ -25,7 +25,6 @@
 
     <artifactId>mqtt-to-pubsub</artifactId>
     <properties>
-        <testcontainers.version>1.21.3</testcontainers.version>
     </properties>
     <dependencies>
         <dependency>

--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -35,7 +35,6 @@
     <packaging>pom</packaging>
 
     <properties>
-        <autovalue.service.version>1.0-rc6</autovalue.service.version>
         <jib.maven.version>3.4.0</jib.maven.version>
         <kafka-clients.version>3.7.0</kafka-clients.version>
         <opencensus.version>0.31.1</opencensus.version>
@@ -45,7 +44,6 @@
         <excluded.spanner.tests>com.google.cloud.teleport.v2.spanner.IntegrationTest</excluded.spanner.tests>
 
         <licenseHeaderFile>../JAVA_LICENSE_HEADER</licenseHeaderFile>
-        <cassandra-java-driver-core.version>4.18.1</cassandra-java-driver-core.version>
     </properties>
 
     <dependencyManagement>

--- a/v2/pubsub-to-jms/pom.xml
+++ b/v2/pubsub-to-jms/pom.xml
@@ -29,7 +29,6 @@
         <!-- ActiveMQ uses JMS 1.1 until 5.17.6 -->
         <!-- This can only be upgraded after Beam moves to JMS 2.0 -->
         <activemq.version>5.17.7</activemq.version>
-        <testcontainers.version>1.17.5</testcontainers.version>
     </properties>
 
     <dependencies>

--- a/yaml/pom.xml
+++ b/yaml/pom.xml
@@ -36,7 +36,6 @@
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <postgresql.version>42.6.1</postgresql.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
1. Some submodule poms have duplicate properties, so removing those and moving to parent pom.
2. Some properties in submodule poms are already covered by the parent pom, so removing those.