### PR TITLE
Fix Transformation Failed for Dropped Columns

### DIFF
--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertor.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertor.java
@@ -301,17 +301,19 @@ public class GenericRecordTypeConvertor {
       }
       Schema fieldSchema = filterNullSchema(field.schema(), fieldName, fieldValue);
       // Handle logical/record types.
-      CassandraAnnotations cassandraAnnotations = null;
-      try {
-        cassandraAnnotations =
-            schemaMapper.getSpannerColumnCassandraAnnotations(
-                namespace,
-                schemaMapper.getSpannerTableName(namespace, srcTableName),
-                schemaMapper.getSpannerColumnName(namespace, srcTableName, fieldName));
-      } catch (NoSuchElementException e) {
-        // For Non-Existant Columns or Tables, we initialize Cassandra Annotations to empty array.
-        cassandraAnnotations = CassandraAnnotations.fromColumnOptions(List.of(), fieldName);
-      }
+      final CassandraAnnotations cassandraAnnotations =
+          ((java.util.function.Supplier<CassandraAnnotations>)
+                  () -> {
+                    try {
+                      return schemaMapper.getSpannerColumnCassandraAnnotations(
+                          namespace,
+                          schemaMapper.getSpannerTableName(namespace, srcTableName),
+                          schemaMapper.getSpannerColumnName(namespace, srcTableName, fieldName));
+                    } catch (NoSuchElementException e) {
+                      return CassandraAnnotations.fromColumnOptions(List.of(), fieldName);
+                    }
+                  })
+              .get();
       fieldValue =
           handleNonPrimitiveAvroTypes(fieldValue, fieldSchema, fieldName, cassandraAnnotations);
       // Standardizing the types for custom jar input.

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertorTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertorTest.java
@@ -701,6 +701,103 @@ public class GenericRecordTypeConvertorTest {
                 "timeStampArrayCol", Value.timestampArray(expectedTimeStampArray)));
   }
 
+  @Test
+  public void testDroppedColumnHandlingInCustomTransformation()
+      throws InvalidTransformationException {
+    final String tableName = "test_table";
+    final ISchemaMapper schemaMapper = org.mockito.Mockito.mock(ISchemaMapper.class);
+
+    org.mockito.Mockito.when(schemaMapper.getDialect())
+        .thenReturn(com.google.cloud.spanner.Dialect.GOOGLE_STANDARD_SQL);
+    org.mockito.Mockito.when(
+            schemaMapper.getSpannerTableName(
+                org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString()))
+        .thenReturn(tableName);
+    org.mockito.Mockito.when(
+            schemaMapper.getSpannerColumns(
+                org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyString()))
+        .thenReturn(ImmutableList.of("id"));
+
+    org.mockito.Mockito.when(
+            schemaMapper.getSpannerColumnName(
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.eq("id")))
+        .thenReturn("id");
+    org.mockito.Mockito.when(
+            schemaMapper.getSpannerColumnCassandraAnnotations(
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.eq("id")))
+        .thenReturn(getTestCassandraAnnotationNone());
+    org.mockito.Mockito.when(
+            schemaMapper.getSpannerColumnType(
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.eq("id")))
+        .thenReturn(Type.int64());
+
+    org.mockito.Mockito.when(
+            schemaMapper.getSpannerColumnName(
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.eq("dropped_col")))
+        .thenThrow(new java.util.NoSuchElementException("Dropped column"));
+
+    ISpannerMigrationTransformer customTransformer =
+        new ISpannerMigrationTransformer() {
+          @Override
+          public void init(String customParameters) {}
+
+          @Override
+          public MigrationTransformationResponse toSpannerRow(
+              MigrationTransformationRequest request) {
+            Map<String, Object> requestRow = request.getRequestRow();
+            Map<String, Object> responseRow = new HashMap<>();
+            if (requestRow.containsKey("dropped_col")) {
+              responseRow.put("id", 100L);
+            }
+            return new MigrationTransformationResponse(responseRow, false);
+          }
+
+          @Override
+          public MigrationTransformationResponse toSourceRow(
+              MigrationTransformationRequest request) {
+            return new MigrationTransformationResponse(new HashMap<>(), false);
+          }
+
+          @Override
+          public MigrationTransformationResponse transformFailedSpannerMutation(
+              MigrationTransformationRequest request) {
+            return new MigrationTransformationResponse(new HashMap<>(), false);
+          }
+        };
+
+    GenericRecordTypeConvertor genericRecordTypeConvertor =
+        new GenericRecordTypeConvertor(schemaMapper, "", null, customTransformer);
+
+    Schema payloadSchema =
+        SchemaBuilder.record("payload")
+            .fields()
+            .name("id")
+            .type(Schema.create(Schema.Type.LONG))
+            .noDefault()
+            .name("dropped_col")
+            .type(Schema.create(Schema.Type.STRING))
+            .noDefault()
+            .endRecord();
+
+    GenericRecord payload =
+        new GenericRecordBuilder(payloadSchema)
+            .set("id", 1L)
+            .set("dropped_col", "some_value")
+            .build();
+
+    Map<String, Value> result = genericRecordTypeConvertor.transformChangeEvent(payload, tableName);
+
+    assertThat(result.get("id")).isEqualTo(Value.int64(100L));
+  }
+
   /*
    * Test conversion of Interval Nano to String for various cases.
    */


