### PR TITLE
feat(Spanner): Live Migration: Remove generated columns from change events during transformation and add tests for this behavior

### DIFF
--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SpannerTransactionWriterDoFn.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/SpannerTransactionWriterDoFn.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Options;
 import com.google.cloud.spanner.SpannerException;
+import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.TransactionRunner;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.ChangeEventConvertorException;
@@ -279,7 +280,7 @@ class SpannerTransactionWriterDoFn
             c, changeEventContext, currentChangeEventSequence, shadowTableDdl, ddl);
       } else {
         processSingleDatabaseTransaction(
-            c, changeEventContext, currentChangeEventSequence, shadowTableDdl);
+            c, changeEventContext, currentChangeEventSequence, shadowTableDdl, ddl);
       }
       com.google.cloud.Timestamp timestamp = com.google.cloud.Timestamp.now();
       c.output(timestamp);
@@ -378,7 +379,8 @@ class SpannerTransactionWriterDoFn
       ProcessContext c,
       ChangeEventContext changeEventContext,
       ChangeEventSequence currentChangeEventSequence,
-      Ddl shadowDdl) {
+      Ddl shadowDdl,
+      Ddl ddl) {
 
     spannerAccessor
         .getDatabaseClient()
@@ -403,7 +405,14 @@ class SpannerTransactionWriterDoFn
                     skippedEvents.inc();
                     return null;
                   }
-                  // Apply shadow and data table mutations.
+                  // Execute DML if applicable
+                  Statement dataDml = changeEventContext.getDataDmlStatement(ddl);
+
+                  if (dataDml != null) {
+                    transaction.executeUpdate(dataDml);
+                  }
+
+                  // Apply shadow and data table mutations (only if they exist)
                   transaction.buffer(changeEventContext.getMutations());
                   isInTransaction.set(false);
                   return null;
@@ -504,8 +513,17 @@ class SpannerTransactionWriterDoFn
                                       "Shadow table sequence changed during transaction");
                                 }
 
+                                // Execute Data DML if applicable
+                                Statement dataDml =
+                                    changeEventContext.getDataDmlStatement(dataTableDdl);
+                                if (dataDml != null) {
+                                  mainTxn.executeUpdate(dataDml);
+                                }
+
                                 // Write to main table
