### PR TITLE
Spanner Cassandra ITs - Fix non-idempotent Cassandra schema creation

### DIFF
--- a/v2/sourcedb-to-spanner/src/test/resources/DataTypesIT/cassandra-data-types.csql
+++ b/v2/sourcedb-to-spanner/src/test/resources/DataTypesIT/cassandra-data-types.csql
@@ -1,5 +1,4 @@
-DROP TABLE IF EXISTS all_data_types;
-CREATE TABLE all_data_types (
+CREATE TABLE IF NOT EXISTS all_data_types (
     primary_key UUID PRIMARY KEY,
     ascii_col ASCII,
     bigint_col BIGINT,
@@ -767,7 +766,7 @@ VALUES (
     {184467440000000000000:BigIntAsBlob(9223372036854775807), -184467440000000000000:BigintAsBlob(-9223372036854775808)} -- varint_blob_map_col
 );
 
-CREATE TABLE "true" (
+CREATE TABLE IF NOT EXISTS "true" (
   "KEY" bigint PRIMARY KEY,
   "CLUSTERING" text
 );

--- a/v2/spanner-to-sourcedb/src/test/resources/SpannerCassandraReservedKeywordsIT/cassandra-schema.cql
+++ b/v2/spanner-to-sourcedb/src/test/resources/SpannerCassandraReservedKeywordsIT/cassandra-schema.cql
@@ -1,4 +1,4 @@
-CREATE TABLE "true" (
+CREATE TABLE IF NOT EXISTS "true" (
   "COLUMN" bigint PRIMARY KEY,
   "TABLE" text,
   "WITH" text

--- a/v2/spanner-to-sourcedb/src/test/resources/SpannerToCassandraSourceIT/cassandra-schema.sql
+++ b/v2/spanner-to-sourcedb/src/test/resources/SpannerToCassandraSourceIT/cassandra-schema.sql
@@ -1,15 +1,15 @@
-CREATE TABLE users (
+CREATE TABLE IF NOT EXISTS users (
     id int PRIMARY KEY,
     full_name text,
     "from" text
 );
 
-CREATE TABLE users2 (
+CREATE TABLE IF NOT EXISTS users2 (
     id int PRIMARY KEY,
     full_name text
 );
 
-CREATE TABLE AllDatatypeTransformation (
+CREATE TABLE IF NOT EXISTS AllDatatypeTransformation (
     varchar_column text PRIMARY KEY,
     tinyint_column tinyint,
     text_column text,
@@ -58,7 +58,7 @@ CREATE TABLE AllDatatypeTransformation (
     bytes_column BLOB
 );
 
-CREATE TABLE AllDatatypeColumns (
+CREATE TABLE IF NOT EXISTS AllDatatypeColumns (
     varchar_column text PRIMARY KEY,
     tinyint_column tinyint,
     text_column text,
@@ -110,7 +110,7 @@ CREATE TABLE AllDatatypeColumns (
 
 );
 
-CREATE TABLE BoundaryConversionTestTable (
+CREATE TABLE IF NOT EXISTS BoundaryConversionTestTable (
     varchar_column text PRIMARY KEY,
     tinyint_column tinyint,
     smallint_column smallint,
@@ -151,7 +151,7 @@ CREATE TABLE BoundaryConversionTestTable (
     map_inet_column map<inet, inet>
 );
 
-CREATE TABLE EmptyStringJsonTable (
+CREATE TABLE IF NOT EXISTS EmptyStringJsonTable (
     varchar_column TEXT PRIMARY KEY,
     empty_column TEXT,
     double_float_map_col MAP<DOUBLE, FLOAT>,
@@ -217,7 +217,7 @@ CREATE TABLE EmptyStringJsonTable (
     frozen_ascii_set_col frozen<SET<ASCII>>
 );
 
-CREATE TABLE testtable_03tpcovf16ed0klxm3v808ch3btgq0uk (
+CREATE TABLE IF NOT EXISTS testtable_03tpcovf16ed0klxm3v808ch3btgq0uk (
     id TEXT PRIMARY KEY,
     col_qcbf69rmxtre3b_03tpcovf16ed TEXT
 );

--- a/v2/spanner-to-sourcedb/src/test/resources/SpannerToCassandraSourceIT/cassandra-transformation-schema.sql
+++ b/v2/spanner-to-sourcedb/src/test/resources/SpannerToCassandraSourceIT/cassandra-transformation-schema.sql
@@ -1,5 +1,4 @@
-DROP TABLE IF EXISTS customers;
-CREATE TABLE customers (
+CREATE TABLE IF NOT EXISTS customers (
     id int PRIMARY KEY,
     full_name text,
     first_name text,

--- a/v2/spanner-to-sourcedb/src/test/resources/SpannerToSourceDbWideRowIT/cassandra-10mb-schema.sql
+++ b/v2/spanner-to-sourcedb/src/test/resources/SpannerToSourceDbWideRowIT/cassandra-10mb-schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE large_data (
+CREATE TABLE IF NOT EXISTS large_data (
     id UUID PRIMARY KEY,
     large_blob blob
 );


### PR DESCRIPTION
This PR addresses intermittent AlreadyExistsException failures in Cassandra-based integration tests (specifically CassandraAllDataTypesIT). 

Example: https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/runs/22293136720/job/64485274459?pr=3380  https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/runs/22366068580/job/64734193159

The issue stems from the interaction between the CassandraResourceManager's retry policy (via dev.failsafe) and non-idempotent CSQL statements. When Cassandra is under load, a CREATE TABLE statement may succeed on the server but fail to return a response to the client within the timeout window. Failsafe then triggers a retry, which fails immediately because the table was successfully created in the first attempt.

*Changes*
Updated the CSQL resource files to use IF NOT EXISTS for all CREATE TABLE statements. Ensures that schema setup is idempotent, allowing the CassandraResourceManager to safely retry without failing the test suite.

Unlike CREATE TABLE statements, INSERT statements in Casandra are natively upserts and doesn't cause errors on retry.