### PR TITLE
Fix DLQWriteTransform: DLQ file overwrites by adding window token to shard template

### DIFF
--- a/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/DLQWriteTransform.java
+++ b/v2/common/src/main/java/com/google/cloud/teleport/v2/transforms/DLQWriteTransform.java
@@ -93,7 +93,7 @@ public class DLQWriteTransform {
 
     private String getShardTemplate() {
       String paneStr = includePaneInfo() ? "-P" : "";
-      return paneStr + "-SSSSS-of-NNNNN";
+      return "-W" + paneStr + "-SSSSS-of-NNNNN";
     }
 
     /** Builder for {@link WriteDLQ}. */

--- a/v2/datastream-common/src/test/java/com/google/cloud/teleport/v2/transforms/DLQWriteTransformTest.java
+++ b/v2/datastream-common/src/test/java/com/google/cloud/teleport/v2/transforms/DLQWriteTransformTest.java
@@ -100,6 +100,40 @@ public class DLQWriteTransformTest {
     assertThat(reader.readLine()).isEqualTo(JSON_ROW_CONTENT);
   }
 
+  @Test
+  public void testFilesAreWrittenWithWindowToken() throws IOException {
+    // Arrange
+    File dlqDir = folder.newFolder(dlqFolderName(name.getMethodName()));
+    p.apply(Create.of(JSON_ROW_CONTENT).withCoder(StringUtf8Coder.of()))
+        .apply(
+            "Write To DLQ/Writer",
+            DLQWriteTransform.WriteDLQ.newBuilder()
+                .withDlqDirectory(dlqDir.getAbsolutePath())
+                .withTmpDirectory(
+                    folder.newFolder(tmpFolderName(name.getMethodName())).getAbsolutePath())
+                .build());
+
+    // Act
+    p.run().waitUntilFinish();
+
+    // Assert
+    File[] files = dlqDir.listFiles();
+    assertThat(files).isNotEmpty();
+
+    ResourceId resourceId = FileSystems.matchNewResource(files[0].getAbsolutePath(), false);
+    // The W token is replaced by the window start and end times, e.g.,
+    // 2026-03-10T04:52:00.000Z-2026-03-10T04:53:00.000Z
+    // We verify the filename matches the expected pattern including the window token.
+    // Example filename:
+    // `error-2026-03-10T06:47:00.000Z-2026-03-10T06:48:00.000Z-00005-of-00020.json`
+    assertThat(resourceId.getFilename())
+        .matches(
+            "error-\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z-\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z-\\d{5}-of-\\d{5}\\.json");
+
+    BufferedReader reader = FileBasedDeadLetterQueueReconsumer.readFile(resourceId);
+    assertThat(reader.readLine()).isEqualTo(JSON_ROW_CONTENT);
+  }
+
   private static String dlqFolderName(String testName) {
     return testName + "/";
   }


### PR DESCRIPTION
This PR fixes a bug in DLQWriteTransform

### The Problem
DLQWriteTransform applies a 1-minute `FixedWindows` before writing to GCS. However, the getShardTemplate() method previously returned a shard template (`-SSSSS-of-NNNNN` or `-P-SSSSS-of-NNNNN`) that **lacked a window token**. 

Because the window token was missing, files generated in different 1-minute time windows but assigned to the same shard number were given identical filenames. This resulted in newer files silently overwriting older files in the GCS bucket, leading to a discrepancy between the expected and actual number of DLQ events.

### The Solution
This PR adds the `-W` (window) token to the getShardTemplate() method. 

By including the `-W` token, the `DefaultFilenamePolicy` now correctly resolves the window start and end times (in ISO-8601 format) and injects them into the filename. This ensures that every DLQ file generated across different time windows has a globally unique name, preventing any overwrites.

**Example of the new filename format:**
`[prefix]-2026-03-10T06:47:00.000Z-2026-03-10T06:48:00.000Z-00005-of-00020.json`

### GCS Quota Considerations
The addition of the `-W` token adds exactly 49 bytes to the filename. 
- In a **Hierarchical Namespace** bucket, the base name limit is 512 bytes. Our base name uses ~169 bytes (~33%).
- In a **Flat Namespace** bucket, the total object name limit is 1024 bytes. Even with a deeply nested directory structure or dynamic streaming paths, the total size remains well under 300 bytes (< 30%).

While this decreases the available filepath/filename length for customers by 49 characters, it is highly unlikely to cause `Invalid Object Name` errors and is a necessary trade-off to ensure data integrity.

## Testing
- **Unit Tests:** Added testFilesAreWrittenWithWindowToken to DLQWriteTransformTest to verify that the generated filenames.
- **Integration Tests:** `MySQLAllDataTypesBulkAndLiveIT`
