### PR TITLE
Changes in Reader Interface to support multi-shard reader

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/Reader.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/Reader.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.source.reader;
 
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchema;
 import com.google.cloud.teleport.v2.source.reader.io.transform.ReaderTransform;
+import com.google.common.collect.ImmutableList;
 
 /**
  * The Reader interfaces with the source-db allowing the pipeline to read from various data sources
@@ -62,7 +63,17 @@ import com.google.cloud.teleport.v2.source.reader.io.transform.ReaderTransform;
  * </ol>
  */
 public interface Reader {
-  SourceSchema getSourceSchema();
+  /**
+   * Returns the schemas discovered from the source database(s).
+   *
+   * @return A list of {@link SourceSchema} objects representing the structure of the sources.
+   */
+  ImmutableList<SourceSchema> getSourceSchema();
 
+  /**
+   * Returns the reader transform to be applied to the pipeline.
+   *
+   * @return The {@link ReaderTransform} for reading data.
+   */
   ReaderTransform getReaderTransform();
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/ReaderImpl.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/ReaderImpl.java
@@ -19,17 +19,18 @@ import com.google.auto.value.AutoValue;
 import com.google.cloud.teleport.v2.source.reader.io.IoWrapper;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchema;
 import com.google.cloud.teleport.v2.source.reader.io.transform.ReaderTransform;
+import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 
 @AutoValue
 public abstract class ReaderImpl implements Reader, Serializable {
 
-  abstract SourceSchema sourceSchema();
+  abstract ImmutableList<SourceSchema> sourceSchema();
 
   abstract ReaderTransform readerTransform();
 
   public static ReaderImpl of(IoWrapper ioWrapper) {
-    SourceSchema sourceSchema = ioWrapper.discoverTableSchema();
+    ImmutableList<SourceSchema> sourceSchema = ioWrapper.discoverTableSchema();
     ReaderTransform.Builder readerTransformBuilder = ReaderTransform.builder();
     ioWrapper
         .getTableReaders()
@@ -40,7 +41,7 @@ public abstract class ReaderImpl implements Reader, Serializable {
   }
 
   @Override
-  public SourceSchema getSourceSchema() {
+  public ImmutableList<SourceSchema> getSourceSchema() {
     return this.sourceSchema();
   }
 
@@ -49,7 +50,8 @@ public abstract class ReaderImpl implements Reader, Serializable {
     return this.readerTransform();
   }
 
-  static ReaderImpl create(SourceSchema sourceSchema, ReaderTransform readerTransform) {
+  static ReaderImpl create(
+      ImmutableList<SourceSchema> sourceSchema, ReaderTransform readerTransform) {
     return new AutoValue_ReaderImpl(sourceSchema, readerTransform);
   }
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/IoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/IoWrapper.java
@@ -28,9 +28,28 @@ import org.apache.beam.sdk.values.PCollection;
 public interface IoWrapper {
 
   /** Get a list of reader transforms. */
+  /**
+   * Returns a mapping of table reference groups to their corresponding reader transforms.
+   *
+   * <p>For legacy single-table reads, the list will contain a single {@link SourceTableReference}.
+   * For optimized multi-table reads, the list will contain all table references handled by that
+   * specific transform.
+   *
+   * <p>Note: The {@link SourceRow} generics are handled by the caller. Ensure that the PCollection
+   * produced by the transform is compatible with the expected pipeline schema to avoid type erasure
+   * issues in Beam.
+   *
+   * @return A map where the key is a list of tables and the value is the transform to read them.
+   */
   ImmutableMap<ImmutableList<SourceTableReference>, PTransform<PBegin, PCollection<SourceRow>>>
       getTableReaders();
 
-  /** Discover source schema. */
-  SourceSchema discoverTableSchema();
+  /**
+   * Discover source schema.
+   *
+   * @return List of discovered schemas for all the passed sources. For single shard migration the
+   *     returned list will contain a single element. Note that datasources like Cassandra support
+   *     only single shard migration.
+   */
+  ImmutableList<SourceSchema> discoverTableSchema();
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIoWrapper.java
@@ -84,7 +84,7 @@ public final class CassandraIoWrapper implements IoWrapper {
 
   /** Discover source schema for Cassandra. */
   @Override
-  public SourceSchema discoverTableSchema() {
-    return sourceSchema;
+  public ImmutableList<SourceSchema> discoverTableSchema() {
+    return ImmutableList.of(sourceSchema);
   }
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
@@ -68,7 +68,7 @@ public final class JdbcIoWrapper implements IoWrapper {
   private final ImmutableMap<
           ImmutableList<SourceTableReference>, PTransform<PBegin, PCollection<SourceRow>>>
       tableReaders;
-  private final SourceSchema sourceSchema;
+  private final ImmutableList<SourceSchema> sourceSchema;
 
   private static final Logger logger = LoggerFactory.getLogger(JdbcIoWrapper.class);
 
@@ -97,7 +97,7 @@ public final class JdbcIoWrapper implements IoWrapper {
     ImmutableMap<ImmutableList<SourceTableReference>, PTransform<PBegin, PCollection<SourceRow>>>
         tableReaders =
             buildTableReaders(config, tableConfigs, dataSourceConfiguration, sourceSchema);
-    return new JdbcIoWrapper(tableReaders, sourceSchema);
+    return new JdbcIoWrapper(tableReaders, ImmutableList.of(sourceSchema));
   }
 
   /**
@@ -172,7 +172,7 @@ public final class JdbcIoWrapper implements IoWrapper {
    * @return SourceSchema.
    */
   @Override
-  public SourceSchema discoverTableSchema() {
+  public ImmutableList<SourceSchema> discoverTableSchema() {
     return this.sourceSchema;
   }
 
@@ -599,7 +599,7 @@ public final class JdbcIoWrapper implements IoWrapper {
   private JdbcIoWrapper(
       ImmutableMap<ImmutableList<SourceTableReference>, PTransform<PBegin, PCollection<SourceRow>>>
           tableReaders,
-      SourceSchema sourceSchema) {
+      ImmutableList<SourceSchema> sourceSchema) {
     this.tableReaders = tableReaders;
     this.sourceSchema = sourceSchema;
   }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/JdbcIOWrapperConfig.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/JdbcIOWrapperConfig.java
@@ -29,8 +29,10 @@ import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transf
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference.Kind;
 import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedTypeMapper.MapperType;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.UUID;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.Wait.OnSignal;
@@ -266,10 +268,36 @@ public abstract class JdbcIOWrapperConfig {
   @Nullable
   public abstract Integer workerCores();
 
+  /**
+   * Returns a unique identifier for this configuration instance.
+   *
+   * @return The configuration ID.
+   */
+  public abstract String id();
+
   public abstract Builder toBuilder();
 
+  /**
+   * Returns a new builder for {@link JdbcIOWrapperConfig}.
+   *
+   * @return A new builder instance with a generated ID.
+   */
+  public static Builder builder() {
+    return new AutoValue_JdbcIOWrapperConfig.Builder().setId(generateId());
+  }
+
+  /**
+   * Generates a unique identifier for a configuration.
+   *
+   * @return A random UUID string.
+   */
+  @VisibleForTesting
+  public static String generateId() {
+    return UUID.randomUUID().toString();
+  }
+
   public static Builder builderWithMySqlDefaults() {
-    return new AutoValue_JdbcIOWrapperConfig.Builder()
+    return builder()
         .setSourceDbDialect(SQLDialect.MYSQL)
         .setSchemaMapperType(MySqlConfigDefaults.DEFAULT_MYSQL_SCHEMA_MAPPER_TYPE)
         .setDialectAdapter(MySqlConfigDefaults.DEFAULT_MYSQL_DIALECT_ADAPTER)
@@ -299,7 +327,7 @@ public abstract class JdbcIOWrapperConfig {
   }
 
   public static Builder builderWithPostgreSQLDefaults() {
-    return new AutoValue_JdbcIOWrapperConfig.Builder()
+    return builder()
         .setSourceDbDialect(SQLDialect.POSTGRESQL)
         .setSchemaMapperType(PostgreSQLConfigDefaults.DEFAULT_POSTGRESQL_SCHEMA_MAPPER_TYPE)
         .setDialectAdapter(PostgreSQLConfigDefaults.DEFAULT_POSTGRESQL_DIALECT_ADAPTER)
@@ -404,6 +432,8 @@ public abstract class JdbcIOWrapperConfig {
     public abstract Builder setWorkerMemoryBytes(Long value);
 
     public abstract Builder setWorkerCores(Integer value);
+
+    public abstract Builder setId(String value);
 
     public abstract JdbcIOWrapperConfig autoBuild();
 

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/FakeReader.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/FakeReader.java
@@ -20,6 +20,7 @@ import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchema;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.transform.ReaderTransform;
 import com.google.cloud.teleport.v2.source.reader.io.transform.ReaderTransformTestUtils;
+import com.google.common.collect.ImmutableList;
 
 /** Fake Implementation of {@link Reader} interface. */
 public class FakeReader implements Reader {
@@ -41,12 +42,12 @@ public class FakeReader implements Reader {
   }
 
   @Override
-  public SourceSchema getSourceSchema() {
+  public ImmutableList<SourceSchema> getSourceSchema() {
     var builder = SourceSchema.builder().setSchemaReference(this.sourceSchemaReference);
     this.readerTransformTestUtils
         .getTestTableSchemas()
         .forEach(tableSchema -> builder.addTableSchema(tableSchema));
-    return builder.build();
+    return ImmutableList.of(builder.build());
   }
 
   @Override

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperFactoryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIOWrapperFactoryTest.java
@@ -146,7 +146,7 @@ public class CassandraIOWrapperFactoryTest {
         CassandraIOWrapperFactory.fromPipelineOptions(mockOptions);
     assertThat(cassandraIOWrapperFactory.gcsConfigPath()).isEqualTo(testConfigPath);
     assertThat(cassandraIOWrapperFactory.getIOWrapper(TABLES_TO_READ, null).discoverTableSchema())
-        .isEqualTo(mockSourceSchema);
+        .isEqualTo(ImmutableList.of(mockSourceSchema));
     assertThat(cassandraIOWrapperFactory.cassandraDialect()).isEqualTo(CassandraDialect.OSS);
     assertThat(cassandraIOWrapperFactory.astraDBKeyspace()).isEqualTo("");
     assertThat(cassandraIOWrapperFactory.astraDBRegion()).isEqualTo("");

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIoWrapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/cassandra/iowrapper/CassandraIoWrapperTest.java
@@ -159,7 +159,8 @@ public class CassandraIoWrapperTest {
               "",
               "",
               "");
-      assertThat(cassandraIoWrapper.discoverTableSchema()).isEqualTo(mockSourceSchema);
+      assertThat(cassandraIoWrapper.discoverTableSchema())
+          .isEqualTo(ImmutableList.of(mockSourceSchema));
       assertThat(cassandraIoWrapper.getTableReaders()).isEqualTo(mockTableReaders);
 
       CassandraIoWrapper cassandraIoWrapperAstra =
@@ -172,7 +173,8 @@ public class CassandraIoWrapperTest {
               astraDataSource.cassandra().astra().databaseId(),
               astraDataSource.cassandra().astra().keySpace(),
               astraDataSource.cassandra().astra().astraDbRegion());
-      assertThat(cassandraIoWrapperAstra.discoverTableSchema()).isEqualTo(mockSourceSchema);
+      assertThat(cassandraIoWrapperAstra.discoverTableSchema())
+          .isEqualTo(ImmutableList.of(mockSourceSchema));
       assertThat(cassandraIoWrapperAstra.getTableReaders()).isEqualTo(mockTableReaders);
     }
   }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
@@ -119,7 +119,7 @@ public class JdbcIoWrapperTest {
                 .setJdbcDriverClassName("org.apache.derby.jdbc.EmbeddedDriver")
                 .setDialectAdapter(mockDialectAdapter)
                 .build());
-    SourceSchema sourceSchema = jdbcIoWrapper.discoverTableSchema();
+    SourceSchema sourceSchema = jdbcIoWrapper.discoverTableSchema().get(0);
     assertThat(sourceSchema.schemaReference()).isEqualTo(testSourceSchemaReference);
     assertThat(sourceSchema.tableSchemas().size()).isEqualTo(1);
     SourceTableSchema tableSchema = sourceSchema.tableSchemas().get(0);
@@ -171,7 +171,7 @@ public class JdbcIoWrapperTest {
                 .setJdbcDriverClassName("org.apache.derby.jdbc.EmbeddedDriver")
                 .setDialectAdapter(mockDialectAdapter)
                 .build());
-    SourceSchema sourceSchema = jdbcIoWrapper.discoverTableSchema();
+    SourceSchema sourceSchema = jdbcIoWrapper.discoverTableSchema().get(0);
     assertThat(sourceSchema.schemaReference()).isEqualTo(testSourceSchemaReference);
     assertThat(sourceSchema.tableSchemas().size()).isEqualTo(1);
     SourceTableSchema tableSchema = sourceSchema.tableSchemas().get(0);
@@ -707,5 +707,10 @@ public class JdbcIoWrapperTest {
   public void testIdentifierEscaping() {
     assertThat(JdbcIoWrapper.delimitIdentifier("key")).isEqualTo("\"key\"");
     assertThat(JdbcIoWrapper.delimitIdentifier("ke\"y")).isEqualTo("\"ke\"\"y\"");
+  }
+
+  @Test
+  public void testIdGeneration() {
+    assertThat(JdbcIOWrapperConfig.generateId()).isNotEqualTo(JdbcIOWrapperConfig.generateId());
   }
 }


### PR DESCRIPTION
# Core Interface Refactor for Multi-Transform Routing.

This is the second child PR of #3684 

## Design Decision
This PR refactors the core `Reader` and `IoWrapper` interfaces to support mapping groups of tables to specific reader transforms. 

### Key Changes:
- **`IoWrapper.getTableReaders()`**: Refactored to return an `ImmutableMap<ImmutableList<SourceTableReference>, PTransform<PBegin, PCollection<SourceRow>>>`. 
- **Mapping Logic**: Instead of a simple list of transforms, the wrapper now explicitly states which tables are handled by which transform. This is essential for the `PipelineController` to correctly iterate and apply constant-size multi-table transforms.

### Rationale:
In a multi-shard world, we need a way for the IO layer (e.g., `JdbcIoWrapper`) to signal to the orchestration layer (e.g., `PipelineController`) that a set of tables from multiple shards can be efficiently processed by a single, consolidated transform. This interface change enables that signaling.

---

## Why it's Safe (Generics & Backward Compatibility)
- **Generics Preservation**: The `SourceRow` generics are strictly enforced in the new map structure. This prevents type erasure issues that can occur in Beam pipelines when processing heterogeneous data streams.
- **Minimal Surface Change**: While the method signature changed, the underlying data models for `SourceTableReference` and `SourceRow` remain backward compatible with existing single-source logic.
- **Cassandra Compatibility**: The `CassandraIoWrapper` implementation was updated to return a single-entry map, maintaining its existing behavior while complying with the new interface.

---


The added tests confirm that the map-based return type is correctly populated and that table-to-transform routing is accurate.