-                                mainTxn.buffer(changeEventContext.getDataMutation());
+                                if (changeEventContext.getDataMutation() != null) {
+                                  mainTxn.buffer(changeEventContext.getDataMutation());
+                                }
                                 return null;
                               });
 

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/spanner/ShadowTableCreator.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/spanner/ShadowTableCreator.java
@@ -70,6 +70,10 @@ public class ShadowTableCreator {
             .filter(col -> primaryKeyColNames.contains(col.name()))
             .collect(Collectors.toList());
     for (Column col : primaryKeyCols) {
+      // In Shadow table we only have primary keys. If primary key is dependent on
+      // non-primary key column, then shadow table creation will fail.
+      // Hence, generated expression should be removed from the shadow table columns.
+      col = col.toBuilder().isGenerated(false).generationExpression("").autoBuild();
       shadowTableBuilder.addColumn(col);
     }
 

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventContextTest.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/datastream/ChangeEventContextTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.datastream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.migrations.exceptions.ChangeEventConvertorException;
+import com.google.cloud.teleport.v2.spanner.migrations.exceptions.DroppedTableException;
+import com.google.cloud.teleport.v2.spanner.migrations.exceptions.InvalidChangeEventException;
+import java.io.IOException;
+import java.util.Collections;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class ChangeEventContextTest {
+
+  private static class TestChangeEventContext extends ChangeEventContext {
+    public TestChangeEventContext(JsonNode changeEvent, Ddl ddl, String shadowTablePrefix)
+        throws ChangeEventConvertorException, InvalidChangeEventException, DroppedTableException {
+      super(changeEvent, ddl, Collections.emptyMap());
+      this.shadowTablePrefix = shadowTablePrefix;
+      convertChangeEventToMutation(ddl, ddl);
+    }
+
+    @Override
+    Mutation generateShadowTableMutation(Ddl ddl, Ddl shadowDdl)
+        throws ChangeEventConvertorException {
+      return Mutation.newInsertBuilder("shadow_table").build();
+    }
+  }
+
+  private JsonNode getJsonNode(String json) throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+    return mapper.readTree(json);
+  }
+
+  @Test
+  public void testConvertChangeEventToMutation_Insert() throws Exception {
+    Ddl ddl = ChangeEventConvertorTest.getTestDdl();
+    JSONObject changeEvent = ChangeEventConvertorTest.getTestChangeEvent("Users");
+    changeEvent.put(DatastreamConstants.EVENT_CHANGE_TYPE_KEY, "INSERT");
+
+    ChangeEventContext context =
+        new TestChangeEventContext(getJsonNode(changeEvent.toString()), ddl, "shadow_");
+
+    Mutation mutation = context.getDataMutation();
+    assertEquals("Users", mutation.getTable());
+    assertEquals(Mutation.Op.INSERT_OR_UPDATE, mutation.getOperation());
+  }
+
+  @Test
+  public void testConvertChangeEventToMutation_Delete() throws Exception {
+    Ddl ddl = ChangeEventConvertorTest.getTestDdl();
+    JSONObject changeEvent = ChangeEventConvertorTest.getTestChangeEvent("Users");
+    changeEvent.put(DatastreamConstants.EVENT_CHANGE_TYPE_KEY, "DELETE");
+
+    ChangeEventContext context =
+        new TestChangeEventContext(getJsonNode(changeEvent.toString()), ddl, "shadow_");
+
+    Mutation mutation = context.getDataMutation();
+    assertEquals("Users", mutation.getTable());
+    assertEquals(Mutation.Op.DELETE, mutation.getOperation());
+  }
+
+  @Test
+  public void testConvertChangeEventToMutation_DeleteWithGeneratedPK() throws Exception {
+    Ddl ddl =
+        Ddl.builder()
+            .createTable("Users")
+            .column("id")
+            .string()
+            .max()
+            .generatedAs("uuid()")
+            .endColumn()
+            .column("name")
+            .string()
+            .max()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .build();
+
+    JSONObject changeEvent = new JSONObject();
+    changeEvent.put(DatastreamConstants.EVENT_TABLE_NAME_KEY, "Users");
+    changeEvent.put(DatastreamConstants.EVENT_CHANGE_TYPE_KEY, "DELETE");
+    changeEvent.put("id", "123");
+    changeEvent.put("name", "Test");
+
+    ChangeEventContext context =
+        new TestChangeEventContext(getJsonNode(changeEvent.toString()), ddl, "shadow_");
+
+    // Mutation should be null for DELETE on table with generated PK
+    assertNull(context.getDataMutation());
+  }
+
+  @Test
+  public void testGetDataDmlStatement_DeleteWithGeneratedPK() throws Exception {
+    Ddl ddl =
+        Ddl.builder()
+            .createTable("Users")
+            .column("id")
+            .string()
+            .max()
+            .generatedAs("uuid()")
+            .endColumn()
+            .column("name")
+            .string()
+            .max()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .build();
+
+    JSONObject changeEvent = new JSONObject();
+    changeEvent.put(DatastreamConstants.EVENT_TABLE_NAME_KEY, "Users");
+    changeEvent.put(DatastreamConstants.EVENT_CHANGE_TYPE_KEY, "DELETE");
+    changeEvent.put("id", "123");
+    changeEvent.put("name", "Test");
+
+    ChangeEventContext context =
+        new TestChangeEventContext(getJsonNode(changeEvent.toString()), ddl, "shadow_");
+
+    Statement statement = context.getDataDmlStatement(ddl);
+    assertNotNull(statement);
+    assertEquals("DELETE FROM Users WHERE name = @name", statement.getSql());
+    assertEquals("Test", statement.getParameters().get("name").getString());
+  }
+
+  @Test
+  public void testGetDataDmlStatement_DeleteWithoutGeneratedPK() throws Exception {
+    Ddl ddl = ChangeEventConvertorTest.getTestDdl();
+    JSONObject changeEvent = ChangeEventConvertorTest.getTestChangeEvent("Users");
+    changeEvent.put(DatastreamConstants.EVENT_CHANGE_TYPE_KEY, "DELETE");
+
+    ChangeEventContext context =
+        new TestChangeEventContext(getJsonNode(changeEvent.toString()), ddl, "shadow_");
+
+    Statement statement = context.getDataDmlStatement(ddl);
+    assertNull(statement);
+  }
+
+  @Test
+  public void testGetDataDmlStatement_InsertWithGeneratedPK() throws Exception {
+    Ddl ddl =
+        Ddl.builder()
+            .createTable("Users")
+            .column("id")
+            .string()
+            .max()
+            .generatedAs("uuid()")
+            .endColumn()
+            .column("name")
+            .string()
+            .max()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .build();
+
+    JSONObject changeEvent = new JSONObject();
+    changeEvent.put(DatastreamConstants.EVENT_TABLE_NAME_KEY, "Users");
+    changeEvent.put(DatastreamConstants.EVENT_CHANGE_TYPE_KEY, "INSERT");
+    changeEvent.put("id", "123");
+    changeEvent.put("name", "Test");
+
+    ChangeEventContext context =
+        new TestChangeEventContext(getJsonNode(changeEvent.toString()), ddl, "shadow_");
+
+    Statement statement = context.getDataDmlStatement(ddl);
+    assertNull(statement);
+  }
+}

