### PR TITLE
feat(graph-size-per-shard): Parallelizing Schema Discovery for 5K Table Support

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/DialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/DialectAdapter.java
@@ -128,4 +128,23 @@ public interface DialectAdapter extends RetriableSchemaDiscovery, UniformSplitte
         .map(jdbcValueMappingsProvider::estimateColumnSize)
         .reduce(0, Integer::sum);
   }
+
+  /**
+   * Utility function that generates a parameterized IN clause string: "(?, ?, ..., ?)".
+   *
+   * @param size number of placeholders.
+   * @return the IN clause string.
+   */
+  static String generateInClause(int size) {
+    Preconditions.checkArgument(size > 0, "size must be greater than 0");
+    StringBuilder sb = new StringBuilder("(");
+    for (int i = 0; i < size; i++) {
+      sb.append("?");
+      if (i < size - 1) {
+        sb.append(",");
+      }
+    }
+    sb.append(")");
+    return sb.toString();
+  }
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapter.java
@@ -37,6 +37,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.re2j.Pattern;
 import java.math.BigDecimal;
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -127,7 +128,8 @@ public final class MysqlDialectAdapter implements DialectAdapter {
                 + "TABLE_TYPE = 'BASE TABLE' AND TABLE_SCHEMA = '%s' ",
             sourceSchemaReference.dbName());
     ImmutableList.Builder<String> tablesBuilder = ImmutableList.builder();
