### PR TITLE
add addition label to release label workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,17 +1,23 @@
+# Note: If updating these categories, also update 
+# .github/workflows/release-notes-labels.yml and 
+# contributor-docs/code-contributions.md.
 changelog:
   exclude:
     labels:
       - ignore-for-release
   categories:
-    - title: New Templates
+    - title: Additional New Features
       labels:
-        - new-template
-    - title: Improvements
-      labels:
-        - improvement
+        - addition
     - title: Bug fixes
       labels:
         - bug-fix
+    - title: Improvements
+      labels:
+        - improvement
+    - title: New Templates
+      labels:
+        - new-template
     - title: Package Upgrades
       labels:
         - package-upgrade

--- a/.github/workflows/release-notes-labels.yml
+++ b/.github/workflows/release-notes-labels.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           mode: minimum
           count: 1
+          # Note: If updating these labels, also update .github/release.yml 
+          # and contributor-docs/code-contributions.md.
           labels: |
             addition
             bug-fix

--- a/contributor-docs/code-contributions.md
+++ b/contributor-docs/code-contributions.md
@@ -488,8 +488,11 @@ Release notes are [automatically generated](https://docs.github.com/en/repositor
 based on the PR labels defined in [release.yml](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/.github/release.yml).
 Before submitting your PR, a repo maintainer must add one of the following labels in order for all checks to pass:
 
-- `ignore-for-release`: Changes that should not appear in release notes (e.g., documentation updates, internal refactoring)
-- `new-template`: Addition of new Dataflow templates
-- `improvement`: Enhancements to existing functionality or performance improvements
+- `addition`: Addition of new functionality
 - `bug-fix`: Fixes for bugs or issues in existing code
+- `ignore-for-release`: Changes that should not appear in release notes (e.g., documentation updates, internal refactoring)
+- `improvement`: Enhancements to existing functionality or performance improvements
+- `new-template`: Addition of new Dataflow templates
 - `package-upgrade`: Updates to dependencies, libraries, or package versions
+
+Note: If updating these labels, also update .github/release.yml and .github/workflows/release-notes-labels.yml.


### PR DESCRIPTION
1. Existing release label workflow considers 5 different labels with one being `improvement`.  To me `improvement` would be about improving on existing code to make it faster, better logic, etc.
2. There is another label `addition` that seems to be geared more to new features and such, so adding that label to the release label check.
3. Also, making the labels in alphanumeric order.
4. If reviewer thinks we should not do this, should we just delete the addition label to minimize confusion with the release label workflow? Thanks.