--- a/v2/datastream-to-spanner/src/test/resources/MySQLDataTypesIT/mysql-data-types.sql
+++ b/v2/datastream-to-spanner/src/test/resources/MySQLDataTypesIT/mysql-data-types.sql
@@ -357,6 +357,36 @@ CREATE TABLE IF NOT EXISTS json_to_string_table (
   json_to_string_col JSON
 );
 
+CREATE TABLE IF NOT EXISTS `generated_pk_column_table` ( 
+	`first_name_col` varchar(50) DEFAULT NULL,
+	`last_name_col` varchar(50) DEFAULT NULL,
+	`generated_column_col` varchar(100) GENERATED ALWAYS AS (concat(`first_name_col`,' ')) STORED NOT NULL,
+	PRIMARY KEY (`generated_column_col`)
+);
+
+CREATE TABLE IF NOT EXISTS `generated_non_pk_column_table` ( 
+	`first_name_col` varchar(50) DEFAULT NULL,
+	`last_name_col` varchar(50) DEFAULT NULL,
+	`generated_column_col` varchar(100) GENERATED ALWAYS AS (concat(`first_name_col`,' ')) STORED NOT NULL,
+  `id` int not null,
+	PRIMARY KEY (`id`)
+);
+
+CREATE TABLE IF NOT EXISTS `non_generated_to_generated_column_table` ( 
+	`first_name_col` varchar(50) DEFAULT NULL,
+	`last_name_col` varchar(50) DEFAULT NULL,
+  `generated_column_col` varchar(100) NOT NULL,
+	`generated_column_pk_col` varchar(100) NOT NULL,
+	PRIMARY KEY (`generated_column_pk_col`)
+);
+
+CREATE TABLE IF NOT EXISTS `generated_to_non_generated_column_table` ( 
+	`first_name_col` varchar(50) DEFAULT NULL,
+	`last_name_col` varchar(50) DEFAULT NULL,
+  `generated_column_col` varchar(100) GENERATED ALWAYS AS (concat(`first_name_col`,' ')) STORED NOT NULL,
+	`generated_column_pk_col` varchar(100) GENERATED ALWAYS AS (concat(`first_name_col`,' ')) STORED NOT NULL,
+	PRIMARY KEY (`generated_column_pk_col`)
+);
 
 ALTER TABLE `bigint_table` MODIFY `id` INT AUTO_INCREMENT;
 ALTER TABLE `bigint_unsigned_table` MODIFY `id` INT AUTO_INCREMENT;
