### PR TITLE
[Not-for-review] Graph Size Optimization Milestone-2 multi shard read.

### DIFF
--- a/it/google-cloud-platform/pom.xml
+++ b/it/google-cloud-platform/pom.xml
@@ -61,6 +61,11 @@
             <artifactId>google-api-services-dataflow</artifactId>
             <version>${dataflow-api.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.apis</groupId>
+            <artifactId>google-api-services-sqladmin</artifactId>
+            <version>${sqladmin-api.version}</version>
+        </dependency>
 
         <!-- JDBC dependencies for CloudSQL -->
         <dependency>

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudMySQLResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudMySQLResourceManager.java
@@ -63,6 +63,27 @@ public class CloudMySQLResourceManager extends CloudSqlResourceManager {
     }
 
     @Override
+    public Builder maybeUseStaticInstance(String host, int port, String userName, String password) {
+      super.maybeUseStaticInstance(host, port, userName, password);
+      return this;
+    }
+
+    public Builder setProjectId(String projectId) {
+      this.projectId = projectId;
+      return this;
+    }
+
+    public Builder setRegion(String region) {
+      this.region = region;
+      return this;
+    }
+
+    public Builder setCredentials(com.google.auth.oauth2.GoogleCredentials credentials) {
+      this.credentials = credentials;
+      return this;
+    }
+
+    @Override
     public @NonNull CloudMySQLResourceManager build() {
       return new CloudMySQLResourceManager(this);
     }

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudPostgresResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudPostgresResourceManager.java
@@ -365,6 +365,27 @@ public class CloudPostgresResourceManager extends CloudSqlResourceManager {
     }
 
     @Override
+    public Builder maybeUseStaticInstance(String host, int port, String userName, String password) {
+      super.maybeUseStaticInstance(host, port, userName, password);
+      return this;
+    }
+
+    public Builder setProjectId(String projectId) {
+      this.projectId = projectId;
+      return this;
+    }
+
+    public Builder setRegion(String region) {
+      this.region = region;
+      return this;
+    }
+
+    public Builder setCredentials(com.google.auth.oauth2.GoogleCredentials credentials) {
+      this.credentials = credentials;
+      return this;
+    }
+
+    @Override
     public @NonNull CloudPostgresResourceManager build() {
       return new CloudPostgresResourceManager(this);
     }

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManager.java
@@ -19,6 +19,7 @@ package org.apache.beam.it.gcp.cloudsql;
 
 import static org.apache.beam.it.gcp.cloudsql.CloudSqlResourceManagerUtils.generateDatabaseName;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.it.jdbc.AbstractJDBCResourceManager;
@@ -151,6 +152,10 @@ public abstract class CloudSqlResourceManager
   public abstract static class Builder
       extends AbstractJDBCResourceManager.Builder<@NonNull CloudSqlContainer<?>> {
 
+    protected String projectId;
+    protected String region;
+    protected GoogleCredentials credentials;
+
     private String dbName;
     private boolean usingCustomDb;
 
@@ -171,6 +176,31 @@ public abstract class CloudSqlResourceManager
       this.configurePassword();
       this.useStaticContainer();
 
+      return this;
+    }
+
+    public Builder maybeUseStaticInstance(String host, int port, String userName, String password) {
+      this.setHost(host);
+      this.setPort(port);
+      this.setUsername(userName);
+      this.setPassword(password);
+      this.useStaticContainer();
+
+      return this;
+    }
+
+    public Builder setProjectId(String projectId) {
+      this.projectId = projectId;
+      return this;
+    }
+
+    public Builder setRegion(String region) {
+      this.region = region;
+      return this;
+    }
+
+    public Builder setCredentials(GoogleCredentials credentials) {
+      this.credentials = credentials;
       return this;
     }
 

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudMySQLResourceManagerTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudMySQLResourceManagerTest.java
@@ -54,4 +54,21 @@ public class CloudMySQLResourceManagerTest {
   public void testGetJDBCPrefixReturnsCorrectValue() {
     assertThat(testManager.getJDBCPrefix()).isEqualTo("mysql");
   }
+
+  @Test
+  public void testBuilder() {
+    CloudMySQLResourceManager.Builder builder = CloudMySQLResourceManager.builder(TEST_ID);
+
+    com.google.auth.oauth2.GoogleCredentials credentials =
+        org.mockito.Mockito.mock(com.google.auth.oauth2.GoogleCredentials.class);
+    builder
+        .setProjectId("test-project")
+        .setRegion("test-region")
+        .setCredentials(credentials)
+        .maybeUseStaticInstance("1.1.1.1", 3306, "u", "p");
+
+    assertThat(builder.projectId).isEqualTo("test-project");
+    assertThat(builder.region).isEqualTo("test-region");
+    assertThat(builder.credentials).isEqualTo(credentials);
+  }
 }

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudPostgresResourceManagerTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudPostgresResourceManagerTest.java
@@ -155,6 +155,23 @@ public class CloudPostgresResourceManagerTest {
     verify(mockConnection).rollback();
   }
 
+  @Test
+  public void testBuilder() {
+    CloudPostgresResourceManager.Builder builder = CloudPostgresResourceManager.builder(TEST_ID);
+
+    com.google.auth.oauth2.GoogleCredentials credentials =
+        org.mockito.Mockito.mock(com.google.auth.oauth2.GoogleCredentials.class);
+    builder
+        .setProjectId("test-project")
+        .setRegion("test-region")
+        .setCredentials(credentials)
+        .maybeUseStaticInstance("1.1.1.1", 5432, "u", "p");
+
+    assertThat(builder.projectId).isEqualTo("test-project");
+    assertThat(builder.region).isEqualTo("test-region");
+    assertThat(builder.credentials).isEqualTo(credentials);
+  }
+
   /** Helper mock implementation of {@link CloudPostgresResourceManager} for testing. */
   private static class MockCloudPostgresResourceManager extends CloudPostgresResourceManager {
 

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManagerTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudSqlResourceManagerTest.java
@@ -48,10 +48,16 @@ public class CloudSqlResourceManagerTest {
     private final boolean initialized;
     private boolean createdDatabase;
     private String lastRunSqlCommand;
+    private final String projectId;
+    private final String region;
+    private final com.google.auth.oauth2.GoogleCredentials credentials;
 
     private MockCloudSqlResourceManager(Builder builder) {
       super(builder);
       this.initialized = true;
+      this.projectId = builder.projectId;
+      this.region = builder.region;
+      this.credentials = builder.credentials;
     }
 
     @Override
@@ -181,6 +187,59 @@ public class CloudSqlResourceManagerTest {
 
     assertThat(testManager.lastRunSqlCommand).contains("DROP TABLE");
     assertThat(testManager.createdTables).isEmpty();
+  }
+
+  @Test
+  public void testMaybeUseStaticInstanceWithHost() {
+    CloudSqlResourceManager.Builder builder =
+        new CloudSqlResourceManager.Builder(TEST_ID) {
+          @Override
+          public @NonNull CloudSqlResourceManager build() {
+            return new MockCloudSqlResourceManager(this);
+          }
+
+          @Override
+          protected void configurePort() {
+            this.setPort(1234);
+          }
+        };
+
+    String customHost = "10.1.1.1";
+    builder.maybeUseStaticInstance(customHost, 1234, "testUser", "testPassword");
+    CloudSqlResourceManager manager = (CloudSqlResourceManager) builder.build();
+
+    assertThat(manager.getHost()).isEqualTo(customHost);
+  }
+
+  @Test
+  public void testBuilder() {
+    CloudSqlResourceManager.Builder builder =
+        new CloudSqlResourceManager.Builder(TEST_ID) {
+          @Override
+          public @NonNull CloudSqlResourceManager build() {
+            return new MockCloudSqlResourceManager(this);
+          }
+
+          @Override
+          protected void configurePort() {
+            this.setPort(1234);
+          }
+        };
+
+    com.google.auth.oauth2.GoogleCredentials credentials =
+        org.mockito.Mockito.mock(com.google.auth.oauth2.GoogleCredentials.class);
+    builder
+        .setProjectId("test-project")
+        .setRegion("test-region")
+        .setCredentials(credentials)
+        .setHost(HOST)
+        .setPort(Integer.parseInt(PORT));
+
+    MockCloudSqlResourceManager manager = (MockCloudSqlResourceManager) builder.build();
+
+    assertThat(manager.projectId).isEqualTo("test-project");
+    assertThat(manager.region).isEqualTo("test-region");
+    assertThat(manager.credentials).isEqualTo(credentials);
   }
 
   /*

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
     <truth.version>1.4.5</truth.version>
     <netty.version>4.2.12.Final</netty.version>
     <zookeeper.version>3.9.5</zookeeper.version>
+    <sqladmin-api.version>v1beta4-rev20240115-2.0.0</sqladmin-api.version>
 
     <!-- Drop pinned version once maven-dependency-plugin gets past plexus-archiver 4.8.0 -->
     <plexus-archiver.version>4.8.0</plexus-archiver.version>

--- a/v2/sourcedb-to-spanner/README.md
+++ b/v2/sourcedb-to-spanner/README.md
@@ -138,3 +138,12 @@ gcloud storage ls <outputDirectory>/dlq/severe/**.json | wc -l
 However, because the continuous reader watches the `retry/` directory indefinitely in `regular` and `retryAllDLQ` modes, the job graph will remain RUNNING indefinitely for those modes. To know when all errors have finished their retry cycles:
 * **Dataflow Counters and Throughput Graph Check:** Flatlined counters (e.g., successful events, elementsReconsumedFromDeadLetterQueue, Event retries_COUNT) staying fixed for several minutes indicate there is no throughput in flight.
 * **GCS Bucket Check:** When the `retry/` folder sits completely empty for a cooldown period (e.g., 5 minutes), it is safe to stop the job.
+
+#### Assumptions
+* The template assumes that:
+  - The source and spanner schemas are compatible with each other.
+  - In case of multi-sharded migrations:
+    * All shards have the same mapping for table and columns from source to spanner.
+    * All shards have same dialect (mixed dialect migration will cause pipeline failure during initialization)
+    * For tables with string primary key, all shards have the same weights for a given collation (the collection weight detection
+      is queried on available shards for efficient parallel discovery).

--- a/v2/sourcedb-to-spanner/pom.xml
+++ b/v2/sourcedb-to-spanner/pom.xml
@@ -104,6 +104,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.apis</groupId>
+            <artifactId>google-api-services-sqladmin</artifactId>
+            <version>${sqladmin-api.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-it-jdbc</artifactId>
             <scope>test</scope>

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
@@ -49,6 +49,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -77,10 +78,13 @@ import org.slf4j.LoggerFactory;
  *  and maxPartitionHints (auto inferred) to the pipeline controller helping a better sequencing of tables.
  */
 public final class JdbcIoWrapper implements IoWrapper {
+
   private static final Logger LOG = LoggerFactory.getLogger(JdbcIoWrapper.class);
   // We parallelize to 4 threads to work well with the default launcher machine we get.
   // With this for 1024 shards test we have the launcher complete in 4 minutes in the load test.
   private static final int SOURCE_DISCOVERY_PARALLELISM = 4;
+  // Number of shards per log emitted at the end of discovery.
+  public static final int MAX_SHARDS_PER_LOG = 50;
 
   private final ImmutableMap<
           ImmutableList<SourceTableReference>, PTransform<PBegin, PCollection<SourceRow>>>
@@ -334,6 +338,12 @@ public final class JdbcIoWrapper implements IoWrapper {
 
   private static int getFetchSize(
       JdbcIOWrapperConfig config, TableConfig tableConfig, SourceTableSchema sourceTableSchema) {
+    if (tableConfig.fetchSize() != null) {
+      return tableConfig.fetchSize();
+    }
+    if (config.maxFetchSize() != null) {
+      return config.maxFetchSize();
+    }
     return FetchSizeCalculator.getFetchSize(
         tableConfig,
         sourceTableSchema.estimatedRowSize(),
@@ -640,42 +650,50 @@ public final class JdbcIoWrapper implements IoWrapper {
 
     /* Todo  in subsequent PR for multishard graphsize support, pass this to table reader. */
     DataSourceProvider dataSourceProvider = getDataSourceProvider(perSourceDiscoveries);
-    for (PerSourceDiscovery perSourceDiscovery : perSourceDiscoveries) {
-      ImmutableList.Builder<SourceTableReference> tableReferencesBuilder = ImmutableList.builder();
-      ImmutableList.Builder<TableSplitSpecification> splitSpecsBuilder = ImmutableList.builder();
-      ImmutableMap.Builder<TableIdentifier, TableReadSpecification<SourceRow>> readSpecsBuilder =
-          ImmutableMap.builder();
-      JdbcIOWrapperConfig config = perSourceDiscovery.config();
-      DataSourceConfiguration dataSourceConfiguration =
-          perSourceDiscovery.dataSourceConfiguration();
-      ImmutableList<TableConfig> tableConfigs = perSourceDiscovery.tableConfigs();
+    ImmutableList.Builder<SourceTableReference> tableReferencesBuilder = ImmutableList.builder();
+    ImmutableList.Builder<TableSplitSpecification> splitSpecsBuilder = ImmutableList.builder();
+    ImmutableMap.Builder<TableIdentifier, TableReadSpecification<SourceRow>> readSpecsBuilder =
+        ImmutableMap.builder();
+    accumulateSpecs(
+        perSourceDiscoveries, tableReferencesBuilder, splitSpecsBuilder, readSpecsBuilder);
 
-      if (!config.readWithUniformPartitionsFeatureEnabled() || tableConfigs.isEmpty()) {
-        continue;
-      }
-      accumulateSpecs(
-          perSourceDiscovery, tableReferencesBuilder, splitSpecsBuilder, readSpecsBuilder);
-
-      ReadWithUniformPartitions<SourceRow> readWithUniformPartitions =
-          ReadWithUniformPartitions.<SourceRow>builder()
-              .setTableSplitSpecifications(splitSpecsBuilder.build())
-              .setTableReadSpecifications(readSpecsBuilder.build())
-              .setDataSourceProviderFn(
-                  JdbcIO.PoolableDataSourceProvider.of(dataSourceConfiguration))
-              .setDbAdapter(dialectAdapter)
-              .setWaitOn(waitOn)
-              .setDbParallelizationForSplitProcess(dbParallelizationForSplitProcess)
-              .setDbParallelizationForReads(dbParallelizationForReads)
-              .setAdditionalOperationsOnRanges(additionalOperationsOnRanges)
-              .build();
-
-      LOG.info(
-          "Configured Multi-Table ReadWithUniformPartitions {} for tables {} with config {}",
-          readWithUniformPartitions,
-          tableConfigs.stream().map(TableConfig::tableName).collect(Collectors.toList()),
-          config);
-      tableReadersBuilder.put(tableReferencesBuilder.build(), readWithUniformPartitions);
+    ImmutableList<SourceTableReference> tableReferences = tableReferencesBuilder.build();
+    if (tableReferences.isEmpty()) {
+      return ImmutableMap.of();
     }
+
+    ReadWithUniformPartitions<SourceRow> readWithUniformPartitions =
+        ReadWithUniformPartitions.<SourceRow>builder()
+            .setTableSplitSpecifications(splitSpecsBuilder.build())
+            .setTableReadSpecifications(readSpecsBuilder.build())
+            .setDataSourceProvider(dataSourceProvider)
+            .setDbAdapter(dialectAdapter)
+            .setWaitOn(waitOn)
+            .setDbParallelizationForSplitProcess(dbParallelizationForSplitProcess)
+            .setDbParallelizationForReads(dbParallelizationForReads)
+            .setAdditionalOperationsOnRanges(additionalOperationsOnRanges)
+            .build();
+
+    // We batch the partitions in groups of MAX_SHARDS_PER_LOG batches for
+    // enhanced log readability and debuggability at the same time containing
+    // the number of logs emitted.
+    Lists.partition(perSourceDiscoveries, MAX_SHARDS_PER_LOG)
+        .forEach(
+            batch ->
+                LOG.info(
+                    "Configured Multi-Table ReadWithUniformPartitions for sources batch: {}",
+                    batch.stream()
+                        .map(
+                            d ->
+                                "id="
+                                    + d.config().id()
+                                    + ":"
+                                    + "shard_id="
+                                    + d.config().shardID()
+                                    + ":'"
+                                    + d.sourceSchema().schemaReference().jdbc().toString())
+                        .collect(Collectors.joining(","))));
+    tableReadersBuilder.put(tableReferences, readWithUniformPartitions);
     return tableReadersBuilder.build();
   }
 
@@ -701,58 +719,72 @@ public final class JdbcIoWrapper implements IoWrapper {
   /* Todo  in subsequent PR for multishard graphsize support accumulate specs across a list of sourceDiscovereies */
   @VisibleForTesting
   protected static void accumulateSpecs(
-      PerSourceDiscovery perSourceDiscovery,
+      ImmutableList<PerSourceDiscovery> perSourceDiscoveries,
       ImmutableList.Builder<SourceTableReference> tableReferencesBuilder,
       ImmutableList.Builder<TableSplitSpecification> splitSpecsBuilder,
       ImmutableMap.Builder<TableIdentifier, TableReadSpecification<SourceRow>> readSpecsBuilder) {
 
-    JdbcIOWrapperConfig config = perSourceDiscovery.config();
-    SourceSchemaReference sourceSchemaReference =
-        perSourceDiscovery.sourceSchema().schemaReference();
-    ImmutableList<TableConfig> tableConfigs = perSourceDiscovery.tableConfigs();
-    for (TableConfig tableConfig : tableConfigs) {
-      SourceTableSchema sourceTableSchema =
-          findSourceTableSchema(perSourceDiscovery.sourceSchema(), tableConfig);
-      int fetchSize = getFetchSize(config, tableConfig, sourceTableSchema);
-      TableIdentifier tableIdentifier = getTableIdentifier(tableConfig);
-
-      TableSplitSpecification.Builder tableSplitSpecificationBuilder =
-          TableSplitSpecification.builder()
-              .setTableIdentifier(tableIdentifier)
-              .setPartitionColumns(tableConfig.partitionColumns())
-              .setApproxRowCount(tableConfig.approxRowCount());
-      if (tableConfig.maxPartitions() != null) {
-        tableSplitSpecificationBuilder =
-            tableSplitSpecificationBuilder.setMaxPartitionsHint((long) tableConfig.maxPartitions());
+    for (PerSourceDiscovery perSourceDiscovery : perSourceDiscoveries) {
+      JdbcIOWrapperConfig config = perSourceDiscovery.config();
+      SourceSchemaReference sourceSchemaReference =
+          perSourceDiscovery.sourceSchema().schemaReference();
+      ImmutableList<TableConfig> tableConfigs = perSourceDiscovery.tableConfigs();
+      if (!config.readWithUniformPartitionsFeatureEnabled() || tableConfigs.isEmpty()) {
+        continue;
       }
-      if (config.splitStageCountHint() >= 0) {
-        tableSplitSpecificationBuilder =
-            tableSplitSpecificationBuilder.setSplitStagesCount((long) config.splitStageCountHint());
-      }
-      splitSpecsBuilder.add(tableSplitSpecificationBuilder.build());
+      for (TableConfig tableConfig : tableConfigs) {
 
-      TableReadSpecification.Builder<SourceRow> tableReadSpecificationBuilder =
-          TableReadSpecification.<SourceRow>builder()
-              .setFetchSize(fetchSize)
-              .setTableIdentifier(tableIdentifier)
-              .setRowMapper(
-                  new JdbcSourceRowMapper(
-                      config.valueMappingsProvider(),
-                      sourceSchemaReference,
-                      sourceTableSchema,
-                      config.shardID()));
-      if (config.maxFetchSize() != null) {
-        tableReadSpecificationBuilder =
-            tableReadSpecificationBuilder.setFetchSize(config.maxFetchSize());
-      }
-      readSpecsBuilder.put(tableIdentifier, tableReadSpecificationBuilder.build());
+        SourceTableSchema sourceTableSchema =
+            findSourceTableSchema(perSourceDiscovery.sourceSchema(), tableConfig);
+        // This returns configured fetchSize if user has configured it in pipeline options,
+        // otherwise it auto-infers the fetchsize.
+        int fetchSize = getFetchSize(config, tableConfig, sourceTableSchema);
+        TableIdentifier tableIdentifier = getTableIdentifier(tableConfig);
 
-      tableReferencesBuilder.add(
-          SourceTableReference.builder()
-              .setSourceSchemaReference(sourceSchemaReference)
-              .setSourceTableName(delimitIdentifier(sourceTableSchema.tableName()))
-              .setSourceTableSchemaUUID(sourceTableSchema.tableSchemaUUID())
-              .build());
+        TableSplitSpecification.Builder tableSplitSpecificationBuilder =
+            TableSplitSpecification.builder()
+                .setTableIdentifier(tableIdentifier)
+                .setPartitionColumns(tableConfig.partitionColumns())
+                .setApproxRowCount(tableConfig.approxRowCount());
+        if (tableConfig.maxPartitions() != null) {
+          tableSplitSpecificationBuilder =
+              tableSplitSpecificationBuilder.setMaxPartitionsHint(
+                  (long) tableConfig.maxPartitions());
+        }
+        // If the splitStageCountHint is not overridden,
+        // it's auto inferred by ReadWithUniformPartitions.
+        // Please see Javadocs of ReadWithUniformPartitions for additional information.
+        if (config.splitStageCountHint() >= 0) {
+          tableSplitSpecificationBuilder =
+              tableSplitSpecificationBuilder.setSplitStagesCount(
+                  (long) config.splitStageCountHint());
+        }
+        splitSpecsBuilder.add(tableSplitSpecificationBuilder.build());
+
+        TableReadSpecification.Builder<SourceRow> tableReadSpecificationBuilder =
+            TableReadSpecification.<SourceRow>builder()
+                .setFetchSize(fetchSize)
+                .setTableIdentifier(tableIdentifier)
+                .setRowMapper(
+                    new JdbcSourceRowMapper(
+                        config.valueMappingsProvider(),
+                        sourceSchemaReference,
+                        sourceTableSchema,
+                        config.shardID()));
+        readSpecsBuilder.put(tableIdentifier, tableReadSpecificationBuilder.build());
+
+        tableReferencesBuilder.add(
+            SourceTableReference.builder()
+                .setSourceSchemaReference(sourceSchemaReference)
+                .setSourceTableName(delimitIdentifier(sourceTableSchema.tableName()))
+                .setSourceTableSchemaUUID(sourceTableSchema.tableSchemaUUID())
+                .build());
+        LOG.info(
+            "Configuring Multi-Table ReadWithUniformPartitions for source-id {} tables {} with config {}",
+            config.id(),
+            tableConfigs.stream().map(TableConfig::tableName).collect(Collectors.toList()),
+            config);
+      }
     }
   }
 

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/CollationMapperDoFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/CollationMapperDoFn.java
@@ -15,9 +15,8 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
 
-import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProvider;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationMapper;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
@@ -27,48 +26,44 @@ import java.sql.SQLException;
 import javax.annotation.Nullable;
 import javax.sql.DataSource;
 import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.KV;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Discover the Collation Mapping information for a given {@link CollationReference}. */
 public class CollationMapperDoFn
-    extends DoFn<CollationReference, KV<CollationReference, CollationMapper>>
+    extends DoFn<KV<String, CollationReference>, KV<CollationReference, CollationMapper>>
     implements Serializable {
 
   private static final Logger logger = LoggerFactory.getLogger(CollationMapper.class);
-  private final SerializableFunction<Void, DataSource> dataSourceProviderFn;
+  private final DataSourceProvider dataSourceProvider;
   private final UniformSplitterDBAdapter dbAdapter;
+  private transient DataSourceManager dataSourceManager;
 
   @JsonIgnore private transient @Nullable DataSource dataSource;
 
   public CollationMapperDoFn(
-      SerializableFunction<Void, DataSource> dataSourceProviderFn,
-      UniformSplitterDBAdapter dbAdapter) {
-    this.dataSourceProviderFn = dataSourceProviderFn;
+      DataSourceProvider dataSourceProvider, UniformSplitterDBAdapter dbAdapter) {
+    this.dataSourceProvider = dataSourceProvider;
     this.dbAdapter = dbAdapter;
     this.dataSource = null;
   }
 
-  @Setup
-  public void setup() throws Exception {
-    dataSource = dataSourceProviderFn.apply(null);
-  }
-
-  private Connection acquireConnection() throws SQLException {
-    return checkStateNotNull(this.dataSource).getConnection();
+  @StartBundle
+  public void startBundle() throws Exception {
+    this.dataSourceManager =
+        DataSourceManagerImpl.builder().setDataSourceProvider(dataSourceProvider).build();
   }
 
   @ProcessElement
   public void processElement(
-      @Element CollationReference input,
+      @Element KV<String, CollationReference> input,
       OutputReceiver<KV<CollationReference, CollationMapper>> out)
       throws SQLException {
-
-    try (Connection conn = acquireConnection()) {
-      CollationMapper mapper = CollationMapper.fromDB(conn, dbAdapter, input);
-      out.output(KV.of(input, mapper));
+    DataSource dataSource = dataSourceManager.getDatasource(input.getKey());
+    try (Connection conn = dataSource.getConnection()) {
+      CollationMapper mapper = CollationMapper.fromDB(conn, dbAdapter, input.getValue());
+      out.output(KV.of(input.getValue(), mapper));
     } catch (Exception e) {
       logger.error(
           "Exception: {} while generating collationMapper for dataSource: {}, collationReference: {}",
@@ -77,6 +72,23 @@ public class CollationMapperDoFn
           input);
       // Beam will re-try exceptions generation during pipeline-run phase.
       throw e;
+    }
+  }
+
+  @FinishBundle
+  public void finishBundle() throws Exception {
+    cleanupDataSource();
+  }
+
+  @Teardown
+  public void tearDown() throws Exception {
+    cleanupDataSource();
+  }
+
+  void cleanupDataSource() {
+    if (this.dataSourceManager != null) {
+      this.dataSourceManager.closeAll();
+      this.dataSourceManager = null;
     }
   }
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/CollationMapperTransform.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/CollationMapperTransform.java
@@ -16,21 +16,21 @@
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
 
 import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProvider;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationMapper;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Map;
-import java.util.stream.Collectors;
-import javax.sql.DataSource;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.View;
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollectionView;
 
@@ -44,10 +44,10 @@ public abstract class CollationMapperTransform
     implements Serializable {
 
   /** List of {@link CollationReference} to discover the mapping for. */
-  public abstract ImmutableList<CollationReference> collationReferences();
+  public abstract ImmutableList<KV<String, CollationReference>> collationReferences();
 
   /** Provider for connection pool. */
-  public abstract SerializableFunction<Void, DataSource> dataSourceProviderFn();
+  public abstract DataSourceProvider dataSourceProvider();
 
   /** Provider to dialect specific Collation mapping query. */
   public abstract UniformSplitterDBAdapter dbAdapter();
@@ -73,12 +73,10 @@ public abstract class CollationMapperTransform
             .apply("To Empty Map View", View.asMap());
       }
       return input
-          .apply(
-              "Create-Collation-References",
-              Create.of(collationReferences().stream().distinct().collect(Collectors.toList())))
+          .apply("Create-Collation-References", Create.of(collationReferences()))
           .apply(
               "Generate-Mappers",
-              ParDo.of(new CollationMapperDoFn(dataSourceProviderFn(), dbAdapter())))
+              ParDo.of(new CollationMapperDoFn(dataSourceProvider(), dbAdapter())))
           .setCoder(
               KvCoder.of(
                   input.getPipeline().getCoderRegistry().getCoder(CollationReference.class),
@@ -96,13 +94,40 @@ public abstract class CollationMapperTransform
 
   @AutoValue.Builder
   public abstract static class Builder {
+    private ImmutableList<CollationReference> collationReferencesToDiscover;
 
-    public abstract Builder setCollationReferences(ImmutableList<CollationReference> value);
+    public Builder setCollationReferencesToDiscover(ImmutableList<CollationReference> value) {
+      this.collationReferencesToDiscover = value;
+      return this;
+    }
 
-    public abstract Builder setDataSourceProviderFn(SerializableFunction<Void, DataSource> value);
+    abstract Builder setCollationReferences(ImmutableList<KV<String, CollationReference>> value);
+
+    public abstract Builder setDataSourceProvider(DataSourceProvider value);
+
+    abstract DataSourceProvider dataSourceProvider();
 
     public abstract Builder setDbAdapter(UniformSplitterDBAdapter value);
 
-    public abstract CollationMapperTransform build();
+    public abstract CollationMapperTransform autoBuild();
+
+    public CollationMapperTransform build() {
+      ImmutableList<CollationReference> deDupedRefs =
+          collationReferencesToDiscover.stream()
+              .distinct()
+              .collect(ImmutableList.toImmutableList());
+      ImmutableList<String> ids =
+          ImmutableList.copyOf(this.dataSourceProvider().getDataSourceIds());
+      Preconditions.checkState(ids.size() > 0, "No DataSources Configured for collation detection");
+      ImmutableList.Builder<KV<String, CollationReference>> collationReferencesBuilder =
+          ImmutableList.builder();
+      // Round-robin collations across available shards.
+      // All shards of the same database should have the same collation mapping.
+      for (int i = 0; i < deDupedRefs.size(); i++) {
+        collationReferencesBuilder.add(KV.of(ids.get(i % ids.size()), deDupedRefs.get(i)));
+      }
+      this.setCollationReferences(collationReferencesBuilder.build());
+      return autoBuild();
+    }
   }
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/CollationMapperTransform.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/CollationMapperTransform.java
@@ -36,7 +36,12 @@ import org.apache.beam.sdk.values.PCollectionView;
 
 /**
  * Generate the Side-Input that encodes the Collation Mapping information for given instance of
- * {@link ReadWithUniformPartitions}.
+ * {@link ReadWithUniformPartitions}. Note: this PTransform Round-robins collations across available
+ * shards. All shards of for a given migration are assumed to have the same collation mapping. It's
+ * unlikely for different shards to have a different mapping of collations, this assumption helps us
+ * avoid the need for maintaining a per-Shard map of collation (which would add significant
+ * presssure on the worker memory). It also helps us parallelize the discovery across shards to get
+ * better performance.
  */
 @AutoValue
 public abstract class CollationMapperTransform

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MultiTableReadAll.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MultiTableReadAll.java
@@ -20,6 +20,8 @@ import static org.apache.beam.sdk.util.Preconditions.checkArgumentNotNull;
 import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
 
 import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProvider;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProviderImpl;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.TableIdentifier;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.TableReadSpecification;
 import com.google.common.annotations.VisibleForTesting;
@@ -83,7 +85,7 @@ public abstract class MultiTableReadAll<ParameterT, OutputT>
   private static final boolean DEFAULT_DISABLE_AUTO_COMMIT = true;
 
   @Pure
-  protected abstract @Nullable SerializableFunction<Void, DataSource> getDataSourceProviderFn();
+  protected abstract @Nullable DataSourceProvider getDataSourceProvider();
 
   @Pure
   protected abstract @Nullable ValueProvider<QueryProvider> getQueryProvider();
@@ -121,8 +123,8 @@ public abstract class MultiTableReadAll<ParameterT, OutputT>
 
   @AutoValue.Builder
   abstract static class Builder<ParameterT, OutputT> {
-    abstract Builder<ParameterT, OutputT> setDataSourceProviderFn(
-        SerializableFunction<Void, DataSource> dataSourceProviderFn);
+    abstract Builder<ParameterT, OutputT> setDataSourceProvider(
+        DataSourceProvider dataSourceProvider);
 
     abstract Builder<ParameterT, OutputT> setQueryProvider(ValueProvider<QueryProvider> query);
 
@@ -151,8 +153,8 @@ public abstract class MultiTableReadAll<ParameterT, OutputT>
    * @return a new transform instance with the data source configured.
    */
   public MultiTableReadAll<ParameterT, OutputT> withDataSourceConfiguration(
-      DataSourceConfiguration config) {
-    return withDataSourceProviderFn(DataSourceProviderFromDataSourceConfiguration.of(config));
+      String id, DataSourceConfiguration config) {
+    return withDataSourceProviderFn(id, DataSourceProviderFromDataSourceConfiguration.of(config));
   }
 
   /**
@@ -162,13 +164,34 @@ public abstract class MultiTableReadAll<ParameterT, OutputT>
    * @return a new transform instance.
    */
   public MultiTableReadAll<ParameterT, OutputT> withDataSourceProviderFn(
-      SerializableFunction<Void, DataSource> dataSourceProviderFn) {
-    if (getDataSourceProviderFn() != null) {
+      String id, SerializableFunction<Void, DataSource> dataSourceProviderFn) {
+    if (getDataSourceProvider() != null) {
       throw new IllegalArgumentException(
           "A dataSourceConfiguration or dataSourceProviderFn has "
               + "already been provided, and does not need to be provided again.");
     }
-    return toBuilder().setDataSourceProviderFn(dataSourceProviderFn).build();
+    return withDataSourceProvider(
+        DataSourceProviderImpl.builder().addDataSource(id, dataSourceProviderFn).build());
+  }
+
+  /**
+   * Configures a provider function for the data source.
+   *
+   * @param dataSourceProvider the data source provider function.
+   * @return a new transform instance.
+   */
+  public MultiTableReadAll<ParameterT, OutputT> withDataSourceProvider(
+      DataSourceProvider dataSourceProvider) {
+    if (dataSourceProvider == null) {
+      throw new IllegalArgumentException(
+          "DataSource can not be null "
+              + "already been provided, and does not need to be provided again.");
+    }
+    if (getDataSourceProvider() != null) {
+      throw new IllegalArgumentException(
+          "A dataSource has " + "already been provided, and does not need to be provided again.");
+    }
+    return toBuilder().setDataSourceProvider(dataSourceProvider).build();
   }
 
   /**
@@ -322,7 +345,7 @@ public abstract class MultiTableReadAll<ParameterT, OutputT>
             .apply(
                 ParDo.of(
                     new MultiTableReadFn<>(
-                        checkStateNotNull(getDataSourceProviderFn()),
+                        checkStateNotNull(getDataSourceProvider()),
                         checkStateNotNull(getQueryProvider()),
                         checkStateNotNull(getParameterSetter()),
                         getTableReadSpecifications(),
@@ -371,8 +394,8 @@ public abstract class MultiTableReadAll<ParameterT, OutputT>
     if (getCoder() != null) {
       builder.add(DisplayData.item("coder", getCoder().getClass().getName()));
     }
-    if (getDataSourceProviderFn() instanceof HasDisplayData) {
-      ((HasDisplayData) getDataSourceProviderFn()).populateDisplayData(builder);
+    if (getDataSourceProvider() instanceof HasDisplayData) {
+      ((HasDisplayData) getDataSourceProvider()).populateDisplayData(builder);
     }
   }
 

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MultiTableReadFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MultiTableReadFn.java
@@ -304,10 +304,10 @@ public class MultiTableReadFn<ParameterT, OutputT> extends DoFn<ParameterT, Outp
       }
       connections.clear();
     } finally {
-      connectionLock.unlock();
       dataSourceManager.closeAll();
       this.connections = null;
       this.dataSourceManager = null;
+      connectionLock.unlock();
     }
   }
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MultiTableReadFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MultiTableReadFn.java
@@ -15,8 +15,7 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
 
-import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
-
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProvider;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.TableIdentifier;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.TableReadSpecification;
@@ -28,6 +27,8 @@ import com.google.re2j.Pattern;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
@@ -61,7 +62,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MultiTableReadFn<ParameterT, OutputT> extends DoFn<ParameterT, OutputT> {
 
-  private final SerializableFunction<Void, DataSource> dataSourceProviderFn;
+  private final DataSourceProvider dataSourceProvider;
   private final ValueProvider<QueryProvider> query;
   private final PreparedStatementSetter<ParameterT> parameterSetter;
   private final ImmutableMap<TableIdentifier, TableReadSpecification<OutputT>>
@@ -69,10 +70,10 @@ public class MultiTableReadFn<ParameterT, OutputT> extends DoFn<ParameterT, Outp
   private final SerializableFunction<ParameterT, TableIdentifier> tableIdentifierFn;
   private final boolean disableAutoCommit;
 
-  private Lock connectionLock = new ReentrantLock();
-  private @Nullable DataSource dataSource;
+  private transient Lock connectionLock;
+  private transient DataSourceManager dataSourceManager;
   // Connections are instance-local and handled per-bundle for thread safety.
-  private @Nullable Connection connection;
+  private transient Map<String, Connection> connections;
 
   /** Keep track of the tables for which lineage has already been reported to avoid duplicates. */
   private transient Set<KV<String, String>> reportedLineages = ConcurrentHashMap.newKeySet();
@@ -80,13 +81,13 @@ public class MultiTableReadFn<ParameterT, OutputT> extends DoFn<ParameterT, Outp
   private static final Logger LOG = LoggerFactory.getLogger(MultiTableReadFn.class);
 
   public MultiTableReadFn(
-      SerializableFunction<Void, DataSource> dataSourceProviderFn,
+      DataSourceProvider dataSourceProvider,
       ValueProvider<QueryProvider> query,
       PreparedStatementSetter<ParameterT> parameterSetter,
       ImmutableMap<TableIdentifier, TableReadSpecification<OutputT>> tableReadSpecifications,
       SerializableFunction<ParameterT, TableIdentifier> tableIdentifierFn,
       boolean disableAutoCommit) {
-    this.dataSourceProviderFn = dataSourceProviderFn;
+    this.dataSourceProvider = dataSourceProvider;
     this.query = query;
     this.parameterSetter = parameterSetter;
     this.tableReadSpecifications = tableReadSpecifications;
@@ -97,7 +98,14 @@ public class MultiTableReadFn<ParameterT, OutputT> extends DoFn<ParameterT, Outp
   @Setup
   public void setup() throws Exception {
     this.reportedLineages = ConcurrentHashMap.newKeySet();
-    dataSource = dataSourceProviderFn.apply(null);
+    this.connectionLock = new ReentrantLock();
+  }
+
+  @StartBundle
+  public void startBundle() {
+    this.connections = new ConcurrentHashMap<>();
+    this.dataSourceManager =
+        DataSourceManagerImpl.builder().setDataSourceProvider(dataSourceProvider).build();
   }
 
   /**
@@ -111,31 +119,32 @@ public class MultiTableReadFn<ParameterT, OutputT> extends DoFn<ParameterT, Outp
    */
   @VisibleForTesting
   protected Connection getConnection(ParameterT element) throws Exception {
-    Connection connection = this.connection;
+    TableIdentifier tableIdentifier = tableIdentifierFn.apply(element);
+    String dataSourceId = tableIdentifier.dataSourceId();
+    Connection connection = this.connections.get(dataSourceId);
     if (connection == null) {
-      DataSource validSource = checkStateNotNull(this.dataSource);
       connectionLock.lock();
       try {
-        // Double-checked locking to ensure only one connection is created per DoFn instance.
-        // This If Case is missing in upstream JDBCIO.ReadFN.
-        if (this.connection == null) {
-          connection = validSource.getConnection();
-          this.connection = connection;
+        connection = this.connections.get(dataSourceId);
+        if (connection == null) {
+          DataSource dataSource = dataSourceManager.getDatasource(dataSourceId);
+          connection = dataSource.getConnection();
+          this.connections.put(dataSourceId, connection);
 
           // PostgreSQL requires autocommit to be disabled to enable cursor streaming
           // see https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor
           // This option is configurable as Informix will error
           // if calling setAutoCommit on a non-logged database
           if (disableAutoCommit) {
-            LOG.info("Autocommit has been disabled");
+            LOG.info("Autocommit has been disabled for shard {}", dataSourceId);
             connection.setAutoCommit(false);
           }
+
+          reportLineage(element, connection, dataSource, query, reportedLineages);
         }
       } finally {
         connectionLock.unlock();
       }
-
-      reportLineage(element, connection, validSource, query, reportedLineages);
     }
     return connection;
   }
@@ -208,7 +217,7 @@ public class MultiTableReadFn<ParameterT, OutputT> extends DoFn<ParameterT, Outp
   // https://github.com/apache/beam/blob/676c998dec78e878d54ad21cde46f91cc9a598b7/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcUtil.java#L836
   private static final Pattern READ_STATEMENT_PATTERN =
       Pattern.compile(
-          "SELECT\\s+.+?\\s+FROM\\s+(\\[?`?(?<schemaName>[^\\s\\[\\]`]+)\\]?`?\\.)?\\[?`?(?<tableName>[^\\s\\[\\]`]+)\\]?`?",
+          "SELECT\\s+.+?\\s+FROM\\s+(\\[?`?(?P<schemaName>[^\\s\\[\\]`]+)\\]?`?\\.)?\\[?`?(?P<tableName>[^\\s\\[\\]`]+)\\]?`?",
           Pattern.CASE_INSENSITIVE);
 
   /**
@@ -275,13 +284,30 @@ public class MultiTableReadFn<ParameterT, OutputT> extends DoFn<ParameterT, Outp
     cleanUpConnection();
   }
 
-  private void cleanUpConnection() throws Exception {
-    if (connection != null) {
-      try {
-        connection.close();
-      } finally {
-        connection = null;
+  private void cleanUpConnection() {
+    if (connectionLock == null || connections == null) {
+      return;
+    }
+    connectionLock.lock();
+    try {
+      if (connections == null) {
+        return;
       }
+      for (Connection conn : connections.values()) {
+        if (conn != null) {
+          try {
+            conn.close();
+          } catch (SQLException e) {
+            LOG.warn("Failed to close connection", e);
+          }
+        }
+      }
+      connections.clear();
+    } finally {
+      connectionLock.unlock();
+      dataSourceManager.closeAll();
+      this.connections = null;
+      this.dataSourceManager = null;
     }
   }
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryDoFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryDoFn.java
@@ -18,6 +18,7 @@ package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.trans
 import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProvider;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary.ColumnForBoundaryQuery;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary.ColumnForBoundaryQueryPreparedStatementSetter;
@@ -38,7 +39,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.sql.DataSource;
 import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 final class RangeBoundaryDoFn extends DoFn<ColumnForBoundaryQuery, Range> implements Serializable {
 
   private static final Logger logger = LoggerFactory.getLogger(RangeBoundaryDoFn.class);
-  private final SerializableFunction<Void, DataSource> dataSourceProviderFn;
+  private final DataSourceProvider dataSourceProvider;
 
   private final UniformSplitterDBAdapter dbAdapter;
 
@@ -54,23 +54,22 @@ final class RangeBoundaryDoFn extends DoFn<ColumnForBoundaryQuery, Range> implem
   private final ColumnForBoundaryQueryPreparedStatementSetter
       columnForBoundaryQueryPreparedStatementSetter;
 
+  private transient DataSourceManager dataSourceManager;
+
   @JsonIgnore
   private transient @Nullable Map<TableIdentifier, TableSplitSpecification>
       tableSplitSpecificationMap;
 
   @Nullable private BoundaryTypeMapper boundaryTypeMapper;
 
-  @JsonIgnore private transient @Nullable DataSource dataSource;
-
   RangeBoundaryDoFn(
-      SerializableFunction<Void, DataSource> dataSourceProviderFn,
+      DataSourceProvider dataSourceProvider,
       UniformSplitterDBAdapter dbAdapter,
       ImmutableList<TableSplitSpecification> tableSplitSpecifications,
       BoundaryTypeMapper boundaryTypeMapper) {
-    this.dataSourceProviderFn = dataSourceProviderFn;
+    this.dataSourceProvider = dataSourceProvider;
     this.dbAdapter = dbAdapter;
     this.tableSplitSpecifications = tableSplitSpecifications;
-    this.dataSource = null;
     this.boundaryTypeMapper = boundaryTypeMapper;
     this.columnForBoundaryQueryPreparedStatementSetter =
         new ColumnForBoundaryQueryPreparedStatementSetter(tableSplitSpecifications);
@@ -78,15 +77,16 @@ final class RangeBoundaryDoFn extends DoFn<ColumnForBoundaryQuery, Range> implem
 
   @Setup
   public void setup() throws Exception {
-    dataSource = dataSourceProviderFn.apply(null);
     this.tableSplitSpecificationMap =
         this.tableSplitSpecifications.stream()
             .collect(
                 Collectors.toMap(TableSplitSpecification::tableIdentifier, Function.identity()));
   }
 
-  private Connection acquireConnection() throws SQLException {
-    return checkStateNotNull(this.dataSource).getConnection();
+  @StartBundle
+  public void startBundle() {
+    this.dataSourceManager =
+        DataSourceManagerImpl.builder().setDataSourceProvider(dataSourceProvider).build();
   }
 
   /**
@@ -110,8 +110,8 @@ final class RangeBoundaryDoFn extends DoFn<ColumnForBoundaryQuery, Range> implem
                 .map(pc -> pc.columnName())
                 .collect(ImmutableList.toImmutableList()),
             input.columnName());
-
-    try (Connection conn = acquireConnection()) {
+    DataSource dataSource = dataSourceManager.getDatasource(input.tableIdentifier().dataSourceId());
+    try (Connection conn = dataSource.getConnection()) {
       PreparedStatement stmt =
           conn.prepareStatement(
               boundaryQuery, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
@@ -149,6 +149,29 @@ final class RangeBoundaryDoFn extends DoFn<ColumnForBoundaryQuery, Range> implem
           boundaryQuery,
           dataSource);
       throw new RuntimeException(e);
+    }
+  }
+
+  @FinishBundle
+  public void finishBundle() throws Exception {
+    cleanupDataSource();
+  }
+
+  @Teardown
+  public void tearDown() throws Exception {
+    cleanupDataSource();
+  }
+
+  /**
+   * Closes all active data source connections.
+   *
+   * <p>This method ensures that the {@link DataSourceManager} releases all resources, preventing
+   * connection pool leaks during bundle finish or worker teardown.
+   */
+  void cleanupDataSource() {
+    if (this.dataSourceManager != null) {
+      this.dataSourceManager.closeAll();
+      this.dataSourceManager = null;
     }
   }
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryTransform.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryTransform.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
 
 import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProvider;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary.ColumnForBoundaryQuery;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundaryTypeMapper;
@@ -28,7 +29,6 @@ import javax.sql.DataSource;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
-import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.PCollection;
 
 /**
@@ -41,7 +41,7 @@ public abstract class RangeBoundaryTransform
     implements Serializable {
 
   /** Provider for {@link DataSource}. */
-  abstract SerializableFunction<Void, DataSource> dataSourceProviderFn();
+  abstract DataSourceProvider dataSourceProvider();
 
   /**
    * Implementations of {@link UniformSplitterDBAdapter} to get queries as per the dialect of the
@@ -61,7 +61,7 @@ public abstract class RangeBoundaryTransform
     SingleOutput<ColumnForBoundaryQuery, Range> parDo =
         ParDo.of(
             new RangeBoundaryDoFn(
-                dataSourceProviderFn(),
+                dataSourceProvider(),
                 dbAdapter(),
                 tableSplitSpecifications(),
                 boundaryTypeMapper()));
@@ -78,7 +78,7 @@ public abstract class RangeBoundaryTransform
   @AutoValue.Builder
   public abstract static class Builder {
 
-    public abstract Builder setDataSourceProviderFn(SerializableFunction<Void, DataSource> value);
+    public abstract Builder setDataSourceProvider(DataSourceProvider value);
 
     public abstract Builder setDbAdapter(UniformSplitterDBAdapter value);
 

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountDoFn.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountDoFn.java
@@ -15,9 +15,7 @@
  */
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
 
-import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProvider;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.RangePreparedStatementSetter;
@@ -32,10 +30,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLTimeoutException;
-import javax.annotation.Nullable;
 import javax.sql.DataSource;
 import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +49,7 @@ final class RangeCountDoFn extends DoFn<Range, Range> implements Serializable {
   private static final long TIMEOUT_GRACE_MILLIS = 1500;
 
   private static final Logger logger = LoggerFactory.getLogger(RangeCountDoFn.class);
-  private final SerializableFunction<Void, DataSource> dataSourceProviderFn;
+  private final DataSourceProvider dataSourceProvider;
   private final long timeoutMillis;
 
   private final UniformSplitterDBAdapter dbAdapter;
@@ -62,14 +58,14 @@ final class RangeCountDoFn extends DoFn<Range, Range> implements Serializable {
 
   private final RangePreparedStatementSetter rangePreparedStatementSetter;
 
-  @JsonIgnore private transient @Nullable DataSource dataSource;
+  private transient DataSourceManager dataSourceManager;
 
   RangeCountDoFn(
-      SerializableFunction<Void, DataSource> dataSourceProviderFn,
+      DataSourceProvider dataSourceProvider,
       long timeoutMillis,
       UniformSplitterDBAdapter dbAdapter,
       ImmutableList<TableSplitSpecification> tableSplitSpecifications) {
-    this.dataSourceProviderFn = dataSourceProviderFn;
+    this.dataSourceProvider = dataSourceProvider;
     this.timeoutMillis = timeoutMillis;
     this.dbAdapter = dbAdapter;
     ImmutableMap.Builder<TableIdentifier, String> countQueriesBuilder = ImmutableMap.builder();
@@ -85,16 +81,14 @@ final class RangeCountDoFn extends DoFn<Range, Range> implements Serializable {
     }
     this.countQueries = countQueriesBuilder.build();
     this.rangePreparedStatementSetter = new RangePreparedStatementSetter(tableSplitSpecifications);
-    this.dataSource = null;
+    this.dataSourceManager =
+        DataSourceManagerImpl.builder().setDataSourceProvider(dataSourceProvider).build();
   }
 
-  @Setup
-  public void setup() throws Exception {
-    dataSource = dataSourceProviderFn.apply(null);
-  }
-
-  private Connection acquireConnection() throws SQLException {
-    return checkStateNotNull(this.dataSource).getConnection();
+  @StartBundle
+  public void startBundle() throws Exception {
+    this.dataSourceManager =
+        DataSourceManagerImpl.builder().setDataSourceProvider(dataSourceProvider).build();
   }
 
   /**
@@ -118,8 +112,10 @@ final class RangeCountDoFn extends DoFn<Range, Range> implements Serializable {
           countQueries);
       throw new RuntimeException("Invalid Range");
     }
+
+    DataSource dataSource = dataSourceManager.getDatasource(input.tableIdentifier().dataSourceId());
     String countQuery = countQueries.get(input.tableIdentifier());
-    try (Connection conn = acquireConnection()) {
+    try (Connection conn = dataSource.getConnection()) {
       PreparedStatement stmt =
           conn.prepareStatement(
               countQuery, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
@@ -197,5 +193,28 @@ final class RangeCountDoFn extends DoFn<Range, Range> implements Serializable {
       return true;
     }
     return dbAdapter.checkForTimeout(e);
+  }
+
+  @FinishBundle
+  public void finishBundle() throws Exception {
+    cleanupDataSource();
+  }
+
+  @Teardown
+  public void tearDown() throws Exception {
+    cleanupDataSource();
+  }
+
+  /**
+   * Closes all active data source connections.
+   *
+   * <p>This method ensures that the {@link DataSourceManager} releases all resources, preventing
+   * connection pool leaks during bundle finish or worker teardown.
+   */
+  void cleanupDataSource() {
+    if (this.dataSourceManager != null) {
+      this.dataSourceManager.closeAll();
+      this.dataSourceManager = null;
+    }
   }
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountTransform.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountTransform.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
 
 import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProvider;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundaryTypeMapper;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
@@ -27,7 +28,6 @@ import javax.sql.DataSource;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
-import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.PCollection;
 
 /** PTransform to wrap {@link RangeCountDoFn}. */
@@ -36,7 +36,7 @@ public abstract class RangeCountTransform extends PTransform<PCollection<Range>,
     implements Serializable {
 
   /** Provider for {@link DataSource}. */
-  abstract SerializableFunction<Void, DataSource> dataSourceProviderFn();
+  abstract DataSourceProvider dataSourceProvider();
 
   /**
    * Implementations of {@link UniformSplitterDBAdapter} to get queries as per the dialect of the
@@ -59,7 +59,7 @@ public abstract class RangeCountTransform extends PTransform<PCollection<Range>,
     SingleOutput<Range, Range> parDo =
         ParDo.of(
             new RangeCountDoFn(
-                dataSourceProviderFn(), timeoutMillis(), dbAdapter(), tableSplitSpecifications()));
+                dataSourceProvider(), timeoutMillis(), dbAdapter(), tableSplitSpecifications()));
 
     if (boundaryTypeMapper() != null) {
       parDo = parDo.withSideInputs(boundaryTypeMapper().getCollationMapperView());
@@ -74,7 +74,7 @@ public abstract class RangeCountTransform extends PTransform<PCollection<Range>,
   @AutoValue.Builder
   public abstract static class Builder {
 
-    public abstract Builder setDataSourceProviderFn(SerializableFunction<Void, DataSource> value);
+    public abstract Builder setDataSourceProvider(DataSourceProvider value);
 
     public abstract Builder setDbAdapter(UniformSplitterDBAdapter value);
 

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitions.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitions.java
@@ -18,7 +18,6 @@ package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.trans
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.memoized.Memoized;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProvider;
-import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProviderImpl;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary.ColumnForBoundaryQuery;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundaryTypeMapper;
@@ -569,15 +568,6 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
 
     public abstract Builder<T> setDataSourceProvider(DataSourceProvider value);
 
-    // TODO Remove in subsequent PR
-    private SerializableFunction<Void, DataSource> dataSourceProviderSerializableFunction = null;
-
-    // TODO Remove in subsequent PR
-    public Builder<T> setDataSourceProviderFn(SerializableFunction<Void, DataSource> value) {
-      this.dataSourceProviderSerializableFunction = value;
-      return this;
-    }
-
     public abstract Builder<T> setDbAdapter(UniformSplitterDBAdapter value);
 
     public abstract Builder<T> setCountQueryTimeoutMillis(long value);
@@ -626,15 +616,6 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
     }
 
     public ReadWithUniformPartitions<T> build() {
-      // TODO Remove in subsequent PR
-      if (this.dataSourceProviderSerializableFunction != null) {
-        this.setDataSourceProvider(
-            DataSourceProviderImpl.builder()
-                .addDataSource(
-                    this.tableSplitSpecifications().get(0).tableIdentifier().dataSourceId(),
-                    this.dataSourceProviderSerializableFunction)
-                .build());
-      }
       validateParameters();
 
       java.util.Set<TableIdentifier> splitIdentifiers =

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitions.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitions.java
@@ -17,6 +17,8 @@ package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.trans
 
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.memoized.Memoized;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProvider;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProviderImpl;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary.ColumnForBoundaryQuery;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundaryTypeMapper;
@@ -45,6 +47,7 @@ import org.apache.beam.sdk.io.jdbc.JdbcIO.ReadAll;
 import org.apache.beam.sdk.io.jdbc.JdbcIO.RowMapper;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Flatten;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
@@ -91,8 +94,15 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
 
   private static final long SPLITTER_DEFAULT_COUNT_QUERY_TIMEOUT_MILLIS = 5 * 1000;
 
-  /** Provider for {@link DataSource}. Required parameter. */
-  abstract SerializableFunction<Void, DataSource> dataSourceProviderFn();
+  /**
+   * Provider for {@link DataSource}.
+   *
+   * <p>Note: The implementation of {@link DataSourceProvider} must be fully serializable as it is a
+   * member of this transform and will be serialized to Dataflow workers.
+   *
+   * @return The data source provider.
+   */
+  abstract DataSourceProvider dataSourceProvider();
 
   /**
    * Implementations of {@link UniformSplitterDBAdapter} to get queries as per the dialect of the
@@ -174,7 +184,6 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
    */
   @Override
   public PCollection<T> expand(PBegin input) {
-    // TODO(vardhanvthigle): Move this side-input generation out to DB level.
     PCollectionView<Map<CollationReference, CollationMapper>> collationMapperView =
         getCollationMapperView(input);
     BoundaryTypeMapper typeMapper =
@@ -207,7 +216,7 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
 
       RangeCountTransform rangeCountTransform =
           RangeCountTransform.builder()
-              .setDataSourceProviderFn(dataSourceProviderFn())
+              .setDataSourceProvider(dataSourceProvider())
               .setDbAdapter(dbAdapter())
               .setTableSplitSpecifications(tableSplitSpecifications())
               .setBoundaryTypeMapper(typeMapper)
@@ -216,7 +225,7 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
 
       RangeBoundaryTransform rangeBoundaryTransform =
           RangeBoundaryTransform.builder()
-              .setDataSourceProviderFn(dataSourceProviderFn())
+              .setDataSourceProvider(dataSourceProvider())
               .setBoundaryTypeMapper(typeMapper)
               .setDbAdapter(dbAdapter())
               .setTableSplitSpecifications(tableSplitSpecifications())
@@ -326,7 +335,7 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
                 tableReadSpecifications(),
                 dbAdapter(),
                 rangePrepareator,
-                dataSourceProviderFn()));
+                dataSourceProvider()));
   }
 
   @VisibleForTesting
@@ -358,7 +367,7 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
    * @param tableReadSpecifications specifications for reading tables.
    * @param dbAdapter the database adapter for generating queries.
    * @param rangePrepareator the parameter setter for the read query.
-   * @param dataSourceProviderFn the provider for the data source.
+   * @param dataSourceProvider the provider for the data source.
    * @return a configured MultiTableReadAll transform.
    */
   @VisibleForTesting
@@ -368,7 +377,7 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
       ImmutableMap<TableIdentifier, TableReadSpecification<T>> tableReadSpecifications,
       UniformSplitterDBAdapter dbAdapter,
       PreparedStatementSetter<Range> rangePrepareator,
-      SerializableFunction<Void, DataSource> dataSourceProviderFn) {
+      DataSourceProvider dataSourceProvider) {
     QueryProviderImpl queryProvider =
         QueryProviderImpl.builder()
             .setTableSplitSpecifications(tableSplitSpecifications, dbAdapter)
@@ -378,7 +387,7 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
             .setOutputParallelization(false)
             .setQueryProvider(StaticValueProvider.of(queryProvider))
             .setParameterSetter(rangePrepareator)
-            .setDataSourceProviderFn(dataSourceProviderFn)
+            .setDataSourceProvider(dataSourceProvider)
             .setTableReadSpecifications(tableReadSpecifications)
             .setTableIdentifierFn(new RangeToTableIdentifierFn())
             .setDisableAutoCommit(true)
@@ -402,9 +411,9 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
     return input.apply(
         getTransformName("CollationMapper", null, null),
         CollationMapperTransform.builder()
-            .setCollationReferences(collationReferences)
+            .setCollationReferencesToDiscover(collationReferences)
             .setDbAdapter(dbAdapter())
-            .setDataSourceProviderFn(dataSourceProviderFn())
+            .setDataSourceProvider(dataSourceProvider())
             .build());
   }
 
@@ -435,7 +444,7 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
     RangeBoundaryTransform rangeBoundaryTransform =
         RangeBoundaryTransform.builder()
             .setBoundaryTypeMapper(typeMapper)
-            .setDataSourceProviderFn(dataSourceProviderFn())
+            .setDataSourceProvider(dataSourceProvider())
             .setDbAdapter(dbAdapter())
             .setTableSplitSpecifications(tableSplitSpecifications())
             .build();
@@ -558,8 +567,16 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
   @AutoValue.Builder
   public abstract static class Builder<T> {
 
-    public abstract Builder<T> setDataSourceProviderFn(
-        SerializableFunction<Void, DataSource> value);
+    public abstract Builder<T> setDataSourceProvider(DataSourceProvider value);
+
+    // TODO Remove in subsequent PR
+    private SerializableFunction<Void, DataSource> dataSourceProviderSerializableFunction = null;
+
+    // TODO Remove in subsequent PR
+    public Builder<T> setDataSourceProviderFn(SerializableFunction<Void, DataSource> value) {
+      this.dataSourceProviderSerializableFunction = value;
+      return this;
+    }
 
     public abstract Builder<T> setDbAdapter(UniformSplitterDBAdapter value);
 
@@ -609,6 +626,15 @@ public abstract class ReadWithUniformPartitions<T> extends PTransform<PBegin, PC
     }
 
     public ReadWithUniformPartitions<T> build() {
+      // TODO Remove in subsequent PR
+      if (this.dataSourceProviderSerializableFunction != null) {
+        this.setDataSourceProvider(
+            DataSourceProviderImpl.builder()
+                .addDataSource(
+                    this.tableSplitSpecifications().get(0).tableIdentifier().dataSourceId(),
+                    this.dataSourceProviderSerializableFunction)
+                .build());
+      }
       validateParameters();
 
       java.util.Set<TableIdentifier> splitIdentifiers =

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
@@ -1009,19 +1009,19 @@ public class JdbcIoWrapperTest {
 
     // Assert
     // Legacy: shard2.t2 (1), shard3.t3a (1), shard3.t3b (1) = 3 transforms
-    // Uniform: shard5 (1), shard6 (1) = 2 transforms
-    // Total = 5 entries
-    assertThat(tableReaders).hasSize(5);
+    // Uniform: shard5 (1), shard6 (1) = 1 transform (combined)
+    // Total = 4 entries
+    assertThat(tableReaders).hasSize(4);
 
     // Verify Legacy readers
     long legacyCount =
         tableReaders.values().stream().filter(v -> v instanceof JdbcIO.ReadWithPartitions).count();
     assertThat(legacyCount).isEqualTo(3);
 
-    // Verify Uniform readers
+    // Verify that we have one combined Uniform reader
     long uniformCount =
         tableReaders.values().stream().filter(v -> v instanceof ReadWithUniformPartitions).count();
-    assertThat(uniformCount).isEqualTo(2);
+    assertThat(uniformCount).isEqualTo(1);
 
     // Verify table names in keys
     java.util.List<String> allTableNames =
@@ -1095,6 +1095,10 @@ public class JdbcIoWrapperTest {
         .containsNoDuplicates();
   }
 
+  /**
+   * Tests that {@link JdbcIoWrapper#getPerSourceDiscoveries} correctly propagates exceptions when
+   * schema discovery fails for a shard.
+   */
   @Test
   public void testGetPerSourceDiscoveries_Fails() throws RetriableSchemaDiscoveryException {
     SourceSchemaReference schemaRef =
@@ -1122,6 +1126,10 @@ public class JdbcIoWrapperTest {
     assertThrows(RuntimeException.class, () -> JdbcIoWrapper.getPerSourceDiscoveries(group));
   }
 
+  /**
+   * Tests that {@link JdbcIoWrapper#getPerSourceDiscoveries} logs a warning and continues when
+   * closing a data source fails after discovery.
+   */
   @Test
   public void testGetPerSourceDiscovery_LogsWarning_WhenCloseFails() throws Exception {
     SourceSchemaReference schemaRef =
@@ -1304,7 +1312,7 @@ public class JdbcIoWrapperTest {
         ImmutableMap.builder();
 
     JdbcIoWrapper.accumulateSpecs(
-        discovery, tableReferencesBuilder, splitSpecsBuilder, readSpecsBuilder);
+        ImmutableList.of(discovery), tableReferencesBuilder, splitSpecsBuilder, readSpecsBuilder);
 
     ImmutableList<SourceTableReference> tableRefs = tableReferencesBuilder.build();
     ImmutableList<TableSplitSpecification> splitSpecs = splitSpecsBuilder.build();
@@ -1357,7 +1365,7 @@ public class JdbcIoWrapperTest {
         ImmutableMap.builder();
 
     JdbcIoWrapper.accumulateSpecs(
-        discovery, tableReferencesBuilder, splitSpecsBuilder, readSpecsBuilder);
+        ImmutableList.of(discovery), tableReferencesBuilder, splitSpecsBuilder, readSpecsBuilder);
 
     assertThat(tableReferencesBuilder.build()).isEmpty();
     assertThat(splitSpecsBuilder.build()).isEmpty();
@@ -1368,6 +1376,41 @@ public class JdbcIoWrapperTest {
    * Tests that {@link JdbcIoWrapper#accumulateSpecs} does not generate split specifications when
    * the uniform partitions feature is disabled.
    */
+  @Test
+  public void testAccumulateSpecs_FeatureDisabled() {
+    SourceSchemaReference schemaRef =
+        SourceSchemaReference.ofJdbc(JdbcSchemaReference.builder().setDbName("testDB").build());
+    JdbcIOWrapperConfig config =
+        JdbcIOWrapperConfig.builderWithMySqlDefaults()
+            .setReadWithUniformPartitionsFeatureEnabled(false)
+            .setSourceDbURL("jdbc:mysql://localhost/test")
+            .setDbAuth(
+                LocalCredentialsProvider.builder().setUserName("user").setPassword("pass").build())
+            .setJdbcDriverJars("")
+            .setJdbcDriverClassName("com.mysql.cj.jdbc.Driver")
+            .setSourceSchemaReference(schemaRef)
+            .build();
+    TableConfig tableConfig = TableConfig.builder("testTable").setDataSourceId("shard1").build();
+    JdbcIoWrapper.PerSourceDiscovery discovery =
+        JdbcIoWrapper.PerSourceDiscovery.builder()
+            .setConfig(config)
+            .setDataSourceConfiguration(JdbcIO.DataSourceConfiguration.create("c", "u"))
+            .setTableConfigs(ImmutableList.of(tableConfig))
+            .setSourceSchema(SourceSchema.builder().setSchemaReference(schemaRef).build())
+            .build();
+
+    ImmutableList.Builder<SourceTableReference> tableReferencesBuilder = ImmutableList.builder();
+    ImmutableList.Builder<TableSplitSpecification> splitSpecsBuilder = ImmutableList.builder();
+    ImmutableMap.Builder<TableIdentifier, TableReadSpecification<SourceRow>> readSpecsBuilder =
+        ImmutableMap.builder();
+
+    JdbcIoWrapper.accumulateSpecs(
+        ImmutableList.of(discovery), tableReferencesBuilder, splitSpecsBuilder, readSpecsBuilder);
+
+    assertThat(splitSpecsBuilder.build()).isEmpty();
+    assertThat(readSpecsBuilder.build()).isEmpty();
+  }
+
   @Test
   public void testGetDataSourceProvider() {
     JdbcIOWrapperConfig config1 =

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/CollationMapperDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/CollationMapperDoFnTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.withSettings;
 
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProvider;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationMapper;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
 import java.sql.Connection;
@@ -39,7 +40,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import javax.sql.DataSource;
 import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
-import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.KV;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,8 +52,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 /** Test class for {@link CollationMapperDoFn}. */
 @RunWith(MockitoJUnitRunner.class)
 public class CollationMapperDoFnTest {
-  SerializableFunction<Void, DataSource> mockDataSourceProviderFn =
-      Mockito.mock(SerializableFunction.class, withSettings().serializable());
+  DataSourceProvider mockDataSourceProvider =
+      Mockito.mock(DataSourceProvider.class, withSettings().serializable());
   DataSource mockDataSource = Mockito.mock(DataSource.class, withSettings().serializable());
 
   Connection mockConnection = Mockito.mock(Connection.class, withSettings().serializable());
@@ -68,7 +68,7 @@ public class CollationMapperDoFnTest {
   @Test
   public void testCollationMapperDoFnBasic() throws Exception {
 
-    when(mockDataSourceProviderFn.apply(any())).thenReturn(mockDataSource);
+    when(mockDataSourceProvider.getDataSource(any())).thenReturn(mockDataSource);
     when(mockDataSource.getConnection()).thenReturn(mockConnection);
     when(mockConnection.createStatement()).thenReturn(mockStatement);
     when(mockStatement.execute(any())).thenReturn(false);
@@ -96,9 +96,10 @@ public class CollationMapperDoFnTest {
 
     CollationMapperDoFn collationMapperDoFn =
         new CollationMapperDoFn(
-            mockDataSourceProviderFn, new MysqlDialectAdapter(MySqlVersion.DEFAULT));
-    collationMapperDoFn.setup();
-    collationMapperDoFn.processElement(testCollationReference, mockOut);
+            mockDataSourceProvider, new MysqlDialectAdapter(MySqlVersion.DEFAULT));
+    collationMapperDoFn.startBundle();
+    collationMapperDoFn.processElement(
+        KV.of("b1a1ec3b-195d-4755-b04b-02bc64dc4458", testCollationReference), mockOut);
     verify(mockOut).output(collationMapperCaptor.capture());
     KV<CollationReference, CollationMapper> mapperKV = collationMapperCaptor.getValue();
     assertThat(mapperKV.getKey()).isEqualTo(testCollationReference);
@@ -110,7 +111,7 @@ public class CollationMapperDoFnTest {
   @Test
   public void testCollationMapperDoFnException() throws Exception {
 
-    when(mockDataSourceProviderFn.apply(any())).thenReturn(mockDataSource);
+    when(mockDataSourceProvider.getDataSource(any())).thenReturn(mockDataSource);
     when(mockDataSource.getConnection())
         .thenThrow(new SQLException("test"))
         .thenReturn(mockConnection);
@@ -125,13 +126,17 @@ public class CollationMapperDoFnTest {
 
     CollationMapperDoFn collationMapperDoFn =
         new CollationMapperDoFn(
-            mockDataSourceProviderFn, new MysqlDialectAdapter(MySqlVersion.DEFAULT));
-    collationMapperDoFn.setup();
+            mockDataSourceProvider, new MysqlDialectAdapter(MySqlVersion.DEFAULT));
+    collationMapperDoFn.startBundle();
     assertThrows(
         SQLException.class,
-        () -> collationMapperDoFn.processElement(testCollationReference, mockOut));
+        () ->
+            collationMapperDoFn.processElement(
+                KV.of("b1a1ec3b-195d-4755-b04b-02bc64dc4458", testCollationReference), mockOut));
     assertThrows(
         SQLException.class,
-        () -> collationMapperDoFn.processElement(testCollationReference, mockOut));
+        () ->
+            collationMapperDoFn.processElement(
+                KV.of("b1a1ec3b-195d-4755-b04b-02bc64dc4458", testCollationReference), mockOut));
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/CollationMapperTransformTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/CollationMapperTransformTest.java
@@ -23,15 +23,18 @@ import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter
 import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.IS_EMPTY_COL;
 import static com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationOrderRow.CollationsOrderQueryColumns.IS_SPACE_COL;
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProvider;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationMapper;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.stringmapper.CollationReference;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -44,7 +47,6 @@ import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
 import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
@@ -62,9 +64,9 @@ import org.mockito.quality.Strictness;
 @RunWith(MockitoJUnitRunner.class)
 public class CollationMapperTransformTest implements Serializable {
 
-  SerializableFunction<Void, DataSource> mockDataSourceProviderFn =
+  DataSourceProvider mockDataSourceProvider =
       Mockito.mock(
-          SerializableFunction.class, withSettings().serializable().strictness(Strictness.LENIENT));
+          DataSourceProvider.class, withSettings().serializable().strictness(Strictness.LENIENT));
 
   DataSource mockDataSource =
       Mockito.mock(DataSource.class, withSettings().serializable().strictness(Strictness.LENIENT));
@@ -90,7 +92,9 @@ public class CollationMapperTransformTest implements Serializable {
 
   @Test
   public void testCollationMapperTransform() throws SQLException {
-    when(mockDataSourceProviderFn.apply(any())).thenReturn(mockDataSource);
+    when(mockDataSourceProvider.getDataSourceIds())
+        .thenReturn(ImmutableSet.of("b1a1ec3b-195d-4755-b04b-02bc64dc4458", "67890-shard2"));
+    when(mockDataSourceProvider.getDataSource(any())).thenReturn(mockDataSource);
     when(mockDataSource.getConnection()).thenReturn(mockConnection);
     when(mockConnection.createStatement())
         .thenReturn(mockStatementFirst)
@@ -145,12 +149,12 @@ public class CollationMapperTransformTest implements Serializable {
             .build();
     CollationMapperTransform collationMapperTransform =
         CollationMapperTransform.builder()
-            .setCollationReferences(
+            .setCollationReferencesToDiscover(
                 ImmutableList.of(
                     testCollationReferenceFirst,
                     testCollationReferenceSecond,
                     /* test that pick distinct collationReferences to avoid un-necessary collation discovery work. */ testCollationReferenceFirst))
-            .setDataSourceProviderFn(mockDataSourceProviderFn)
+            .setDataSourceProvider(mockDataSourceProvider)
             .setDbAdapter(new MysqlDialectAdapter(MySqlVersion.DEFAULT))
             .build();
     PCollectionView<Map<CollationReference, CollationMapper>> collationMapperView =
@@ -167,6 +171,150 @@ public class CollationMapperTransformTest implements Serializable {
                             testCollationReferenceSecond))
                     .withSideInputs(collationMapperView));
     testPipeline.run().waitUntilFinish();
+  }
+
+  /**
+   * Tests that {@link CollationMapperTransform} throws an {@link IllegalStateException} when no
+   * data sources are provided.
+   */
+  @Test
+  public void testCollationMapperTransform_NoDataSources() {
+    when(mockDataSourceProvider.getDataSourceIds()).thenReturn(ImmutableSet.of());
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          CollationMapperTransform collationMapperTransform =
+              CollationMapperTransform.builder()
+                  .setCollationReferencesToDiscover(ImmutableList.of())
+                  .setDataSourceProvider(mockDataSourceProvider)
+                  .setDbAdapter(new MysqlDialectAdapter(MySqlVersion.DEFAULT))
+                  .build();
+          testPipeline.apply(collationMapperTransform);
+        });
+  }
+
+  @Test
+  public void testCollationMapperTransform_multiShardWorkDistribution() throws SQLException {
+    String shard1 = "shard1";
+    String shard2 = "shard2";
+    DataSource mockDataSource1 =
+        Mockito.mock(
+            DataSource.class, withSettings().serializable().strictness(Strictness.LENIENT));
+    DataSource mockDataSource2 =
+        Mockito.mock(
+            DataSource.class, withSettings().serializable().strictness(Strictness.LENIENT));
+    Connection mockConnection1 =
+        Mockito.mock(
+            Connection.class, withSettings().serializable().strictness(Strictness.LENIENT));
+    Connection mockConnection2 =
+        Mockito.mock(
+            Connection.class, withSettings().serializable().strictness(Strictness.LENIENT));
+
+    when(mockDataSourceProvider.getDataSourceIds()).thenReturn(ImmutableSet.of(shard1, shard2));
+    when(mockDataSourceProvider.getDataSource(shard1)).thenReturn(mockDataSource1);
+    when(mockDataSourceProvider.getDataSource(shard2)).thenReturn(mockDataSource2);
+    when(mockDataSource1.getConnection()).thenReturn(mockConnection1);
+    when(mockDataSource2.getConnection()).thenReturn(mockConnection2);
+
+    // Setup statements and result sets for shard 1 (will handle refA and refC)
+    Statement stmt1 =
+        Mockito.mock(Statement.class, withSettings().serializable().strictness(Strictness.LENIENT));
+    when(mockConnection1.createStatement()).thenReturn(stmt1);
+    setupMockStatement(stmt1, mockResultSetFirst); // refA
+    setupMockStatement(stmt1, mockResultSetFirst); // refC
+
+    // Setup statements and result sets for shard 2 (will handle refB)
+    Statement stmt2 =
+        Mockito.mock(Statement.class, withSettings().serializable().strictness(Strictness.LENIENT));
+    when(mockConnection2.createStatement()).thenReturn(stmt2);
+    setupMockStatement(stmt2, mockResultSetSecond); // refB
+
+    setupMockResultSet(mockResultSetFirst, "A", "a");
+    setupMockResultSet(mockResultSetSecond, "a", "A");
+
+    CollationReference refA =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharSet")
+            .setDbCollation("refA")
+            .setPadSpace(false)
+            .build();
+    CollationReference refB =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharSet")
+            .setDbCollation("refB")
+            .setPadSpace(false)
+            .build();
+    CollationReference refC =
+        CollationReference.builder()
+            .setDbCharacterSet("testCharSet")
+            .setDbCollation("refC")
+            .setPadSpace(false)
+            .build();
+
+    CollationMapperTransform collationMapperTransform =
+        CollationMapperTransform.builder()
+            .setCollationReferencesToDiscover(ImmutableList.of(refA, refB, refC))
+            .setDataSourceProvider(mockDataSourceProvider)
+            .setDbAdapter(new MysqlDialectAdapter(MySqlVersion.DEFAULT))
+            .build();
+
+    PCollectionView<Map<CollationReference, CollationMapper>> collationMapperView =
+        testPipeline.apply(collationMapperTransform);
+
+    testPipeline
+        .apply(Create.of("test"))
+        .apply(
+            "verifyMultiShard",
+            ParDo.of(new VerifyMultiShardMapper(collationMapperView, refA, refB, refC))
+                .withSideInputs(collationMapperView));
+
+    testPipeline.run().waitUntilFinish();
+  }
+
+  private void setupMockStatement(Statement stmt, ResultSet rs) throws SQLException {
+    when(stmt.execute(any())).thenReturn(false);
+    when(stmt.getMoreResults()).thenReturn(false).thenReturn(false).thenReturn(true);
+    when(stmt.getUpdateCount()).thenReturn(0);
+    when(stmt.getResultSet()).thenReturn(rs);
+  }
+
+  private void setupMockResultSet(ResultSet rs, String char1, String char2) throws SQLException {
+    when(rs.next()).thenReturn(true).thenReturn(true).thenReturn(false);
+    when(rs.getString(CHARSET_CHAR_COL)).thenReturn(char1).thenReturn(char2);
+    when(rs.getString(EQUIVALENT_CHARSET_CHAR_COL)).thenReturn(char2).thenReturn(char2);
+    when(rs.getLong(CODEPOINT_RANK_COL)).thenReturn(0L).thenReturn(0L);
+    when(rs.getString(EQUIVALENT_CHARSET_CHAR_PAD_SPACE_COL)).thenReturn(char2).thenReturn(char2);
+    when(rs.getLong(CODEPOINT_RANK_PAD_SPACE_COL)).thenReturn(0L).thenReturn(0L);
+    when(rs.getBoolean(IS_EMPTY_COL)).thenReturn(false).thenReturn(false);
+    when(rs.getBoolean(IS_SPACE_COL)).thenReturn(false).thenReturn(false);
+  }
+
+  static class VerifyMultiShardMapper extends DoFn<String, Void> implements Serializable {
+    private final PCollectionView<Map<CollationReference, CollationMapper>> view;
+    private final CollationReference refA;
+    private final CollationReference refB;
+    private final CollationReference refC;
+
+    VerifyMultiShardMapper(
+        PCollectionView<Map<CollationReference, CollationMapper>> view,
+        CollationReference refA,
+        CollationReference refB,
+        CollationReference refC) {
+      this.view = view;
+      this.refA = refA;
+      this.refB = refB;
+      this.refC = refC;
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      Map<CollationReference, CollationMapper> map = c.sideInput(view);
+      assertThat(map).hasSize(3);
+      assertThat(map).containsKey(refA);
+      assertThat(map).containsKey(refB);
+      assertThat(map).containsKey(refC);
+    }
   }
 
   static class VerifyMapper extends DoFn<String, Void> implements Serializable {

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MultiTableReadAllTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MultiTableReadAllTest.java
@@ -20,7 +20,10 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProvider;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProviderImpl;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.TableIdentifier;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.TableReadSpecification;
 import com.google.common.collect.ImmutableMap;
@@ -76,6 +79,8 @@ public class MultiTableReadAllTest {
   @Test
   public void testFluentApiMethods() {
     SerializableFunction<Void, DataSource> mockProvider = mock(SerializableFunction.class);
+    DataSource mockDataSource = mock(DataSource.class);
+    when(mockProvider.apply(null)).thenReturn(mockDataSource);
     JdbcIO.PreparedStatementSetter<String> mockSetter = mock(JdbcIO.PreparedStatementSetter.class);
     JdbcIO.RowMapper<String> mockMapper = mock(JdbcIO.RowMapper.class);
     TableIdentifier tableId =
@@ -92,7 +97,10 @@ public class MultiTableReadAllTest {
 
     MultiTableReadAll<String, String> readAll =
         MultiTableReadAll.<String, String>builder()
-            .setDataSourceProviderFn(mockProvider)
+            .setDataSourceProvider(
+                DataSourceProviderImpl.builder()
+                    .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", mockProvider)
+                    .build())
             .setQueryProvider(StaticValueProvider.of(new TestQueryProvider()))
             .setParameterSetter(mockSetter)
             .setTableReadSpecifications(ImmutableMap.of(tableId, spec))
@@ -100,7 +108,9 @@ public class MultiTableReadAllTest {
             .setOutputParallelization(true)
             .build();
 
-    assertThat(readAll.getDataSourceProviderFn()).isEqualTo(mockProvider);
+    assertThat(
+            readAll.getDataSourceProvider().getDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458"))
+        .isEqualTo(mockDataSource);
     assertThat(readAll.getParameterSetter()).isEqualTo(mockSetter);
     assertThat(readAll.getOutputParallelization()).isTrue();
 
@@ -135,9 +145,9 @@ public class MultiTableReadAllTest {
             .setTableIdentifierFn(mock(SerializableFunction.class))
             .setOutputParallelization(false)
             .build()
-            .withDataSourceConfiguration(config);
+            .withDataSourceConfiguration("b1a1ec3b-195d-4755-b04b-02bc64dc4458", config);
 
-    assertThat(readAll.getDataSourceProviderFn()).isNotNull();
+    assertThat(readAll.getDataSourceProvider()).isNotNull();
   }
 
   @Test
@@ -156,9 +166,13 @@ public class MultiTableReadAllTest {
 
     MultiTableReadAll<String, String> readAll =
         MultiTableReadAll.<String, String>builder()
-            .setDataSourceProviderFn(
-                JdbcIO.DataSourceProviderFromDataSourceConfiguration.of(
-                    JdbcIO.DataSourceConfiguration.create(DRIVER_CLASS_NAME, JDBC_URL)))
+            .setDataSourceProvider(
+                DataSourceProviderImpl.builder()
+                    .addDataSource(
+                        tableId.dataSourceId(),
+                        JdbcIO.DataSourceProviderFromDataSourceConfiguration.of(
+                            JdbcIO.DataSourceConfiguration.create(DRIVER_CLASS_NAME, JDBC_URL)))
+                    .build())
             .setQueryProvider(StaticValueProvider.of(new TestQueryProvider()))
             .setParameterSetter((element, preparedStatement) -> {})
             .setTableReadSpecifications(ImmutableMap.of(tableId, spec))
@@ -199,9 +213,13 @@ public class MultiTableReadAllTest {
 
     MultiTableReadAll<String, TestRow> readAll =
         MultiTableReadAll.<String, TestRow>builder()
-            .setDataSourceProviderFn(
-                JdbcIO.DataSourceProviderFromDataSourceConfiguration.of(
-                    JdbcIO.DataSourceConfiguration.create(DRIVER_CLASS_NAME, JDBC_URL)))
+            .setDataSourceProvider(
+                DataSourceProviderImpl.builder()
+                    .addDataSource(
+                        tableId.dataSourceId(),
+                        JdbcIO.DataSourceProviderFromDataSourceConfiguration.of(
+                            JdbcIO.DataSourceConfiguration.create(DRIVER_CLASS_NAME, JDBC_URL)))
+                    .build())
             .setQueryProvider(StaticValueProvider.of(new TestQueryProvider()))
             .setParameterSetter((element, preparedStatement) -> {})
             .setTableReadSpecifications(ImmutableMap.of(tableId, spec))
@@ -233,7 +251,10 @@ public class MultiTableReadAllTest {
 
     MultiTableReadAll<String, Uncodable> readAll =
         MultiTableReadAll.<String, Uncodable>builder()
-            .setDataSourceProviderFn(mock(SerializableFunction.class))
+            .setDataSourceProvider(
+                DataSourceProviderImpl.builder()
+                    .addDataSource(tableId.dataSourceId(), mock(SerializableFunction.class))
+                    .build())
             .setQueryProvider(StaticValueProvider.of(new TestQueryProvider()))
             .setParameterSetter((element, preparedStatement) -> {})
             .setTableReadSpecifications(ImmutableMap.of(tableId, spec))
@@ -286,7 +307,10 @@ public class MultiTableReadAllTest {
 
     MultiTableReadAll<String, String> readAll =
         MultiTableReadAll.<String, String>builder()
-            .setDataSourceProviderFn(mockProvider)
+            .setDataSourceProvider(
+                DataSourceProviderImpl.builder()
+                    .addDataSource(tableId.dataSourceId(), mockProvider)
+                    .build())
             .setQueryProvider(StaticValueProvider.of(new TestQueryProvider()))
             .setTableReadSpecifications(ImmutableMap.of(tableId, spec))
             .setTableIdentifierFn((element) -> tableId)
@@ -301,13 +325,21 @@ public class MultiTableReadAllTest {
   @Test(expected = IllegalArgumentException.class)
   public void testWithDataSourceProviderFn_duplicate_throwsException() {
     SerializableFunction<Void, DataSource> mockProvider = mock(SerializableFunction.class);
+    TableIdentifier tableId =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("testTable")
+            .build();
     MultiTableReadAll.<String, String>builder()
-        .setDataSourceProviderFn(mockProvider)
+        .setDataSourceProvider(
+            DataSourceProviderImpl.builder()
+                .addDataSource(tableId.dataSourceId(), mock(SerializableFunction.class))
+                .build())
         .setTableReadSpecifications(ImmutableMap.of())
         .setTableIdentifierFn(mock(SerializableFunction.class))
         .setOutputParallelization(false)
         .build()
-        .withDataSourceProviderFn(mockProvider);
+        .withDataSourceProviderFn("b1a1ec3b-195d-4755-b04b-02bc64dc4458", mockProvider);
   }
 
   @Test
@@ -429,6 +461,32 @@ public class MultiTableReadAllTest {
     IllegalArgumentException thrown =
         assertThrows(IllegalArgumentException.class, () -> readAll.withCoder(null));
     assertThat(thrown).hasMessageThat().contains("called with null coder");
+  }
+
+  @Test
+  public void testWithDataSourceProvider_nullThrows() {
+    MultiTableReadAll.Builder<String, String> builder = MultiTableReadAll.builder();
+    MultiTableReadAll<String, String> readAll =
+        builder
+            .setTableReadSpecifications(ImmutableMap.of())
+            .setTableIdentifierFn(mock(SerializableFunction.class))
+            .setOutputParallelization(false)
+            .build();
+    assertThrows(IllegalArgumentException.class, () -> readAll.withDataSourceProvider(null));
+  }
+
+  @Test
+  public void testWithMultipleDataSourceProvider_Throws() {
+    MultiTableReadAll readAll =
+        MultiTableReadAll.builder()
+            .setTableReadSpecifications(ImmutableMap.of())
+            .setTableIdentifierFn(mock(SerializableFunction.class))
+            .setOutputParallelization(false)
+            .setDataSourceProvider(mock(DataSourceProvider.class))
+            .build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> readAll.withDataSourceProvider(mock(DataSourceProviderImpl.class)));
   }
 
   @Test

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MultiTableReadFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MultiTableReadFnTest.java
@@ -22,12 +22,15 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProvider;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProviderImpl;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.TableIdentifier;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.TableReadSpecification;
 import com.google.common.collect.ImmutableMap;
@@ -50,6 +53,20 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MultiTableReadFnTest {
+
+  private DataSourceProvider getMockDataSourceProvider(DataSource mockDataSource) {
+    return new DataSourceProvider() {
+      @Override
+      public DataSource getDataSource(String datasourceId) {
+        return mockDataSource;
+      }
+
+      @Override
+      public com.google.common.collect.ImmutableSet<String> getDataSourceIds() {
+        return com.google.common.collect.ImmutableSet.of("b1a1ec3b-195d-4755-b04b-02bc64dc4458");
+      }
+    };
+  }
 
   @Test
   public void testExtractTableFromReadQuery_null() {
@@ -174,7 +191,9 @@ public class MultiTableReadFnTest {
     SerializableFunction<Void, DataSource> dataSourceProviderFn = (v) -> mockDataSource;
     MultiTableReadFn<String, String> readFn =
         new MultiTableReadFn<>(
-            dataSourceProviderFn,
+            DataSourceProviderImpl.builder()
+                .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", dataSourceProviderFn)
+                .build(),
             StaticValueProvider.of(new TestQueryProvider()),
             mock(JdbcIO.PreparedStatementSetter.class),
             ImmutableMap.of(),
@@ -186,6 +205,7 @@ public class MultiTableReadFnTest {
             true);
 
     readFn.setup();
+    readFn.startBundle();
 
     try (MockedStatic<Lineage> mockedLineage = mockStatic(Lineage.class)) {
       mockedLineage.when(Lineage::getSources).thenReturn(mockLineage);
@@ -225,7 +245,9 @@ public class MultiTableReadFnTest {
       // Path: schemaWithTable is NOT null, fqn is NOT null, reportedLineages.add returns true
       MultiTableReadFn<String, String> readFn1 =
           new MultiTableReadFn<>(
-              dataSourceProviderFn,
+              DataSourceProviderImpl.builder()
+                  .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", dataSourceProviderFn)
+                  .build(),
               StaticValueProvider.of((el) -> "SELECT * FROM schema1.table1"),
               mock(JdbcIO.PreparedStatementSetter.class),
               ImmutableMap.of(),
@@ -236,6 +258,7 @@ public class MultiTableReadFnTest {
                       .build(),
               false);
       readFn1.setup();
+      readFn1.startBundle();
       readFn1.getConnection("el1");
       verify(mockLineage, times(1))
           .add(eq("mysql"), eq(List.of("localhost:3306", "testdb", "schema1", "table1")));
@@ -243,7 +266,9 @@ public class MultiTableReadFnTest {
       // Path: schemaWithTable is null (invalid query)
       MultiTableReadFn<String, String> readFn2 =
           new MultiTableReadFn<>(
-              dataSourceProviderFn,
+              DataSourceProviderImpl.builder()
+                  .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", dataSourceProviderFn)
+                  .build(),
               StaticValueProvider.of((el) -> "INVALID QUERY"),
               mock(JdbcIO.PreparedStatementSetter.class),
               ImmutableMap.of(),
@@ -254,6 +279,7 @@ public class MultiTableReadFnTest {
                       .build(),
               false);
       readFn2.setup();
+      readFn2.startBundle();
       readFn2.getConnection("el2");
       // Lineage.add should not be called more than once (from previous readFn1)
       verify(mockLineage, times(1)).add(anyString(), anyList());
@@ -297,7 +323,7 @@ public class MultiTableReadFnTest {
 
     MultiTableReadFn<String, String> readFn =
         new MultiTableReadFn<>(
-            v -> mockDataSource,
+            getMockDataSourceProvider(mockDataSource),
             StaticValueProvider.of(el -> "SELECT * FROM testTable"),
             mock(JdbcIO.PreparedStatementSetter.class),
             ImmutableMap.of(tableId, spec),
@@ -305,6 +331,7 @@ public class MultiTableReadFnTest {
             false);
 
     readFn.setup();
+    readFn.startBundle();
     DoFn<String, String>.ProcessContext mockContext = mock(DoFn.ProcessContext.class);
     when(mockContext.element()).thenReturn("element");
 
@@ -350,7 +377,7 @@ public class MultiTableReadFnTest {
 
     MultiTableReadFn<String, String> readFn =
         new MultiTableReadFn<>(
-            v -> mockDataSource,
+            getMockDataSourceProvider(mockDataSource),
             StaticValueProvider.of(el -> "SELECT * FROM testTable"),
             mock(JdbcIO.PreparedStatementSetter.class),
             ImmutableMap.of(tableId, spec),
@@ -358,6 +385,7 @@ public class MultiTableReadFnTest {
             false);
 
     readFn.setup();
+    readFn.startBundle();
     DoFn<String, String>.ProcessContext mockContext = mock(DoFn.ProcessContext.class);
     when(mockContext.element()).thenReturn("element");
 
@@ -396,7 +424,7 @@ public class MultiTableReadFnTest {
 
     MultiTableReadFn<String, String> readFn =
         new MultiTableReadFn<>(
-            v -> mockDataSource,
+            getMockDataSourceProvider(mockDataSource),
             StaticValueProvider.of(el -> "SELECT * FROM testTable"),
             mock(JdbcIO.PreparedStatementSetter.class),
             ImmutableMap.of(tableId, spec),
@@ -404,6 +432,7 @@ public class MultiTableReadFnTest {
             false);
 
     readFn.setup();
+    readFn.startBundle();
     DoFn<String, String>.ProcessContext mockContext = mock(DoFn.ProcessContext.class);
     when(mockContext.element()).thenReturn("element");
 
@@ -426,7 +455,7 @@ public class MultiTableReadFnTest {
 
     MultiTableReadFn<String, String> readFn =
         new MultiTableReadFn<>(
-            v -> mockDataSource,
+            getMockDataSourceProvider(mockDataSource),
             StaticValueProvider.of(el -> "SELECT * FROM test"),
             mock(JdbcIO.PreparedStatementSetter.class),
             ImmutableMap.of(),
@@ -438,6 +467,7 @@ public class MultiTableReadFnTest {
             false);
 
     readFn.setup();
+    readFn.startBundle();
     try (MockedStatic<Lineage> mockedLineage = mockStatic(Lineage.class)) {
       mockedLineage.when(Lineage::getSources).thenReturn(mockLineage);
       readFn.getConnection("element"); // initialize connection
@@ -453,39 +483,124 @@ public class MultiTableReadFnTest {
   }
 
   @Test
-  public void testTearDown_twice() throws Exception {
-    DataSource mockDataSource = mock(DataSource.class);
-    Connection mockConnection = mock(Connection.class);
+  public void testGetConnection_multiShard() throws Exception {
+    DataSourceProvider mockProvider = mock(DataSourceProvider.class);
+    DataSource mockDataSource1 = mock(DataSource.class);
+    Connection mockConnection1 = mock(Connection.class);
+    DataSource mockDataSource2 = mock(DataSource.class);
+    Connection mockConnection2 = mock(Connection.class);
     DatabaseMetaData mockMetaData = mock(DatabaseMetaData.class);
     Lineage mockLineage = mock(Lineage.class);
 
-    when(mockDataSource.getConnection()).thenReturn(mockConnection);
-    when(mockConnection.getMetaData()).thenReturn(mockMetaData);
+    when(mockProvider.getDataSource("shard1")).thenReturn(mockDataSource1);
+    when(mockProvider.getDataSource("shard2")).thenReturn(mockDataSource2);
+    when(mockDataSource1.getConnection()).thenReturn(mockConnection1);
+    when(mockDataSource2.getConnection()).thenReturn(mockConnection2);
+    when(mockConnection1.getMetaData()).thenReturn(mockMetaData);
     when(mockMetaData.getURL()).thenReturn("jdbc:mysql://localhost:3306/testdb");
 
     MultiTableReadFn<String, String> readFn =
         new MultiTableReadFn<>(
-            v -> mockDataSource,
+            mockProvider,
             StaticValueProvider.of(el -> "SELECT * FROM test"),
             mock(JdbcIO.PreparedStatementSetter.class),
             ImmutableMap.of(),
             el ->
                 TableIdentifier.builder()
-                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setDataSourceId(el.toString())
                     .setTableName("test")
                     .build(),
             false);
 
     readFn.setup();
+    readFn.startBundle();
+
     try (MockedStatic<Lineage> mockedLineage = mockStatic(Lineage.class)) {
       mockedLineage.when(Lineage::getSources).thenReturn(mockLineage);
-      readFn.getConnection("element"); // initialize connection
+
+      Connection conn1 = readFn.getConnection("shard1");
+      Connection conn2 = readFn.getConnection("shard2");
+      Connection conn1Again = readFn.getConnection("shard1");
+
+      assertThat(conn1).isEqualTo(mockConnection1);
+      assertThat(conn2).isEqualTo(mockConnection2);
+      assertThat(conn1Again).isEqualTo(mockConnection1);
+
+      verify(mockProvider, times(1)).getDataSource("shard1");
+      verify(mockProvider, times(1)).getDataSource("shard2");
+      verify(mockDataSource1, times(1)).getConnection();
+      verify(mockDataSource2, times(1)).getConnection();
     }
 
     readFn.tearDown();
-    readFn.tearDown(); // second call
+    verify(mockConnection1).close();
+    verify(mockConnection2).close();
+  }
 
-    verify(mockConnection, times(1)).close();
+  @Test
+  public void testCleanUpConnection_withSqlException() throws Exception {
+    DataSourceProvider mockProvider = mock(DataSourceProvider.class);
+    DataSource mockDataSource = mock(DataSource.class);
+    Connection mockConnection = mock(Connection.class);
+    DatabaseMetaData mockMetaData = mock(DatabaseMetaData.class);
+
+    when(mockProvider.getDataSource("shard1")).thenReturn(mockDataSource);
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.getMetaData()).thenReturn(mockMetaData);
+    when(mockMetaData.getURL()).thenReturn("jdbc:mysql://localhost:3306/testdb");
+    // Throw exception on close, should be caught and logged
+    doThrow(new java.sql.SQLException("Close failed")).when(mockConnection).close();
+
+    MultiTableReadFn<String, String> readFn =
+        new MultiTableReadFn<>(
+            mockProvider,
+            StaticValueProvider.of(el -> "SELECT * FROM test"),
+            mock(JdbcIO.PreparedStatementSetter.class),
+            ImmutableMap.of(),
+            el -> TableIdentifier.builder().setDataSourceId("shard1").setTableName("test").build(),
+            false);
+
+    readFn.setup();
+    readFn.startBundle();
+    try (MockedStatic<Lineage> mockedLineage = mockStatic(Lineage.class)) {
+      mockedLineage.when(Lineage::getSources).thenReturn(mock(Lineage.class));
+      readFn.getConnection("element");
+    }
+
+    // Should not throw
+    readFn.tearDown();
+    verify(mockConnection).close();
+  }
+
+  /**
+   * Tests that {@link MultiTableReadFn#tearDown()} handles a race condition where connections might
+   * be nulled out by another thread.
+   */
+  @Test
+  public void testCleanUpConnection_RaceCondition() throws Exception {
+    MultiTableReadFn<String, String> readFn =
+        new MultiTableReadFn<>(
+            mock(DataSourceProvider.class),
+            StaticValueProvider.of(el -> "SELECT * FROM test"),
+            mock(JdbcIO.PreparedStatementSetter.class),
+            ImmutableMap.of(),
+            el -> mock(TableIdentifier.class),
+            false);
+
+    readFn.setup();
+    readFn.startBundle();
+
+    // Use reflection to null out connections after the first check in cleanUpConnection but before
+    // the second.
+    // This is hard to do with pure Mockito, so we just manually call it with reflection if needed,
+    // or simulate the logic.
+    // For now, we'll just exercise the logic where connections is already null.
+    java.lang.reflect.Field connectionsField =
+        MultiTableReadFn.class.getDeclaredField("connections");
+    connectionsField.setAccessible(true);
+    connectionsField.set(readFn, null);
+
+    readFn.tearDown(); // Should hit the first 'if (connections == null) return;'
   }
 
   @Test
@@ -505,7 +620,9 @@ public class MultiTableReadFnTest {
 
     MultiTableReadFn<String, String> readFn =
         new MultiTableReadFn<>(
-            mockProvider,
+            DataSourceProviderImpl.builder()
+                .addDataSource(knownTable.dataSourceId(), mockProvider)
+                .build(),
             StaticValueProvider.of(new TestQueryProvider()),
             mockSetter,
             ImmutableMap.of(knownTable, mock(TableReadSpecification.class)),
@@ -516,6 +633,24 @@ public class MultiTableReadFnTest {
     when(mockContext.element()).thenReturn("someElement");
 
     assertThrows(RuntimeException.class, () -> readFn.processElement(mockContext));
+  }
+
+  /**
+   * Tests that {@link MultiTableReadFn#tearDown()} handles null connections and connection lock
+   * gracefully (e.g., if called before setup).
+   */
+  @Test
+  public void testCleanUpConnection_Nulls() throws Exception {
+    MultiTableReadFn<String, String> readFn =
+        new MultiTableReadFn<>(
+            mock(DataSourceProvider.class),
+            StaticValueProvider.of(el -> "SELECT * FROM test"),
+            mock(JdbcIO.PreparedStatementSetter.class),
+            ImmutableMap.of(),
+            el -> mock(TableIdentifier.class),
+            false);
+    // connections and connectionLock are null before setup/startBundle
+    readFn.tearDown(); // should return early without exception
   }
 
   private static class TestQueryProvider implements MultiTableReadAll.QueryProvider<String> {

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryDoFnTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.withSettings;
 
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProviderImpl;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary.ColumnForBoundaryQuery;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundarySplitterFactory;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.PartitionColumn;
@@ -82,7 +83,9 @@ public class RangeBoundaryDoFnTest {
     when(mockResultSet.getLong(2)).thenReturn(42L);
     RangeBoundaryDoFn rangeBoundaryDoFn =
         new RangeBoundaryDoFn(
-            mockDataSourceProviderFn,
+            DataSourceProviderImpl.builder()
+                .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", mockDataSourceProviderFn)
+                .build(),
             new MysqlDialectAdapter(MySqlVersion.DEFAULT),
             ImmutableList.of(
                 TableSplitSpecification.builder()
@@ -115,6 +118,7 @@ public class RangeBoundaryDoFnTest {
             .setParentRange(null)
             .build();
     rangeBoundaryDoFn.setup();
+    rangeBoundaryDoFn.startBundle();
     rangeBoundaryDoFn.processElement(input, mockOut, mockProcessContext);
 
     verify(mockOut).output(rangeCaptor.capture());
@@ -147,7 +151,9 @@ public class RangeBoundaryDoFnTest {
 
     RangeBoundaryDoFn rangeBoundaryDoFn =
         new RangeBoundaryDoFn(
-            mockDataSourceProviderFn,
+            DataSourceProviderImpl.builder()
+                .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", mockDataSourceProviderFn)
+                .build(),
             new MysqlDialectAdapter(MySqlVersion.DEFAULT),
             ImmutableList.of(
                 TableSplitSpecification.builder()
@@ -180,6 +186,7 @@ public class RangeBoundaryDoFnTest {
             .setParentRange(null)
             .build();
     rangeBoundaryDoFn.setup();
+    rangeBoundaryDoFn.startBundle();
 
     assertThrows(
         SQLException.class,
@@ -201,7 +208,9 @@ public class RangeBoundaryDoFnTest {
 
     RangeBoundaryDoFn rangeBoundaryDoFn =
         new RangeBoundaryDoFn(
-            mockDataSourceProviderFn,
+            DataSourceProviderImpl.builder()
+                .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", mockDataSourceProviderFn)
+                .build(),
             new MysqlDialectAdapter(MySqlVersion.DEFAULT),
             ImmutableList.of(
                 TableSplitSpecification.builder()
@@ -251,6 +260,7 @@ public class RangeBoundaryDoFnTest {
             .setParentRange(null)
             .build();
     rangeBoundaryDoFn.setup();
+    rangeBoundaryDoFn.startBundle();
     rangeBoundaryDoFn.processElement(input, mockOut, mockProcessContext);
 
     verify(mockOut).output(rangeCaptor.capture());

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryTransformTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryTransformTest.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.trans
 
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProviderImpl;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.columnboundary.ColumnForBoundaryQuery;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundarySplitterFactory;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.PartitionColumn;
@@ -46,6 +47,9 @@ public class RangeBoundaryTransformTest {
   SerializableFunction<Void, DataSource> dataSourceProviderFn =
       ignored -> TransformTestUtils.DATA_SOURCE;
 
+  SerializableFunction<Void, DataSource> dataSourceProviderFnShard2 =
+      ignored -> TransformTestUtils.DATA_SOURCE_SHARD_2;
+
   @Rule public final transient TestPipeline testPipeline = TestPipeline.create();
 
   @BeforeClass
@@ -56,6 +60,122 @@ public class RangeBoundaryTransformTest {
     System.setProperty("derby.stream.error.file", "build/derby.log");
     TransformTestUtils.createDerbyTable("RBT_table1");
     TransformTestUtils.createDerbyTable("RBT_table2");
+    TransformTestUtils.createDerbyTable("RBT_multi_shard1");
+    TransformTestUtils.createDerbyTableShard2("RBT_multi_shard2");
+  }
+
+  @Test
+  public void testRangeBoundaryTransform_multiShard() throws Exception {
+    String shard1Id = "shard1";
+    String shard2Id = "shard2";
+    String table1Name = "RBT_multi_shard1";
+    String table2Name = "RBT_multi_shard2";
+
+    ColumnForBoundaryQuery query1 =
+        ColumnForBoundaryQuery.builder()
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId(shard1Id)
+                    .setTableName(table1Name)
+                    .build())
+            .setColumnName("col1")
+            .setColumnClass(Integer.class)
+            .build();
+
+    ColumnForBoundaryQuery query2 =
+        ColumnForBoundaryQuery.builder()
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId(shard2Id)
+                    .setTableName(table2Name)
+                    .build())
+            .setColumnName("col1")
+            .setColumnClass(Integer.class)
+            .build();
+
+    Range expectedRange1 =
+        Range.builder()
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId(shard1Id)
+                    .setTableName(table1Name)
+                    .build())
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(10)
+            .setEnd(40)
+            .setIsFirst(true)
+            .setIsLast(true)
+            .build();
+
+    Range expectedRange2 =
+        Range.builder()
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId(shard2Id)
+                    .setTableName(table2Name)
+                    .build())
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(10)
+            .setEnd(40)
+            .setIsFirst(true)
+            .setIsLast(true)
+            .build();
+
+    RangeBoundaryTransform transform =
+        RangeBoundaryTransform.builder()
+            .setDbAdapter(new MysqlDialectAdapter(MySqlVersion.DEFAULT))
+            .setTableSplitSpecifications(
+                ImmutableList.of(
+                    TableSplitSpecification.builder()
+                        .setTableIdentifier(
+                            TableIdentifier.builder()
+                                .setDataSourceId(shard1Id)
+                                .setTableName(table1Name)
+                                .build())
+                        .setPartitionColumns(
+                            ImmutableList.of(
+                                PartitionColumn.builder()
+                                    .setColumnName("col1")
+                                    .setColumnClass(Integer.class)
+                                    .build()))
+                        .setApproxRowCount(100L)
+                        .setMaxPartitionsHint(10L)
+                        .setInitialSplitHeight(5L)
+                        .setSplitStagesCount(1L)
+                        .build(),
+                    TableSplitSpecification.builder()
+                        .setTableIdentifier(
+                            TableIdentifier.builder()
+                                .setDataSourceId(shard2Id)
+                                .setTableName(table2Name)
+                                .build())
+                        .setPartitionColumns(
+                            ImmutableList.of(
+                                PartitionColumn.builder()
+                                    .setColumnName("col1")
+                                    .setColumnClass(Integer.class)
+                                    .build()))
+                        .setApproxRowCount(100L)
+                        .setMaxPartitionsHint(10L)
+                        .setInitialSplitHeight(5L)
+                        .setSplitStagesCount(1L)
+                        .build()))
+            .setDataSourceProvider(
+                DataSourceProviderImpl.builder()
+                    .addDataSource(shard1Id, dataSourceProviderFn)
+                    .addDataSource(shard2Id, dataSourceProviderFnShard2)
+                    .build())
+            .build();
+
+    PCollection<Range> output = testPipeline.apply(Create.of(query1, query2)).apply(transform);
+
+    PAssert.that(output).containsInAnyOrder(expectedRange1, expectedRange2);
+
+    testPipeline.run().waitUntilFinish();
   }
 
   @Test
@@ -183,7 +303,10 @@ public class RangeBoundaryTransformTest {
                         .setInitialSplitHeight(5L)
                         .setSplitStagesCount(1L)
                         .build()))
-            .setDataSourceProviderFn(dataSourceProviderFn)
+            .setDataSourceProvider(
+                DataSourceProviderImpl.builder()
+                    .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", dataSourceProviderFn)
+                    .build())
             .build();
     PCollection<Range> output = input.apply(rangeBoundaryTransform);
 
@@ -298,7 +421,10 @@ public class RangeBoundaryTransformTest {
                         .setInitialSplitHeight(5L)
                         .setSplitStagesCount(1L)
                         .build()))
-            .setDataSourceProviderFn(dataSourceProviderFn)
+            .setDataSourceProvider(
+                DataSourceProviderImpl.builder()
+                    .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", dataSourceProviderFn)
+                    .build())
             .build();
     PCollection<Range> output = input.apply(rangeBoundaryTransform);
 
@@ -311,5 +437,13 @@ public class RangeBoundaryTransformTest {
   public static void exitDerby() throws SQLException {
     TransformTestUtils.dropDerbyTable("RBT_table1");
     TransformTestUtils.dropDerbyTable("RBT_table2");
+    TransformTestUtils.dropDerbyTable("RBT_multi_shard1");
+    // Shard 2 uses a different connection, but dropDerbyTable by default uses shard 1 connection.
+    // I should probably add a way to drop from shard 2 or just let it go as it's in-memory.
+    // However, let's be consistent if possible.
+    try (java.sql.Connection connection = TransformTestUtils.getConnectionShard2()) {
+      java.sql.Statement statement = connection.createStatement();
+      statement.executeUpdate("drop table RBT_multi_shard2");
+    }
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountDoFnTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.withSettings;
 
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProviderImpl;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.UniformSplitterDBAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundarySplitterFactory;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.PartitionColumn;
@@ -84,7 +85,9 @@ public class RangeCountDoFnTest {
     when(mockResultSet.getLong(1)).thenReturn(42L);
     RangeCountDoFn rangeCountDoFn =
         new RangeCountDoFn(
-            mockDataSourceProviderFn,
+            DataSourceProviderImpl.builder()
+                .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", mockDataSourceProviderFn)
+                .build(),
             2000L,
             new MysqlDialectAdapter(MySqlVersion.DEFAULT),
             ImmutableList.of(
@@ -118,7 +121,6 @@ public class RangeCountDoFnTest {
             .setStart(0)
             .setEnd(100)
             .build();
-    rangeCountDoFn.setup();
     rangeCountDoFn.processElement(input, mockOut, mockProcessContext);
 
     verify(mockOut).output(rangeCaptor.capture());
@@ -145,7 +147,9 @@ public class RangeCountDoFnTest {
                 "Query execution was interrupted, maximum statement execution time exceeded"));
     RangeCountDoFn rangeCountDoFn =
         new RangeCountDoFn(
-            mockDataSourceProviderFn,
+            DataSourceProviderImpl.builder()
+                .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", mockDataSourceProviderFn)
+                .build(),
             2000L,
             new MysqlDialectAdapter(MySqlVersion.DEFAULT),
             ImmutableList.of(
@@ -179,7 +183,6 @@ public class RangeCountDoFnTest {
             .setStart(0)
             .setEnd(100)
             .build();
-    rangeCountDoFn.setup();
     rangeCountDoFn.processElement(input, mockOut, mockProcessContext);
     rangeCountDoFn.processElement(input, mockOut, mockProcessContext);
 
@@ -203,7 +206,9 @@ public class RangeCountDoFnTest {
     when(mockPreparedStatemet.executeQuery()).thenThrow(new SQLException("test"));
     RangeCountDoFn rangeCountDoFn =
         new RangeCountDoFn(
-            mockDataSourceProviderFn,
+            DataSourceProviderImpl.builder()
+                .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", mockDataSourceProviderFn)
+                .build(),
             2000L,
             new MysqlDialectAdapter(MySqlVersion.DEFAULT),
             ImmutableList.of(
@@ -237,7 +242,6 @@ public class RangeCountDoFnTest {
             .setStart(0)
             .setEnd(100)
             .build();
-    rangeCountDoFn.setup();
     assertThrows(
         SQLException.class,
         () -> rangeCountDoFn.processElement(input, mockOut, mockProcessContext));
@@ -258,7 +262,9 @@ public class RangeCountDoFnTest {
     when(mockResultSet.wasNull()).thenReturn(true) /* Null ResultSet */;
     RangeCountDoFn rangeCountDoFn =
         new RangeCountDoFn(
-            mockDataSourceProviderFn,
+            DataSourceProviderImpl.builder()
+                .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", mockDataSourceProviderFn)
+                .build(),
             2000L,
             new MysqlDialectAdapter(MySqlVersion.DEFAULT),
             ImmutableList.of(
@@ -292,7 +298,6 @@ public class RangeCountDoFnTest {
             .setStart(0)
             .setEnd(100)
             .build();
-    rangeCountDoFn.setup();
     rangeCountDoFn.processElement(input, mockOut, mockProcessContext);
     rangeCountDoFn.processElement(input, mockOut, mockProcessContext);
     verify(mockOut, times(2)).output(rangeCaptor.capture());
@@ -323,7 +328,9 @@ public class RangeCountDoFnTest {
 
     RangeCountDoFn rangeCountDoFn =
         new RangeCountDoFn(
-            mockDataSourceProviderFn,
+            DataSourceProviderImpl.builder()
+                .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", mockDataSourceProviderFn)
+                .build(),
             2000L,
             new MysqlDialectAdapter(MySqlVersion.DEFAULT),
             ImmutableList.of(tableSpec1));
@@ -342,7 +349,6 @@ public class RangeCountDoFnTest {
             .setEnd(100)
             .build();
 
-    rangeCountDoFn.setup();
     assertThrows(
         RuntimeException.class,
         () -> rangeCountDoFn.processElement(inputMissingTable, mockOut, mockProcessContext));
@@ -463,7 +469,9 @@ public class RangeCountDoFnTest {
 
     RangeCountDoFn rangeCountDoFn =
         new RangeCountDoFn(
-            mockDataSourceProviderFn,
+            DataSourceProviderImpl.builder()
+                .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", mockDataSourceProviderFn)
+                .build(),
             2000L,
             new MysqlDialectAdapter(MySqlVersion.DEFAULT),
             ImmutableList.of(tableSpec1, tableSpec2));
@@ -523,7 +531,6 @@ public class RangeCountDoFnTest {
             .setEnd(200)
             .build();
 
-    rangeCountDoFn.setup();
     rangeCountDoFn.processElement(input1, mockOut, mockProcessContext);
     rangeCountDoFn.processElement(input2, mockOut, mockProcessContext);
 

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountTransformTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountTransformTest.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.trans
 
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProviderImpl;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundarySplitterFactory;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.PartitionColumn;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
@@ -45,6 +46,9 @@ public class RangeCountTransformTest {
   SerializableFunction<Void, DataSource> dataSourceProviderFn =
       ignored -> TransformTestUtils.DATA_SOURCE;
 
+  SerializableFunction<Void, DataSource> dataSourceProviderFnShard2 =
+      ignored -> TransformTestUtils.DATA_SOURCE_SHARD_2;
+
   @Rule public final transient TestPipeline testPipeline = TestPipeline.create();
 
   @BeforeClass
@@ -54,11 +58,112 @@ public class RangeCountTransformTest {
     System.setProperty("derby.locks.waitTimeout", "2");
     System.setProperty("derby.stream.error.file", "build/derby.log");
     TransformTestUtils.createDerbyTable(tableName);
+    TransformTestUtils.createDerbyTable("RCT_multi_shard1");
+    TransformTestUtils.createDerbyTableShard2("RCT_multi_shard2");
   }
 
   @AfterClass
   public static void exitDerby() throws SQLException {
     TransformTestUtils.dropDerbyTable(tableName);
+    TransformTestUtils.dropDerbyTable("RCT_multi_shard1");
+    try (java.sql.Connection connection = TransformTestUtils.getConnectionShard2()) {
+      java.sql.Statement statement = connection.createStatement();
+      statement.executeUpdate("drop table RCT_multi_shard2");
+    }
+  }
+
+  @Test
+  public void testRangeCountTransform_multiShard() throws Exception {
+    String shard1Id = "shard1";
+    String shard2Id = "shard2";
+    String table1Name = "RCT_multi_shard1";
+    String table2Name = "RCT_multi_shard2";
+
+    Range range1 =
+        Range.builder()
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId(shard1Id)
+                    .setTableName(table1Name)
+                    .build())
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(10)
+            .setEnd(40)
+            .setIsFirst(true)
+            .setIsLast(true)
+            .build();
+
+    Range range2 =
+        Range.builder()
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId(shard2Id)
+                    .setTableName(table2Name)
+                    .build())
+            .setColName("col1")
+            .setColClass(Integer.class)
+            .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
+            .setStart(10)
+            .setEnd(40)
+            .setIsFirst(true)
+            .setIsLast(true)
+            .build();
+
+    RangeCountTransform transform =
+        RangeCountTransform.builder()
+            .setDbAdapter(new MysqlDialectAdapter(MySqlVersion.DEFAULT))
+            .setTableSplitSpecifications(
+                ImmutableList.of(
+                    TableSplitSpecification.builder()
+                        .setTableIdentifier(
+                            TableIdentifier.builder()
+                                .setDataSourceId(shard1Id)
+                                .setTableName(table1Name)
+                                .build())
+                        .setPartitionColumns(
+                            ImmutableList.of(
+                                PartitionColumn.builder()
+                                    .setColumnName("col1")
+                                    .setColumnClass(Integer.class)
+                                    .build()))
+                        .setApproxRowCount(100L)
+                        .setMaxPartitionsHint(10L)
+                        .setInitialSplitHeight(5L)
+                        .setSplitStagesCount(1L)
+                        .build(),
+                    TableSplitSpecification.builder()
+                        .setTableIdentifier(
+                            TableIdentifier.builder()
+                                .setDataSourceId(shard2Id)
+                                .setTableName(table2Name)
+                                .build())
+                        .setPartitionColumns(
+                            ImmutableList.of(
+                                PartitionColumn.builder()
+                                    .setColumnName("col1")
+                                    .setColumnClass(Integer.class)
+                                    .build()))
+                        .setApproxRowCount(100L)
+                        .setMaxPartitionsHint(10L)
+                        .setInitialSplitHeight(5L)
+                        .setSplitStagesCount(1L)
+                        .build()))
+            .setDataSourceProvider(
+                DataSourceProviderImpl.builder()
+                    .addDataSource(shard1Id, dataSourceProviderFn)
+                    .addDataSource(shard2Id, dataSourceProviderFnShard2)
+                    .build())
+            .setTimeoutMillis(42L)
+            .build();
+
+    PCollection<Range> output = testPipeline.apply(Create.of(range1, range2)).apply(transform);
+
+    // Both tables have 6 rows in TransformTestUtils
+    PAssert.that(output).containsInAnyOrder(range1.withCount(6L, null), range2.withCount(6L, null));
+
+    testPipeline.run().waitUntilFinish();
   }
 
   @Test
@@ -133,7 +238,10 @@ public class RangeCountTransformTest {
                         .setInitialSplitHeight(5L)
                         .setSplitStagesCount(1L)
                         .build()))
-            .setDataSourceProviderFn(dataSourceProviderFn)
+            .setDataSourceProvider(
+                DataSourceProviderImpl.builder()
+                    .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", dataSourceProviderFn)
+                    .build())
             .setTimeoutMillis(42L)
             .build();
     PCollection<Range> output = input.apply(rangeCountTransform);

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitionsTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitionsTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.mysql.MysqlDialectAdapter.MySqlVersion;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProviderImpl;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.BoundarySplitterFactory;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.PartitionColumn;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.Range;
@@ -81,6 +82,97 @@ public class ReadWithUniformPartitionsTest implements Serializable {
     System.setProperty("derby.locks.waitTimeout", "2");
     System.setProperty("derby.stream.error.file", "build/derby.log");
     TransformTestUtils.createDerbyTable(tableName);
+    TransformTestUtils.createDerbyTable("RWUP_multi_shard1");
+    TransformTestUtils.createDerbyTableShard2("RWUP_multi_shard2");
+  }
+
+  /**
+   * Tests the multi-shard reading capability end-to-end using two different in-memory Derby
+   * databases. This ensures that the transform can correctly route requests to multiple physical
+   * shards and aggregate results.
+   */
+  @Test
+  public void testReadWithUniformPartitions_multiShardEndToEnd() throws Exception {
+    String shard1Id = "shard1";
+    String shard2Id = "shard2";
+    String table1Name = "RWUP_multi_shard1";
+    String table2Name = "RWUP_multi_shard2";
+
+    TableIdentifier id1 =
+        TableIdentifier.builder().setDataSourceId(shard1Id).setTableName(table1Name).build();
+    TableIdentifier id2 =
+        TableIdentifier.builder().setDataSourceId(shard2Id).setTableName(table2Name).build();
+
+    TableSplitSpecification spec1 =
+        TableSplitSpecification.builder()
+            .setTableIdentifier(id1)
+            .setApproxRowCount(6L)
+            .setPartitionColumns(
+                ImmutableList.of(
+                    PartitionColumn.builder()
+                        .setColumnName("col1")
+                        .setColumnClass(Integer.class)
+                        .build()))
+            .setMaxPartitionsHint(1L) // Force single partition for simplicity
+            .build();
+
+    TableSplitSpecification spec2 =
+        TableSplitSpecification.builder()
+            .setTableIdentifier(id2)
+            .setApproxRowCount(6L)
+            .setPartitionColumns(
+                ImmutableList.of(
+                    PartitionColumn.builder()
+                        .setColumnName("col1")
+                        .setColumnClass(Integer.class)
+                        .build()))
+            .setMaxPartitionsHint(1L) // Force single partition for simplicity
+            .build();
+
+    RowMapper<String> rowMapper =
+        new RowMapper<String>() {
+          @Override
+          public String mapRow(ResultSet rs) throws Exception {
+            return rs.getString(3);
+          }
+        };
+
+    TableReadSpecification<String> readSpec1 =
+        TableReadSpecification.<String>builder()
+            .setTableIdentifier(id1)
+            .setRowMapper(rowMapper)
+            .build();
+
+    TableReadSpecification<String> readSpec2 =
+        TableReadSpecification.<String>builder()
+            .setTableIdentifier(id2)
+            .setRowMapper(rowMapper)
+            .build();
+
+    ReadWithUniformPartitions<String> readWithUniformPartitions =
+        ReadWithUniformPartitions.<String>builder()
+            .setTableSplitSpecifications(ImmutableList.of(spec1, spec2))
+            .setTableReadSpecifications(ImmutableMap.of(id1, readSpec1, id2, readSpec2))
+            .setDbAdapter(new MysqlDialectAdapter(MySqlVersion.DEFAULT))
+            .setDataSourceProvider(
+                DataSourceProviderImpl.builder()
+                    .addDataSource(shard1Id, dataSourceProviderFn)
+                    .addDataSource(shard2Id, ignored -> TransformTestUtils.DATA_SOURCE_SHARD_2)
+                    .build())
+            .setAutoAdjustMaxPartitions(false)
+            .build();
+
+    PCollection<String> output =
+        (PCollection<String>) testPipeline.apply(readWithUniformPartitions);
+
+    // Both shards have 6 rows: "Data A" to "Data F"
+    // So we expect 12 rows total, two of each "Data A" to "Data F"
+    PAssert.that(output)
+        .containsInAnyOrder(
+            "Data A", "Data B", "Data C", "Data D", "Data E", "Data F", "Data A", "Data B",
+            "Data C", "Data D", "Data E", "Data F");
+
+    testPipeline.run().waitUntilFinish();
   }
 
   @Test
@@ -387,7 +479,10 @@ public class ReadWithUniformPartitionsTest implements Serializable {
             .setTableSplitSpecifications(ImmutableList.of(specBuilder.build()))
             .setTableReadSpecifications(ImmutableMap.of(tableIdentifier, readSpec))
             .setDbAdapter(new MysqlDialectAdapter(MySqlVersion.DEFAULT))
-            .setDataSourceProviderFn(dataSourceProviderFn)
+            .setDataSourceProvider(
+                DataSourceProviderImpl.builder()
+                    .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", dataSourceProviderFn)
+                    .build())
             .setAdditionalOperationsOnRanges(testRangesPeek);
     if (maxPartitionHint != null) {
       // For the purpose of this UT we disable auto adjustment as we try to verify the partitioning
@@ -455,6 +550,11 @@ public class ReadWithUniformPartitionsTest implements Serializable {
   @AfterClass
   public static void exitDerby() throws SQLException {
     TransformTestUtils.dropDerbyTable(tableName);
+    TransformTestUtils.dropDerbyTable("RWUP_multi_shard1");
+    try (java.sql.Connection connection = TransformTestUtils.getConnectionShard2()) {
+      java.sql.Statement statement = connection.createStatement();
+      statement.executeUpdate("drop table RWUP_multi_shard2");
+    }
   }
 
   @Test
@@ -674,7 +774,10 @@ public class ReadWithUniformPartitionsTest implements Serializable {
             .setTableSplitSpecifications(ImmutableList.of(spec))
             .setTableReadSpecifications(ImmutableMap.of(tableIdentifier, readSpec))
             .setDbAdapter(new MysqlDialectAdapter(MySqlVersion.DEFAULT))
-            .setDataSourceProviderFn(dataSourceProviderFn)
+            .setDataSourceProvider(
+                DataSourceProviderImpl.builder()
+                    .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", dataSourceProviderFn)
+                    .build())
             .setTransformPrefix("CustomPrefix")
             .build();
 
@@ -771,7 +874,10 @@ public class ReadWithUniformPartitionsTest implements Serializable {
                   ImmutableMap.of(
                       spec1.tableIdentifier(), readSpec1, spec2.tableIdentifier(), readSpec2))
               .setDbAdapter(new MysqlDialectAdapter(MySqlVersion.DEFAULT))
-              .setDataSourceProviderFn(dataSourceProviderFn)
+              .setDataSourceProvider(
+                  DataSourceProviderImpl.builder()
+                      .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", dataSourceProviderFn)
+                      .build())
               .build();
 
       PCollection<String> output =
@@ -951,7 +1057,10 @@ public class ReadWithUniformPartitionsTest implements Serializable {
             .setTableSplitSpecifications(ImmutableList.of(splitSpec1))
             .setTableReadSpecifications(ImmutableMap.of(tableIdentifier2, readSpec2))
             .setDbAdapter(new MysqlDialectAdapter(MySqlVersion.DEFAULT))
-            .setDataSourceProviderFn(dataSourceProviderFn);
+            .setDataSourceProvider(
+                DataSourceProviderImpl.builder()
+                    .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", dataSourceProviderFn)
+                    .build());
 
     IllegalStateException exception = assertThrows(IllegalStateException.class, builder::build);
     assertThat(exception)

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/TransformTestUtils.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/TransformTestUtils.java
@@ -28,13 +28,29 @@ class TransformTestUtils {
   static final DataSourceConfiguration DATA_SOURCE_CONFIGURATION =
       DataSourceConfiguration.create(
           "org.apache.derby.jdbc.EmbeddedDriver", "jdbc:derby:memory:testDB;create=true");
+  static final DataSourceConfiguration DATA_SOURCE_CONFIGURATION_SHARD_2 =
+      DataSourceConfiguration.create(
+          "org.apache.derby.jdbc.EmbeddedDriver", "jdbc:derby:memory:testDB2;create=true");
   static final DataSource DATA_SOURCE = DATA_SOURCE_CONFIGURATION.buildDatasource();
+  static final DataSource DATA_SOURCE_SHARD_2 = DATA_SOURCE_CONFIGURATION_SHARD_2.buildDatasource();
 
   private TransformTestUtils() {}
 
   static void createDerbyTable(String tableName) throws SQLException {
     try (java.sql.Connection connection = getConnection()) {
-      Statement stmtCreateTable = connection.createStatement();
+      createTableForConnection(tableName, connection);
+    }
+  }
+
+  static void createDerbyTableShard2(String tableName) throws SQLException {
+    try (java.sql.Connection connection = getConnectionShard2()) {
+      createTableForConnection(tableName, connection);
+    }
+  }
+
+  private static void createTableForConnection(String tableName, Connection connection)
+      throws SQLException {
+    try (Statement stmtCreateTable = connection.createStatement()) {
       String createTableSQL =
           "CREATE TABLE "
               + tableName
@@ -111,5 +127,9 @@ class TransformTestUtils {
 
   static Connection getConnection() throws SQLException {
     return DATA_SOURCE.getConnection();
+  }
+
+  static Connection getConnectionShard2() throws SQLException {
+    return DATA_SOURCE_SHARD_2.getConnection();
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/CloudSqlShardOrchestrator.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/CloudSqlShardOrchestrator.java
@@ -1,0 +1,492 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.loadtesting;
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.services.sqladmin.SQLAdmin;
+import com.google.api.services.sqladmin.model.DatabaseInstance;
+import com.google.api.services.sqladmin.model.IpMapping;
+import com.google.api.services.sqladmin.model.Operation;
+import com.google.api.services.sqladmin.model.Settings;
+import com.google.api.services.sqladmin.model.User;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.SQLDialect;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.beam.it.gcp.artifacts.GcsArtifact;
+import org.apache.beam.it.gcp.cloudsql.CloudMySQLResourceManager;
+import org.apache.beam.it.gcp.cloudsql.CloudPostgresResourceManager;
+import org.apache.beam.it.gcp.cloudsql.CloudSqlResourceManager;
+import org.apache.beam.it.gcp.storage.GcsResourceManager;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Orchestrates the lifecycle of Cloud SQL physical instances and logical database shards for
+ * high-scale load testing.
+ *
+ * <p><b>Networking & Safety:</b> This orchestrator connects directly to Private IPs for maximum
+ * performance during high-scale (1,024 shards) migrations. At this scale, the Cloud SQL Auth Proxy
+ * would become a significant network bottleneck. Security is maintained through VPC-level
+ * isolation; these instances have no public IPs and are only reachable from within the trusted VPC
+ * network.
+ *
+ * <p><b>Credential Management:</b> To maintain portability across projects and parallel test
+ * safety, the orchestrator explicitly synchronizes the 'root' password on all physical instances
+ * during the provisioning stage using the provided 'cloudProxyPassword'.
+ *
+ * <p>The class follows an initialize-cleanup lifecycle to ensure that logical resources are purged
+ * even if the initialization or the test itself fails partially.
+ */
+public class CloudSqlShardOrchestrator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CloudSqlShardOrchestrator.class);
+
+  protected final SQLDialect dbType;
+  protected final int port;
+  protected final String project;
+  protected final String region;
+  protected final String username;
+  protected final String password;
+  protected final GcsResourceManager gcsResourceManager;
+  protected final Map<String, CloudSqlResourceManager> managers;
+  protected final Map<String, String> instanceIpMap;
+  protected Map<String, List<String>> requestedShardMap;
+  protected final SQLAdmin sqlAdmin;
+
+  /**
+   * Constructs a new orchestrator for the specified database dialect.
+   *
+   * @param dbType The dialect of the source database (e.g., MYSQL, POSTGRESQL).
+   * @param project The GCP project ID.
+   * @param region The GCP region for Cloud SQL instances.
+   * @param gcsResourceManager The GCS resource manager for uploading configuration artifacts.
+   */
+  public CloudSqlShardOrchestrator(
+      SQLDialect dbType, String project, String region, GcsResourceManager gcsResourceManager) {
+    this(
+        dbType,
+        project,
+        region,
+        gcsResourceManager,
+        System.getProperty(
+            "cloudProxyUsername", (dbType == SQLDialect.MYSQL) ? "root" : "postgres"),
+        System.getProperty("cloudProxyPassword", ""),
+        null);
+  }
+
+  /**
+   * Constructs a new orchestrator with explicit credentials.
+   *
+   * @param dbType The dialect of the source database.
+   * @param project The GCP project ID.
+   * @param region The GCP region.
+   * @param gcsResourceManager The GCS resource manager.
+   * @param username The database username.
+   * @param password The database password.
+   * @param credentials The GCP credentials to use.
+   */
+  public CloudSqlShardOrchestrator(
+      SQLDialect dbType,
+      String project,
+      String region,
+      GcsResourceManager gcsResourceManager,
+      String username,
+      String password,
+      GoogleCredentials credentials) {
+    this.dbType = dbType;
+    this.project = project;
+    this.region = region;
+    this.gcsResourceManager = gcsResourceManager;
+    this.username = username;
+    this.password = password;
+    this.managers = new ConcurrentHashMap<>();
+    this.instanceIpMap = new ConcurrentHashMap<>();
+    this.requestedShardMap = new HashMap<>();
+
+    try {
+      this.sqlAdmin =
+          new SQLAdmin.Builder(
+                  GoogleNetHttpTransport.newTrustedTransport(),
+                  GsonFactory.getDefaultInstance(),
+                  new HttpCredentialsAdapter(
+                      credentials == null
+                          ? GoogleCredentials.getApplicationDefault()
+                          : credentials))
+              .setApplicationName("BeamIT")
+              .build();
+    } catch (GeneralSecurityException | IOException e) {
+      LOG.error("Exception while initializing SQL Admin", e);
+      throw new RuntimeException("Failed to initialize SQLAdmin client", e);
+    }
+    port = (dbType == SQLDialect.MYSQL) ? 3306 : 5432;
+  }
+
+  protected ExecutorService getExecutorService() {
+    return Executors.newFixedThreadPool(10);
+  }
+
+  private static final int MAX_RETRIES = 10;
+  private static final long INITIAL_BACKOFF_MS = 1000; // 1 second
+
+  /**
+   * Executes a Cloud SQL Admin API request with retries for 409 (Conflict) and 429 (Rate Limit)
+   * errors.
+   */
+  protected <T> T executeWithRetries(
+      com.google.api.client.googleapis.services.AbstractGoogleClientRequest<T> request)
+      throws IOException, InterruptedException {
+    int retries = 0;
+    long backoff = INITIAL_BACKOFF_MS;
+
+    while (true) {
+      try {
+        return request.execute();
+      } catch (GoogleJsonResponseException e) {
+        if ((e.getStatusCode() == 409 || e.getStatusCode() == 429) && retries < MAX_RETRIES) {
+          LOG.warn(
+              "Cloud SQL API returned {}. Retrying in {}ms... (Attempt {}/{})",
+              e.getStatusCode(),
+              backoff,
+              retries + 1,
+              MAX_RETRIES);
+          Thread.sleep(backoff);
+          retries++;
+          backoff *= 2; // Exponential backoff
+        } else {
+          throw e;
+        }
+      }
+    }
+  }
+
+  /**
+   * Initializes the physical and logical sharded environment.
+   *
+   * @param shardMap A mapping of physical instance names to the list of logical DB names to create.
+   * @param artifactName The name of the artifact file (e.g., "shards.json").
+   * @return The full GCS URI to the generated bulkShardConfig.json.
+   * @throws ShardOrchestrationException if provisioning or creation fails after retries.
+   */
+  public String initialize(Map<String, List<String>> shardMap, String artifactName)
+      throws ShardOrchestrationException {
+    this.requestedShardMap = new HashMap<>(shardMap);
+
+    LOG.info("Initializing shard orchestrator for {} physical instances", shardMap.size());
+
+    try {
+      // Stage 1: Physical Provisioning (Parallel)
+      provisionPhysicalInstances();
+
+      // Stage 2: Logical Setup (Parallel)
+      createLogicalDatabases();
+
+      return generateAndUploadConfig(artifactName);
+    } catch (Exception e) {
+      LOG.error("Exception while initializing sharded environment", e);
+      throw new ShardOrchestrationException("Failed to initialize sharded environment", e);
+    }
+  }
+
+  protected void provisionPhysicalInstances() {
+    LOG.info("Stage 1: Provisioning physical instances and synchronizing credentials...");
+    ExecutorService executor = getExecutorService();
+    List<java.util.concurrent.Future<?>> futures = new java.util.ArrayList<>();
+    for (String instanceName : requestedShardMap.keySet()) {
+      futures.add(
+          executor.submit(
+              () -> {
+                try {
+                  String ip = ensureInstanceAndGetIp(instanceName);
+                  instanceIpMap.put(instanceName, ip);
+                  updateUserPassword(instanceName);
+                } catch (Exception e) {
+                  throw new RuntimeException("Failed to provision instance " + instanceName, e);
+                }
+              }));
+    }
+    awaitAndShutdownExecutor(executor, futures, "Physical provisioning");
+  }
+
+  /**
+   * Synchronizes the database password for the specified user across physical shards.
+   *
+   * @param instanceName The name of the Cloud SQL instance to update.
+   */
+  protected void updateUserPassword(String instanceName) throws IOException, InterruptedException {
+    LOG.info("Updating password for user {} on instance {}", username, instanceName);
+    User user = new User().setName(username).setPassword(password);
+
+    // MySQL requires a '%' host for connections from any IP within the VPC.
+    if (dbType == SQLDialect.MYSQL) {
+      user.setHost("%");
+    }
+
+    // MySQL requires name and host to identify the user. PostgreSQL only needs the name.
+    // These are passed as query parameters in the Update request.
+    SQLAdmin.Users.Update request = sqlAdmin.users().update(project, instanceName, user);
+    request.setName(username);
+    if (dbType == SQLDialect.MYSQL) {
+      // In MySQL, host is part of the primary key for a user. '%' allows the user to connect from
+      // any VPC IP.
+      request.setHost("%");
+    }
+    Operation operation = executeWithRetries(request);
+    waitForOperation(operation);
+  }
+
+  protected String ensureInstanceAndGetIp(String instanceName)
+      throws IOException, InterruptedException {
+    DatabaseInstance instance;
+    try {
+      instance = executeWithRetries(sqlAdmin.instances().get(project, instanceName));
+      LOG.info("Instance {} already exists.", instanceName);
+    } catch (IOException e) {
+      if (e.getMessage().contains("404")) {
+        LOG.info("Instance {} not found, creating...", instanceName);
+        createPhysicalInstance(instanceName);
+        instance = executeWithRetries(sqlAdmin.instances().get(project, instanceName));
+      } else {
+        throw e;
+      }
+    }
+
+    waitForInstanceReady(instanceName);
+    instance = executeWithRetries(sqlAdmin.instances().get(project, instanceName));
+
+    String privateIp = null;
+    if (instance.getIpAddresses() != null) {
+      for (IpMapping ipMapping : instance.getIpAddresses()) {
+        if ("PRIVATE".equals(ipMapping.getType())) {
+          privateIp = ipMapping.getIpAddress();
+          break;
+        }
+      }
+    }
+
+    if (privateIp == null) {
+      throw new RuntimeException("Instance " + instanceName + " does not have a private IP.");
+    }
+    return privateIp;
+  }
+
+  protected void createPhysicalInstance(String instanceName)
+      throws IOException, InterruptedException {
+    String databaseVersion = dbType == SQLDialect.MYSQL ? "MYSQL_8_0" : "POSTGRES_14";
+    String tier = dbType == SQLDialect.MYSQL ? "db-n1-standard-2" : "db-custom-2-7680";
+    DatabaseInstance instance =
+        new DatabaseInstance()
+            .setName(instanceName)
+            .setRegion(region)
+            .setDatabaseVersion(databaseVersion)
+            .setSettings(
+                new Settings()
+                    .setTier(tier)
+                    .setIpConfiguration(
+                        new com.google.api.services.sqladmin.model.IpConfiguration()
+                            .setPrivateNetwork(
+                                String.format("projects/%s/global/networks/default", project))
+                            .setEnablePrivatePathForGoogleCloudServices(true)));
+
+    Operation operation = executeWithRetries(sqlAdmin.instances().insert(project, instance));
+    waitForOperation(operation);
+  }
+
+  protected void waitForInstanceReady(String instanceName)
+      throws IOException, InterruptedException {
+    LOG.info("Waiting for instance {} to be ready...", instanceName);
+    for (int i = 0; i < 60; i++) {
+      DatabaseInstance instance =
+          executeWithRetries(sqlAdmin.instances().get(project, instanceName));
+      if ("RUNNABLE".equals(instance.getState())) {
+        return;
+      }
+      Thread.sleep(10000);
+    }
+    throw new RuntimeException("Timeout waiting for instance " + instanceName);
+  }
+
+  protected void waitForOperation(Operation operation) throws IOException, InterruptedException {
+    String operationId = operation.getName();
+    for (int i = 0; i < 120; i++) {
+      Operation op = executeWithRetries(sqlAdmin.operations().get(project, operationId));
+      if ("DONE".equals(op.getStatus())) {
+        if (op.getError() != null) {
+          throw new RuntimeException(
+              "Operation failed: " + op.getError().getErrors().get(0).getMessage());
+        }
+        return;
+      }
+      Thread.sleep(10000);
+    }
+    throw new RuntimeException("Timeout waiting for operation " + operationId);
+  }
+
+  protected CloudSqlResourceManager createManager(String instanceName) {
+    String ip = instanceIpMap.get(instanceName);
+    if (dbType == SQLDialect.MYSQL) {
+      return (CloudSqlResourceManager)
+          CloudMySQLResourceManager.builder(instanceName)
+              .maybeUseStaticInstance(ip, port, username, password)
+              .build();
+    } else if (dbType == SQLDialect.POSTGRESQL) {
+      return (CloudSqlResourceManager)
+          CloudPostgresResourceManager.builder(instanceName)
+              .maybeUseStaticInstance(ip, port, username, password)
+              .setDatabaseName("postgres")
+              .build();
+    } else {
+      throw new IllegalArgumentException("Unsupported database type: " + dbType);
+    }
+  }
+
+  protected void createLogicalDatabases() {
+    LOG.info("Stage 2: Creating logical databases...");
+    ExecutorService executor = getExecutorService();
+    List<java.util.concurrent.Future<?>> futures = new java.util.ArrayList<>();
+    for (Map.Entry<String, List<String>> entry : requestedShardMap.entrySet()) {
+      String instanceName = entry.getKey();
+      List<String> dbNames = entry.getValue();
+
+      futures.add(
+          executor.submit(
+              () -> {
+                CloudSqlResourceManager manager = createManager(instanceName);
+                managers.put(instanceName, manager);
+                for (String dbName : dbNames) {
+                  manager.createDatabase(dbName);
+                }
+              }));
+    }
+    awaitAndShutdownExecutor(executor, futures, "Logical database creation");
+  }
+
+  protected String generateAndUploadConfig(String artifactName) {
+    LOG.info("Generating and uploading shard configuration...");
+    JSONObject config = new JSONObject();
+    config.put("configType", "dataflow");
+    JSONObject shardConfigBulk = new JSONObject();
+    JSONArray dataShards = new JSONArray();
+
+    int shardIdx = 0;
+    for (Map.Entry<String, List<String>> entry : requestedShardMap.entrySet()) {
+      String instanceName = entry.getKey();
+      String ip = instanceIpMap.get(instanceName);
+      List<String> dbNames = entry.getValue();
+
+      JSONObject dataShard = new JSONObject();
+      dataShard.put("dataShardId", instanceName);
+      dataShard.put("host", ip);
+      dataShard.put("port", port);
+      dataShard.put("user", username);
+      dataShard.put("password", password);
+
+      JSONArray databases = new JSONArray();
+      for (String dbName : dbNames) {
+        JSONObject db = new JSONObject();
+        db.put("dbName", dbName);
+        db.put("databaseId", String.format("%s%02d%s", "shard_", shardIdx, dbName));
+        db.put("refDataShardId", instanceName);
+        databases.put(db);
+      }
+      shardIdx++;
+      dataShard.put("databases", databases);
+      dataShards.put(dataShard);
+    }
+
+    shardConfigBulk.put("dataShards", dataShards);
+    config.put("shardConfigurationBulk", shardConfigBulk);
+
+    String configContent = config.toString();
+    GcsArtifact artifact =
+        (GcsArtifact) gcsResourceManager.createArtifact(artifactName, configContent.getBytes());
+    BlobInfo blobInfo = artifact.getBlob().asBlobInfo();
+
+    return String.format("gs://%s/%s", blobInfo.getBucket(), blobInfo.getName());
+  }
+
+  protected void awaitAndShutdownExecutor(
+      ExecutorService executor, List<java.util.concurrent.Future<?>> futures, String phase) {
+    executor.shutdown();
+    try {
+      if (!executor.awaitTermination(60, TimeUnit.MINUTES)) {
+        throw new ShardOrchestrationException(phase + " phase timed out");
+      }
+      for (java.util.concurrent.Future<?> future : futures) {
+        future.get();
+      }
+    } catch (java.util.concurrent.ExecutionException e) {
+      throw new ShardOrchestrationException(phase + " phase failed", e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new ShardOrchestrationException(phase + " phase interrupted", e);
+    }
+  }
+
+  /**
+   * Purges all logical databases created during the initialization phase.
+   *
+   * <p>Physical instances are preserved for reuse.
+   */
+  public void cleanup() {
+    LOG.info("Starting cleanup of logical shards");
+    if (managers.isEmpty()) {
+      return;
+    }
+
+    ExecutorService executor = getExecutorService();
+    List<java.util.concurrent.Future<?>> futures = new java.util.ArrayList<>();
+    for (Map.Entry<String, CloudSqlResourceManager> entry : managers.entrySet()) {
+      String instanceName = entry.getKey();
+      CloudSqlResourceManager manager = entry.getValue();
+      List<String> shardDbs = requestedShardMap.get(instanceName);
+
+      futures.add(
+          executor.submit(
+              () -> {
+                if (shardDbs != null) {
+                  // We must explicitly drop shard databases here because CloudSqlResourceManager
+                  // only tracks the single "primary" database it was initialized with.
+                  // It is unaware of additional databases created via
+                  // manager.createDatabase(dbName).
+                  for (String dbName : shardDbs) {
+                    try {
+                      manager.dropDatabase(dbName);
+                    } catch (Exception e) {
+                      LOG.warn(
+                          "Failed to drop shard database {} on instance {}", dbName, instanceName);
+                    }
+                  }
+                }
+                manager.cleanupAll();
+              }));
+    }
+    awaitAndShutdownExecutor(executor, futures, "Cleanup");
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/CloudSqlShardOrchestratorTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/CloudSqlShardOrchestratorTest.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.loadtesting;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpResponseException;
+import com.google.api.services.sqladmin.SQLAdmin;
+import com.google.api.services.sqladmin.model.DatabaseInstance;
+import com.google.api.services.sqladmin.model.IpMapping;
+import com.google.api.services.sqladmin.model.Operation;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.SQLDialect;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import org.apache.beam.it.gcp.artifacts.GcsArtifact;
+import org.apache.beam.it.gcp.cloudsql.CloudMySQLResourceManager;
+import org.apache.beam.it.gcp.cloudsql.CloudPostgresResourceManager;
+import org.apache.beam.it.gcp.storage.GcsResourceManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Unit tests for {@link CloudSqlShardOrchestrator}. */
+@RunWith(MockitoJUnitRunner.class)
+public class CloudSqlShardOrchestratorTest {
+
+  private static final String PROJECT_ID = "test_project";
+  private static final String REGION = "test_region";
+  private static final String INSTANCE_NAME = "instance-1";
+  private static final String PRIVATE_IP = "10.0.0.1";
+
+  @Mock private GcsResourceManager gcsResourceManager;
+  @Mock private GcsArtifact mockArtifact;
+  @Mock private Blob mockBlob;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private SQLAdmin sqlAdmin;
+
+  @Mock private CloudMySQLResourceManager mockMySqlManager;
+  @Mock private CloudMySQLResourceManager.Builder mockMySqlBuilder;
+  @Mock private CloudPostgresResourceManager mockPostgresManager;
+  @Mock private CloudPostgresResourceManager.Builder mockPostgresBuilder;
+
+  private Map<String, List<String>> shardMap;
+
+  /** Helper subclass to inject mock SQLAdmin and synchronous executor. */
+  private static class TestCloudSqlShardOrchestrator extends CloudSqlShardOrchestrator {
+    public TestCloudSqlShardOrchestrator(
+        SQLDialect dbType,
+        String project,
+        String region,
+        GcsResourceManager gcsResourceManager,
+        SQLAdmin sqlAdmin) {
+      super(dbType, project, region, gcsResourceManager);
+      // Overwrite the real sqlAdmin created in super constructor
+      try {
+        java.lang.reflect.Field field =
+            CloudSqlShardOrchestrator.class.getDeclaredField("sqlAdmin");
+        field.setAccessible(true);
+        field.set(this, sqlAdmin);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    protected ExecutorService getExecutorService() {
+      return MoreExecutors.newDirectExecutorService();
+    }
+  }
+
+  @Before
+  public void setUp() {
+    shardMap = Map.of(INSTANCE_NAME, Arrays.asList("db1", "db2"));
+
+    // Mock GCS
+    when(mockArtifact.getBlob()).thenReturn(mockBlob);
+    when(gcsResourceManager.createArtifact(anyString(), any(byte[].class)))
+        .thenReturn(mockArtifact);
+
+    // Mock MySQL Builder
+    when(mockMySqlBuilder.maybeUseStaticInstance(anyString(), anyInt(), anyString(), anyString()))
+        .thenReturn(mockMySqlBuilder);
+    when(mockMySqlBuilder.build()).thenReturn(mockMySqlManager);
+
+    // Mock Postgres Builder
+    when(mockPostgresBuilder.maybeUseStaticInstance(
+            anyString(), anyInt(), anyString(), anyString()))
+        .thenReturn(mockPostgresBuilder);
+    when(mockPostgresBuilder.setDatabaseName(anyString())).thenReturn(mockPostgresBuilder);
+    when(mockPostgresBuilder.build()).thenReturn(mockPostgresManager);
+  }
+
+  @Test
+  public void testInitialize_provisionsAndSetsUpCorrectly() throws Exception {
+    TestCloudSqlShardOrchestrator orchestrator =
+        new TestCloudSqlShardOrchestrator(
+            SQLDialect.MYSQL, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
+
+    // Mock Stage 1: Physical Provisioning
+    DatabaseInstance instance =
+        new DatabaseInstance()
+            .setState("RUNNABLE")
+            .setIpAddresses(
+                Collections.singletonList(
+                    new IpMapping().setType("PRIVATE").setIpAddress(PRIVATE_IP)));
+
+    when(sqlAdmin.instances().get(PROJECT_ID, INSTANCE_NAME).execute()).thenReturn(instance);
+
+    Operation passwordOp = new Operation().setName("pw-op").setStatus("DONE");
+    when(sqlAdmin.users().update(eq(PROJECT_ID), eq(INSTANCE_NAME), any()).execute())
+        .thenReturn(passwordOp);
+    when(sqlAdmin.operations().get(PROJECT_ID, "pw-op").execute()).thenReturn(passwordOp);
+
+    try (MockedStatic<CloudMySQLResourceManager> mockedMySql =
+        mockStatic(CloudMySQLResourceManager.class)) {
+      mockedMySql
+          .when(() -> CloudMySQLResourceManager.builder(anyString()))
+          .thenReturn(mockMySqlBuilder);
+
+      when(mockBlob.asBlobInfo())
+          .thenReturn(BlobInfo.newBuilder("test-bucket", "test-run/shards.json").build());
+
+      String configPath = orchestrator.initialize(shardMap, "shards.json");
+
+      // Verify config path
+      assertThat(configPath).isEqualTo("gs://test-bucket/test-run/shards.json");
+
+      // Verify Manager creation with discovered IP and correct MySQL port
+      verify(mockMySqlBuilder)
+          .maybeUseStaticInstance(eq(PRIVATE_IP), eq(3306), anyString(), anyString());
+
+      // Verify Database creation delegation
+      verify(mockMySqlManager).createDatabase("db1");
+      verify(mockMySqlManager).createDatabase("db2");
+
+      // Verify artifact content
+      ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+      verify(gcsResourceManager).createArtifact(eq("shards.json"), captor.capture());
+      String content = new String(captor.getValue());
+      assertThat(content).contains("\"host\":\"" + PRIVATE_IP + "\"");
+    }
+  }
+
+  @Test
+  public void testInitialize_createsInstance_whenMissing() throws Exception {
+    TestCloudSqlShardOrchestrator orchestrator =
+        new TestCloudSqlShardOrchestrator(
+            SQLDialect.MYSQL, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
+
+    // Mock 404 for first call, then 200 for refresh
+    when(sqlAdmin.instances().get(PROJECT_ID, INSTANCE_NAME).execute())
+        .thenThrow(new IOException("404 Not Found"))
+        .thenReturn(
+            new DatabaseInstance()
+                .setState("RUNNABLE")
+                .setIpAddresses(
+                    Collections.singletonList(
+                        new IpMapping().setType("PRIVATE").setIpAddress(PRIVATE_IP))));
+
+    Operation op = new Operation().setName("op1").setStatus("DONE");
+    when(sqlAdmin.instances().insert(eq(PROJECT_ID), any(DatabaseInstance.class)).execute())
+        .thenReturn(op);
+    when(sqlAdmin.operations().get(PROJECT_ID, "op1").execute()).thenReturn(op);
+
+    Operation passwordOp = new Operation().setName("pw-op").setStatus("DONE");
+    when(sqlAdmin.users().update(eq(PROJECT_ID), eq(INSTANCE_NAME), any()).execute())
+        .thenReturn(passwordOp);
+    when(sqlAdmin.operations().get(PROJECT_ID, "pw-op").execute()).thenReturn(passwordOp);
+
+    try (MockedStatic<CloudMySQLResourceManager> mockedMySql =
+        mockStatic(CloudMySQLResourceManager.class)) {
+      mockedMySql
+          .when(() -> CloudMySQLResourceManager.builder(anyString()))
+          .thenReturn(mockMySqlBuilder);
+      when(mockBlob.asBlobInfo()).thenReturn(BlobInfo.newBuilder("b", "r/shards.json").build());
+
+      orchestrator.initialize(shardMap, "shards.json");
+
+      verify(sqlAdmin.instances()).insert(eq(PROJECT_ID), any(DatabaseInstance.class));
+    }
+  }
+
+  @Test
+  public void testCleanup_delegatesToManagers() throws Exception {
+    TestCloudSqlShardOrchestrator orchestrator =
+        new TestCloudSqlShardOrchestrator(
+            SQLDialect.MYSQL, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
+
+    // Mock successful initialization to populate managers map
+    when(sqlAdmin.instances().get(PROJECT_ID, INSTANCE_NAME).execute())
+        .thenReturn(
+            new DatabaseInstance()
+                .setState("RUNNABLE")
+                .setIpAddresses(
+                    Collections.singletonList(
+                        new IpMapping().setType("PRIVATE").setIpAddress(PRIVATE_IP))));
+
+    Operation passwordOp = new Operation().setName("pw-op").setStatus("DONE");
+    when(sqlAdmin.users().update(eq(PROJECT_ID), eq(INSTANCE_NAME), any()).execute())
+        .thenReturn(passwordOp);
+    when(sqlAdmin.operations().get(PROJECT_ID, "pw-op").execute()).thenReturn(passwordOp);
+
+    try (MockedStatic<CloudMySQLResourceManager> mockedMySql =
+        mockStatic(CloudMySQLResourceManager.class)) {
+      mockedMySql
+          .when(() -> CloudMySQLResourceManager.builder(anyString()))
+          .thenReturn(mockMySqlBuilder);
+      when(mockBlob.asBlobInfo()).thenReturn(BlobInfo.newBuilder("b", "r/shards.json").build());
+
+      orchestrator.initialize(shardMap, "shards.json");
+      orchestrator.cleanup();
+
+      verify(mockMySqlManager).cleanupAll();
+    }
+  }
+
+  @Test
+  public void testConstructor_withDefaultCredentials() throws Exception {
+    try (MockedStatic<GoogleCredentials> mockedCredentials = mockStatic(GoogleCredentials.class);
+        MockedStatic<GoogleNetHttpTransport> mockedTransport =
+            mockStatic(GoogleNetHttpTransport.class)) {
+      mockedCredentials
+          .when(GoogleCredentials::getApplicationDefault)
+          .thenReturn(mock(GoogleCredentials.class));
+      mockedTransport
+          .when(GoogleNetHttpTransport::newTrustedTransport)
+          .thenReturn(mock(com.google.api.client.http.javanet.NetHttpTransport.class));
+
+      CloudSqlShardOrchestrator orchestrator =
+          new CloudSqlShardOrchestrator(SQLDialect.MYSQL, PROJECT_ID, REGION, gcsResourceManager);
+
+      assertThat(orchestrator.project).isEqualTo(PROJECT_ID);
+    }
+  }
+
+  @Test
+  public void testInitialize_provisionsAndSetsUpPostgresCorrectly() throws Exception {
+    TestCloudSqlShardOrchestrator orchestrator =
+        new TestCloudSqlShardOrchestrator(
+            SQLDialect.POSTGRESQL, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
+
+    DatabaseInstance instance =
+        new DatabaseInstance()
+            .setState("RUNNABLE")
+            .setIpAddresses(
+                Collections.singletonList(
+                    new IpMapping().setType("PRIVATE").setIpAddress(PRIVATE_IP)));
+
+    when(sqlAdmin.instances().get(PROJECT_ID, INSTANCE_NAME).execute()).thenReturn(instance);
+
+    Operation passwordOp = new Operation().setName("pw-op").setStatus("DONE");
+    when(sqlAdmin.users().update(eq(PROJECT_ID), eq(INSTANCE_NAME), any()).execute())
+        .thenReturn(passwordOp);
+    when(sqlAdmin.operations().get(PROJECT_ID, "pw-op").execute()).thenReturn(passwordOp);
+
+    try (MockedStatic<CloudPostgresResourceManager> mockedPostgres =
+        mockStatic(CloudPostgresResourceManager.class)) {
+      mockedPostgres
+          .when(() -> CloudPostgresResourceManager.builder(anyString()))
+          .thenReturn(mockPostgresBuilder);
+
+      when(mockBlob.asBlobInfo()).thenReturn(BlobInfo.newBuilder("b", "r").build());
+
+      orchestrator.initialize(shardMap, "shards.json");
+
+      verify(mockPostgresBuilder)
+          .maybeUseStaticInstance(eq(PRIVATE_IP), eq(5432), anyString(), anyString());
+      verify(mockPostgresManager).createDatabase("db1");
+    }
+  }
+
+  @Test
+  public void testInitialize_throwsOnFailure() throws Exception {
+    TestCloudSqlShardOrchestrator orchestrator =
+        new TestCloudSqlShardOrchestrator(
+            SQLDialect.MYSQL, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
+
+    when(sqlAdmin.instances().get(anyString(), anyString()).execute())
+        .thenThrow(new IOException("API Error"));
+
+    assertThrows(
+        ShardOrchestrationException.class, () -> orchestrator.initialize(shardMap, "shards.json"));
+  }
+
+  @Test
+  public void testExecuteWithRetries_retriesOn409() throws Exception {
+    TestCloudSqlShardOrchestrator orchestrator =
+        new TestCloudSqlShardOrchestrator(
+            SQLDialect.MYSQL, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
+
+    com.google.api.client.googleapis.services.AbstractGoogleClientRequest<DatabaseInstance>
+        mockRequest =
+            mock(com.google.api.client.googleapis.services.AbstractGoogleClientRequest.class);
+
+    GoogleJsonResponseException exception409 =
+        new GoogleJsonResponseException(
+            new HttpResponseException.Builder(409, "Conflict", new HttpHeaders()), null);
+
+    DatabaseInstance instance = new DatabaseInstance().setName("inst1");
+
+    when(mockRequest.execute()).thenThrow(exception409).thenReturn(instance);
+
+    DatabaseInstance result = orchestrator.executeWithRetries(mockRequest);
+
+    assertThat(result).isEqualTo(instance);
+    verify(mockRequest, times(2)).execute();
+  }
+
+  @Test
+  public void testWaitForOperation_throwsOnOpError() throws Exception {
+    TestCloudSqlShardOrchestrator orchestrator =
+        new TestCloudSqlShardOrchestrator(
+            SQLDialect.MYSQL, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
+
+    Operation op = mock(Operation.class, Answers.RETURNS_DEEP_STUBS);
+    when(op.getName()).thenReturn("op-error");
+    when(op.getStatus()).thenReturn("DONE");
+    when(op.getError().getErrors().get(0).getMessage()).thenReturn("Operation Failed Message");
+
+    when(sqlAdmin.operations().get(PROJECT_ID, "op-error").execute()).thenReturn(op);
+
+    RuntimeException ex =
+        assertThrows(RuntimeException.class, () -> orchestrator.waitForOperation(op));
+    assertThat(ex.getMessage()).contains("Operation failed: Operation Failed Message");
+  }
+
+  @Test
+  public void testCleanup_handlesDropDatabaseError() throws Exception {
+    TestCloudSqlShardOrchestrator orchestrator =
+        new TestCloudSqlShardOrchestrator(
+            SQLDialect.MYSQL, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
+
+    // Mock successful initialization
+    DatabaseInstance instance =
+        new DatabaseInstance()
+            .setState("RUNNABLE")
+            .setIpAddresses(
+                Collections.singletonList(
+                    new IpMapping().setType("PRIVATE").setIpAddress(PRIVATE_IP)));
+    when(sqlAdmin.instances().get(PROJECT_ID, INSTANCE_NAME).execute()).thenReturn(instance);
+    Operation passwordOp = new Operation().setName("pw-op").setStatus("DONE");
+    when(sqlAdmin.users().update(anyString(), anyString(), any()).execute()).thenReturn(passwordOp);
+    when(sqlAdmin.operations().get(anyString(), anyString()).execute()).thenReturn(passwordOp);
+
+    try (MockedStatic<CloudMySQLResourceManager> mockedMySql =
+        mockStatic(CloudMySQLResourceManager.class)) {
+      mockedMySql
+          .when(() -> CloudMySQLResourceManager.builder(anyString()))
+          .thenReturn(mockMySqlBuilder);
+      when(mockBlob.asBlobInfo()).thenReturn(BlobInfo.newBuilder("b", "r").build());
+
+      orchestrator.initialize(shardMap, "shards.json");
+
+      // Mock error on dropDatabase
+      doThrow(new RuntimeException("Drop Failed")).when(mockMySqlManager).dropDatabase("db1");
+
+      orchestrator.cleanup();
+
+      verify(mockMySqlManager).dropDatabase("db1");
+      verify(mockMySqlManager).dropDatabase("db2");
+      verify(mockMySqlManager).cleanupAll();
+    }
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/MySQL5KTablesLT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/MySQL5KTablesLT.java
@@ -115,14 +115,6 @@ public class MySQL5KTablesLT extends SourceDbToSpannerLTBase {
     columns.put("id", "BIGINT UNSIGNED");
     JDBCResourceManager.JDBCSchema schema = new JDBCResourceManager.JDBCSchema(columns, "id");
 
-    // OPTIMIZE MYSQL:
-    // We disable synchronous flushing and binary logging to speed up the creation and
-    // population of 5,000 tables on the source database.
-    try (Connection jdbcConnection = getJdbcConnection(mySQLResourceManager);
-        PreparedStatement pstmt =
-            jdbcConnection.prepareStatement("SET GLOBAL innodb_flush_log_at_trx_commit = 0;")) {
-      pstmt.executeUpdate();
-    }
     try (Connection jdbcConnection = getJdbcConnection(mySQLResourceManager);
         PreparedStatement pstmt = jdbcConnection.prepareStatement("SET GLOBAL sync_binlog = 0;")) {
       pstmt.executeUpdate();
@@ -145,18 +137,6 @@ public class MySQL5KTablesLT extends SourceDbToSpannerLTBase {
       if (i % 500 == 0) {
         LOG.info("Created {} tables so far on Source", i);
       }
-    }
-
-    // Restore MySQL durability settings to ensure a realistic state for the template.
-    try (Connection jdbcConnection = getJdbcConnection(mySQLResourceManager);
-        PreparedStatement pstmt =
-            jdbcConnection.prepareStatement("SET GLOBAL innodb_flush_log_at_trx_commit = 1;")) {
-      pstmt.executeUpdate();
-    }
-
-    try (Connection jdbcConnection = getJdbcConnection(mySQLResourceManager);
-        PreparedStatement pstmt = jdbcConnection.prepareStatement("SET GLOBAL sync_binlog = 1;")) {
-      pstmt.executeUpdate();
     }
 
     // PARALLEL DDL EXECUTION:

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/MySQLMultiSharded1024ShardsLT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/MySQLMultiSharded1024ShardsLT.java
@@ -1,0 +1,378 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.loadtesting;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
+
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
+import com.google.cloud.teleport.metadata.TemplateLoadTest;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.SQLDialect;
+import com.google.cloud.teleport.v2.templates.SourceDbToSpanner;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.beam.it.common.PipelineLauncher;
+import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
+import org.apache.beam.it.common.PipelineOperator;
+import org.apache.beam.it.common.utils.ResourceManagerUtils;
+import org.apache.beam.it.gcp.artifacts.GcsArtifact;
+import org.apache.beam.it.gcp.cloudsql.CloudSqlResourceManager;
+import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A load test for {@link SourceDbToSpanner} Flex template which tests a massive 1,024 shards
+ * migration from MySQL to Spanner.
+ *
+ * <p>This test validates the graph size optimization by ensuring that a single Dataflow job can
+ * successfully manage connections and data movement for thousands of tables across 32 physical
+ * MySQL instances.
+ */
+@Category({TemplateLoadTest.class, SkipDirectRunnerTest.class})
+@TemplateLoadTest(SourceDbToSpanner.class)
+@RunWith(JUnit4.class)
+@Ignore("Waiting Dataflow release b/504521494")
+public class MySQLMultiSharded1024ShardsLT extends SourceDbToSpannerLTBase {
+  private static final Logger LOG = LoggerFactory.getLogger(MySQLMultiSharded1024ShardsLT.class);
+  private Instant startTime;
+
+  private CloudSqlShardOrchestrator orchestrator;
+
+  private final int numPhysicalInstances = 32;
+  private final int numLogicalInstances = 32;
+
+  private final Boolean skipBaseCleanup = true;
+
+  @Before
+  public void setUp() throws IOException {
+    LOG.info("Began Setup for 1,024 Shards test");
+    super.setUp();
+    startTime = Instant.now();
+
+    String password = System.getProperty("cloudProxyPassword");
+    if (password == null || password.isEmpty()) {
+      throw new IllegalArgumentException("cloudProxyPassword system property must be set");
+    }
+
+    spannerResourceManager =
+        SpannerResourceManager.builder(testName, project, region)
+            .maybeUseStaticInstance()
+            .setMonitoringClient(monitoringClient)
+            .build();
+
+    gcsResourceManager = createSpannerLTGcsResourceManager();
+    this.dialect = SQLDialect.MYSQL;
+
+    orchestrator =
+        new CloudSqlShardOrchestrator(SQLDialect.MYSQL, project, region, gcsResourceManager);
+  }
+
+  @After
+  public void cleanUp() {
+    if (skipBaseCleanup) {
+      LOG.warn("skipping cleanup");
+      return;
+    }
+    java.util.List<org.apache.beam.it.common.ResourceManager> resources = new ArrayList<>();
+    resources.add(spannerResourceManager);
+    resources.add(gcsResourceManager);
+    ResourceManagerUtils.cleanResources(
+        resources.toArray(new org.apache.beam.it.common.ResourceManager[0]));
+
+    if (orchestrator != null) {
+      orchestrator.cleanup();
+      orchestrator = null;
+    }
+
+    LOG.info(
+        "CleanupCompleted for 1,024 Shards test. Test took {}",
+        Duration.between(startTime, Instant.now()));
+  }
+
+  @Test
+  public void mySQLToSpanner1024ShardsTest() throws Exception {
+    int numPhysicalShards = numPhysicalInstances;
+    int numLogicalShardsPerPhysical = numLogicalInstances;
+    int tablesPerShard = 5;
+
+    // Step 1: Generate Shard Map
+    Map<String, List<String>> shardMap = new HashMap<>();
+    String randomSuffix =
+        org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric(4).toLowerCase();
+    String timestamp =
+        java.time.format.DateTimeFormatter.ofPattern("yyyy_MM_dd_HH_mm_ss")
+            .withZone(java.time.ZoneId.of("UTC"))
+            .format(java.time.Instant.now());
+
+    for (int i = 0; i < numPhysicalShards; i++) {
+      String instanceName = String.format("nokill-1k-shard-mysql-%02d", i);
+      List<String> logicalDbs = new ArrayList<>();
+      for (int j = 1; j <= numLogicalShardsPerPhysical; j++) {
+        // Name pattern: d_<random>_<timestamp>_p<physicalIdx>_l<logicalIdx>
+        // Example: d_a7b2_2026_03_31_05_30_43_p00_l01 (approx 35 characters)
+        // This is well within the 64-character limit for MySQL and 63 for PostgreSQL.
+        logicalDbs.add(String.format("d_%s_%s_p%02d_l%02d", randomSuffix, timestamp, i, j));
+      }
+      shardMap.put(instanceName, logicalDbs);
+    }
+
+    // Step 2: Initialize physical and logical environment
+    String sourceConfigPath = orchestrator.initialize(shardMap, "shards.json");
+
+    // Step 3: Data Generation within logical shards
+    populateSourceDatabases(tablesPerShard);
+
+    // Step 4: Spanner Setup
+    createSpannerTables(tablesPerShard);
+
+    String sessionFilePath = createAndUploadSessionFile(tablesPerShard);
+
+    Map<String, String> params = getCommonParameters();
+    params.put("sourceConfigURL", sourceConfigPath);
+    params.put("sessionFilePath", sessionFilePath);
+    params.put("maxConnections", "16");
+    params.put("numWorkers", "16");
+    params.put("maxNumWorkers", "16");
+    params.put("workerMachineType", "n2-standard-4");
+
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, SPEC_PATH).setParameters(params);
+    PipelineLauncher.LaunchInfo jobInfo = launchJob(options);
+
+    PipelineOperator.Result result =
+        pipelineOperator.waitUntilDone(createConfig(jobInfo, Duration.ofMinutes(60L)));
+    assertThatResult(result).isLaunchFinished();
+
+    // Step 6: Verification
+    verifyMigration(numPhysicalShards * numLogicalShardsPerPhysical, tablesPerShard);
+
+    // Collect metrics
+    collectAndExportMetrics(jobInfo);
+  }
+
+  private void populateSourceDatabases(int tablesPerShard) throws Exception {
+    LOG.info("Populating logical shards with data");
+    ExecutorService executor = Executors.newFixedThreadPool(64);
+
+    for (Map.Entry<String, CloudSqlResourceManager> entry : orchestrator.managers.entrySet()) {
+      String physicalInstanceName = entry.getKey();
+      final CloudSqlResourceManager manager = entry.getValue();
+
+      // Find logical DBs for this physical instance
+      List<String> dbNames = orchestrator.requestedShardMap.get(physicalInstanceName);
+
+      for (String dbName : dbNames) {
+        executor.submit(
+            () -> {
+              try (Connection dbConn = getJdbcConnectionForDb(manager, dbName)) {
+                for (int k = 0; k < tablesPerShard; k++) {
+                  String tableName = "table_" + k;
+                  try (Statement stmt = dbConn.createStatement()) {
+                    stmt.executeUpdate(
+                        "CREATE TABLE IF NOT EXISTS "
+                            + tableName
+                            + " (id INT PRIMARY KEY, data VARCHAR(100))");
+                    stmt.executeUpdate(
+                        "INSERT INTO "
+                            + tableName
+                            + " VALUES (1, 'data_from_instance_"
+                            + physicalInstanceName
+                            + "_db_"
+                            + dbName
+                            + "') ON DUPLICATE KEY UPDATE data=VALUES(data)");
+                  }
+                }
+              } catch (SQLException e) {
+                LOG.error("Failed to populate shard {}", dbName, e);
+                throw new RuntimeException(e);
+              }
+            });
+      }
+    }
+
+    executor.shutdown();
+    if (!executor.awaitTermination(60, TimeUnit.MINUTES)) {
+      throw new RuntimeException("Source DB population timed out");
+    }
+  }
+
+  private void createSpannerTables(int tablesPerShard) {
+    LOG.info("Creating {} Spanner tables", tablesPerShard);
+    for (int i = 0; i < tablesPerShard; i++) {
+      String ddl =
+          String.format(
+              "CREATE TABLE table_%d ("
+                  + "  migration_shard_id STRING(50) NOT NULL,"
+                  + "  id INT64 NOT NULL,"
+                  + "  data STRING(100),"
+                  + ") PRIMARY KEY (migration_shard_id, id)",
+              i);
+      spannerResourceManager.executeDdlStatements(ImmutableList.of(ddl));
+    }
+  }
+
+  private void verifyMigration(int numShards, int tablesPerShard) {
+    LOG.info("Verifying migration of {} shards", numShards);
+    for (int i = 0; i < tablesPerShard; i++) {
+      String tableName = "table_" + i;
+      assertThat(spannerResourceManager.getRowCount(tableName)).isEqualTo((long) numShards);
+
+      // Verify distinct shard IDs
+      ImmutableList<Struct> rows =
+          spannerResourceManager.runQuery(
+              "SELECT COUNT(DISTINCT migration_shard_id) FROM " + tableName);
+      assertThat(rows.size()).isEqualTo(1);
+      assertThat(rows.get(0).getLong(0)).isEqualTo((long) numShards);
+    }
+  }
+
+  private Connection getJdbcConnectionForDb(CloudSqlResourceManager manager, String dbName)
+      throws SQLException {
+    String uri =
+        String.format("jdbc:mysql://%s:%d/%s", manager.getHost(), manager.getPort(), dbName);
+    return DriverManager.getConnection(uri, manager.getUsername(), manager.getPassword());
+  }
+
+  private String createAndUploadSessionFile(int tablesPerShard) throws IOException {
+    JSONObject session = new JSONObject();
+    JSONObject spSchema = new JSONObject();
+    JSONObject srcSchema = new JSONObject();
+    JSONObject toSpanner = new JSONObject();
+    JSONObject toSource = new JSONObject();
+    JSONObject spannerToId = new JSONObject();
+    JSONObject srcToId = new JSONObject();
+
+    for (int i = 0; i < tablesPerShard; i++) {
+      String tableName = "table_" + i;
+      String tableId = tableName;
+
+      // Spanner Schema: migration_shard_id (c1), id (c2), data (c3)
+      JSONObject spTable = new JSONObject();
+      spTable.put("Name", tableName);
+      spTable.put("ColIds", new JSONArray(List.of("c1", "c2", "c3")));
+
+      JSONObject spColDefs = new JSONObject();
+      spColDefs.put(
+          "c1",
+          new JSONObject()
+              .put("Name", "migration_shard_id")
+              .put("T", new JSONObject().put("Name", "STRING")));
+      spColDefs.put(
+          "c2", new JSONObject().put("Name", "id").put("T", new JSONObject().put("Name", "INT64")));
+      spColDefs.put(
+          "c3",
+          new JSONObject().put("Name", "data").put("T", new JSONObject().put("Name", "STRING")));
+      spTable.put("ColDefs", spColDefs);
+
+      JSONArray pks = new JSONArray();
+      pks.put(new JSONObject().put("ColId", "c1"));
+      pks.put(new JSONObject().put("ColId", "c2"));
+      spTable.put("PrimaryKeys", pks);
+      spTable.put("ShardIdColumn", "c1");
+
+      spSchema.put(tableId, spTable);
+
+      // Source Schema: must use SAME IDs for mapped columns (c2, c3)
+      JSONObject srcTable = new JSONObject();
+      srcTable.put("Name", tableName);
+      srcTable.put("ColIds", new JSONArray(List.of("c2", "c3")));
+      JSONObject srcColDefs = new JSONObject();
+      srcColDefs.put(
+          "c2",
+          new JSONObject().put("Name", "id").put("Type", new JSONObject().put("Name", "INT")));
+      srcColDefs.put(
+          "c3",
+          new JSONObject()
+              .put("Name", "data")
+              .put("Type", new JSONObject().put("Name", "VARCHAR")));
+      srcTable.put("ColDefs", srcColDefs);
+      srcTable.put("PrimaryKeys", new JSONArray(List.of(new JSONObject().put("ColId", "c2"))));
+
+      srcSchema.put(tableId, srcTable);
+
+      // ToSpanner: Map Source Column Name to Spanner Column ID
+      toSpanner.put(
+          tableName,
+          new JSONObject()
+              .put("Name", tableName)
+              .put("Cols", new JSONObject().put("id", "c2").put("data", "c3")));
+
+      // ToSource: Map Spanner Table Name to Source Table Name and Spanner Column ID to Source
+      // Column Name
+      toSource.put(
+          tableName,
+          new JSONObject()
+              .put("Name", tableName)
+              .put("Cols", new JSONObject().put("c2", "id").put("c3", "data")));
+
+      // SpannerToID: Map Spanner Table Name to internal Table ID and Spanner Column Name to ID
+      spannerToId.put(
+          tableName,
+          new JSONObject()
+              .put("Name", tableId)
+              .put(
+                  "Cols",
+                  new JSONObject()
+                      .put("migration_shard_id", "c1")
+                      .put("id", "c2")
+                      .put("data", "c3")));
+
+      // SrcToID: Map Source Table Name to internal Table ID and Source Column Name to ID
+      srcToId.put(
+          tableName,
+          new JSONObject()
+              .put("Name", tableId)
+              .put("Cols", new JSONObject().put("id", "c2").put("data", "c3")));
+    }
+
+    session.put("SpSchema", spSchema);
+    session.put("SrcSchema", srcSchema);
+    session.put("ToSpanner", toSpanner);
+    session.put("ToSource", toSource);
+    session.put("SpannerToID", spannerToId);
+    session.put("SrcToID", srcToId);
+    session.put("SyntheticPKeys", new JSONObject());
+
+    String content = session.toString();
+    GcsArtifact artifact =
+        (GcsArtifact) gcsResourceManager.createArtifact("session.json", content.getBytes());
+    com.google.cloud.storage.BlobInfo blobInfo = artifact.getBlob().asBlobInfo();
+    return String.format("gs://%s/%s", blobInfo.getBucket(), blobInfo.getName());
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/PostgreSQLMultiSharded1024ShardsLT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/PostgreSQLMultiSharded1024ShardsLT.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.loadtesting;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
+
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
+import com.google.cloud.teleport.metadata.TemplateLoadTest;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.SQLDialect;
+import com.google.cloud.teleport.v2.templates.SourceDbToSpanner;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.beam.it.common.PipelineLauncher;
+import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
+import org.apache.beam.it.common.PipelineOperator;
+import org.apache.beam.it.common.utils.ResourceManagerUtils;
+import org.apache.beam.it.gcp.artifacts.GcsArtifact;
+import org.apache.beam.it.gcp.cloudsql.CloudSqlResourceManager;
+import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A load test for {@link SourceDbToSpanner} Flex template which tests a massive 1,024 shards
+ * migration from PostgreSQL to Spanner.
+ *
+ * <p>This test validates the graph size optimization by ensuring that a single Dataflow job can
+ * successfully manage connections and data movement for thousands of tables across 32 physical
+ * PostgreSQL instances.
+ */
+@Category({TemplateLoadTest.class, SkipDirectRunnerTest.class})
+@TemplateLoadTest(SourceDbToSpanner.class)
+@RunWith(JUnit4.class)
+@Ignore("Waiting Dataflow release b/504521494")
+public class PostgreSQLMultiSharded1024ShardsLT extends SourceDbToSpannerLTBase {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(PostgreSQLMultiSharded1024ShardsLT.class);
+  private Instant startTime;
+
+  private CloudSqlShardOrchestrator orchestrator;
+
+  private final int numPhysicalInstances = 32;
+  private final int numLogicalInstances = 32;
+
+  private final Boolean skipBaseCleanup = true;
+
+  @Before
+  public void setUp() throws IOException {
+    LOG.info("Began Setup for 1,024 Shards test (PostgreSQL)");
+    super.setUp();
+    startTime = Instant.now();
+
+    String password = System.getProperty("cloudProxyPassword");
+    if (password == null || password.isEmpty()) {
+      throw new IllegalArgumentException("cloudProxyPassword system property must be set");
+    }
+
+    spannerResourceManager =
+        SpannerResourceManager.builder(testName, project, region)
+            .maybeUseStaticInstance()
+            .setMonitoringClient(monitoringClient)
+            .build();
+
+    gcsResourceManager = createSpannerLTGcsResourceManager();
+    this.dialect = SQLDialect.POSTGRESQL;
+
+    orchestrator =
+        new CloudSqlShardOrchestrator(SQLDialect.POSTGRESQL, project, region, gcsResourceManager);
+  }
+
+  @After
+  public void cleanUp() {
+    if (skipBaseCleanup) {
+      LOG.warn("skipping cleanup");
+      return;
+    }
+    java.util.List<org.apache.beam.it.common.ResourceManager> resources = new ArrayList<>();
+    resources.add(spannerResourceManager);
+    resources.add(gcsResourceManager);
+    ResourceManagerUtils.cleanResources(
+        resources.toArray(new org.apache.beam.it.common.ResourceManager[0]));
+
+    if (orchestrator != null) {
+      orchestrator.cleanup();
+      orchestrator = null;
+    }
+
+    LOG.info(
+        "CleanupCompleted for 1,024 Shards test (PostgreSQL). Test took {}",
+        Duration.between(startTime, Instant.now()));
+  }
+
+  @Test
+  public void postgreSQLToSpanner1024ShardsTest() throws Exception {
+    int numPhysicalShards = numPhysicalInstances;
+    int numLogicalShardsPerPhysical = numLogicalInstances;
+    int tablesPerShard = 5;
+
+    // Step 1: Generate Shard Map
+    Map<String, List<String>> shardMap = new HashMap<>();
+    String randomSuffix =
+        org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric(4).toLowerCase();
+    String timestamp =
+        java.time.format.DateTimeFormatter.ofPattern("yyyy_MM_dd_HH_mm_ss")
+            .withZone(java.time.ZoneId.of("UTC"))
+            .format(java.time.Instant.now());
+
+    for (int i = 0; i < numPhysicalShards; i++) {
+      String instanceName = String.format("nokill-1k-shard-postgresql-%02d", i);
+      List<String> logicalDbs = new ArrayList<>();
+      for (int j = 1; j <= numLogicalShardsPerPhysical; j++) {
+        // Name pattern: d_<random>_<timestamp>_p<physicalIdx>_l<logicalIdx>
+        logicalDbs.add(String.format("d_%s_%s_p%02d_l%02d", randomSuffix, timestamp, i, j));
+      }
+      shardMap.put(instanceName, logicalDbs);
+    }
+
+    // Step 2: Initialize physical and logical environment
+    String sourceConfigPath = orchestrator.initialize(shardMap, "shards.json");
+
+    // Step 3: Data Generation within logical shards
+    populateSourceDatabases(tablesPerShard);
+
+    // Step 4: Spanner Setup
+    createSpannerTables(tablesPerShard);
+
+    String sessionFilePath = createAndUploadSessionFile(tablesPerShard);
+
+    Map<String, String> params = getCommonParameters();
+    params.put("sourceConfigURL", sourceConfigPath);
+    params.put("sessionFilePath", sessionFilePath);
+    params.put("sourceDbDialect", SQLDialect.POSTGRESQL.name());
+    params.put("jdbcDriverClassName", "org.postgresql.Driver");
+    params.put("maxConnections", "16");
+    params.put("numWorkers", "16");
+    params.put("maxNumWorkers", "16");
+    params.put("workerMachineType", "n2-standard-4");
+
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, SPEC_PATH).setParameters(params);
+    PipelineLauncher.LaunchInfo jobInfo = launchJob(options);
+
+    PipelineOperator.Result result =
+        pipelineOperator.waitUntilDone(createConfig(jobInfo, Duration.ofMinutes(60L)));
+    assertThatResult(result).isLaunchFinished();
+
+    // Step 6: Verification
+    verifyMigration(numPhysicalShards * numLogicalShardsPerPhysical, tablesPerShard);
+
+    // Collect metrics
+    collectAndExportMetrics(jobInfo);
+  }
+
+  private void populateSourceDatabases(int tablesPerShard) throws Exception {
+    LOG.info("Populating logical shards with data (PostgreSQL)");
+    ExecutorService executor = Executors.newFixedThreadPool(64);
+
+    for (Map.Entry<String, CloudSqlResourceManager> entry : orchestrator.managers.entrySet()) {
+      String physicalInstanceName = entry.getKey();
+      final CloudSqlResourceManager manager = entry.getValue();
+
+      // Find logical DBs for this physical instance
+      List<String> dbNames = orchestrator.requestedShardMap.get(physicalInstanceName);
+
+      for (String dbName : dbNames) {
+        executor.submit(
+            () -> {
+              try (Connection dbConn = getJdbcConnectionForDb(manager, dbName)) {
+                for (int k = 0; k < tablesPerShard; k++) {
+                  String tableName = "table_" + k;
+                  try (Statement stmt = dbConn.createStatement()) {
+                    stmt.executeUpdate(
+                        "CREATE TABLE IF NOT EXISTS "
+                            + tableName
+                            + " (id INT PRIMARY KEY, data VARCHAR(100))");
+                    stmt.executeUpdate(
+                        "INSERT INTO "
+                            + tableName
+                            + " VALUES (1, 'data_from_instance_"
+                            + physicalInstanceName
+                            + "_db_"
+                            + dbName
+                            + "') ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data");
+                  }
+                }
+              } catch (SQLException e) {
+                LOG.error("Failed to populate shard {}", dbName, e);
+                throw new RuntimeException(e);
+              }
+            });
+      }
+    }
+
+    executor.shutdown();
+    if (!executor.awaitTermination(60, TimeUnit.MINUTES)) {
+      throw new RuntimeException("Source DB population timed out");
+    }
+  }
+
+  private void createSpannerTables(int tablesPerShard) {
+    LOG.info("Creating {} Spanner tables", tablesPerShard);
+    for (int i = 0; i < tablesPerShard; i++) {
+      String ddl =
+          String.format(
+              "CREATE TABLE table_%d ("
+                  + "  migration_shard_id STRING(50) NOT NULL,"
+                  + "  id INT64 NOT NULL,"
+                  + "  data STRING(100),"
+                  + ") PRIMARY KEY (migration_shard_id, id)",
+              i);
+      spannerResourceManager.executeDdlStatements(ImmutableList.of(ddl));
+    }
+  }
+
+  private void verifyMigration(int numShards, int tablesPerShard) {
+    LOG.info("Verifying migration of {} shards", numShards);
+    for (int i = 0; i < tablesPerShard; i++) {
+      String tableName = "table_" + i;
+      assertThat(spannerResourceManager.getRowCount(tableName)).isEqualTo((long) numShards);
+
+      // Verify distinct shard IDs
+      ImmutableList<Struct> rows =
+          spannerResourceManager.runQuery(
+              "SELECT COUNT(DISTINCT migration_shard_id) FROM " + tableName);
+      assertThat(rows.size()).isEqualTo(1);
+      assertThat(rows.get(0).getLong(0)).isEqualTo((long) numShards);
+    }
+  }
+
+  private Connection getJdbcConnectionForDb(CloudSqlResourceManager manager, String dbName)
+      throws SQLException {
+    String uri =
+        String.format("jdbc:postgresql://%s:%d/%s", manager.getHost(), manager.getPort(), dbName);
+    return DriverManager.getConnection(uri, manager.getUsername(), manager.getPassword());
+  }
+
+  private String createAndUploadSessionFile(int tablesPerShard) throws IOException {
+    JSONObject session = new JSONObject();
+    JSONObject spSchema = new JSONObject();
+    JSONObject srcSchema = new JSONObject();
+    JSONObject toSpanner = new JSONObject();
+    JSONObject toSource = new JSONObject();
+    JSONObject spannerToId = new JSONObject();
+    JSONObject srcToId = new JSONObject();
+
+    for (int i = 0; i < tablesPerShard; i++) {
+      String tableName = "table_" + i;
+      String tableId = tableName;
+
+      // Spanner Schema: migration_shard_id (c1), id (c2), data (c3)
+      JSONObject spTable = new JSONObject();
+      spTable.put("Name", tableName);
+      spTable.put("ColIds", new JSONArray(List.of("c1", "c2", "c3")));
+
+      JSONObject spColDefs = new JSONObject();
+      spColDefs.put(
+          "c1",
+          new JSONObject()
+              .put("Name", "migration_shard_id")
+              .put("T", new JSONObject().put("Name", "STRING")));
+      spColDefs.put(
+          "c2", new JSONObject().put("Name", "id").put("T", new JSONObject().put("Name", "INT64")));
+      spColDefs.put(
+          "c3",
+          new JSONObject().put("Name", "data").put("T", new JSONObject().put("Name", "STRING")));
+      spTable.put("ColDefs", spColDefs);
+
+      JSONArray pks = new JSONArray();
+      pks.put(new JSONObject().put("ColId", "c1"));
+      pks.put(new JSONObject().put("ColId", "c2"));
+      spTable.put("PrimaryKeys", pks);
+      spTable.put("ShardIdColumn", "c1");
+
+      spSchema.put(tableId, spTable);
+
+      // Source Schema: must use SAME IDs for mapped columns (c2, c3)
+      JSONObject srcTable = new JSONObject();
+      srcTable.put("Name", tableName);
+      srcTable.put("ColIds", new JSONArray(List.of("c2", "c3")));
+      JSONObject srcColDefs = new JSONObject();
+      srcColDefs.put(
+          "c2",
+          new JSONObject().put("Name", "id").put("Type", new JSONObject().put("Name", "INTEGER")));
+      srcColDefs.put(
+          "c3",
+          new JSONObject()
+              .put("Name", "data")
+              .put("Type", new JSONObject().put("Name", "VARCHAR")));
+      srcTable.put("ColDefs", srcColDefs);
+      srcTable.put("PrimaryKeys", new JSONArray(List.of(new JSONObject().put("ColId", "c2"))));
+
+      srcSchema.put(tableId, srcTable);
+
+      // ToSpanner: Map Source Column Name to Spanner Column ID
+      toSpanner.put(
+          tableName,
+          new JSONObject()
+              .put("Name", tableName)
+              .put("Cols", new JSONObject().put("id", "c2").put("data", "c3")));
+
+      // ToSource: Map Spanner Table Name to Source Table Name and Spanner Column ID to Source
+      // Column Name
+      toSource.put(
+          tableName,
+          new JSONObject()
+              .put("Name", tableName)
+              .put("Cols", new JSONObject().put("c2", "id").put("c3", "data")));
+
+      // SpannerToID: Map Spanner Table Name to internal Table ID and Spanner Column Name to ID
+      spannerToId.put(
+          tableName,
+          new JSONObject()
+              .put("Name", tableId)
+              .put(
+                  "Cols",
+                  new JSONObject()
+                      .put("migration_shard_id", "c1")
+                      .put("id", "c2")
+                      .put("data", "c3")));
+
+      // SrcToID: Map Source Table Name to internal Table ID and Source Column Name to ID
+      srcToId.put(
+          tableName,
+          new JSONObject()
+              .put("Name", tableId)
+              .put("Cols", new JSONObject().put("id", "c2").put("data", "c3")));
+    }
+
+    session.put("SpSchema", spSchema);
+    session.put("SrcSchema", srcSchema);
+    session.put("ToSpanner", toSpanner);
+    session.put("ToSource", toSource);
+    session.put("SpannerToID", spannerToId);
+    session.put("SrcToID", srcToId);
+    session.put("SyntheticPKeys", new JSONObject());
+
+    String content = session.toString();
+    GcsArtifact artifact =
+        (GcsArtifact) gcsResourceManager.createArtifact("session.json", content.getBytes());
+    com.google.cloud.storage.BlobInfo blobInfo = artifact.getBlob().asBlobInfo();
+    return String.format("gs://%s/%s", blobInfo.getBucket(), blobInfo.getName());
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/ShardOrchestrationException.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/ShardOrchestrationException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.loadtesting;
+
+/** Exception thrown when Cloud SQL shard orchestration fails. */
+public class ShardOrchestrationException extends RuntimeException {
+  public ShardOrchestrationException(String message) {
+    super(message);
+  }
+
+  public ShardOrchestrationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
# PR Description: Constant-Size Dataflow Graph for Multi-Shard JDBC Migrations (Milestone 2)

## Executive Summary
This project enhances the `sourcedb-to-spanner` Dataflow template to support massive-scale multi-shard database migrations. Building on the previous "Graph Size Optimization" work, this milestone achieves **O(1) constant graph complexity** across both multiple tables AND multiple physical shards.  This is the second milestone and followup to #3399 

This optimization enables a single Dataflow job to migrate thousands of tables distributed across hundreds of physical database instances (MySQL or PostgreSQL) without exceeding Dataflow's graph size limits or worker resource constraints.

This PR is a way to give complete picture of the child PRs described below and is not for review by itself.

## The Problem: Shard-induced Graph Bloat
Previously, while we could handle many tables within a *single* shard using a constant graph, the `PipelineController` still instantiated a unique set of transforms for every *physical shard*. For migrations involving hundreds of shards, this resulted in:
1.  **Deployment Failures:** Large-scale sharded jobs hitting Dataflow's serialized graph size limits.
2.  **Resource Inefficiency:** High worker-side overhead as every worker had to manage a linear number of transform instances.
3.  **Complex Orchestration:** Inability to perform bulk schema discovery and partitioning across shards.

## The Solution: Multi-Shard Orchestration
We have extended the "Data-Driven" architecture to the shard level. The Dataflow graph is now decoupled from both the table count and the shard count. 

### Key Architectural Pillars

#### 1. Unified Multi-Shard Graph
The `ReadWithUniformPartitions` transform now accepts a `DataSourceProvider`, which dynamically routes requests to the correct physical shard based on a `datasourceId` attached to each range. This allows a single set of Dataflow stages to process data from ALL configured shards for a given dependency level.

#### 2. Centralized DataSource Management
Introduced `DataSourceManager`, a thread-safe component that manages connection pools across multiple shards within a single worker. It uses a lazy initialization strategy with double-checked locking to ensure that workers only create connections to the shards they are actually processing, preventing connection exhaustion at the source.

#### 3. Parallel Cross-Shard Schema Discovery
Schema discovery is now performed in parallel across all shards. The `JdbcIoWrapper` aggregates metadata from multiple shards and produces a consolidated view for the pipeline, drastically reducing job startup time.

#### 4. Unified DLQ and Record Routing
The Dead Letter Queue (DLQ) logic was refactored to remove shard-specific folder paths. Shard identification is now embedded directly in the record metadata, allowing for a simplified, unified DLQ directory structure in GCS while maintaining full traceability.


## Key Components & Child PRs
This milestone is delivered through a suite of logical PRs:

1.  **Foundations (POJO-PR):** Introduces `DataSourceManager` and configuration POJOs for multi-shard support. #3685
2.  **Interface Refactor (Interface-PR):** Updates core `Reader` and `IoWrapper` interfaces to support multi-transform routing.  #3686 
3.  **TableIdentifier-PR:** Propagates `dataSourceId` through the system for precise routing. #3697 
4.  **JDBCIOWrapper-PR:** Implements parallel cross-shard discovery and bulk transform building. [PR #TBD]
5.  **Controller Wiring (PipelineController-PR):** Refactors the main controller to move from shard-loops to level-loops. [PR #TBD]
6.  **Read With Uniform Partition:** Updates the partitioning engine to support dynamic shard routing. [PR #TBD]
7.  **Integration (Together-pr):** Final glue logic and integration of all components. [PR #TBD]
8.  **Scalability (Load-test-pr):** Integration tests and massive 1,024-shard load tests. [PR #TBD]

---

## Testing & Validation
- **Unit Tests:** Full coverage (95%+) for all new multi-shard components.
- **Integration Tests:** Verified multi-shard routing using in-memory Derby instances.
- **Massive Scale Load Test:** Validated the solution with **1,024 logical shards** across **32 physical instances** (5,120 total tables) in a single Dataflow job.
    - **Result:** Successful migration with a small, constant Dataflow graph.
    - **Dialects:** Verified for both MySQL and PostgreSQL.
