### PR TITLE
MySQLAllDataTypesBulkAndLiveIT - Skipping GCS cleanup if the test failed

### DIFF
--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLAllDataTypesBulkAndLiveIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLAllDataTypesBulkAndLiveIT.java
@@ -84,6 +84,8 @@ public class MySQLAllDataTypesBulkAndLiveIT extends SourceDbToSpannerFTBase {
   public static SpannerResourceManager spannerResourceManager;
   private static GcsResourceManager gcsResourceManager;
 
+  private boolean testPassed = false;
+
   @Before
   public void setUp() throws Exception {
 
@@ -110,8 +112,10 @@ public class MySQLAllDataTypesBulkAndLiveIT extends SourceDbToSpannerFTBase {
 
   @After
   public void cleanUp() {
-    ResourceManagerUtils.cleanResources(
-        spannerResourceManager, mySQLResourceManager, gcsResourceManager);
+    ResourceManagerUtils.cleanResources(spannerResourceManager, mySQLResourceManager);
+    if (testPassed) {
+      ResourceManagerUtils.cleanResources(gcsResourceManager);
+    }
   }
 
   @Test
@@ -235,6 +239,8 @@ public class MySQLAllDataTypesBulkAndLiveIT extends SourceDbToSpannerFTBase {
     // Verify SWF Data
     SpannerAsserts.assertThatStructs(spannerResourceManager.runQuery("SELECT * FROM " + TABLE_SWF))
         .hasRecordsUnorderedCaseInsensitiveColumns(expectedDataNonNull);
+
+    testPassed = true;
   }
 
   private void verifyNullRow(List<com.google.cloud.spanner.Struct> structs) {


### PR DESCRIPTION
The MySQLAllDataTypesBulkAndLiveIT is sometimes failing with error saying Bulk migration template is not producing all the required messages in the DLQ gcs folder. 

Skipping the GCS cleanup if the test failed in order to allow to debug the issue when there is this error.