### PR TITLE
add defaults for retries - elasticsearch

### DIFF
--- a/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
+++ b/v2/elasticsearch-common/src/main/java/com/google/cloud/teleport/v2/elasticsearch/options/ElasticsearchWriteOptions.java
@@ -102,7 +102,8 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
       optional = true,
       description = "Max retry attempts.",
       helpText =
-          "The maximum number of retry attempts. Must be greater than zero. Defaults to `no retries`.")
+          "The maximum number of retry attempts. Must be greater than zero. Defaults to `5`.")
+  @Default.Integer(5)
   Integer getMaxRetryAttempts();
 
   void setMaxRetryAttempts(Integer maxRetryAttempts);
@@ -112,7 +113,8 @@ public interface ElasticsearchWriteOptions extends PipelineOptions {
       optional = true,
       description = "Max retry duration.",
       helpText =
-          "The maximum retry duration in milliseconds. Must be greater than zero. Defaults to `no retries`.")
+          "The maximum retry duration in milliseconds. Must be greater than zero. Defaults to `60000` (1 minute).")
+  @Default.Long(60000)
   Long getMaxRetryDuration();
 
   void setMaxRetryDuration(Long maxRetryDuration);


### PR DESCRIPTION
1. Current templates like BQ to ES will exit execution after one simple failure trying to write to ES.
2. Customers have ran into transient errors where the pipeline fails but on subsequent retry it works fine.
3. Adding retry defaults to ES writeoptions like PubSubToClickHouseOptions and BigtableChangeStreamsToPubSubOptions does.