### PR TITLE
feat(dv): main template implementation

### DIFF
--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/templates/GCSSpannerDV.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/templates/GCSSpannerDV.java
@@ -47,7 +47,7 @@ import org.apache.beam.sdk.values.PCollectionView;
 import org.joda.time.Instant;
 
 @Template(
-    name = "GCS_Spanner_DV",
+    name = "GCS_Spanner_Data_Validator",
     category = TemplateCategory.BATCH,
     displayName = "GCS Spanner Data Validation",
     description =
@@ -61,7 +61,7 @@ import org.joda.time.Instant;
     requirements = {
       "The GCS directory for AVRO files must exist before pipeline execution.",
       "The Spanner tables must exist before pipeline execution.",
-      "The Spanner tables must have a compatible schema."
+      "The Spanner tables must have a compatible schema (either directly or schema mapping)."
     })
 public class GCSSpannerDV {
 


### PR DESCRIPTION
### TL;DR 
Added the main template class `GCSSpannerDV` for the GCS-Spanner Data Validation pipeline. This class acts as the entry point, defining the pipeline options and wiring together the reader, matching, and reporting transforms.
### What changed?
- **GCSSpannerDV**: New main class that orchestrates the data validation pipeline.
- Defined the `GCSSpannerDV.Options` interface to capture all necessary pipeline parameters, including project/Spanner specifics, instance/database IDs, GCS input paths, schema/table/column overrides, and BigQuery dataset configurations for reporting.
- Wired the end-to-end pipeline in the `run` method:
  1. **Schema Retrieval**: Reads Spanner Information Schema via `SpannerInformationSchemaProcessorTransform` as a side input.
  2. **Schema Mapping**: Initializes `SchemaMapperProviderFn` with session files and overrides.
  3. **Data Ingestion**: Reads and parses both source records from GCS (`SourceReaderTransform`) and Spanner records (`SpannerReaderTransform`).
  4. **Data Matching**: Pits the two datasets against each other through the `MatchRecordsTransform` to determine equivalence.
  5. **Validation Reporting**: Aggregates and reports the match/mismatch results using `ReportResultsTransform` to BigQuery.