### PR TITLE
Fix CVE-2024-25710

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <caffeine.version>3.2.2</caffeine.version>
     <checkstyle.version>12.3.0</checkstyle.version>
     <commons-codec.version>1.17.0</commons-codec.version>
+    <commons-compress.version>1.26.2</commons-compress.version>
     <commons-io.version>2.16.1</commons-io.version>
     <commons-lang3.version>3.18.0</commons-lang3.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
@@ -146,6 +147,11 @@
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>${commons-codec.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>${commons-compress.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>


### PR DESCRIPTION
Fixes Vulnerability CVE-2024-25710

internal tickets: b/471023574 and b/471025453

https://pantheon.corp.google.com/artifacts/docker/dataflow-templates/us/gcr.io/managed-io-to-managed-io/sha256:a643a702cdf40d2d9d114f454cd5e4bd5b7e814cff6c1434b07ace9471440eeb;tab=vulnerabilities?e=13802955&mods=-ai_platform_fake_service&project=dataflow-templates&pageState=(%22ar-vulnerabilities%22:(%22f%22:%22%255B%257B_22k_22_3A_22_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22CVE-2024-25710_5C_22_22_2C_22s_22_3Atrue%257D%255D%22))

As per my analysis testcontainers dependency is bringing this

`[INFO] -------< com.google.cloud.teleport.v2:managed-io-to-managed-io >--------
[INFO] Building managed-io-to-managed-io 1.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- dependency:3.8.1:tree (default-cli) @ managed-io-to-managed-io ---
[INFO] com.google.cloud.teleport.v2:managed-io-to-managed-io:jar:1.0-SNAPSHOT
[INFO] \- org.testcontainers:testcontainers:jar:1.17.5:test
[INFO]    \- org.apache.commons:commons-compress:jar:1.21:compile
[INFO] ------------------------------------------------------------------------`

as testcontainers is used in other placess too ex: jms-to-pubsub and pubsub-to-jms which also have this issue. So, i am fixing this globally

`[INFO] -------< com.google.cloud.teleport.v2:managed-io-to-managed-io >--------
[INFO] Building managed-io-to-managed-io 1.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- dependency:3.8.1:tree (default-cli) @ managed-io-to-managed-io ---
[INFO] com.google.cloud.teleport.v2:managed-io-to-managed-io:jar:1.0-SNAPSHOT
[INFO] \- org.testcontainers:testcontainers:jar:1.17.5:test
[INFO]    \- org.apache.commons:commons-compress:jar:1.26.2:compile
[INFO] ------------------------------------------------------------------------`