### PR TITLE
Removes mentioning UDF support in PubsubToRedis, since this has not yet been implemented.

### DIFF
--- a/v2/pubsub-to-redis/README_Cloud_PubSub_to_Redis.md
+++ b/v2/pubsub-to-redis/README_Cloud_PubSub_to_Redis.md
@@ -6,10 +6,6 @@ Pub/Sub subscription and writes the message payload to Redis. The most common us
 case of this template is to export logs to Redis Enterprise for advanced
 search-based log analysis in real time.
 
-Before writing to Redis, you can apply a JavaScript user-defined function to the
-message payload. Any messages that experience processing failures are forwarded
-to a Pub/Sub unprocessed topic for further troubleshooting and reprocessing.
-
 For added security, enable an SSL connection when setting up your database
 endpoint connection.
 
@@ -37,20 +33,7 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 * **redisSinkType**: The Redis sink. Supported values are `STRING_SINK, HASH_SINK, STREAMS_SINK, and LOGGING_SINK`. For example, `STRING_SINK`. Defaults to: STRING_SINK.
 * **connectionTimeout**: The Redis connection timeout in milliseconds.  For example, `2000`. Defaults to: 2000.
 * **ttl**: The key expiration time in seconds. The `ttl` default for `HASH_SINK` is -1, which means it never expires.
