### PR TITLE
feat(graph-size-per-shard): Load test 5000 tables for a single shard

### DIFF
--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/MySQL5KTablesLT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/MySQL5KTablesLT.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.loadtesting;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
+
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
+import com.google.cloud.teleport.metadata.TemplateLoadTest;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.SQLDialect;
+import com.google.cloud.teleport.v2.templates.SourceDbToSpanner;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.beam.it.common.PipelineLauncher;
+import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
+import org.apache.beam.it.common.PipelineOperator;
+import org.apache.beam.it.common.utils.ResourceManagerUtils;
+import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
+import org.apache.beam.it.jdbc.JDBCResourceManager;
+import org.apache.beam.it.jdbc.MySQLResourceManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A load test for {@link SourceDbToSpanner} Flex template which tests 5,000 tables migration.
+ *
+ * <p>This test verifies the template's ability to handle a massive number of tables by:
+ *
+ * <ol>
+ *   <li>Generating 5,000 tables in a source MySQL database.
+ *   <li>Executing 5,000 DDL statements on the destination Spanner database in parallel.
+ *   <li>Migrating the data using the Flex template with a constant-size graph.
+ *   <li>Validating the results using a high-concurrency verification process.
+ * </ol>
+ */
+@Category({TemplateLoadTest.class, SkipDirectRunnerTest.class})
+@TemplateLoadTest(SourceDbToSpanner.class)
+@RunWith(JUnit4.class)
+public class MySQL5KTablesLT extends SourceDbToSpannerLTBase {
+  private static final Logger LOG = LoggerFactory.getLogger(MySQL5KTablesLT.class);
+  private Instant startTime;
+
+  private MySQLResourceManager mySQLResourceManager;
+
+  @Before
+  public void setUp() throws IOException {
+    LOG.info("Began Setup for 5K Table test");
+    super.setUp();
+    startTime = Instant.now();
+
+    // Initialize Resource Managers directly to avoid base class constraints
+    mySQLResourceManager = MySQLResourceManager.builder(testName).build();
+    spannerResourceManager =
+        SpannerResourceManager.builder(testName, project, region)
+            .maybeUseStaticInstance()
+            .setMonitoringClient(monitoringClient)
+            .build();
+
+    gcsResourceManager = createSpannerLTGcsResourceManager();
+
+    this.dialect = SQLDialect.MYSQL;
+  }
+
+  @After
+  public void cleanUp() {
+    ResourceManagerUtils.cleanResources(
+        spannerResourceManager, mySQLResourceManager, gcsResourceManager);
+    LOG.info(
+        "CleanupCompleted for 5K Table test. Test took {}",
+        Duration.between(startTime, Instant.now()));
+  }
+
+  /**
+   * Tests the bulk migration of 5,000 tables from MySQL to Spanner.
+   *
+   * @throws Exception if any part of the test setup or execution fails.
+   */
+  @Test
+  public void mySQLToSpannerBulkFiveThousandTablesTest() throws Exception {
+    int numTables = 5000;
+
+    HashMap<String, String> columns = new HashMap<>();
+    columns.put("id", "BIGINT UNSIGNED");
+    JDBCResourceManager.JDBCSchema schema = new JDBCResourceManager.JDBCSchema(columns, "id");
+
+    // OPTIMIZE MYSQL:
+    // We disable synchronous flushing and binary logging to speed up the creation and
+    // population of 5,000 tables on the source database.
+    try (Connection jdbcConnection = getJdbcConnection(mySQLResourceManager);
+        PreparedStatement pstmt =
+            jdbcConnection.prepareStatement("SET GLOBAL innodb_flush_log_at_trx_commit = 0;")) {
+      pstmt.executeUpdate();
+    }
+    try (Connection jdbcConnection = getJdbcConnection(mySQLResourceManager);
+        PreparedStatement pstmt = jdbcConnection.prepareStatement("SET GLOBAL sync_binlog = 0;")) {
+      pstmt.executeUpdate();
+    }
+
+    List<String> spannerDdlStatements = new ArrayList<>();
+
+    LOG.info("Creating {} tables on Source and collecting Spanner DDLs", numTables);
+    for (int i = 0; i < numTables; i++) {
+      String tableName = "table_" + i;
+      mySQLResourceManager.createTable(tableName, schema);
+
+      try (Connection jdbcConnection = getJdbcConnection(mySQLResourceManager);
+          PreparedStatement pstmt =
+              jdbcConnection.prepareStatement("INSERT INTO " + tableName + " (id) VALUES (42)")) {
+        pstmt.executeUpdate();
+      }
+      spannerDdlStatements.add("CREATE TABLE " + tableName + " (id INT64) PRIMARY KEY (id)");
+
+      if (i % 500 == 0) {
+        LOG.info("Created {} tables so far on Source", i);
+      }
+    }
+
+    // Restore MySQL durability settings to ensure a realistic state for the template.
+    try (Connection jdbcConnection = getJdbcConnection(mySQLResourceManager);
+        PreparedStatement pstmt =
+            jdbcConnection.prepareStatement("SET GLOBAL innodb_flush_log_at_trx_commit = 1;")) {
+      pstmt.executeUpdate();
+    }
+
+    try (Connection jdbcConnection = getJdbcConnection(mySQLResourceManager);
+        PreparedStatement pstmt = jdbcConnection.prepareStatement("SET GLOBAL sync_binlog = 1;")) {
+      pstmt.executeUpdate();
+    }
+
+    // PARALLEL DDL EXECUTION:
+    // Batch and execute spanner DDL statements in parallel to reduce setup time.
+    LOG.info("Executing Spanner DDLs in parallel batches");
+    int batchSize = 100;
+    ExecutorService ddlExecutor = Executors.newFixedThreadPool(3);
+    for (int i = 0; i < spannerDdlStatements.size(); i += batchSize) {
+      int end = Math.min(spannerDdlStatements.size(), i + batchSize);
+      List<String> batch = spannerDdlStatements.subList(i, end);
+      ddlExecutor.submit(
+          () -> {
+            try {
+              spannerResourceManager.executeDdlStatements(batch);
+            } catch (Exception e) {
+              LOG.error("Failed to execute Spanner DDL batch", e);
+            }
+          });
+    }
+    ddlExecutor.shutdown();
+    if (!ddlExecutor.awaitTermination(60, TimeUnit.MINUTES)) {
+      throw new RuntimeException("Spanner DDL timed out after 60 minutes");
+    }
+
+    // Prepare parameters and launch job
+    Map<String, String> params = getCommonParameters();
+    params.putAll(
+        getJdbcParameters(
+            mySQLResourceManager.getUri(),
+            mySQLResourceManager.getUsername(),
+            mySQLResourceManager.getPassword(),
+            "com.mysql.jdbc.Driver"));
+    params.put("maxConnections", "16");
+    params.put("numWorkers", "16");
+    params.put("maxNumWorkers", "16");
+    params.put("workerMachineType", "n2-standard-4");
+
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, SPEC_PATH).setParameters(params);
+
+    PipelineLauncher.LaunchInfo jobInfo = launchJob(options);
+
+    // Wait for completion
+    PipelineOperator.Result result =
+        pipelineOperator.waitUntilDone(createConfig(jobInfo, Duration.ofMinutes(60L)));
+    assertThatResult(result).isLaunchFinished();
+
+    // High-concurrency validation
+    validateResult(spannerResourceManager, numTables);
+
+    // Collect and export metrics
+    collectAndExportMetrics(jobInfo);
+  }
+
+  private static Connection getJdbcConnection(MySQLResourceManager mySQLResourceManager)
+      throws SQLException {
+    try {
+      return DriverManager.getConnection(
+          mySQLResourceManager.getUri(),
+          mySQLResourceManager.getUsername(),
+          mySQLResourceManager.getPassword());
+    } catch (Exception e) {
+      LOG.error("Could not open connection to MySql", e);
+      throw e;
+    }
+  }
+
+  /**
+   * Validates that all 5,000 tables were correctly migrated and contain the expected data.
+   *
+   * <p>To handle the large number of tables, validation is performed in parallel using a large
+   * thread pool.
+   *
+   * @param resourceManager the Spanner resource manager.
+   * @param numTables the total number of tables to validate.
+   * @throws InterruptedException if validation is interrupted.
+   */
+  private void validateResult(SpannerResourceManager resourceManager, int numTables)
+      throws InterruptedException {
+    LOG.info("Validating {} tables on Spanner", numTables);
+    ExecutorService executor = Executors.newFixedThreadPool(100);
+    for (int i = 0; i < numTables; i++) {
+      String tableName = "table_" + i;
+      executor.submit(
+          () -> {
+            assertThat(resourceManager.getRowCount(tableName)).isEqualTo(1L);
+            List<Struct> rows = resourceManager.readTableRecords(tableName, "id");
+            assertThat(rows.get(0).getLong("id")).isEqualTo(42L);
+          });
+    }
+    executor.shutdown();
+    if (!executor.awaitTermination(30, TimeUnit.MINUTES)) {
+      throw new RuntimeException("Validation timed out after 30 minutes");
+    }
+    LOG.info("Validation successful for all {} tables", numTables);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/PostgreSQL5KTablesLT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/PostgreSQL5KTablesLT.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.loadtesting;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
+
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
+import com.google.cloud.teleport.metadata.TemplateLoadTest;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.SQLDialect;
+import com.google.cloud.teleport.v2.templates.SourceDbToSpanner;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.beam.it.common.PipelineLauncher;
+import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
+import org.apache.beam.it.common.PipelineOperator;
+import org.apache.beam.it.common.utils.ResourceManagerUtils;
+import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
+import org.apache.beam.it.jdbc.JDBCResourceManager;
+import org.apache.beam.it.jdbc.PostgresResourceManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A load test for {@link SourceDbToSpanner} Flex template which tests 5,000 tables migration for
+ * PostgreSQL.
+ *
+ * <p>This test follows the same massive-scale verification strategy as {@link MySQL5KTablesLT},
+ * tailored for PostgreSQL specific optimizations and drivers.
+ */
+@Category({TemplateLoadTest.class, SkipDirectRunnerTest.class})
+@TemplateLoadTest(SourceDbToSpanner.class)
+@RunWith(JUnit4.class)
+public class PostgreSQL5KTablesLT extends SourceDbToSpannerLTBase {
+  private static final Logger LOG = LoggerFactory.getLogger(PostgreSQL5KTablesLT.class);
+  private Instant startTime;
+
+  private PostgresResourceManager postgresResourceManager;
+
+  @Before
+  public void setUp() throws IOException {
+    LOG.info("Began Setup for 5K Table test (PostgreSQL)");
+    super.setUp();
+    startTime = Instant.now();
+
+    // Initialize Resource Managers directly to avoid base class constraints
+    postgresResourceManager = PostgresResourceManager.builder(testName).build();
+    spannerResourceManager =
+        SpannerResourceManager.builder(testName, project, region)
+            .maybeUseStaticInstance()
+            .setMonitoringClient(monitoringClient)
+            .build();
+
+    gcsResourceManager = createSpannerLTGcsResourceManager();
+
+    this.dialect = SQLDialect.POSTGRESQL;
+  }
+
+  @After
+  public void cleanUp() {
+    ResourceManagerUtils.cleanResources(
+        spannerResourceManager, postgresResourceManager, gcsResourceManager);
+    LOG.info(
+        "CleanupCompleted for 5K Table test. Test took {}",
+        Duration.between(startTime, Instant.now()));
+  }
+
+  /**
+   * Tests the bulk migration of 5,000 tables from PostgreSQL to Spanner.
+   *
+   * @throws Exception if any part of the test setup or execution fails.
+   */
+  @Test
+  public void postgresToSpannerBulkFiveThousandTablesTest() throws Exception {
+    int numTables = 5000;
+
+    HashMap<String, String> columns = new HashMap<>();
+    columns.put("id", "BIGINT");
+    JDBCResourceManager.JDBCSchema schema = new JDBCResourceManager.JDBCSchema(columns, "id");
+
+    // OPTIMIZE POSTGRESQL:
+    // We disable synchronous commit to speed up the massive number of INSERT and DDL operations
+    // required for 5,000 tables.
+    try (Connection jdbcConnection = getJdbcConnection(postgresResourceManager);
+        PreparedStatement pstmt =
+            jdbcConnection.prepareStatement("SET synchronous_commit = off;")) {
+      pstmt.executeUpdate();
+    }
+
+    List<String> spannerDdlStatements = new ArrayList<>();
+
+    LOG.info("Creating {} tables on Source and collecting Spanner DDLs", numTables);
+    for (int i = 0; i < numTables; i++) {
+      String tableName = "table_" + i;
+      postgresResourceManager.createTable(tableName, schema);
+
+      try (Connection jdbcConnection = getJdbcConnection(postgresResourceManager);
+          PreparedStatement pstmt =
+              jdbcConnection.prepareStatement("INSERT INTO " + tableName + " (id) VALUES (42)")) {
+        pstmt.executeUpdate();
+      }
+      spannerDdlStatements.add("CREATE TABLE " + tableName + " (id INT64) PRIMARY KEY (id)");
+
+      if (i % 500 == 0) {
+        LOG.info("Created {} tables so far on Source", i);
+      }
+    }
+
+    // Restore PostgreSQL durability settings.
+    try (Connection jdbcConnection = getJdbcConnection(postgresResourceManager);
+        PreparedStatement pstmt = jdbcConnection.prepareStatement("SET synchronous_commit = on;")) {
+      pstmt.executeUpdate();
+    }
+
+    // Parallelize Spanner DDL execution.
+    LOG.info("Executing Spanner DDLs in parallel batches");
+    int batchSize = 100;
+    ExecutorService ddlExecutor = Executors.newFixedThreadPool(3);
+    for (int i = 0; i < spannerDdlStatements.size(); i += batchSize) {
+      int end = Math.min(spannerDdlStatements.size(), i + batchSize);
+      List<String> batch = spannerDdlStatements.subList(i, end);
+      ddlExecutor.submit(
+          () -> {
+            try {
+              spannerResourceManager.executeDdlStatements(batch);
+            } catch (Exception e) {
+              LOG.error("Failed to execute Spanner DDL batch", e);
+            }
+          });
+    }
+    ddlExecutor.shutdown();
+    if (!ddlExecutor.awaitTermination(60, TimeUnit.MINUTES)) {
+      throw new RuntimeException("Spanner DDL timed out after 60 minutes");
+    }
+
+    // Prepare parameters and launch job
+    Map<String, String> params = getCommonParameters();
+    params.putAll(
+        getJdbcParameters(
+            postgresResourceManager.getUri(),
+            postgresResourceManager.getUsername(),
+            postgresResourceManager.getPassword(),
+            "org.postgresql.Driver"));
+    params.put("maxConnections", "16");
+    params.put("numWorkers", "16");
+    params.put("maxNumWorkers", "16");
+    params.put("workerMachineType", "n2-standard-4");
+
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, SPEC_PATH).setParameters(params);
+
+    PipelineLauncher.LaunchInfo jobInfo = launchJob(options);
+
+    // Wait for completion
+    PipelineOperator.Result result =
+        pipelineOperator.waitUntilDone(createConfig(jobInfo, Duration.ofMinutes(60L)));
+    assertThatResult(result).isLaunchFinished();
+
+    // High-concurrency validation
+    validateResult(spannerResourceManager, numTables);
+
+    // Collect and export metrics
+    collectAndExportMetrics(jobInfo);
+  }
+
+  private static Connection getJdbcConnection(PostgresResourceManager postgresResourceManager)
+      throws SQLException {
+    try {
+      return DriverManager.getConnection(
+          postgresResourceManager.getUri(),
+          postgresResourceManager.getUsername(),
+          postgresResourceManager.getPassword());
+    } catch (Exception e) {
+      LOG.error("Could not open connection to PostgreSQL", e);
+      throw e;
+    }
+  }
+
+  /**
+   * Validates that all 5,000 tables were correctly migrated and contain the expected data.
+   *
+   * @param resourceManager the Spanner resource manager.
+   * @param numTables the total number of tables to validate.
+   * @throws InterruptedException if validation is interrupted.
+   */
+  private void validateResult(SpannerResourceManager resourceManager, int numTables)
+      throws InterruptedException {
+    LOG.info("Validating {} tables on Spanner", numTables);
+    ExecutorService executor = Executors.newFixedThreadPool(100);
+    for (int i = 0; i < numTables; i++) {
+      String tableName = "table_" + i;
+      executor.submit(
+          () -> {
+            assertThat(resourceManager.getRowCount(tableName)).isEqualTo(1L);
+            List<Struct> rows = resourceManager.readTableRecords(tableName, "id");
+            assertThat(rows.get(0).getLong("id")).isEqualTo(42L);
+          });
+    }
+    executor.shutdown();
+    if (!executor.awaitTermination(30, TimeUnit.MINUTES)) {
+      throw new RuntimeException("Validation timed out after 30 minutes");
+    }
+    LOG.info("Validation successful for all {} tables", numTables);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/SourceDbToSpannerLTBase.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/SourceDbToSpannerLTBase.java
@@ -44,10 +44,24 @@ import org.apache.beam.it.jdbc.StaticPostgresqlResource;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.io.Resources;
 import org.junit.After;
 
+/**
+ * Base class for Load Tests (LT) of the Source-to-Spanner template.
+ *
+ * <p>This class provides common infrastructure for large-scale migrations, including:
+ *
+ * <ul>
+ *   <li><b>Spanner Configuration</b>: Automatic setup of large Spanner instances (e.g., 10 nodes).
+ *   <li><b>JDBC Resource Management</b>: Handling static connections to source databases (MySQL,
+ *       PostgreSQL).
+ *   <li><b>VPC Networking</b>: Support for shared VPCs required for template-to-DB connectivity.
+ *   <li><b>Metrics Collection</b>: Integration with BigQuery for long-term performance tracking.
+ * </ul>
+ */
 public class SourceDbToSpannerLTBase extends TemplateLoadTestBase {
 
-  private static final String SPEC_PATH =
-      "gs://dataflow-templates/latest/flex/Sourcedb_to_Spanner_Flex";
+  protected static final String SPEC_PATH =
+      System.getProperty(
+          "specPath", "gs://dataflow-templates/latest/flex/Sourcedb_to_Spanner_Flex");
   private static final int SPANNER_NODE_COUNT = 10;
 
   private static final int MAX_WORKERS = 100;
@@ -58,15 +72,20 @@ public class SourceDbToSpannerLTBase extends TemplateLoadTestBase {
   private static final Duration CHECK_INTERVAL = Duration.ofMinutes(5);
   private static final Duration DONE_TIMEOUT = Duration.ofMinutes(20);
 
-  private SQLDialect dialect;
-  private GcsResourceManager gcsResourceManager;
+  protected SQLDialect dialect;
+  protected GcsResourceManager gcsResourceManager;
   private StaticJDBCResource sourceDatabaseResource;
-  private SpannerResourceManager spannerResourceManager;
+  protected SpannerResourceManager spannerResourceManager;
 
   private final SecretManagerResourceManager secretClient;
   private final String testRootDir;
 
+  /**
+   * VPC configuration required for large-scale tests where the Dataflow workers must connect to
+   * databases within a private network.
+   */
   protected static final String VPC_NAME = "spanner-wide-row-pr-test-vpc";
+
   protected static final String VPC_REGION = "us-central1";
   protected static final String SUBNET_NAME = "regions/" + VPC_REGION + "/subnetworks/" + VPC_NAME;
   protected static final Map<String, String> ADDITIONAL_JOB_PARAMS = new HashMap<>();
@@ -125,36 +144,78 @@ public class SourceDbToSpannerLTBase extends TemplateLoadTestBase {
     runLoadTest(expectations, new HashMap<>(), new HashMap<>());
   }
 
+  protected PipelineLauncher.LaunchInfo launchJob(LaunchConfig.Builder options) throws IOException {
+    PipelineLauncher.LaunchInfo jobInfo = pipelineLauncher.launch(project, region, options.build());
+    assertThatPipeline(jobInfo).isRunning();
+    return jobInfo;
+  }
+
+  protected void collectAndExportMetrics(PipelineLauncher.LaunchInfo jobInfo)
+      throws ParseException, IOException, InterruptedException {
+    Map<String, Double> metrics = getMetrics(jobInfo);
+    populateResourceManagerMetrics(metrics);
+    exportMetricsToBigQuery(jobInfo, metrics);
+  }
+
+  protected Map<String, String> getCommonParameters() {
+    Map<String, String> params = new HashMap<>();
+    params.put("projectId", project);
+    params.put("instanceId", spannerResourceManager.getInstanceId());
+    params.put("databaseId", spannerResourceManager.getDatabaseId());
+    params.put("outputDirectory", getOutputDirectory());
+    return params;
+  }
+
+  protected String getOutputDirectory() {
+    return "gs://"
+        + gcsResourceManager.getBucket()
+        + "/"
+        + String.join(
+            "/", new String[] {testRootDir, gcsResourceManager.runId(), testName, "output"});
+  }
+
+  protected Map<String, String> getJdbcParameters(StaticJDBCResource jdbcResource) {
+    return getJdbcParameters(
+        jdbcResource.getconnectionURL(),
+        jdbcResource.username(),
+        jdbcResource.password(),
+        driverClassName());
+  }
+
+  protected Map<String, String> getJdbcParameters(
+      String connectionUrl, String username, String password, String driverClassName) {
+    Map<String, String> params = new HashMap<>();
+    params.put("sourceDbDialect", dialect.name());
+    params.put("sourceConfigURL", connectionUrl);
+    params.put("username", username);
+    params.put("password", password);
+    params.put("jdbcDriverClassName", driverClassName);
+    return params;
+  }
+
+  /**
+   * Orchestrates the execution of a load test, including job launch, row count verification, and
+   * metrics export.
+   *
+   * @param expectations map of table names to expected row counts.
+   * @param templateParameters additional parameters for the Dataflow template.
+   * @param environmentOptions Dataflow environment options (e.g., workers, machine type).
+   * @throws IOException if job launch fails.
+   * @throws ParseException if metrics parsing fails.
+   * @throws InterruptedException if waiting for the job is interrupted.
+   */
   public void runLoadTest(
       Map<String, Integer> expectations,
       Map<String, String> templateParameters,
       Map<String, String> environmentOptions)
       throws IOException, ParseException, InterruptedException {
 
-    // Add all parameters for the template
-    String outputDirectory =
-        String.join(
-            "/", new String[] {testRootDir, gcsResourceManager.runId(), testName, "output"});
-    Map<String, String> params =
-        new HashMap<>() {
-          {
-            put("projectId", project);
-            put("instanceId", spannerResourceManager.getInstanceId());
-            put("databaseId", spannerResourceManager.getDatabaseId());
-            put("sourceDbDialect", dialect.name());
-            put("sourceConfigURL", sourceDatabaseResource.getconnectionURL());
-            put("username", sourceDatabaseResource.username());
-            put("password", sourceDatabaseResource.password());
-            put(
-                "outputDirectory",
-                "gs://" + gcsResourceManager.getBucket() + "/" + outputDirectory);
-            put("jdbcDriverClassName", driverClassName());
-            put("workerMachineType", "n2-standard-4");
-          }
-        };
+    Map<String, String> params = getCommonParameters();
+    params.putAll(getJdbcParameters(sourceDatabaseResource));
+    params.put("workerMachineType", "n2-standard-4");
+
     params.putAll(ADDITIONAL_JOB_PARAMS);
     params.putAll(templateParameters);
-
     // Configure job
     LaunchConfig.Builder options =
         LaunchConfig.builder(getClass().getSimpleName(), SPEC_PATH)
@@ -164,8 +225,7 @@ public class SourceDbToSpannerLTBase extends TemplateLoadTestBase {
     environmentOptions.forEach(options::addEnvironment);
 
     // Act
-    PipelineLauncher.LaunchInfo jobInfo = pipelineLauncher.launch(project, region, options.build());
-    assertThatPipeline(jobInfo).isRunning();
+    PipelineLauncher.LaunchInfo jobInfo = launchJob(options);
 
     ConditionCheck[] checks =
         expectations.entrySet().stream()
@@ -186,11 +246,7 @@ public class SourceDbToSpannerLTBase extends TemplateLoadTestBase {
     result = pipelineOperator.waitUntilDone(createConfig(jobInfo, DONE_TIMEOUT));
     assertThatResult(result).isLaunchFinished();
 
-    Map<String, Double> metrics = getMetrics(jobInfo);
-    populateResourceManagerMetrics(metrics);
-
-    // Export results
-    exportMetricsToBigQuery(jobInfo, metrics);
+    collectAndExportMetrics(jobInfo);
   }
 
   public void populateResourceManagerMetrics(Map<String, Double> metrics) {


### PR DESCRIPTION
## Summary
This PR introduces the **5K Tables per shard Load test**  for `sourcedb-to-spanner` template. This is needed for supporting the scale of 5K Tables w/o pipeline timeout. With this PR on the default launcher VM we are able to verify that we discover and migrate 5000 tables in O(10) mins (w/o parallelization it takes more than 30 mins).  This is not a scale test so each table has a single row.  The split of 10 mins is 3 mins for docker image load , 3 mins for discovery and 3 mins for migration - 10 mins of minimum is the default base line for pretty much any bulk run. Here we achieve the same for 5000 tables.

This is (fourth and final) child of [pull/3399](https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/3399). Please refer to the parent PR to get a complete context on the changes involved.

## Test Results

Both PG to spanner migrations jobs complete in 10 mins.


<img width="3768" height="1948" alt="image" src="https://github.com/user-attachments/assets/0b623bc3-54ae-41bc-ac0e-c2a0c9b3a55f" />

<img width="3762" height="1932" alt="image" src="https://github.com/user-attachments/assets/db1bd2d8-d0ec-42fb-81f8-d5f8e4797032" />


## Todos
These items will be covered in followup activities
1. Monitoring/metrics for per-table ranges  produced and read.
2. Multi Shard support.

## Out of scope
These items are out of scope of the current work:

1. Checkpointed migrations.
2. Fixed graph size for multi level migrations.
3. Any architectural changes.