### PR TITLE
Remove notthreadsafe causing test running sequentially

### DIFF
--- a/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexIT.java
+++ b/v2/kafka-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/KafkaToBigQueryFlexIT.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import net.jcip.annotations.NotThreadSafe;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
@@ -74,7 +73,6 @@ import org.slf4j.LoggerFactory;
 @Category(TemplateIntegrationTest.class)
 @TemplateIntegrationTest(KafkaToBigQueryFlex.class)
 @RunWith(JUnit4.class)
-@NotThreadSafe
 public final class KafkaToBigQueryFlexIT extends TemplateTestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(KafkaToBigQueryFlexIT.class);


### PR DESCRIPTION
The annotation was added in #1275. The race was later fixed in https://github.com/apache/beam/pull/33979. We can remove the annotation for now.

Fixes Release workflow timeout