### PR TITLE
feat(bigtable): add protobuf decoding to Bigtable Change Streams to BigQuery

### DIFF
--- a/v2/googlecloud-to-googlecloud/README_Bigtable_Change_Streams_to_BigQuery.md
+++ b/v2/googlecloud-to-googlecloud/README_Bigtable_Change_Streams_to_BigQuery.md
@@ -33,6 +33,10 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 * **bigQueryChangelogTablePartitionExpirationMs**: Sets the changelog table partition expiration time, in milliseconds. When set to `true`, partitions older than the specified number of milliseconds are deleted. By default, no expiration is set.
 * **bigQueryChangelogTableFieldsToIgnore**: A comma-separated list of the changelog columns that, when specified, aren't created and populated. Use one of the following supported values: `is_gc`, `source_instance`, `source_cluster`, `source_table`, `tiebreaker`, or `big_query_commit_timestamp`. By default, all columns are populated.
 * **dlqDirectory**: The directory to use for the dead-letter queue. Records that fail to be processed are stored in this directory. The default is a directory under the Dataflow job's temp location. In most cases, you can use the default path.
+* **columnTransforms**: A comma-separated list of column value transforms. Each entry has the format column_family:column_qualifier:TRANSFORM_TYPE. Supported TRANSFORM_TYPE values: BIG_ENDIAN_TIMESTAMP (interprets 8-byte big-endian values as Unix epoch millis), PROTO_DECODE(package.MessageName) (decodes protobuf-encoded values to JSON; requires protoSchemaPath). For complex transformations, consider using a JavaScript UDF. Note that column qualifiers containing commas are not supported since comma is used as the entry delimiter. Defaults to empty.
+* **protoSchemaPath**: The Cloud Storage location of the self-contained proto schema file. For example, gs://path/to/my/file.pb. This file can be generated with the --descriptor_set_out flag of the protoc command. The --include_imports flag guarantees that the file is self-contained. Required whenever a PROTO_DECODE() entry is used in columnTransforms. Defaults to empty.
+* **preserveProtoFieldNames**: When set to true, preserves original proto field names (snake_case) in the JSON output. When set to false, uses lowerCamelCase. Defaults to false.
+* **maxDecodedValueBytes**: Maximum allowed UTF-8 byte size of a PROTO_DECODE() result written to the BigQuery `value` column. Larger decoded values are routed to the severe DLQ instead of being written. Defaults to a conservative value below Dataflow Streaming Engine's per-element commit limit and cannot be set above that default.
 * **bigtableChangeStreamMetadataInstanceId**: The Bigtable change streams metadata instance ID. Defaults to empty.
 * **bigtableChangeStreamMetadataTableTableId**: The ID of the Bigtable change streams connector metadata table. If not provided, a Bigtable change streams connector metadata table is automatically created during pipeline execution. Defaults to empty.
 * **bigtableChangeStreamCharset**: The Bigtable change streams charset name. Defaults to: UTF-8.
@@ -150,6 +154,10 @@ export BIG_QUERY_CHANGELOG_TABLE_PARTITION_GRANULARITY=""
 export BIG_QUERY_CHANGELOG_TABLE_PARTITION_EXPIRATION_MS=<bigQueryChangelogTablePartitionExpirationMs>
 export BIG_QUERY_CHANGELOG_TABLE_FIELDS_TO_IGNORE=<bigQueryChangelogTableFieldsToIgnore>
 export DLQ_DIRECTORY=""
+export COLUMN_TRANSFORMS=""
+export PROTO_SCHEMA_PATH=""
+export PRESERVE_PROTO_FIELD_NAMES=false
+export MAX_DECODED_VALUE_BYTES=82837504
 export BIGTABLE_CHANGE_STREAM_METADATA_INSTANCE_ID=""
 export BIGTABLE_CHANGE_STREAM_METADATA_TABLE_TABLE_ID=""
 export BIGTABLE_CHANGE_STREAM_CHARSET=UTF-8
@@ -175,6 +183,10 @@ gcloud dataflow flex-template run "bigtable-change-streams-to-bigquery-job" \
   --parameters "bigQueryChangelogTablePartitionExpirationMs=$BIG_QUERY_CHANGELOG_TABLE_PARTITION_EXPIRATION_MS" \
   --parameters "bigQueryChangelogTableFieldsToIgnore=$BIG_QUERY_CHANGELOG_TABLE_FIELDS_TO_IGNORE" \
   --parameters "dlqDirectory=$DLQ_DIRECTORY" \
+  --parameters "columnTransforms=$COLUMN_TRANSFORMS" \
+  --parameters "protoSchemaPath=$PROTO_SCHEMA_PATH" \
+  --parameters "preserveProtoFieldNames=$PRESERVE_PROTO_FIELD_NAMES" \
+  --parameters "maxDecodedValueBytes=$MAX_DECODED_VALUE_BYTES" \
   --parameters "bigtableChangeStreamMetadataInstanceId=$BIGTABLE_CHANGE_STREAM_METADATA_INSTANCE_ID" \
   --parameters "bigtableChangeStreamMetadataTableTableId=$BIGTABLE_CHANGE_STREAM_METADATA_TABLE_TABLE_ID" \
   --parameters "bigtableChangeStreamAppProfile=$BIGTABLE_CHANGE_STREAM_APP_PROFILE" \
@@ -221,6 +233,10 @@ export BIG_QUERY_CHANGELOG_TABLE_PARTITION_GRANULARITY=""
 export BIG_QUERY_CHANGELOG_TABLE_PARTITION_EXPIRATION_MS=<bigQueryChangelogTablePartitionExpirationMs>
 export BIG_QUERY_CHANGELOG_TABLE_FIELDS_TO_IGNORE=<bigQueryChangelogTableFieldsToIgnore>
 export DLQ_DIRECTORY=""
+export COLUMN_TRANSFORMS=""
+export PROTO_SCHEMA_PATH=""
+export PRESERVE_PROTO_FIELD_NAMES=false
+export MAX_DECODED_VALUE_BYTES=82837504
 export BIGTABLE_CHANGE_STREAM_METADATA_INSTANCE_ID=""
 export BIGTABLE_CHANGE_STREAM_METADATA_TABLE_TABLE_ID=""
 export BIGTABLE_CHANGE_STREAM_CHARSET=UTF-8
@@ -239,7 +255,7 @@ mvn clean package -PtemplatesRun \
 -Dregion="$REGION" \
 -DjobName="bigtable-change-streams-to-bigquery-job" \
 -DtemplateName="Bigtable_Change_Streams_to_BigQuery" \