-* **javascriptTextTransformGcsPath**: The Cloud Storage URI of the .js file that defines the JavaScript user-defined function (UDF) to use. For example, `gs://my-bucket/my-udfs/my_file.js`.
-* **javascriptTextTransformFunctionName**: The name of the JavaScript user-defined function (UDF) to use. For example, if your JavaScript function code is `myTransform(inJson) { /*...do stuff...*/ }`, then the function name is `myTransform`. For sample JavaScript UDFs, see UDF Examples (https://github.com/GoogleCloudPlatform/DataflowTemplates#udf-examples).
-* **javascriptTextTransformReloadIntervalMinutes**: Specifies how frequently to reload the UDF, in minutes. If the value is greater than 0, Dataflow periodically checks the UDF file in Cloud Storage, and reloads the UDF if the file is modified. This parameter allows you to update the UDF while the pipeline is running, without needing to restart the job. If the value is `0`, UDF reloading is disabled. The default value is `0`.
 
-
-## User-Defined functions (UDFs)
-
-The Pub/Sub to Redis Template supports User-Defined functions (UDFs).
-UDFs allow you to customize functionality by providing a JavaScript function
-without having to maintain or build the entire template code.
-
-Check [Create user-defined functions for Dataflow templates](https://cloud.google.com/dataflow/docs/guides/templates/create-template-udf)
-and [Using UDFs](https://github.com/GoogleCloudPlatform/DataflowTemplates#using-udfs)
-for more information about how to create and test those functions.
 
 
 ## Getting Started
@@ -152,9 +135,6 @@ export SSL_ENABLED=false
 export REDIS_SINK_TYPE=STRING_SINK
 export CONNECTION_TIMEOUT=2000
 export TTL=-1
-export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
-export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
-export JAVASCRIPT_TEXT_TRANSFORM_RELOAD_INTERVAL_MINUTES=0
 
 gcloud dataflow flex-template run "cloud-pubsub-to-redis-job" \
   --project "$PROJECT" \
@@ -167,10 +147,7 @@ gcloud dataflow flex-template run "cloud-pubsub-to-redis-job" \
   --parameters "sslEnabled=$SSL_ENABLED" \
   --parameters "redisSinkType=$REDIS_SINK_TYPE" \
   --parameters "connectionTimeout=$CONNECTION_TIMEOUT" \
-  --parameters "ttl=$TTL" \
-  --parameters "javascriptTextTransformGcsPath=$JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH" \
-  --parameters "javascriptTextTransformFunctionName=$JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME" \
-  --parameters "javascriptTextTransformReloadIntervalMinutes=$JAVASCRIPT_TEXT_TRANSFORM_RELOAD_INTERVAL_MINUTES"
+  --parameters "ttl=$TTL"
 ```
 
 For more information about the command, please check:
@@ -199,9 +176,6 @@ export SSL_ENABLED=false
 export REDIS_SINK_TYPE=STRING_SINK
 export CONNECTION_TIMEOUT=2000
 export TTL=-1
-export JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH=<javascriptTextTransformGcsPath>
-export JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME=<javascriptTextTransformFunctionName>
-export JAVASCRIPT_TEXT_TRANSFORM_RELOAD_INTERVAL_MINUTES=0
 
 mvn clean package -PtemplatesRun \
 -DskipTests \
@@ -210,7 +184,7 @@ mvn clean package -PtemplatesRun \
 -Dregion="$REGION" \
 -DjobName="cloud-pubsub-to-redis-job" \
 -DtemplateName="Cloud_PubSub_to_Redis" \
--Dparameters="inputSubscription=$INPUT_SUBSCRIPTION,redisHost=$REDIS_HOST,redisPort=$REDIS_PORT,redisPassword=$REDIS_PASSWORD,sslEnabled=$SSL_ENABLED,redisSinkType=$REDIS_SINK_TYPE,connectionTimeout=$CONNECTION_TIMEOUT,ttl=$TTL,javascriptTextTransformGcsPath=$JAVASCRIPT_TEXT_TRANSFORM_GCS_PATH,javascriptTextTransformFunctionName=$JAVASCRIPT_TEXT_TRANSFORM_FUNCTION_NAME,javascriptTextTransformReloadIntervalMinutes=$JAVASCRIPT_TEXT_TRANSFORM_RELOAD_INTERVAL_MINUTES" \
+-Dparameters="inputSubscription=$INPUT_SUBSCRIPTION,redisHost=$REDIS_HOST,redisPort=$REDIS_PORT,redisPassword=$REDIS_PASSWORD,sslEnabled=$SSL_ENABLED,redisSinkType=$REDIS_SINK_TYPE,connectionTimeout=$CONNECTION_TIMEOUT,ttl=$TTL" \
 -f v2/pubsub-to-redis
 ```
 
@@ -263,9 +237,6 @@ resource "google_dataflow_flex_template_job" "cloud_pubsub_to_redis" {
     # redisSinkType = "STRING_SINK"
     # connectionTimeout = "2000"
     # ttl = "-1"
-    # javascriptTextTransformGcsPath = "<javascriptTextTransformGcsPath>"
-    # javascriptTextTransformFunctionName = "<javascriptTextTransformFunctionName>"
-    # javascriptTextTransformReloadIntervalMinutes = "0"
   }
 }
 ```

--- a/v2/pubsub-to-redis/src/main/java/com/google/cloud/teleport/v2/templates/PubSubToRedis.java
+++ b/v2/pubsub-to-redis/src/main/java/com/google/cloud/teleport/v2/templates/PubSubToRedis.java
@@ -27,7 +27,6 @@ import com.google.cloud.teleport.metadata.TemplateParameter.TemplateEnumOption;
 import com.google.cloud.teleport.v2.common.UncaughtExceptionLogger;
 import com.google.cloud.teleport.v2.templates.io.RedisHashIO;
 import com.google.cloud.teleport.v2.templates.transforms.MessageTransformation;
-import com.google.cloud.teleport.v2.transforms.JavascriptTextTransformer;
 import java.util.Map;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
@@ -94,9 +93,6 @@ import org.slf4j.LoggerFactory;
       "The Pub/Sub to Redis template is a streaming pipeline that reads messages from a Pub/Sub subscription and "
           + "writes the message payload to Redis. The most common use case of this template is to export logs to Redis "
           + "Enterprise for advanced search-based log analysis in real time.",
-      "Before writing to Redis, you can apply a JavaScript user-defined function to the message payload. Any "
-          + "messages that experience processing failures are forwarded to a Pub/Sub unprocessed topic for further "
-          + "troubleshooting and reprocessing.",
       "For added security, enable an SSL connection when setting up your database endpoint connection."
     },
     optionsClass = PubSubToRedis.PubSubToRedisOptions.class,
@@ -106,7 +102,6 @@ import org.slf4j.LoggerFactory;
         "https://cloud.google.com/dataflow/docs/guides/templates/provided/pubsub-to-redis",
     requirements = {
       "The source Pub/Sub subscription must exist prior to running the pipeline.",
-      "The Pub/Sub unprocessed topic must exist prior to running the pipeline.",
       "The Redis database endpoint must be accessible from the Dataflow workers' subnetwork.",
     },
     preview = true,
@@ -126,11 +121,9 @@ public class PubSubToRedis {
    * The {@link PubSubToRedisOptions} class provides the custom execution options passed by the
    * executor at the command-line.
    *
-   * <p>Inherits standard configuration options, options from {@link
-   * JavascriptTextTransformer.JavascriptTextTransformerOptions}.
+   * <p>Inherits standard configuration options.
    */
-  public interface PubSubToRedisOptions
-      extends JavascriptTextTransformer.JavascriptTextTransformerOptions, PipelineOptions {
+  public interface PubSubToRedisOptions extends PipelineOptions {
     @TemplateParameter.PubsubSubscription(
         order = 1,
         groupName = "Source",


### PR DESCRIPTION
Pubsub-To-Redis template does not implement custom UDF support yet, even though it previously extended the `JavascriptTextTransformerOptions` interface.

This change removes the unsupported interface and regenerates the docs.

FR to add support: https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/3243