### PR TITLE
[DataStreamToSpanner] Increase condition wait timeout by 5 minutes to account for Job Initialization time

### DIFF
--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerDDLIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerDDLIT.java
@@ -150,7 +150,11 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -217,7 +221,11 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -277,7 +285,11 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -337,7 +349,11 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -367,7 +383,11 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -397,7 +417,11 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -427,7 +451,11 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -457,7 +485,11 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -486,7 +518,11 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerDDLIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerDDLIT.java
@@ -150,11 +150,9 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -221,11 +219,9 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -285,11 +281,9 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -349,11 +343,9 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -383,11 +375,9 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -417,11 +407,9 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -451,11 +439,9 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -485,11 +471,9 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -518,11 +502,9 @@ public class DataStreamToSpannerDDLIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerEventsIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerEventsIT.java
@@ -158,11 +158,9 @@ public class DataStreamToSpannerEventsIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -200,11 +198,9 @@ public class DataStreamToSpannerEventsIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerEventsIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerEventsIT.java
@@ -158,7 +158,11 @@ public class DataStreamToSpannerEventsIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -196,7 +200,11 @@ public class DataStreamToSpannerEventsIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -245,7 +253,7 @@ public class DataStreamToSpannerEventsIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(12)), conditionCheck);
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(18)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerFileOverridesIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerFileOverridesIT.java
@@ -148,7 +148,11 @@ public class DataStreamToSpannerFileOverridesIT extends DataStreamToSpannerITBas
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerFileOverridesIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerFileOverridesIT.java
@@ -148,11 +148,9 @@ public class DataStreamToSpannerFileOverridesIT extends DataStreamToSpannerITBas
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerITBase.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerITBase.java
@@ -66,6 +66,13 @@ public abstract class DataStreamToSpannerITBase extends TemplateTestBase {
 
   public static final int CUTOVER_MILLIS = 30 * 1000;
 
+  // Time to wait for the job to start processing after pipeline launch.
+  // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is the
+  // time between Job start to when workers start requesting work. Need to account for this
+  // latency in the first condition check after the job start. The subsequent condition check
+  // waits don't need to account for this latency.
+  public static final int JOB_START_PROCESSING_WAIT_MINUTES = 15;
+
   public PubsubResourceManager setUpPubSubResourceManager() throws IOException {
     return PubsubResourceManager.builder(testName, PROJECT, credentialsProvider).build();
   }

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerMixedIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerMixedIT.java
@@ -145,7 +145,11 @@ public class DataStreamToSpannerMixedIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     TimeUnit.MINUTES.sleep(1);
     // Assert Conditions

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerMixedIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerMixedIT.java
@@ -145,11 +145,9 @@ public class DataStreamToSpannerMixedIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     TimeUnit.MINUTES.sleep(1);
     // Assert Conditions

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerSessionIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerSessionIT.java
@@ -140,7 +140,11 @@ public class DataStreamToSpannerSessionIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -201,7 +205,11 @@ public class DataStreamToSpannerSessionIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerSessionIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerSessionIT.java
@@ -140,11 +140,9 @@ public class DataStreamToSpannerSessionIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -205,11 +203,9 @@ public class DataStreamToSpannerSessionIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerShardedMigrationWithMigrationShardIdColumnIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerShardedMigrationWithMigrationShardIdColumnIT.java
@@ -214,11 +214,9 @@ public class DataStreamToSpannerShardedMigrationWithMigrationShardIdColumnIT
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo1, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
     // Assert Conditions to check if uploads are successful (not row contents)
     assertThatResult(result).meetsConditions();
 
@@ -306,11 +304,9 @@ public class DataStreamToSpannerShardedMigrationWithMigrationShardIdColumnIT
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo1, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -357,11 +353,9 @@ public class DataStreamToSpannerShardedMigrationWithMigrationShardIdColumnIT
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo1, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerShardedMigrationWithMigrationShardIdColumnIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerShardedMigrationWithMigrationShardIdColumnIT.java
@@ -214,7 +214,11 @@ public class DataStreamToSpannerShardedMigrationWithMigrationShardIdColumnIT
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(15)), conditionCheck);
     // Assert Conditions to check if uploads are successful (not row contents)
     assertThatResult(result).meetsConditions();
 
