### PR TITLE
fix(spanner): make invalidOutputPath required to prevent infinite job hangs

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/spanner/TextImportPipeline.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/TextImportPipeline.java
@@ -291,10 +291,9 @@ public class TextImportPipeline {
     @TemplateParameter.GcsWriteFolder(
         order = 16,
         description = "Invalid rows output path",
-        optional = true,
+        optional = false,
         helpText = "The Cloud Storage path to use when writing rows that cannot be imported.",
         example = "gs://your-bucket/your-path")
-    @Default.String("")
     ValueProvider<String> getInvalidOutputPath();
 
     void setInvalidOutputPath(ValueProvider<String> value);


### PR DESCRIPTION
**Problem:**

- Currently, invalidOutputPath is marked as optional with an empty default string in TextImportPipeline.java. If a user runs the pipeline with malformed source data and omits this parameter, the Dead Letter Queue attempts to write the failed Spanner mutations to a null or empty GCS bucket path.
- Because there is no pre-flight validation for this path, the worker fails during the Finalize step when attempting to copy the temporary file. Dataflow then infinitely retries this failed bundle, causing the job to hang indefinitely at 100% completion rather than failing gracefully. This results in runaway compute costs for users who encounter a bad record without a configured error bucket.

**Solution:**
This commit updates invalidOutputPath to be a strictly required parameter. This forces the pipeline to validate the parameter at initialization, ensuring the job fails instantly on launch if a Dead Letter Queue path is missing.

**Changes Made:**

- Modified TextImportPipeline.java to set optional = false for the invalidOutputPath parameter.
- Removed the @Default.String("") annotation from invalidOutputPath to ensure validation catches missing paths before worker spin-up.

**Testing:**

- Attempting to trigger the pipeline without providing an invalidOutputPath now immediately fails validation before job creation.
- Providing a valid GCS path successfully routes errored Spanner mutations to the bucket and allows the job to complete successfully.

Fixes #3722 