### PR TITLE
update yaml-pr.yml to include better plugin path changes

### DIFF
--- a/.github/workflows/yaml-pr.yml
+++ b/.github/workflows/yaml-pr.yml
@@ -29,7 +29,9 @@ on:
       - '**/requirements.txt'
       - 'python/default_base_*.txt'
       - 'python/generate_all_dependencies.sh'
-      - 'plugins/core-plugin/src/main/resources/**'
+      # Plugin updates
+      - 'plugins/core-plugin/**'
+      - 'plugins/templates-maven-plugin/**'
       # Include relevant GitHub Action files for running these checks.
       # This will make it easier to verify action changes don't break anything.
       - '.github/actions/setup-env/*'


### PR DESCRIPTION
1. Noticed on some recent PRs that the yaml-pr.yml workflow wasn't running in particular for changes in template plugins.
2. Adding better paths for those areas.