-    try (Statement stmt = dataSource.getConnection().createStatement()) {
+    try (Connection conn = dataSource.getConnection();
+        Statement stmt = conn.createStatement()) {
       ResultSet rs = stmt.executeQuery(tableDiscoveryQuery);
       while (rs.next()) {
         tablesBuilder.add(rs.getString(1));
@@ -187,18 +189,34 @@ public final class MysqlDialectAdapter implements DialectAdapter {
       JdbcSchemaReference sourceSchemaReference,
       ImmutableList<String> tables)
       throws SchemaDiscoveryException, RetriableSchemaDiscoveryException {
+    if (tables.isEmpty()) {
+      return ImmutableMap.of();
+    }
     logger.info(
         String.format(
             "Discovering table schema for Datasource: %s, JdbcSchemaReference: %s, tables: %s",
             dataSource, sourceSchemaReference, tables));
 
-    String discoveryQuery = getSchemaDiscoveryQuery(sourceSchemaReference);
+    String discoveryQuery = getSchemaDiscoveryQuery(sourceSchemaReference, tables.size());
 
-    ImmutableMap.Builder<String, ImmutableMap<String, SourceColumnType>> tableSchemaBuilder =
-        ImmutableMap.<String, ImmutableMap<String, SourceColumnType>>builder();
-    try (PreparedStatement statement =
-        dataSource.getConnection().prepareStatement(discoveryQuery)) {
-      tables.forEach(table -> tableSchemaBuilder.put(table, getTableCols(table, statement)));
+    Map<String, ImmutableMap.Builder<String, SourceColumnType>> builders = new HashMap<>();
+    tables.forEach(table -> builders.put(table, ImmutableMap.builder()));
+
+    try (Connection conn = dataSource.getConnection();
+        PreparedStatement statement = conn.prepareStatement(discoveryQuery)) {
+      statement.setFetchSize(1000);
+      for (int i = 0; i < tables.size(); i++) {
+        statement.setString(i + 1, tables.get(i));
+      }
+      ResultSet rs = statement.executeQuery();
+      while (rs.next()) {
+        String tableName = rs.getString("TABLE_NAME");
+        String colName = rs.getString(InformationSchemaCols.NAME_COL);
+        SourceColumnType colType = resultSetToSourceColumnType(rs);
+        if (builders.containsKey(tableName)) {
+          builders.get(tableName).put(colName, colType);
+        }
+      }
     } catch (SQLTransientConnectionException e) {
       logger.warn(
           String.format(
@@ -225,12 +243,15 @@ public final class MysqlDialectAdapter implements DialectAdapter {
       schemaDiscoveryErrors.inc();
       throw e;
     }
-    ImmutableMap<String, ImmutableMap<String, SourceColumnType>> tableSchema =
-        tableSchemaBuilder.build();
+    ImmutableMap.Builder<String, ImmutableMap<String, SourceColumnType>> result =
+        ImmutableMap.builder();
+    builders.forEach((table, builder) -> result.put(table, builder.build()));
+
+    ImmutableMap<String, ImmutableMap<String, SourceColumnType>> tableSchema = result.build();
     logger.info(
         String.format(
-            "Discovered table schema for Datasource: %s, JdbcSchemaReference: %s, tables: %s, schema: %s",
-            dataSource, sourceSchemaReference, tables, tableSchema));
+            "Discovered table schema for Datasource: %s, JdbcSchemaReference: %s, tables: %s",
+            dataSource, sourceSchemaReference, tables));
 
     return tableSchema;
   }
@@ -251,17 +272,32 @@ public final class MysqlDialectAdapter implements DialectAdapter {
       JdbcSchemaReference sourceSchemaReference,
       ImmutableList<String> tables)
       throws SchemaDiscoveryException, RetriableSchemaDiscoveryException {
+    if (tables.isEmpty()) {
+      return ImmutableMap.of();
+    }
     logger.info(
         String.format(
             "Discovering Indexes for DataSource: %s, JdbcSchemaReference: %s, Tables: %s",
             dataSource, sourceSchemaReference, tables));
-    String discoveryQuery = getIndexDiscoveryQuery(sourceSchemaReference);
-    ImmutableMap.Builder<String, ImmutableList<SourceColumnIndexInfo>> tableIndexesBuilder =
-        ImmutableMap.<String, ImmutableList<SourceColumnIndexInfo>>builder();
+    String discoveryQuery = getIndexDiscoveryQuery(sourceSchemaReference, tables.size());
 
-    try (PreparedStatement statement =
-        dataSource.getConnection().prepareStatement(discoveryQuery)) {
-      tables.forEach(table -> tableIndexesBuilder.put(table, getTableIndexes(table, statement)));
+    Map<String, ImmutableList.Builder<SourceColumnIndexInfo>> builders = new HashMap<>();
+    tables.forEach(table -> builders.put(table, ImmutableList.builder()));
+
+    try (Connection conn = dataSource.getConnection();
+        PreparedStatement statement = conn.prepareStatement(discoveryQuery)) {
+      statement.setFetchSize(1000);
+      for (int i = 0; i < tables.size(); i++) {
+        statement.setString(i + 1, tables.get(i));
+      }
+      ResultSet rs = statement.executeQuery();
+      while (rs.next()) {
+        String tableName = rs.getString("TABLE_NAME");
+        SourceColumnIndexInfo info = resultSetToSourceColumnIndexInfo(rs);
+        if (builders.containsKey(tableName)) {
+          builders.get(tableName).add(info);
+        }
+      }
     } catch (SQLTransientConnectionException e) {
       logger.warn(
           String.format(
@@ -288,35 +324,78 @@ public final class MysqlDialectAdapter implements DialectAdapter {
       schemaDiscoveryErrors.inc();
       throw e;
     }
-    ImmutableMap<String, ImmutableList<SourceColumnIndexInfo>> tableIndexes =
-        tableIndexesBuilder.build();
+    ImmutableMap.Builder<String, ImmutableList<SourceColumnIndexInfo>> result =
+        ImmutableMap.builder();
+    builders.forEach((table, builder) -> result.put(table, builder.build()));
+
+    ImmutableMap<String, ImmutableList<SourceColumnIndexInfo>> tableIndexes = result.build();
     logger.info(
         String.format(
-            "Discovered Indexes for DataSource: %s, JdbcSchemaReference: %s, Tables: %s.\nIndexes: %s",
-            dataSource, sourceSchemaReference, tables, tableIndexes));
+            "Discovered Indexes for DataSource: %s, JdbcSchemaReference: %s, Tables: %s",
+            dataSource, sourceSchemaReference, tables));
     return tableIndexes;
   }
 
-  protected static String getSchemaDiscoveryQuery(JdbcSchemaReference sourceSchemaReference) {
-    return "SELECT "
+  protected static String getSchemaDiscoveryQuery(
+      JdbcSchemaReference sourceSchemaReference, int numTables) {
+    return "SELECT TABLE_NAME, "
         + String.join(",", InformationSchemaCols.colList())
         + " FROM INFORMATION_SCHEMA.Columns WHERE TABLE_SCHEMA = "
         + "'"
         + sourceSchemaReference.dbName()
         + "'"
         + " AND"
-        + " TABLE_NAME = ?";
+        + " TABLE_NAME IN "
+        + DialectAdapter.generateInClause(numTables);
   }
 
   /**
    * Discover Indexed columns and their Collations(if applicable). You could try this on <a href =
-   * https://www.db-fiddle.com/f/kRVPA5jDwZYNj2rsdtif4K/3>db-fiddle</a>
+   * https://www.db-fiddle.com/f/kRVPA5jDwZYNj2rsdtif4K/5>db-fiddle</a>
    *
    * @param sourceSchemaReference
    * @return
    */
-  protected static String getIndexDiscoveryQuery(JdbcSchemaReference sourceSchemaReference) {
-    return "SELECT *"
+  protected static String getIndexDiscoveryQuery(
+      JdbcSchemaReference sourceSchemaReference, int numTables) {
+    // We are selecting only the necessary columns as are quering multiple tables
+    // And we would like the resultset to be crisp.
+    return "SELECT stats.TABLE_NAME, stats.COLUMN_NAME as '"
+        + InformationSchemaStatsCols.COL_NAME_COL
+        + "', "
+        + "stats.INDEX_NAME as '"
+        + InformationSchemaStatsCols.INDEX_NAME_COL
+        + "', "
+        + "stats.SEQ_IN_INDEX as '"
+        + InformationSchemaStatsCols.ORDINAL_POS_COL
+        + "', "
+        + "stats.NON_UNIQUE as '"
+        + InformationSchemaStatsCols.NON_UNIQ_COL
+        + "', "
+        + "stats.CARDINALITY as '"
+        + InformationSchemaStatsCols.CARDINALITY_COL
+        + "', "
+        + "cols.COLUMN_TYPE as '"
+        + InformationSchemaStatsCols.TYPE_COL
+        + "', "
+        + "cols.CHARACTER_MAXIMUM_LENGTH as '"
+        + InformationSchemaStatsCols.CHAR_MAX_LENGTH_COL
+        + "', "
+        + "cols.CHARACTER_SET_NAME as '"
+        + InformationSchemaStatsCols.CHARACTER_SET_COL
+        + "', "
+        + "cols.COLLATION_NAME as '"
+        + InformationSchemaStatsCols.COLLATION_COL
+        + "', "
+        + "cols.DATETIME_PRECISION as '"
+        + InformationSchemaStatsCols.DATETIME_PRECISION_COL
+        + "', "
+        + "collations.PAD_ATTRIBUTE as '"
+        + InformationSchemaStatsCols.PAD_SPACE_COL
+        + "', "
+        + "cols.NUMERIC_SCALE as '"
+        + InformationSchemaStatsCols.NUMERIC_SCALE_COL
+        + "' "
         + " FROM INFORMATION_SCHEMA.STATISTICS stats"
         + " JOIN "
         + "INFORMATION_SCHEMA.COLUMNS cols"
@@ -333,28 +412,8 @@ public final class MysqlDialectAdapter implements DialectAdapter {
         + sourceSchemaReference.dbName()
         + "'"
         + " AND"
-        + " stats.TABLE_NAME = ?";
-  }
-
-  private ImmutableMap<String, SourceColumnType> getTableCols(
-      String table, PreparedStatement statement) throws SchemaDiscoveryException {
-    var colsBuilder = ImmutableMap.<String, SourceColumnType>builder();
-    try {
-      statement.setString(1, table);
-      ResultSet rs = statement.executeQuery();
-      while (rs.next()) {
-        String colName = rs.getString(InformationSchemaCols.NAME_COL);
-        SourceColumnType colType = resultSetToSourceColumnType(rs);
-        colsBuilder.put(colName, colType);
-      }
-    } catch (java.sql.SQLException e) {
-      logger.error(
-          String.format(
-              "Sql error while discovering table schema with statement=%s table=%s, cause=%s",
-              statement, table, e));
-      throw new SchemaDiscoveryException(e);
-    }
-    return colsBuilder.build();
+        + " stats.TABLE_NAME IN "
+        + DialectAdapter.generateInClause(numTables);
   }
 
   private static final ImmutableMap<String, SourceColumnIndexInfo.IndexType> INDEX_TYPE_MAPPING =
@@ -395,8 +454,8 @@ public final class MysqlDialectAdapter implements DialectAdapter {
 
   /**
    * Get the PadSpace attribute from {@link ResultSet} for index discovery query {@link
-   * #getIndexDiscoveryQuery(JdbcSchemaReference)}. This method takes care of the fact that older
-   * versions of MySQL notably Mysql5.7 don't have a {@link
+   * #getIndexDiscoveryQuery(JdbcSchemaReference, int)}. This method takes care of the fact that
+   * older versions of MySQL notably Mysql5.7 don't have a {@link
    * InformationSchemaStatsCols#PAD_SPACE_COL} column and default to PAD SPACE comparisons.
    */
   @VisibleForTesting
@@ -408,113 +467,97 @@ public final class MysqlDialectAdapter implements DialectAdapter {
         return resultSet.getString(InformationSchemaStatsCols.PAD_SPACE_COL);
       }
     }
-    // For MySql5.7 there is no pad-space column
+    // For MySql5.7 there is no pad-space column in the INFORMATION_SCHEMA.COLLATIONS table.
+    // In these older versions, non-binary string comparisons (like VARCHAR) always follow
+    // PAD SPACE rules (where trailing spaces are ignored). We default to this behavior
+    // to ensure correct partitioning across both MySQL 5.7 and 8.x.
     logger.info(
         "Did not find {} column in INFORMATION_SCHEMA.COLLATIONS table. Assuming PAD-SPACE collation for non-binary strings as per MySQL5.7 spec",
         InformationSchemaStatsCols.PAD_SPACE_COL);
     return PAD_SPACE;
   }
 
-  private ImmutableList<SourceColumnIndexInfo> getTableIndexes(
-      String table, PreparedStatement statement) throws SchemaDiscoveryException {
-
-    ImmutableList.Builder<SourceColumnIndexInfo> indexesBuilder =
-        ImmutableList.<SourceColumnIndexInfo>builder();
-    try {
-      statement.setString(1, table);
-      ResultSet rs = statement.executeQuery();
-      while (rs.next()) {
-        String colName = rs.getString(InformationSchemaStatsCols.COL_NAME_COL);
-        String indexName = rs.getString(InformationSchemaStatsCols.INDEX_NAME_COL);
-        boolean isUnique = !rs.getBoolean(InformationSchemaStatsCols.NON_UNIQ_COL);
-        boolean isPrimary = indexName.trim().toUpperCase().equals("PRIMARY");
-        long cardinality = rs.getLong(InformationSchemaStatsCols.CARDINALITY_COL);
-        long ordinalPosition = rs.getLong(InformationSchemaStatsCols.ORDINAL_POS_COL);
-        @Nullable
-        Integer stringMaxLength = rs.getInt(InformationSchemaStatsCols.CHAR_MAX_LENGTH_COL);
-        if (rs.wasNull()) {
-          stringMaxLength = null;
-        }
-        @Nullable String characterSet = rs.getString(InformationSchemaStatsCols.CHARACTER_SET_COL);
-        @Nullable String collation = rs.getString(InformationSchemaStatsCols.COLLATION_COL);
-        @Nullable String padSpace = getPadSpaceString(rs);
-        int numericScale = rs.getInt(InformationSchemaStatsCols.NUMERIC_SCALE_COL);
-        boolean hasNumericScale = !rs.wasNull();
-        @Nullable
-        Integer datetimePrecision = rs.getInt(InformationSchemaStatsCols.DATETIME_PRECISION_COL);
-        if (rs.wasNull()) {
-          datetimePrecision = null;
-        }
-        logger.debug(
-            "Discovered column {} from index {}, isUnique {}, isPrimary {}, cardinality {}, ordinalPosition {}, character-set {}, collation {}, pad-space {}, numericScale {}, datetimePrecision {}",
-            colName,
-            indexName,
-            isUnique,
-            isPrimary,
-            cardinality,
-            ordinalPosition,
-            characterSet,
-            collation,
-            padSpace,
-            numericScale,
-            datetimePrecision);
-        // TODO(vardhanvthigle): MySql 5.7 is always PAD space and does not have PAD_ATTRIBUTE
-        // Column.
-        String columType = normalizeColumnType(rs.getString(InformationSchemaStatsCols.TYPE_COL));
-        IndexType indexType = INDEX_TYPE_MAPPING.getOrDefault(columType, IndexType.OTHER);
-        CollationReference collationReference = null;
-        if (indexType.equals(IndexType.STRING)) {
-          collationReference =
-              CollationReference.builder()
-                  .setDbCharacterSet(escapeMySql(characterSet))
-                  .setDbCollation(escapeMySql(collation))
-                  .setPadSpace(
-                      (padSpace == null) ? false : padSpace.trim().toUpperCase().equals(PAD_SPACE))
-                  .build();
-        } else {
-          stringMaxLength = null;
-        }
-
-        BigDecimal decimalStepSize = null;
-        if (indexType.equals(IndexType.FLOAT) || indexType.equals(IndexType.DOUBLE)) {
-          if (numericScale > 0) {
-            // Example: If scale is 2, decimal step is 0.01
-            decimalStepSize = BigDecimal.ONE.scaleByPowerOfTen(-numericScale);
-          } else if (indexType.equals(IndexType.FLOAT)) {
-            // Trying to pick a sane default 1e-5 (there is no defined default step for float point
-            // type)
-            decimalStepSize = new BigDecimal("0.00001");
-          } else {
-            // Trying to pick a sane default 1e-10 (there is no defined default step for double
-            // type)
-            decimalStepSize = new BigDecimal("0.0000000001");
-          }
-        }
-
-        indexesBuilder.add(
-            SourceColumnIndexInfo.builder()
-                .setColumnName(colName)
-                .setIndexName(indexName)
-                .setIsUnique(isUnique)
-                .setIsPrimary(isPrimary)
-                .setCardinality(cardinality)
-                .setOrdinalPosition(ordinalPosition)
-                .setIndexType(indexType)
-                .setCollationReference(collationReference)
-                .setStringMaxLength(stringMaxLength)
-                .setNumericScale(hasNumericScale ? numericScale : null)
-                .setDecimalStepSize(decimalStepSize)
-                .setDatetimePrecision(datetimePrecision)
-                .build());
-      }
-    } catch (java.sql.SQLException e) {
-      logger.error(
-          String.format(
-              "Sql error while discovering table schema with statement=%s table=%s, cause=%s",
-              statement, table, e));
-      throw new SchemaDiscoveryException(e);
+  private SourceColumnIndexInfo resultSetToSourceColumnIndexInfo(ResultSet rs) throws SQLException {
+    String colName = rs.getString(InformationSchemaStatsCols.COL_NAME_COL);
+    String indexName = rs.getString(InformationSchemaStatsCols.INDEX_NAME_COL);
+    boolean isUnique = !rs.getBoolean(InformationSchemaStatsCols.NON_UNIQ_COL);
+    boolean isPrimary = indexName.trim().toUpperCase().equals("PRIMARY");
+    long cardinality = rs.getLong(InformationSchemaStatsCols.CARDINALITY_COL);
+    long ordinalPosition = rs.getLong(InformationSchemaStatsCols.ORDINAL_POS_COL);
+    @Nullable Integer stringMaxLength = rs.getInt(InformationSchemaStatsCols.CHAR_MAX_LENGTH_COL);
+    if (rs.wasNull()) {
+      stringMaxLength = null;
     }
-    return indexesBuilder.build();
+    @Nullable String characterSet = rs.getString(InformationSchemaStatsCols.CHARACTER_SET_COL);
+    @Nullable String collation = rs.getString(InformationSchemaStatsCols.COLLATION_COL);
+    @Nullable String padSpace = getPadSpaceString(rs);
+    int numericScale = rs.getInt(InformationSchemaStatsCols.NUMERIC_SCALE_COL);
+    boolean hasNumericScale = !rs.wasNull();
+    @Nullable
+    Integer datetimePrecision = rs.getInt(InformationSchemaStatsCols.DATETIME_PRECISION_COL);
+    if (rs.wasNull()) {
+      datetimePrecision = null;
+    }
+    logger.debug(
+        "Discovered column {} from index {}, isUnique {}, isPrimary {}, cardinality {}, ordinalPosition {}, character-set {}, collation {}, pad-space {}, numericScale {}, datetimePrecision {}",
+        colName,
+        indexName,
+        isUnique,
+        isPrimary,
+        cardinality,
+        ordinalPosition,
+        characterSet,
+        collation,
+        padSpace,
+        numericScale,
+        datetimePrecision);
+    // TODO(vardhanvthigle): MySql 5.7 is always PAD space and does not have PAD_ATTRIBUTE
+    // Column.
+    String columType = normalizeColumnType(rs.getString(InformationSchemaStatsCols.TYPE_COL));
+    IndexType indexType = INDEX_TYPE_MAPPING.getOrDefault(columType, IndexType.OTHER);
+    CollationReference collationReference = null;
+    if (indexType.equals(IndexType.STRING)) {
+      collationReference =
+          CollationReference.builder()
+              .setDbCharacterSet(escapeMySql(characterSet))
+              .setDbCollation(escapeMySql(collation))
+              .setPadSpace(
+                  (padSpace == null) ? false : padSpace.trim().toUpperCase().equals(PAD_SPACE))
+              .build();
+    } else {
+      stringMaxLength = null;
+    }
+
+    BigDecimal decimalStepSize = null;
+    if (indexType.equals(IndexType.FLOAT) || indexType.equals(IndexType.DOUBLE)) {
+      if (numericScale > 0) {
+        // Example: If scale is 2, decimal step is 0.01
+        decimalStepSize = BigDecimal.ONE.scaleByPowerOfTen(-numericScale);
+      } else if (indexType.equals(IndexType.FLOAT)) {
+        // Trying to pick a sane default 1e-5 (there is no defined default step for float point
+        // type)
+        decimalStepSize = new BigDecimal("0.00001");
+      } else {
+        // Trying to pick a sane default 1e-10 (there is no defined default step for double
+        // type)
+        decimalStepSize = new BigDecimal("0.0000000001");
+      }
+    }
+
+    return SourceColumnIndexInfo.builder()
+        .setColumnName(colName)
+        .setIndexName(indexName)
+        .setIsUnique(isUnique)
+        .setIsPrimary(isPrimary)
+        .setCardinality(cardinality)
+        .setOrdinalPosition(ordinalPosition)
+        .setIndexType(indexType)
+        .setCollationReference(collationReference)
+        .setStringMaxLength(stringMaxLength)
+        .setNumericScale(hasNumericScale ? numericScale : null)
+        .setDecimalStepSize(decimalStepSize)
+        .setDatetimePrecision(datetimePrecision)
+        .build();
   }
 
   @VisibleForTesting

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/DialectAdapterTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/DialectAdapterTest.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.teleport.v2.source.reader.io.cassandra.iowrapper.CassandraDataSource;
@@ -38,6 +39,19 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class DialectAdapterTest {
   @Mock CassandraSchemaReference mockCassandraSchemaReference;
   @Mock CassandraDataSource mockCassandraDataSource;
+
+  @Test
+  public void testGenerateInClause() {
+    assertThat(DialectAdapter.generateInClause(1)).isEqualTo("(?)");
+    assertThat(DialectAdapter.generateInClause(2)).isEqualTo("(?,?)");
+    assertThat(DialectAdapter.generateInClause(5)).isEqualTo("(?,?,?,?,?)");
+  }
+
+  @Test
+  public void testGenerateInClause_invalidSize() {
+    assertThrows(IllegalArgumentException.class, () -> DialectAdapter.generateInClause(0));
+    assertThrows(IllegalArgumentException.class, () -> DialectAdapter.generateInClause(-1));
+  }
 
   @Test
   public void testMismatchedSource() {

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapterTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/mysql/MysqlDialectAdapterTest.java
@@ -69,7 +69,7 @@ public class MysqlDialectAdapterTest {
     final String testTable = "testTable";
     final JdbcSchemaReference sourceSchemaReference =
         JdbcSchemaReference.builder().setDbName("testDB").build();
-    final ResultSet mockResultSet = getMockInfoSchemaRs();
+    final ResultSet mockResultSet = getMockInfoSchemaRs(testTable);
 
     when(mockDataSource.getConnection()).thenReturn(mockConnection);
     when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
@@ -84,6 +84,37 @@ public class MysqlDialectAdapterTest {
                     SourceSchemaReference.ofJdbc(sourceSchemaReference),
                     ImmutableList.of(testTable)))
         .isEqualTo(getExpectedColumnMapping(testTable));
+  }
+
+  @Test
+  public void testDiscoverTableSchemaBulk() throws SQLException, RetriableSchemaDiscoveryException {
+    final String table1 = "table1";
+    final String table2 = "table2";
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
+
+    final ResultSet mockResultSet = mock(ResultSet.class);
+    when(mockResultSet.next()).thenReturn(true, true, false);
+    when(mockResultSet.getString("TABLE_NAME")).thenReturn(table1, table2);
+    when(mockResultSet.getString(InformationSchemaCols.NAME_COL)).thenReturn("col1", "col2");
+    when(mockResultSet.getString(InformationSchemaCols.TYPE_COL)).thenReturn("int", "int");
+    when(mockResultSet.wasNull()).thenReturn(true, true, true, true, true, true);
+
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+
+    ImmutableMap<String, ImmutableMap<String, SourceColumnType>> result =
+        new MysqlDialectAdapter(MySqlVersion.DEFAULT)
+            .discoverTableSchema(
+                com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource.ofJdbc(
+                    mockDataSource),
+                SourceSchemaReference.ofJdbc(sourceSchemaReference),
+                ImmutableList.of(table1, table2));
+
+    assertThat(result).hasSize(2);
+    assertThat(result).containsKey(table1);
+    assertThat(result).containsKey(table2);
   }
 
   @Test
@@ -192,9 +223,9 @@ public class MysqlDialectAdapterTest {
   public void testGetSchemaDiscoveryQuery() {
     assertThat(
             MysqlDialectAdapter.getSchemaDiscoveryQuery(
-                JdbcSchemaReference.builder().setDbName("testDB").build()))
+                JdbcSchemaReference.builder().setDbName("testDB").build(), 1))
         .isEqualTo(
-            "SELECT COLUMN_NAME,COLUMN_TYPE,CHARACTER_MAXIMUM_LENGTH,NUMERIC_PRECISION,NUMERIC_SCALE FROM INFORMATION_SCHEMA.Columns WHERE TABLE_SCHEMA = 'testDB' AND TABLE_NAME = ?");
+            "SELECT TABLE_NAME, COLUMN_NAME,COLUMN_TYPE,CHARACTER_MAXIMUM_LENGTH,NUMERIC_PRECISION,NUMERIC_SCALE FROM INFORMATION_SCHEMA.Columns WHERE TABLE_SCHEMA = 'testDB' AND TABLE_NAME IN (?)");
   }
 
   @Test
@@ -318,6 +349,7 @@ public class MysqlDialectAdapterTest {
 
     wireMockResultSet(
         colTypes, getExpectedSourceColumnIndexInfosForBasicIndexes(true), mockResultSet);
+    when(mockResultSet.getString("TABLE_NAME")).thenReturn(testTables.get(0));
 
     ImmutableMap<String, ImmutableList<SourceColumnIndexInfo>> discoveredIndexes =
         new MysqlDialectAdapter(MySqlVersion.DEFAULT)
@@ -329,6 +361,46 @@ public class MysqlDialectAdapterTest {
 
     assertThat(discoveredIndexes)
         .isEqualTo(ImmutableMap.of(testTables.get(0), expectedSourceColumnIndexInfos));
+  }
+
+  @Test
+  public void testDiscoverTableIndexesBulk()
+      throws SQLException, RetriableSchemaDiscoveryException {
+    final String table1 = "table1";
+    final String table2 = "table2";
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
+
+    final ResultSet mockResultSet = mock(ResultSet.class);
+    when(mockResultSet.next()).thenReturn(true, true, false);
+    when(mockResultSet.getString("TABLE_NAME")).thenReturn(table1, table2);
+    when(mockResultSet.getMetaData()).thenReturn(mock(ResultSetMetaData.class));
+    when(mockResultSet.getString(InformationSchemaStatsCols.COL_NAME_COL))
+        .thenReturn("col1", "col2");
+    when(mockResultSet.getString(InformationSchemaStatsCols.INDEX_NAME_COL))
+        .thenReturn("pk1", "pk2");
+    when(mockResultSet.getBoolean(InformationSchemaStatsCols.NON_UNIQ_COL))
+        .thenReturn(false, false);
+    when(mockResultSet.getLong(InformationSchemaStatsCols.CARDINALITY_COL)).thenReturn(10L, 20L);
+    when(mockResultSet.getLong(InformationSchemaStatsCols.ORDINAL_POS_COL)).thenReturn(1L, 1L);
+    when(mockResultSet.getString(InformationSchemaStatsCols.TYPE_COL)).thenReturn("int", "int");
+    when(mockResultSet.wasNull()).thenReturn(true, true, true, true, true, true);
+
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+
+    ImmutableMap<String, ImmutableList<SourceColumnIndexInfo>> result =
+        new MysqlDialectAdapter(MySqlVersion.DEFAULT)
+            .discoverTableIndexes(
+                com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource.ofJdbc(
+                    mockDataSource),
+                SourceSchemaReference.ofJdbc(sourceSchemaReference),
+                ImmutableList.of(table1, table2));
+
+    assertThat(result).hasSize(2);
+    assertThat(result).containsKey(table1);
+    assertThat(result).containsKey(table2);
   }
 
   private ImmutableList<SourceColumnIndexInfo> getExpectedSourceColumnIndexInfosForBasicIndexes(
@@ -538,9 +610,14 @@ public class MysqlDialectAdapterTest {
     when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
 
     wireMockResultSet(colTypes, expectedSourceColumnIndexInfos, mockResultSet);
+    when(mockResultSet.getString("TABLE_NAME")).thenReturn(testTables.get(0));
     ImmutableMap<String, ImmutableList<SourceColumnIndexInfo>> discoveredIndexes =
         new MysqlDialectAdapter(MySqlVersion.DEFAULT)
-            .discoverTableIndexes(mockDataSource, sourceSchemaReference, testTables);
+            .discoverTableIndexes(
+                com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource.ofJdbc(
+                    mockDataSource),
+                SourceSchemaReference.ofJdbc(sourceSchemaReference),
+                testTables);
 
     assertThat(discoveredIndexes)
         .isEqualTo(ImmutableMap.of(testTables.get(0), expectedSourceColumnIndexInfos));
@@ -651,9 +728,9 @@ public class MysqlDialectAdapterTest {
   public void testGetIndexDiscoveryQuery() {
     assertThat(
             MysqlDialectAdapter.getIndexDiscoveryQuery(
-                JdbcSchemaReference.builder().setDbName("testDB").build()))
+                JdbcSchemaReference.builder().setDbName("testDB").build(), 1))
         .isEqualTo(
-            "SELECT * FROM INFORMATION_SCHEMA.STATISTICS stats JOIN INFORMATION_SCHEMA.COLUMNS cols ON stats.table_schema = cols.table_schema AND stats.table_name = cols.table_name AND stats.column_name = cols.column_name LEFT JOIN INFORMATION_SCHEMA.COLLATIONS collations ON cols.COLLATION_NAME = collations.COLLATION_NAME WHERE stats.TABLE_SCHEMA = 'testDB' AND stats.TABLE_NAME = ?");
+            "SELECT stats.TABLE_NAME, stats.COLUMN_NAME as 'stats.COLUMN_NAME', stats.INDEX_NAME as 'stats.INDEX_NAME', stats.SEQ_IN_INDEX as 'stats.SEQ_IN_INDEX', stats.NON_UNIQUE as 'stats.NON_UNIQUE', stats.CARDINALITY as 'stats.CARDINALITY', cols.COLUMN_TYPE as 'cols.COLUMN_TYPE', cols.CHARACTER_MAXIMUM_LENGTH as 'cols.CHARACTER_MAXIMUM_LENGTH', cols.CHARACTER_SET_NAME as 'cols.CHARACTER_SET_NAME', cols.COLLATION_NAME as 'cols.COLLATION_NAME', cols.DATETIME_PRECISION as 'cols.DATETIME_PRECISION', collations.PAD_ATTRIBUTE as 'collations.PAD_ATTRIBUTE', cols.NUMERIC_SCALE as 'cols.NUMERIC_SCALE'  FROM INFORMATION_SCHEMA.STATISTICS stats JOIN INFORMATION_SCHEMA.COLUMNS cols ON stats.table_schema = cols.table_schema AND stats.table_name = cols.table_name AND stats.column_name = cols.column_name LEFT JOIN INFORMATION_SCHEMA.COLLATIONS collations ON cols.COLLATION_NAME = collations.COLLATION_NAME WHERE stats.TABLE_SCHEMA = 'testDB' AND stats.TABLE_NAME IN (?)");
   }
 
   @Test
@@ -795,28 +872,229 @@ public class MysqlDialectAdapterTest {
         .isEqualTo(java.time.Duration.ofHours(-838).minusMinutes(59).minusSeconds(59));
   }
 
-  private static ResultSet getMockInfoSchemaRs() throws SQLException {
+  public void testGetCollationsOrderQuery() {
+    MysqlDialectAdapter adapter = new MysqlDialectAdapter(MySqlVersion.DEFAULT);
+    String dbCharset = "utf8mb4";
+    String dbCollation = "utf8mb4_0900_ai_ci";
+    boolean padSpace = true; // padSpace doesn't affect the query string in MySQL implementation
+
+    String query = adapter.getCollationsOrderQuery(dbCharset, dbCollation, padSpace);
+
+    assertThat(query).contains("'" + dbCharset + "'");
+    assertThat(query).contains("'" + dbCollation + "'");
+  }
+
+  @Test
+  public void testEscapeMySql() {
+    assertThat(MysqlDialectAdapter.escapeMySql("binary")).isEqualTo("`binary`");
+    assertThat(MysqlDialectAdapter.escapeMySql("`binary`")).isEqualTo("`binary`");
+  }
+
+  @Test
+  public void testDiscoverTableSchema_emptyTableList()
+      throws SQLException, RetriableSchemaDiscoveryException {
+    JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
+    MysqlDialectAdapter adapter = new MysqlDialectAdapter(MySqlVersion.DEFAULT);
+    ImmutableMap<String, ImmutableMap<String, SourceColumnType>> result =
+        adapter.discoverTableSchema(
+            com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource.ofJdbc(
+                mockDataSource),
+            SourceSchemaReference.ofJdbc(sourceSchemaReference),
+            ImmutableList.of());
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void testDiscoverTableIndexes_emptyTableList()
+      throws SQLException, RetriableSchemaDiscoveryException {
+    JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
+    MysqlDialectAdapter adapter = new MysqlDialectAdapter(MySqlVersion.DEFAULT);
+    ImmutableMap<String, ImmutableList<SourceColumnIndexInfo>> result =
+        adapter.discoverTableIndexes(
+            com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource.ofJdbc(
+                mockDataSource),
+            SourceSchemaReference.ofJdbc(sourceSchemaReference),
+            ImmutableList.of());
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void testDiscoverTableSchema_skipsExtraTables()
+      throws SQLException, RetriableSchemaDiscoveryException {
+    final String table1 = "table1";
+    final String extraTable = "extraTable";
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
+
+    final ResultSet mockResultSet = mock(ResultSet.class);
+    when(mockResultSet.next()).thenReturn(true, true, false);
+    when(mockResultSet.getString("TABLE_NAME")).thenReturn(table1, extraTable);
+    when(mockResultSet.getString(InformationSchemaCols.NAME_COL)).thenReturn("col1", "col2");
+    when(mockResultSet.getString(InformationSchemaCols.TYPE_COL)).thenReturn("int", "int");
+    when(mockResultSet.wasNull()).thenReturn(true, true, true, true, true, true);
+
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+
+    ImmutableMap<String, ImmutableMap<String, SourceColumnType>> result =
+        new MysqlDialectAdapter(MySqlVersion.DEFAULT)
+            .discoverTableSchema(
+                com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource.ofJdbc(
+                    mockDataSource),
+                SourceSchemaReference.ofJdbc(sourceSchemaReference),
+                ImmutableList.of(table1));
+
+    assertThat(result).hasSize(1);
+    assertThat(result).containsKey(table1);
+    assertThat(result).doesNotContainKey(extraTable);
+  }
+
+  @Test
+  public void testDiscoverTableIndexes_skipsExtraTables()
+      throws SQLException, RetriableSchemaDiscoveryException {
+    final String table1 = "table1";
+    final String extraTable = "extraTable";
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
+
+    final ResultSet mockResultSet = mock(ResultSet.class);
+    when(mockResultSet.next()).thenReturn(true, true, false);
+    when(mockResultSet.getString("TABLE_NAME")).thenReturn(table1, extraTable);
+    when(mockResultSet.getMetaData()).thenReturn(mock(ResultSetMetaData.class));
+    when(mockResultSet.getString(InformationSchemaStatsCols.COL_NAME_COL))
+        .thenReturn("col1", "col2");
+    when(mockResultSet.getString(InformationSchemaStatsCols.INDEX_NAME_COL))
+        .thenReturn("pk1", "pk2");
+    when(mockResultSet.getBoolean(InformationSchemaStatsCols.NON_UNIQ_COL))
+        .thenReturn(false, false);
+    when(mockResultSet.getLong(InformationSchemaStatsCols.CARDINALITY_COL)).thenReturn(10L, 20L);
+    when(mockResultSet.getLong(InformationSchemaStatsCols.ORDINAL_POS_COL)).thenReturn(1L, 1L);
+    when(mockResultSet.getString(InformationSchemaStatsCols.TYPE_COL)).thenReturn("int", "int");
+    when(mockResultSet.wasNull()).thenReturn(true, true, true, true, true, true);
+
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+
+    ImmutableMap<String, ImmutableList<SourceColumnIndexInfo>> result =
+        new MysqlDialectAdapter(MySqlVersion.DEFAULT)
+            .discoverTableIndexes(
+                com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource.ofJdbc(
+                    mockDataSource),
+                SourceSchemaReference.ofJdbc(sourceSchemaReference),
+                ImmutableList.of(table1));
+
+    assertThat(result).hasSize(1);
+    assertThat(result).containsKey(table1);
+    assertThat(result).doesNotContainKey(extraTable);
+  }
+
+  @Test
+  public void testGetPadSpaceString() throws SQLException {
+    MysqlDialectAdapter adapter = new MysqlDialectAdapter(MySqlVersion.DEFAULT);
+    ResultSet mockRs = mock(ResultSet.class);
+    ResultSetMetaData mockMd = mock(ResultSetMetaData.class);
+    when(mockRs.getMetaData()).thenReturn(mockMd);
+
+    // Case 1: Column exists, returns value
+    when(mockMd.getColumnCount()).thenReturn(1);
+    when(mockMd.getColumnName(1)).thenReturn(InformationSchemaStatsCols.PAD_SPACE_COL);
+    when(mockRs.getString(InformationSchemaStatsCols.PAD_SPACE_COL)).thenReturn("NO PAD");
+    assertThat(adapter.getPadSpaceString(mockRs)).isEqualTo("NO PAD");
+
+    // Case 2: Column exists, returns null
+    when(mockRs.getString(InformationSchemaStatsCols.PAD_SPACE_COL)).thenReturn(null);
+    assertThat(adapter.getPadSpaceString(mockRs)).isNull();
+
+    // Case 3: Column does not exist, returns PAD SPACE
+    when(mockMd.getColumnCount()).thenReturn(0);
+    assertThat(adapter.getPadSpaceString(mockRs)).isEqualTo(MysqlDialectAdapter.PAD_SPACE);
+  }
+
+  @Test
+  public void testResultSetToSourceColumnIndexInfo_padSpace()
+      throws SQLException, RetriableSchemaDiscoveryException {
+    final String testTable = "testTable";
+    final JdbcSchemaReference sourceSchemaReference =
+        JdbcSchemaReference.builder().setDbName("testDB").build();
+
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+    doNothing().when(mockPreparedStatement).setString(1, testTable);
+
+    // We'll run this with different padSpace return values
+    String[] padSpaceValues = {null, "PAD SPACE", "NO PAD"};
+    Boolean[] expectedPadSpace = {false, true, false};
+
+    for (int i = 0; i < padSpaceValues.length; i++) {
+      final ResultSet mockResultSet = mock(ResultSet.class);
+      ResultSetMetaData mockMd = mock(ResultSetMetaData.class);
+      when(mockResultSet.getMetaData()).thenReturn(mockMd);
+      when(mockMd.getColumnCount()).thenReturn(1);
+      when(mockMd.getColumnName(1)).thenReturn(InformationSchemaStatsCols.PAD_SPACE_COL);
+      when(mockResultSet.getString(InformationSchemaStatsCols.PAD_SPACE_COL))
+          .thenReturn(padSpaceValues[i]);
+
+      when(mockResultSet.next()).thenReturn(true, false);
+      when(mockResultSet.getString("TABLE_NAME")).thenReturn(testTable);
+      when(mockResultSet.getString(InformationSchemaStatsCols.COL_NAME_COL)).thenReturn("col1");
+      when(mockResultSet.getString(InformationSchemaStatsCols.INDEX_NAME_COL)).thenReturn("pk");
+      when(mockResultSet.getBoolean(InformationSchemaStatsCols.NON_UNIQ_COL)).thenReturn(false);
+      when(mockResultSet.getLong(InformationSchemaStatsCols.CARDINALITY_COL)).thenReturn(10L);
+      when(mockResultSet.getLong(InformationSchemaStatsCols.ORDINAL_POS_COL)).thenReturn(1L);
+      when(mockResultSet.getString(InformationSchemaStatsCols.TYPE_COL)).thenReturn("varchar(10)");
+      when(mockResultSet.getInt(InformationSchemaStatsCols.CHAR_MAX_LENGTH_COL)).thenReturn(10);
+      when(mockResultSet.getString(InformationSchemaStatsCols.CHARACTER_SET_COL))
+          .thenReturn("utf8");
+      when(mockResultSet.getString(InformationSchemaStatsCols.COLLATION_COL))
+          .thenReturn("utf8_general_ci");
+      when(mockResultSet.wasNull())
+          .thenReturn(false, true, true); // for charMaxLength, scale, precision
+
+      when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+
+      ImmutableMap<String, ImmutableList<SourceColumnIndexInfo>> result =
+          new MysqlDialectAdapter(MySqlVersion.DEFAULT)
+              .discoverTableIndexes(
+                  com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource.ofJdbc(
+                      mockDataSource),
+                  SourceSchemaReference.ofJdbc(sourceSchemaReference),
+                  ImmutableList.of(testTable));
+
+      assertThat(result.get(testTable).get(0).collationReference().padSpace())
+          .isEqualTo(expectedPadSpace[i]);
+    }
+  }
+
+  private static ResultSet getMockInfoSchemaRs(String tableName) throws SQLException {
     return new MockRSBuilder(
             MockInformationSchema.builder()
                 /* Row of Information Schema Table */
+                .withTableName(tableName)
                 .withColName("int_col")
                 .withDataType("int")
                 .withCharMaxLength(null)
                 .withNumericPrecision(null)
                 .withNumericScale(null)
                 /* Row of Information Schema Table */
+                .withTableName(tableName)
                 .withColName("varbinary_col")
                 .withDataType("varbinary(10)")
                 .withCharMaxLength(10L)
                 .withNumericPrecision(null)
                 .withNumericScale(null)
                 /* Row of Information Schema Table */
+                .withTableName(tableName)
                 .withColName("dec_precision_col")
                 .withDataType("dec(10)")
                 .withCharMaxLength(null)
                 .withNumericPrecision(10L)
                 .withNumericScale(null)
                 /* Row of Information Schema Table. */
+                .withTableName(tableName)
                 .withColName("dec_precision_scale_col")
                 .withDataType("dec")
                 .withCharMaxLength(null)
@@ -824,6 +1102,7 @@ public class MysqlDialectAdapterTest {
                 .withNumericScale(5L)
                 /* Test DataType normalizations */
                 /* Row of Information Schema Table.*/
+                .withTableName(tableName)
                 .withColName("tinyint_col")
                 .withDataType("Tinyint(1)")
                 .withCharMaxLength(null)
@@ -831,6 +1110,7 @@ public class MysqlDialectAdapterTest {
                 .withNumericScale(null)
 
                 /* Row of Information Schema Table.*/
+                .withTableName(tableName)
                 .withColName("bigint_col")
                 .withDataType("BIGINT(20)")
                 .withCharMaxLength(null)
@@ -838,6 +1118,7 @@ public class MysqlDialectAdapterTest {
                 .withNumericScale(null)
 
                 /* Row of Information Schema Table.*/
+                .withTableName(tableName)
                 .withColName("bigint_unsigned_col")
                 .withDataType("BIGINT(20) UNSIGNED")
                 .withCharMaxLength(null)
@@ -845,11 +1126,13 @@ public class MysqlDialectAdapterTest {
                 .withNumericScale(null)
 
                 /* Row of Information Schema Table.*/
+                .withTableName(tableName)
                 .withColName("int_unsigned_col")
                 .withDataType("int(20) UNSIGNED")
                 .withCharMaxLength(null)
                 .withNumericPrecision(null)
                 .withNumericScale(null)
+                .withTableName(tableName)
                 .withColName("tiny_int_unsigned_col")
                 .withDataType("tinyint(20) UNSIGNED")
                 .withCharMaxLength(null)
@@ -880,12 +1163,6 @@ public class MysqlDialectAdapterTest {
             .put("tiny_int_unsigned_col", new SourceColumnType("TINYINT", new Long[] {}, null))
             .build());
   }
-
-  @Test
-  public void testEscapeMySql() {
-    assertThat(MysqlDialectAdapter.escapeMySql("binary")).isEqualTo("`binary`");
-    assertThat(MysqlDialectAdapter.escapeMySql("`binary`")).isEqualTo("`binary`");
-  }
 }
 
 class MockRSBuilder {
@@ -910,6 +1187,14 @@ class MockRSBuilder {
             })
         .when(rs)
         .next();
+
+    // mock rs.getString("TABLE_NAME");
+    doAnswer(
+            invocation -> {
+              return schema.tableNames().get(rowIndex);
+            })
+        .when(rs)
+        .getString("TABLE_NAME");
 
     // mock rs.getString("COLUMN_NAME");
     doAnswer(
@@ -961,6 +1246,8 @@ class MockRSBuilder {
 
 @AutoValue
 abstract class MockInformationSchema {
+  abstract ImmutableList<String> tableNames();
+
   abstract ImmutableList<String> colNames();
 
   abstract ImmutableList<String> dataTypes();
@@ -984,6 +1271,8 @@ abstract class MockInformationSchema {
   @AutoValue.Builder
   abstract static class Builder {
 
+    abstract ImmutableList.Builder<String> tableNamesBuilder();
+
     abstract ImmutableList.Builder<String> colNamesBuilder();
 
     abstract ImmutableList.Builder<String> dataTypesBuilder();
@@ -999,6 +1288,11 @@ abstract class MockInformationSchema {
     abstract ImmutableList.Builder<Long> numericScalesBuilder();
 
     abstract ImmutableList.Builder<Boolean> numericScaleWasNullsBuilder();
+
+    public Builder withTableName(String tableName) {
+      this.tableNamesBuilder().add(tableName);
+      return this;
+    }
 
     public Builder withColName(String colName) {
       this.colNamesBuilder().add(colName);

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaDiscoveryImplTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/SchemaDiscoveryImplTest.java
@@ -25,13 +25,19 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.teleport.v2.source.reader.io.datasource.DataSource;
 import com.google.cloud.teleport.v2.source.reader.io.exception.RetriableSchemaDiscoveryException;
+import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryException;
 import com.google.cloud.teleport.v2.source.reader.io.exception.SchemaDiscoveryRetriesExhaustedException;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceColumnIndexInfo.IndexType;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.SQLTransientConnectionException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import org.apache.beam.sdk.util.BackOff;
 import org.apache.beam.sdk.util.FluentBackoff;
 import org.joda.time.Duration;
@@ -51,14 +57,164 @@ public class SchemaDiscoveryImplTest {
   @Mock SourceSchemaReference mockSourceSchemaReference;
 
   @Test
+  public void testConvertException_SchemaDiscoveryException() {
+    SchemaDiscoveryException expected = new SchemaDiscoveryException(new RuntimeException("test"));
+    SchemaDiscoveryException actual =
+        assertThrows(
+            SchemaDiscoveryException.class, () -> SchemaDiscoveryImpl.convertException(expected));
+    assertThat(actual).isSameInstanceAs(expected);
+  }
+
+  @Test
+  public void testConvertException_SchemaDiscoveryRetriesExhaustedException() {
+    SchemaDiscoveryRetriesExhaustedException expected =
+        new SchemaDiscoveryRetriesExhaustedException(new RuntimeException("test"));
+    SchemaDiscoveryRetriesExhaustedException actual =
+        assertThrows(
+            SchemaDiscoveryRetriesExhaustedException.class,
+            () -> SchemaDiscoveryImpl.convertException(expected));
+    assertThat(actual).isSameInstanceAs(expected);
+  }
+
+  @Test
+  public void testConvertException_NestedSchemaDiscoveryException() {
+    SchemaDiscoveryException expected = new SchemaDiscoveryException(new RuntimeException("test"));
+    RuntimeException wrapper = new RuntimeException(new CompletionException(expected));
+    SchemaDiscoveryException actual =
+        assertThrows(
+            SchemaDiscoveryException.class, () -> SchemaDiscoveryImpl.convertException(wrapper));
+    assertThat(actual).isSameInstanceAs(expected);
+  }
+
+  @Test
+  public void testConvertException_NestedRetriesExhaustedException() {
+    SchemaDiscoveryRetriesExhaustedException expected =
+        new SchemaDiscoveryRetriesExhaustedException(new RuntimeException("test"));
+    ExecutionException wrapper = new ExecutionException(new RuntimeException(expected));
+    SchemaDiscoveryRetriesExhaustedException actual =
+        assertThrows(
+            SchemaDiscoveryRetriesExhaustedException.class,
+            () -> SchemaDiscoveryImpl.convertException(wrapper));
+    assertThat(actual).isSameInstanceAs(expected);
+  }
+
+  @Test
+  public void testConvertException_GenericException() {
+    IOException generic = new IOException("generic");
+    SchemaDiscoveryException actual =
+        assertThrows(
+            SchemaDiscoveryException.class, () -> SchemaDiscoveryImpl.convertException(generic));
+    assertThat(actual.getCause()).isSameInstanceAs(generic);
+  }
+
+  @Test
+  public void testConvertException_NestedGenericException() {
+    IOException generic = new IOException("generic");
+    RuntimeException wrapper = new RuntimeException(new ExecutionException(generic));
+    SchemaDiscoveryException actual =
+        assertThrows(
+            SchemaDiscoveryException.class, () -> SchemaDiscoveryImpl.convertException(wrapper));
+    assertThat(actual.getCause()).isSameInstanceAs(wrapper);
+  }
+
+  @Test
+  public void testConvertException_NullExceptionCause() {
+    RuntimeException wrapper = new RuntimeException((Throwable) null);
+    SchemaDiscoveryException actual =
+        assertThrows(
+            SchemaDiscoveryException.class, () -> SchemaDiscoveryImpl.convertException(wrapper));
+    assertThat(actual.getCause()).isSameInstanceAs(wrapper);
+  }
+
+  @Test
+  public void testDiscoverTableSchema_EmptyTables() {
+    SchemaDiscoveryImpl schemaDiscovery =
+        new SchemaDiscoveryImpl(mockRetriableSchemaDiscovery, FluentBackoff.DEFAULT);
+    assertThat(
+            schemaDiscovery.discoverTableSchema(
+                mockDataSource, mockSourceSchemaReference, ImmutableList.of()))
+        .isEmpty();
+  }
+
+  @Test
+  public void testDiscoverTableIndexes_EmptyTables() {
+    SchemaDiscoveryImpl schemaDiscovery =
+        new SchemaDiscoveryImpl(mockRetriableSchemaDiscovery, FluentBackoff.DEFAULT);
+    assertThat(
+            schemaDiscovery.discoverTableIndexes(
+                mockDataSource, mockSourceSchemaReference, ImmutableList.of()))
+        .isEmpty();
+  }
+
+  @Test
+  public void testDiscoverTableSchema_ExceptionInFuture() throws RetriableSchemaDiscoveryException {
+    SchemaDiscoveryImpl schemaDiscovery =
+        new SchemaDiscoveryImpl(mockRetriableSchemaDiscovery, FluentBackoff.DEFAULT);
+    when(mockRetriableSchemaDiscovery.discoverTableSchema(any(), any(), any()))
+        .thenThrow(new SchemaDiscoveryException(new RuntimeException("test")));
+
+    assertThrows(
+        SchemaDiscoveryException.class,
+        () ->
+            schemaDiscovery.discoverTableSchema(
+                mockDataSource, mockSourceSchemaReference, ImmutableList.of("testTable")));
+  }
+
+  @Test
+  public void testDiscoverTableSchema_RetriesExhaustedExceptionInFuture()
+      throws RetriableSchemaDiscoveryException {
+    SchemaDiscoveryImpl schemaDiscovery =
+        new SchemaDiscoveryImpl(mockRetriableSchemaDiscovery, FluentBackoff.DEFAULT);
+    when(mockRetriableSchemaDiscovery.discoverTableSchema(any(), any(), any()))
+        .thenThrow(new SchemaDiscoveryRetriesExhaustedException(new RuntimeException("test")));
+
+    assertThrows(
+        SchemaDiscoveryRetriesExhaustedException.class,
+        () ->
+            schemaDiscovery.discoverTableSchema(
+                mockDataSource, mockSourceSchemaReference, ImmutableList.of("testTable")));
+  }
+
+  @Test
+  public void testDiscoverTableIndexes_ExceptionInFuture()
+      throws RetriableSchemaDiscoveryException {
+    SchemaDiscoveryImpl schemaDiscovery =
+        new SchemaDiscoveryImpl(mockRetriableSchemaDiscovery, FluentBackoff.DEFAULT);
+    when(mockRetriableSchemaDiscovery.discoverTableIndexes(any(), any(), any()))
+        .thenThrow(new SchemaDiscoveryException(new RuntimeException("test")));
+
+    assertThrows(
+        SchemaDiscoveryException.class,
+        () ->
+            schemaDiscovery.discoverTableIndexes(
+                mockDataSource, mockSourceSchemaReference, ImmutableList.of("testTable")));
+  }
+
+  @Test
+  public void testDiscoverTableIndexes_RetriesExhaustedExceptionInFuture()
+      throws RetriableSchemaDiscoveryException {
+    SchemaDiscoveryImpl schemaDiscovery =
+        new SchemaDiscoveryImpl(mockRetriableSchemaDiscovery, FluentBackoff.DEFAULT);
+    when(mockRetriableSchemaDiscovery.discoverTableIndexes(any(), any(), any()))
+        .thenThrow(new SchemaDiscoveryRetriesExhaustedException(new RuntimeException("test")));
+
+    assertThrows(
+        SchemaDiscoveryRetriesExhaustedException.class,
+        () ->
+            schemaDiscovery.discoverTableIndexes(
+                mockDataSource, mockSourceSchemaReference, ImmutableList.of("testTable")));
+  }
+
+  @Test
   public void testSchemaDiscoveryImpl() throws RetriableSchemaDiscoveryException {
     final int testRetryCount = 2;
     final int expectedCallsCount = testRetryCount + 1;
+    final ImmutableList<String> tables = ImmutableList.of("testTable");
     when(mockRetriableSchemaDiscovery.discoverTableSchema(
-            mockDataSource, mockSourceSchemaReference, ImmutableList.of()))
+            mockDataSource, mockSourceSchemaReference, tables))
         .thenThrow(new RetriableSchemaDiscoveryException(new SQLTransientConnectionException()))
         .thenThrow(new RetriableSchemaDiscoveryException(new SQLTransientConnectionException()))
-        .thenReturn(ImmutableMap.of());
+        .thenReturn(ImmutableMap.of("testTable", ImmutableMap.of()));
     assertThat(
             new SchemaDiscoveryImpl(
                     mockRetriableSchemaDiscovery,
@@ -66,8 +222,8 @@ public class SchemaDiscoveryImplTest {
                         .withInitialBackoff(Duration.millis(10L))
                         .withExponent(1)
                         .withMaxRetries(testRetryCount))
-                .discoverTableSchema(mockDataSource, mockSourceSchemaReference, ImmutableList.of()))
-        .isEqualTo(ImmutableMap.of());
+                .discoverTableSchema(mockDataSource, mockSourceSchemaReference, tables))
+        .isEqualTo(ImmutableMap.of("testTable", ImmutableMap.of()));
     verify(mockRetriableSchemaDiscovery, times(expectedCallsCount))
         .discoverTableSchema(any(), any(), any());
   }
@@ -78,19 +234,19 @@ public class SchemaDiscoveryImplTest {
 
     final FluentBackoff mockFluentBackoff = mock(FluentBackoff.class);
     final BackOff mockBackoff = mock(BackOff.class);
+    final ImmutableList<String> tables = ImmutableList.of("testTable");
 
     when(mockFluentBackoff.backoff()).thenReturn(mockBackoff);
     when(mockBackoff.nextBackOffMillis()).thenThrow(new RuntimeException("test"));
     when(mockRetriableSchemaDiscovery.discoverTableSchema(
-            mockDataSource, mockSourceSchemaReference, ImmutableList.of()))
+            mockDataSource, mockSourceSchemaReference, tables))
         .thenThrow(new RetriableSchemaDiscoveryException(new SQLTransientConnectionException()));
 
     assertThrows(
         SchemaDiscoveryRetriesExhaustedException.class,
         () ->
             new SchemaDiscoveryImpl(mockRetriableSchemaDiscovery, mockFluentBackoff)
-                .discoverTableSchema(
-                    mockDataSource, mockSourceSchemaReference, ImmutableList.of()));
+                .discoverTableSchema(mockDataSource, mockSourceSchemaReference, tables));
     verify(mockRetriableSchemaDiscovery, times(1 /* No Retries */))
         .discoverTableSchema(any(), any(), any());
   }
@@ -101,8 +257,9 @@ public class SchemaDiscoveryImplTest {
 
     final int testRetryCount = 2;
     final int expectedCallsCount = testRetryCount + 1;
+    final ImmutableList<String> tables = ImmutableList.of("testTable");
     when(mockRetriableSchemaDiscovery.discoverTableSchema(
-            mockDataSource, mockSourceSchemaReference, ImmutableList.of()))
+            mockDataSource, mockSourceSchemaReference, tables))
         .thenThrow(new RetriableSchemaDiscoveryException(new SQLTransientConnectionException()));
 
     assertThrows(
@@ -114,8 +271,7 @@ public class SchemaDiscoveryImplTest {
                         .withInitialBackoff(Duration.millis(10L))
                         .withExponent(1)
                         .withMaxRetries(testRetryCount))
-                .discoverTableSchema(
-                    mockDataSource, mockSourceSchemaReference, ImmutableList.of()));
+                .discoverTableSchema(mockDataSource, mockSourceSchemaReference, tables));
     verify(mockRetriableSchemaDiscovery, times(expectedCallsCount))
         .discoverTableSchema(any(), any(), any());
   }
@@ -176,5 +332,57 @@ public class SchemaDiscoveryImplTest {
         .isEqualTo(discoveredIndexes);
     verify(mockRetriableSchemaDiscovery, times(expectedCallsCount))
         .discoverTableIndexes(any(), any(), any());
+  }
+
+  @Test
+  public void testPartitionWork() {
+    List<String> tables = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      tables.add("table" + i);
+    }
+
+    List<List<String>> partitioned = SchemaDiscoveryImpl.partitionWork(tables, 3);
+    assertThat(partitioned).hasSize(4);
+    assertThat(partitioned.get(0)).containsExactly("table0", "table1", "table2");
+    assertThat(partitioned.get(3)).containsExactly("table9");
+
+    assertThat(SchemaDiscoveryImpl.partitionWork(new ArrayList<>(), 3)).isEmpty();
+  }
+
+  @Test
+  public void testParallelBatchDiscovery() throws RetriableSchemaDiscoveryException {
+    // Generate 1001 tables to trigger 3 batches (BATCH_SIZE is 500)
+    List<String> tables = new ArrayList<>();
+    for (int i = 0; i < 1001; i++) {
+      tables.add("table" + i);
+    }
+
+    SchemaDiscoveryImpl schemaDiscovery =
+        new SchemaDiscoveryImpl(mockRetriableSchemaDiscovery, FluentBackoff.DEFAULT);
+
+    // Mock returns for each batch
+    // Batch 1: 0-499
+    // Batch 2: 500-999
+    // Batch 3: 1000
+    when(mockRetriableSchemaDiscovery.discoverTableSchema(any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              ImmutableList<String> batch = invocation.getArgument(2);
+              ImmutableMap.Builder<String, ImmutableMap<String, SourceColumnType>> builder =
+                  ImmutableMap.builder();
+              for (String table : batch) {
+                builder.put(table, ImmutableMap.of());
+              }
+              return builder.build();
+            });
+
+    ImmutableMap<String, ImmutableMap<String, SourceColumnType>> result =
+        schemaDiscovery.discoverTableSchema(
+            mockDataSource, mockSourceSchemaReference, ImmutableList.copyOf(tables));
+
+    assertThat(result).hasSize(1001);
+    for (int i = 0; i < 1001; i++) {
+      assertThat(result).containsKey("table" + i);
+    }
   }
 }


### PR DESCRIPTION
# PR Description: Adding MultiTable Read Transform to optimize Graph Size




## Summary
This PR introduces the **Parallel Schema Discovery**  for `sourcedb-to-spanner` template. This is needed for supporting the scale of 5K Tables w/o pipeline timeout. With this PR on the default launcher VM we are able to discover 5000 tables in 3 mins (w/o parallelization it takes more than 15 mins).

This is (third) child of [pull/3399](https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/3399). Please refer to the parent PR to get a complete context on the changes involved.

## Key Changes
- **Parallel Schema Discovery:** Implemented parallelized discovery for table schemas and indexes in `SchemaDiscoveryImpl`. By partitioning the table list into batches (default 500) and using a fixed thread pool (4 threads), the pipeline significantly reduces initialization time for large-scale migrations (e.g., 5,000 tables in ~3 mins vs. 15+ mins).
- **Bulk Metadata Discovery (MySQL & PostgreSQL):** Refactored `MysqlDialectAdapter` and `PostgreSQLDialectAdapter` to support bulk discovery using SQL `IN` clauses. This transitions metadata fetching from $O(N_{tables})$ individual queries to $O(N_{tables} / 500)$ bulk queries, minimizing database round-trip overhead.
- **Memory Efficiency:** Integrated `setFetchSize(1000)` into metadata `PreparedStatements` to ensure that the Dataflow Launcher VM can process large result sets without encountering `OutOfMemoryError`.
- **MySQL 5.7 & 8.x Compatibility:** Enhanced `MysqlDialectAdapter` to dynamically detect the `PAD_ATTRIBUTE` column in `INFORMATION_SCHEMA.COLLATIONS`. It provides a safe fallback to `PAD SPACE` for MySQL 5.7, ensuring correct string partitioning across different database versions.
- **Reliable Thread Management:** Implemented robust exception unwrapping in `SchemaDiscoveryImpl` to preserve `SchemaDiscoveryException` types during parallel execution and ensured proper `ExecutorService` shutdown to prevent thread leaks in the launcher environment.
- **Cassandra Impact Analysis:** While `SchemaDiscoveryImpl` (the orchestrator) is updated to support parallel batches, the **Cassandra implementation remains functionally unchanged**. Unlike the JDBC adapters, `CassandraSchemaDiscovery` relies on the Datastax Java Driver's `Metadata` API, which fetches the entire keyspace metadata (including all tables) in a single underlying driver operation. Consequently, while Cassandra now benefits from the parallel orchestration layer, it was already performing a form of bulk discovery and is not affected by the SQL-specific `IN` clause refactoring.

## Todos
These items will be covered in followup activities
1. Monitoring/metrics for per-table ranges  produced and read.
2. Multi Shard support.

## Out of scope
These items are out of scope of the current work:

1. Checkpointed migrations.
2. Fixed graph size for multi level migrations.
3. Any architectural changes.