### PR TITLE
Single container layer for command spec files

### DIFF
--- a/plugins/core-plugin/src/main/java/com/google/cloud/teleport/plugin/TemplateSpecsGenerator.java
+++ b/plugins/core-plugin/src/main/java/com/google/cloud/teleport/plugin/TemplateSpecsGenerator.java
@@ -38,6 +38,10 @@ public class TemplateSpecsGenerator {
   /** Gson helper to pretty-print metadata/specs. */
   private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
+  public static final String IMAGE_SPEC_SUFFIX = "-spec-generated-metadata.json";
+  public static final String METADATA_SUFFIX = "-generated-metadata.json";
+  public static final String COMMAND_SPEC_SUFFIX = "-generated-command-spec.json";
+
   /**
    * Scan the classloader for all Template classes, and then builds spec + saves the metadata for
    * every Template.
@@ -77,8 +81,7 @@ public class TemplateSpecsGenerator {
       targetDirectory.mkdirs();
     }
 
-    File file =
-        new File(targetDirectory, templateDash.toLowerCase() + "-spec-generated-metadata.json");
+    File file = new File(targetDirectory, templateDash.toLowerCase() + IMAGE_SPEC_SUFFIX);
     LOG.info("Saving image spec " + file.getAbsolutePath());
 
     // The serialized image spec should match com.google.api.services.dataflow.model.ContainerSpec
@@ -120,7 +123,7 @@ public class TemplateSpecsGenerator {
     }
 
     String imageName = templateDash.toLowerCase();
-    File file = new File(targetDirectory, imageName + "-generated-metadata.json");
+    File file = new File(targetDirectory, imageName + METADATA_SUFFIX);
     LOG.info("Saving image spec metadata " + file.getAbsolutePath());
 
     try (FileWriter writer = new FileWriter(file)) {
@@ -142,8 +145,7 @@ public class TemplateSpecsGenerator {
       targetDirectory.mkdirs();
     }
 
-    File file =
-        new File(targetDirectory, templateDash.toLowerCase() + "-generated-command-spec.json");
+    File file = new File(targetDirectory, templateDash.toLowerCase() + COMMAND_SPEC_SUFFIX);
     LOG.info("Saving command spec " + file.getAbsolutePath());
 
     try (FileWriter writer = new FileWriter(file)) {

--- a/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
+++ b/plugins/templates-maven-plugin/src/main/java/com/google/cloud/teleport/plugin/maven/TemplatesStageMojo.java
@@ -816,14 +816,13 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
       if (System.getProperty("skipShade") == null
           || System.getProperty("skipShade").equalsIgnoreCase("false")) {
         List<Element> paths = new ArrayList<>();
-        for (File commandSpecFile : containerStageTracker.getCommandSpecFile(containerName)) {
-          paths.add(
-              element(
-                  "path",
-                  element("from", targetDirectory + "/classes"),
-                  element("includes", commandSpecFile.getName()),
-                  element("into", "/template/" + containerName + "/resources")));
-        }
+        File commandSpecFolder = containerStageTracker.getCommandSpecFolder(containerName);
+        paths.add(
+            element(
+                "path",
+                element("from", commandSpecFolder.getPath()),
+                element("includes", "*" + TemplateSpecsGenerator.COMMAND_SPEC_SUFFIX),
+                element("into", "/template/" + containerName + "/resources")));
 
         elements.add(element("extraDirectories", element("paths", paths.toArray(new Element[0]))));
 
@@ -1607,6 +1606,23 @@ public class TemplatesStageMojo extends TemplatesBaseMojo {
 
     Collection<File> getCommandSpecFile(String containerName) {
       return containers.get(containerName).commandSpecFiles.values();
+    }
+
+    /** Get command spec file common folder. */
+    File getCommandSpecFolder(String containerName) {
+      Collection<File> files = containers.get(containerName).commandSpecFiles.values();
+      File commonFolder = null;
+      for (File file : files) {
+        if (commonFolder == null) {
+          commonFolder = file.getParentFile();
+        } else {
+          if (!commonFolder.equals(file.getParentFile())) {
+            throw new IllegalArgumentException(
+                "Command spec needs to be in same folder to be staged within single container layer");
+          }
+        }
+      }
+      return commonFolder;
     }
 
     String getMappingJson(String containerName) {


### PR DESCRIPTION
Number of layers for googlecloud-to-googlecloud reduced from 27 to 13

gcr.io/dataflow-templates/googlecloud-to-googlecloud:latest

and

comparing gcr.io/cloud-teleport-testing/googlecloud-to-googlecloud:test-single-layer
