### PR TITLE
Remove automatic GitHub issue creation from Spanner load tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/spanner-load-test-failure-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/spanner-load-test-failure-issue-template.md
@@ -1,5 +1,0 @@
----
-title: Spanner templates Load test failure! {{ env.DATE }}
-labels: bug
----
-{{ env.DATE }} Check: {{ env.JOB_URL }}

--- a/.github/workflows/spanner-load-tests.yml
+++ b/.github/workflows/spanner-load-tests.yml
@@ -52,15 +52,6 @@ jobs:
         --lt-export-project="cloud-teleport-testing" \
         --lt-export-dataset="performance_tests" \
         --lt-export-table="template_performance_metrics" \
-    - name: Create Github issue on failure
-      if: failure()
-      uses: JasonEtco/create-an-issue@v2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        DATE: ${{ steps.date.outputs.date }}
-      with:
-        filename: .github/ISSUE_TEMPLATE/spanner-load-test-failure-issue-template.md
     - name: Upload Load Tests Report
       uses: actions/upload-artifact@v6
       if: always() # always run even if the previous step fails
@@ -112,15 +103,6 @@ jobs:
         --lt-export-project="cloud-teleport-testing" \
         --lt-export-dataset="performance_tests" \
         --lt-export-table="template_performance_metrics"
-    - name: Create Github issue on failure
-      if: failure()
-      uses: JasonEtco/create-an-issue@v2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        DATE: ${{ steps.date.outputs.date }}
-      with:
-        filename: .github/ISSUE_TEMPLATE/spanner-load-test-failure-issue-template.md
     - name: Upload Load Test Observer Report
       uses: actions/upload-artifact@v6
       if: always() # always run even if the previous step fails


### PR DESCRIPTION
We have a kokoro based mechanism for polling, alerting and tracking spanner load test failures. The Github issue creation and sync mechanism is not needed now for `spanner-load-tests` failures.