### PR TITLE
Add timeout to Kafka integration tests

### DIFF
--- a/.github/actions/publish-site-report/action.yml
+++ b/.github/actions/publish-site-report/action.yml
@@ -35,5 +35,8 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.output-zip-file }}
-        path: 'target/site/'
+        path: |
+          **/surefire-reports/TEST-*.xml
+          **/surefire-reports/*.html
+          **/surefire-reports/html/**
         retention-days: 7

--- a/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexIT.java
+++ b/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexIT.java
@@ -61,8 +61,10 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
@@ -76,6 +78,7 @@ import org.slf4j.LoggerFactory;
 public final class KafkaToBigQueryFlexIT extends TemplateTestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(KafkaToBigQueryFlexIT.class);
+  @Rule public Timeout testTimeout = new Timeout(30, TimeUnit.MINUTES);
 
   private static KafkaResourceManager kafkaResourceManager;
   private BigQueryResourceManager bigQueryClient;

--- a/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryIT.java
+++ b/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryIT.java
@@ -57,8 +57,10 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
@@ -71,6 +73,7 @@ import org.slf4j.LoggerFactory;
 public final class KafkaToBigQueryIT extends TemplateTestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(KafkaToBigQueryIT.class);
+  @Rule public Timeout testTimeout = new Timeout(30, TimeUnit.MINUTES);
 
   private static KafkaResourceManager kafkaResourceManager;
   private BigQueryResourceManager bigQueryClient;

--- a/v2/kafka-to-gcs/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToGcsAvroBinaryIT.java
+++ b/v2/kafka-to-gcs/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToGcsAvroBinaryIT.java
@@ -50,8 +50,10 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
@@ -62,6 +64,7 @@ import org.slf4j.LoggerFactory;
 @RunWith(JUnit4.class)
 public class KafkaToGcsAvroBinaryIT extends TemplateTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(KafkaToGcsAvroBinaryIT.class);
+  @Rule public Timeout testTimeout = new Timeout(30, TimeUnit.MINUTES);
   private static final Pattern RESULT_REGEX = Pattern.compile(".*\\.avro$");
 
   private KafkaResourceManager kafkaResourceManager;

--- a/v2/kafka-to-gcs/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToGcsFlexJsonIT.java
+++ b/v2/kafka-to-gcs/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToGcsFlexJsonIT.java
@@ -40,8 +40,10 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
@@ -52,6 +54,7 @@ import org.slf4j.LoggerFactory;
 @RunWith(JUnit4.class)
 public class KafkaToGcsFlexJsonIT extends TemplateTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(KafkaToGcsFlex.class);
+  @Rule public Timeout testTimeout = new Timeout(30, TimeUnit.MINUTES);
   private static final Pattern RESULT_REGEX = Pattern.compile(".*\\.json$");
   private KafkaResourceManager kafkaResourceManager;
 

--- a/v2/kafka-to-gcs/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToGcsIT.java
+++ b/v2/kafka-to-gcs/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToGcsIT.java
@@ -48,8 +48,10 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
@@ -62,7 +64,7 @@ import org.slf4j.LoggerFactory;
 public class KafkaToGcsIT extends TemplateTestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(KafkaToGcsIT.class);
-
+  @Rule public Timeout testTimeout = new Timeout(30, TimeUnit.MINUTES);
   private KafkaResourceManager kafkaResourceManager;
   private Schema avroSchema;
 

--- a/v2/kafka-to-kafka/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToKafkaIT.java
+++ b/v2/kafka-to-kafka/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToKafkaIT.java
@@ -26,6 +26,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
 import org.apache.beam.it.common.PipelineLauncher.LaunchInfo;
@@ -43,8 +44,10 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
@@ -56,6 +59,7 @@ import org.slf4j.LoggerFactory;
 public final class KafkaToKafkaIT extends TemplateTestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(KafkaToKafka.class);
+  @Rule public Timeout testTimeout = new Timeout(30, TimeUnit.MINUTES);
   private KafkaResourceManager kafkaResourceManager;
 
   @Before

--- a/v2/kafka-to-pubsub/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToPubsubTest.java
+++ b/v2/kafka-to-pubsub/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToPubsubTest.java
@@ -22,13 +22,17 @@ import static com.google.cloud.teleport.v2.templates.KafkaPubsubConstants.USERNA
 import com.google.cloud.teleport.v2.kafka.consumer.Utils;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.security.scram.internals.ScramMechanism;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /** Test class for {@link KafkaToPubsub}. */
 public class KafkaToPubsubTest {
+  @Rule public Timeout testTimeout = new Timeout(30, TimeUnit.MINUTES);
 
   /** Tests configureKafka() with a null input properties. */
   @Test


### PR DESCRIPTION
Also fix test report path

To investigate which test being stuck.

release workflow stuck at kafka tests: https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/runs/21165542889/job/60869290749

while kafka pr workflow run successfully. Unfortunately the test report isn't updated due to empty matching path