### PR TITLE
Aligning Spanner load test schedule with spanner migration oncall schedule

### DIFF
--- a/.github/workflows/spanner-load-tests.yml
+++ b/.github/workflows/spanner-load-tests.yml
@@ -18,8 +18,8 @@ name: Spanner Load Tests
 
 on:
   schedule:
-  # at 02:00 weekly on every Friday.
-  - cron: '0 2 * * 5'
+  # at 02:00 weekly on every Tuesday.
+  - cron: '0 2 * * 2'
   workflow_dispatch:
 
 permissions: write-all


### PR DESCRIPTION
Changing the `spanner-load-test` schedule to trigger at `02:00 weekly on every Tuesday`. This aligns with the oncall rotation schedule and gives the oncaller enough time to triage.

Why `02:00 weekly on every Tuesday`? -- the `load-test` workflow is scheduled at `00:00 weekly on every saturday` and it usually takes 2 days 3 hours to complete. Leaving 3 days to avoid any overlapping between these two workflows.
Why `02:00`? -- all main line IT workflows are scheduled to run every 12 hours at 00:00 and 12:00. 02:00 avoids overlapping with them.