@@ -302,7 +306,11 @@ public class DataStreamToSpannerShardedMigrationWithMigrationShardIdColumnIT
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -349,7 +357,11 @@ public class DataStreamToSpannerShardedMigrationWithMigrationShardIdColumnIT
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerShardedMigrationWithoutMigrationShardIdColumnIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerShardedMigrationWithoutMigrationShardIdColumnIT.java
@@ -184,11 +184,9 @@ public class DataStreamToSpannerShardedMigrationWithoutMigrationShardIdColumnIT
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo1, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerShardedMigrationWithoutMigrationShardIdColumnIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerShardedMigrationWithoutMigrationShardIdColumnIT.java
@@ -184,7 +184,11 @@ public class DataStreamToSpannerShardedMigrationWithoutMigrationShardIdColumnIT
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerStringOverridesIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerStringOverridesIT.java
@@ -140,11 +140,9 @@ public class DataStreamToSpannerStringOverridesIT extends DataStreamToSpannerITB
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerStringOverridesIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerStringOverridesIT.java
@@ -140,7 +140,11 @@ public class DataStreamToSpannerStringOverridesIT extends DataStreamToSpannerITB
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerTimezoneIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerTimezoneIT.java
@@ -139,7 +139,11 @@ public class DataStreamToSpannerTimezoneIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerTimezoneIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerTimezoneIT.java
@@ -139,11 +139,9 @@ public class DataStreamToSpannerTimezoneIT extends DataStreamToSpannerITBase {
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DatastreamToSpannerSingleDFShardedMigrationIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DatastreamToSpannerSingleDFShardedMigrationIT.java
@@ -182,11 +182,9 @@ public class DatastreamToSpannerSingleDFShardedMigrationIT extends DataStreamToS
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DatastreamToSpannerSingleDFShardedMigrationIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DatastreamToSpannerSingleDFShardedMigrationIT.java
@@ -182,7 +182,11 @@ public class DatastreamToSpannerSingleDFShardedMigrationIT extends DataStreamToS
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLDatastreamToSpannerDataTypesAndExpressionIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLDatastreamToSpannerDataTypesAndExpressionIT.java
@@ -188,7 +188,11 @@ public class MySQLDatastreamToSpannerDataTypesAndExpressionIT extends DataStream
     LOG.info("Waiting for pipeline to process data...");
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(10)), condition);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), condition);
     assertThatResult(result).meetsConditions();
 
     validateResult(spannerResourceManager, expectedData);
@@ -253,7 +257,11 @@ public class MySQLDatastreamToSpannerDataTypesAndExpressionIT extends DataStream
     LOG.info("Waiting for pipeline to process data...");
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(10)), condition);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), condition);
     assertThatResult(result).meetsConditions();
 
     validateResult(pgDialectSpannerResourceManager, expectedData);

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLDatastreamToSpannerDataTypesAndExpressionIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLDatastreamToSpannerDataTypesAndExpressionIT.java
@@ -188,11 +188,9 @@ public class MySQLDatastreamToSpannerDataTypesAndExpressionIT extends DataStream
     LOG.info("Waiting for pipeline to process data...");
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), condition);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                condition);
     assertThatResult(result).meetsConditions();
 
     validateResult(spannerResourceManager, expectedData);
