### PR TITLE
AstraDBToBigQueryIT fix - different region and dataset issues

### DIFF
--- a/v2/astradb-to-bigquery/src/test/java/com/google/cloud/teleport/v2/astradb/templates/AstraDbToBigQueryIT.java
+++ b/v2/astradb-to-bigquery/src/test/java/com/google/cloud/teleport/v2/astradb/templates/AstraDbToBigQueryIT.java
@@ -37,6 +37,7 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 import org.apache.beam.it.common.PipelineLauncher;
 import org.apache.beam.it.common.PipelineOperator;
+import org.apache.beam.it.common.TestProperties;
 import org.apache.beam.it.common.utils.ResourceManagerUtils;
 import org.apache.beam.it.gcp.TemplateTestBase;
 import org.apache.beam.it.gcp.bigquery.BigQueryResourceManager;
@@ -69,7 +70,7 @@ public class AstraDbToBigQueryIT extends TemplateTestBase implements Serializabl
 
   private static final String ASTRA_DB = "dataflow_integration_tests";
 
-  private static final String ASTRA_DB_REGION = System.getProperty("region", "us-east1");
+  private static final String ASTRA_DB_REGION = TestProperties.region();
 
   private static final String ASTRA_KS = "beam";
 


### PR DESCRIPTION
1. Tries to fix - https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/runs/21922736267/job/63323185228?pr=3321
2. Can't find dataset, so creates one in the same region as IT.
3. Also, makes sure the region is same throughout for AstraDB, BigQuery, and execution location.