### PR TITLE
fix: use ISO-8601 date format in MongoDB to BigQuery template to maintain precision of timestamps (currently trimmed to seconds)

### DIFF
--- a/v2/googlecloud-and-mongodb/README_MongoDB_to_BigQuery.md
+++ b/v2/googlecloud-and-mongodb/README_MongoDB_to_BigQuery.md
@@ -28,6 +28,7 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 
 * **KMSEncryptionKey**: Cloud KMS Encryption Key to decrypt the mongodb uri connection string. If Cloud KMS key is passed in, the mongodb uri connection string must all be passed in encrypted. For example, `projects/your-project/locations/global/keyRings/your-keyring/cryptoKeys/your-key`.
 * **filter**: Bson filter in json format. For example, `{ "val": { $gt: 0, $lt: 9 }}`.
+* **useIso8601DateFormat**: If true, MongoDB date and timestamp values are serialized as ISO-8601 strings (for example, `2026-02-03T15:31:41.924Z`), preserving millisecond precision. If false (the default), the previous serialization format is used, which trims timestamps to second precision and depends on the JVM locale.
 * **useStorageWriteApi**: If `true`, the pipeline uses the BigQuery Storage Write API (https://cloud.google.com/bigquery/docs/write-api). The default value is `false`. For more information, see Using the Storage Write API (https://beam.apache.org/documentation/io/built-in/google-bigquery/#storage-write-api).
 * **useStorageWriteApiAtLeastOnce**: When using the Storage Write API, specifies the write semantics. To use at-least-once semantics (https://beam.apache.org/documentation/io/built-in/google-bigquery/#at-least-once-semantics), set this parameter to `true`. To use exactly-once semantics, set the parameter to `false`. This parameter applies only when `useStorageWriteApi` is `true`. The default value is `false`.
 * **bigQuerySchemaPath**: The Cloud Storage path for the BigQuery JSON schema. For example, `gs://your-bucket/your-schema.json`.
@@ -134,6 +135,7 @@ export OUTPUT_TABLE_SPEC=<outputTableSpec>
 ### Optional
 export KMSENCRYPTION_KEY=<KMSEncryptionKey>
 export FILTER=<filter>
+export USE_ISO8601DATE_FORMAT=false
 export USE_STORAGE_WRITE_API=false
 export USE_STORAGE_WRITE_API_AT_LEAST_ONCE=false
 export BIG_QUERY_SCHEMA_PATH=<bigQuerySchemaPath>
@@ -150,6 +152,7 @@ gcloud dataflow flex-template run "mongodb-to-bigquery-job" \
   --parameters "userOption=$USER_OPTION" \
   --parameters "KMSEncryptionKey=$KMSENCRYPTION_KEY" \
   --parameters "filter=$FILTER" \
+  --parameters "useIso8601DateFormat=$USE_ISO8601DATE_FORMAT" \
   --parameters "useStorageWriteApi=$USE_STORAGE_WRITE_API" \
   --parameters "useStorageWriteApiAtLeastOnce=$USE_STORAGE_WRITE_API_AT_LEAST_ONCE" \
   --parameters "outputTableSpec=$OUTPUT_TABLE_SPEC" \
@@ -183,6 +186,7 @@ export OUTPUT_TABLE_SPEC=<outputTableSpec>
 ### Optional
 export KMSENCRYPTION_KEY=<KMSEncryptionKey>
 export FILTER=<filter>
+export USE_ISO8601DATE_FORMAT=false
 export USE_STORAGE_WRITE_API=false
 export USE_STORAGE_WRITE_API_AT_LEAST_ONCE=false
 export BIG_QUERY_SCHEMA_PATH=<bigQuerySchemaPath>
@@ -196,7 +200,7 @@ mvn clean package -PtemplatesRun \
 -Dregion="$REGION" \
 -DjobName="mongodb-to-bigquery-job" \
 -DtemplateName="MongoDB_to_BigQuery" \
--Dparameters="mongoDbUri=$MONGO_DB_URI,database=$DATABASE,collection=$COLLECTION,userOption=$USER_OPTION,KMSEncryptionKey=$KMSENCRYPTION_KEY,filter=$FILTER,useStorageWriteApi=$USE_STORAGE_WRITE_API,useStorageWriteApiAtLeastOnce=$USE_STORAGE_WRITE_API_AT_LEAST_ONCE,outputTableSpec=$OUTPUT_TABLE_SPEC,bigQuerySchemaPath=$BIG_QUERY_SCHEMA_PATH,javascriptDocumentTransformGcsPath=$JAVASCRIPT_DOCUMENT_TRANSFORM_GCS_PATH,javascriptDocumentTransformFunctionName=$JAVASCRIPT_DOCUMENT_TRANSFORM_FUNCTION_NAME" \
+-Dparameters="mongoDbUri=$MONGO_DB_URI,database=$DATABASE,collection=$COLLECTION,userOption=$USER_OPTION,KMSEncryptionKey=$KMSENCRYPTION_KEY,filter=$FILTER,useIso8601DateFormat=$USE_ISO8601DATE_FORMAT,useStorageWriteApi=$USE_STORAGE_WRITE_API,useStorageWriteApiAtLeastOnce=$USE_STORAGE_WRITE_API_AT_LEAST_ONCE,outputTableSpec=$OUTPUT_TABLE_SPEC,bigQuerySchemaPath=$BIG_QUERY_SCHEMA_PATH,javascriptDocumentTransformGcsPath=$JAVASCRIPT_DOCUMENT_TRANSFORM_GCS_PATH,javascriptDocumentTransformFunctionName=$JAVASCRIPT_DOCUMENT_TRANSFORM_FUNCTION_NAME" \
 -f v2/googlecloud-and-mongodb
 ```
 
@@ -248,6 +252,7 @@ resource "google_dataflow_flex_template_job" "mongodb_to_bigquery" {
     outputTableSpec = "<outputTableSpec>"
     # KMSEncryptionKey = "<KMSEncryptionKey>"
     # filter = "<filter>"
+    # useIso8601DateFormat = "false"
     # useStorageWriteApi = "false"
     # useStorageWriteApiAtLeastOnce = "false"
     # bigQuerySchemaPath = "<bigQuerySchemaPath>"

--- a/v2/googlecloud-and-mongodb/README_MongoDB_to_BigQuery_CDC.md
+++ b/v2/googlecloud-and-mongodb/README_MongoDB_to_BigQuery_CDC.md
@@ -31,6 +31,7 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 * **useStorageWriteApiAtLeastOnce**: When using the Storage Write API, specifies the write semantics. To use at-least-once semantics (https://beam.apache.org/documentation/io/built-in/google-bigquery/#at-least-once-semantics), set this parameter to `true`. To use exactly- once semantics, set the parameter to `false`. This parameter applies only when `useStorageWriteApi` is `true`. The default value is `false`.
 * **KMSEncryptionKey**: Cloud KMS Encryption Key to decrypt the mongodb uri connection string. If Cloud KMS key is passed in, the mongodb uri connection string must all be passed in encrypted. For example, `projects/your-project/locations/global/keyRings/your-keyring/cryptoKeys/your-key`.
 * **filter**: Bson filter in json format. For example, `{ "val": { $gt: 0, $lt: 9 }}`.
+* **useIso8601DateFormat**: If true, MongoDB date and timestamp values are serialized as ISO-8601 strings (for example, `2026-02-03T15:31:41.924Z`), preserving millisecond precision. If false (the default), the previous serialization format is used, which trims timestamps to second precision and depends on the JVM locale.
 * **useStorageWriteApi**: If true, the pipeline uses the BigQuery Storage Write API (https://cloud.google.com/bigquery/docs/write-api). The default value is `false`. For more information, see Using the Storage Write API (https://beam.apache.org/documentation/io/built-in/google-bigquery/#storage-write-api).
 * **numStorageWriteApiStreams**: When using the Storage Write API, specifies the number of write streams. If `useStorageWriteApi` is `true` and `useStorageWriteApiAtLeastOnce` is `false`, then you must set this parameter. Defaults to: 0.
 * **storageWriteApiTriggeringFrequencySec**: When using the Storage Write API, specifies the triggering frequency, in seconds. If `useStorageWriteApi` is `true` and `useStorageWriteApiAtLeastOnce` is `false`, then you must set this parameter.
@@ -140,6 +141,7 @@ export OUTPUT_TABLE_SPEC=<outputTableSpec>
 export USE_STORAGE_WRITE_API_AT_LEAST_ONCE=false
 export KMSENCRYPTION_KEY=<KMSEncryptionKey>
 export FILTER=<filter>
+export USE_ISO8601DATE_FORMAT=false
 export USE_STORAGE_WRITE_API=false
 export NUM_STORAGE_WRITE_API_STREAMS=0
 export STORAGE_WRITE_API_TRIGGERING_FREQUENCY_SEC=<storageWriteApiTriggeringFrequencySec>
@@ -158,6 +160,7 @@ gcloud dataflow flex-template run "mongodb-to-bigquery-cdc-job" \
   --parameters "userOption=$USER_OPTION" \
   --parameters "KMSEncryptionKey=$KMSENCRYPTION_KEY" \
   --parameters "filter=$FILTER" \
+  --parameters "useIso8601DateFormat=$USE_ISO8601DATE_FORMAT" \
   --parameters "useStorageWriteApi=$USE_STORAGE_WRITE_API" \
   --parameters "numStorageWriteApiStreams=$NUM_STORAGE_WRITE_API_STREAMS" \
   --parameters "storageWriteApiTriggeringFrequencySec=$STORAGE_WRITE_API_TRIGGERING_FREQUENCY_SEC" \
@@ -195,6 +198,7 @@ export OUTPUT_TABLE_SPEC=<outputTableSpec>
 export USE_STORAGE_WRITE_API_AT_LEAST_ONCE=false
 export KMSENCRYPTION_KEY=<KMSEncryptionKey>
 export FILTER=<filter>
+export USE_ISO8601DATE_FORMAT=false
 export USE_STORAGE_WRITE_API=false
 export NUM_STORAGE_WRITE_API_STREAMS=0
 export STORAGE_WRITE_API_TRIGGERING_FREQUENCY_SEC=<storageWriteApiTriggeringFrequencySec>
@@ -209,7 +213,7 @@ mvn clean package -PtemplatesRun \
 -Dregion="$REGION" \
 -DjobName="mongodb-to-bigquery-cdc-job" \
 -DtemplateName="MongoDB_to_BigQuery_CDC" \
--Dparameters="useStorageWriteApiAtLeastOnce=$USE_STORAGE_WRITE_API_AT_LEAST_ONCE,mongoDbUri=$MONGO_DB_URI,database=$DATABASE,collection=$COLLECTION,userOption=$USER_OPTION,KMSEncryptionKey=$KMSENCRYPTION_KEY,filter=$FILTER,useStorageWriteApi=$USE_STORAGE_WRITE_API,numStorageWriteApiStreams=$NUM_STORAGE_WRITE_API_STREAMS,storageWriteApiTriggeringFrequencySec=$STORAGE_WRITE_API_TRIGGERING_FREQUENCY_SEC,inputTopic=$INPUT_TOPIC,outputTableSpec=$OUTPUT_TABLE_SPEC,bigQuerySchemaPath=$BIG_QUERY_SCHEMA_PATH,javascriptDocumentTransformGcsPath=$JAVASCRIPT_DOCUMENT_TRANSFORM_GCS_PATH,javascriptDocumentTransformFunctionName=$JAVASCRIPT_DOCUMENT_TRANSFORM_FUNCTION_NAME" \
+-Dparameters="useStorageWriteApiAtLeastOnce=$USE_STORAGE_WRITE_API_AT_LEAST_ONCE,mongoDbUri=$MONGO_DB_URI,database=$DATABASE,collection=$COLLECTION,userOption=$USER_OPTION,KMSEncryptionKey=$KMSENCRYPTION_KEY,filter=$FILTER,useIso8601DateFormat=$USE_ISO8601DATE_FORMAT,useStorageWriteApi=$USE_STORAGE_WRITE_API,numStorageWriteApiStreams=$NUM_STORAGE_WRITE_API_STREAMS,storageWriteApiTriggeringFrequencySec=$STORAGE_WRITE_API_TRIGGERING_FREQUENCY_SEC,inputTopic=$INPUT_TOPIC,outputTableSpec=$OUTPUT_TABLE_SPEC,bigQuerySchemaPath=$BIG_QUERY_SCHEMA_PATH,javascriptDocumentTransformGcsPath=$JAVASCRIPT_DOCUMENT_TRANSFORM_GCS_PATH,javascriptDocumentTransformFunctionName=$JAVASCRIPT_DOCUMENT_TRANSFORM_FUNCTION_NAME" \
 -f v2/googlecloud-and-mongodb
 ```
 
@@ -263,6 +267,7 @@ resource "google_dataflow_flex_template_job" "mongodb_to_bigquery_cdc" {
     # useStorageWriteApiAtLeastOnce = "false"
     # KMSEncryptionKey = "<KMSEncryptionKey>"
     # filter = "<filter>"
+    # useIso8601DateFormat = "false"
     # useStorageWriteApi = "false"
     # numStorageWriteApiStreams = "0"
     # storageWriteApiTriggeringFrequencySec = "<storageWriteApiTriggeringFrequencySec>"

--- a/v2/googlecloud-and-mongodb/src/main/java/com/google/cloud/teleport/v2/mongodb/options/MongoDbToBigQueryOptions.java
+++ b/v2/googlecloud-and-mongodb/src/main/java/com/google/cloud/teleport/v2/mongodb/options/MongoDbToBigQueryOptions.java
@@ -96,6 +96,20 @@ public class MongoDbToBigQueryOptions {
     String getFilter();
 
     void setFilter(String jsonFilter);
+
+    @TemplateParameter.Boolean(
+        order = 7,
+        optional = true,
+        description = "Use ISO-8601 date format",
+        helpText =
+            "If true, MongoDB date and timestamp values are serialized as ISO-8601 strings"
+                + " (for example, `2026-02-03T15:31:41.924Z`), preserving millisecond precision."
+                + " If false (the default), the previous serialization format is used, which trims"
+                + " timestamps to second precision and depends on the JVM locale.")
+    @Default.Boolean(false)
+    Boolean getUseIso8601DateFormat();
+
+    void setUseIso8601DateFormat(Boolean useIso8601DateFormat);
   }
 
   /** Options for reading from PubSub. */

--- a/v2/googlecloud-and-mongodb/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbCdcToBigQuery.java
+++ b/v2/googlecloud-and-mongodb/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbCdcToBigQuery.java
@@ -136,6 +136,7 @@ public class MongoDbCdcToBigQuery {
     options.setStreaming(true);
     Pipeline pipeline = Pipeline.create(options);
     String userOption = options.getUserOption();
+    boolean useIso8601DateFormat = options.getUseIso8601DateFormat();
     String inputOption = options.getInputTopic();
 
     TableSchema bigquerySchema;
@@ -184,7 +185,8 @@ public class MongoDbCdcToBigQuery {
                   @ProcessElement
                   public void process(ProcessContext c) {
                     Document document = c.element();
-                    TableRow row = MongoDbUtils.getTableSchema(document, userOption);
+                    TableRow row =
+                        MongoDbUtils.getTableSchema(document, userOption, useIso8601DateFormat);
                     c.output(row);
                   }
                 }))

--- a/v2/googlecloud-and-mongodb/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQuery.java
+++ b/v2/googlecloud-and-mongodb/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQuery.java
@@ -106,6 +106,7 @@ public class MongoDbToBigQuery {
       throws ScriptException, IOException, NoSuchMethodException {
     Pipeline pipeline = Pipeline.create(options);
     String userOption = options.getUserOption();
+    boolean useIso8601DateFormat = options.getUseIso8601DateFormat();
 
     TableSchema bigquerySchema;
 
@@ -163,7 +164,8 @@ public class MongoDbToBigQuery {
                   @ProcessElement
                   public void process(ProcessContext c) {
                     Document document = c.element();
-                    TableRow row = MongoDbUtils.getTableSchema(document, userOption);
+                    TableRow row =
+                        MongoDbUtils.getTableSchema(document, userOption, useIso8601DateFormat);
                     c.output(row);
                   }
                 }))

--- a/v2/googlecloud-and-mongodb/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbUtils.java
+++ b/v2/googlecloud-and-mongodb/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbUtils.java
@@ -172,7 +172,8 @@ public class MongoDbUtils implements Serializable {
           });
       row.set("timestamp", localDate.format(TIMEFORMAT));
     } else if (userOption.equals("JSON")) {
-      String jsonString = document.toJson(EXTENDED_JSON_WRITER_SETTINGS);
+      String jsonString =
+          ((Document) stripNullValues(document)).toJson(EXTENDED_JSON_WRITER_SETTINGS);
       JsonObject sourceDataJsonObject = GSON.fromJson(jsonString, JsonObject.class);
 
       // Convert to a Map
@@ -183,13 +184,42 @@ public class MongoDbUtils implements Serializable {
           .set("source_data", sourceDataMap)
           .set("timestamp", localDate.format(TIMEFORMAT));
     } else {
-      String sourceData = document.toJson(EXTENDED_JSON_WRITER_SETTINGS);
+      String sourceData =
+          ((Document) stripNullValues(document)).toJson(EXTENDED_JSON_WRITER_SETTINGS);
 
       row.set("id", document.get("_id").toString())
           .set("source_data", sourceData)
           .set("timestamp", localDate.format(TIMEFORMAT));
     }
     return row;
+  }
+
+  /**
+   * Returns a copy of {@code value} with null-valued fields removed, recursing into nested {@link
+   * Document}s and {@link List}s. This preserves the previous Gson behavior of omitting nulls from
+   * the serialized output, consistent with the FLATTEN path which also skips null values.
+   */
+  private static Object stripNullValues(Object value) {
+    if (value instanceof Document) {
+      Document out = new Document();
+      ((Document) value)
+          .forEach(
+              (key, val) -> {
+                if (val != null) {
+                  out.put(key, stripNullValues(val));
+                }
+              });
+      return out;
+    } else if (value instanceof List) {
+      List<Object> out = new ArrayList<>();
+      for (Object item : (List<?>) value) {
+        if (item != null) {
+          out.add(stripNullValues(item));
+        }
+      }
+      return out;
+    }
+    return value;
   }
 
   public static TableSchema getTableFieldSchemaForUDF(

--- a/v2/googlecloud-and-mongodb/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbUtils.java
+++ b/v2/googlecloud-and-mongodb/src/main/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbUtils.java
@@ -130,6 +130,20 @@ public class MongoDbUtils implements Serializable {
   }
 
   public static TableRow getTableSchema(Document document, String userOption) {
+    // Preserve the historical (locale-dependent, second-precision) serialization by default.
+    return getTableSchema(document, userOption, false);
+  }
+
+  /**
+   * Builds a {@link TableRow} from a MongoDB {@link Document}.
+   *
+   * @param useIso8601DateFormat when {@code true}, dates and timestamps are serialized as ISO-8601
+   *     strings using MongoDB's relaxed extended JSON ({@link #EXTENDED_JSON_WRITER_SETTINGS}),
+   *     preserving millisecond precision. When {@code false}, the previous Gson-based behavior is
+   *     retained for backward compatibility.
+   */
+  public static TableRow getTableSchema(
+      Document document, String userOption, boolean useIso8601DateFormat) {
     TableRow row = new TableRow();
     LocalDateTime localDate = LocalDateTime.now(ZoneId.of("UTC"));
     if (userOption.equals("FLATTEN")) {
@@ -150,19 +164,26 @@ public class MongoDbUtils implements Serializable {
                 row.set(key, value);
                 break;
               case "org.bson.Document":
-                String data = ((Document) value).toJson(EXTENDED_JSON_WRITER_SETTINGS);
+                String data =
+                    useIso8601DateFormat
+                        ? ((Document) value).toJson(EXTENDED_JSON_WRITER_SETTINGS)
+                        : GSON.toJson(value);
                 row.set(key, data);
                 break;
               case "java.util.Date":
-                // Format dates as ISO-8601 strings
-                Document tempDoc = new Document("date", value);
-                String dateJson = tempDoc.toJson(EXTENDED_JSON_WRITER_SETTINGS);
-                // Extract just the date value from {"date":{"$date":"2026-02-03T15:31:41.924Z"}}
-                try {
-                  JsonObject dateObj = GSON.fromJson(dateJson, JsonObject.class);
-                  String dateStr = dateObj.getAsJsonObject("date").get("$date").getAsString();
-                  row.set(key, dateStr);
-                } catch (Exception e) {
+                if (useIso8601DateFormat) {
+                  // Format dates as ISO-8601 strings
+                  Document tempDoc = new Document("date", value);
+                  String dateJson = tempDoc.toJson(EXTENDED_JSON_WRITER_SETTINGS);
+                  // Extract just the value from {"date":{"$date":"2026-02-03T15:31:41.924Z"}}
+                  try {
+                    JsonObject dateObj = GSON.fromJson(dateJson, JsonObject.class);
+                    String dateStr = dateObj.getAsJsonObject("date").get("$date").getAsString();
+                    row.set(key, dateStr);
+                  } catch (Exception e) {
+                    row.set(key, value.toString());
+                  }
+                } else {
                   row.set(key, value.toString());
                 }
                 break;
@@ -172,9 +193,14 @@ public class MongoDbUtils implements Serializable {
           });
       row.set("timestamp", localDate.format(TIMEFORMAT));
     } else if (userOption.equals("JSON")) {
-      String jsonString =
-          ((Document) stripNullValues(document)).toJson(EXTENDED_JSON_WRITER_SETTINGS);
-      JsonObject sourceDataJsonObject = GSON.fromJson(jsonString, JsonObject.class);
+      JsonObject sourceDataJsonObject;
+      if (useIso8601DateFormat) {
+        String jsonString =
+            ((Document) stripNullValues(document)).toJson(EXTENDED_JSON_WRITER_SETTINGS);
+        sourceDataJsonObject = GSON.fromJson(jsonString, JsonObject.class);
+      } else {
+        sourceDataJsonObject = GSON.toJsonTree(document).getAsJsonObject();
+      }
 
       // Convert to a Map
       Map<String, Object> sourceDataMap =
@@ -185,7 +211,9 @@ public class MongoDbUtils implements Serializable {
           .set("timestamp", localDate.format(TIMEFORMAT));
     } else {
       String sourceData =
-          ((Document) stripNullValues(document)).toJson(EXTENDED_JSON_WRITER_SETTINGS);
+          useIso8601DateFormat
+              ? ((Document) stripNullValues(document)).toJson(EXTENDED_JSON_WRITER_SETTINGS)
+              : GSON.toJson(document);
 
       row.set("id", document.get("_id").toString())
           .set("source_data", sourceData)
@@ -241,8 +269,7 @@ public class MongoDbUtils implements Serializable {
     }
 
     Document doc;
-    Object result =
-        invocable.invokeFunction(udfFunctionName, document.toJson(EXTENDED_JSON_WRITER_SETTINGS));
+    Object result = invocable.invokeFunction(udfFunctionName, document.toJson());
     if (result == null || ScriptObjectMirror.isUndefined(result)) {
       return null;
     } else if (result instanceof Document) {

--- a/v2/googlecloud-and-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/JavascriptDocumentTransformer.java
+++ b/v2/googlecloud-and-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/JavascriptDocumentTransformer.java
@@ -18,7 +18,6 @@ package com.google.cloud.teleport.v2.transforms;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 
 import com.google.auto.value.AutoValue;
-import com.google.cloud.teleport.v2.mongodb.templates.MongoDbUtils;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.UncheckedIOException;
@@ -148,10 +147,7 @@ public abstract class JavascriptDocumentTransformer {
         throw new RuntimeException("No udf was loaded");
       }
 
-      Object result =
-          getInvocable()
-              .invokeFunction(
-                  functionName(), data.toJson(MongoDbUtils.EXTENDED_JSON_WRITER_SETTINGS));
+      Object result = getInvocable().invokeFunction(functionName(), data.toJson());
       if (result == null || ScriptObjectMirror.isUndefined(result)) {
         return null;
       } else if (result instanceof Document) {

--- a/v2/googlecloud-and-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/JavascriptDocumentTransformer.java
+++ b/v2/googlecloud-and-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/JavascriptDocumentTransformer.java
@@ -18,6 +18,7 @@ package com.google.cloud.teleport.v2.transforms;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 
 import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.mongodb.templates.MongoDbUtils;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.UncheckedIOException;
@@ -147,7 +148,10 @@ public abstract class JavascriptDocumentTransformer {
         throw new RuntimeException("No udf was loaded");
       }
 
-      Object result = getInvocable().invokeFunction(functionName(), data.toJson());
+      Object result =
+          getInvocable()
+              .invokeFunction(
+                  functionName(), data.toJson(MongoDbUtils.EXTENDED_JSON_WRITER_SETTINGS));
       if (result == null || ScriptObjectMirror.isUndefined(result)) {
         return null;
       } else if (result instanceof Document) {

--- a/v2/googlecloud-and-mongodb/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQueryIT.java
+++ b/v2/googlecloud-and-mongodb/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbToBigQueryIT.java
@@ -215,7 +215,8 @@ public final class MongoDbToBigQueryIT extends TemplateTestBase {
     Map<String, JSONObject> mongoMap = new HashMap<>();
     mongoDocuments.forEach(
         mongoDocument -> {
-          JSONObject mongoDbJson = new JSONObject(mongoDocument.toJson());
+          JSONObject mongoDbJson =
+              new JSONObject(mongoDocument.toJson(MongoDbUtils.EXTENDED_JSON_WRITER_SETTINGS));
           String mongoId = mongoDbJson.getJSONObject(MONGO_DB_FLATTEN_ID).getString("$oid");
           if (applyUdf) {
             mongoDbJson.put("udf", "out");

--- a/v2/googlecloud-and-mongodb/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbUtilsTest.java
+++ b/v2/googlecloud-and-mongodb/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbUtilsTest.java
@@ -15,10 +15,13 @@
  */
 package com.google.cloud.teleport.v2.mongodb.templates;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.api.services.bigquery.model.TableRow;
+import java.util.Date;
 import org.bson.Document;
 import org.junit.Test;
 
@@ -68,5 +71,56 @@ public class MongoDbUtilsTest {
     assertNotNull("JSON string should not be null", jsonString);
     assertTrue("JSON should contain Infinity", jsonString.contains("Infinity"));
     assertTrue("JSON should contain NaN", jsonString.contains("NaN"));
+  }
+
+  @Test
+  public void testExtendedJsonDateSerialization() {
+    // Create document with date field
+    Date testDate = new Date(1738598501924L); // 2026-02-03T15:31:41.924Z
+    Document document = new Document();
+    document.put("_id", "test-id");
+    document.put("createdAt", testDate);
+
+    // Serialize with EXTENDED_JSON_WRITER_SETTINGS
+    String jsonString = document.toJson(MongoDbUtils.EXTENDED_JSON_WRITER_SETTINGS);
+
+    // Verify Extended JSON format with ISO-8601
+    assertNotNull("JSON string should not be null", jsonString);
+    assertTrue("Should contain $date key", jsonString.contains("\"$date\""));
+    assertTrue(
+        "Should contain ISO-8601 formatted date",
+        jsonString.matches(
+            ".*\"\\$date\"\\s*:\\s*\"\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z\".*"));
+    assertFalse(
+        "Should NOT contain locale-based date format",
+        jsonString.matches(".*[A-Z][a-z]{2}\\s+\\d+,\\s+\\d{4}.*"));
+
+    // Verify round-trip conversion
+    Document parsedDocument = Document.parse(jsonString);
+    assertEquals("Document ID should match", "test-id", parsedDocument.get("_id"));
+  }
+
+  @Test
+  public void testExtendedJsonWithMultipleDateTypes() {
+    Document document = new Document();
+    document.put("_id", "test-id");
+    document.put("currentDate", new Date());
+    document.put("pastDate", new Date(0L)); // 1970-01-01T00:00:00.000Z
+    document.put("futureDate", new Date(4102444800000L)); // 2100-01-01
+    document.put("nullDate", null);
+    document.put("stringField", "not a date");
+
+    String jsonString = document.toJson(MongoDbUtils.EXTENDED_JSON_WRITER_SETTINGS);
+
+    assertNotNull("JSON string should not be null", jsonString);
+    // Verify all date fields use Extended JSON format
+    int dateCount = jsonString.split("\"\\$date\"").length - 1;
+    assertEquals("Should have 3 $date entries", 3, dateCount);
+
+    // Verify round-trip conversion
+    Document parsedDocument = Document.parse(jsonString);
+    assertNotNull(parsedDocument.get("currentDate"));
+    assertNotNull(parsedDocument.get("pastDate"));
+    assertNotNull(parsedDocument.get("futureDate"));
   }
 }

--- a/v2/googlecloud-and-mongodb/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbUtilsTest.java
+++ b/v2/googlecloud-and-mongodb/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbUtilsTest.java
@@ -124,7 +124,7 @@ public class MongoDbUtilsTest {
     document.put("_id", "test-id");
     document.put("createdAt", testDate);
 
-    TableRow result = MongoDbUtils.getTableSchema(document, "FLATTEN");
+    TableRow result = MongoDbUtils.getTableSchema(document, "FLATTEN", true);
 
     assertNotNull(result);
     String dateValue = (String) result.get("createdAt");
@@ -133,6 +133,63 @@ public class MongoDbUtilsTest {
     assertTrue(
         "Date should be in ISO-8601 format",
         dateValue.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z"));
+  }
+
+  @Test
+  public void testGetTableSchemaFlattenWithDateFieldLegacyDefault() {
+    // With the flag disabled (the default), dates retain the previous Date.toString() output.
+    Date testDate = new Date(1738598501924L);
+    Document document = new Document();
+    document.put("_id", "test-id");
+    document.put("createdAt", testDate);
+
+    TableRow defaultResult = MongoDbUtils.getTableSchema(document, "FLATTEN");
+    TableRow explicitFalse = MongoDbUtils.getTableSchema(document, "FLATTEN", false);
+
+    assertEquals(
+        "2-arg overload must default to legacy behavior",
+        defaultResult.get("createdAt"),
+        explicitFalse.get("createdAt"));
+    assertEquals(
+        "Legacy FLATTEN date should be Date.toString()",
+        testDate.toString(),
+        defaultResult.get("createdAt"));
+  }
+
+  @Test
+  public void testGetTableSchemaFlattenWithDateFieldFallbackForOutOfRangeYear() {
+    // Relaxed extended JSON only emits an ISO string for years 1970-9999; outside that range it
+    // emits {"$date":{"$numberLong":...}}, so the ISO extraction fails and we fall back to
+    // Date.toString(). This exercises the catch branch.
+    Date outOfRangeDate = new Date(253402300800000L); // year 10000-01-01
+    Document document = new Document();
+    document.put("_id", "test-id");
+    document.put("createdAt", outOfRangeDate);
+
+    TableRow result = MongoDbUtils.getTableSchema(document, "FLATTEN", true);
+
+    assertEquals(
+        "Out-of-range date should fall back to Date.toString()",
+        outOfRangeDate.toString(),
+        result.get("createdAt"));
+  }
+
+  @Test
+  public void testGetTableSchemaJsonIso8601DateSerialization() {
+    // ISO path: dates become $date Extended JSON and null fields are still omitted.
+    Document document = new Document();
+    document.put("_id", "test-id");
+    document.put("createdAt", new Date(1738598501924L));
+    document.put("nullField", null);
+
+    TableRow result = MongoDbUtils.getTableSchema(document, "JSON", true);
+
+    @SuppressWarnings("unchecked")
+    java.util.Map<String, Object> sourceData =
+        (java.util.Map<String, Object>) result.get("source_data");
+    assertNotNull("source_data should be set", sourceData);
+    assertFalse("Null field should be omitted", sourceData.containsKey("nullField"));
+    assertTrue("Date field should be present", sourceData.containsKey("createdAt"));
   }
 
   @Test
@@ -186,7 +243,7 @@ public class MongoDbUtilsTest {
     document.put("nullField", null);
     document.put("createdAt", new Date(1738598501924L)); // 2026-02-03T15:31:41.924Z
 
-    TableRow result = MongoDbUtils.getTableSchema(document, "NONE");
+    TableRow result = MongoDbUtils.getTableSchema(document, "NONE", true);
 
     assertNotNull(result);
     // source_data is a raw JSON string for the NONE user option.
@@ -196,5 +253,20 @@ public class MongoDbUtilsTest {
     assertFalse("Null field should be omitted", sourceData.contains("nullField"));
     // Date fields must still serialize as ISO-8601 Extended JSON alongside null omission.
     assertTrue("Date should remain ISO-8601 $date", sourceData.contains("\"$date\""));
+  }
+
+  @Test
+  public void testGetTableSchemaNoneLegacyDefaultDoesNotUseExtendedJson() {
+    // With the flag disabled (the default), serialization stays on the previous Gson path, which
+    // does not emit Extended JSON $date markers. This guards the non-breaking default.
+    Document document = new Document();
+    document.put("_id", "test-id");
+    document.put("createdAt", new Date(1738598501924L));
+
+    TableRow result = MongoDbUtils.getTableSchema(document, "NONE");
+
+    String sourceData = (String) result.get("source_data");
+    assertNotNull("source_data should be set", sourceData);
+    assertFalse("Legacy output must not contain Extended JSON $date", sourceData.contains("$date"));
   }
 }

--- a/v2/googlecloud-and-mongodb/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbUtilsTest.java
+++ b/v2/googlecloud-and-mongodb/src/test/java/com/google/cloud/teleport/v2/mongodb/templates/MongoDbUtilsTest.java
@@ -158,4 +158,43 @@ public class MongoDbUtilsTest {
     assertNotNull(parsedDocument.get("pastDate"));
     assertNotNull(parsedDocument.get("futureDate"));
   }
+
+  @Test
+  public void testGetTableSchemaJsonOmitsNullFields() {
+    Document document = new Document();
+    document.put("_id", "test-id");
+    document.put("presentField", "value");
+    document.put("nullField", null);
+
+    TableRow result = MongoDbUtils.getTableSchema(document, "JSON");
+
+    assertNotNull(result);
+    // source_data is a Map for the JSON user option.
+    @SuppressWarnings("unchecked")
+    java.util.Map<String, Object> sourceData =
+        (java.util.Map<String, Object>) result.get("source_data");
+    assertNotNull("source_data should be set", sourceData);
+    assertTrue("Non-null field should be present", sourceData.containsKey("presentField"));
+    assertFalse("Null field should be omitted", sourceData.containsKey("nullField"));
+  }
+
+  @Test
+  public void testGetTableSchemaNoneOmitsNullFields() {
+    Document document = new Document();
+    document.put("_id", "test-id");
+    document.put("presentField", "value");
+    document.put("nullField", null);
+    document.put("createdAt", new Date(1738598501924L)); // 2026-02-03T15:31:41.924Z
+
+    TableRow result = MongoDbUtils.getTableSchema(document, "NONE");
+
+    assertNotNull(result);
+    // source_data is a raw JSON string for the NONE user option.
+    String sourceData = (String) result.get("source_data");
+    assertNotNull("source_data should be set", sourceData);
+    assertTrue("Non-null field should be present", sourceData.contains("presentField"));
+    assertFalse("Null field should be omitted", sourceData.contains("nullField"));
+    // Date fields must still serialize as ISO-8601 Extended JSON alongside null omission.
+    assertTrue("Date should remain ISO-8601 $date", sourceData.contains("\"$date\""));
+  }
 }


### PR DESCRIPTION
This MR fixes #3308 

⚠️ This changes are not backward compatible. Breaking change is change of timestamp format.

MongoDB ISODate fields were being serialized using the JVM's default locale, resulting in descriptive date formats like "Feb 3, 2026, 3:31:41 PM" instead of ISO-8601 format, thanks to which it maintains the precision of the source data - currently, ISODate has truncated precision to seconds.

This change configures MongoDB's JsonWriterSettings to use JsonMode.RELAXED, which outputs dates in ISO-8601 format: {"$date": "2026-02-03T15:31:41.924Z"}.

Changes:
- Added EXTENDED_JSON_WRITER_SETTINGS constant to MongoDbUtils
- Updated getTableSchema() to use MongoDB JsonWriterSettings for all user options (FLATTEN, JSON, NONE)
- Updated JavascriptDocumentTransformer to use consistent date serialization
- Added unit tests to verify ISO-8601 date format
- Updated integration test for consistency

Fixes locale-dependent date serialization issues in BigQuery output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)