@@ -639,6 +669,12 @@ INSERT INTO `varbinary_to_string_table` (`varbinary_to_string_col`) VALUES (NULL
 INSERT INTO `varchar_table` (`varchar_col`) VALUES (NULL);
 INSERT INTO `year_table` (`year_col`) VALUES (NULL);
 INSERT INTO set_table (set_col) VALUES (NULL);
+
+INSERT INTO `generated_pk_column_table`(`first_name_col`, `last_name_col`) VALUES("AA", "BB");
+INSERT INTO `generated_non_pk_column_table`(`id`, `first_name_col`, `last_name_col`) VALUES(1, "AA", "BB");
+INSERT INTO `generated_non_pk_column_table`(`id`, `first_name_col`, `last_name_col`) VALUES(10, "AA", "BB");
+INSERT INTO `non_generated_to_generated_column_table`(`first_name_col`, `last_name_col`, `generated_column_col`, `generated_column_pk_col`) VALUES("AA", "BB", "AA ", "AA ");
+INSERT INTO `generated_to_non_generated_column_table`(`first_name_col`, `last_name_col`) VALUES("AA", "BB");
 
 
 CREATE TABLE IF NOT EXISTS spatial_point (

--- a/v2/datastream-to-spanner/src/test/resources/MySQLDataTypesIT/mysql-generated-col.sql
+++ b/v2/datastream-to-spanner/src/test/resources/MySQLDataTypesIT/mysql-generated-col.sql
@@ -1,0 +1,17 @@
+DELETE FROM `generated_pk_column_table` WHERE `first_name_col` = "AA";
+DELETE FROM `generated_non_pk_column_table` WHERE `id` = 1;
+DELETE FROM `non_generated_to_generated_column_table` WHERE `first_name_col` = "AA";
+DELETE FROM `generated_to_non_generated_column_table` WHERE `first_name_col` = "AA";
+
+INSERT INTO `generated_pk_column_table`(`first_name_col`, `last_name_col`) VALUES("BB", "CC");
+INSERT INTO `generated_non_pk_column_table`(`id`, `first_name_col`, `last_name_col`) VALUES(2, "BB", "CC");
+INSERT INTO `non_generated_to_generated_column_table`(`first_name_col`, `last_name_col`, `generated_column_col`, `generated_column_pk_col`) VALUES("BB", "CC", "BB ", "BB ");
+INSERT INTO `generated_to_non_generated_column_table`(`first_name_col`, `last_name_col`) VALUES("BB", "CC");
+
+UPDATE `generated_pk_column_table` SET `first_name_col` = "CC" WHERE `first_name_col` = "BB";
+UPDATE `generated_non_pk_column_table` SET `first_name_col` = "CC" WHERE `id` = 2;
+UPDATE `generated_non_pk_column_table` SET `id` = 11 WHERE `id` = 10;
+UPDATE `non_generated_to_generated_column_table` SET `first_name_col` = "CC" WHERE `first_name_col` = "BB";
+UPDATE `generated_to_non_generated_column_table` SET `first_name_col` = "CC" WHERE `first_name_col` = "BB";
+
+INSERT INTO `generated_non_pk_column_table`(`id`, `first_name_col`, `last_name_col`) VALUES(3, "DD", "EE");

--- a/v2/datastream-to-spanner/src/test/resources/MySQLDataTypesIT/spanner-schema.sql
+++ b/v2/datastream-to-spanner/src/test/resources/MySQLDataTypesIT/spanner-schema.sql
@@ -398,3 +398,29 @@ CREATE TABLE IF NOT EXISTS spatial_geometrycollection (
   geom_coll STRING(MAX),
 ) PRIMARY KEY (id);
 
+CREATE TABLE IF NOT EXISTS `generated_pk_column_table` ( 
+	`first_name_col` STRING(50),
+	`last_name_col` STRING(50) DEFAULT(NULL),
+	`generated_column_col` STRING(100) AS (concat(`first_name_col`,' ')) STORED,	
+) PRIMARY KEY (`generated_column_col`);
+
+CREATE TABLE IF NOT EXISTS `generated_non_pk_column_table` ( 
+	`first_name_col` STRING(50),
+	`last_name_col` STRING(50) DEFAULT(NULL),
+	`generated_column_col` STRING(100) AS (concat(`first_name_col`,' ')) STORED,
+  `id` INT64 not null,
+) PRIMARY KEY (`id`);
+
+CREATE TABLE IF NOT EXISTS `non_generated_to_generated_column_table` ( 
+	`first_name_col` STRING(50),
+	`last_name_col` STRING(50) DEFAULT(NULL),
+	`generated_column_col` STRING(100) AS (concat(`first_name_col`,' ')) STORED,
+	`generated_column_pk_col` STRING(100) AS (concat(`first_name_col`,' ')) STORED,
+) PRIMARY KEY (`generated_column_pk_col`);
+
+CREATE TABLE IF NOT EXISTS `generated_to_non_generated_column_table` ( 
+	`first_name_col` STRING(50),
+	`last_name_col` STRING(50) DEFAULT(NULL),
+	`generated_column_col` STRING(100) DEFAULT(NULL),
+	`generated_column_pk_col` STRING(100) DEFAULT(NULL),
+) PRIMARY KEY (`generated_column_pk_col`);


### PR DESCRIPTION
If a primary is Generated Column within Spanner and the change stream event is DELETE, then DML will be used
Else Mutation is used.

For DML, we include all the non-generated columns in the where clause. This is so because we do not have the list of dependent columns.

If column is Generated Column in Spanner, then the column is omitted from both DML or Mutations.