@@ -257,11 +255,9 @@ public class MySQLDatastreamToSpannerDataTypesAndExpressionIT extends DataStream
     LOG.info("Waiting for pipeline to process data...");
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), condition);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                condition);
     assertThatResult(result).meetsConditions();
 
     validateResult(pgDialectSpannerResourceManager, expectedData);

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseDDLIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseDDLIT.java
@@ -163,11 +163,9 @@ public class SeparateShadowTableDatabaseDDLIT extends DataStreamToSpannerITBase 
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -234,11 +232,9 @@ public class SeparateShadowTableDatabaseDDLIT extends DataStreamToSpannerITBase 
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -298,11 +294,9 @@ public class SeparateShadowTableDatabaseDDLIT extends DataStreamToSpannerITBase 
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -362,11 +356,9 @@ public class SeparateShadowTableDatabaseDDLIT extends DataStreamToSpannerITBase 
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -396,11 +388,9 @@ public class SeparateShadowTableDatabaseDDLIT extends DataStreamToSpannerITBase 
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -430,11 +420,9 @@ public class SeparateShadowTableDatabaseDDLIT extends DataStreamToSpannerITBase 
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -464,11 +452,9 @@ public class SeparateShadowTableDatabaseDDLIT extends DataStreamToSpannerITBase 
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -498,11 +484,9 @@ public class SeparateShadowTableDatabaseDDLIT extends DataStreamToSpannerITBase 
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseDDLIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseDDLIT.java
@@ -163,7 +163,11 @@ public class SeparateShadowTableDatabaseDDLIT extends DataStreamToSpannerITBase 
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -230,7 +234,11 @@ public class SeparateShadowTableDatabaseDDLIT extends DataStreamToSpannerITBase 
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -290,7 +298,11 @@ public class SeparateShadowTableDatabaseDDLIT extends DataStreamToSpannerITBase 
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -350,7 +362,11 @@ public class SeparateShadowTableDatabaseDDLIT extends DataStreamToSpannerITBase 
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -380,7 +396,11 @@ public class SeparateShadowTableDatabaseDDLIT extends DataStreamToSpannerITBase 
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -410,7 +430,11 @@ public class SeparateShadowTableDatabaseDDLIT extends DataStreamToSpannerITBase 
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -440,7 +464,11 @@ public class SeparateShadowTableDatabaseDDLIT extends DataStreamToSpannerITBase 
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -470,7 +498,11 @@ public class SeparateShadowTableDatabaseDDLIT extends DataStreamToSpannerITBase 
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseEventsIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseEventsIT.java
@@ -166,11 +166,9 @@ public class SeparateShadowTableDatabaseEventsIT extends DataStreamToSpannerITBa
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -208,11 +206,9 @@ public class SeparateShadowTableDatabaseEventsIT extends DataStreamToSpannerITBa
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseEventsIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseEventsIT.java
@@ -166,7 +166,11 @@ public class SeparateShadowTableDatabaseEventsIT extends DataStreamToSpannerITBa
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -204,7 +208,11 @@ public class SeparateShadowTableDatabaseEventsIT extends DataStreamToSpannerITBa
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -253,7 +261,7 @@ public class SeparateShadowTableDatabaseEventsIT extends DataStreamToSpannerITBa
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(12)), conditionCheck);
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(18)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseFileOverridesIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseFileOverridesIT.java
@@ -159,11 +159,9 @@ public class SeparateShadowTableDatabaseFileOverridesIT extends DataStreamToSpan
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseFileOverridesIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseFileOverridesIT.java
@@ -159,7 +159,11 @@ public class SeparateShadowTableDatabaseFileOverridesIT extends DataStreamToSpan
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseMixedIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseMixedIT.java
@@ -156,7 +156,11 @@ public class SeparateShadowTableDatabaseMixedIT extends DataStreamToSpannerITBas
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     TimeUnit.MINUTES.sleep(1);
     // Assert Conditions

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseMixedIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseMixedIT.java
@@ -156,11 +156,9 @@ public class SeparateShadowTableDatabaseMixedIT extends DataStreamToSpannerITBas
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     TimeUnit.MINUTES.sleep(1);
     // Assert Conditions

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabasePKFocusedIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabasePKFocusedIT.java
@@ -176,11 +176,9 @@ public class SeparateShadowTableDatabasePKFocusedIT extends DataStreamToSpannerI
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -251,11 +249,9 @@ public class SeparateShadowTableDatabasePKFocusedIT extends DataStreamToSpannerI
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabasePKFocusedIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabasePKFocusedIT.java
@@ -176,7 +176,11 @@ public class SeparateShadowTableDatabasePKFocusedIT extends DataStreamToSpannerI
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -247,7 +251,11 @@ public class SeparateShadowTableDatabasePKFocusedIT extends DataStreamToSpannerI
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseSessionIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseSessionIT.java
@@ -151,11 +151,9 @@ public class SeparateShadowTableDatabaseSessionIT extends DataStreamToSpannerITB
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -216,11 +214,9 @@ public class SeparateShadowTableDatabaseSessionIT extends DataStreamToSpannerITB
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseSessionIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseSessionIT.java
@@ -151,7 +151,11 @@ public class SeparateShadowTableDatabaseSessionIT extends DataStreamToSpannerITB
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -212,7 +216,11 @@ public class SeparateShadowTableDatabaseSessionIT extends DataStreamToSpannerITB
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseShardedMigrationWithMigrationShardIdColumnIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseShardedMigrationWithMigrationShardIdColumnIT.java
@@ -235,11 +235,9 @@ public class SeparateShadowTableDatabaseShardedMigrationWithMigrationShardIdColu
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo1, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
     // Assert Conditions to check if uploads are successful (not row contents)
     assertThatResult(result).meetsConditions();
 