--Dparameters="bigQueryDataset=$BIG_QUERY_DATASET,writeRowkeyAsBytes=$WRITE_ROWKEY_AS_BYTES,writeValuesAsBytes=$WRITE_VALUES_AS_BYTES,writeNumericTimestamps=$WRITE_NUMERIC_TIMESTAMPS,bigQueryProjectId=$BIG_QUERY_PROJECT_ID,bigQueryChangelogTableName=$BIG_QUERY_CHANGELOG_TABLE_NAME,bigQueryChangelogTablePartitionGranularity=$BIG_QUERY_CHANGELOG_TABLE_PARTITION_GRANULARITY,bigQueryChangelogTablePartitionExpirationMs=$BIG_QUERY_CHANGELOG_TABLE_PARTITION_EXPIRATION_MS,bigQueryChangelogTableFieldsToIgnore=$BIG_QUERY_CHANGELOG_TABLE_FIELDS_TO_IGNORE,dlqDirectory=$DLQ_DIRECTORY,bigtableChangeStreamMetadataInstanceId=$BIGTABLE_CHANGE_STREAM_METADATA_INSTANCE_ID,bigtableChangeStreamMetadataTableTableId=$BIGTABLE_CHANGE_STREAM_METADATA_TABLE_TABLE_ID,bigtableChangeStreamAppProfile=$BIGTABLE_CHANGE_STREAM_APP_PROFILE,bigtableChangeStreamCharset=$BIGTABLE_CHANGE_STREAM_CHARSET,bigtableChangeStreamStartTimestamp=$BIGTABLE_CHANGE_STREAM_START_TIMESTAMP,bigtableChangeStreamIgnoreColumnFamilies=$BIGTABLE_CHANGE_STREAM_IGNORE_COLUMN_FAMILIES,bigtableChangeStreamIgnoreColumns=$BIGTABLE_CHANGE_STREAM_IGNORE_COLUMNS,bigtableChangeStreamName=$BIGTABLE_CHANGE_STREAM_NAME,bigtableChangeStreamResume=$BIGTABLE_CHANGE_STREAM_RESUME,bigtableReadChangeStreamTimeoutMs=$BIGTABLE_READ_CHANGE_STREAM_TIMEOUT_MS,bigtableReadInstanceId=$BIGTABLE_READ_INSTANCE_ID,bigtableReadTableId=$BIGTABLE_READ_TABLE_ID,bigtableReadProjectId=$BIGTABLE_READ_PROJECT_ID" \
+-Dparameters="bigQueryDataset=$BIG_QUERY_DATASET,writeRowkeyAsBytes=$WRITE_ROWKEY_AS_BYTES,writeValuesAsBytes=$WRITE_VALUES_AS_BYTES,writeNumericTimestamps=$WRITE_NUMERIC_TIMESTAMPS,bigQueryProjectId=$BIG_QUERY_PROJECT_ID,bigQueryChangelogTableName=$BIG_QUERY_CHANGELOG_TABLE_NAME,bigQueryChangelogTablePartitionGranularity=$BIG_QUERY_CHANGELOG_TABLE_PARTITION_GRANULARITY,bigQueryChangelogTablePartitionExpirationMs=$BIG_QUERY_CHANGELOG_TABLE_PARTITION_EXPIRATION_MS,bigQueryChangelogTableFieldsToIgnore=$BIG_QUERY_CHANGELOG_TABLE_FIELDS_TO_IGNORE,dlqDirectory=$DLQ_DIRECTORY,columnTransforms=$COLUMN_TRANSFORMS,protoSchemaPath=$PROTO_SCHEMA_PATH,preserveProtoFieldNames=$PRESERVE_PROTO_FIELD_NAMES,maxDecodedValueBytes=$MAX_DECODED_VALUE_BYTES,bigtableChangeStreamMetadataInstanceId=$BIGTABLE_CHANGE_STREAM_METADATA_INSTANCE_ID,bigtableChangeStreamMetadataTableTableId=$BIGTABLE_CHANGE_STREAM_METADATA_TABLE_TABLE_ID,bigtableChangeStreamAppProfile=$BIGTABLE_CHANGE_STREAM_APP_PROFILE,bigtableChangeStreamCharset=$BIGTABLE_CHANGE_STREAM_CHARSET,bigtableChangeStreamStartTimestamp=$BIGTABLE_CHANGE_STREAM_START_TIMESTAMP,bigtableChangeStreamIgnoreColumnFamilies=$BIGTABLE_CHANGE_STREAM_IGNORE_COLUMN_FAMILIES,bigtableChangeStreamIgnoreColumns=$BIGTABLE_CHANGE_STREAM_IGNORE_COLUMNS,bigtableChangeStreamName=$BIGTABLE_CHANGE_STREAM_NAME,bigtableChangeStreamResume=$BIGTABLE_CHANGE_STREAM_RESUME,bigtableReadChangeStreamTimeoutMs=$BIGTABLE_READ_CHANGE_STREAM_TIMEOUT_MS,bigtableReadInstanceId=$BIGTABLE_READ_INSTANCE_ID,bigtableReadTableId=$BIGTABLE_READ_TABLE_ID,bigtableReadProjectId=$BIGTABLE_READ_PROJECT_ID" \
 -f v2/googlecloud-to-googlecloud
 ```
 
@@ -297,6 +313,10 @@ resource "google_dataflow_flex_template_job" "bigtable_change_streams_to_bigquer
     # bigQueryChangelogTablePartitionExpirationMs = "<bigQueryChangelogTablePartitionExpirationMs>"
     # bigQueryChangelogTableFieldsToIgnore = "<bigQueryChangelogTableFieldsToIgnore>"
     # dlqDirectory = ""
+    # columnTransforms = ""
+    # protoSchemaPath = ""
+    # preserveProtoFieldNames = "false"
+    # maxDecodedValueBytes = "82837504"
     # bigtableChangeStreamMetadataInstanceId = ""
     # bigtableChangeStreamMetadataTableTableId = ""
     # bigtableChangeStreamCharset = "UTF-8"

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/BigtableChangeStreamToBigQueryOptions.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/BigtableChangeStreamToBigQueryOptions.java
@@ -28,6 +28,8 @@ import org.apache.beam.sdk.options.Validation;
 public interface BigtableChangeStreamToBigQueryOptions
     extends DataflowPipelineOptions, ReadChangeStreamOptions {
 
+  long DEFAULT_MAX_DECODED_VALUE_BYTES = 83_886_080L - (1L << 20);
+
   @TemplateParameter.Text(
       order = 1,
       groupName = "Target",
@@ -149,4 +151,62 @@ public interface BigtableChangeStreamToBigQueryOptions
   String getDlqDirectory();
 
   void setDlqDirectory(String value);
+
+  @TemplateParameter.Text(
+      order = 11,
+      optional = true,
+      description = "Column value transforms",
+      helpText =
+          "A comma-separated list of column value transforms. Each entry has the format "
+              + "column_family:column_qualifier:TRANSFORM_TYPE. Supported TRANSFORM_TYPE values: "
+              + "BIG_ENDIAN_TIMESTAMP (interprets 8-byte big-endian values as Unix epoch millis), "
+              + "PROTO_DECODE(package.MessageName) (decodes protobuf-encoded values to JSON; "
+              + "requires protoSchemaPath). For complex transformations, consider using a "
+              + "JavaScript UDF. Note that column qualifiers containing commas are not supported "
+              + "since comma is used as the entry delimiter.")
+  @Default.String("")
+  String getColumnTransforms();
+
+  void setColumnTransforms(String value);
+
+  @TemplateParameter.GcsReadFile(
+      order = 12,
+      optional = true,
+      description = "Cloud Storage path to the proto schema file",
+      helpText =
+          "The Cloud Storage location of the self-contained proto schema file. "
+              + "For example, gs://path/to/my/file.pb. This file can be generated with the "
+              + "--descriptor_set_out flag of the protoc command. The --include_imports flag "
+              + "guarantees that the file is self-contained. Required whenever a "
+              + "PROTO_DECODE() entry is used in columnTransforms.")
+  @Default.String("")
+  String getProtoSchemaPath();
+
+  void setProtoSchemaPath(String value);
+
+  @TemplateParameter.Boolean(
+      order = 13,
+      optional = true,
+      description = "Preserve proto field names in JSON output",
+      helpText =
+          "When set to true, preserves original proto field names (snake_case) in the "
+              + "JSON output. When set to false, uses lowerCamelCase. Defaults to false.")
+  @Default.Boolean(false)
+  Boolean getPreserveProtoFieldNames();
+
+  void setPreserveProtoFieldNames(Boolean value);
+
+  @TemplateParameter.Long(
+      order = 14,
+      optional = true,
+      description = "Maximum decoded proto JSON size in bytes",
+      helpText =
+          "Maximum allowed UTF-8 byte size of a PROTO_DECODE() result written to the BigQuery "
+              + "`value` column. Larger decoded values are routed to the severe DLQ instead of "
+              + "being written. Defaults to a conservative value below Dataflow Streaming "
+              + "Engine's per-element commit limit and cannot be set above that default.")
+  @Default.Long(DEFAULT_MAX_DECODED_VALUE_BYTES)
+  Long getMaxDecodedValueBytes();
+
+  void setMaxDecodedValueBytes(Long value);
 }

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/BigtableChangeStreamsToBigQuery.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/BigtableChangeStreamsToBigQuery.java
@@ -35,10 +35,16 @@ import com.google.cloud.teleport.v2.options.BigtableChangeStreamToBigQueryOption
 import com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.model.BigQueryDestination;
 import com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.model.Mod;
 import com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.model.ModType;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.model.OversizedValue;
 import com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils.BigQueryUtils;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils.OversizedValueDlqSanitizer;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils.TransformResult;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils.ValueTransformerRegistry;
 import com.google.cloud.teleport.v2.transforms.DLQWriteTransform;
 import com.google.cloud.teleport.v2.utils.BigtableSource;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.sdk.Pipeline;
@@ -51,12 +57,17 @@ import org.apache.beam.sdk.io.gcp.bigquery.InsertRetryPolicy;
 import org.apache.beam.sdk.io.gcp.bigquery.WriteResult;
 import org.apache.beam.sdk.io.gcp.bigtable.BigtableIO;
 import org.apache.beam.sdk.io.gcp.bigtable.BigtableIO.ExistingPipelineOptions;
+import org.apache.beam.sdk.metrics.Distribution;
+import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Values;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.TupleTagList;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.Instant;
 import org.slf4j.Logger;
@@ -94,6 +105,25 @@ public final class BigtableChangeStreamsToBigQuery {
   private static final Logger LOG = LoggerFactory.getLogger(BigtableChangeStreamsToBigQuery.class);
 
   private static final String USE_RUNNER_V2_EXPERIMENT = "use_runner_v2";
+
+  /**
+   * Dataflow Streaming Engine's per-element commit limit. Elements larger than this are rejected by
+   * Windmill and cause work-item commit failures that freeze the partition indefinitely. See
+   * https://cloud.google.com/dataflow/quotas.
+   */
+  @VisibleForTesting static final long WINDMILL_ELEMENT_LIMIT_BYTES = 83_886_080L; // 80 MiB
+
+  /**
+   * Ceiling for a decoded value written to the {@code value} BigQuery column. Slightly below {@link
+   * #WINDMILL_ELEMENT_LIMIT_BYTES} to leave headroom for the remainder of the TableRow envelope
+   * (row key, metadata columns, JSON field names). BigQuery may further reject smaller rows
+   * depending on the write method in use (e.g. Storage Write API enforces an AppendRows cap of ~10
+   * MB); those rejections are already handled by {@link BigQueryDeadLetterQueueSanitizer} via
+   * {@code writeResult.getFailedStorageApiInserts()}.
+   */
+  @VisibleForTesting
+  static final long DEFAULT_MAX_DECODED_VALUE_BYTES =
+      BigtableChangeStreamToBigQueryOptions.DEFAULT_MAX_DECODED_VALUE_BYTES;
 
   /**
    * Main entry point for executing the pipeline.
@@ -181,6 +211,29 @@ public final class BigtableChangeStreamsToBigQuery {
             options.getBigQueryChangelogTableFieldsToIgnore());
 
     BigQueryUtils bigQuery = new BigQueryUtils(sourceInfo, destinationInfo);
+    long maxDecodedValueBytes = options.getMaxDecodedValueBytes();
+
+    if (maxDecodedValueBytes <= 0) {
+      throw new IllegalArgumentException("maxDecodedValueBytes must be greater than 0");
+    }
+    if (maxDecodedValueBytes > DEFAULT_MAX_DECODED_VALUE_BYTES) {
+      throw new IllegalArgumentException(
+          "maxDecodedValueBytes must be less than or equal to " + DEFAULT_MAX_DECODED_VALUE_BYTES);
+    }
+
+    if (!StringUtils.isBlank(options.getColumnTransforms())) {
+      if (options.getWriteValuesAsBytes()) {
+        throw new IllegalArgumentException(
+            "columnTransforms can only be used when writeValuesAsBytes is false");
+      }
+      LOG.info("Column transforms: {}", options.getColumnTransforms());
+    }
+
+    ValueTransformerRegistry transformerRegistry =
+        ValueTransformerRegistry.parse(
+            options.getColumnTransforms(),
+            options.getProtoSchemaPath(),
+            options.getPreserveProtoFieldNames());
 
     Pipeline pipeline = Pipeline.create(options);
     DeadLetterQueueManager dlqManager = buildDlqManager(options);
@@ -210,10 +263,34 @@ public final class BigtableChangeStreamsToBigQuery {
             .apply("Read from Cloud Bigtable Change Streams", readChangeStream)
             .apply(Values.create());
 
-    PCollection<TableRow> changeStreamMutationToTableRow =
+    PCollectionTuple processed =
         dataChangeRecord.apply(
             "ChangeStreamMutation To TableRow",
-            ParDo.of(new ChangeStreamMutationToTableRowFn(sourceInfo, bigQuery)));
+            ParDo.of(
+                    new ChangeStreamMutationToTableRowFn(
+                        sourceInfo,
+                        bigQuery,
+                        transformerRegistry,
+                        maxDecodedValueBytes))
+                .withOutputTags(
+                    ChangeStreamMutationToTableRowFn.MAIN_OUT,
+                    TupleTagList.of(ChangeStreamMutationToTableRowFn.OVERSIZED_DLQ_OUT)));
+
+    PCollection<TableRow> changeStreamMutationToTableRow =
+        processed.get(ChangeStreamMutationToTableRowFn.MAIN_OUT);
+
+    // Route oversized decoded values to the severe DLQ with metadata only; the cell is not
+    // retried against BigQuery because it would also fail the Storage Write API's row-size limit.
+    processed
+        .get(ChangeStreamMutationToTableRowFn.OVERSIZED_DLQ_OUT)
+        .apply("Sanitize Oversized Values", MapElements.via(new OversizedValueDlqSanitizer()))
+        .apply(
+            "Write Oversized Values To DLQ",
+            DLQWriteTransform.WriteDLQ.newBuilder()
+                .withDlqDirectory(dlqManager.getSevereDlqDirectory() + "YYYY/MM/dd/HH/mm/")
+                .withTmpDirectory(dlqManager.getSevereDlqDirectory() + "tmp/")
+                .setIncludePaneInfo(true)
+                .build());
 
     Write<TableRow> bigQueryWrite =
         BigQueryIO.<TableRow>write()
@@ -319,27 +396,66 @@ public final class BigtableChangeStreamsToBigQuery {
 
   /**
    * DoFn that converts a {@link ChangeStreamMutation} to multiple {@link Mod} in serialized JSON
-   * format.
+   * format. SET_CELL mutations whose decoded value exceeds the configured byte limit are emitted to
+   * {@link #OVERSIZED_DLQ_OUT} as a metadata-only record instead of the main {@link TableRow}
+   * output.
    */
   static class ChangeStreamMutationToTableRowFn extends DoFn<ChangeStreamMutation, TableRow> {
+
+    /** Main output: successfully built {@link TableRow}s to write to BigQuery. */
+    public static final TupleTag<TableRow> MAIN_OUT = new TupleTag<TableRow>() {};
+
+    /** Side output: metadata describing oversized decoded values, routed to DLQ. */
+    public static final TupleTag<OversizedValue> OVERSIZED_DLQ_OUT =
+        new TupleTag<OversizedValue>() {};
+
     private final BigtableSource sourceInfo;
     private final BigQueryUtils bigQuery;
+    private final ValueTransformerRegistry transformerRegistry;
+    private final long maxDecodedValueBytes;
 
-    ChangeStreamMutationToTableRowFn(BigtableSource source, BigQueryUtils bigQuery) {
+    private final org.apache.beam.sdk.metrics.Counter oversizedDecodesCounter =
+        Metrics.counter(ChangeStreamMutationToTableRowFn.class, "oversizedDecodes");
+    private final Distribution decodedValueBytesDistribution =
+        Metrics.distribution(ChangeStreamMutationToTableRowFn.class, "decodedValueBytes");
+
+    ChangeStreamMutationToTableRowFn(
+        BigtableSource source,
+        BigQueryUtils bigQuery,
+        ValueTransformerRegistry transformerRegistry,
+        long maxDecodedValueBytes) {
       this.sourceInfo = source;
       this.bigQuery = bigQuery;
+      this.transformerRegistry = transformerRegistry;
+      this.maxDecodedValueBytes = maxDecodedValueBytes;
     }
 
     @ProcessElement
-    public void process(@Element ChangeStreamMutation input, OutputReceiver<TableRow> receiver)
+    public void process(@Element ChangeStreamMutation input, MultiOutputReceiver receiver)
         throws Exception {
       for (Entry entry : input.getEntries()) {
         ModType modType = getModType(entry);
 
-        Mod mod = null;
+        Mod mod;
         switch (modType) {
           case SET_CELL:
-            mod = new Mod(sourceInfo, input, (SetCell) entry);
+            SetCell setCell = (SetCell) entry;
+            Mod.SetCellBuildResult buildResult =
+                Mod.buildSetCell(
+                    sourceInfo,
+                    input,
+                    setCell,
+                    transformerRegistry,
+                    maxDecodedValueBytes);
+            TransformResult result = buildResult.transformResult();
+            if (result.status() == TransformResult.Status.SUCCESS) {
+              decodedValueBytesDistribution.update(result.decodedBytes());
+            } else if (result.status() == TransformResult.Status.OVERSIZED) {
+              oversizedDecodesCounter.inc();
+              receiver.get(OVERSIZED_DLQ_OUT).output(toOversizedValue(input, setCell, result));
+              continue;
+            }
+            mod = buildResult.mod();
             break;
           case DELETE_CELLS:
             mod = new Mod(sourceInfo, input, (DeleteCells) entry);
@@ -358,9 +474,26 @@ public final class BigtableChangeStreamsToBigQuery {
 
         TableRow tableRow = new TableRow();
         if (bigQuery.setTableRowFields(mod, tableRow)) {
-          receiver.output(tableRow);
+          receiver.get(MAIN_OUT).output(tableRow);
         }
       }
+    }
+
+    private OversizedValue toOversizedValue(
+        ChangeStreamMutation mutation, SetCell setCell, TransformResult result) {
+      return new OversizedValue(
+          mutation.getRowKey().toStringUtf8(),
+          Base64.getEncoder().encodeToString(mutation.getRowKey().toByteArray()),
+          mutation.getCommitTimestamp(),
+          setCell.getFamilyName(),
+          setCell.getQualifier().toStringUtf8(),
+          Base64.getEncoder().encodeToString(setCell.getQualifier().toByteArray()),
+          result.rawBytes(),
+          result.decodedBytes(),
+          maxDecodedValueBytes,
+          sourceInfo.getInstanceId(),
+          mutation.getSourceClusterId(),
+          sourceInfo.getTableId());
     }
 
     private ModType getModType(Entry entry) {

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/model/Mod.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/model/Mod.java
@@ -23,6 +23,9 @@ import com.google.cloud.bigtable.data.v2.models.DeleteCells;
 import com.google.cloud.bigtable.data.v2.models.DeleteFamily;
 import com.google.cloud.bigtable.data.v2.models.Range.BoundType;
 import com.google.cloud.bigtable.data.v2.models.SetCell;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils.TransformResult;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils.ValueTransformer;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils.ValueTransformerRegistry;
 import com.google.cloud.teleport.v2.utils.BigtableSource;
 import com.google.common.collect.Maps;
 import com.google.protobuf.ByteString;
@@ -33,6 +36,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.DefaultCoder;
 import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
 import org.threeten.bp.Instant;
@@ -48,6 +52,8 @@ public final class Mod implements Serializable {
   private static final long serialVersionUID = 8703757194338184299L;
 
   private static final String PATTERN_FORMAT = "yyyy-MM-dd HH:mm:ss.SSSSSS";
+
+  public static final String TRANSFORMED_VALUE = "TRANSFORMED_VALUE";
 
   private static final ThreadLocal<ObjectMapper> OBJECT_MAPPER =
       ThreadLocal.withInitial(ObjectMapper::new);
@@ -101,6 +107,54 @@ public final class Mod implements Serializable {
     this.changeJson = convertPropertiesToJson(propertiesMap);
   }
 
+  /**
+   * Builds a SET_CELL {@link Mod} while enforcing an upper bound on the decoded-value size. The
+   * returned {@link SetCellBuildResult} carries the {@link TransformResult} so the pipeline can
+   * route oversized decodes to the dead-letter queue without the Mod needing to hold transient
+   * state.
+   *
+   * <p>When {@code transformerRegistry} is {@code null} or no transformer is registered for the
+   * column, no decode is attempted and the raw cell bytes are left untouched — in particular the
+   * potentially 100 MB {@link SetCell#getValue()} is not copied via {@code toByteArray()}.
+   */
+  public static SetCellBuildResult buildSetCell(
+      BigtableSource source,
+      ChangeStreamMutation mutation,
+      SetCell setCell,
+      @Nullable ValueTransformerRegistry transformerRegistry,
+      long maxDecodedValueBytes) {
+    TransformResult result;
+    if (transformerRegistry == null) {
+      result = TransformResult.noTransformer();
+    } else {
+      String qualifierStr = setCell.getQualifier().toStringUtf8();
+      ValueTransformer transformer =
+          transformerRegistry.getTransformer(setCell.getFamilyName(), qualifierStr);
+      if (transformer == null) {
+        result = TransformResult.noTransformer();
+      } else {
+        byte[] valueBytes = setCell.getValue().toByteArray();
+        result = transformer.transformBounded(valueBytes, maxDecodedValueBytes);
+      }
+    }
+
+    if (result.status() == TransformResult.Status.OVERSIZED) {
+      return new SetCellBuildResult(null, result);
+    }
+
+    Mod mod = new Mod(mutation.getCommitTimestamp(), ModType.SET_CELL);
+    Map<String, Object> propertiesMap = Maps.newHashMap();
+    mod.setCommonProperties(propertiesMap, source, mutation);
+    boolean includeRawValueBytes = result.status() != TransformResult.Status.SUCCESS;
+    mod.setSpecificProperties(propertiesMap, setCell, includeRawValueBytes);
+    // Preserve legacy behavior: only SUCCESS populates TRANSFORMED_VALUE.
+    if (result.status() == TransformResult.Status.SUCCESS) {
+      propertiesMap.put(TRANSFORMED_VALUE, result.value());
+    }
+    mod.changeJson = mod.convertPropertiesToJson(propertiesMap);
+    return new SetCellBuildResult(mod, result);
+  }
+
   private void setCommonProperties(
       Map<String, Object> propertiesMap, BigtableSource source, ChangeStreamMutation mutation) {
     propertiesMap.put(ChangelogColumn.ROW_KEY_BYTES.name(), encodeBytes(mutation.getRowKey()));
@@ -116,6 +170,11 @@ public final class Mod implements Serializable {
   }
 
   private void setSpecificProperties(Map<String, Object> propertiesMap, SetCell setCell) {
+    setSpecificProperties(propertiesMap, setCell, true);
+  }
+
+  private void setSpecificProperties(
+      Map<String, Object> propertiesMap, SetCell setCell, boolean includeRawValueBytes) {
     propertiesMap.put(ChangelogColumn.MOD_TYPE.name(), ModType.SET_CELL.getCode());
     propertiesMap.put(ChangelogColumn.COLUMN_FAMILY.name(), setCell.getFamilyName());
     propertiesMap.put(ChangelogColumn.COLUMN.name(), encodeBytes(setCell.getQualifier()));
@@ -124,7 +183,9 @@ public final class Mod implements Serializable {
     propertiesMap.put(
         ChangelogColumn.TIMESTAMP_NUM.name(),
         cbtTimestampMicrosToBigQueryInt(setCell.getTimestamp()));
-    propertiesMap.put(ChangelogColumn.VALUE_BYTES.name(), encodeBytes(setCell.getValue()));
+    if (includeRawValueBytes) {
+      propertiesMap.put(ChangelogColumn.VALUE_BYTES.name(), encodeBytes(setCell.getValue()));
+    }
   }
 
   private void setSpecificProperties(Map<String, Object> propertiesMap, DeleteCells deleteCells) {
@@ -255,6 +316,27 @@ public final class Mod implements Serializable {
       return OBJECT_MAPPER.get().writeValueAsString(propertiesMap);
     } catch (IOException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  /** Result of {@link #buildSetCell}: the built {@link Mod} plus the transform outcome. */
+  public static final class SetCellBuildResult {
+    @Nullable private final Mod mod;
+    private final TransformResult transformResult;
+
+    SetCellBuildResult(@Nullable Mod mod, TransformResult transformResult) {
+      this.mod = mod;
+      this.transformResult = transformResult;
+    }
+
+    /** The built {@link Mod}, or {@code null} when the decoded value was {@link OVERSIZED}. */
+    @Nullable
+    public Mod mod() {
+      return mod;
+    }
+
+    public TransformResult transformResult() {
+      return transformResult;
     }
   }
 }

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/model/OversizedValue.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/model/OversizedValue.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.model;
+
+import java.io.Serializable;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.coders.DefaultCoder;
+import org.apache.beam.sdk.coders.SerializableCoder;
+import org.threeten.bp.Instant;
+
+/**
+ * Pure-data side-output record describing a Bigtable SET_CELL whose transformer output exceeded the
+ * configured byte budget. Routed to the severe dead-letter queue by the pipeline; serialized to
+ * JSON by {@code OversizedValueDlqSanitizer}.
+ */
+@DefaultCoder(SerializableCoder.class)
+public final class OversizedValue implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String rowKey;
+  private final String rowKeyBytes;
+  @Nullable private final Instant commitTimestamp;
+  private final String columnFamily;
+  private final String column;
+  private final String columnBytes;
+  private final long rawBytes;
+  private final long estimatedDecodedBytes;
+  private final long maxBytes;
+  private final String sourceInstance;
+  @Nullable private final String sourceCluster;
+  private final String sourceTable;
+
+  public OversizedValue(
+      String rowKey,
+      String rowKeyBytes,
+      @Nullable Instant commitTimestamp,
+      String columnFamily,
+      String column,
+      String columnBytes,
+      long rawBytes,
+      long estimatedDecodedBytes,
+      long maxBytes,
+      String sourceInstance,
+      @Nullable String sourceCluster,
+      String sourceTable) {
+    this.rowKey = rowKey;
+    this.rowKeyBytes = rowKeyBytes;
+    this.commitTimestamp = commitTimestamp;
+    this.columnFamily = columnFamily;
+    this.column = column;
+    this.columnBytes = columnBytes;
+    this.rawBytes = rawBytes;
+    this.estimatedDecodedBytes = estimatedDecodedBytes;
+    this.maxBytes = maxBytes;
+    this.sourceInstance = sourceInstance;
+    this.sourceCluster = sourceCluster;
+    this.sourceTable = sourceTable;
+  }
+
+  public String rowKey() {
+    return rowKey;
+  }
+
+  public String rowKeyBytes() {
+    return rowKeyBytes;
+  }
+
+  @Nullable
+  public Instant commitTimestamp() {
+    return commitTimestamp;
+  }
+
+  public String columnFamily() {
+    return columnFamily;
+  }
+
+  public String column() {
+    return column;
+  }
+
+  public String columnBytes() {
+    return columnBytes;
+  }
+
+  public long rawBytes() {
+    return rawBytes;
+  }
+
+  public long estimatedDecodedBytes() {
+    return estimatedDecodedBytes;
+  }
+
+  public long maxBytes() {
+    return maxBytes;
+  }
+
+  public String sourceInstance() {
+    return sourceInstance;
+  }
+
+  @Nullable
+  public String sourceCluster() {
+    return sourceCluster;
+  }
+
+  public String sourceTable() {
+    return sourceTable;
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/BigEndianTimestampTransformer.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/BigEndianTimestampTransformer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Transforms an 8-byte big-endian 64-bit integer representing Unix epoch milliseconds into a
+ * BigQuery-compatible timestamp string.
+ */
+public class BigEndianTimestampTransformer implements ValueTransformer {
+
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(BigEndianTimestampTransformer.class);
+  private static final DateTimeFormatter FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS").withZone(ZoneId.of("UTC"));
+
+  @Override
+  public String transform(byte[] bytes) {
+    if (bytes == null || bytes.length != 8) {
+      LOG.warn(
+          "Expected 8 bytes for big-endian uint64 timestamp, got {}",
+          bytes == null ? "null" : bytes.length);
+      return null;
+    }
+    try {
+      long millis = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN).getLong();
+      return FORMATTER.format(Instant.ofEpochMilli(millis));
+    } catch (Exception e) {
+      LOG.warn("Failed to decode big-endian timestamp: {}", e.getMessage());
+      return null;
+    }
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/BigQueryUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/BigQueryUtils.java
@@ -94,10 +94,12 @@ public class BigQueryUtils implements Serializable {
     FORMATTERS.put(
         ChangelogColumn.VALUE_STRING,
         (bq, chg) -> {
+          if (chg.has(Mod.TRANSFORMED_VALUE)) {
+            return chg.getString(Mod.TRANSFORMED_VALUE);
+          }
           if (!chg.has(ChangelogColumn.VALUE_BYTES.name())) {
             return null;
           }
-
           String valueEncoded = chg.getString(ChangelogColumn.VALUE_BYTES.name());
           return bq.convertBase64ToString(valueEncoded);
         });

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/OversizedJsonException.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/OversizedJsonException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils;
+
+/**
+ * Thrown by {@link Utf8BoundedAppendable} when the running UTF-8 byte count crosses the configured
+ * upper bound during {@code JsonFormat.Printer#appendTo}. Unchecked so it can unwind through Guava
+ * / protobuf appendable callers cleanly.
+ */
+final class OversizedJsonException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  private final long bytesSoFar;
+
+  OversizedJsonException(long bytesSoFar) {
+    super(
+        "JSON output exceeded the configured maximum byte size (" + bytesSoFar + " bytes so far)");
+    this.bytesSoFar = bytesSoFar;
+  }
+
+  long bytesSoFar() {
+    return bytesSoFar;
+  }
+
+  @Override
+  public synchronized Throwable fillInStackTrace() {
+    return this;
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/OversizedValueDlqSanitizer.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/OversizedValueDlqSanitizer.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils;
+
+import com.google.cloud.teleport.v2.cdc.dlq.DeadLetterQueueSanitizer;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.model.ChangelogColumn;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.model.OversizedValue;
+import com.google.gson.Gson;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Sanitizes {@link OversizedValue} records into compact JSON lines suitable for the severe dead
+ * letter queue. Produces one JSON object per input; keys reuse the canonical BigQuery column names
+ * from {@link ChangelogColumn} where applicable.
+ */
+public final class OversizedValueDlqSanitizer
+    extends DeadLetterQueueSanitizer<OversizedValue, String> {
+
+  /** Non-column JSON keys. Keep aligned with the integration test assertions. */
+  static final String RAW_BYTES = "raw_bytes";
+
+  static final String ROW_KEY_BYTES = "row_key_bytes";
+  static final String COLUMN_BYTES = "column_bytes";
+  static final String ESTIMATED_DECODED_BYTES = "estimated_decoded_bytes";
+  static final String MAX_BYTES = "max_bytes";
+  static final String REASON = "reason";
+  static final String REASON_VALUE = "decoded_value_exceeds_max_bytes";
+
+  private static final ThreadLocal<Gson> GSON = ThreadLocal.withInitial(Gson::new);
+
+  public OversizedValueDlqSanitizer() {}
+
+  @Override
+  public String getJsonMessage(OversizedValue input) {
+    Map<String, Object> record = new LinkedHashMap<>();
+    record.put(ChangelogColumn.ROW_KEY_STRING.getBqColumnName(), input.rowKey());
+    record.put(ROW_KEY_BYTES, input.rowKeyBytes());
+    record.put(ChangelogColumn.COMMIT_TIMESTAMP.getBqColumnName(), formatCommitTimestamp(input));
+    record.put(ChangelogColumn.COLUMN_FAMILY.getBqColumnName(), input.columnFamily());
+    record.put(ChangelogColumn.COLUMN.getBqColumnName(), input.column());
+    record.put(COLUMN_BYTES, input.columnBytes());
+    record.put(RAW_BYTES, input.rawBytes());
+    record.put(ESTIMATED_DECODED_BYTES, input.estimatedDecodedBytes());
+    record.put(MAX_BYTES, input.maxBytes());
+    record.put(REASON, REASON_VALUE);
+    record.put(ChangelogColumn.SOURCE_INSTANCE.getBqColumnName(), input.sourceInstance());
+    record.put(ChangelogColumn.SOURCE_CLUSTER.getBqColumnName(), input.sourceCluster());
+    record.put(ChangelogColumn.SOURCE_TABLE.getBqColumnName(), input.sourceTable());
+    return GSON.get().toJson(record);
+  }
+
+  @Override
+  public String getErrorMessageJson(OversizedValue input) {
+    return REASON_VALUE;
+  }
+
+  private static String formatCommitTimestamp(OversizedValue input) {
+    org.threeten.bp.Instant ts = input.commitTimestamp();
+    if (ts == null) {
+      return null;
+    }
+    return java.time.Instant.ofEpochSecond(ts.getEpochSecond(), ts.getNano()).toString();
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/ProtoDecodeTransformer.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/ProtoDecodeTransformer.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils;
+
+import com.google.cloud.teleport.v2.utils.SchemaUtils;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link ValueTransformer} that decodes protobuf-encoded byte values into JSON strings.
+ *
+ * <p>The transformer lazily initializes the proto {@link Descriptor} and {@link JsonFormat.Printer}
+ * on first use, since these objects are not serializable and must be created on the worker after
+ * deserialization.
+ */
+public class ProtoDecodeTransformer implements ValueTransformer {
+
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(ProtoDecodeTransformer.class);
+
+  private final String protoSchemaPath;
+  private final String fullMessageName;
+  private final boolean preserveFieldNames;
+
+  private volatile boolean initialized = false;
+  private transient Descriptor descriptor;
+  private transient JsonFormat.Printer printer;
+
+  public ProtoDecodeTransformer(
+      String protoSchemaPath, String fullMessageName, boolean preserveFieldNames) {
+    this.protoSchemaPath = protoSchemaPath;
+    this.fullMessageName = fullMessageName;
+    this.preserveFieldNames = preserveFieldNames;
+  }
+
+  private void ensureInitialized() {
+    if (initialized) {
+      return;
+    }
+    synchronized (this) {
+      if (initialized) {
+        return;
+      }
+      descriptor = SchemaUtils.getProtoDomain(protoSchemaPath).getDescriptor(fullMessageName);
+      if (descriptor == null) {
+        throw new IllegalArgumentException(
+            fullMessageName + " is not a recognized message in " + protoSchemaPath);
+      }
+      JsonFormat.Printer basePrinter = JsonFormat.printer();
+      printer = preserveFieldNames ? basePrinter.preservingProtoFieldNames() : basePrinter;
+      initialized = true;
+    }
+  }
+
+  /** Package-private constructor for testing with a pre-built descriptor. */
+  ProtoDecodeTransformer(Descriptor descriptor, boolean preserveFieldNames) {
+    this.protoSchemaPath = null;
+    this.fullMessageName = null;
+    this.preserveFieldNames = preserveFieldNames;
+    this.descriptor = descriptor;
+    JsonFormat.Printer basePrinter = JsonFormat.printer();
+    this.printer = preserveFieldNames ? basePrinter.preservingProtoFieldNames() : basePrinter;
+    this.initialized = true;
+  }
+
+  /**
+   * Decodes protobuf bytes into a JSON string.
+   *
+   * @param bytes the serialized protobuf message bytes
+   * @return the JSON representation, or null if decoding fails
+   */
+  @Override
+  public String transform(byte[] bytes) {
+    ensureInitialized();
+    try {
+      DynamicMessage message = DynamicMessage.parseFrom(descriptor, bytes);
+      return printer.print(message);
+    } catch (InvalidProtocolBufferException e) {
+      LOG.warn("Failed to decode protobuf message for {}: {}", fullMessageName, e.getMessage());
+      return null;
+    }
+  }
+
+  /**
+   * Decodes protobuf bytes into a JSON string while enforcing a byte-size bound on the JSON output.
+   *
+   * <p>Behaviour:
+   *
+   * <ul>
+   *   <li>{@code maxBytes <= 0} disables the bound and behaves like {@link #transform(byte[])}.
+   *   <li>A cheap pre-check rejects payloads whose raw protobuf wire size already exceeds the
+   *       decoded-value budget. This preserves the original protection for very large inputs
+   *       without incorrectly rejecting mid-sized string-heavy messages that still fit once
+   *       rendered as JSON.
+   *   <li>Otherwise the printer writes into a {@link Utf8BoundedAppendable} that aborts
+   *       mid-serialization once the UTF-8 byte budget is exceeded.
+   *   <li>Malformed proto input yields {@link TransformResult.Status#DECODE_ERROR}.
+   * </ul>
+   *
+   * @param bytes the serialized protobuf message bytes
+   * @param maxBytes the maximum allowed UTF-8 byte size of the JSON output; {@code <= 0} disables
+   *     the bound
+   * @return a {@link TransformResult} describing the outcome
+   */
+  @Override
+  public TransformResult transformBounded(byte[] bytes, long maxBytes) {
+    ensureInitialized();
+    long rawBytes = bytes.length;
+
+    if (maxBytes > 0 && rawBytes > maxBytes) {
+      return TransformResult.oversized(rawBytes, rawBytes);
+    }
+
+    try {
+      DynamicMessage message = DynamicMessage.parseFrom(descriptor, bytes);
+      Utf8BoundedAppendable appendable = new Utf8BoundedAppendable(maxBytes);
+      try {
+        printer.appendTo(message, appendable);
+      } catch (OversizedJsonException e) {
+        return TransformResult.oversized(rawBytes, e.bytesSoFar());
+      } catch (IOException e) {
+        // StringBuilder-backed Appendable should not throw IOException.
+        LOG.warn("Unexpected IO error while serializing proto to JSON: {}", e.getMessage());
+        return TransformResult.decodeError(rawBytes);
+      }
+      return TransformResult.success(appendable.toJson(), rawBytes, appendable.byteCount());
+    } catch (InvalidProtocolBufferException e) {
+      LOG.warn("Failed to decode protobuf message for {}: {}", fullMessageName, e.getMessage());
+      return TransformResult.decodeError(rawBytes);
+    }
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/TransformResult.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/TransformResult.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils;
+
+import javax.annotation.Nullable;
+
+/** Outcome of applying a {@link ValueTransformer} with a decoded-size bound. */
+public final class TransformResult {
+  /** Status of a bounded transform attempt. */
+  public enum Status {
+    /** The transformer produced a value that fits within the decoded-size bound. */
+    SUCCESS,
+    /** The transformer failed to decode the raw bytes (e.g. malformed proto). */
+    DECODE_ERROR,
+    /** The decoded output exceeded the configured byte budget and was abandoned. */
+    OVERSIZED,
+    /** No transformer is registered for the column; raw bytes should be used as-is. */
+    NO_TRANSFORMER
+  }
+
+  private final Status status;
+  @Nullable private final String value;
+  private final long rawBytes;
+  // Exact for SUCCESS/OVERSIZED, 0 otherwise.
+  private final long decodedBytes;
+
+  private TransformResult(Status status, @Nullable String value, long rawBytes, long decodedBytes) {
+    this.status = status;
+    this.value = value;
+    this.rawBytes = rawBytes;
+    this.decodedBytes = decodedBytes;
+  }
+
+  public static TransformResult success(String value, long rawBytes, long decodedBytes) {
+    return new TransformResult(Status.SUCCESS, value, rawBytes, decodedBytes);
+  }
+
+  public static TransformResult decodeError(long rawBytes) {
+    return new TransformResult(Status.DECODE_ERROR, null, rawBytes, 0);
+  }
+
+  public static TransformResult oversized(long rawBytes, long estimatedDecodedBytes) {
+    return new TransformResult(Status.OVERSIZED, null, rawBytes, estimatedDecodedBytes);
+  }
+
+  public static TransformResult noTransformer() {
+    return new TransformResult(Status.NO_TRANSFORMER, null, 0, 0);
+  }
+
+  public Status status() {
+    return status;
+  }
+
+  @Nullable
+  public String value() {
+    return value;
+  }
+
+  public long rawBytes() {
+    return rawBytes;
+  }
+
+  public long decodedBytes() {
+    return decodedBytes;
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/Utf8BoundedAppendable.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/Utf8BoundedAppendable.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils;
+
+import com.google.common.base.Utf8;
+
+/**
+ * An {@link Appendable} that buffers text into a {@link StringBuilder} while tracking the exact
+ * UTF-8 byte length of the output. Once the running UTF-8 byte count would exceed {@code maxBytes},
+ * the appendable throws {@link OversizedJsonException} so that in-progress serializers (notably
+ * {@code JsonFormat.Printer#appendTo}) abort instead of inflating a huge JSON document in memory.
+ *
+ * <p>Pass {@code maxBytes &lt;= 0} to disable bounding (the appendable accepts an unlimited amount
+ * of text).
+ *
+ * <p>Package-private: only meant to be used from this package's transformers.
+ */
+final class Utf8BoundedAppendable implements Appendable {
+
+  private final StringBuilder sb;
+  private final long maxBytes;
+  private long byteCount;
+
+  Utf8BoundedAppendable(long maxBytes) {
+    int cap = (int) Math.max(64, Math.min(maxBytes > 0 ? maxBytes : 1024L, 1L << 20));
+    this.sb = new StringBuilder(cap);
+    this.maxBytes = maxBytes;
+    this.byteCount = 0L;
+  }
+
+  @Override
+  public Appendable append(CharSequence csq) {
+    CharSequence s = csq == null ? "null" : csq;
+    return appendSegment(s, 0, s.length());
+  }
+
+  @Override
+  public Appendable append(CharSequence csq, int start, int end) {
+    CharSequence s = csq == null ? "null" : csq;
+    return appendSegment(s, start, end);
+  }
+
+  @Override
+  public Appendable append(char c) {
+    return appendSegment(String.valueOf(c), 0, 1);
+  }
+
+  private Appendable appendSegment(CharSequence csq, int start, int end) {
+    if (start >= end) {
+      return this;
+    }
+    CharSequence segment = start == 0 && end == csq.length() ? csq : csq.subSequence(start, end);
+    long delta = Utf8.encodedLength(segment);
+    long projected = byteCount + delta;
+    if (maxBytes > 0 && projected > maxBytes) {
+      throw new OversizedJsonException(projected);
+    }
+    sb.append(segment);
+    byteCount = projected;
+    return this;
+  }
+
+  String toJson() {
+    return sb.toString();
+  }
+
+  long byteCount() {
+    return byteCount;
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/ValueTransformer.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/ValueTransformer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils;
+
+import com.google.common.base.Utf8;
+import java.io.Serializable;
+
+/** Transforms a Bigtable cell value from raw bytes to a string representation for BigQuery. */
+public interface ValueTransformer extends Serializable {
+
+  /**
+   * Transforms raw cell value bytes to a string for BigQuery.
+   *
+   * @param bytes the raw cell value bytes
+   * @return the transformed string, or null if transformation fails
+   */
+  String transform(byte[] bytes);
+
+  /**
+   * Transforms raw cell value bytes into a string while enforcing an upper bound on the UTF-8 byte
+   * size of the decoded output.
+   *
+   * <p>The default implementation is a post-hoc bound: it calls {@link #transform(byte[])} and
+   * measures the resulting string. Transformers whose output can dwarf available memory (e.g.
+   * {@link ProtoDecodeTransformer}) should override this to abort mid-serialization instead.
+   *
+   * @param bytes the raw cell value bytes
+   * @param maxBytes maximum allowed UTF-8 byte size of the decoded output; {@code <= 0} disables
+   *     the bound
+   * @return a {@link TransformResult} describing the outcome
+   */
+  default TransformResult transformBounded(byte[] bytes, long maxBytes) {
+    long rawBytes = bytes.length;
+    String result = transform(bytes);
+    if (result == null) {
+      return TransformResult.decodeError(rawBytes);
+    }
+    long decodedBytes = Utf8.encodedLength(result);
+    if (maxBytes > 0 && decodedBytes > maxBytes) {
+      return TransformResult.oversized(rawBytes, decodedBytes);
+    }
+    return TransformResult.success(result, rawBytes, decodedBytes);
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/ValueTransformerRegistry.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/ValueTransformerRegistry.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Registry that maps column family/qualifier pairs to {@link ValueTransformer} instances.
+ *
+ * <p>The configuration string is a comma-separated list of entries with the format:
+ *
+ * <pre>column_family:column_qualifier:TRANSFORM_TYPE</pre>
+ *
+ * <p>Supported TRANSFORM_TYPE values:
+ *
+ * <ul>
+ *   <li>{@code BIG_ENDIAN_TIMESTAMP} - interprets 8-byte big-endian values as Unix epoch millis
+ *   <li>{@code PROTO_DECODE(package.MessageName)} - decodes protobuf-encoded values to JSON
+ *       (requires {@code protoSchemaPath})
+ * </ul>
+ *
+ * <p><b>Note:</b> Column qualifiers containing commas are not supported since comma is used as the
+ * entry delimiter.
+ */
+public class ValueTransformerRegistry implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  /** Two-level map: family -> column -> transformer. */
+  private final Map<String, Map<String, ValueTransformer>> transformers;
+
+  private ValueTransformerRegistry(Map<String, Map<String, ValueTransformer>> transformers) {
+    this.transformers = transformers;
+  }
+
+  /**
+   * Creates a registry from a flat map keyed by "family:column". Package-private for testing.
+   *
+   * @param flat map from "family:column" to transformer
+   * @return a registry backed by the converted two-level map
+   */
+  static ValueTransformerRegistry of(Map<String, ValueTransformer> flat) {
+    Map<String, Map<String, ValueTransformer>> twoLevel = new HashMap<>();
+    flat.forEach(
+        (key, transformer) -> {
+          int colon = key.indexOf(':');
+          String family = key.substring(0, colon);
+          String column = key.substring(colon + 1);
+          twoLevel.computeIfAbsent(family, k -> new HashMap<>()).put(column, transformer);
+        });
+    return new ValueTransformerRegistry(twoLevel);
+  }
+
+  /**
+   * Returns the transformer for the given column family and qualifier, or null if none is
+   * registered.
+   */
+  @Nullable
+  public ValueTransformer getTransformer(String columnFamily, String columnQualifier) {
+    Map<String, ValueTransformer> familyMap = transformers.get(columnFamily);
+    return familyMap != null ? familyMap.get(columnQualifier) : null;
+  }
+
+  /**
+   * Applies the registered transformer for the given column with an upper bound on the decoded
+   * output size, delegating the per-transformer bounded semantics to {@link
+   * ValueTransformer#transformBounded(byte[], long)}. Returns {@link
+   * TransformResult.Status#NO_TRANSFORMER} when no transformer is registered so callers can fall
+   * back to the raw cell value.
+   *
+   * @param columnFamily Bigtable column family
+   * @param columnQualifier Bigtable column qualifier (UTF-8 string form)
+   * @param bytes raw cell value bytes
+   * @param maxBytes maximum allowed UTF-8 byte size of the decoded output; {@code <= 0} disables
+   *     the bound
+   * @return a {@link TransformResult} describing the outcome; never null
+   */
+  public TransformResult transformBounded(
+      String columnFamily, String columnQualifier, byte[] bytes, long maxBytes) {
+    ValueTransformer transformer = getTransformer(columnFamily, columnQualifier);
+    return transformer == null
+        ? TransformResult.noTransformer()
+        : transformer.transformBounded(bytes, maxBytes);
+  }
+
+  /**
+   * Parses a column transforms configuration string without proto support.
+   *
+   * @param config comma-separated list of {@code column_family:column:TRANSFORM_TYPE} entries, or
+   *     null/empty for no transforms
+   * @return a registry with the configured transformers
+   */
+  public static ValueTransformerRegistry parse(@Nullable String config) {
+    return parse(config, null, false);
+  }
+
+  /**
+   * Parses a column transforms configuration string.
+   *
+   * <p>The format is a comma-separated list of entries:
+   *
+   * <pre>column_family:column_qualifier:TRANSFORM_TYPE</pre>
+   *
+   * <p><b>Note:</b> Column qualifiers containing commas are not supported since comma is used as
+   * the entry delimiter.
+   *
+   * @param config comma-separated list of {@code column_family:column:TRANSFORM_TYPE} entries, or
+   *     null/empty for no transforms
+   * @param protoSchemaPath GCS path to the proto schema file, required for PROTO_DECODE transforms
+   * @param preserveProtoFieldNames whether to preserve proto field names in JSON output
+   * @return a registry with the configured transformers
+   */
+  public static ValueTransformerRegistry parse(
+      @Nullable String config, @Nullable String protoSchemaPath, boolean preserveProtoFieldNames) {
+    Map<String, Map<String, ValueTransformer>> transformers = new HashMap<>();
+
+    if (config == null || config.trim().isEmpty()) {
+      return new ValueTransformerRegistry(transformers);
+    }
+
+    // Cache so that identical type strings share transformer instances.
+    Map<String, ValueTransformer> transformerCache = new HashMap<>();
+
+    String[] entries = config.split(",");
+    for (String entry : entries) {
+      String trimmed = entry.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+
+      int firstColon = trimmed.indexOf(':');
+      int lastColon = trimmed.lastIndexOf(':');
+      if (firstColon == -1 || firstColon == lastColon) {
+        throw new IllegalArgumentException(
+            "Invalid columnTransforms entry '"
+                + trimmed
+                + "'. Expected format: column_family:column:TRANSFORM_TYPE");
+      }
+      String family = trimmed.substring(0, firstColon);
+      String column = trimmed.substring(firstColon + 1, lastColon);
+      String type = trimmed.substring(lastColon + 1);
+
+      ValueTransformer transformer =
+          transformerCache.computeIfAbsent(
+              type, t -> createTransformer(t, protoSchemaPath, preserveProtoFieldNames));
+      transformers.computeIfAbsent(family, k -> new HashMap<>()).put(column, transformer);
+    }
+
+    return new ValueTransformerRegistry(transformers);
+  }
+
+  private static ValueTransformer createTransformer(
+      String type, @Nullable String protoSchemaPath, boolean preserveProtoFieldNames) {
+    if ("BIG_ENDIAN_TIMESTAMP".equals(type)) {
+      return new BigEndianTimestampTransformer();
+    }
+
+    if (type.startsWith("PROTO_DECODE(") && type.endsWith(")")) {
+      String messageName = type.substring("PROTO_DECODE(".length(), type.length() - 1);
+      if (messageName.isEmpty()) {
+        throw new IllegalArgumentException(
+            "PROTO_DECODE requires a message name, e.g. PROTO_DECODE(package.MessageName)");
+      }
+      if (protoSchemaPath == null || protoSchemaPath.isEmpty()) {
+        throw new IllegalArgumentException(
+            "PROTO_DECODE transform requires protoSchemaPath to be set");
+      }
+      return new ProtoDecodeTransformer(protoSchemaPath, messageName, preserveProtoFieldNames);
+    }
+
+    throw new IllegalArgumentException(
+        "Unknown TRANSFORM_TYPE '"
+            + type
+            + "'. Supported types: BIG_ENDIAN_TIMESTAMP, PROTO_DECODE(package.MessageName)");
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/BigtableChangeStreamsToBigQueryIT.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/BigtableChangeStreamsToBigQueryIT.java
@@ -38,7 +38,17 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
 import com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.model.ChangelogColumn;
 import com.google.common.collect.Lists;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.DynamicMessage;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.time.Duration;
 import java.util.Date;
 import java.util.HashSet;
@@ -447,5 +457,372 @@ public final class BigtableChangeStreamsToBigQueryIT extends TemplateTestBase {
         + (value != null
             ? String.format(" AND %s = '%s'", ChangelogColumn.VALUE_STRING.getBqColumnName(), value)
             : "");
+  }
+
+  @Test
+  public void testBigtableChangeStreamsToBigQueryColumnTransform() throws Exception {
+    String appProfileId = generateAppProfileId();
+
+    BigtableTableSpec cdcTableSpec = new BigtableTableSpec();
+    cdcTableSpec.setCdcEnabled(true);
+    cdcTableSpec.setColumnFamilies(Lists.asList(SOURCE_COLUMN_FAMILY, new String[] {}));
+
+    String table = BigtableResourceManagerUtils.generateTableId("col-transform");
+    String cdcTable = BigtableResourceManagerUtils.generateTableId("cdc-col-transform");
+    bigtableResourceManager.createTable(table, cdcTableSpec);
+
+    bigtableResourceManager.createAppProfile(
+        appProfileId, true, bigtableResourceManager.getClusterNames());
+    bigQueryResourceManager.createDataset(REGION);
+
+    String rowkey = UUID.randomUUID().toString();
+    String column = "ts_col";
+
+    // Encode 1704067200000L (2024-01-01T00:00:00Z) as 8-byte big-endian uint64
+    long timestampMillis = 1704067200000L;
+    byte[] timestampBytes = new byte[8];
+    ByteBuffer.wrap(timestampBytes).order(ByteOrder.BIG_ENDIAN).putLong(timestampMillis);
+
+    Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder = Function.identity();
+    launchInfo =
+        launchTemplate(
+            paramsAdder.apply(
+                LaunchConfig.builder(testName, specPath)
+                    .addParameter("bigtableReadTableId", table)
+                    .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                    .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                    .addParameter("bigQueryDataset", bigQueryResourceManager.getDatasetId())
+                    .addParameter("bigQueryChangelogTableName", cdcTable)
+                    .addParameter(
+                        "columnTransforms",
+                        SOURCE_COLUMN_FAMILY + ":" + column + ":BIG_ENDIAN_TIMESTAMP")));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    RowMutation rowMutation =
+        RowMutation.create(table, rowkey)
+            .setCell(
+                SOURCE_COLUMN_FAMILY,
+                ByteString.copyFromUtf8(column),
+                ByteString.copyFrom(timestampBytes));
+    bigtableResourceManager.write(rowMutation);
+
+    String query = newLookForValuesQuery(cdcTable, rowkey, column, null);
+    waitForQueryToReturnRows(query, 1, true);
+
+    TableResult tableResult = bigQueryResourceManager.runQuery(query);
+    tableResult
+        .iterateAll()
+        .forEach(
+            fvl -> {
+              String value =
+                  fvl.get(ChangelogColumn.VALUE_STRING.getBqColumnName()).getStringValue();
+              // BigEndianTimestampTransformer formats as "yyyy-MM-dd HH:mm:ss.SSSSSS"
+              assertEquals("2024-01-01 00:00:00.000000", value);
+              assertFalse(fvl.get(ChangelogColumn.IS_GC.getBqColumnName()).getBooleanValue());
+              assertEquals(
+                  table, fvl.get(ChangelogColumn.SOURCE_TABLE.getBqColumnName()).getStringValue());
+              assertEquals(
+                  bigtableResourceManager.getInstanceId(),
+                  fvl.get(ChangelogColumn.SOURCE_INSTANCE.getBqColumnName()).getStringValue());
+            });
+  }
+
+  @Test
+  public void testBigtableChangeStreamsToBigQueryProtoDecodeMultipleColumnsViaTransform()
+      throws Exception {
+    String appProfileId = generateAppProfileId();
+
+    BigtableTableSpec cdcTableSpec = new BigtableTableSpec();
+    cdcTableSpec.setCdcEnabled(true);
+    cdcTableSpec.setColumnFamilies(Lists.asList(SOURCE_COLUMN_FAMILY, new String[] {}));
+
+    String table = BigtableResourceManagerUtils.generateTableId("proto-transform");
+    String cdcTable = BigtableResourceManagerUtils.generateTableId("cdc-proto-transform");
+    bigtableResourceManager.createTable(table, cdcTableSpec);
+
+    bigtableResourceManager.createAppProfile(
+        appProfileId, true, bigtableResourceManager.getClusterNames());
+    bigQueryResourceManager.createDataset(REGION);
+
+    // Build a simple proto descriptor programmatically and upload as a .pb file to GCS
+    FileDescriptorProto fileProto =
+        FileDescriptorProto.newBuilder()
+            .setName("test.proto")
+            .setPackage("test")
+            .addMessageType(
+                DescriptorProto.newBuilder()
+                    .setName("SimpleMessage")
+                    .addField(
+                        FieldDescriptorProto.newBuilder()
+                            .setName("user_name")
+                            .setNumber(1)
+                            .setType(FieldDescriptorProto.Type.TYPE_STRING)
+                            .build())
+                    .addField(
+                        FieldDescriptorProto.newBuilder()
+                            .setName("id")
+                            .setNumber(2)
+                            .setType(FieldDescriptorProto.Type.TYPE_INT32)
+                            .build())
+                    .build())
+            .build();
+
+    FileDescriptorSet descriptorSet = FileDescriptorSet.newBuilder().addFile(fileProto).build();
+
+    gcsClient.createArtifact("proto-schema.pb", descriptorSet.toByteArray());
+    String protoSchemaGcsPath = getGcsPath("proto-schema.pb");
+
+    // Build a protobuf message matching the descriptor
+    FileDescriptor fileDescriptor = FileDescriptor.buildFrom(fileProto, new FileDescriptor[] {});
+    Descriptor descriptor = fileDescriptor.findMessageTypeByName("SimpleMessage");
+
+    DynamicMessage protoMessage =
+        DynamicMessage.newBuilder(descriptor)
+            .setField(descriptor.findFieldByName("user_name"), "test_user")
+            .setField(descriptor.findFieldByName("id"), 42)
+            .build();
+    byte[] protoBytes = protoMessage.toByteArray();
+    DynamicMessage colonColumnProtoMessage =
+        DynamicMessage.newBuilder(descriptor)
+            .setField(descriptor.findFieldByName("user_name"), "colon_user")
+            .setField(descriptor.findFieldByName("id"), 7)
+            .build();
+    byte[] colonColumnProtoBytes = colonColumnProtoMessage.toByteArray();
+
+    String rowkey = UUID.randomUUID().toString();
+    String colonColumnRowkey = UUID.randomUUID().toString();
+    String column = "proto_col";
+    String colonColumn = "profile:v1";
+
+    Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder = Function.identity();
+    launchInfo =
+        launchTemplate(
+            paramsAdder.apply(
+                LaunchConfig.builder(testName, specPath)
+                    .addParameter("bigtableReadTableId", table)
+                    .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                    .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                    .addParameter("bigQueryDataset", bigQueryResourceManager.getDatasetId())
+                    .addParameter("bigQueryChangelogTableName", cdcTable)
+                    .addParameter(
+                        "columnTransforms",
+                        SOURCE_COLUMN_FAMILY
+                            + ":"
+                            + column
+                            + ":PROTO_DECODE(test.SimpleMessage),"
+                            + SOURCE_COLUMN_FAMILY
+                            + ":"
+                            + colonColumn
+                            + ":PROTO_DECODE(test.SimpleMessage)")
+                    .addParameter("protoSchemaPath", protoSchemaGcsPath)));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    bigtableResourceManager.write(
+        RowMutation.create(table, rowkey)
+            .setCell(
+                SOURCE_COLUMN_FAMILY,
+                ByteString.copyFromUtf8(column),
+                ByteString.copyFrom(protoBytes)));
+    bigtableResourceManager.write(
+        RowMutation.create(table, colonColumnRowkey)
+            .setCell(
+                SOURCE_COLUMN_FAMILY,
+                ByteString.copyFromUtf8(colonColumn),
+                ByteString.copyFrom(colonColumnProtoBytes)));
+
+    String query = newLookForValuesQuery(cdcTable, rowkey, column, null);
+    waitForQueryToReturnRows(query, 1, false);
+    assertProtoDecodedValue(query, "test_user", "42", table);
+
+    String colonColumnQuery = newLookForValuesQuery(cdcTable, colonColumnRowkey, colonColumn, null);
+    waitForQueryToReturnRows(colonColumnQuery, 1, true);
+    assertProtoDecodedValue(colonColumnQuery, "colon_user", "7", table);
+  }
+
+  private void assertProtoDecodedValue(String query, String expectedName, String expectedId, String table)
+      throws IOException {
+    TableResult tableResult = bigQueryResourceManager.runQuery(query);
+    tableResult
+        .iterateAll()
+        .forEach(
+            fvl -> {
+              String value =
+                  fvl.get(ChangelogColumn.VALUE_STRING.getBqColumnName()).getStringValue();
+              assertNotNull("Expected non-null decoded proto value", value);
+              // JsonFormat.printer() uses camelCase by default: "userName" not "user_name".
+              assertTrue(
+                  "Expected decoded JSON to contain 'userName', got: " + value,
+                  value.contains("userName"));
+              assertTrue(
+                  "Expected decoded JSON to contain '" + expectedName + "', got: " + value,
+                  value.contains(expectedName));
+              assertTrue(
+                  "Expected decoded JSON to contain '" + expectedId + "', got: " + value,
+                  value.contains(expectedId));
+              assertFalse(fvl.get(ChangelogColumn.IS_GC.getBqColumnName()).getBooleanValue());
+              assertEquals(
+                  table, fvl.get(ChangelogColumn.SOURCE_TABLE.getBqColumnName()).getStringValue());
+              assertEquals(
+                  bigtableResourceManager.getInstanceId(),
+                  fvl.get(ChangelogColumn.SOURCE_INSTANCE.getBqColumnName()).getStringValue());
+            });
+  }
+
+  @Test
+  public void testBigtableChangeStreamsToBigQueryProtoDecodeOversizedRoutesToDlq()
+      throws Exception {
+    String appProfileId = generateAppProfileId();
+
+    BigtableTableSpec cdcTableSpec = new BigtableTableSpec();
+    cdcTableSpec.setCdcEnabled(true);
+    cdcTableSpec.setColumnFamilies(Lists.asList(SOURCE_COLUMN_FAMILY, new String[] {}));
+
+    String table = BigtableResourceManagerUtils.generateTableId("proto-oversized");
+    String cdcTable = BigtableResourceManagerUtils.generateTableId("cdc-proto-oversized");
+    bigtableResourceManager.createTable(table, cdcTableSpec);
+
+    bigtableResourceManager.createAppProfile(
+        appProfileId, true, bigtableResourceManager.getClusterNames());
+    bigQueryResourceManager.createDataset(REGION);
+
+    FileDescriptorProto fileProto =
+        FileDescriptorProto.newBuilder()
+            .setName("test.proto")
+            .setPackage("test")
+            .addMessageType(
+                DescriptorProto.newBuilder()
+                    .setName("SimpleMessage")
+                    .addField(
+                        FieldDescriptorProto.newBuilder()
+                            .setName("user_name")
+                            .setNumber(1)
+                            .setType(FieldDescriptorProto.Type.TYPE_STRING)
+                            .build())
+                    .addField(
+                        FieldDescriptorProto.newBuilder()
+                            .setName("id")
+                            .setNumber(2)
+                            .setType(FieldDescriptorProto.Type.TYPE_INT32)
+                            .build())
+                    .build())
+            .build();
+
+    FileDescriptorSet descriptorSet = FileDescriptorSet.newBuilder().addFile(fileProto).build();
+    gcsClient.createArtifact("proto-schema-oversized.pb", descriptorSet.toByteArray());
+    String protoSchemaGcsPath = getGcsPath("proto-schema-oversized.pb");
+
+    FileDescriptor fileDescriptor = FileDescriptor.buildFrom(fileProto, new FileDescriptor[] {});
+    Descriptor descriptor = fileDescriptor.findMessageTypeByName("SimpleMessage");
+
+    // Small cell — must land in BigQuery.
+    byte[] smallProtoBytes =
+        DynamicMessage.newBuilder(descriptor)
+            .setField(descriptor.findFieldByName("user_name"), "ok_user")
+            .setField(descriptor.findFieldByName("id"), 1)
+            .build()
+            .toByteArray();
+
+    // Big cell — must be routed to the severe DLQ, not BigQuery. Set user_name to ~50KB so the
+    // decoded JSON comfortably exceeds the 10_000 byte cap configured below.
+    String hugeName = org.apache.commons.lang3.StringUtils.repeat('x', 50_000);
+    byte[] hugeProtoBytes =
+        DynamicMessage.newBuilder(descriptor)
+            .setField(descriptor.findFieldByName("user_name"), hugeName)
+            .setField(descriptor.findFieldByName("id"), 2)
+            .build()
+            .toByteArray();
+
+    String okRow = UUID.randomUUID().toString();
+    String hugeRow = UUID.randomUUID().toString();
+    String column = "proto_col";
+
+    Function<LaunchConfig.Builder, LaunchConfig.Builder> paramsAdder = Function.identity();
+    launchInfo =
+        launchTemplate(
+            paramsAdder.apply(
+                LaunchConfig.builder(testName, specPath)
+                    .addParameter("bigtableReadTableId", table)
+                    .addParameter("bigtableReadInstanceId", bigtableResourceManager.getInstanceId())
+                    .addParameter("bigtableChangeStreamAppProfile", appProfileId)
+                    .addParameter("bigQueryDataset", bigQueryResourceManager.getDatasetId())
+                    .addParameter("bigQueryChangelogTableName", cdcTable)
+                    .addParameter(
+                        "columnTransforms",
+                        SOURCE_COLUMN_FAMILY + ":" + column + ":PROTO_DECODE(test.SimpleMessage)")
+                    .addParameter("protoSchemaPath", protoSchemaGcsPath)
+                    .addParameter("maxDecodedValueBytes", "10000")
+                    .addParameter("dlqDirectory", getGcsPath("dlq"))));
+
+    assertThatPipeline(launchInfo).isRunning();
+
+    bigtableResourceManager.write(
+        RowMutation.create(table, okRow)
+            .setCell(
+                SOURCE_COLUMN_FAMILY,
+                ByteString.copyFromUtf8(column),
+                ByteString.copyFrom(smallProtoBytes)));
+    bigtableResourceManager.write(
+        RowMutation.create(table, hugeRow)
+            .setCell(
+                SOURCE_COLUMN_FAMILY,
+                ByteString.copyFromUtf8(column),
+                ByteString.copyFrom(hugeProtoBytes)));
+
+    // The small row should land in BigQuery.
+    String okQuery = newLookForValuesQuery(cdcTable, okRow, column, null);
+    waitForQueryToReturnRows(okQuery, 1, false);
+
+    // The huge row's metadata should appear in the severe DLQ.
+    Storage storage = StorageOptions.newBuilder().setProjectId(PROJECT).build().getService();
+    String filterPrefix =
+        String.join("/", getClass().getSimpleName(), gcsClient.runId(), "dlq", "severe");
+    LOG.info("Looking for oversized DLQ files with prefix: {}", filterPrefix);
+    await("The oversized decoded value was not found in DLQ")
+        .atMost(Duration.ofMinutes(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(
+            () -> {
+              Page<Blob> blobs =
+                  storage.list(artifactBucketName, BlobListOption.prefix(filterPrefix));
+              for (Blob blob : blobs.iterateAll()) {
+                if (blob.getName().contains(".temp-beam/")) {
+                  continue;
+                }
+                String content = new String(storage.readAllBytes(blob.getBlobId()));
+                if (content.contains("decoded_value_exceeds_max_bytes")
+                    && content.contains(hugeRow)) {
+                  ObjectMapper om = new ObjectMapper();
+                  for (String line : content.split("\n")) {
+                    if (line.isEmpty()) {
+                      continue;
+                    }
+                    JsonNode envelope = om.readTree(line);
+                    JsonNode message = envelope.get("message");
+                    if (message != null
+                        && message.has("row_key")
+                        && hugeRow.equals(message.get("row_key").asText())) {
+                      assertEquals(
+                          "decoded_value_exceeds_max_bytes", message.get("reason").asText());
+                      assertEquals(10_000L, message.get("max_bytes").asLong());
+                      assertEquals(column, message.get("column").asText());
+                      assertEquals(SOURCE_COLUMN_FAMILY, message.get("column_family").asText());
+                      assertEquals(
+                          "decoded_value_exceeds_max_bytes",
+                          envelope.get("error_message").asText());
+                      return true;
+                    }
+                  }
+                }
+              }
+              return false;
+            });
+
+    // The huge row should NOT land in BigQuery after it has been observed in the DLQ.
+    String hugeQuery = newLookForValuesQuery(cdcTable, hugeRow, column, null);
+    TableResult tableResult = bigQueryResourceManager.runQuery(hugeQuery);
+    assertEquals("Oversized row must not reach BigQuery", 0L, tableResult.getTotalRows());
+    waitForQueryToReturnRows(okQuery, 1, true);
   }
 }

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/BigQueryUtilTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/BigQueryUtilTest.java
@@ -31,9 +31,17 @@ import com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.mo
 import com.google.cloud.teleport.v2.utils.BigtableSource;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.DynamicMessage;
 import java.nio.charset.Charset;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -308,6 +316,282 @@ public class BigQueryUtilTest {
     Assert.assertArrayEquals(
         TestUtil.TEST_ROWKEY.getBytes(),
         (byte[]) tableRow.get(ChangelogColumn.ROW_KEY_STRING.getBqColumnName()));
+  }
+
+  @Test
+  public void testSetCellWithProtoDecodedValue() throws Exception {
+    BigQueryUtils bigQuery = new BigQueryUtils(getDefaultSourceInfo(), getDefaultDestinationInfo());
+
+    // Build a simple proto descriptor programmatically
+    Descriptor descriptor = buildSimpleMessageDescriptor();
+
+    // Create a ValueTransformerRegistry targeting the test column family and column
+    ValueTransformerRegistry transformerRegistry =
+        ValueTransformerRegistry.of(
+            java.util.Map.of(
+                TestUtil.TEST_GOOD_COLUMN_FAMILY + ":" + TestUtil.TEST_GOOD_COLUMN,
+                new ProtoDecodeTransformer(descriptor, false)));
+
+    // Build a protobuf message matching the descriptor
+    DynamicMessage protoMessage =
+        DynamicMessage.newBuilder(descriptor)
+            .setField(descriptor.findFieldByName("user_name"), "test_user")
+            .setField(descriptor.findFieldByName("id"), 42)
+            .build();
+    byte[] protoBytes = protoMessage.toByteArray();
+
+    // Create a SetCell with proto-encoded bytes as the value
+    SetCell setCell =
+        SetCell.create(
+            TestUtil.TEST_GOOD_COLUMN_FAMILY,
+            getBytesString(TestUtil.TEST_GOOD_COLUMN),
+            TestUtil.TEST_TIMESTAMP,
+            ByteString.copyFrom(protoBytes));
+
+    ChangeStreamMutation mutation = mockMutation(false);
+
+    Mod mod =
+        Mod.buildSetCell(getDefaultSourceInfo(), mutation, setCell, transformerRegistry, 10_000)
+            .mod();
+
+    TableRow tableRow = new TableRow();
+    Assert.assertTrue(bigQuery.setTableRowFields(mod, tableRow));
+
+    // The VALUE_STRING should contain the proto-decoded JSON, not the base64-decoded raw bytes.
+    // Without preserveFieldNames, JsonFormat.printer() uses camelCase ("userName").
+    String valueString = (String) tableRow.get(ChangelogColumn.VALUE_STRING.getBqColumnName());
+    Assert.assertNotNull(valueString);
+    Assert.assertTrue(
+        "Expected decoded JSON to contain 'userName' (camelCase), got: " + valueString,
+        valueString.contains("userName"));
+    Assert.assertTrue(
+        "Expected decoded JSON to contain '42', got: " + valueString, valueString.contains("42"));
+  }
+
+  @Test
+  public void testBuildSetCellOmitsRawValueBytesWhenDecodedStringSucceeds() throws Exception {
+    BigQueryUtils bigQuery = new BigQueryUtils(getDefaultSourceInfo(), getDefaultDestinationInfo());
+    Descriptor descriptor = buildSimpleMessageDescriptor();
+    ValueTransformerRegistry transformerRegistry =
+        ValueTransformerRegistry.of(
+            java.util.Map.of(
+                TestUtil.TEST_GOOD_COLUMN_FAMILY + ":" + TestUtil.TEST_GOOD_COLUMN,
+                new ProtoDecodeTransformer(descriptor, false)));
+
+    byte[] protoBytes =
+        DynamicMessage.newBuilder(descriptor)
+            .setField(descriptor.findFieldByName("user_name"), "test_user")
+            .setField(descriptor.findFieldByName("id"), 42)
+            .build()
+            .toByteArray();
+
+    SetCell setCell =
+        SetCell.create(
+            TestUtil.TEST_GOOD_COLUMN_FAMILY,
+            getBytesString(TestUtil.TEST_GOOD_COLUMN),
+            TestUtil.TEST_TIMESTAMP,
+            ByteString.copyFrom(protoBytes));
+
+    Mod.SetCellBuildResult buildResult =
+        Mod.buildSetCell(
+            getDefaultSourceInfo(),
+            mockMutation(false),
+            setCell,
+            transformerRegistry,
+            10_000);
+    Assert.assertEquals(TransformResult.Status.SUCCESS, buildResult.transformResult().status());
+
+    JSONObject changeJson = new JSONObject(buildResult.mod().getChangeJson());
+    Assert.assertFalse(changeJson.has(ChangelogColumn.VALUE_BYTES.name()));
+    Assert.assertTrue(changeJson.has(Mod.TRANSFORMED_VALUE));
+
+    TableRow tableRow = new TableRow();
+    Assert.assertTrue(bigQuery.setTableRowFields(buildResult.mod(), tableRow));
+    String valueString = (String) tableRow.get(ChangelogColumn.VALUE_STRING.getBqColumnName());
+    Assert.assertNotNull(valueString);
+    Assert.assertTrue(valueString.contains("test_user"));
+  }
+
+  @Test
+  public void testSetCellWithProtoDecodedValuePreserveFieldNames() throws Exception {
+    BigQueryUtils bigQuery = new BigQueryUtils(getDefaultSourceInfo(), getDefaultDestinationInfo());
+
+    Descriptor descriptor = buildSimpleMessageDescriptor();
+
+    // Create ValueTransformerRegistry with preserveFieldNames=true
+    ValueTransformerRegistry transformerRegistry =
+        ValueTransformerRegistry.of(
+            java.util.Map.of(
+                TestUtil.TEST_GOOD_COLUMN_FAMILY + ":" + TestUtil.TEST_GOOD_COLUMN,
+                new ProtoDecodeTransformer(descriptor, true)));
+
+    DynamicMessage protoMessage =
+        DynamicMessage.newBuilder(descriptor)
+            .setField(descriptor.findFieldByName("user_name"), "alice")
+            .setField(descriptor.findFieldByName("id"), 7)
+            .build();
+    byte[] protoBytes = protoMessage.toByteArray();
+
+    SetCell setCell =
+        SetCell.create(
+            TestUtil.TEST_GOOD_COLUMN_FAMILY,
+            getBytesString(TestUtil.TEST_GOOD_COLUMN),
+            TestUtil.TEST_TIMESTAMP,
+            ByteString.copyFrom(protoBytes));
+
+    ChangeStreamMutation mutation = mockMutation(false);
+    Mod mod =
+        Mod.buildSetCell(getDefaultSourceInfo(), mutation, setCell, transformerRegistry, 10_000)
+            .mod();
+
+    TableRow tableRow = new TableRow();
+    Assert.assertTrue(bigQuery.setTableRowFields(mod, tableRow));
+
+    String valueString = (String) tableRow.get(ChangelogColumn.VALUE_STRING.getBqColumnName());
+    Assert.assertNotNull(valueString);
+    // With preserveFieldNames, the JSON should use the original proto field name "user_name"
+    Assert.assertTrue(
+        "Expected preserved field name 'user_name', got: " + valueString,
+        valueString.contains("user_name"));
+  }
+
+  @Test
+  public void testSetCellWithProtoDecoderNonMatchingColumn() throws Exception {
+    BigQueryUtils bigQuery = new BigQueryUtils(getDefaultSourceInfo(), getDefaultDestinationInfo());
+
+    Descriptor descriptor = buildSimpleMessageDescriptor();
+
+    // ValueTransformerRegistry targets a different column than the SetCell
+    ValueTransformerRegistry transformerRegistry =
+        ValueTransformerRegistry.of(
+            java.util.Map.of(
+                TestUtil.TEST_GOOD_COLUMN_FAMILY + ":other_column",
+                new ProtoDecodeTransformer(descriptor, false)));
+
+    SetCell setCell =
+        SetCell.create(
+            TestUtil.TEST_GOOD_COLUMN_FAMILY,
+            getBytesString(TestUtil.TEST_GOOD_COLUMN),
+            TestUtil.TEST_TIMESTAMP,
+            getBytesString(TestUtil.TEST_GOOD_VALUE));
+
+    ChangeStreamMutation mutation = mockMutation(false);
+    Mod mod =
+        Mod.buildSetCell(getDefaultSourceInfo(), mutation, setCell, transformerRegistry, 10_000)
+            .mod();
+
+    TableRow tableRow = new TableRow();
+    Assert.assertTrue(bigQuery.setTableRowFields(mod, tableRow));
+
+    // Non-matching column: should fall back to standard base64-decoded value
+    Assert.assertEquals(
+        TestUtil.TEST_GOOD_VALUE, tableRow.get(ChangelogColumn.VALUE_STRING.getBqColumnName()));
+  }
+
+  @Test
+  public void testSetCellWithProtoDecoderInvalidBytes() throws Exception {
+    BigQueryUtils bigQuery = new BigQueryUtils(getDefaultSourceInfo(), getDefaultDestinationInfo());
+
+    Descriptor descriptor = buildSimpleMessageDescriptor();
+
+    ValueTransformerRegistry transformerRegistry =
+        ValueTransformerRegistry.of(
+            java.util.Map.of(
+                TestUtil.TEST_GOOD_COLUMN_FAMILY + ":" + TestUtil.TEST_GOOD_COLUMN,
+                new ProtoDecodeTransformer(descriptor, false)));
+
+    // Use bytes that are NOT valid protobuf -- ProtoDecodeTransformer.transform returns null for
+    // invalid bytes, which means TRANSFORMED_VALUE won't be added to the Mod JSON
+    byte[] invalidBytes = new byte[] {(byte) 0xFF, (byte) 0xFE, (byte) 0xFD};
+
+    SetCell setCell =
+        SetCell.create(
+            TestUtil.TEST_GOOD_COLUMN_FAMILY,
+            getBytesString(TestUtil.TEST_GOOD_COLUMN),
+            TestUtil.TEST_TIMESTAMP,
+            ByteString.copyFrom(invalidBytes));
+
+    ChangeStreamMutation mutation = mockMutation(false);
+    Mod mod =
+        Mod.buildSetCell(getDefaultSourceInfo(), mutation, setCell, transformerRegistry, 10_000)
+            .mod();
+
+    TableRow tableRow = new TableRow();
+    Assert.assertTrue(bigQuery.setTableRowFields(mod, tableRow));
+
+    // Invalid proto bytes: transform returns null, so TRANSFORMED_VALUE is not set.
+    // The formatter should fall back to base64-decoded string.
+    Object valueString = tableRow.get(ChangelogColumn.VALUE_STRING.getBqColumnName());
+    Assert.assertNotNull(valueString);
+    // The value should be the base64-decoded representation of the invalid bytes, not a proto JSON
+    Assert.assertFalse(
+        "Should not contain proto JSON fields", valueString.toString().contains("testUser"));
+  }
+
+  @Test
+  public void testSetCellWithNullProtoDecoder() throws Exception {
+    BigQueryUtils bigQuery = new BigQueryUtils(getDefaultSourceInfo(), getDefaultDestinationInfo());
+
+    SetCell setCell =
+        SetCell.create(
+            TestUtil.TEST_GOOD_COLUMN_FAMILY,
+            getBytesString(TestUtil.TEST_GOOD_COLUMN),
+            TestUtil.TEST_TIMESTAMP,
+            getBytesString(TestUtil.TEST_GOOD_VALUE));
+
+    ChangeStreamMutation mutation = mockMutation(false);
+
+    // Without a proto decoder, Mod should behave identically to the original constructor.
+    Mod mod = new Mod(getDefaultSourceInfo(), mutation, setCell);
+
+    TableRow tableRow = new TableRow();
+    Assert.assertTrue(bigQuery.setTableRowFields(mod, tableRow));
+
+    Assert.assertEquals(
+        TestUtil.TEST_GOOD_VALUE, tableRow.get(ChangelogColumn.VALUE_STRING.getBqColumnName()));
+  }
+
+  /**
+   * Builds a simple proto descriptor programmatically for testing. The message has two fields:
+   * user_name (string, field 1) and id (int32, field 2).
+   */
+  private Descriptor buildSimpleMessageDescriptor() throws DescriptorValidationException {
+    FileDescriptorProto fileProto =
+        FileDescriptorProto.newBuilder()
+            .setName("test.proto")
+            .setPackage("test")
+            .addMessageType(
+                DescriptorProto.newBuilder()
+                    .setName("SimpleMessage")
+                    .addField(
+                        FieldDescriptorProto.newBuilder()
+                            .setName("user_name")
+                            .setNumber(1)
+                            .setType(FieldDescriptorProto.Type.TYPE_STRING)
+                            .build())
+                    .addField(
+                        FieldDescriptorProto.newBuilder()
+                            .setName("id")
+                            .setNumber(2)
+                            .setType(FieldDescriptorProto.Type.TYPE_INT32)
+                            .build())
+                    .build())
+            .build();
+
+    FileDescriptor fileDescriptor = FileDescriptor.buildFrom(fileProto, new FileDescriptor[] {});
+    return fileDescriptor.findMessageTypeByName("SimpleMessage");
+  }
+
+  private ChangeStreamMutation mockMutation(boolean noRowkey) {
+    ChangeStreamMutation mutation = Mockito.mock(ChangeStreamMutation.class);
+    Mockito.when(mutation.getSourceClusterId()).thenReturn(TestUtil.TEST_CBT_CLUSTER);
+    Mockito.when(mutation.getCommitTimestamp())
+        .thenReturn(getSimpleTimestamp(TestUtil.TEST_COMMIT_TIMESTAMP));
+    Mockito.when(mutation.getRowKey()).thenReturn(noRowkey ? null : getSimpleRowKey());
+    Mockito.when(mutation.getTieBreaker()).thenReturn(TestUtil.TEST_TIEBREAKER);
+    Mockito.when(mutation.getToken()).thenReturn("token");
+    Mockito.when(mutation.getType()).thenReturn(MutationType.USER);
+    return mutation;
   }
 
   @Test

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/OversizedValueDlqSanitizerTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/OversizedValueDlqSanitizerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.model.OversizedValue;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.threeten.bp.Instant;
+
+/** Tests for {@link OversizedValueDlqSanitizer}. */
+@RunWith(JUnit4.class)
+public class OversizedValueDlqSanitizerTest {
+
+  @Test
+  public void jsonSchemaMatchesExpectedKeysAndTypes() throws Exception {
+    OversizedValue value =
+        new OversizedValue(
+            "row-1",
+            "cm93LTE=",
+            Instant.ofEpochSecond(1_700_000_000L, 123_456_789L),
+            "cf",
+            "proto_col",
+            "cHJvdG9fY29s",
+            100L,
+            50_000L,
+            10_000L,
+            "inst-a",
+            "cluster-b",
+            "tbl-c");
+
+    OversizedValueDlqSanitizer sanitizer = new OversizedValueDlqSanitizer();
+    String envelopeJson = sanitizer.apply(value);
+
+    ObjectMapper om = new ObjectMapper();
+    JsonNode envelope = om.readTree(envelopeJson);
+    JsonNode message = envelope.get("message");
+    assertEquals("row-1", message.get("row_key").asText());
+    assertEquals("cm93LTE=", message.get("row_key_bytes").asText());
+    // ISO-8601 UTC with nanosecond precision, e.g. 2023-11-14T22:13:20.123456789Z.
+    String commitTs = message.get("commit_timestamp").asText();
+    assertTrue(
+        "unexpected commit_timestamp format: " + commitTs,
+        commitTs.startsWith("2023-11-14T22:13:20") && commitTs.endsWith("Z"));
+    assertTrue(commitTs.contains(".123456789"));
+    assertEquals("cf", message.get("column_family").asText());
+    assertEquals("proto_col", message.get("column").asText());
+    assertEquals("cHJvdG9fY29s", message.get("column_bytes").asText());
+    assertEquals(100L, message.get("raw_bytes").asLong());
+    assertEquals(50_000L, message.get("estimated_decoded_bytes").asLong());
+    assertEquals(10_000L, message.get("max_bytes").asLong());
+    assertEquals("decoded_value_exceeds_max_bytes", message.get("reason").asText());
+    assertEquals("inst-a", message.get("source_instance").asText());
+    assertEquals("cluster-b", message.get("source_cluster").asText());
+    assertEquals("tbl-c", message.get("source_table").asText());
+
+    assertEquals("decoded_value_exceeds_max_bytes", envelope.get("error_message").asText());
+  }
+
+  @Test
+  public void nullCommitTimestampOmittedByDefaultGson() throws Exception {
+    OversizedValue value =
+        new OversizedValue(
+            "row-2", "cm93LTI=", null, "cf", "col", "Y29s", 10L, 20L, 5L, "inst", "cluster", "tbl");
+    String envelopeJson = new OversizedValueDlqSanitizer().apply(value);
+    ObjectMapper om = new ObjectMapper();
+    JsonNode message = om.readTree(envelopeJson).get("message");
+    // Default Gson drops null fields — assert the key is absent rather than explicitly null.
+    assertTrue(
+        "commit_timestamp should not be present when the input instant is null",
+        !message.has("commit_timestamp") || message.get("commit_timestamp").isNull());
+    assertEquals("row-2", message.get("row_key").asText());
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/ProtoDecodeTransformerTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/ProtoDecodeTransformerTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.DynamicMessage;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ProtoDecodeTransformer}, focusing on {@code transformBounded}. */
+@RunWith(JUnit4.class)
+public class ProtoDecodeTransformerTest {
+
+  @Test
+  public void transformBoundedSuccessOnSmallMessage() throws Exception {
+    Descriptor descriptor = buildSimpleMessageDescriptor();
+    ProtoDecodeTransformer transformer = new ProtoDecodeTransformer(descriptor, false);
+
+    byte[] protoBytes =
+        DynamicMessage.newBuilder(descriptor)
+            .setField(descriptor.findFieldByName("user_name"), "alice")
+            .setField(descriptor.findFieldByName("id"), 7)
+            .build()
+            .toByteArray();
+
+    TransformResult result = transformer.transformBounded(protoBytes, 10_000);
+    assertEquals(TransformResult.Status.SUCCESS, result.status());
+    assertNotNull(result.value());
+    assertTrue("expected JSON output, got: " + result.value(), result.value().contains("alice"));
+    assertEquals(protoBytes.length, result.rawBytes());
+    assertEquals(result.value().length(), result.decodedBytes());
+  }
+
+  @Test
+  public void transformBoundedAllowsStringHeavyMessageThatFitsJsonBudget() throws Exception {
+    Descriptor descriptor = buildSimpleMessageDescriptor();
+    ProtoDecodeTransformer transformer = new ProtoDecodeTransformer(descriptor, false);
+
+    byte[] protoBytes =
+        DynamicMessage.newBuilder(descriptor)
+            .setField(descriptor.findFieldByName("user_name"), "x".repeat(10_000))
+            .setField(descriptor.findFieldByName("id"), 7)
+            .build()
+            .toByteArray();
+
+    String expectedJson = transformer.transform(protoBytes);
+    long maxBytes = expectedJson.length();
+
+    // This payload used to be rejected by the old raw*4/3 heuristic even though the rendered JSON
+    // still fits within maxBytes.
+    assertTrue(((long) protoBytes.length * 4L) / 3L > maxBytes);
+
+    TransformResult result = transformer.transformBounded(protoBytes, maxBytes);
+    assertEquals(TransformResult.Status.SUCCESS, result.status());
+    assertEquals(expectedJson, result.value());
+    assertEquals(protoBytes.length, result.rawBytes());
+    assertEquals(maxBytes, result.decodedBytes());
+  }
+
+  @Test
+  public void transformBoundedShortCircuitsWhenRawPayloadAlreadyExceedsBudget() throws Exception {
+    Descriptor descriptor = buildSimpleMessageDescriptor();
+    ProtoDecodeTransformer transformer = new ProtoDecodeTransformer(descriptor, false);
+
+    byte[] fakeBytes = new byte[101];
+    TransformResult result = transformer.transformBounded(fakeBytes, 100);
+    assertEquals(TransformResult.Status.OVERSIZED, result.status());
+    assertEquals(101L, result.rawBytes());
+    assertEquals(101L, result.decodedBytes());
+    assertNull(result.value());
+  }
+
+  @Test
+  public void transformBoundedDetectsOversizedDuringSerialization() throws Exception {
+    // Use a repeated int32 field so the proto wire form is very compact (packed varints) while
+    // the JSON form is verbose ({"values":[0,1,2,...]}), forcing appendTo to overflow mid-decode
+    // rather than the cheap pre-check catching it.
+    Descriptor descriptor = buildRepeatedIntsDescriptor();
+    ProtoDecodeTransformer transformer = new ProtoDecodeTransformer(descriptor, false);
+
+    DynamicMessage.Builder builder = DynamicMessage.newBuilder(descriptor);
+    for (int i = 0; i < 500; i++) {
+      builder.addRepeatedField(descriptor.findFieldByName("values"), i);
+    }
+    byte[] protoBytes = builder.build().toByteArray();
+
+    // Keep the cap above the raw protobuf wire size so we do not fast-reject before serialization.
+    long maxBytes = protoBytes.length + 10;
+
+    TransformResult result = transformer.transformBounded(protoBytes, maxBytes);
+    assertEquals(
+        "raw size should pass the pre-check and appendTo should overflow during JSON rendering",
+        TransformResult.Status.OVERSIZED,
+        result.status());
+    assertEquals(protoBytes.length, result.rawBytes());
+    assertTrue(result.decodedBytes() > maxBytes);
+  }
+
+  @Test
+  public void transformBoundedReturnsDecodeErrorOnMalformedBytes() throws Exception {
+    Descriptor descriptor = buildSimpleMessageDescriptor();
+    ProtoDecodeTransformer transformer = new ProtoDecodeTransformer(descriptor, false);
+
+    // Garbage bytes that cannot parse as SimpleMessage.
+    byte[] garbage = new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
+    TransformResult result = transformer.transformBounded(garbage, 10_000);
+    assertEquals(TransformResult.Status.DECODE_ERROR, result.status());
+    assertEquals(garbage.length, result.rawBytes());
+    assertNull(result.value());
+  }
+
+  @Test
+  public void transformBoundedWithZeroMaxBytesIsUnbounded() throws Exception {
+    Descriptor descriptor = buildSimpleMessageDescriptor();
+    ProtoDecodeTransformer transformer = new ProtoDecodeTransformer(descriptor, false);
+
+    byte[] protoBytes =
+        DynamicMessage.newBuilder(descriptor)
+            .setField(descriptor.findFieldByName("user_name"), "x".repeat(1_000))
+            .setField(descriptor.findFieldByName("id"), 1)
+            .build()
+            .toByteArray();
+
+    TransformResult result = transformer.transformBounded(protoBytes, 0L);
+    assertEquals(TransformResult.Status.SUCCESS, result.status());
+    assertNotNull(result.value());
+  }
+
+  /** Builds a simple proto descriptor with two scalar fields: user_name (string) and id (int32). */
+  private Descriptor buildSimpleMessageDescriptor() throws DescriptorValidationException {
+    FileDescriptorProto fileProto =
+        FileDescriptorProto.newBuilder()
+            .setName("test.proto")
+            .setPackage("test")
+            .addMessageType(
+                DescriptorProto.newBuilder()
+                    .setName("SimpleMessage")
+                    .addField(
+                        FieldDescriptorProto.newBuilder()
+                            .setName("user_name")
+                            .setNumber(1)
+                            .setType(FieldDescriptorProto.Type.TYPE_STRING)
+                            .build())
+                    .addField(
+                        FieldDescriptorProto.newBuilder()
+                            .setName("id")
+                            .setNumber(2)
+                            .setType(FieldDescriptorProto.Type.TYPE_INT32)
+                            .build())
+                    .build())
+            .build();
+    FileDescriptor fileDescriptor = FileDescriptor.buildFrom(fileProto, new FileDescriptor[] {});
+    return fileDescriptor.findMessageTypeByName("SimpleMessage");
+  }
+
+  /** Builds a descriptor with a single repeated int32 field. */
+  private Descriptor buildRepeatedIntsDescriptor() throws DescriptorValidationException {
+    FileDescriptorProto fileProto =
+        FileDescriptorProto.newBuilder()
+            .setName("test_repeated.proto")
+            .setPackage("test")
+            .addMessageType(
+                DescriptorProto.newBuilder()
+                    .setName("RepeatedIntsMessage")
+                    .addField(
+                        FieldDescriptorProto.newBuilder()
+                            .setName("values")
+                            .setNumber(1)
+                            .setLabel(FieldDescriptorProto.Label.LABEL_REPEATED)
+                            .setType(FieldDescriptorProto.Type.TYPE_INT32)
+                            .build())
+                    .build())
+            .build();
+    FileDescriptor fileDescriptor = FileDescriptor.buildFrom(fileProto, new FileDescriptor[] {});
+    return fileDescriptor.findMessageTypeByName("RepeatedIntsMessage");
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/Utf8BoundedAppendableTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/Utf8BoundedAppendableTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link Utf8BoundedAppendable}. */
+@RunWith(JUnit4.class)
+public class Utf8BoundedAppendableTest {
+
+  @Test
+  public void asciiCountedOneBytePerChar() {
+    Utf8BoundedAppendable sb = new Utf8BoundedAppendable(100);
+    sb.append("hello world");
+    assertEquals(11L, sb.byteCount());
+    assertEquals("hello world", sb.toJson());
+    assertEquals(11, "hello world".getBytes(StandardCharsets.UTF_8).length);
+  }
+
+  @Test
+  public void twoByteCharCountedAsTwo() {
+    Utf8BoundedAppendable sb = new Utf8BoundedAppendable(100);
+    sb.append("\u00e9"); // "é" -> 0xC3 0xA9
+    assertEquals(2L, sb.byteCount());
+    assertEquals(2, "\u00e9".getBytes(StandardCharsets.UTF_8).length);
+  }
+
+  @Test
+  public void threeByteCharCountedAsThree() {
+    Utf8BoundedAppendable sb = new Utf8BoundedAppendable(100);
+    sb.append("\u4e2d"); // "中" -> 3 bytes
+    assertEquals(3L, sb.byteCount());
+    assertEquals(3, "\u4e2d".getBytes(StandardCharsets.UTF_8).length);
+  }
+
+  @Test
+  public void supplementaryCodePointCountedAsFour() {
+    Utf8BoundedAppendable sb = new Utf8BoundedAppendable(100);
+    // U+1F600 GRINNING FACE, encoded as a surrogate pair in Java, 4 UTF-8 bytes.
+    String emoji = new String(Character.toChars(0x1F600));
+    sb.append(emoji);
+    assertEquals(4L, sb.byteCount());
+    assertEquals(4, emoji.getBytes(StandardCharsets.UTF_8).length);
+  }
+
+  @Test
+  public void mixedCharactersAccumulateExactly() {
+    Utf8BoundedAppendable sb = new Utf8BoundedAppendable(100);
+    String text = "a\u00e9\u4e2d" + new String(Character.toChars(0x1F600));
+    sb.append(text);
+    // 1 + 2 + 3 + 4 = 10
+    assertEquals(10L, sb.byteCount());
+    assertEquals(text.getBytes(StandardCharsets.UTF_8).length, sb.byteCount());
+  }
+
+  @Test
+  public void boundaryExactlyAtMaxBytesPasses() {
+    Utf8BoundedAppendable sb = new Utf8BoundedAppendable(5);
+    sb.append("hello"); // exactly 5 bytes
+    assertEquals(5L, sb.byteCount());
+  }
+
+  @Test
+  public void oneByteOverThrows() {
+    Utf8BoundedAppendable sb = new Utf8BoundedAppendable(5);
+    assertThrows(OversizedJsonException.class, () -> sb.append("hello!"));
+  }
+
+  @Test
+  public void multibyteOverflowThrowsAtFirstExceedingChar() {
+    // max = 3 bytes; "é" = 2 bytes, a second "é" would be 4 bytes total -> throws on second append.
+    Utf8BoundedAppendable sb = new Utf8BoundedAppendable(3);
+    sb.append("\u00e9");
+    assertEquals(2L, sb.byteCount());
+    assertThrows(OversizedJsonException.class, () -> sb.append("\u00e9"));
+  }
+
+  @Test
+  public void appendCharByCharTracksBytesCorrectly() {
+    Utf8BoundedAppendable sb = new Utf8BoundedAppendable(100);
+    sb.append('a');
+    sb.append('b');
+    sb.append('c');
+    assertEquals(3L, sb.byteCount());
+    assertEquals("abc", sb.toJson());
+  }
+
+  @Test
+  public void zeroOrNegativeMaxBytesDisablesBound() {
+    Utf8BoundedAppendable sb = new Utf8BoundedAppendable(0);
+    String bigger = "a".repeat(10_000);
+    sb.append(bigger);
+    assertEquals(10_000L, sb.byteCount());
+  }
+
+  @Test
+  public void appendSubSequenceRespectsOffsetAndCountsBytes() {
+    Utf8BoundedAppendable sb = new Utf8BoundedAppendable(100);
+    sb.append("hello world", 6, 11); // "world"
+    assertEquals(5L, sb.byteCount());
+    assertEquals("world", sb.toJson());
+  }
+}

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/ValueTransformerRegistryTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/bigtablechangestreamstobigquery/schemautils/ValueTransformerRegistryTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.bigtablechangestreamstobigquery.schemautils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.DynamicMessage;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ValueTransformerRegistry#transformBounded}. */
+@RunWith(JUnit4.class)
+public class ValueTransformerRegistryTest {
+
+  @Test
+  public void protoDecodeDispatchesToBoundedImpl() throws Exception {
+    Descriptor descriptor = buildSimpleMessageDescriptor();
+    ValueTransformerRegistry registry =
+        ValueTransformerRegistry.of(
+            Map.of("cf:proto_col", new ProtoDecodeTransformer(descriptor, false)));
+
+    byte[] protoBytes =
+        DynamicMessage.newBuilder(descriptor)
+            .setField(descriptor.findFieldByName("user_name"), "alice")
+            .setField(descriptor.findFieldByName("id"), 42)
+            .build()
+            .toByteArray();
+
+    TransformResult ok = registry.transformBounded("cf", "proto_col", protoBytes, 10_000);
+    assertEquals(TransformResult.Status.SUCCESS, ok.status());
+    assertNotNull(ok.value());
+    assertTrue(ok.value().contains("alice"));
+
+    byte[] stringHeavyProto =
+        DynamicMessage.newBuilder(descriptor)
+            .setField(descriptor.findFieldByName("user_name"), "x".repeat(10_000))
+            .setField(descriptor.findFieldByName("id"), 43)
+            .build()
+            .toByteArray();
+    long maxBytes = transformerOutputBytes(registry, "cf", "proto_col", stringHeavyProto);
+    assertTrue(((long) stringHeavyProto.length * 4L) / 3L > maxBytes);
+
+    TransformResult fits = registry.transformBounded("cf", "proto_col", stringHeavyProto, maxBytes);
+    assertEquals(TransformResult.Status.SUCCESS, fits.status());
+    assertEquals(maxBytes, fits.decodedBytes());
+  }
+
+  @Test
+  public void bigEndianTimestampDispatchedViaFallback() {
+    ValueTransformerRegistry registry =
+        ValueTransformerRegistry.of(Map.of("cf:ts", new BigEndianTimestampTransformer()));
+
+    byte[] eightBytes =
+        ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(1_700_000_000_000L).array();
+    TransformResult ok = registry.transformBounded("cf", "ts", eightBytes, 1_000);
+    assertEquals(TransformResult.Status.SUCCESS, ok.status());
+    assertNotNull(ok.value());
+    assertEquals(eightBytes.length, ok.rawBytes());
+    assertTrue(ok.decodedBytes() > 0);
+
+    // Non-8-byte input -> transformer returns null -> DECODE_ERROR.
+    TransformResult bad = registry.transformBounded("cf", "ts", new byte[] {1, 2, 3}, 1_000);
+    assertEquals(TransformResult.Status.DECODE_ERROR, bad.status());
+  }
+
+  @Test
+  public void missingTransformerReturnsNoTransformer() {
+    ValueTransformerRegistry registry = ValueTransformerRegistry.of(Map.of());
+    TransformResult result = registry.transformBounded("cf", "missing", new byte[] {1}, 1_000);
+    assertEquals(TransformResult.Status.NO_TRANSFORMER, result.status());
+    assertNull(result.value());
+  }
+
+  @Test
+  public void nonProtoTransformerOutputRespectsMaxBytes() {
+    // BigEndianTimestamp produces a ~26-char timestamp string; with maxBytes=5 it should be
+    // reported as OVERSIZED even though its raw input is small.
+    ValueTransformerRegistry registry =
+        ValueTransformerRegistry.of(Map.of("cf:ts", new BigEndianTimestampTransformer()));
+    byte[] eightBytes =
+        ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(1_700_000_000_000L).array();
+    TransformResult result = registry.transformBounded("cf", "ts", eightBytes, 5);
+    assertEquals(TransformResult.Status.OVERSIZED, result.status());
+  }
+
+  @Test
+  public void defaultTransformBoundedRunsForCustomTransformer() {
+    // A custom (non-proto) transformer exercising the default ValueTransformer#transformBounded
+    // method: SUCCESS path with exact decoded-byte measurement.
+    ValueTransformer echo = bytes -> "decoded:" + bytes.length;
+    ValueTransformerRegistry registry = ValueTransformerRegistry.of(Map.of("cf:c", echo));
+    byte[] raw = new byte[] {1, 2, 3};
+
+    TransformResult ok = registry.transformBounded("cf", "c", raw, 1_000);
+    assertEquals(TransformResult.Status.SUCCESS, ok.status());
+    assertEquals("decoded:3", ok.value());
+    assertEquals(raw.length, ok.rawBytes());
+    assertEquals("decoded:3".length(), ok.decodedBytes());
+
+    // DECODE_ERROR: transformer returns null.
+    ValueTransformer nullReturner = bytes -> null;
+    ValueTransformerRegistry nullRegistry =
+        ValueTransformerRegistry.of(Map.of("cf:c", nullReturner));
+    TransformResult err = nullRegistry.transformBounded("cf", "c", raw, 1_000);
+    assertEquals(TransformResult.Status.DECODE_ERROR, err.status());
+    assertEquals(raw.length, err.rawBytes());
+
+    // OVERSIZED: decoded string overruns the byte budget.
+    TransformResult over = registry.transformBounded("cf", "c", raw, 3);
+    assertEquals(TransformResult.Status.OVERSIZED, over.status());
+    assertTrue(over.decodedBytes() > 3);
+  }
+
+  @Test
+  public void parseSupportsMultipleProtoColumnsAndColonQualifier() {
+    ValueTransformerRegistry registry =
+        ValueTransformerRegistry.parse(
+            "cf:profile:v1:PROTO_DECODE(test.Profile),"
+                + "cf:profile:v2:PROTO_DECODE(test.Profile),"
+                + "cf2:event:PROTO_DECODE(test.Event)",
+            "gs://bucket/schema.pb",
+            false);
+
+    assertNotNull(registry.getTransformer("cf", "profile:v1"));
+    assertSame(
+        registry.getTransformer("cf", "profile:v1"),
+        registry.getTransformer("cf", "profile:v2"));
+    assertNotNull(registry.getTransformer("cf2", "event"));
+    assertNull(registry.getTransformer("cf", "profile"));
+    assertNull(registry.getTransformer("cf2", "missing"));
+  }
+
+  private Descriptor buildSimpleMessageDescriptor() throws DescriptorValidationException {
+    FileDescriptorProto fileProto =
+        FileDescriptorProto.newBuilder()
+            .setName("test.proto")
+            .setPackage("test")
+            .addMessageType(
+                DescriptorProto.newBuilder()
+                    .setName("SimpleMessage")
+                    .addField(
+                        FieldDescriptorProto.newBuilder()
+                            .setName("user_name")
+                            .setNumber(1)
+                            .setType(FieldDescriptorProto.Type.TYPE_STRING)
+                            .build())
+                    .addField(
+                        FieldDescriptorProto.newBuilder()
+                            .setName("id")
+                            .setNumber(2)
+                            .setType(FieldDescriptorProto.Type.TYPE_INT32)
+                            .build())
+                    .build())
+            .build();
+    FileDescriptor fileDescriptor = FileDescriptor.buildFrom(fileProto, new FileDescriptor[] {});
+    return fileDescriptor.findMessageTypeByName("SimpleMessage");
+  }
+
+  private long transformerOutputBytes(
+      ValueTransformerRegistry registry, String family, String column, byte[] protoBytes) {
+    String json = registry.getTransformer(family, column).transform(protoBytes);
+    assertNotNull(json);
+    return json.length();
+  }
+}


### PR DESCRIPTION
## Summary

Adds optional protobuf decoding support to the **Bigtable Change Streams to BigQuery** template. When configured, matching cell values are decoded from proto binary to JSON and written as a STRING to the BigQuery `value` column.

This fills a gap: the [Pub/Sub Proto to BigQuery](https://cloud.google.com/dataflow/docs/guides/templates/provided/pubsub-proto-to-bigquery) template already supports proto decoding, but the Bigtable CDC template does not — despite Bigtable being a common store for protobuf-encoded data (as evidenced by the [Query protobuf data](https://cloud.google.com/bigtable/docs/query-protobuf-data) docs).

### New parameters (all optional, backwards compatible)

| Parameter | Description |
|-----------|-------------|
| `protoSchemaPath` | GCS path to a self-contained `FileDescriptorSet` (.pb) file |
| `fullProtoMessageName` | Fully qualified proto message name (e.g. `package.MessageName`) |
| `protoColumnFamily` | Column family containing proto-encoded values |
| `protoColumn` | Column qualifier containing proto-encoded values |
| `preserveProtoFieldNames` | Use snake_case (true) or camelCase (false, default) in JSON |

When all four required params are set, `SetCell` entries matching the configured column family and qualifier are decoded via `DynamicMessage.parseFrom()` + `JsonFormat.printer()`. Non-matching cells and decode failures fall back to the existing raw value behavior.

### Reuses existing infrastructure

- `SchemaUtils.getProtoDomain()` / `SchemaUtils.createBigQuerySchema()` from `v2/common`
- `DynamicMessage` + `JsonFormat.Printer` (same pattern as `PubsubProtoToBigQuery`)
- `ProtoDecoder` is `Serializable` with lazy init of transient `Descriptor`/`Printer` for worker-side initialization

### Files changed

- `BigtableChangeStreamToBigQueryOptions.java` — 5 new pipeline parameters
- `BigtableChangeStreamsToBigQuery.java` — validation, `ProtoDecoder` wiring, updated `ChangeStreamMutationToTableRowFn`
- `Mod.java` — proto-aware `SetCell` constructor
- `BigQueryUtils.java` — `VALUE_STRING` formatter checks for decoded proto JSON
- `ProtoDecoder.java` — new class, ~120 lines
- `BigQueryUtilTest.java` — 5 new tests covering decode, field name preservation, fallback, and backwards compat

## Test plan

- [x] All 13 unit tests pass (8 existing + 5 new) via `mvn test -Dtest=BigQueryUtilTest`
- [x] `mvn spotless:check` passes
- [x] `mvn compile` succeeds
- [ ] Integration test with real Bigtable change stream + proto data (manual)