### PR TITLE
Bigtbale: update beam import version

### DIFF
--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <open-census.version>0.31.1</open-census.version>
     <!-- TODO: check if this could be declared on a Beam BOM instead of here -->
-    <bigtable-beam-import.version>2.16.1</bigtable-beam-import.version>
+    <bigtable-beam-import.version>2.18.1</bigtable-beam-import.version>
     <protobuf.version>4.29.4</protobuf.version>
     <junit.jupiter.version>6.0.1</junit.jupiter.version>
     <codehaus-jackson.version>1.9.13</codehaus-jackson.version>


### PR DESCRIPTION
This version uses an improved splitting logic and increased the timeout for sample row keys to 20 minutes. See details in https://github.com/googleapis/java-bigtable-hbase/pull/4554.