@@ -327,11 +325,9 @@ public class SeparateShadowTableDatabaseShardedMigrationWithMigrationShardIdColu
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo1, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -386,11 +382,9 @@ public class SeparateShadowTableDatabaseShardedMigrationWithMigrationShardIdColu
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo1, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseShardedMigrationWithMigrationShardIdColumnIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseShardedMigrationWithMigrationShardIdColumnIT.java
@@ -235,7 +235,11 @@ public class SeparateShadowTableDatabaseShardedMigrationWithMigrationShardIdColu
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(15)), conditionCheck);
     // Assert Conditions to check if uploads are successful (not row contents)
     assertThatResult(result).meetsConditions();
 
@@ -323,7 +327,11 @@ public class SeparateShadowTableDatabaseShardedMigrationWithMigrationShardIdColu
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();
@@ -378,7 +386,11 @@ public class SeparateShadowTableDatabaseShardedMigrationWithMigrationShardIdColu
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseShardedMigrationWithoutMigrationShardIdColumnIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseShardedMigrationWithoutMigrationShardIdColumnIT.java
@@ -202,7 +202,11 @@ public class SeparateShadowTableDatabaseShardedMigrationWithoutMigrationShardIdC
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseShardedMigrationWithoutMigrationShardIdColumnIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseShardedMigrationWithoutMigrationShardIdColumnIT.java
@@ -202,11 +202,9 @@ public class SeparateShadowTableDatabaseShardedMigrationWithoutMigrationShardIdC
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo1, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo1, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseSingleDFShardedMigrationIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseSingleDFShardedMigrationIT.java
@@ -196,7 +196,11 @@ public class SeparateShadowTableDatabaseSingleDFShardedMigrationIT
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseSingleDFShardedMigrationIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseSingleDFShardedMigrationIT.java
@@ -196,11 +196,9 @@ public class SeparateShadowTableDatabaseSingleDFShardedMigrationIT
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseStringOverridesIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseStringOverridesIT.java
@@ -152,7 +152,11 @@ public class SeparateShadowTableDatabaseStringOverridesIT extends DataStreamToSp
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
 
     // Assert conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseStringOverridesIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/SeparateShadowTableDatabaseStringOverridesIT.java
@@ -152,11 +152,9 @@ public class SeparateShadowTableDatabaseStringOverridesIT extends DataStreamToSp
     // Wait for conditions
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
 
     // Assert conditions
     assertThatResult(result).meetsConditions();

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/endtoend/BulkForwardAndReverseMigrationNonShardedEndToEndIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/endtoend/BulkForwardAndReverseMigrationNonShardedEndToEndIT.java
@@ -237,7 +237,11 @@ public class BulkForwardAndReverseMigrationNonShardedEndToEndIT extends EndToEnd
 
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(fwdJobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(fwdJobInfo, Duration.ofMinutes(15)), conditionCheck);
     assertThatResult(result).meetsConditions();
   }
 

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/endtoend/BulkForwardAndReverseMigrationNonShardedEndToEndIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/endtoend/BulkForwardAndReverseMigrationNonShardedEndToEndIT.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.templates.endtoend;
 
 import static com.google.cloud.teleport.v2.spanner.migrations.constants.Constants.MYSQL_SOURCE_TYPE;
