### PR TITLE
Fixing index discovery for PG bulk w/ partitioned tables

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
@@ -295,13 +295,22 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
         sourceSchemaReference,
         tables);
 
+    // https://www.db-fiddle.com/f/eUSGErdEWNQL8FhMj99Kb7/0
     final String query =
         "SELECT ixs.tablename AS table_name,"
             + "  a.attname AS column_name,"
             + "  ixs.indexname AS index_name,"
             + "  ix.indisunique AS is_unique,"
             + "  ix.indisprimary AS is_primary,"
-            + "  c.reltuples AS cardinality,"
+            + "("
+            + "SELECT SUM(pc.reltuples)"
+            + " FROM pg_catalog.pg_class pc"
+            + "  WHERE pc.oid IN ("
+            + "  SELECT inhrelid FROM pg_catalog.pg_inherits WHERE inhparent = c.oid"
+            + "  UNION"
+            + "  SELECT c.oid"
+            + " )"
+            + ") AS cardinality,"
             + "  a.attnum AS ordinal_position,"
             + "  t.typname AS type_name,"
             + "  information_schema._pg_char_max_length(a.atttypid, a.atttypmod) AS type_length,"


### PR DESCRIPTION
## Description
This pull request fixes a bug with index discovery for PostgreSQL partitioned tables during bulk operations. Specifically, it corrects the cardinality calculation so that it accurately reflects the total number of rows across all partitions, rather than incorrectly reporting `0`.

### The Problem
In PostgreSQL, a parent partitioned table (and its partitioned index) acts as a logical router and does not store physical data pages itself. All physical data lives inside the child partitions. Because `reltuples` in `pg_class` is a raw count of physical tuples, querying it directly for a parent table/index natively returns `0`. This leads to inaccurate statistics being fetched during index discovery for partitioned tables. 

### The Solution
This PR updates the index discovery SQL query to properly handle both standard and partitioned tables. We replaced the direct `c.reltuples` reference with a correlated subquery utilizing `pg_catalog.pg_inherits`. 

The new query sums the `reltuples` of the parent table and all of its inherited child partitions:
* **For standard tables:** The subquery simply returns the table's own tuple count (functioning exactly as before).
* **For partitioned tables:** The subquery aggregates the row counts of all physical child partitions to provide the true, accurate cardinality.

### Changes Made
* **Updated SQL Query:** Modified the cardinality extraction in the PostgreSQL index discovery query to use `SUM(pc.reltuples)` joined against `pg_inherits`.


### Testing
* Verified the query correctly aggregates child partition counts for `RANGE` partitioned tables. ([db-fiddle](https://www.db-fiddle.com/f/eUSGErdEWNQL8FhMj99Kb7/0))
* Verified the query causes no regressions and maintains exact behavior for standard, non-partitioned tables. ([db-fiddle](https://www.db-fiddle.com/f/eUSGErdEWNQL8FhMj99Kb7/0)) 
* Scale test w/ this fix - In progress.