### PR TITLE
[yaml] - update yaml-pr workflow to check for diff in generated templates

### DIFF
--- a/.github/workflows/yaml-pr.yml
+++ b/.github/workflows/yaml-pr.yml
@@ -60,6 +60,23 @@ permissions:
   statuses: write
 
 jobs:
+  verify_generated_templates:
+    name: Verify Generated Templates
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Environment
+        id: setup-env
+        uses: ./.github/actions/setup-env
+      - name: Install dependencies
+        run: pip install pyyaml
+      - name: Generate Templates
+        run: python yaml/src/main/python/generate_yaml_java_templates.py yaml/src/main/yaml
+      - name: Check for Uncommitted Changes
+        run: |
+          git diff --exit-code || (echo "::error::Generated templates are out of date. Please run 'python yaml/src/main/python/generate_yaml_java_templates.py yaml/src/main/yaml' locally and commit the changes." && exit 1)
   spotless_check:
     name: Spotless
     timeout-minutes: 10


### PR DESCRIPTION
1. The generated yaml templates recently got out of sync and there is currently no mechanism to ensure they stay in sync except manually pushing the changes.
2. This PR adds a workflow job to detect the diff of the currently golden yaml templates.