### PR TITLE
Pin dependency io.airlift:aircompres due to a vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,13 @@
         <artifactId>jetty-websocket-jetty-common</artifactId>
         <version>${jetty.version}</version>
       </dependency>
+      <!--Pinning this dependency due to CVE-2025-67721-->
+      <dependency>
+        <groupId>io.airlift</groupId>
+        <artifactId>aircompressor</artifactId>
+        <version>2.0.3</version>
+        <scope>compile</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Pinning due to CVE-2025-67721: https://mvnrepository.com/artifact/io.airlift/aircompressor