### PR TITLE
[Datastream] - Update gcs subscriber and file pattern as optional 

### DIFF
--- a/v2/datastream-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToBigQuery.java
+++ b/v2/datastream-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToBigQuery.java
@@ -150,6 +150,7 @@ public class DataStreamToBigQuery {
 
     @TemplateParameter.GcsReadFile(
         order = 1,
+        optional = true,
         groupName = "Source",
         description = "File location for Datastream file output in Cloud Storage.",
         helpText =
@@ -171,6 +172,7 @@ public class DataStreamToBigQuery {
 
     @TemplateParameter.PubsubSubscription(
         order = 3,
+        optional = true,
         description = "The Pub/Sub subscription on the Cloud Storage bucket.",
         helpText =
             "The Pub/Sub subscription used by Cloud Storage to notify Dataflow of new files available for processing, in the format: `projects/<PROJECT_ID>/subscriptions/<SUBSCRIPTION_NAME>`.")


### PR DESCRIPTION
Based on the public documentation of datastream to bigquery, setting gcs pubsub AND  inputFilePattern as an optional