### PR DESCRIPTION
https://b.corp.google.com/issues/491398071
When running sourcedb-to-spanner with custom transformations, if a source column is dropped in Spanner (i.e., not present in the Spanner schema), GenericRecordTypeConvertor.genericRecordToMap fails with NoSuchElementException. This happens because it attempts to resolve the Spanner column name and annotations for every field in the source record without catching exceptions for unmapped columns.

DLQ Entry:
```
{"message":{"_metadata_source_type":"mysql","_metadata_read_timestamp":1773135954151740,"_metadata_change_type":"UPDATE-INSERT","_metadata_timestamp":1773135954151740,"_metadata_shard_id":"shard0_db","CreditLimit":"2000.00","LegacyRegion":"EAST","CustomerId":4,"CustomerName":"David E.","_metadata_table":"Customers","_metadata_dataflow_timestamp":1773135954151740},"error_message":"TransformationFailed: java.util.NoSuchElementException: Resolved Spanner column 'LegacyRegion' (from source column 'Customers.LegacyRegion') not found in Spanner table 'Customers' in DDL.\njava.util.NoSuchElementException: Resolved Spanner column 'LegacyRegion' (from source column 'Customers.LegacyRegion') not found in Spanner table 'Customers' in DDL.\n\tat com.google.cloud.teleport.v2.spanner.migrations.schema.SchemaFileOverridesBasedMapper.getSpannerColumnName(SchemaFileOverridesBasedMapper.java:118)\n\tat com.google.cloud.teleport.v2.spanner.migrations.avro.GenericRecordTypeConvertor.genericRecordToMap(GenericRecordTypeConvertor.java:308)\n\tat com.google.cloud.teleport.v2.spanner.migrations.avro.GenericRecordTypeConvertor.populateCustomTransformations(GenericRecordTypeConvertor.java:255)\n\tat com.google.cloud.teleport.v2.spanner.migrations.avro.GenericRecordTypeConvertor.transformChangeEvent(GenericRecordTypeConvertor.java:136)\n\tat com.google.cloud.teleport.v2.transformer.SourceRowToMutationDoFn.processElement(SourceRowToMutationDoFn.java:104)\n\tat com.google.cloud.teleport.v2.transformer.AutoValue_SourceRowToMutationDoFn$DoFnInvoker.invokeProcessElement(Unknown Source)\n\tat org.apache.beam.fn.harness.FnApiDoFnRunner.processElementForParDo(FnApiDoFnRunner.java:626)\n\tat org.apache.beam.fn.harness.data.PCollectionConsumerRegistry$MultiplexingMetricTrackingFnDataReceiver.accept(PCollectionConsumerRegistry.java:462)\n\tat org.apache.beam.fn.harness.data.PCollectionConsumerRegistry$MultiplexingMetricTrackingFnDataReceiver.accept(PCollectionConsumerRegistry.java:391)\n\tat org.apache.beam.fn.harness.FnApiDoFnRunner.outputTo(FnApiDoFnRunner.java:1319)\n\tat org.apache.beam.fn.harness.FnApiDoFnRunner.access$2700(FnApiDoFnRunner.java:139)\n\tat org.apache.beam.fn.harness.FnApiDoFnRunner$NonWindowObservingProcessBundleContext.output(FnApiDoFnRunner.java:1875)\n\tat org.apache.beam.sdk.io.jdbc.JdbcIO$ReadFn.processElement(JdbcIO.java:1774)\n\tat org.apache.beam.sdk.io.jdbc.JdbcIO$ReadFn$DoFnInvoker.invokeProcessElement(Unknown Source)\n\tat org.apache.beam.fn.harness.FnApiDoFnRunner.processElementForParDo(FnApiDoFnRunner.java:626)\n\tat org.apache.beam.fn.harness.data.PCollectionConsumerRegistry$MetricTrackingFnDataReceiver.accept(PCollectionConsumerRegistry.java:375)\n\tat org.apache.beam.fn.harness.data.PCollectionConsumerRegistry$MetricTrackingFnDataReceiver.accept(PCollectionConsumerRegistry.java:303)\n\tat org.apache.beam.fn.harness.FnApiDoFnRunner.outputTo(FnApiDoFnRunner.java:1319)\n\tat org.apache.beam.fn.harness.FnApiDoFnRunner.access$2700(FnApiDoFnRunner.java:139)\n\tat org.apache.beam.fn.harness.FnApiDoFnRunner$NonWindowObservingProcessBundleContext.output(FnApiDoFnRunner.java:1875)\n\tat org.apache.beam.sdk.transforms.MapElements$2.processElement(MapElements.java:151)\n\tat org.apache.beam.sdk.transforms.MapElements$2$DoFnInvoker.invokeProcessElement(Unknown Source)\n\tat org.apache.beam.fn.harness.FnApiDoFnRunner.processElementForParDo(FnApiDoFnRunner.java:626)\n\tat org.apache.beam.fn.harness.data.PCollectionConsumerRegistry$MetricTrackingFnDataReceiver.accept(PCollectionConsumerRegistry.java:375)\n\tat org.apache.beam.fn.harness.data.PCollectionConsumerRegistry$MetricTrackingFnDataReceiver.accept(PCollectionConsumerRegistry.java:303)\n\tat org.apache.beam.fn.harness.FnApiDoFnRunner.outputTo(FnApiDoFnRunner.java:1319)\n\tat org.apache.beam.fn.harness.FnApiDoFnRunner.access$2700(FnApiDoFnRunner.java:139)\n\tat org.apache.beam.fn.harness.FnApiDoFnRunner$NonWindowObservingProcessBundleContext.lambda$builder$0(FnApiDoFnRunner.java:1864)\n\tat org.apache.beam.sdk.values.WindowedValues$Builder.output(WindowedValues.java:222)\n\tat org.apache.beam.sdk.transforms.Reshuffle$RestoreMetadata$1.processElement(Reshuffle.java:193)\n\tat org.apache.beam.sdk.transforms.Reshuffle$RestoreMetadata$1$DoFnInvoker.invokeProcessElement(Unknown Source)\n\tat org.apache.beam.fn.harness.FnApiDoFnRunner.processElementForParDo(FnApiDoFnRunner.java:626)\n\tat org.apache.beam.fn.harness.data.PCollectionConsumerRegistry$MetricTrackingFnDataReceiver.accept(PCollectionConsumerRegistry.java:375)\n\tat org.apache.beam.fn.harness.data.PCollectionConsumerRegistry$MetricTrackingFnDataReceiver.accept(PCollectionConsumerRegistry.java:303)\n\tat org.apache.beam.fn.harness.FnApiDoFnRunner.outputTo(FnApiDoFnRunner.java:1319)\n\tat org.apache.beam.fn.harness.FnApiDoFnRunner.access$2700(FnApiDoFnRunner.java:139)\n\tat org.apache.beam.fn.harness.FnApiDoFnRunner$NonWindowObservingProcessBundleContext.output(FnApiDoFnRunner.java:1875)\n\tat org.apache.beam.sdk.transforms.Reshuffle$1.processElement(Reshuffle.java:122)\n\tat org.apache.beam.sdk.transforms.Reshuffle$1$DoFnInvoker.invokeProcessElement(Unknown Source)\n\tat org.apache.beam.fn.harness.FnApiDoFnRunner.processElementForParDo(FnApiDoFnRunner.java:626)\n\tat org.apache.beam.fn.harness.data.PCollectionConsumerRegistry$MetricTrackingFnDataReceiver.accept(PCollectionConsumerRegistry.java:375)\n\tat org.apache.beam.fn.harness.data.PCollectionConsumerRegistry$MetricTrackingFnDataReceiver.accept(PCollectionConsumerRegistry.java:303)\n\tat org.apache.beam.fn.harness.BeamFnDataReadRunner.forwardElementToConsumer(BeamFnDataReadRunner.java:228)\n\tat org.apache.beam.sdk.fn.data.BeamFnDataInboundObserver.multiplexElements(BeamFnDataInboundObserver.java:232)\n\tat org.apache.beam.fn.harness.control.ProcessBundleHandler.processBundle(ProcessBundleHandler.java:536)\n\tat org.apache.beam.fn.harness.control.BeamFnControlClient.delegateOnInstructionRequestType(BeamFnControlClient.java:150)\n\tat org.apache.beam.fn.harness.control.BeamFnControlClient$InboundObserver.lambda$onNext$0(BeamFnControlClient.java:115)\n\tat java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)\n\tat java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)\n\tat org.apache.beam.sdk.util.UnboundedScheduledExecutorService$ScheduledFutureTask.run(UnboundedScheduledExecutorService.java:163)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)\n\tat java.base/java.lang.Thread.run(Thread.java:840)\n"}
```

# Testing
- Locally tested by building template: For bulk migration setup with custom transformation and dropped column in Spanner, the above error did not occur and rows correctly migrated to spanner
- Added Unit test: Fails without change, passes with new change