### PR TITLE
Added write to GCS incase of failed mutations - Import template

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/spanner/TextImportTransform.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/TextImportTransform.java
@@ -196,7 +196,7 @@ public class TextImportTransform extends PTransform<PBegin, PDone> {
               .apply("Reshuffle text files " + depth, Reshuffle.viaRandomKey())
               .apply(
                   "Text files as mutations. Depth: " + depth,
-                  new TextTableFilesAsMutations(ddlView, tableColumnsView));
+                  new TextTableFilesAsMutations(ddlView, tableColumnsView, depth));
 
       SpannerWriteResult result =
           mutations
@@ -249,12 +249,15 @@ public class TextImportTransform extends PTransform<PBegin, PDone> {
 
     private final PCollectionView<Ddl> ddlView;
     private final PCollectionView<Map<String, List<TableManifest.Column>>> tableColumnsView;
+    private final int depth;
 
     public TextTableFilesAsMutations(
         PCollectionView<Ddl> ddlView,
-        PCollectionView<Map<String, List<TableManifest.Column>>> tableColumnsView) {
+        PCollectionView<Map<String, List<TableManifest.Column>>> tableColumnsView,
+        int depth) {
       this.ddlView = ddlView;
       this.tableColumnsView = tableColumnsView;
+      this.depth = depth;
     }
 
     @Override
@@ -320,7 +323,12 @@ public class TextImportTransform extends PTransform<PBegin, PDone> {
           .apply(
               TextIO.<String>writeCustomType()
                   .to(options.getInvalidOutputPath())
-                  .withSuffix("-" + java.util.UUID.randomUUID().toString() + "-parsing-errors.csv")
+                  .withSuffix(
+                      "-"
+                          + java.util.UUID.randomUUID().toString()
+                          + "-spanner-depth-"
+                          + depth
+                          + ".csv")
                   .skipIfEmpty()
                   .withFormatFunction(SerializableFunctions.identity()));
 


### PR DESCRIPTION
**What changed?**
Currently, the "Text Files on Cloud Storage to Cloud Spanner" template fails the entire Dataflow job when it encounters invalid records that violate Spanner schema constraints (e.g., `FAILED_PRECONDITION` due to missing `NOT NULL` fields). When this happens, all bad records are lost, the workers crash, and the records are never ultimately written to the configured `invalidOutputPath`.
This PR fixes the issue by writing the failed records from the Spanner write phase to invalidOutputPath.
**Key changes:**
* **Enabled Failure Reporting:** Configured `SpannerIO.write()` to use `FailureMode.REPORT_FAILURES` to prevent the connector from throwing fatal exceptions on bad transactions.
* **Error Routing:** Captured the MutationGroup failures from `SpannerWriteResult.getFailedMutations()` and mapped them to the user-defined `invalidOutputPath`.
* **Added Telemetry:** Introduced a new Beam metric `Counter` named `FailedSpannerWrites` so users can track exactly how many records are rejected natively within the Dataflow Monitoring UI.
* **Prevented File Overwrites:** Appended a `UUID` and the execution `depth` to the `TextIO` output file suffix (e.g., `<uuid>-spanner-depth-0.csv`). This ensures that files safely isolate their error records without overwriting each other across multiple nested tables or recurrent pipeline runs.
