### PR TITLE
POJOs for MultiShard TableReader.

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/JdbcIoWrapperConfigGroup.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/JdbcIoWrapperConfigGroup.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+/**
+ * Encapsulates the configuration for multiple JDBC shards. This is used to build a unified IO
+ * wrapper for a single dependency level.
+ *
+ * <p>To optimize resource usage, callers should ensure that all tables belonging to a specific
+ * logical shard for a given dependency level are included within a single configuration group.
+ * Passing the same shard multiple times across different groups may lead to duplicate {@link
+ * javax.sql.DataSource} instances. At the moment this fits naturally in the flow of pipeline
+ * controller.
+ */
+@AutoValue
+public abstract class JdbcIoWrapperConfigGroup {
+
+  /**
+   * Mapping from shard identifier to its individual JDBC configuration.
+   *
+   * @return A list of {@link JdbcIOWrapperConfig} instances.
+   */
+  public abstract ImmutableList<JdbcIOWrapperConfig> shardConfigs();
+
+  /**
+   * The SQL dialect of the source databases. Expected to be uniform across shards.
+   *
+   * @return The {@link SQLDialect} of the source databases.
+   */
+  public abstract SQLDialect sourceDbDialect();
+
+  /**
+   * Returns a new builder for {@link JdbcIoWrapperConfigGroup}.
+   *
+   * @return A new builder instance.
+   */
+  public static Builder builder() {
+    return new AutoValue_JdbcIoWrapperConfigGroup.Builder();
+  }
+
+  /** Builder for {@link JdbcIoWrapperConfigGroup}. */
+  @AutoValue.Builder
+  public abstract static class Builder {
+    /**
+     * Internal builder for the list of shard configurations.
+     *
+     * @return The shard configurations builder.
+     */
+    abstract ImmutableList.Builder<JdbcIOWrapperConfig> shardConfigsBuilder();
+
+    /**
+     * Adds a single shard configuration to the group.
+     *
+     * <p>This method ensures that the dialect of the added shard matches the dialect of the group.
+     * If the group doesn't have a dialect set yet, it will be automatically set to the shard's
+     * dialect.
+     *
+     * @param config The JDBC configuration for the shard.
+     * @return This builder instance for fluent chaining.
+     * @throws IllegalArgumentException if the shard's dialect doesn't match the group's dialect.
+     */
+    public Builder addShardConfig(JdbcIOWrapperConfig config) {
+      if (!this.sourceDbDialect().isPresent()) {
+        this.setSourceDbDialect(config.sourceDbDialect());
+      } else {
+        Preconditions.checkArgument(
+            this.sourceDbDialect().get().equals(config.sourceDbDialect()),
+            "Migrating mixed SourceDB Dialects is not supported");
+      }
+      shardConfigsBuilder().add(config);
+      return this;
+    }
+
+    /**
+     * Sets multiple shard configurations at once.
+     *
+     * @param shardConfigs A list of shard configurations.
+     * @return This builder instance for fluent chaining.
+     */
+    public Builder setShardConfigs(ImmutableList<JdbcIOWrapperConfig> shardConfigs) {
+      shardConfigs.forEach(this::addShardConfig);
+      return this;
+    }
+
+    /**
+     * Internal optional for checking the currently set dialect.
+     *
+     * @return An optional containing the SQL dialect.
+     */
+    @Nullable
+    abstract Optional<SQLDialect> sourceDbDialect();
+
+    /**
+     * Explicitly sets the SQL dialect for the configuration group.
+     *
+     * @param sourceDbDialect The SQL dialect to set.
+     * @return This builder instance.
+     */
+    public abstract Builder setSourceDbDialect(SQLDialect sourceDbDialect);
+
+    /**
+     * Builds the {@link JdbcIoWrapperConfigGroup} instance.
+     *
+     * @return The built configuration group.
+     */
+    public abstract JdbcIoWrapperConfigGroup build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/DataSourceProvider.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/DataSourceProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter;
+
+import com.google.common.collect.ImmutableSet;
+import java.io.Serializable;
+import javax.sql.DataSource;
+
+/**
+ * Interface for providing {@link DataSource} instances based on a shard identifier. This enables
+ * dynamic routing of queries in a multi-shard environment.
+ */
+public interface DataSourceProvider extends Serializable {
+  /**
+   * Returns a {@link DataSource} for the given identifier.
+   *
+   * @param datasourceId The unique ID of the physical shard.
+   * @return The DataSource for the shard.
+   * @throws IllegalArgumentException if no DataSource is found for the given ID.
+   */
+  DataSource getDataSource(String datasourceId);
+
+  /**
+   * Returns a set of all DataSource identifiers managed by this provider.
+   *
+   * @return An immutable set of DataSource IDs.
+   */
+  ImmutableSet<String> getDataSourceIds();
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/DataSourceProviderImpl.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/DataSourceProviderImpl.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.display.DisplayData;
+import org.apache.beam.sdk.transforms.display.HasDisplayData;
+
+/**
+ * Concrete implementation of {@link DataSourceProvider} using {@link AutoValue}. It stores a
+ * mapping of shard IDs to serializable DataSource provider functions.
+ */
+@AutoValue
+public abstract class DataSourceProviderImpl implements DataSourceProvider, HasDisplayData {
+
+  /**
+   * Returns a mapping of shard identifiers to their corresponding serializable {@link DataSource}
+   * provider functions.
+   *
+   * @return The immutable map of providers.
+   */
+  public abstract ImmutableMap<String, SerializableFunction<Void, DataSource>> providers();
+
+  /**
+   * Returns a new builder for {@link DataSourceProviderImpl}.
+   *
+   * @return A new builder instance.
+   */
+  public static Builder builder() {
+    return new AutoValue_DataSourceProviderImpl.Builder();
+  }
+
+  /**
+   * Returns a {@link DataSource} for the given identifier.
+   *
+   * @param datasourceId The unique ID of the physical shard.
+   * @return The DataSource for the shard.
+   * @throws IllegalArgumentException if no provider is found for the given ID.
+   */
+  @Override
+  public DataSource getDataSource(String datasourceId) {
+    SerializableFunction<Void, DataSource> provider = providers().get(datasourceId);
+    if (provider == null) {
+      throw new IllegalArgumentException("Unknown datasourceId: " + datasourceId);
+    }
+    return provider.apply(null);
+  }
+
+  /**
+   * Returns a set of all DataSource identifiers managed by this provider.
+   *
+   * @return An immutable set of DataSource IDs.
+   */
+  @Override
+  public ImmutableSet<String> getDataSourceIds() {
+    return ImmutableSet.copyOf(providers().keySet());
+  }
+
+  /**
+   * Populates display data with information about each configured data source.
+   *
+   * @param builder The display data builder.
+   */
+  @Override
+  public void populateDisplayData(DisplayData.Builder builder) {
+    for (Map.Entry<String, SerializableFunction<Void, DataSource>> entry : providers().entrySet()) {
+      if (entry.getValue() instanceof HasDisplayData) {
+        builder.include("dataSource-" + entry.getKey(), (HasDisplayData) entry.getValue());
+      }
+    }
+  }
+
+  /** Builder for {@link DataSourceProviderImpl}. */
+  @AutoValue.Builder
+  public abstract static class Builder {
+    /**
+     * Internal builder for the providers map.
+     *
+     * @return The providers builder.
+     */
+    abstract ImmutableMap.Builder<String, SerializableFunction<Void, DataSource>>
+        providersBuilder();
+
+    /**
+     * Adds a DataSource provider with a specific identifier.
+     *
+     * @param datasourceId The unique ID for this physical shard.
+     * @param provider The serializable function to provide the DataSource.
+     * @return This builder instance for fluent chaining.
+     * @throws IllegalArgumentException if the datasourceId has already been added.
+     */
+    public Builder addDataSource(
+        String datasourceId, SerializableFunction<Void, DataSource> provider) {
+      providersBuilder().put(datasourceId, provider);
+      return this;
+    }
+
+    /**
+     * Builds the {@link DataSourceProviderImpl} instance.
+     *
+     * @return The built instance.
+     */
+    public abstract DataSourceProviderImpl build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/DataSourceManager.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/DataSourceManager.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import java.io.Serializable;
+import javax.sql.DataSource;
+
+/**
+ * Interface for managing the lifecycle of {@link DataSource} instances within a Dataflow worker.
+ *
+ * <p>In a multi-shard migration, a single worker may need to interact with multiple physical
+ * shards. This interface provides a centralized mechanism for:
+ *
+ * <ul>
+ *   <li>On-demand initialization of {@link DataSource}s.
+ *   <li>Caching of initialized instances to avoid redundant connection pool creation.
+ *   <li>Coordinated shutdown of all active data sources during worker teardown.
+ * </ul>
+ */
+public interface DataSourceManager extends Serializable {
+
+  /**
+   * Returns a {@link DataSource} for the specified identifier.
+   *
+   * <p>If the data source for the given ID has not been initialized yet, it will be created using
+   * the configured provider and cached for subsequent calls.
+   *
+   * @param dataSourceId The unique identifier for the physical data source.
+   * @return The initialized {@link DataSource} instance.
+   */
+  DataSource getDatasource(String dataSourceId);
+
+  /**
+   * Closes all active data source connections and releases associated resources.
+   *
+   * <p>This method should be called during the teardown phase of a Dataflow bundle or worker to
+   * ensure that connection pools are gracefully shut down and no leaks occur.
+   */
+  void closeAll();
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/DataSourceManagerImpl.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/DataSourceManagerImpl.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProvider;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Concrete implementation of {@link DataSourceManager} using {@link AutoValue}.
+ *
+ * <p>This class is responsible for the thread-safe initialization and caching of {@link DataSource}
+ * instances within a Dataflow worker. By using a {@link DataSourceProvider}, it can dynamically
+ * create connections to different physical shards as needed by the pipeline's processing logic.
+ *
+ * <p><b>Note on Future Enhancements for Multi-Shard Connectivity (MySQL & PostgreSQL):</b>
+ *
+ * <p>Currently, this implementation provides a baseline for managing multiple data sources. For
+ * large-scale migrations involving hundreds or thousands of physical shards, the following
+ * enhancements should be considered to optimize connectivity for MySQL and PostgreSQL:
+ *
+ * <ul>
+ *   <li><b>Per-Physical Shard Connection Pooling:</b> Instead of a single shared pool or raw
+ *       connections, the manager should be enhanced to maintain dedicated, properly sized
+ *       connection pools for each distinct physical database instance. This prevents "noisy
+ *       neighbor" scenarios where one slow shard exhausts the connection capacity for others.
+ *   <li><b>Dialect-Specific Optimization:</b> Future iterations should allow for injecting
+ *       dialect-specific connection properties. For example, MySQL might benefit from specific
+ *       buffer sizes or SSL configurations, while PostgreSQL might require specific search paths or
+ *       statement timeouts.
+ *   <li><b>Global Connection Throttling:</b> To avoid overwhelming a single physical database
+ *       instance when a Dataflow job scales to hundreds of workers, a mechanism for global
+ *       (cross-worker) connection throttling or a centralized connection proxy (like Cloud SQL Auth
+ *       Proxy or a custom middle tier) could be integrated into the lookup logic.
+ *   <li><b>Dynamic Resource Rebalancing:</b> If some shards are significantly more active than
+ *       others, the manager could implement a policy to dynamically shrink idle pools and expand
+ *       active ones, respecting the total connection limit of the worker and the source DB.
+ * </ul>
+ */
+@AutoValue
+public abstract class DataSourceManagerImpl implements DataSourceManager {
+  /**
+   * Returns the provider used to create new {@link DataSource} instances.
+   *
+   * @return The data source provider.
+   */
+  public abstract DataSourceProvider dataSourceProvider();
+
+  // DataSources are instance-local and handled per-bundle for thread safety.
+  // These fields are transient as they are not meant to be serialized; they are re-initialized
+  // or checked for nullity during the worker's bundle lifecycle.
+  private final transient Map<String, DataSource> dataSources = new ConcurrentHashMap<>();
+  private final transient Lock dataSourceLock = new ReentrantLock();
+  private static final Logger LOG = LoggerFactory.getLogger(DataSourceManagerImpl.class);
+
+  /**
+   * Initializes the Datasource if needed and returns it.
+   *
+   * <p>This implementation ensures that only one {@link DataSource} is created per shard ID even in
+   * a multi-threaded execution environment within the worker. It uses double-checked locking
+   * pattern with {@link #dataSourceLock}.
+   *
+   * @param dataSourceId reference to the datasource.
+   * @return The initialized {@link DataSource} for the shard.
+   */
+  @Override
+  public DataSource getDatasource(String dataSourceId) {
+
+    DataSource dataSource = this.dataSources.get(dataSourceId);
+    if (dataSource == null) {
+      // Note: dataSourceLock is transient. If this manager is used in a context
+      // where it was serialized, re-initialization logic would be required.
+      // Currently, it is expected to be used within a single worker's bundle lifecycle.
+      dataSourceLock.lock();
+      try {
+        dataSource = this.dataSources.get(dataSourceId);
+        if (dataSource == null) {
+          dataSource = dataSourceProvider().getDataSource(dataSourceId);
+          this.dataSources.put(dataSourceId, dataSource);
+        }
+      } finally {
+        dataSourceLock.unlock();
+      }
+    }
+    return dataSource;
+  }
+
+  /**
+   * Closes all the active connection during teardown.
+   *
+   * <p>Iterates through all cached {@link DataSource} instances. If a data source implements {@link
+   * Closeable}, it will be closed gracefully. Errors during closure are logged but not re-thrown to
+   * avoid interrupting the teardown process.
+   *
+   * <p>Robustness: This method checks for nullity of {@code dataSourceLock} to safely handle cases
+   * where it might be called on a deserialized instance.
+   */
+  @Override
+  public void closeAll() {
+    if (dataSourceLock == null) {
+      return;
+    }
+    dataSourceLock.lock();
+    try {
+      for (var entry : dataSources.entrySet()) {
+        DataSource dataSource = entry.getValue();
+        if (dataSource instanceof Closeable) {
+          try {
+            ((Closeable) dataSource).close();
+          } catch (IOException e) {
+            LOG.warn("Failed to close DataSource {}", entry.getKey(), e);
+          }
+        }
+      }
+      dataSources.clear();
+    } finally {
+      dataSourceLock.unlock();
+    }
+  }
+
+  /**
+   * Returns a new builder for {@link DataSourceManagerImpl}.
+   *
+   * @return A new builder instance.
+   */
+  public static Builder builder() {
+    return new AutoValue_DataSourceManagerImpl.Builder();
+  }
+
+  /** Builder for {@link DataSourceManagerImpl}. */
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    /**
+     * Sets the {@link DataSourceProvider} for the manager.
+     *
+     * @param value The provider to set.
+     * @return This builder instance.
+     */
+    public abstract Builder setDataSourceProvider(DataSourceProvider value);
+
+    /**
+     * Builds the {@link DataSourceManagerImpl} instance.
+     *
+     * @return The built instance.
+     */
+    public abstract DataSourceManagerImpl build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/JdbcIoWrapperConfigGroupTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/JdbcIoWrapperConfigGroupTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link JdbcIoWrapperConfigGroup}. */
+@RunWith(JUnit4.class)
+public class JdbcIoWrapperConfigGroupTest {
+
+  /**
+   * Tests that the builder correctly initializes the group and that equality and hashing work as
+   * expected.
+   */
+  @Test
+  public void testBuilderAndEquality() {
+    JdbcIOWrapperConfig mockConfig1 = mock(JdbcIOWrapperConfig.class);
+    JdbcIOWrapperConfig mockConfig2 = mock(JdbcIOWrapperConfig.class);
+    when(mockConfig1.sourceDbDialect()).thenReturn(SQLDialect.MYSQL);
+    when(mockConfig2.sourceDbDialect()).thenReturn(SQLDialect.MYSQL);
+
+    JdbcIoWrapperConfigGroup group1 =
+        JdbcIoWrapperConfigGroup.builder()
+            .setSourceDbDialect(SQLDialect.MYSQL)
+            .setShardConfigs(ImmutableList.of(mockConfig1, mockConfig2))
+            .build();
+
+    JdbcIoWrapperConfigGroup group2 =
+        JdbcIoWrapperConfigGroup.builder()
+            .setSourceDbDialect(SQLDialect.MYSQL)
+            .setShardConfigs(ImmutableList.of(mockConfig1, mockConfig2))
+            .build();
+
+    assertThat(group1).isEqualTo(group2);
+    assertThat(group1.hashCode()).isEqualTo(group2.hashCode());
+    assertThat(group1.shardConfigs()).hasSize(2);
+    assertThat(group1.sourceDbDialect()).isEqualTo(SQLDialect.MYSQL);
+  }
+
+  /**
+   * Tests that attempting to create a group with mixed SQL dialects throws an {@link
+   * IllegalArgumentException}.
+   */
+  @Test
+  public void testMixedDialectMigrationsNotSupported() {
+    JdbcIOWrapperConfig mockConfig1 = mock(JdbcIOWrapperConfig.class);
+    JdbcIOWrapperConfig mockConfig2 = mock(JdbcIOWrapperConfig.class);
+    when(mockConfig1.sourceDbDialect()).thenReturn(SQLDialect.MYSQL);
+    when(mockConfig2.sourceDbDialect()).thenReturn(SQLDialect.POSTGRESQL);
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            JdbcIoWrapperConfigGroup.builder()
+                .addShardConfig(mockConfig1)
+                .addShardConfig(mockConfig2)
+                .build());
+  }
+
+  /**
+   * Tests that the dialect is automatically set based on the first shard configuration added to the
+   * builder.
+   */
+  @Test
+  public void testAddShardConfig_dialectAutoSet() {
+    JdbcIOWrapperConfig mockConfig = mock(JdbcIOWrapperConfig.class);
+    JdbcIoWrapperConfigGroup.Builder builder = JdbcIoWrapperConfigGroup.builder();
+
+    when(mockConfig.sourceDbDialect()).thenReturn(SQLDialect.POSTGRESQL);
+    builder.setSourceDbDialect(SQLDialect.POSTGRESQL).addShardConfig(mockConfig);
+
+    JdbcIoWrapperConfigGroup group = builder.build();
+    assertThat(group.shardConfigs()).containsExactly(mockConfig);
+    assertThat(
+            JdbcIoWrapperConfigGroup.builder().addShardConfig(mockConfig).build().sourceDbDialect())
+        .isEqualTo(SQLDialect.POSTGRESQL);
+  }
+
+  /** Tests that the group can be built with an empty list of shard configurations. */
+  @Test
+  public void testEmptyConfigs() {
+    JdbcIoWrapperConfigGroup group =
+        JdbcIoWrapperConfigGroup.builder()
+            .setShardConfigs(ImmutableList.of())
+            .setSourceDbDialect(SQLDialect.MYSQL)
+            .build();
+
+    assertThat(group.shardConfigs()).isEmpty();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/DataSourceProviderImplTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/DataSourceProviderImplTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.google.common.collect.ImmutableSet;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import javax.sql.DataSource;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.display.DisplayData;
+import org.apache.beam.sdk.transforms.display.HasDisplayData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link DataSourceProviderImpl}. */
+@RunWith(JUnit4.class)
+public class DataSourceProviderImplTest {
+
+  /**
+   * Tests that the provider correctly returns the expected {@link DataSource} instances for valid
+   * identifiers.
+   */
+  @Test
+  public void testGetDataSource_success() {
+    DataSource mockDs1 = mock(DataSource.class);
+    DataSource mockDs2 = mock(DataSource.class);
+
+    SerializableFunction<Void, DataSource> provider1 = _unused -> mockDs1;
+    SerializableFunction<Void, DataSource> provider2 = _unused -> mockDs2;
+
+    DataSourceProviderImpl provider =
+        DataSourceProviderImpl.builder()
+            .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", provider1)
+            .addDataSource("4560d550-7e9d-4129-b5da-3f6468f3a8cf", provider2)
+            .build();
+
+    assertThat(provider.getDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458"))
+        .isSameInstanceAs(mockDs1);
+    assertThat(provider.getDataSource("4560d550-7e9d-4129-b5da-3f6468f3a8cf"))
+        .isSameInstanceAs(mockDs2);
+    assertThat(provider.getDataSourceIds())
+        .isEqualTo(
+            ImmutableSet.of(
+                "b1a1ec3b-195d-4755-b04b-02bc64dc4458", "4560d550-7e9d-4129-b5da-3f6468f3a8cf"));
+  }
+
+  /**
+   * Tests that attempting to retrieve a {@link DataSource} for an unknown identifier throws an
+   * {@link IllegalArgumentException}.
+   */
+  @Test
+  public void testGetDataSource_unknownId_throwsException() {
+    DataSourceProviderImpl provider = DataSourceProviderImpl.builder().build();
+
+    IllegalArgumentException thrown =
+        assertThrows(IllegalArgumentException.class, () -> provider.getDataSource("unknown"));
+    assertThat(thrown).hasMessageThat().contains("Unknown datasourceId: unknown");
+  }
+
+  /**
+   * Tests that the {@link DataSourceProviderImpl} can be correctly serialized and deserialized
+   * while maintaining its functionality.
+   */
+  @Test
+  public void testSerialization() throws Exception {
+    // Need a truly serializable function for this test
+    SerializableFunction<Void, DataSource> serializableProvider = new TestDataSourceProvider();
+
+    DataSourceProviderImpl provider =
+        DataSourceProviderImpl.builder()
+            .addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", serializableProvider)
+            .build();
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(provider);
+    }
+
+    DataSourceProviderImpl deserialized;
+    try (ObjectInputStream ois =
+        new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+      deserialized = (DataSourceProviderImpl) ois.readObject();
+    }
+
+    assertThat(deserialized.getDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458"))
+        .isSameInstanceAs(provider.getDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458"));
+  }
+
+  /** Tests that the builder prevents adding multiple providers for the same shard identifier. */
+  @Test
+  public void testDuplicateDataSourceId_throwsException() {
+    DataSourceProviderImpl.Builder builder = DataSourceProviderImpl.builder();
+    SerializableFunction<Void, DataSource> provider = _unused -> null;
+
+    builder.addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", provider);
+    builder.addDataSource("b1a1ec3b-195d-4755-b04b-02bc64dc4458", provider);
+    assertThrows(IllegalArgumentException.class, () -> builder.build());
+  }
+
+  /** A simple serializable provider for testing. */
+  private static class TestDataSourceProvider
+      implements SerializableFunction<Void, DataSource>, Serializable {
+    @Override
+    public DataSource apply(Void input) {
+      return null;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof TestDataSourceProvider;
+    }
+
+    @Override
+    public int hashCode() {
+      return TestDataSourceProvider.class.hashCode();
+    }
+  }
+
+  /** Tests that display data is correctly populated from the configured providers. */
+  @Test
+  public void testPopulateDisplayData() {
+    TestDataSourceProviderWithDisplayData providerWithDisplayData =
+        new TestDataSourceProviderWithDisplayData();
+    DataSourceProviderImpl provider =
+        DataSourceProviderImpl.builder()
+            .addDataSource("shard1", providerWithDisplayData)
+            .addDataSource("shard2", new TestDataSourceProvider())
+            .build();
+
+    DisplayData displayData = DisplayData.from(provider);
+    java.util.Collection<DisplayData.Item> items = displayData.items();
+
+    assertThat(
+            items.stream()
+                .anyMatch(
+                    i ->
+                        "testKey".equals(i.getKey())
+                            && "testValue".equals(i.getValue())
+                            && i.getPath().toString().contains("dataSource-shard1")))
+        .isTrue();
+  }
+
+  /** A simple serializable provider with display data for testing. */
+  private static class TestDataSourceProviderWithDisplayData
+      implements SerializableFunction<Void, DataSource>, Serializable, HasDisplayData {
+    @Override
+    public DataSource apply(Void input) {
+      return null;
+    }
+
+    @Override
+    public void populateDisplayData(DisplayData.Builder builder) {
+      builder.add(DisplayData.item("testKey", "testValue"));
+    }
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/DataSourceManagerImplTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/DataSourceManagerImplTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.DataSourceProvider;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import javax.sql.DataSource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link DataSourceManagerImpl}. */
+@RunWith(JUnit4.class)
+public class DataSourceManagerImplTest {
+
+  private DataSourceProvider mockProvider;
+  private DataSource mockDataSource;
+
+  @Before
+  public void setUp() {
+    mockProvider = mock(DataSourceProvider.class);
+    mockDataSource = mock(DataSource.class);
+  }
+
+  /**
+   * Tests that {@link DataSourceManagerImpl#getDatasource} correctly initializes a new data source
+   * on the first call and returns the cached instance on subsequent calls.
+   */
+  @Test
+  public void testGetDatasource_initializesAndCaches() {
+    DataSourceManagerImpl manager =
+        DataSourceManagerImpl.builder().setDataSourceProvider(mockProvider).build();
+    when(mockProvider.getDataSource("ds1")).thenReturn(mockDataSource);
+
+    // First call should call provider
+    DataSource ds1 = manager.getDatasource("ds1");
+    assertThat(ds1).isSameInstanceAs(mockDataSource);
+    verify(mockProvider, times(1)).getDataSource("ds1");
+
+    // Second call should return cached instance
+    DataSource ds2 = manager.getDatasource("ds1");
+    assertThat(ds2).isSameInstanceAs(mockDataSource);
+    verify(mockProvider, times(1)).getDataSource("ds1");
+  }
+
+  /**
+   * Tests that {@link DataSourceManagerImpl#closeAll} correctly identifies and closes all {@link
+   * Closeable} data sources managed by the instance.
+   *
+   * <p>Note: We use a custom interface {@link CloseableDataSource} and verify the {@code close()}
+   * call explicitly. While Mockito could be used more extensively, this manual verification with
+   * mocks ensures that the implementation correctly handles the {@link Closeable} contract.
+   */
+  @Test
+  public void testCloseAll_closesCloseableDataSources() throws IOException {
+    DataSourceManagerImpl manager =
+        DataSourceManagerImpl.builder().setDataSourceProvider(mockProvider).build();
+    CloseableDataSource mockCloseableDs = mock(CloseableDataSource.class);
+    DataSource mockNonCloseableDs = mock(DataSource.class);
+
+    when(mockProvider.getDataSource("ds1")).thenReturn(mockCloseableDs);
+    when(mockProvider.getDataSource("ds2")).thenReturn(mockNonCloseableDs);
+
+    manager.getDatasource("ds1");
+    manager.getDatasource("ds2");
+
+    manager.closeAll();
+
+    verify(mockCloseableDs, times(1)).close();
+    // Non-closeable should not cause issues (nothing to verify really, just that it doesn't crash)
+  }
+
+  /**
+   * Tests that {@link DataSourceManagerImpl#closeAll} gracefully handles {@link IOException}s
+   * thrown during the closure of a data source.
+   */
+  @Test
+  public void testCloseAll_handlesIOException() throws IOException {
+    DataSourceManagerImpl manager =
+        DataSourceManagerImpl.builder().setDataSourceProvider(mockProvider).build();
+    CloseableDataSource mockCloseableDs = mock(CloseableDataSource.class);
+
+    when(mockProvider.getDataSource("ds1")).thenReturn(mockCloseableDs);
+    doThrow(new IOException("Test exception")).when(mockCloseableDs).close();
+
+    manager.getDatasource("ds1");
+
+    // Should not throw exception
+    manager.closeAll();
+
+    verify(mockCloseableDs, times(1)).close();
+  }
+
+  /**
+   * Tests the behavior of {@link DataSourceManagerImpl} after serialization and deserialization,
+   * specifically verifying that transient fields are correctly handled.
+   */
+  @Test
+  public void testSerialization_transientFieldsBecomeNull() throws Exception {
+    // We need a serializable provider for this test
+    SerializableDataSourceProvider serializableProvider = new SerializableDataSourceProvider();
+    DataSourceManagerImpl manager =
+        DataSourceManagerImpl.builder().setDataSourceProvider(serializableProvider).build();
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(manager);
+    }
+
+    DataSourceManagerImpl deserialized;
+    try (ObjectInputStream ois =
+        new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+      deserialized = (DataSourceManagerImpl) ois.readObject();
+    }
+
+    // closeAll should handle null transient fields gracefully
+    deserialized.closeAll();
+
+    // getDatasource is expected to fail with NPE if transient fields are null and not
+    // re-initialized
+    assertThrows(NullPointerException.class, () -> deserialized.getDatasource("any"));
+  }
+
+  /**
+   * Tests that {@link DataSourceManagerImpl#getDatasource} is thread-safe and ensures only one data
+   * source is created even when accessed concurrently by multiple threads.
+   */
+  @Test
+  public void testGetDatasource_concurrency() throws InterruptedException {
+    DataSourceManagerImpl manager =
+        DataSourceManagerImpl.builder().setDataSourceProvider(mockProvider).build();
+    when(mockProvider.getDataSource(anyString())).thenReturn(mockDataSource);
+
+    int numThreads = 10;
+    Thread[] threads = new Thread[numThreads];
+    for (int i = 0; i < numThreads; i++) {
+      threads[i] = new Thread(() -> manager.getDatasource("ds1"));
+      threads[i].start();
+    }
+
+    for (int i = 0; i < numThreads; i++) {
+      threads[i].join();
+    }
+
+    // Provider should be called only once even with multiple threads
+    verify(mockProvider, times(1)).getDataSource("ds1");
+  }
+
+  /** Interface for mocking a Closeable DataSource. */
+  private interface CloseableDataSource extends DataSource, Closeable {}
+
+  /** A serializable provider for testing serialization. */
+  private static class SerializableDataSourceProvider implements DataSourceProvider, Serializable {
+    @Override
+    public DataSource getDataSource(String dataSourceId) {
+      return null;
+    }
+
+    @Override
+    public com.google.common.collect.ImmutableSet<String> getDataSourceIds() {
+      return com.google.common.collect.ImmutableSet.of();
+    }
+  }
+}


### PR DESCRIPTION
#  Foundations for Multi-Shard Routing (POJOs)
This is the first child of #3684 

## Design Decision
This PR introduces the foundational data models and services required to support multi-shard JDBC migrations. 

### Key Components:
- **`JdbcIoWrapperConfigGroup`**: A container that aggregates multiple `JdbcIOWrapperConfig` instances. It ensures that all shards in a group share a uniform `SQLDialect`, simplifying downstream transform logic.
- **`DataSourceProvider` Interface**: Defines the contract for worker-side connection routing.
- **`DataSourceManager` / `DataSourceManagerImpl`**: A centralized service for managing and caching connection sources across multiple physical shards.

### Rationale:
To achieve a constant graph size, we must move connection details from pipeline construction time (PTransform fields) to element processing time (DoFn logic). These POJOs provide the structure for this dynamic routing.

---

## Why it's Safe (Concurrency & Resource Leaks)
- **Thread-Safe Caching**: `DataSourceManagerImpl` implements a thread-safe cache for `DataSource` instances using `ReentrantLock` and a double-checked locking pattern. This ensures that even when multiple Beam bundles execute concurrently on the same worker, each physical shard connection pool is initialized exactly once.
- **Resource Management**: The `DataSourceManager` provides a `closeAll()` method. This is specifically designed to be called during `DoFn.teardown()` or `finishBundle()` to ensure that all opened connection pools are gracefully released, preventing resource leaks on Dataflow workers.
- **Serialization Robustness**: Fields within `DataSourceManagerImpl` are marked `transient` where appropriate, and the class includes null-safety checks to handle lifecycle transitions in the Dataflow environment.

## Testing
The added tests verify:
- Correct aggregation of shard configurations.
- Thread-safe lazy initialization of data sources.
- Proper handling of unknown shard IDs.
