### PR TITLE
Graph size multi shard table identifier

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapper.java
@@ -311,11 +311,13 @@ public final class JdbcIoWrapper implements IoWrapper {
     return tableConfigsBuilder.build();
   }
 
-  private static TableConfig getTableConfig(
+  @VisibleForTesting
+  protected static TableConfig getTableConfig(
       String tableName,
       JdbcIOWrapperConfig config,
       ImmutableMap<String, ImmutableList<SourceColumnIndexInfo>> indexInfo) {
-    TableConfig.Builder tableConfigBuilder = TableConfig.builder(tableName);
+    TableConfig.Builder tableConfigBuilder =
+        TableConfig.builder(tableName).setDataSourceId(config.id());
     if (config.maxPartitions() != null && config.maxPartitions() != 0) {
       tableConfigBuilder.setMaxPartitions(config.maxPartitions());
     }
@@ -508,10 +510,7 @@ public final class JdbcIoWrapper implements IoWrapper {
     for (TableConfig tableConfig : tableConfigs) {
       SourceTableSchema sourceTableSchema = findSourceTableSchema(sourceSchema, tableConfig);
       int fetchSize = getFetchSize(config, tableConfig, sourceTableSchema);
-      TableIdentifier tableIdentifier =
-          TableIdentifier.builder()
-              .setTableName(delimitIdentifier(tableConfig.tableName()))
-              .build();
+      TableIdentifier tableIdentifier = getTableIdentifier(tableConfig);
 
       TableSplitSpecification.Builder tableSplitSpecificationBuilder =
           TableSplitSpecification.builder()
@@ -571,6 +570,16 @@ public final class JdbcIoWrapper implements IoWrapper {
         config);
 
     return ImmutableMap.of(tableReferencesBuilder.build(), readWithUniformPartitions);
+  }
+
+  @VisibleForTesting
+  protected static TableIdentifier getTableIdentifier(TableConfig tableConfig) {
+    TableIdentifier tableIdentifier =
+        TableIdentifier.builder()
+            .setTableName(delimitIdentifier(tableConfig.tableName()))
+            .setDataSourceId(tableConfig.dataSourceId())
+            .build();
+    return tableIdentifier;
   }
 
   /**

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/TableConfig.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/TableConfig.java
@@ -44,6 +44,9 @@ public abstract class TableConfig {
   @Nullable
   public abstract Integer fetchSize();
 
+  /** Datasource ID for reading this table. */
+  public abstract String dataSourceId();
+
   public static Builder builder(String tableName) {
     return new AutoValue_TableConfig.Builder()
         .setTableName(tableName)
@@ -64,6 +67,8 @@ public abstract class TableConfig {
     public abstract Builder setApproxRowCount(Long value);
 
     public abstract Builder setFetchSize(Integer value);
+
+    public abstract Builder setDataSourceId(String value);
 
     public Builder withPartitionColum(PartitionColumn column) {
       this.partitionColumnsBuilder().add(column);

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/TableIdentifier.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/TableIdentifier.java
@@ -29,8 +29,8 @@ public abstract class TableIdentifier implements Serializable, Comparable<TableI
 
   public abstract String tableName();
 
-  // Future extension:
-  // public abstract String databaseIdentifier();
+  /** Datasource ID for reading this table. */
+  public abstract String dataSourceId();
 
   public static Builder builder() {
     return new AutoValue_TableIdentifier.Builder();
@@ -38,12 +38,15 @@ public abstract class TableIdentifier implements Serializable, Comparable<TableI
 
   @Override
   public int compareTo(TableIdentifier other) {
-    return this.tableName().compareTo(other.tableName());
+    int c = this.dataSourceId().compareTo(other.dataSourceId());
+    return (c != 0) ? c : this.tableName().compareTo(other.tableName());
   }
 
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder setTableName(String value);
+
+    public abstract Builder setDataSourceId(String value);
 
     public abstract TableIdentifier build();
   }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/FetchSizeCalculatorTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/FetchSizeCalculatorTest.java
@@ -30,7 +30,11 @@ public final class FetchSizeCalculatorTest {
 
   @Before
   public void setUp() {
-    tableConfig = TableConfig.builder("t1").setApproxRowCount(100L).build();
+    tableConfig =
+        TableConfig.builder("t1")
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setApproxRowCount(100L)
+            .build();
   }
 
   @Test
@@ -43,7 +47,11 @@ public final class FetchSizeCalculatorTest {
   @Test
   public void testGetFetchSize_ExplicitFetchSize() {
     // Test when fetch size is explicitly configured in TableConfig.
-    TableConfig configWithFetchSize = TableConfig.builder("t1").setFetchSize(12345).build();
+    TableConfig configWithFetchSize =
+        TableConfig.builder("t1")
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setFetchSize(12345)
+            .build();
     int fetchSize = FetchSizeCalculator.getFetchSize(configWithFetchSize, 100L, null, null);
     assertEquals(12345, fetchSize);
   }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/JdbcIoWrapperTest.java
@@ -33,6 +33,8 @@ import com.google.cloud.teleport.v2.source.reader.io.jdbc.JdbcSchemaReference;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.dialectadapter.DialectAdapter;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.JdbcIOWrapperConfig;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.SQLDialect;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.TableConfig;
+import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.range.TableIdentifier;
 import com.google.cloud.teleport.v2.source.reader.io.jdbc.uniformsplitter.transforms.ReadWithUniformPartitions;
 import com.google.cloud.teleport.v2.source.reader.io.row.SourceRow;
 import com.google.cloud.teleport.v2.source.reader.io.schema.SourceColumnIndexInfo;
@@ -712,5 +714,64 @@ public class JdbcIoWrapperTest {
   @Test
   public void testIdGeneration() {
     assertThat(JdbcIOWrapperConfig.generateId()).isNotEqualTo(JdbcIOWrapperConfig.generateId());
+  }
+
+  @Test
+  public void testGetTableConfig() {
+
+    SourceSchemaReference testSourceSchemaReference =
+        SourceSchemaReference.ofJdbc(JdbcSchemaReference.builder().setDbName("testDB").build());
+
+    JdbcIOWrapperConfig config =
+        JdbcIOWrapperConfig.builderWithMySqlDefaults()
+            .setSourceDbURL("jdbc:derby://myhost/memory:TestingDB;create=true")
+            .setSourceSchemaReference(testSourceSchemaReference)
+            .setShardID("test")
+            .setTableVsPartitionColumns(ImmutableMap.of("testTable", ImmutableList.of("id")))
+            .setDbAuth(
+                LocalCredentialsProvider.builder()
+                    .setUserName("testUser")
+                    .setPassword("testPassword")
+                    .build())
+            .setMaxPartitions(10)
+            .setMaxFetchSize(1000)
+            .setJdbcDriverJars("")
+            .setJdbcDriverClassName("org.apache.derby.jdbc.EmbeddedDriver")
+            .setDialectAdapter(mockDialectAdapter)
+            .build();
+    String tableName = "testTable";
+    SourceColumnIndexInfo indexInfo =
+        SourceColumnIndexInfo.builder()
+            .setColumnName("id")
+            .setIndexType(IndexType.NUMERIC)
+            .setIndexName("PRIMARY")
+            .setIsPrimary(true)
+            .setCardinality(100L)
+            .setIsUnique(true)
+            .setOrdinalPosition(1)
+            .build();
+    ImmutableMap<String, ImmutableList<SourceColumnIndexInfo>> indexInfoMap =
+        ImmutableMap.of(tableName, ImmutableList.of(indexInfo));
+
+    TableConfig tableConfig = JdbcIoWrapper.getTableConfig(tableName, config, indexInfoMap);
+
+    assertThat(tableConfig.tableName()).isEqualTo(tableName);
+    assertThat(tableConfig.dataSourceId()).isEqualTo(config.id());
+    assertThat(tableConfig.approxRowCount()).isEqualTo(100L);
+    assertThat(tableConfig.maxPartitions()).isEqualTo(10);
+    assertThat(tableConfig.fetchSize()).isEqualTo(1000);
+    assertThat(tableConfig.partitionColumns()).hasSize(1);
+    assertThat(tableConfig.partitionColumns().get(0).columnName()).isEqualTo("\"id\"");
+  }
+
+  @Test
+  public void testGetTableIdentifier() {
+    TableConfig tableConfig =
+        TableConfig.builder("testTable").setDataSourceId("testDataSource").build();
+
+    TableIdentifier tableIdentifier = JdbcIoWrapper.getTableIdentifier(tableConfig);
+
+    assertThat(tableIdentifier.tableName()).isEqualTo("\"testTable\"");
+    assertThat(tableIdentifier.dataSourceId()).isEqualTo("testDataSource");
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/TableConfigTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/iowrapper/config/TableConfigTest.java
@@ -36,6 +36,7 @@ public class TableConfigTest {
         TableConfig.builder(testTable)
             .withPartitionColum(partitionColumn)
             .setApproxRowCount(42L)
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
             .build();
     assertThat(tableConfig.tableName()).isEqualTo(testTable);
     assertThat(tableConfig.maxPartitions()).isNull();
@@ -52,6 +53,7 @@ public class TableConfigTest {
 
     TableConfig tableConfig =
         TableConfig.builder(testTable)
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
             .withPartitionColum(partitionColumn)
             .setMaxPartitions(maxPartitions)
             .setApproxRowCount(42L)

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/ColumnForBoundaryQueryPreparedStatementSetterTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/ColumnForBoundaryQueryPreparedStatementSetterTest.java
@@ -101,7 +101,10 @@ public class ColumnForBoundaryQueryPreparedStatementSetterTest {
   @Test
   public void testSetParameters_withNullParentRange() throws Exception {
     TableIdentifier testTableIdentifier =
-        TableIdentifier.builder().setTableName("test_table_column_boundary").build();
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("test_table_column_boundary")
+            .build();
     TableSplitSpecification tableSplitSpec =
         TableSplitSpecification.builder()
             .setTableIdentifier(testTableIdentifier)
@@ -139,7 +142,10 @@ public class ColumnForBoundaryQueryPreparedStatementSetterTest {
   @Test
   public void testSetParameters_withSingleLevelParentRange() throws Exception {
     TableIdentifier testTableIdentifier =
-        TableIdentifier.builder().setTableName("test_table_column_boundary").build();
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("test_table_column_boundary")
+            .build();
     TableSplitSpecification tableSplitSpec =
         TableSplitSpecification.builder()
             .setTableIdentifier(testTableIdentifier)
@@ -196,7 +202,10 @@ public class ColumnForBoundaryQueryPreparedStatementSetterTest {
   @Test
   public void testSetParameters_withMultiLevelParentRange() throws Exception {
     TableIdentifier testTableIdentifier =
-        TableIdentifier.builder().setTableName("test_table_column_boundary").build();
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("test_table_column_boundary")
+            .build();
     TableSplitSpecification tableSplitSpec =
         TableSplitSpecification.builder()
             .setTableIdentifier(testTableIdentifier)
@@ -273,7 +282,10 @@ public class ColumnForBoundaryQueryPreparedStatementSetterTest {
   @Test
   public void testSetParameters_withSingleLevelParentRange_mockRange() throws Exception {
     TableIdentifier testTableIdentifier =
-        TableIdentifier.builder().setTableName("testTable").build();
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("testTable")
+            .build();
     TableSplitSpecification tableSplitSpec =
         TableSplitSpecification.builder()
             .setTableIdentifier(testTableIdentifier)
@@ -330,7 +342,10 @@ public class ColumnForBoundaryQueryPreparedStatementSetterTest {
   @Test
   public void testSetParameters_withMultiLevelParentRange_mockRange() throws Exception {
     TableIdentifier testTableIdentifier =
-        TableIdentifier.builder().setTableName("testTable").build();
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("testTable")
+            .build();
     TableSplitSpecification tableSplitSpec =
         TableSplitSpecification.builder()
             .setTableIdentifier(testTableIdentifier)
@@ -405,7 +420,10 @@ public class ColumnForBoundaryQueryPreparedStatementSetterTest {
   @Test
   public void testSetParameters_withDbIntegration() throws Exception {
     TableIdentifier tableId =
-        TableIdentifier.builder().setTableName("test_table_column_boundary").build();
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("test_table_column_boundary")
+            .build();
     ColumnForBoundaryQueryPreparedStatementSetter setter =
         new ColumnForBoundaryQueryPreparedStatementSetter(
             ImmutableList.of(
@@ -480,7 +498,10 @@ public class ColumnForBoundaryQueryPreparedStatementSetterTest {
   @Test
   public void testSetParameters_withDbIntegration_literalSql() throws Exception {
     TableIdentifier testTableIdentifier =
-        TableIdentifier.builder().setTableName("test_table_column_boundary").build();
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("test_table_column_boundary")
+            .build();
     TableSplitSpecification tableSplitSpec =
         TableSplitSpecification.builder()
             .setTableIdentifier(testTableIdentifier)

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/ColumnForBoundaryQueryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/columnboundary/ColumnForBoundaryQueryTest.java
@@ -31,7 +31,11 @@ public class ColumnForBoundaryQueryTest {
   public void testColumnForBoundaryQuery() {
     Range parentRange =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
             .setColName("col1")
             .setColClass(Integer.class)
@@ -40,13 +44,21 @@ public class ColumnForBoundaryQueryTest {
             .build();
     ColumnForBoundaryQuery columnForBoundaryQueryWithDefaults =
         ColumnForBoundaryQuery.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColumnName("col1")
             .setColumnClass(Integer.class)
             .build();
     ColumnForBoundaryQuery columnForBoundaryQueryRange =
         ColumnForBoundaryQuery.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColumnName("col2")
             .setColumnClass(Integer.class)
             .setParentRange(parentRange)

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryExtractorFactoryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryExtractorFactoryTest.java
@@ -64,7 +64,10 @@ public class BoundaryExtractorFactoryTest {
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
 
     assertThat(boundary.tableIdentifier().tableName()).isEqualTo("testTable");
     assertThat(boundary.start()).isEqualTo(0L);
@@ -81,7 +84,10 @@ public class BoundaryExtractorFactoryTest {
                     .build(),
                 mockResultSet,
                 null,
-                TableIdentifier.builder().setTableName("testTable").build()));
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build()));
   }
 
   @Test
@@ -97,7 +103,10 @@ public class BoundaryExtractorFactoryTest {
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
 
     assertThat(boundary.tableIdentifier().tableName()).isEqualTo("testTable");
     assertThat(boundary.start()).isEqualTo(0);
@@ -111,7 +120,10 @@ public class BoundaryExtractorFactoryTest {
                 PartitionColumn.builder().setColumnName("col1").setColumnClass(Long.class).build(),
                 mockResultSet,
                 null,
-                TableIdentifier.builder().setTableName("testTable").build()));
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build()));
   }
 
   @Test
@@ -137,13 +149,19 @@ public class BoundaryExtractorFactoryTest {
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
     Boundary<BigDecimal> boundaryNull =
         extractor.getBoundary(
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
 
     assertThat(boundaryMinMax.tableIdentifier().tableName()).isEqualTo("testTable");
     assertThat(boundaryMinMax.start()).isEqualTo(new BigDecimal(BigInteger.ZERO));
@@ -161,7 +179,10 @@ public class BoundaryExtractorFactoryTest {
                 PartitionColumn.builder().setColumnName("col1").setColumnClass(long.class).build(),
                 mockResultSet,
                 null,
-                TableIdentifier.builder().setTableName("testTable").build()));
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build()));
   }
 
   @Test
@@ -184,7 +205,10 @@ public class BoundaryExtractorFactoryTest {
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
     assertThat(boundary1.start()).isEqualTo(new BigDecimal("1.1"));
     assertThat(boundary1.end()).isEqualTo(new BigDecimal("1.2"));
     assertThat(boundary1.split(null).getLeft().end()).isEqualTo(new BigDecimal("1.15"));
@@ -200,7 +224,10 @@ public class BoundaryExtractorFactoryTest {
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
     assertThat(boundary2.isSplittable(null)).isFalse();
 
     // Mismatched Type
@@ -211,7 +238,10 @@ public class BoundaryExtractorFactoryTest {
                 PartitionColumn.builder().setColumnName("col1").setColumnClass(Long.class).build(),
                 mockResultSet,
                 null,
-                TableIdentifier.builder().setTableName("testTable").build()));
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build()));
   }
 
   @Test
@@ -232,7 +262,10 @@ public class BoundaryExtractorFactoryTest {
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
 
     assertThat(boundary.tableIdentifier().tableName()).isEqualTo("testTable");
     assertThat(boundary.start()).isNull();
@@ -285,7 +318,10 @@ public class BoundaryExtractorFactoryTest {
                 return null;
               }
             },
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
 
     assertThat(boundary.tableIdentifier().tableName()).isEqualTo("testTable");
     assertThat(boundary.start()).isEqualTo("cloud");
@@ -299,7 +335,10 @@ public class BoundaryExtractorFactoryTest {
                 partitionColumn,
                 mockResultSet,
                 null,
-                TableIdentifier.builder().setTableName("testTable").build()));
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build()));
     // Mismatched Type
     assertThrows(
         IllegalArgumentException.class,
@@ -311,7 +350,10 @@ public class BoundaryExtractorFactoryTest {
                     .build(),
                 mockResultSet,
                 null,
-                TableIdentifier.builder().setTableName("testTable").build()));
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build()));
   }
 
   @Test
@@ -328,13 +370,19 @@ public class BoundaryExtractorFactoryTest {
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
     Boundary<byte[]> boundaryNull =
         extractor.getBoundary(
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
 
     assertThat(boundaryMinMax.tableIdentifier().tableName()).isEqualTo("testTable");
     assertThat(boundaryMinMax.start()).isEqualTo(BigInteger.ZERO.toByteArray());
@@ -352,7 +400,10 @@ public class BoundaryExtractorFactoryTest {
                 PartitionColumn.builder().setColumnName("col1").setColumnClass(long.class).build(),
                 mockResultSet,
                 null,
-                TableIdentifier.builder().setTableName("testTable").build()));
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build()));
   }
 
   @Test
@@ -371,7 +422,10 @@ public class BoundaryExtractorFactoryTest {
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
     assertThat(boundary.tableIdentifier().tableName()).isEqualTo("testTable");
     assertThat(boundary.start()).isEqualTo(start);
     assertThat(boundary.end()).isEqualTo(end);
@@ -395,7 +449,10 @@ public class BoundaryExtractorFactoryTest {
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
 
     assertThat(boundary.tableIdentifier().tableName()).isEqualTo("testTable");
     assertThat(boundary.start()).isNull();
@@ -406,7 +463,10 @@ public class BoundaryExtractorFactoryTest {
   @Test
   public void testFromDurationWithAdapter() throws SQLException {
     TableIdentifier testTabelIdentifier =
-        TableIdentifier.builder().setTableName("testTabe").build();
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("testTabe")
+            .build();
     PartitionColumn partitionColumn =
         PartitionColumn.builder()
             .setColumnName("col1")
@@ -449,7 +509,10 @@ public class BoundaryExtractorFactoryTest {
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
     assertThat(boundary.start()).isEqualTo(start);
     assertThat(boundary.end()).isEqualTo(end);
     Pair<Boundary<Date>, Boundary<Date>> split = boundary.split(null);
@@ -472,7 +535,10 @@ public class BoundaryExtractorFactoryTest {
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
 
     assertThat(boundary.start()).isNull();
     assertThat(boundary.end()).isNull();
@@ -498,7 +564,10 @@ public class BoundaryExtractorFactoryTest {
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
     // The diff is > minimum delta, boundary is splittable
     assertThat(boundary1.start()).isEqualTo(1.001f);
     assertThat(boundary1.end()).isEqualTo(1.002f);
@@ -515,7 +584,10 @@ public class BoundaryExtractorFactoryTest {
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
     // The diff is < minimum delta, boundary is NOT splittable
     assertThat(boundary2.isSplittable(null)).isFalse();
 
@@ -527,7 +599,10 @@ public class BoundaryExtractorFactoryTest {
                 PartitionColumn.builder().setColumnName("col1").setColumnClass(Long.class).build(),
                 mockResultSet,
                 null,
-                TableIdentifier.builder().setTableName("testTable").build()));
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build()));
   }
 
   @Test
@@ -549,7 +624,10 @@ public class BoundaryExtractorFactoryTest {
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
     // The diff is > minimum delta, boundary is splittable
     assertThat(boundary1.start()).isEqualTo(1.001);
     assertThat(boundary1.end()).isEqualTo(1.002);
@@ -566,7 +644,10 @@ public class BoundaryExtractorFactoryTest {
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
     // The diff is < minimum delta, boundary is NOT splittable
     assertThat(boundary2.isSplittable(null)).isFalse();
 
@@ -578,7 +659,10 @@ public class BoundaryExtractorFactoryTest {
                 PartitionColumn.builder().setColumnName("col1").setColumnClass(Long.class).build(),
                 mockResultSet,
                 null,
-                TableIdentifier.builder().setTableName("testTable").build()));
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build()));
   }
 
   @Test
@@ -603,7 +687,10 @@ public class BoundaryExtractorFactoryTest {
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
     assertThat(boundary.start()).isEqualTo(start);
     assertThat(boundary.end()).isEqualTo(end);
     Pair<Boundary<Duration>, Boundary<Duration>> split = boundary.split(null);
@@ -620,7 +707,10 @@ public class BoundaryExtractorFactoryTest {
                 PartitionColumn.builder().setColumnName("col1").setColumnClass(long.class).build(),
                 mockResultSet,
                 null,
-                TableIdentifier.builder().setTableName("testTable").build()));
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build()));
   }
 
   @Test
@@ -640,7 +730,10 @@ public class BoundaryExtractorFactoryTest {
             partitionColumn,
             mockResultSet,
             null,
-            TableIdentifier.builder().setTableName("testTable").build());
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName("testTable")
+                .build());
 
     assertThat(boundary.start()).isNull();
     assertThat(boundary.end()).isNull();

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/BoundaryTest.java
@@ -41,7 +41,11 @@ public class BoundaryTest {
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
             .setNumericScale(0)
             .setDatetimePrecision(2)
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .build();
     assertThat(boundary.start()).isEqualTo(0);
     assertThat(boundary.end()).isEqualTo(42);
@@ -53,7 +57,11 @@ public class BoundaryTest {
     assertThat(boundary)
         .isNotEqualTo(
             boundary.toBuilder()
-                .setTableIdentifier(TableIdentifier.builder().setTableName("otherTable").build())
+                .setTableIdentifier(
+                    TableIdentifier.builder()
+                        .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                        .setTableName("otherTable")
+                        .build())
                 .build());
   }
 
@@ -69,7 +77,11 @@ public class BoundaryTest {
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
             .setNumericScale(null)
             .setDatetimePrecision(null)
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .build();
 
     Boundary<Integer> boundaryNullBoth =
@@ -79,7 +91,11 @@ public class BoundaryTest {
             .setStart(null)
             .setEnd(null)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .build();
 
     assertThat(boundaryNullStart.start()).isNull();
@@ -103,7 +119,11 @@ public class BoundaryTest {
             .setEnd(42)
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .build();
     Boundary stringBoundary =
         Boundary.<String>builder()
@@ -121,7 +141,11 @@ public class BoundaryTest {
                     .setPadSpace(true)
                     .build())
             .setStringMaxLength(255)
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .build();
 
     assertThat(integerBoundary.isSplittable(null)).isTrue();
@@ -157,7 +181,11 @@ public class BoundaryTest {
             .setEnd(20)
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .build();
 
     Boundary<Integer> secondBoundary =
@@ -168,7 +196,11 @@ public class BoundaryTest {
             .setEnd(42)
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .build();
 
     Boundary<Integer> mergedBoundary =
@@ -179,7 +211,11 @@ public class BoundaryTest {
             .setEnd(42)
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .build();
     assertThat(firstBoundary.isMergable(secondBoundary)).isTrue();
     assertThat(secondBoundary.isMergable(firstBoundary)).isTrue();
@@ -210,7 +246,11 @@ public class BoundaryTest {
             .setEnd(1.02f)
             .setDecimalStepSize(BigDecimal.valueOf(0.01))
             .setBoundarySplitter(BoundarySplitterFactory.create(Float.class))
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .build();
 
     // float to non-float (double) comparison
@@ -236,7 +276,11 @@ public class BoundaryTest {
             .setEnd(1.02)
             .setDecimalStepSize(BigDecimal.valueOf(0.001))
             .setBoundarySplitter(BoundarySplitterFactory.create(Double.class))
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .build();
 
     // double to non-double (float) comparison
@@ -266,7 +310,11 @@ public class BoundaryTest {
             .setEnd(1.02f)
             .setDecimalStepSize(decimalStepSize)
             .setBoundarySplitter(BoundarySplitterFactory.create(Float.class))
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .build();
 
     Boundary<Float> secondBoundary =
@@ -277,7 +325,11 @@ public class BoundaryTest {
             .setEnd(1.03f)
             .setDecimalStepSize(decimalStepSize)
             .setBoundarySplitter(BoundarySplitterFactory.create(Float.class))
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .build();
 
     Boundary<Float> mergedBoundary =
@@ -288,7 +340,11 @@ public class BoundaryTest {
             .setEnd(1.03f)
             .setDecimalStepSize(decimalStepSize)
             .setBoundarySplitter(BoundarySplitterFactory.create(Float.class))
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .build();
     assertThat(firstBoundary.isMergable(secondBoundary)).isTrue();
     assertThat(secondBoundary.isMergable(firstBoundary)).isTrue();
@@ -318,7 +374,11 @@ public class BoundaryTest {
             .setStart(0)
             .setEnd(32)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .build();
     Pair<Boundary<Integer>, Boundary<Integer>> firstLevelSplit = rootBoundary.split(null);
     Boundary<Integer> firstLevelFirstBoundary = firstLevelSplit.getLeft();
@@ -356,12 +416,20 @@ public class BoundaryTest {
             .setStart(0)
             .setEnd(32)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
-            .setTableIdentifier(TableIdentifier.builder().setTableName("TableA").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("TableA")
+                    .build())
             .build();
 
     Boundary<Integer> boundaryTableB =
         boundaryTableA.toBuilder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("TableB").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("TableB")
+                    .build())
             .build();
 
     Boundary<Integer> boundaryTableACol2 = boundaryTableA.toBuilder().setColName("col2").build();
@@ -385,7 +453,11 @@ public class BoundaryTest {
             .setStart(0)
             .setEnd(42)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .build();
 
     Range parentRange =
@@ -395,7 +467,11 @@ public class BoundaryTest {
             .setStart(42)
             .setEnd(42)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .build();
     Range newRangeWithoutParent = newBoundary.toRange(null, null);
     Range newRangeWithParent = newBoundary.toRange(parentRange, null);
@@ -456,7 +532,11 @@ public class BoundaryTest {
                 .setStart(1)
                 .setEnd(10.30)
                 .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
-                .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                .setTableIdentifier(
+                    TableIdentifier.builder()
+                        .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                        .setTableName("testTable")
+                        .build())
                 .build());
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/RangePreparedStatementSetterTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/RangePreparedStatementSetterTest.java
@@ -108,7 +108,11 @@ public class RangePreparedStatementSetterTest {
   public void testSetParameters_throwsExceptionOnNullElement() throws Exception {
     TableSplitSpecification tableSplitSpecification =
         TableSplitSpecification.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setPartitionColumns(
                 ImmutableList.of(
                     PartitionColumn.builder()
@@ -129,7 +133,11 @@ public class RangePreparedStatementSetterTest {
   public void testSetRangeParameters_throwsOnUnknownTable() throws Exception {
     TableSplitSpecification tableSplitSpecification =
         TableSplitSpecification.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("knownTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("knownTable")
+                    .build())
             .setPartitionColumns(
                 ImmutableList.of(
                     PartitionColumn.builder()
@@ -146,7 +154,11 @@ public class RangePreparedStatementSetterTest {
     Range unknownTableRange =
         Range.<Integer>builder()
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
-            .setTableIdentifier(TableIdentifier.builder().setTableName("unknownTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("unknownTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setStart(10)
@@ -164,7 +176,11 @@ public class RangePreparedStatementSetterTest {
     ImmutableList<String> partitionCols = ImmutableList.of("col1", "col2");
     TableSplitSpecification tableSplitSpecification =
         TableSplitSpecification.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setPartitionColumns(
                 ImmutableList.of(
                     PartitionColumn.builder()

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/RangeTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/RangeTest.java
@@ -33,8 +33,16 @@ public class RangeTest {
     long end = 42L;
     Range range =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
             .setColName("long_col_1")
             .setColClass(Long.class)
@@ -73,8 +81,16 @@ public class RangeTest {
   public void testRangeWithChild() {
     Range basicRange =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
             .setColName("long_col_1")
             .setColClass(Long.class)
@@ -112,8 +128,16 @@ public class RangeTest {
 
     Range rangeBase =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
             .setColName("long_col_base")
             .setColClass(Long.class)
@@ -129,8 +153,16 @@ public class RangeTest {
     long mid = 21L;
     Range rangeChild =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
             .setColName("long_col_child")
             .setColClass(Long.class)
@@ -179,8 +211,16 @@ public class RangeTest {
   public void testAccumulateCount() {
     Range uncountedRange =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
             .setColName("long_col_1")
             .setColClass(Long.class)
@@ -203,7 +243,11 @@ public class RangeTest {
 
     Range rangeBase =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
             .setColName("long_col_base")
             .setColClass(Long.class)
@@ -219,7 +263,11 @@ public class RangeTest {
     long mid = 21L;
     Range leftChild =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
             .setColName("long_col_child")
             .setColClass(Long.class)
@@ -232,7 +280,11 @@ public class RangeTest {
 
     Range rightChild =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
             .setColName("long_col_child")
             .setColClass(Long.class)
@@ -255,7 +307,10 @@ public class RangeTest {
             leftRange.isMergable(
                 rightRange.toBuilder()
                     .setTableIdentifier(
-                        TableIdentifier.builder().setTableName("testTable2").build())
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable2")
+                            .build())
                     .build()))
         .isFalse();
 
@@ -263,14 +318,20 @@ public class RangeTest {
             rightRange.isMergable(
                 leftRange.toBuilder()
                     .setTableIdentifier(
-                        TableIdentifier.builder().setTableName("testTable2").build())
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable2")
+                            .build())
                     .build()))
         .isFalse();
     assertThat(
             leftChild.isMergable(
                 rightChild.toBuilder()
                     .setTableIdentifier(
-                        TableIdentifier.builder().setTableName("testTable2").build())
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable2")
+                            .build())
                     .build()))
         .isFalse();
     // Non-Overlapping ranges are not mergable.
@@ -304,7 +365,11 @@ public class RangeTest {
   public void testRangeEquality() {
     Range basicRange =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
             .setColName("long_col_1")
             .setColClass(Long.class)
@@ -328,7 +393,11 @@ public class RangeTest {
     assertThat(basicRange)
         .isNotEqualTo(
             Range.builder()
-                .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                .setTableIdentifier(
+                    TableIdentifier.builder()
+                        .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                        .setTableName("testTable")
+                        .build())
                 .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
                 .setColName(basicRange.colName())
                 .setColClass(Integer.class)

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/TableIdentifierTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/TableIdentifierTest.java
@@ -27,9 +27,21 @@ public class TableIdentifierTest {
 
   @Test
   public void testTableIdentifierEquality() {
-    TableIdentifier identifier1 = TableIdentifier.builder().setTableName("table1").build();
-    TableIdentifier identifier2 = TableIdentifier.builder().setTableName("table1").build();
-    TableIdentifier identifier3 = TableIdentifier.builder().setTableName("table2").build();
+    TableIdentifier identifier1 =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("table1")
+            .build();
+    TableIdentifier identifier2 =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("table1")
+            .build();
+    TableIdentifier identifier3 =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("table2")
+            .build();
 
     // Test for self-equality and equality with another identical object
     assertThat(identifier1).isEqualTo(identifier1);
@@ -46,12 +58,31 @@ public class TableIdentifierTest {
 
   @Test
   public void testTableIdentifierComparison() {
-    TableIdentifier identifierA = TableIdentifier.builder().setTableName("tableA").build();
-    TableIdentifier identifierB = TableIdentifier.builder().setTableName("tableB").build();
-    TableIdentifier anotherIdentifierA = TableIdentifier.builder().setTableName("tableA").build();
+    TableIdentifier identifierA =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("tableA")
+            .build();
+    TableIdentifier identifierB =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("tableB")
+            .build();
+    TableIdentifier identifierC =
+        TableIdentifier.builder()
+            .setDataSourceId("a1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("tableB")
+            .build();
+    TableIdentifier anotherIdentifierA =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("tableA")
+            .build();
 
     assertThat(identifierA).isEquivalentAccordingToCompareTo(anotherIdentifierA);
     assertThat(identifierA).isLessThan(identifierB);
     assertThat(identifierB).isGreaterThan(identifierA);
+    assertThat(identifierC).isLessThan(identifierA);
+    assertThat(identifierC).isLessThan(identifierB);
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/TableReadSpecificationTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/TableReadSpecificationTest.java
@@ -28,7 +28,11 @@ public class TableReadSpecificationTest {
 
   @Test
   public void testTableReadSpecificationBuilder() {
-    TableIdentifier tableId = TableIdentifier.builder().setTableName("test_table").build();
+    TableIdentifier tableId =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("test_table")
+            .build();
     JdbcIO.RowMapper<String> mockMapper = mock(JdbcIO.RowMapper.class);
 
     TableReadSpecification<String> spec =
@@ -45,7 +49,11 @@ public class TableReadSpecificationTest {
 
   @Test
   public void testTableReadSpecificationDefaultFetchSize() {
-    TableIdentifier tableId = TableIdentifier.builder().setTableName("test_table").build();
+    TableIdentifier tableId =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("test_table")
+            .build();
     JdbcIO.RowMapper<String> mockMapper = mock(JdbcIO.RowMapper.class);
 
     TableReadSpecification<String> spec =

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/TableSplitSpecificationTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/range/TableSplitSpecificationTest.java
@@ -29,7 +29,11 @@ public class TableSplitSpecificationTest {
 
   @Test
   public void testTableSplitSpecificationAutoDerivation() {
-    TableIdentifier tableIdentifier = TableIdentifier.builder().setTableName("test_table").build();
+    TableIdentifier tableIdentifier =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("test_table")
+            .build();
     PartitionColumn partitionColumn =
         PartitionColumn.builder().setColumnName("id").setColumnClass(Long.class).build();
     ImmutableList<PartitionColumn> partitionColumns = ImmutableList.of(partitionColumn);
@@ -56,7 +60,11 @@ public class TableSplitSpecificationTest {
 
   @Test
   public void testTableSplitSpecificationExplicitValues() {
-    TableIdentifier tableIdentifier = TableIdentifier.builder().setTableName("test_table").build();
+    TableIdentifier tableIdentifier =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("test_table")
+            .build();
     PartitionColumn partitionColumn =
         PartitionColumn.builder().setColumnName("id").setColumnClass(Long.class).build();
     ImmutableList<PartitionColumn> partitionColumns = ImmutableList.of(partitionColumn);
@@ -102,7 +110,11 @@ public class TableSplitSpecificationTest {
 
   @Test
   public void testTableSplitSpecificationWithInitialRange() {
-    TableIdentifier tableIdentifier = TableIdentifier.builder().setTableName("test_table").build();
+    TableIdentifier tableIdentifier =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("test_table")
+            .build();
     PartitionColumn col1 =
         PartitionColumn.builder().setColumnName("col1").setColumnClass(Long.class).build();
     PartitionColumn col2 =
@@ -132,8 +144,16 @@ public class TableSplitSpecificationTest {
 
   @Test
   public void testTableSplitSpecificationWithInitialRangeMismatchTable() {
-    TableIdentifier tableIdentifier = TableIdentifier.builder().setTableName("test_table").build();
-    TableIdentifier otherTable = TableIdentifier.builder().setTableName("other_table").build();
+    TableIdentifier tableIdentifier =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("test_table")
+            .build();
+    TableIdentifier otherTable =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("other_table")
+            .build();
     PartitionColumn col1 =
         PartitionColumn.builder().setColumnName("col1").setColumnClass(Long.class).build();
 
@@ -161,7 +181,11 @@ public class TableSplitSpecificationTest {
   @Test
   public void testTableSplitSpecificationWithInitialRangeMismatchColumn() {
 
-    TableIdentifier tableIdentifier = TableIdentifier.builder().setTableName("test_table").build();
+    TableIdentifier tableIdentifier =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("test_table")
+            .build();
 
     PartitionColumn col1 =
         PartitionColumn.builder().setColumnName("col1").setColumnClass(Long.class).build();
@@ -190,7 +214,11 @@ public class TableSplitSpecificationTest {
   @Test
   public void testTableSplitSpecificationWithInitialRangeChildMismatchColumn() {
 
-    TableIdentifier tableIdentifier = TableIdentifier.builder().setTableName("test_table").build();
+    TableIdentifier tableIdentifier =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("test_table")
+            .build();
 
     PartitionColumn col1 =
         PartitionColumn.builder().setColumnName("col1").setColumnClass(Long.class).build();
@@ -232,7 +260,11 @@ public class TableSplitSpecificationTest {
 
   @Test
   public void testTableSplitSpecificationAutoDerivationWithZeroApproxRowCount() {
-    TableIdentifier tableIdentifier = TableIdentifier.builder().setTableName("test_table").build();
+    TableIdentifier tableIdentifier =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("test_table")
+            .build();
     PartitionColumn partitionColumn =
         PartitionColumn.builder().setColumnName("id").setColumnClass(Long.class).build();
     ImmutableList<PartitionColumn> partitionColumns = ImmutableList.of(partitionColumn);

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/AssignSyntheticKeyDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/AssignSyntheticKeyDoFnTest.java
@@ -36,8 +36,16 @@ public class AssignSyntheticKeyDoFnTest {
 
   @Test
   public void testAssignSyntheticKey() {
-    TableIdentifier table1 = TableIdentifier.builder().setTableName("table1").build();
-    TableIdentifier table2 = TableIdentifier.builder().setTableName("table2").build();
+    TableIdentifier table1 =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("table1")
+            .build();
+    TableIdentifier table2 =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("table2")
+            .build();
 
     Range range1 =
         Range.<Long>builder()

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/InitialSplitRangeDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/InitialSplitRangeDoFnTest.java
@@ -44,7 +44,11 @@ public class InitialSplitRangeDoFnTest {
 
   private TableSplitSpecification getTableSplitSpecification(String tableName, long splitHeight) {
     return TableSplitSpecification.builder()
-        .setTableIdentifier(TableIdentifier.builder().setTableName(tableName).build())
+        .setTableIdentifier(
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName(tableName)
+                .build())
         .setPartitionColumns(
             ImmutableList.of(
                 PartitionColumn.builder().setColumnName("col1").setColumnClass(Long.class).build()))
@@ -57,7 +61,11 @@ public class InitialSplitRangeDoFnTest {
 
   private Range getRange(String tableName, long start, long end) {
     return Range.builder()
-        .setTableIdentifier(TableIdentifier.builder().setTableName(tableName).build())
+        .setTableIdentifier(
+            TableIdentifier.builder()
+                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                .setTableName(tableName)
+                .build())
         .setColName("col1")
         .setStart(start)
         .setEnd(end)

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MergeRangesDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MergeRangesDoFnTest.java
@@ -55,7 +55,11 @@ public class MergeRangesDoFnTest {
                 TableSplitSpecification.builder()
                     .setMaxPartitionsHint(2L)
                     .setApproxRowCount(3200L)
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setPartitionColumns(
                         ImmutableList.of(
                             PartitionColumn.builder()
@@ -97,7 +101,11 @@ public class MergeRangesDoFnTest {
                 TableSplitSpecification.builder()
                     .setMaxPartitionsHint(2L)
                     .setApproxRowCount(3200L)
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setPartitionColumns(
                         ImmutableList.of(
                             PartitionColumn.builder()
@@ -142,7 +150,10 @@ public class MergeRangesDoFnTest {
                         .setMaxPartitionsHint(2L)
                         .setApproxRowCount(3200L)
                         .setTableIdentifier(
-                            TableIdentifier.builder().setTableName("testTable").build())
+                            TableIdentifier.builder()
+                                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                                .setTableName("testTable")
+                                .build())
                         .setPartitionColumns(
                             ImmutableList.of(
                                 PartitionColumn.builder()
@@ -156,7 +167,10 @@ public class MergeRangesDoFnTest {
                         .setMaxPartitionsHint(2L)
                         .setApproxRowCount(3200L)
                         .setTableIdentifier(
-                            TableIdentifier.builder().setTableName("testTable2").build())
+                            TableIdentifier.builder()
+                                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                                .setTableName("testTable2")
+                                .build())
                         .setPartitionColumns(
                             ImmutableList.of(
                                 PartitionColumn.builder()
@@ -184,7 +198,10 @@ public class MergeRangesDoFnTest {
                     .setMaxPartitionsHint(2L)
                     .setApproxRowCount(3200L)
                     .setTableIdentifier(
-                        TableIdentifier.builder().setTableName("someOtherTable").build())
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("someOtherTable")
+                            .build())
                     .setPartitionColumns(
                         ImmutableList.of(
                             PartitionColumn.builder()
@@ -211,7 +228,11 @@ public class MergeRangesDoFnTest {
                 TableSplitSpecification.builder()
                     .setMaxPartitionsHint(2L)
                     .setApproxRowCount(3200L)
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setPartitionColumns(
                         ImmutableList.of(
                             PartitionColumn.builder()
@@ -227,7 +248,11 @@ public class MergeRangesDoFnTest {
         ImmutableList.of(
             getDummyRanges(mockProcessContext).get(0),
             getDummyRanges(mockProcessContext).get(0).toBuilder()
-                .setTableIdentifier(TableIdentifier.builder().setTableName("testTable2").build())
+                .setTableIdentifier(
+                    TableIdentifier.builder()
+                        .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                        .setTableName("testTable2")
+                        .build())
                 .build());
     assertThrows(
         RuntimeException.class,
@@ -244,7 +269,11 @@ public class MergeRangesDoFnTest {
                 TableSplitSpecification.builder()
                     .setMaxPartitionsHint(2L)
                     .setApproxRowCount(3200L)
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setPartitionColumns(
                         ImmutableList.of(
                             PartitionColumn.builder()
@@ -262,8 +291,16 @@ public class MergeRangesDoFnTest {
 
   @Test
   public void testMergeRangesForTable_withMismatchedRange_throwsException() {
-    TableIdentifier table1 = TableIdentifier.builder().setTableName("table1").build();
-    TableIdentifier table2 = TableIdentifier.builder().setTableName("table2").build();
+    TableIdentifier table1 =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("table1")
+            .build();
+    TableIdentifier table2 =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("table2")
+            .build();
     MergeRangesDoFn mergeRangesDoFn =
         MergeRangesDoFn.builder()
             .setTableSplitSpecification(
@@ -306,7 +343,11 @@ public class MergeRangesDoFnTest {
     Range testRange =
         dummyCounter(
             Range.builder()
-                .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                .setTableIdentifier(
+                    TableIdentifier.builder()
+                        .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                        .setTableName("testTable")
+                        .build())
                 .setStart(0L)
                 .setEnd(64L)
                 .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MultiTableReadAllTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MultiTableReadAllTest.java
@@ -78,7 +78,11 @@ public class MultiTableReadAllTest {
     SerializableFunction<Void, DataSource> mockProvider = mock(SerializableFunction.class);
     JdbcIO.PreparedStatementSetter<String> mockSetter = mock(JdbcIO.PreparedStatementSetter.class);
     JdbcIO.RowMapper<String> mockMapper = mock(JdbcIO.RowMapper.class);
-    TableIdentifier tableId = TableIdentifier.builder().setTableName("testTable").build();
+    TableIdentifier tableId =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("testTable")
+            .build();
     TableReadSpecification<String> spec =
         TableReadSpecification.<String>builder()
             .setTableIdentifier(tableId)
@@ -138,7 +142,11 @@ public class MultiTableReadAllTest {
 
   @Test
   public void testExpand_withParallelizationAndSchema() {
-    TableIdentifier tableId = TableIdentifier.builder().setTableName("testTable").build();
+    TableIdentifier tableId =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("testTable")
+            .build();
     JdbcIO.RowMapper<String> mockMapper = new StringRowMapper();
     TableReadSpecification<String> spec =
         TableReadSpecification.<String>builder()
@@ -168,7 +176,11 @@ public class MultiTableReadAllTest {
 
   @Test
   public void testExpand_withRegisteredSchema() {
-    TableIdentifier tableId = TableIdentifier.builder().setTableName("testTable").build();
+    TableIdentifier tableId =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("testTable")
+            .build();
     JdbcIO.RowMapper<TestRow> mockMapper = new TestRowMapper();
     TableReadSpecification<TestRow> spec =
         TableReadSpecification.<TestRow>builder()
@@ -206,7 +218,11 @@ public class MultiTableReadAllTest {
 
   @Test
   public void testExpand_coderRegistryException() {
-    TableIdentifier tableId = TableIdentifier.builder().setTableName("testTable").build();
+    TableIdentifier tableId =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("testTable")
+            .build();
     // Use a type that Beam won't have a coder for by default
     JdbcIO.RowMapper<Uncodable> mockMapper = new UncodableRowMapper();
     TableReadSpecification<Uncodable> spec =
@@ -232,7 +248,11 @@ public class MultiTableReadAllTest {
 
   @Test
   public void testInferCoder_manualCoder() {
-    TableIdentifier tableId = TableIdentifier.builder().setTableName("testTable").build();
+    TableIdentifier tableId =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("testTable")
+            .build();
     MultiTableReadAll<String, String> readAll =
         MultiTableReadAll.<String, String>builder()
             .setTableReadSpecifications(ImmutableMap.of())
@@ -248,7 +268,11 @@ public class MultiTableReadAllTest {
 
   @Test
   public void testPopulateDisplayData_withHasDisplayData() {
-    TableIdentifier tableId = TableIdentifier.builder().setTableName("testTable").build();
+    TableIdentifier tableId =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("testTable")
+            .build();
     JdbcIO.RowMapper<String> mockMapper = new StringRowMapper();
     TableReadSpecification<String> spec =
         TableReadSpecification.<String>builder()
@@ -288,7 +312,11 @@ public class MultiTableReadAllTest {
 
   @Test
   public void testPopulateDisplayData() {
-    TableIdentifier tableId = TableIdentifier.builder().setTableName("testTable").build();
+    TableIdentifier tableId =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("testTable")
+            .build();
     JdbcIO.RowMapper<String> mockMapper = new StringRowMapper();
     TableReadSpecification<String> spec =
         TableReadSpecification.<String>builder()
@@ -405,7 +433,11 @@ public class MultiTableReadAllTest {
 
   @Test
   public void testInferCoder() throws CannotProvideCoderException {
-    TableIdentifier tableId = TableIdentifier.builder().setTableName("testTable").build();
+    TableIdentifier tableId =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("testTable")
+            .build();
     JdbcIO.RowMapper<String> mockMapper = new StringRowMapper();
     TableReadSpecification<String> spec =
         TableReadSpecification.<String>builder()

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MultiTableReadFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/MultiTableReadFnTest.java
@@ -178,7 +178,11 @@ public class MultiTableReadFnTest {
             StaticValueProvider.of(new TestQueryProvider()),
             mock(JdbcIO.PreparedStatementSetter.class),
             ImmutableMap.of(),
-            (el) -> TableIdentifier.builder().setTableName("test").build(),
+            (el) ->
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("test")
+                    .build(),
             true);
 
     readFn.setup();
@@ -225,7 +229,11 @@ public class MultiTableReadFnTest {
               StaticValueProvider.of((el) -> "SELECT * FROM schema1.table1"),
               mock(JdbcIO.PreparedStatementSetter.class),
               ImmutableMap.of(),
-              (el) -> TableIdentifier.builder().setTableName("table1").build(),
+              (el) ->
+                  TableIdentifier.builder()
+                      .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                      .setTableName("table1")
+                      .build(),
               false);
       readFn1.setup();
       readFn1.getConnection("el1");
@@ -239,7 +247,11 @@ public class MultiTableReadFnTest {
               StaticValueProvider.of((el) -> "INVALID QUERY"),
               mock(JdbcIO.PreparedStatementSetter.class),
               ImmutableMap.of(),
-              (el) -> TableIdentifier.builder().setTableName("table1").build(),
+              (el) ->
+                  TableIdentifier.builder()
+                      .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                      .setTableName("table1")
+                      .build(),
               false);
       readFn2.setup();
       readFn2.getConnection("el2");
@@ -271,7 +283,11 @@ public class MultiTableReadFnTest {
     when(mockConnection.getMetaData()).thenReturn(mockMetaData);
     when(mockMetaData.getURL()).thenReturn("jdbc:mysql://localhost:3306/testdb");
 
-    TableIdentifier tableId = TableIdentifier.builder().setTableName("testTable").build();
+    TableIdentifier tableId =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("testTable")
+            .build();
     TableReadSpecification<String> spec =
         TableReadSpecification.<String>builder()
             .setTableIdentifier(tableId)
@@ -320,7 +336,11 @@ public class MultiTableReadFnTest {
     when(mockConnection.getMetaData()).thenReturn(mockMetaData);
     when(mockMetaData.getURL()).thenReturn("jdbc:mysql://localhost:3306/testdb");
 
-    TableIdentifier tableId = TableIdentifier.builder().setTableName("testTable").build();
+    TableIdentifier tableId =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("testTable")
+            .build();
     TableReadSpecification<String> spec =
         TableReadSpecification.<String>builder()
             .setTableIdentifier(tableId)
@@ -362,7 +382,11 @@ public class MultiTableReadFnTest {
     when(mockConnection.getMetaData()).thenReturn(mockMetaData);
     when(mockMetaData.getURL()).thenReturn("jdbc:mysql://localhost:3306/testdb");
 
-    TableIdentifier tableId = TableIdentifier.builder().setTableName("testTable").build();
+    TableIdentifier tableId =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("testTable")
+            .build();
     TableReadSpecification<String> spec =
         TableReadSpecification.<String>builder()
             .setTableIdentifier(tableId)
@@ -406,7 +430,11 @@ public class MultiTableReadFnTest {
             StaticValueProvider.of(el -> "SELECT * FROM test"),
             mock(JdbcIO.PreparedStatementSetter.class),
             ImmutableMap.of(),
-            el -> TableIdentifier.builder().setTableName("test").build(),
+            el ->
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("test")
+                    .build(),
             false);
 
     readFn.setup();
@@ -441,7 +469,11 @@ public class MultiTableReadFnTest {
             StaticValueProvider.of(el -> "SELECT * FROM test"),
             mock(JdbcIO.PreparedStatementSetter.class),
             ImmutableMap.of(),
-            el -> TableIdentifier.builder().setTableName("test").build(),
+            el ->
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("test")
+                    .build(),
             false);
 
     readFn.setup();
@@ -460,8 +492,16 @@ public class MultiTableReadFnTest {
   public void testProcessElement_throwsOnMissingSpec() throws Exception {
     SerializableFunction<Void, DataSource> mockProvider = mock(SerializableFunction.class);
     JdbcIO.PreparedStatementSetter<String> mockSetter = mock(JdbcIO.PreparedStatementSetter.class);
-    TableIdentifier knownTable = TableIdentifier.builder().setTableName("knownTable").build();
-    TableIdentifier unknownTable = TableIdentifier.builder().setTableName("unknownTable").build();
+    TableIdentifier knownTable =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("knownTable")
+            .build();
+    TableIdentifier unknownTable =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("unknownTable")
+            .build();
 
     MultiTableReadFn<String, String> readFn =
         new MultiTableReadFn<>(

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/QueryProviderImplTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/QueryProviderImplTest.java
@@ -38,7 +38,11 @@ public class QueryProviderImplTest {
 
   @Test
   public void testGetQuery_success() throws Exception {
-    TableIdentifier knownTable = TableIdentifier.builder().setTableName("knownTable").build();
+    TableIdentifier knownTable =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("knownTable")
+            .build();
     String query = "SELECT * FROM knownTable";
 
     UniformSplitterDBAdapter mockAdapter = mock(UniformSplitterDBAdapter.class);
@@ -77,7 +81,11 @@ public class QueryProviderImplTest {
 
   @Test
   public void testGetQuery_throwsOnUnknownTable() throws Exception {
-    TableIdentifier knownTable = TableIdentifier.builder().setTableName("knownTable").build();
+    TableIdentifier knownTable =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("knownTable")
+            .build();
     UniformSplitterDBAdapter mockAdapter = mock(UniformSplitterDBAdapter.class);
     when(mockAdapter.getReadQuery(eq("knownTable"), any())).thenReturn("SELECT * FROM knownTable");
 
@@ -101,7 +109,11 @@ public class QueryProviderImplTest {
     Range unknownTableRange =
         Range.<Integer>builder()
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
-            .setTableIdentifier(TableIdentifier.builder().setTableName("unknownTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("unknownTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setStart(10)
@@ -114,7 +126,11 @@ public class QueryProviderImplTest {
 
   @Test
   public void testBuilder_setTableSplitSpecifications() {
-    TableIdentifier tableId = TableIdentifier.builder().setTableName("testTable").build();
+    TableIdentifier tableId =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("testTable")
+            .build();
     PartitionColumn col =
         PartitionColumn.builder().setColumnName("col1").setColumnClass(Integer.class).build();
     TableSplitSpecification spec =

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryDoFnTest.java
@@ -86,7 +86,11 @@ public class RangeBoundaryDoFnTest {
             new MysqlDialectAdapter(MySqlVersion.DEFAULT),
             ImmutableList.of(
                 TableSplitSpecification.builder()
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setPartitionColumns(
                         ImmutableList.of(
                             PartitionColumn.builder()
@@ -101,7 +105,11 @@ public class RangeBoundaryDoFnTest {
             null);
     ColumnForBoundaryQuery input =
         ColumnForBoundaryQuery.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColumnClass(Long.class)
             .setColumnName("col1")
             .setParentRange(null)
@@ -114,7 +122,11 @@ public class RangeBoundaryDoFnTest {
     assertThat(newRange)
         .isEqualTo(
             Range.builder()
-                .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                .setTableIdentifier(
+                    TableIdentifier.builder()
+                        .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                        .setTableName("testTable")
+                        .build())
                 .setStart(0L)
                 .setEnd(42L)
                 .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
@@ -139,7 +151,11 @@ public class RangeBoundaryDoFnTest {
             new MysqlDialectAdapter(MySqlVersion.DEFAULT),
             ImmutableList.of(
                 TableSplitSpecification.builder()
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setPartitionColumns(
                         ImmutableList.of(
                             PartitionColumn.builder()
@@ -154,7 +170,11 @@ public class RangeBoundaryDoFnTest {
             null);
     ColumnForBoundaryQuery input =
         ColumnForBoundaryQuery.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColumnClass(Long.class)
             .setColumnName("col1")
             .setParentRange(null)
@@ -185,7 +205,11 @@ public class RangeBoundaryDoFnTest {
             new MysqlDialectAdapter(MySqlVersion.DEFAULT),
             ImmutableList.of(
                 TableSplitSpecification.builder()
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setPartitionColumns(
                         ImmutableList.of(
                             PartitionColumn.builder()
@@ -199,7 +223,10 @@ public class RangeBoundaryDoFnTest {
                     .build(),
                 TableSplitSpecification.builder()
                     .setTableIdentifier(
-                        TableIdentifier.builder().setTableName("testTable2").build())
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable2")
+                            .build())
                     .setPartitionColumns(
                         ImmutableList.of(
                             PartitionColumn.builder()
@@ -214,7 +241,11 @@ public class RangeBoundaryDoFnTest {
             null);
     ColumnForBoundaryQuery input =
         ColumnForBoundaryQuery.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable2").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable2")
+                    .build())
             .setColumnClass(Long.class)
             .setColumnName("col2")
             .setParentRange(null)
@@ -227,7 +258,11 @@ public class RangeBoundaryDoFnTest {
     assertThat(newRange)
         .isEqualTo(
             Range.builder()
-                .setTableIdentifier(TableIdentifier.builder().setTableName("testTable2").build())
+                .setTableIdentifier(
+                    TableIdentifier.builder()
+                        .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                        .setTableName("testTable2")
+                        .build())
                 .setStart(0L)
                 .setEnd(42L)
                 .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryTransformTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeBoundaryTransformTest.java
@@ -63,7 +63,11 @@ public class RangeBoundaryTransformTest {
     ImmutableList<String> partitionCols = ImmutableList.of("col1", "col2");
     TableSplitSpecification tableSplitSpecification =
         TableSplitSpecification.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("RBT_table1").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("RBT_table1")
+                    .build())
             .setPartitionColumns(
                 ImmutableList.of(
                     PartitionColumn.builder()
@@ -83,13 +87,21 @@ public class RangeBoundaryTransformTest {
 
     ColumnForBoundaryQuery firstColumnForBoundaryQuery =
         ColumnForBoundaryQuery.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("RBT_table1").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("RBT_table1")
+                    .build())
             .setColumnName("col1")
             .setColumnClass(Integer.class)
             .build();
     Range fullCol1Range =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("RBT_table1").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("RBT_table1")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -101,7 +113,11 @@ public class RangeBoundaryTransformTest {
 
     Range unSplitableCol1Range =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("RBT_table1").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("RBT_table1")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -112,7 +128,11 @@ public class RangeBoundaryTransformTest {
             .build();
     ColumnForBoundaryQuery secondColumnForBoundaryQuery =
         ColumnForBoundaryQuery.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("RBT_table1").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("RBT_table1")
+                    .build())
             .setColumnName("col2")
             .setColumnClass(Integer.class)
             .setParentRange(unSplitableCol1Range)
@@ -120,7 +140,11 @@ public class RangeBoundaryTransformTest {
     Range col2Range =
         unSplitableCol1Range.withChildRange(
             Range.builder()
-                .setTableIdentifier(TableIdentifier.builder().setTableName("RBT_table1").build())
+                .setTableIdentifier(
+                    TableIdentifier.builder()
+                        .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                        .setTableName("RBT_table1")
+                        .build())
                 .setColName("col2")
                 .setColClass(Integer.class)
                 .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -141,7 +165,10 @@ public class RangeBoundaryTransformTest {
                 ImmutableList.of(
                     TableSplitSpecification.builder()
                         .setTableIdentifier(
-                            TableIdentifier.builder().setTableName("RBT_table1").build())
+                            TableIdentifier.builder()
+                                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                                .setTableName("RBT_table1")
+                                .build())
                         .setPartitionColumns(
                             partitionCols.stream()
                                 .map(
@@ -172,13 +199,21 @@ public class RangeBoundaryTransformTest {
 
     ColumnForBoundaryQuery firstColumnForBoundaryQuery =
         ColumnForBoundaryQuery.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("RBT_table1").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("RBT_table1")
+                    .build())
             .setColumnName("col1")
             .setColumnClass(Integer.class)
             .build();
     Range fullCol1Range =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("RBT_table1").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("RBT_table1")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -190,14 +225,22 @@ public class RangeBoundaryTransformTest {
 
     ColumnForBoundaryQuery secondColumnForBoundaryQuery =
         ColumnForBoundaryQuery.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("RBT_table2").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("RBT_table2")
+                    .build())
             .setColumnName("col1")
             .setColumnClass(Integer.class)
             .setParentRange(null)
             .build();
     Range fullCol3Range =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("RBT_table2").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("RBT_table2")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -217,7 +260,10 @@ public class RangeBoundaryTransformTest {
                 ImmutableList.of(
                     TableSplitSpecification.builder()
                         .setTableIdentifier(
-                            TableIdentifier.builder().setTableName("RBT_table1").build())
+                            TableIdentifier.builder()
+                                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                                .setTableName("RBT_table1")
+                                .build())
                         .setPartitionColumns(
                             partitionCols1.stream()
                                 .map(
@@ -234,7 +280,10 @@ public class RangeBoundaryTransformTest {
                         .build(),
                     TableSplitSpecification.builder()
                         .setTableIdentifier(
-                            TableIdentifier.builder().setTableName("RBT_table2").build())
+                            TableIdentifier.builder()
+                                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                                .setTableName("RBT_table2")
+                                .build())
                         .setPartitionColumns(
                             partitionCols2.stream()
                                 .map(

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeClassifierDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeClassifierDoFnTest.java
@@ -53,7 +53,11 @@ public class RangeClassifierDoFnTest {
         .output(any(), any());
     Range rangeToRetainDueToCount =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -64,7 +68,11 @@ public class RangeClassifierDoFnTest {
             .build();
     Range rangeToSplit =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -75,7 +83,11 @@ public class RangeClassifierDoFnTest {
             .build();
     Range rangeToAddColumn =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -87,7 +99,11 @@ public class RangeClassifierDoFnTest {
 
     Range rangeToRetainUnSplitable =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -97,7 +113,11 @@ public class RangeClassifierDoFnTest {
             .build()
             .withChildRange(
                 Range.builder()
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setColName("col2")
                     .setColClass(Integer.class)
                     .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -110,7 +130,11 @@ public class RangeClassifierDoFnTest {
         RangeClassifierDoFn.builder()
             .setTableSplitSpecification(
                 TableSplitSpecification.builder()
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setInitialSplitHeight(2L)
                     .setSplitStagesCount(2L)
                     .setApproxRowCount(10L)
@@ -147,7 +171,11 @@ public class RangeClassifierDoFnTest {
         .isEqualTo(
             ImmutableList.of(
                 ColumnForBoundaryQuery.builder()
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setColumnName("col2")
                     .setColumnClass(Integer.class)
                     .setParentRange(rangeToAddColumn)
@@ -165,7 +193,11 @@ public class RangeClassifierDoFnTest {
         .output(any(), any());
     Range rangeToRetainDueToCount =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -177,7 +209,11 @@ public class RangeClassifierDoFnTest {
     // Here, the code auto-adjusts to 5 partitions
     Range rangeToRetainAndNotSplit =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -188,7 +224,11 @@ public class RangeClassifierDoFnTest {
             .build();
     Range rangeToRetainNotAddColumn =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -200,7 +240,11 @@ public class RangeClassifierDoFnTest {
 
     Range rangeToRetainUnSplitable =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -210,7 +254,11 @@ public class RangeClassifierDoFnTest {
             .build()
             .withChildRange(
                 Range.builder()
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setColName("col2")
                     .setColClass(Integer.class)
                     .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -223,7 +271,11 @@ public class RangeClassifierDoFnTest {
         RangeClassifierDoFn.builder()
             .setTableSplitSpecification(
                 TableSplitSpecification.builder()
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setInitialSplitHeight(1L)
                     .setSplitStagesCount(2L)
                     .setApproxRowCount(1L)
@@ -269,7 +321,11 @@ public class RangeClassifierDoFnTest {
         .output(any(), any());
     Range rangeToCount =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -281,7 +337,11 @@ public class RangeClassifierDoFnTest {
         RangeClassifierDoFn.builder()
             .setTableSplitSpecification(
                 TableSplitSpecification.builder()
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setInitialSplitHeight(1L)
                     .setSplitStagesCount(1L)
                     .setApproxRowCount(10L)
@@ -325,7 +385,11 @@ public class RangeClassifierDoFnTest {
         .output(any(), any());
     Range rangeToCount =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -339,7 +403,10 @@ public class RangeClassifierDoFnTest {
                 ImmutableList.of(
                     TableSplitSpecification.builder()
                         .setTableIdentifier(
-                            TableIdentifier.builder().setTableName("testTable").build())
+                            TableIdentifier.builder()
+                                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                                .setTableName("testTable")
+                                .build())
                         .setInitialSplitHeight(1L)
                         .setApproxRowCount(10L)
                         .setMaxPartitionsHint(10L)
@@ -353,7 +420,10 @@ public class RangeClassifierDoFnTest {
                         .build(),
                     TableSplitSpecification.builder()
                         .setTableIdentifier(
-                            TableIdentifier.builder().setTableName("testTable2").build())
+                            TableIdentifier.builder()
+                                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                                .setTableName("testTable2")
+                                .build())
                         .setInitialSplitHeight(1L)
                         .setSplitStagesCount(1L)
                         .setApproxRowCount(10L)
@@ -385,7 +455,11 @@ public class RangeClassifierDoFnTest {
   public void testRangeClassifierWithUnknownTableIdentifier() {
     Range rangeToCount =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("unknownTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("unknownTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -396,7 +470,11 @@ public class RangeClassifierDoFnTest {
         RangeClassifierDoFn.builder()
             .setTableSplitSpecification(
                 TableSplitSpecification.builder()
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setInitialSplitHeight(1L)
                     .setSplitStagesCount(1L)
                     .setApproxRowCount(10L)
@@ -424,7 +502,11 @@ public class RangeClassifierDoFnTest {
         RangeClassifierDoFn.builder()
             .setTableSplitSpecification(
                 TableSplitSpecification.builder()
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setInitialSplitHeight(2L)
                     .setApproxRowCount(10L)
                     .setMaxPartitionsHint(10L)
@@ -456,7 +538,11 @@ public class RangeClassifierDoFnTest {
         .output(any(), any());
     Range rangeToAddColumnButNoMoreColumns =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -469,7 +555,11 @@ public class RangeClassifierDoFnTest {
         RangeClassifierDoFn.builder()
             .setTableSplitSpecification(
                 TableSplitSpecification.builder()
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setInitialSplitHeight(1L)
                     .setInitialSplitHeight(2L)
                     .setApproxRowCount(10L)
@@ -530,7 +620,11 @@ public class RangeClassifierDoFnTest {
         .when(mockProcessContext)
         .output(any(), any());
 
-    TableIdentifier table = TableIdentifier.builder().setTableName("testTable").build();
+    TableIdentifier table =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("testTable")
+            .build();
     TableSplitSpecification spec =
         TableSplitSpecification.builder()
             .setTableIdentifier(table)
@@ -589,7 +683,11 @@ public class RangeClassifierDoFnTest {
         .when(mockProcessContext)
         .output(any(), any());
 
-    TableIdentifier table = TableIdentifier.builder().setTableName("testTable").build();
+    TableIdentifier table =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("testTable")
+            .build();
     TableSplitSpecification spec =
         TableSplitSpecification.builder()
             .setTableIdentifier(table)
@@ -643,9 +741,21 @@ public class RangeClassifierDoFnTest {
         .when(mockProcessContext)
         .output(any(), any());
 
-    TableIdentifier table1 = TableIdentifier.builder().setTableName("table1").build();
-    TableIdentifier table2 = TableIdentifier.builder().setTableName("table2").build();
-    TableIdentifier table3 = TableIdentifier.builder().setTableName("table3").build();
+    TableIdentifier table1 =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("table1")
+            .build();
+    TableIdentifier table2 =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("table2")
+            .build();
+    TableIdentifier table3 =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("table3")
+            .build();
 
     TableSplitSpecification spec1 =
         TableSplitSpecification.builder()

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCombinerTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCombinerTest.java
@@ -41,7 +41,11 @@ public class RangeCombinerTest {
 
     Range rangeBase =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setBoundarySplitter(BoundarySplitterFactory.create(Long.class))
             .setColName("long_col_base")
             .setColClass(Long.class)
@@ -89,8 +93,16 @@ public class RangeCombinerTest {
   public void testPerKeyBatched() {
     // Arrange
     final int numBatches = 10;
-    TableIdentifier table1 = TableIdentifier.builder().setTableName("table1").build();
-    TableIdentifier table2 = TableIdentifier.builder().setTableName("table2").build();
+    TableIdentifier table1 =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("table1")
+            .build();
+    TableIdentifier table2 =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("table2")
+            .build();
 
     Range range1 =
         Range.builder()

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountDoFnTest.java
@@ -89,7 +89,11 @@ public class RangeCountDoFnTest {
             new MysqlDialectAdapter(MySqlVersion.DEFAULT),
             ImmutableList.of(
                 TableSplitSpecification.builder()
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setPartitionColumns(
                         ImmutableList.of(
                             PartitionColumn.builder()
@@ -103,7 +107,11 @@ public class RangeCountDoFnTest {
                     .build()));
     Range input =
         Range.<Integer>builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -142,7 +150,11 @@ public class RangeCountDoFnTest {
             new MysqlDialectAdapter(MySqlVersion.DEFAULT),
             ImmutableList.of(
                 TableSplitSpecification.builder()
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setPartitionColumns(
                         ImmutableList.of(
                             PartitionColumn.builder()
@@ -156,7 +168,11 @@ public class RangeCountDoFnTest {
                     .build()));
     Range input =
         Range.<Integer>builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -192,7 +208,11 @@ public class RangeCountDoFnTest {
             new MysqlDialectAdapter(MySqlVersion.DEFAULT),
             ImmutableList.of(
                 TableSplitSpecification.builder()
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setPartitionColumns(
                         ImmutableList.of(
                             PartitionColumn.builder()
@@ -206,7 +226,11 @@ public class RangeCountDoFnTest {
                     .build()));
     Range input =
         Range.<Integer>builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -239,7 +263,11 @@ public class RangeCountDoFnTest {
             new MysqlDialectAdapter(MySqlVersion.DEFAULT),
             ImmutableList.of(
                 TableSplitSpecification.builder()
-                    .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName("testTable")
+                            .build())
                     .setPartitionColumns(
                         ImmutableList.of(
                             PartitionColumn.builder()
@@ -253,7 +281,11 @@ public class RangeCountDoFnTest {
                     .build()));
     Range input =
         Range.<Integer>builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -272,7 +304,11 @@ public class RangeCountDoFnTest {
   public void testRangeCountDoFnMissingTable() throws Exception {
     TableSplitSpecification tableSpec1 =
         TableSplitSpecification.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("existingTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("existingTable")
+                    .build())
             .setPartitionColumns(
                 ImmutableList.of(
                     PartitionColumn.builder()
@@ -294,7 +330,11 @@ public class RangeCountDoFnTest {
 
     Range inputMissingTable =
         Range.<Integer>builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("missingTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("missingTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -310,8 +350,16 @@ public class RangeCountDoFnTest {
 
   @Test
   public void testIsValidRangeHelperFunction() {
-    TableIdentifier existingTable = TableIdentifier.builder().setTableName("existingTable").build();
-    TableIdentifier missingTable = TableIdentifier.builder().setTableName("missingTable").build();
+    TableIdentifier existingTable =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("existingTable")
+            .build();
+    TableIdentifier missingTable =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("missingTable")
+            .build();
 
     ImmutableMap<TableIdentifier, String> countQueries =
         ImmutableMap.of(existingTable, "SELECT COUNT(*) FROM existingTable");
@@ -378,7 +426,11 @@ public class RangeCountDoFnTest {
 
     TableSplitSpecification tableSpec1 =
         TableSplitSpecification.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable1").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable1")
+                    .build())
             .setPartitionColumns(
                 ImmutableList.of(
                     PartitionColumn.builder()
@@ -392,7 +444,11 @@ public class RangeCountDoFnTest {
             .build();
     TableSplitSpecification tableSpec2 =
         TableSplitSpecification.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable2").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable2")
+                    .build())
             .setPartitionColumns(
                 ImmutableList.of(
                     PartitionColumn.builder()
@@ -442,7 +498,11 @@ public class RangeCountDoFnTest {
 
     Range input1 =
         Range.<Integer>builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable1").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable1")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
@@ -451,7 +511,11 @@ public class RangeCountDoFnTest {
             .build();
     Range input2 =
         Range.<Integer>builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable2").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable2")
+                    .build())
             .setColName("col2")
             .setColClass(Integer.class)
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountTransformTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeCountTransformTest.java
@@ -66,7 +66,11 @@ public class RangeCountTransformTest {
     ImmutableList<String> partitionCols = ImmutableList.of("col1", "col2");
     Range singleColNonLastRange =
         Range.<Integer>builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName(tableName).build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName(tableName)
+                    .build())
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
             .setColName("col1")
             .setColClass(Integer.class)
@@ -76,7 +80,11 @@ public class RangeCountTransformTest {
             .build();
     Range bothColRange =
         Range.<Integer>builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName(tableName).build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName(tableName)
+                    .build())
             .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
             .setColName("col1")
             .setColClass(Integer.class)
@@ -86,7 +94,11 @@ public class RangeCountTransformTest {
             .build()
             .withChildRange(
                 Range.<Integer>builder()
-                    .setTableIdentifier(TableIdentifier.builder().setTableName(tableName).build())
+                    .setTableIdentifier(
+                        TableIdentifier.builder()
+                            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                            .setTableName(tableName)
+                            .build())
                     .setBoundarySplitter(BoundarySplitterFactory.create(Integer.class))
                     .setColName("col2")
                     .setColClass(Integer.class)
@@ -103,7 +115,10 @@ public class RangeCountTransformTest {
                 ImmutableList.of(
                     TableSplitSpecification.builder()
                         .setTableIdentifier(
-                            TableIdentifier.builder().setTableName(tableName).build())
+                            TableIdentifier.builder()
+                                .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                                .setTableName(tableName)
+                                .build())
                         .setPartitionColumns(
                             partitionCols.stream()
                                 .map(

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeToTableIdentifierFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/RangeToTableIdentifierFnTest.java
@@ -30,7 +30,11 @@ public class RangeToTableIdentifierFnTest {
 
   @Test
   public void testApply() {
-    TableIdentifier tableIdentifier = TableIdentifier.builder().setTableName("test_table").build();
+    TableIdentifier tableIdentifier =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("test_table")
+            .build();
     Range range =
         Range.builder()
             .setTableIdentifier(tableIdentifier)

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitionsTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/ReadWithUniformPartitionsTest.java
@@ -165,7 +165,11 @@ public class ReadWithUniformPartitionsTest implements Serializable {
 
     Range firstRead =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName(tableName).build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName(tableName)
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setStart(25)
@@ -287,7 +291,11 @@ public class ReadWithUniformPartitionsTest implements Serializable {
   public void testMaxPartitionAutoInferencePreConditions() {
     Range initialRangeWithWrongColumChild =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName(tableName).build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName(tableName)
+                    .build())
             .setColName("wrongCol")
             .setColClass(Integer.class)
             .setStart(0)
@@ -296,7 +304,11 @@ public class ReadWithUniformPartitionsTest implements Serializable {
             .build();
     Range initialRange =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName(tableName).build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName(tableName)
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setStart(42)
@@ -331,7 +343,11 @@ public class ReadWithUniformPartitionsTest implements Serializable {
       tableName = ReadWithUniformPartitionsTest.tableName;
     }
 
-    TableIdentifier tableIdentifier = TableIdentifier.builder().setTableName(tableName).build();
+    TableIdentifier tableIdentifier =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName(tableName)
+            .build();
 
     TableSplitSpecification.Builder specBuilder =
         TableSplitSpecification.builder()
@@ -526,7 +542,11 @@ public class ReadWithUniformPartitionsTest implements Serializable {
 
     TableSplitSpecification spec1 =
         TableSplitSpecification.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("table1").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("table1")
+                    .build())
             .setPartitionColumns(
                 ImmutableList.of(
                     PartitionColumn.builder()
@@ -546,7 +566,11 @@ public class ReadWithUniformPartitionsTest implements Serializable {
 
     TableSplitSpecification spec2 =
         TableSplitSpecification.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("table2").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("table2")
+                    .build())
             .setPartitionColumns(
                 ImmutableList.of(
                     PartitionColumn.builder()
@@ -568,7 +592,11 @@ public class ReadWithUniformPartitionsTest implements Serializable {
 
     TableSplitSpecification spec3 =
         TableSplitSpecification.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("table3").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("table3")
+                    .build())
             .setPartitionColumns(
                 ImmutableList.of(
                     PartitionColumn.builder()
@@ -616,7 +644,11 @@ public class ReadWithUniformPartitionsTest implements Serializable {
 
   @Test
   public void testGetTransformNameWithCustomPrefix() {
-    TableIdentifier tableIdentifier = TableIdentifier.builder().setTableName("test_table").build();
+    TableIdentifier tableIdentifier =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("test_table")
+            .build();
     TableSplitSpecification spec =
         TableSplitSpecification.builder()
             .setTableIdentifier(tableIdentifier)
@@ -660,7 +692,11 @@ public class ReadWithUniformPartitionsTest implements Serializable {
     try {
       TableSplitSpecification spec1 =
           TableSplitSpecification.builder()
-              .setTableIdentifier(TableIdentifier.builder().setTableName(tableName1).build())
+              .setTableIdentifier(
+                  TableIdentifier.builder()
+                      .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                      .setTableName(tableName1)
+                      .build())
               .setApproxRowCount(100L)
               .setPartitionColumns(
                   ImmutableList.of(
@@ -684,7 +720,11 @@ public class ReadWithUniformPartitionsTest implements Serializable {
 
       TableSplitSpecification spec2 =
           TableSplitSpecification.builder()
-              .setTableIdentifier(TableIdentifier.builder().setTableName(tableName2).build())
+              .setTableIdentifier(
+                  TableIdentifier.builder()
+                      .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                      .setTableName(tableName2)
+                      .build())
               .setApproxRowCount(100L)
               .setPartitionColumns(
                   ImmutableList.of(
@@ -750,7 +790,11 @@ public class ReadWithUniformPartitionsTest implements Serializable {
 
   @Test
   public void testValidateParameters_emptyTableSplitSpecifications() {
-    TableIdentifier tableIdentifier = TableIdentifier.builder().setTableName(tableName).build();
+    TableIdentifier tableIdentifier =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName(tableName)
+            .build();
     TableReadSpecification<String> readSpec =
         TableReadSpecification.<String>builder()
             .setTableIdentifier(tableIdentifier)
@@ -768,7 +812,11 @@ public class ReadWithUniformPartitionsTest implements Serializable {
 
   @Test
   public void testValidateParameters_emptyTableReadSpecifications() {
-    TableIdentifier tableIdentifier = TableIdentifier.builder().setTableName(tableName).build();
+    TableIdentifier tableIdentifier =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName(tableName)
+            .build();
     TableSplitSpecification splitSpec =
         TableSplitSpecification.builder()
             .setTableIdentifier(tableIdentifier)
@@ -792,8 +840,16 @@ public class ReadWithUniformPartitionsTest implements Serializable {
 
   @Test
   public void testValidateParameters_sizeMismatch() {
-    TableIdentifier tableIdentifier1 = TableIdentifier.builder().setTableName("t1").build();
-    TableIdentifier tableIdentifier2 = TableIdentifier.builder().setTableName("t2").build();
+    TableIdentifier tableIdentifier1 =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("t1")
+            .build();
+    TableIdentifier tableIdentifier2 =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("t2")
+            .build();
     TableSplitSpecification splitSpec1 =
         TableSplitSpecification.builder()
             .setTableIdentifier(tableIdentifier1)
@@ -831,7 +887,11 @@ public class ReadWithUniformPartitionsTest implements Serializable {
 
   @Test
   public void testValidateParameters_valid() {
-    TableIdentifier tableIdentifier = TableIdentifier.builder().setTableName(tableName).build();
+    TableIdentifier tableIdentifier =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName(tableName)
+            .build();
     TableSplitSpecification splitSpec =
         TableSplitSpecification.builder()
             .setTableIdentifier(tableIdentifier)
@@ -859,8 +919,16 @@ public class ReadWithUniformPartitionsTest implements Serializable {
 
   @Test
   public void testBuild_identifierMismatch() {
-    TableIdentifier tableIdentifier1 = TableIdentifier.builder().setTableName("t1").build();
-    TableIdentifier tableIdentifier2 = TableIdentifier.builder().setTableName("t2").build();
+    TableIdentifier tableIdentifier1 =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("t1")
+            .build();
+    TableIdentifier tableIdentifier2 =
+        TableIdentifier.builder()
+            .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+            .setTableName("t2")
+            .build();
     TableSplitSpecification splitSpec1 =
         TableSplitSpecification.builder()
             .setTableIdentifier(tableIdentifier1)

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/SplitRangeDoFnTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/uniformsplitter/transforms/SplitRangeDoFnTest.java
@@ -44,7 +44,11 @@ public class SplitRangeDoFnTest {
   public void testSplitRangeDoFnBasic() {
     Range splittableRange =
         Range.builder()
-            .setTableIdentifier(TableIdentifier.builder().setTableName("testTable").build())
+            .setTableIdentifier(
+                TableIdentifier.builder()
+                    .setDataSourceId("b1a1ec3b-195d-4755-b04b-02bc64dc4458")
+                    .setTableName("testTable")
+                    .build())
             .setColName("col1")
             .setColClass(Integer.class)
             .setStart(0)


### PR DESCRIPTION
# Propogating DataSourceID as a part of Table Identifier for Multi-Shard Reading
This is the third child of #3684 .

## Design Decision
This PR adds `dataSourceId` to the tableIdentifer.
As a part of Milestone-1, a `Range` now has the `TableIdentifier` which helps move the table level details from `Ptransform` construction to the data layer. As was discussed in the same Milestone, the tableIdentifier was design to be extensible by allowing the DataSourceID to be contained in it. This helps in allowing the reader to correctly select the datasource that the given Range is associated and also eliminates the need to actually embed (and shuffle) the entire dataSource as a part of the range. The DataSourceProvider checked in as a part of #3685 will be provided to the Reader at construction time and that map coupled with the ID provided by the range as a part of this PR will help the Reader connect to the right source.

### Key Changes:
- **`TableIdentifier` Enhancement**: Added a `dataSourceId()` field to correctly distinguish tables with the same name that exist on different physical shards.
- **`JdbcSchemaReference` Integration**: Propagated the `dataSourceId` into the schema reference layer.
- **Unique ID Generation**: Implemented a robust ID generation mechanism in `JdbcIOWrapperConfig` to ensure every shard configuration has a unique identifier throughout the pipeline lifecycle.

### Rationale:
In a multi-shard environment, a table name (e.g., "Users") is no longer unique. We must qualify every table with its source database instance to ensure that Dataflow's grouping and splitting logic routes data to the correct destination.

---

## Why it's Safe (Identity Collision Prevention)
- **Global Uniqueness**: By combining `shardID` and `tableName` into a single identifier, we prevent collisions that would previously have caused Dataflow to aggregate data from different physical sources into a single logical partition.
- **Deterministic Hashing**: Updated `equals()` and `hashCode()` in `TableIdentifier` to include the `dataSourceId`. This is critical for Beam's `GroupByKey` operations, ensuring that ranges from different shards are never incorrectly merged.
- **Nullable Robustness**: Implemented strict null-checks and added `@Nullable` annotations where appropriate to ensure the system handles legacy configurations that may not have an explicit `dataSourceId`.

---

## Tests
The added tests verify that:
- Tables with the same name but different shard IDs are treated as distinct entities.
- Hash collisions are avoided.
- Propagation through the configuration layer is consistent.

--
## A quick note on PR size
This PR is divided into 2 commits - the first one just adds the identifier.
The second one ensures that the builder is correctly initialized in existing UTs - given the spotless requirement, this appears to have gotten into many lines (though in essentiality it's not)