### PR TITLE
Spanner Load tests - Fixing Null pointer in resource cleanup

### DIFF
--- a/v2/gcs-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToJdbcLTBase.java
+++ b/v2/gcs-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToJdbcLTBase.java
@@ -59,7 +59,7 @@ public class SpannerToJdbcLTBase extends TemplateLoadTestBase {
           TestProperties.specPath(), "gs://dataflow-templates/latest/flex/GCS_to_Sourcedb");
   public SpannerResourceManager spannerResourceManager;
   public SpannerResourceManager spannerMetadataResourceManager;
-  public List<JDBCResourceManager> jdbcResourceManagers;
+  public List<JDBCResourceManager> jdbcResourceManagers = new ArrayList<>();
   public GcsResourceManager gcsResourceManager;
 
   public void setupResourceManagers(
@@ -76,7 +76,6 @@ public class SpannerToJdbcLTBase extends TemplateLoadTestBase {
   }
 
   public void setupMySQLResourceManager(int numShards) throws IOException {
-    jdbcResourceManagers = new ArrayList<>();
     for (int i = 0; i < numShards; ++i) {
       jdbcResourceManagers.add(MySQLResourceManager.builder(testName).build());
     }
@@ -87,8 +86,10 @@ public class SpannerToJdbcLTBase extends TemplateLoadTestBase {
   public void cleanupResourceManagers() {
     ResourceManagerUtils.cleanResources(
         spannerResourceManager, spannerMetadataResourceManager, gcsResourceManager);
-    for (JDBCResourceManager jdbcResourceManager : jdbcResourceManagers) {
-      ResourceManagerUtils.cleanResources(jdbcResourceManager);
+    if (jdbcResourceManagers != null) {
+      for (JDBCResourceManager jdbcResourceManager : jdbcResourceManagers) {
+        ResourceManagerUtils.cleanResources(jdbcResourceManager);
+      }
     }
   }
 

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDbLTBase.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDbLTBase.java
@@ -63,7 +63,7 @@ public class SpannerToSourceDbLTBase extends TemplateLoadTestBase {
           TestProperties.specPath(), "gs://dataflow-templates/latest/flex/Spanner_to_SourceDb");
   public SpannerResourceManager spannerResourceManager;
   public SpannerResourceManager spannerMetadataResourceManager;
-  public List<JDBCResourceManager> jdbcResourceManagers;
+  public List<JDBCResourceManager> jdbcResourceManagers = new ArrayList<>();
   public GcsResourceManager gcsResourceManager;
   protected static PubsubResourceManager pubsubResourceManager;
   protected SubscriptionName subscriptionName;
@@ -90,7 +90,6 @@ public class SpannerToSourceDbLTBase extends TemplateLoadTestBase {
   }
 
   public void setupMySQLResourceManager(int numShards) throws IOException {
-    jdbcResourceManagers = new ArrayList<>();
     for (int i = 0; i < numShards; ++i) {
       jdbcResourceManagers.add(MySQLResourceManager.builder(testName).build());
     }
@@ -104,8 +103,10 @@ public class SpannerToSourceDbLTBase extends TemplateLoadTestBase {
         spannerMetadataResourceManager,
         gcsResourceManager,
         pubsubResourceManager);
-    for (JDBCResourceManager jdbcResourceManager : jdbcResourceManagers) {
-      ResourceManagerUtils.cleanResources(jdbcResourceManager);
+    if (jdbcResourceManagers != null) {
+      for (JDBCResourceManager jdbcResourceManager : jdbcResourceManagers) {
+        ResourceManagerUtils.cleanResources(jdbcResourceManager);
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes a NullPointerException that occurred during the teardown phase of Spanner load tests (SpannerToJdbcLTBase and SpannerToSourceDbLTBase). The issue happened when cleanupResourceManagers attempted to iterate over jdbcResourceManagers when it was null (e.g., if the test failed before initializing the JDBC managers).

Issue found in - https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/runs/21850006587/job/63054244744 (b/483473344) 

Changes:

- Initialized jdbcResourceManagers: The jdbcResourceManagers list is now initialized to an empty ArrayList at declaration in both SpannerToJdbcLTBase.java and SpannerToSourceDbLTBase.java.
- Added Null Check: Added a null check for jdbcResourceManagers in the cleanupResourceManagers method to safely handle cases where it might still be null or uninitialized.