+import static com.google.cloud.teleport.v2.templates.DataStreamToSpannerITBase.JOB_START_PROCESSING_WAIT_MINUTES;
 import static com.google.common.truth.Truth.assertThat;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
@@ -237,11 +238,9 @@ public class BulkForwardAndReverseMigrationNonShardedEndToEndIT extends EndToEnd
 
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(fwdJobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(fwdJobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
     assertThatResult(result).meetsConditions();
   }
 

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/endtoend/ForwardAndReverseMigrationShardedEndToEndIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/endtoend/ForwardAndReverseMigrationShardedEndToEndIT.java
@@ -227,7 +227,11 @@ public class ForwardAndReverseMigrationShardedEndToEndIT extends EndToEndTesting
 
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(fwdJobInfo, Duration.ofMinutes(8)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(fwdJobInfo, Duration.ofMinutes(15)), conditionCheck);
     assertThatResult(result).meetsConditions();
   }
 

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/endtoend/ForwardAndReverseMigrationShardedEndToEndIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/endtoend/ForwardAndReverseMigrationShardedEndToEndIT.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.templates.endtoend;
 
 import static com.google.cloud.teleport.v2.spanner.migrations.constants.Constants.MYSQL_SOURCE_TYPE;
+import static com.google.cloud.teleport.v2.templates.DataStreamToSpannerITBase.JOB_START_PROCESSING_WAIT_MINUTES;
 import static com.google.common.truth.Truth.assertThat;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
@@ -227,11 +228,9 @@ public class ForwardAndReverseMigrationShardedEndToEndIT extends EndToEndTesting
 
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(fwdJobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(fwdJobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
     assertThatResult(result).meetsConditions();
   }
 

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/failureinjectiontesting/DataStreamToSpannerMySQLSrcDataflowFT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/failureinjectiontesting/DataStreamToSpannerMySQLSrcDataflowFT.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.templates.failureinjectiontesting;
 
 import static com.google.cloud.teleport.v2.spanner.testutils.failureinjectiontesting.MySQLSrcDataProvider.AUTHORS_TABLE;
 import static com.google.cloud.teleport.v2.spanner.testutils.failureinjectiontesting.MySQLSrcDataProvider.BOOKS_TABLE;
+import static com.google.cloud.teleport.v2.templates.DataStreamToSpannerITBase.JOB_START_PROCESSING_WAIT_MINUTES;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
 
@@ -137,11 +138,9 @@ public class DataStreamToSpannerMySQLSrcDataflowFT extends DataStreamToSpannerFT
 
     PipelineOperator.Result result =
         pipelineOperator()
-            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
-            // the time between Job start to when workers start requesting work. Accounting for this
-            // latency in the first condition check after the job start. The subsequent condition
-            // check waits don't need to account for this latency.
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
+            .waitForCondition(
+                createConfig(jobInfo, Duration.ofMinutes(JOB_START_PROCESSING_WAIT_MINUTES)),
+                conditionCheck);
     assertThatResult(result).meetsConditions();
 
     // Insert more data before killing the dataflow workers

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/failureinjectiontesting/DataStreamToSpannerMySQLSrcDataflowFT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/failureinjectiontesting/DataStreamToSpannerMySQLSrcDataflowFT.java
@@ -137,7 +137,11 @@ public class DataStreamToSpannerMySQLSrcDataflowFT extends DataStreamToSpannerFT
 
     PipelineOperator.Result result =
         pipelineOperator()
-            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(10)), conditionCheck);
+            // Context - b/473707986#comment14 - The Job Initialization latency is 5 mins, that is
+            // the time between Job start to when workers start requesting work. Accounting for this
+            // latency in the first condition check after the job start. The subsequent condition
+            // check waits don't need to account for this latency.
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(15)), conditionCheck);
     assertThatResult(result).meetsConditions();
 
     // Insert more data before killing the dataflow workers


### PR DESCRIPTION
Increase condition wait timeout in IT tests by 5 minutes to account for Job Initialization time