### PR TITLE
Astra to BQ - exclude vulnerable dependencies

### DIFF
--- a/v2/astradb-to-bigquery/pom.xml
+++ b/v2/astradb-to-bigquery/pom.xml
@@ -36,6 +36,16 @@
             <groupId>com.datastax.astra</groupId>
             <artifactId>beam-sdks-java-io-astra</artifactId>
             <version>${astra-io.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Removed beam-vendor-guava-26_0-jre dependency to fix CVE-2023-2976.
              Astra moves past Beam 2.50: https://github.com/DataStax-Examples/beam-sdks-java-io-astra/blob/main/pom.xml#L18


### PR DESCRIPTION
datastax astra io had vulnerable logback dependencies.
PR excludes them. 