### PR TITLE
feat: Add SQL Server support to Datastream-to-SQL template

### DIFF
--- a/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamJsonToJson.java
+++ b/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamJsonToJson.java
@@ -99,7 +99,8 @@ public final class FormatDatastreamJsonToJson
       outputObject.put("_metadata_lsn", getSourceMetadata(record, "database"));
       outputObject.put("_metadata_tx_id", getSourceMetadata(record, "tx_id"));
     } else if (sourceType.equals("sqlserver")) {
-      outputObject.put("_metadata_lsn", getSourceMetadata(record, "database"));
+      outputObject.put("_metadata_schema", getSourceMetadata(record, "schema"));
+      outputObject.put("_metadata_lsn", getSourceMetadata(record, "lsn"));
       outputObject.put("_metadata_tx_id", getSourceMetadata(record, "tx_id"));
     } else if (sourceType.equals("backfill") || sourceType.equals("cdc")) {
       // MongoDB Specific Metadata, MongoDB has different structure for sourceType.
@@ -241,7 +242,11 @@ public final class FormatDatastreamJsonToJson
       return null;
     }
 
-    return md.get("primary_keys");
+    JsonNode primaryKeys = md.get("primary_keys");
+    if (primaryKeys == null || primaryKeys.isNull()) {
+      primaryKeys = md.get("replication_index");
+    }
+    return primaryKeys;
   }
 
   private Long getSourceMetadataAsLong(JsonNode record, String fieldName) {

--- a/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/values/DatastreamRow.java
+++ b/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/values/DatastreamRow.java
@@ -197,6 +197,8 @@ public class DatastreamRow {
       return Arrays.asList("_metadata_timestamp", "_metadata_log_file", "_metadata_log_position");
     } else if (this.getSourceType().equals("postgresql")) {
       return Arrays.asList("_metadata_timestamp", "_metadata_lsn");
+    } else if (this.getSourceType().equals("sqlserver")) {
+      return Arrays.asList("_metadata_timestamp", "_metadata_lsn");
     } else {
       // Current default is oracle.
       return Arrays.asList(

--- a/v2/datastream-common/src/test/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamJsonToJsonTest.java
+++ b/v2/datastream-common/src/test/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamJsonToJsonTest.java
@@ -52,6 +52,14 @@ public class FormatDatastreamJsonToJsonTest {
           + " Relations"
           + " Representative\",\"MIN_SALARY\":4500,\"MAX_SALARY\":10500,\"rowid\":\"AAAEARAAEAAAAC9AAS\",\"_metadata_source\":{\"schema\":\"HR\",\"table\":\"JOBS\",\"database\":\"XE\",\"row_id\":\"AAAEARAAEAAAAC9AAS\",\"scn\":1706664,\"is_deleted\":false,\"change_type\":\"INSERT\",\"ssn\":0,\"rs_id\":\"\",\"tx_id\":null,\"log_file\":\"\",\"primary_keys\":[\"JOB_ID\"]}}";
 
+  private static final String EXAMPLE_SQLSERVER_DATASTREAM_JSON =
+      "{\"uuid\":\"11aabb22-cc33-dd44-ee55-ff6677889900\",\"read_timestamp\":\"2024-01-15"
+          + " 10:30:00.000\","
+          + "\"source_timestamp\":\"2024-01-15T10:30:00.000\",\"object\":\"dbo_EMPLOYEES\",\"read_method\":\"sqlserver-cdc\",\"stream_name\":\"projects/123/locations/us-central1/streams/sqlserver-stream\",\"schema_key\":\"def456\",\"sort_keys\":[1705314600000,0],\"source_metadata\":{\"schema\":\"dbo\",\"table\":\"EMPLOYEES\",\"database\":\"TestDB\",\"is_deleted\":false,\"change_type\":\"INSERT\",\"lsn\":\"00000027:00000ac0:0003\",\"tx_id\":\"0000001a\",\"replication_index\":[\"EMPLOYEE_ID\"]},\"payload\":{\"EMPLOYEE_ID\":101,\"FIRST_NAME\":\"John\",\"LAST_NAME\":\"Doe\"}}";
+
+  private static final String EXAMPLE_SQLSERVER_DATASTREAM_RECORD =
+      "{\"_metadata_stream\":\"my-stream\",\"_metadata_timestamp\":1705314600,\"_metadata_read_timestamp\":1705314600,\"_metadata_read_method\":\"sqlserver-cdc\",\"_metadata_source_type\":\"sqlserver\",\"_metadata_deleted\":false,\"_metadata_database\":\"TestDB\",\"_metadata_schema\":\"dbo\",\"_metadata_table\":\"EMPLOYEES\",\"_metadata_change_type\":\"INSERT\",\"_metadata_primary_keys\":[\"EMPLOYEE_ID\"],\"_metadata_uuid\":\"11aabb22-cc33-dd44-ee55-ff6677889900\",\"_metadata_lsn\":\"00000027:00000ac0:0003\",\"_metadata_tx_id\":\"0000001a\",\"EMPLOYEE_ID\":101,\"FIRST_NAME\":\"John\",\"LAST_NAME\":\"Doe\",\"_metadata_source\":{\"schema\":\"dbo\",\"table\":\"EMPLOYEES\",\"database\":\"TestDB\",\"is_deleted\":false,\"change_type\":\"INSERT\",\"lsn\":\"00000027:00000ac0:0003\",\"tx_id\":\"0000001a\",\"replication_index\":[\"EMPLOYEE_ID\"]}}";
+
   private static final String EXAMPLE_DATASTREAM_RECORD_WITH_HASH_ROWID =
       "{\"_metadata_stream\":\"my-stream\",\"_metadata_timestamp\":1640410924,\"_metadata_read_timestamp\":1640410924,\"_metadata_read_method\":\"oracle-backfill\",\"_metadata_source_type\":\"oracle\",\"_metadata_deleted\":false,\"_metadata_database\":\"XE\",\"_metadata_schema\":\"HR\",\"_metadata_table\":\"JOBS\",\"_metadata_change_type\":\"INSERT\",\"_metadata_primary_keys\":[\"JOB_ID\"],\"_metadata_uuid\":\"00c32134-f50e-4460-a6c0-399900010010\",\"_metadata_row_id\":1019670290924988842,\"_metadata_scn\":1706664,\"_metadata_ssn\":0,\"_metadata_rs_id\":\"\",\"_metadata_tx_id\":null,\"JOB_ID\":\"PR_REP\",\"JOB_TITLE\":\"Public"
           + " Relations"
@@ -112,6 +120,34 @@ public class FormatDatastreamJsonToJsonTest {
                             .withLowercaseSourceColumns(false)))
             .setCoder(failsafeElementCoder)
             .apply("RemoveDataflowTimestampProperty", ParDo.of(new RemoveTimestampPropertyFn()))
+            .setCoder(failsafeElementCoder);
+
+    PAssert.that(pCollection).containsInAnyOrder(expectedElement);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testProcessElement_sqlServerJson() {
+    FailsafeElement<String, String> expectedElement =
+        FailsafeElement.of(
+            EXAMPLE_SQLSERVER_DATASTREAM_RECORD, EXAMPLE_SQLSERVER_DATASTREAM_RECORD);
+
+    FailsafeElementCoder<String, String> failsafeElementCoder =
+        FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of());
+
+    PCollection<FailsafeElement<String, String>> pCollection =
+        pipeline
+            .apply("CreateInput", Create.of(EXAMPLE_SQLSERVER_DATASTREAM_JSON))
+            .apply(
+                "FormatDatastreamJsonToJson",
+                ParDo.of(
+                    (FormatDatastreamJsonToJson)
+                        FormatDatastreamJsonToJson.create()
+                            .withStreamName("my-stream")
+                            .withLowercaseSourceColumns(false)))
+            .setCoder(failsafeElementCoder)
+            .apply("RemoveTimestampProperty", ParDo.of(new RemoveTimestampPropertyFn()))
             .setCoder(failsafeElementCoder);
 
     PAssert.that(pCollection).containsInAnyOrder(expectedElement);

--- a/v2/datastream-common/src/test/java/com/google/cloud/teleport/v2/datastream/values/DatastreamRowTest.java
+++ b/v2/datastream-common/src/test/java/com/google/cloud/teleport/v2/datastream/values/DatastreamRowTest.java
@@ -64,4 +64,38 @@ public class DatastreamRowTest {
     assertEquals(pks.get(0), "id");
     assertEquals(pks.get(1), "name");
   }
+
+  @Test
+  public void testGetSortFields_sqlServer() {
+    TableRow r1 = new TableRow();
+    r1.set("_metadata_source_type", "sqlserver");
+    DatastreamRow row = DatastreamRow.of(r1);
+    List<String> sortFields = row.getSortFields();
+
+    assertEquals(Arrays.asList("_metadata_timestamp", "_metadata_lsn"), sortFields);
+  }
+
+  @Test
+  public void testGetSortFields_oracle() {
+    TableRow r1 = new TableRow();
+    r1.set("_metadata_source_type", "oracle");
+    DatastreamRow row = DatastreamRow.of(r1);
+    List<String> sortFields = row.getSortFields();
+
+    assertEquals(
+        Arrays.asList("_metadata_timestamp", "_metadata_scn", "_metadata_rs_id", "_metadata_ssn"),
+        sortFields);
+  }
+
+  @Test
+  public void testGetSortFields_mysql() {
+    TableRow r1 = new TableRow();
+    r1.set("_metadata_source_type", "mysql");
+    DatastreamRow row = DatastreamRow.of(r1);
+    List<String> sortFields = row.getSortFields();
+
+    assertEquals(
+        Arrays.asList("_metadata_timestamp", "_metadata_log_file", "_metadata_log_position"),
+        sortFields);
+  }
 }


### PR DESCRIPTION
### Summary

  - Add SQL Server as a supported Datastream source type in FormatDatastreamJsonToJson, FormatDatastreamRecordToJson, and DatastreamRow
  - Fix SQL Server metadata extraction: read _metadata_lsn from lsn field (was incorrectly reading from database), and set _metadata_schema from schema
  - Add primary_keys → replication_index fallback for SQL Server sources that use replication_index instead of primary_keys in source metadata
  - Add sqlserver branch to getSortFields() returning [_metadata_timestamp, _metadata_lsn]

### Test plan

  - FormatDatastreamJsonToJsonTest.testProcessElement_sqlServerJson
      - validates end-to-end JSON transformation including _metadata_schema, _metadata_lsn, _metadata_tx_id extraction and replication_index → _metadata_primary_keys fallback
  - DatastreamRowTest.testGetSortFields_sqlServer
      - validates sort field ordering for SQL Server
  - DatastreamRowTest.testGetSortFields_oracle
      - validates sort field ordering for Oracle
  - DatastreamRowTest.testGetSortFields_mysql
      - validates sort field ordering for MySQL
  - All tests pass (mvn test -pl v2/datastream-common -Dtest="FormatDatastreamJsonToJsonTest,DatastreamRowTest")