### PR TITLE
Adding pTransform for generate ticks to match specified qps

### DIFF
--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/ScaleTicksFn.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/ScaleTicksFn.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.dofn;
+
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorSchema;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.values.PCollectionView;
+
+/**
+ * Rescales the input tick stream to match the total target QPS of all root tables in the schema.
+ *
+ * <p>This DoFn acts as a rate converter between the fixed {@code baseTickRate} (configured at
+ * pipeline start) and the dynamic {@code totalQps} (read from the schema side-input). It handles
+ * rate conversion in two ways:
+ *
+ * <ul>
+ *   <li>**Rate Reduction** (Total QPS &lt; baseTickRate): Elements are thinned out by emitting each
+ *       input with a probability of {@code totalQps / baseTickRate}.
+ *   <li>**Rate Amplification** (Total QPS &gt;= baseTickRate): Elements are multiplied. It
+ *       deterministically emits {@code totalQps / baseTickRate} copies per input, and
+ *       probabilistically emits one more copy to account for the fractional remainder.
+ * </ul>
+ */
+public class ScaleTicksFn extends DoFn<Long, Long> {
+
+  private final PCollectionView<DataGeneratorSchema> schemaView;
+  private final int baseTickRate;
+  private transient DataGeneratorSchema cachedSchema;
+
+  private transient int cachedTotalQps;
+
+  public ScaleTicksFn(PCollectionView<DataGeneratorSchema> schemaView, int baseTickRate) {
+    this.schemaView = schemaView;
+    this.baseTickRate = baseTickRate;
+  }
+
+  @ProcessElement
+  public void processElement(ProcessContext c) {
+    DataGeneratorSchema schema = c.sideInput(schemaView);
+
+    // Schemas arrive as a cached side-input object that's reused across
+    // bundles, so this avoids re-summing the QPS on every element.
+    if (cachedSchema != schema) {
+      cachedTotalQps = totalRootQps(schema);
+      cachedSchema = schema;
+    }
+
+    if (cachedTotalQps <= 0) {
+      return; // Nothing to do — no root tables, or all have zero QPS.
+    }
+
+    if (cachedTotalQps < baseTickRate) {
+      double probability = (double) cachedTotalQps / baseTickRate;
+      if (ThreadLocalRandom.current().nextDouble() < probability) {
+        c.output(c.element());
+      }
+      return;
+    }
+
+    // Scale up. Note: multiplier=1/remainder=0 covers the "totalQps == baseTickRate" case, so
+    // we don't need a separate equality branch.
+    int multiplier = cachedTotalQps / baseTickRate;
+    int remainder = cachedTotalQps % baseTickRate;
+
+    for (int i = 0; i < multiplier; i++) {
+      c.output(c.element());
+    }
+    if (remainder > 0) {
+      double probability = (double) remainder / baseTickRate;
+      if (ThreadLocalRandom.current().nextDouble() < probability) {
+        c.output(c.element());
+      }
+    }
+  }
+
+  /** Sum {@code insertQps} across every root table in the schema. */
+  @VisibleForTesting
+  public static int totalRootQps(DataGeneratorSchema schema) {
+    int total = 0;
+    for (DataGeneratorTable table : schema.tables().values()) {
+      if (table.isRoot()) {
+        total += table.insertQps();
+      }
+    }
+    return total;
+  }
+}

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/ScaleTicksFn.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/ScaleTicksFn.java
@@ -20,6 +20,7 @@ import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * <p>Since the input tick rate is 1 tick per second (driven by PeriodicImpulse), this DoFn simply
  * outputs {@code totalQps} copies of the timestamp (in milliseconds) for each incoming tick.
  */
-public class ScaleTicksFn extends DoFn<org.joda.time.Instant, Long> {
+public class ScaleTicksFn extends DoFn<Instant, Long> {
 
   private static final Logger LOG = LoggerFactory.getLogger(ScaleTicksFn.class);
   private final PCollectionView<DataGeneratorSchema> schemaView;
@@ -53,12 +54,16 @@ public class ScaleTicksFn extends DoFn<org.joda.time.Instant, Long> {
     }
 
     if (cachedTotalQps <= 0) {
-      return; // Nothing to do — no root tables, or all have zero QPS.
+      throw new IllegalStateException(
+          "Total QPS must be greater than zero. Found: "
+              + cachedTotalQps
+              + " . Please verify your config.");
     }
 
     // Since base tick rate is effectively 1 per second, we just output totalQps times
+    Long millis = c.element().getMillis();
     for (int i = 0; i < cachedTotalQps; i++) {
-      c.output(c.element().getMillis());
+      c.output(millis);
     }
   }
 

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/ScaleTicksFn.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/ScaleTicksFn.java
@@ -18,36 +18,26 @@ package com.google.cloud.teleport.v2.templates.dofn;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorSchema;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
 import com.google.common.annotations.VisibleForTesting;
-import java.util.concurrent.ThreadLocalRandom;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Rescales the input tick stream to match the total target QPS of all root tables in the schema.
  *
- * <p>This DoFn acts as a rate converter between the fixed {@code baseTickRate} (configured at
- * pipeline start) and the dynamic {@code totalQps} (read from the schema side-input). It handles
- * rate conversion in two ways:
- *
- * <ul>
- *   <li>**Rate Reduction** (Total QPS &lt; baseTickRate): Elements are thinned out by emitting each
- *       input with a probability of {@code totalQps / baseTickRate}.
- *   <li>**Rate Amplification** (Total QPS &gt;= baseTickRate): Elements are multiplied. It
- *       deterministically emits {@code totalQps / baseTickRate} copies per input, and
- *       probabilistically emits one more copy to account for the fractional remainder.
- * </ul>
+ * <p>Since the input tick rate is 1 tick per second (driven by PeriodicImpulse), this DoFn simply
+ * outputs {@code totalQps} copies of the timestamp (in milliseconds) for each incoming tick.
  */
-public class ScaleTicksFn extends DoFn<Long, Long> {
+public class ScaleTicksFn extends DoFn<org.joda.time.Instant, Long> {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ScaleTicksFn.class);
   private final PCollectionView<DataGeneratorSchema> schemaView;
-  private final int baseTickRate;
   private transient DataGeneratorSchema cachedSchema;
-
   private transient int cachedTotalQps;
 
-  public ScaleTicksFn(PCollectionView<DataGeneratorSchema> schemaView, int baseTickRate) {
+  public ScaleTicksFn(PCollectionView<DataGeneratorSchema> schemaView) {
     this.schemaView = schemaView;
-    this.baseTickRate = baseTickRate;
   }
 
   @ProcessElement
@@ -59,33 +49,16 @@ public class ScaleTicksFn extends DoFn<Long, Long> {
     if (cachedSchema != schema) {
       cachedTotalQps = totalRootQps(schema);
       cachedSchema = schema;
+      LOG.info("Total QPS resolved to: {}", cachedTotalQps);
     }
 
     if (cachedTotalQps <= 0) {
       return; // Nothing to do — no root tables, or all have zero QPS.
     }
 
-    if (cachedTotalQps < baseTickRate) {
-      double probability = (double) cachedTotalQps / baseTickRate;
-      if (ThreadLocalRandom.current().nextDouble() < probability) {
-        c.output(c.element());
-      }
-      return;
-    }
-
-    // Scale up. Note: multiplier=1/remainder=0 covers the "totalQps == baseTickRate" case, so
-    // we don't need a separate equality branch.
-    int multiplier = cachedTotalQps / baseTickRate;
-    int remainder = cachedTotalQps % baseTickRate;
-
-    for (int i = 0; i < multiplier; i++) {
-      c.output(c.element());
-    }
-    if (remainder > 0) {
-      double probability = (double) remainder / baseTickRate;
-      if (ThreadLocalRandom.current().nextDouble() < probability) {
-        c.output(c.element());
-      }
+    // Since base tick rate is effectively 1 per second, we just output totalQps times
+    for (int i = 0; i < cachedTotalQps; i++) {
+      c.output(c.element().getMillis());
     }
   }
 

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/transforms/GenerateTicks.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/transforms/GenerateTicks.java
@@ -17,52 +17,30 @@ package com.google.cloud.teleport.v2.templates.transforms;
 
 import com.google.cloud.teleport.v2.templates.dofn.ScaleTicksFn;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorSchema;
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * {@link PTransform} that takes a fixed-rate baseline tick stream and rescales it dynamically to
- * match the total root-table QPS declared by the schema side input.
- *
- * <p>The driver-side baseline (driven by {@code GenerateSequence.withRate(...)}) must be fixed at
- * pipeline construction time because Beam's source rate is a compile-time constant. The schema,
- * however, is read via a side input to avoid the Dataflow template-launcher construction timeout on
- * large (~5000-table) schemas. This transform performs the rate correction at runtime, so the
- * effective emission rate converges to the schema's total root QPS without requiring the schema to
- * be known at construction time.
- *
- * <p>See {@link ScaleTicksFn} for the scaling logic.
+ * {@link PTransform} that takes a stream of periodic impulses (1 tick per second) and expands each
+ * tick into the total number of root-table QPS declared by the schema side input.
  */
-public class GenerateTicks extends PTransform<PCollection<Long>, PCollection<Long>> {
+public class GenerateTicks
+    extends PTransform<PCollection<org.joda.time.Instant>, PCollection<Long>> {
 
-  @VisibleForTesting static final int DEFAULT_BASE_TICK_RATE = 1000;
-
-  private final int insertQps;
+  private static final Logger LOG = LoggerFactory.getLogger(GenerateTicks.class);
   private final PCollectionView<DataGeneratorSchema> schemaView;
 
-  public GenerateTicks(int insertQps, PCollectionView<DataGeneratorSchema> schemaView) {
-    this.insertQps = insertQps;
+  public GenerateTicks(PCollectionView<DataGeneratorSchema> schemaView) {
     this.schemaView = schemaView;
   }
 
   @Override
-  public PCollection<Long> expand(PCollection<Long> input) {
-    int baseTickRate = resolveBaseTickRate(insertQps);
+  public PCollection<Long> expand(PCollection<org.joda.time.Instant> input) {
     return input.apply(
-        "ScaleTicks",
-        ParDo.of(new ScaleTicksFn(schemaView, baseTickRate)).withSideInputs(schemaView));
-  }
-
-  /**
-   * Chooses the baseline tick rate based on insertQps.
-   *
-   * <p>Priority: {@code insertQps} → {@link #DEFAULT_BASE_TICK_RATE}.
-   */
-  @VisibleForTesting
-  public static int resolveBaseTickRate(int insertQps) {
-    return insertQps > 0 ? insertQps : DEFAULT_BASE_TICK_RATE;
+        "ScaleTicks", ParDo.of(new ScaleTicksFn(schemaView)).withSideInputs(schemaView));
   }
 }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/transforms/GenerateTicks.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/transforms/GenerateTicks.java
@@ -21,8 +21,7 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.joda.time.Instant;
 
 /**
  * {@link PTransform} that takes a stream of periodic impulses (1 tick per second) and expands each
@@ -31,7 +30,6 @@ import org.slf4j.LoggerFactory;
 public class GenerateTicks
     extends PTransform<PCollection<org.joda.time.Instant>, PCollection<Long>> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(GenerateTicks.class);
   private final PCollectionView<DataGeneratorSchema> schemaView;
 
   public GenerateTicks(PCollectionView<DataGeneratorSchema> schemaView) {
@@ -39,7 +37,7 @@ public class GenerateTicks
   }
 
   @Override
-  public PCollection<Long> expand(PCollection<org.joda.time.Instant> input) {
+  public PCollection<Long> expand(PCollection<Instant> input) {
     return input.apply(
         "ScaleTicks", ParDo.of(new ScaleTicksFn(schemaView)).withSideInputs(schemaView));
   }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/transforms/GenerateTicks.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/transforms/GenerateTicks.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.transforms;
+
+import com.google.cloud.teleport.v2.templates.dofn.ScaleTicksFn;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorSchema;
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+
+/**
+ * {@link PTransform} that takes a fixed-rate baseline tick stream and rescales it dynamically to
+ * match the total root-table QPS declared by the schema side input.
+ *
+ * <p>The driver-side baseline (driven by {@code GenerateSequence.withRate(...)}) must be fixed at
+ * pipeline construction time because Beam's source rate is a compile-time constant. The schema,
+ * however, is read via a side input to avoid the Dataflow template-launcher construction timeout on
+ * large (~5000-table) schemas. This transform performs the rate correction at runtime, so the
+ * effective emission rate converges to the schema's total root QPS without requiring the schema to
+ * be known at construction time.
+ *
+ * <p>See {@link ScaleTicksFn} for the scaling logic.
+ */
+public class GenerateTicks extends PTransform<PCollection<Long>, PCollection<Long>> {
+
+  @VisibleForTesting static final int DEFAULT_BASE_TICK_RATE = 1000;
+
+  private final int insertQps;
+  private final PCollectionView<DataGeneratorSchema> schemaView;
+
+  public GenerateTicks(int insertQps, PCollectionView<DataGeneratorSchema> schemaView) {
+    this.insertQps = insertQps;
+    this.schemaView = schemaView;
+  }
+
+  @Override
+  public PCollection<Long> expand(PCollection<Long> input) {
+    int baseTickRate = resolveBaseTickRate(insertQps);
+    return input.apply(
+        "ScaleTicks",
+        ParDo.of(new ScaleTicksFn(schemaView, baseTickRate)).withSideInputs(schemaView));
+  }
+
+  /**
+   * Chooses the baseline tick rate based on insertQps.
+   *
+   * <p>Priority: {@code insertQps} → {@link #DEFAULT_BASE_TICK_RATE}.
+   */
+  @VisibleForTesting
+  public static int resolveBaseTickRate(int insertQps) {
+    return insertQps > 0 ? insertQps : DEFAULT_BASE_TICK_RATE;
+  }
+}

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/GenerateTicksTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/GenerateTicksTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.transforms;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.cloud.teleport.v2.templates.dofn.ScaleTicksFn;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorSchema;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.View;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link GenerateTicks} and its {@link ScaleTicksFn}. */
+@RunWith(JUnit4.class)
+public class GenerateTicksTest {
+
+  @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+
+  private static DataGeneratorTable root(String name, int insertQps) {
+    return DataGeneratorTable.builder()
+        .name(name)
+        .insertQps(insertQps)
+        .updateQps(0)
+        .deleteQps(0)
+        .isRoot(true)
+        .columns(ImmutableList.of())
+        .primaryKeys(ImmutableList.of())
+        .foreignKeys(ImmutableList.of())
+        .uniqueKeys(ImmutableList.of())
+        .recordsPerTick(1.0)
+        .build();
+  }
+
+  private static DataGeneratorTable child(String name, String parent, int insertQps) {
+    return DataGeneratorTable.builder()
+        .name(name)
+        .insertQps(insertQps)
+        .updateQps(0)
+        .deleteQps(0)
+        .isRoot(false)
+        .interleavedInTable(parent)
+        .columns(ImmutableList.of())
+        .primaryKeys(ImmutableList.of())
+        .foreignKeys(ImmutableList.of())
+        .uniqueKeys(ImmutableList.of())
+        .recordsPerTick(1.0)
+        .build();
+  }
+
+  @Test
+  public void testResolveBaseTickRate_usesInsertQps() {
+    assertEquals(500, GenerateTicks.resolveBaseTickRate(500));
+  }
+
+  @Test
+  public void testResolveBaseTickRate_defaultsToConstantWhenZeroOrNegative() {
+    assertEquals(GenerateTicks.DEFAULT_BASE_TICK_RATE, GenerateTicks.resolveBaseTickRate(0));
+    assertEquals(GenerateTicks.DEFAULT_BASE_TICK_RATE, GenerateTicks.resolveBaseTickRate(-5));
+  }
+
+  @Test
+  public void testTotalRootQps_sumsOnlyRootTables() {
+    DataGeneratorSchema schema =
+        DataGeneratorSchema.builder()
+            .tables(
+                ImmutableMap.of(
+                    "A", root("A", 10),
+                    "B", child("B", "A", 100),
+                    "C", root("C", 50)))
+            .build();
+    assertEquals(60, ScaleTicksFn.totalRootQps(schema));
+  }
+
+  @Test
+  public void testTotalRootQps_emptySchemaIsZero() {
+    DataGeneratorSchema schema = DataGeneratorSchema.builder().tables(ImmutableMap.of()).build();
+    assertEquals(0, ScaleTicksFn.totalRootQps(schema));
+  }
+
+  @Test
+  public void testTotalRootQps_allNonRoot() {
+    DataGeneratorSchema schema =
+        DataGeneratorSchema.builder().tables(ImmutableMap.of("B", child("B", "A", 100))).build();
+    assertEquals(0, ScaleTicksFn.totalRootQps(schema));
+  }
+
+  @Test
+  public void testScaleTicks_zeroTotalQpsEmitsNothing() {
+    DataGeneratorSchema schema =
+        DataGeneratorSchema.builder().tables(ImmutableMap.of("B", child("B", "A", 42))).build();
+    PCollectionView<DataGeneratorSchema> schemaView =
+        pipeline.apply("MkSchema", Create.of(schema)).apply("AsView", View.asSingleton());
+
+    PCollection<Long> output =
+        pipeline
+            .apply("Input", Create.of(buildSequence(50)))
+            .apply("GenerateTicks", new GenerateTicks(100, schemaView));
+
+    PAssert.that(output).empty();
+    pipeline.run();
+  }
+
+  @Test
+  public void testScaleTicks_totalQpsEqualsBaseRateEmitsSameCount() {
+    DataGeneratorSchema schema =
+        DataGeneratorSchema.builder().tables(ImmutableMap.of("A", root("A", 100))).build();
+    PCollectionView<DataGeneratorSchema> schemaView =
+        pipeline.apply("MkSchema", Create.of(schema)).apply("AsView", View.asSingleton());
+
+    int inputCount = 100;
+    PCollection<Long> output =
+        pipeline
+            .apply("Input", Create.of(buildSequence(inputCount)))
+            .apply("GenerateTicks", new GenerateTicks(100, schemaView));
+
+    PAssert.thatSingleton(output.apply("Count", org.apache.beam.sdk.transforms.Count.globally()))
+        .isEqualTo((long) inputCount);
+    pipeline.run();
+  }
+
+  @Test
+  public void testScaleTicks_totalQpsExactMultipleOfBaseRate() {
+    DataGeneratorSchema schema =
+        DataGeneratorSchema.builder().tables(ImmutableMap.of("A", root("A", 300))).build();
+    PCollectionView<DataGeneratorSchema> schemaView =
+        pipeline.apply("MkSchema", Create.of(schema)).apply("AsView", View.asSingleton());
+
+    int inputCount = 100;
+    PCollection<Long> output =
+        pipeline
+            .apply("Input", Create.of(buildSequence(inputCount)))
+            .apply("GenerateTicks", new GenerateTicks(100, schemaView));
+
+    PAssert.thatSingleton(output.apply("Count", org.apache.beam.sdk.transforms.Count.globally()))
+        .isEqualTo((long) inputCount * 3);
+    pipeline.run();
+  }
+
+  @Test
+  public void testScaleTicks_totalQpsLessThanBaseRateStaysBelow() {
+    DataGeneratorSchema schema =
+        DataGeneratorSchema.builder().tables(ImmutableMap.of("A", root("A", 10))).build();
+    PCollectionView<DataGeneratorSchema> schemaView =
+        pipeline.apply("MkSchema", Create.of(schema)).apply("AsView", View.asSingleton());
+
+    int inputCount = 100;
+    PCollection<Long> output =
+        pipeline
+            .apply("Input", Create.of(buildSequence(inputCount)))
+            .apply("GenerateTicks", new GenerateTicks(100, schemaView));
+
+    PAssert.that(output)
+        .satisfies(
+            iter -> {
+              int count = 0;
+              for (Long ignored : iter) {
+                count++;
+              }
+              if (count > inputCount) {
+                throw new AssertionError(
+                    "Probabilistic filter must not emit more than input; got "
+                        + count
+                        + " for "
+                        + inputCount);
+              }
+              return null;
+            });
+    pipeline.run();
+  }
+
+  @Test
+  public void testScaleTicks_scaleUpWithRemainder_emitsAtLeastMultiplierCopies() {
+    DataGeneratorSchema schema =
+        DataGeneratorSchema.builder().tables(ImmutableMap.of("A", root("A", 250))).build();
+    PCollectionView<DataGeneratorSchema> schemaView =
+        pipeline.apply("MkSchema", Create.of(schema)).apply("AsView", View.asSingleton());
+
+    final int inputCount = 100;
+    PCollection<Long> output =
+        pipeline
+            .apply("Input", Create.of(buildSequence(inputCount)))
+            .apply("GenerateTicks", new GenerateTicks(100, schemaView));
+
+    PAssert.that(output)
+        .satisfies(
+            iter -> {
+              int count = 0;
+              for (Long ignored : iter) {
+                count++;
+              }
+              int lowerBound = 2 * inputCount;
+              int upperBound = 3 * inputCount;
+              if (count < lowerBound || count > upperBound) {
+                throw new AssertionError(
+                    "Expected output in [" + lowerBound + ", " + upperBound + "] but got " + count);
+              }
+              return null;
+            });
+    pipeline.run();
+  }
+
+  private static List<Long> buildSequence(int count) {
+    if (count <= 0) {
+      return Collections.emptyList();
+    }
+    List<Long> out = new ArrayList<>(count);
+    for (long i = 0; i < count; i++) {
+      out.add(i);
+    }
+    return out;
+  }
+}

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/GenerateTicksTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/GenerateTicksTest.java
@@ -31,6 +31,7 @@ import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.joda.time.Instant;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -74,17 +75,6 @@ public class GenerateTicksTest {
   }
 
   @Test
-  public void testResolveBaseTickRate_usesInsertQps() {
-    assertEquals(500, GenerateTicks.resolveBaseTickRate(500));
-  }
-
-  @Test
-  public void testResolveBaseTickRate_defaultsToConstantWhenZeroOrNegative() {
-    assertEquals(GenerateTicks.DEFAULT_BASE_TICK_RATE, GenerateTicks.resolveBaseTickRate(0));
-    assertEquals(GenerateTicks.DEFAULT_BASE_TICK_RATE, GenerateTicks.resolveBaseTickRate(-5));
-  }
-
-  @Test
   public void testTotalRootQps_sumsOnlyRootTables() {
     DataGeneratorSchema schema =
         DataGeneratorSchema.builder()
@@ -119,119 +109,38 @@ public class GenerateTicksTest {
 
     PCollection<Long> output =
         pipeline
-            .apply("Input", Create.of(buildSequence(50)))
-            .apply("GenerateTicks", new GenerateTicks(100, schemaView));
+            .apply("Input", Create.of(buildInstantSequence(50)))
+            .apply("GenerateTicks", new GenerateTicks(schemaView));
 
     PAssert.that(output).empty();
     pipeline.run();
   }
 
   @Test
-  public void testScaleTicks_totalQpsEqualsBaseRateEmitsSameCount() {
-    DataGeneratorSchema schema =
-        DataGeneratorSchema.builder().tables(ImmutableMap.of("A", root("A", 100))).build();
-    PCollectionView<DataGeneratorSchema> schemaView =
-        pipeline.apply("MkSchema", Create.of(schema)).apply("AsView", View.asSingleton());
-
-    int inputCount = 100;
-    PCollection<Long> output =
-        pipeline
-            .apply("Input", Create.of(buildSequence(inputCount)))
-            .apply("GenerateTicks", new GenerateTicks(100, schemaView));
-
-    PAssert.thatSingleton(output.apply("Count", org.apache.beam.sdk.transforms.Count.globally()))
-        .isEqualTo((long) inputCount);
-    pipeline.run();
-  }
-
-  @Test
-  public void testScaleTicks_totalQpsExactMultipleOfBaseRate() {
-    DataGeneratorSchema schema =
-        DataGeneratorSchema.builder().tables(ImmutableMap.of("A", root("A", 300))).build();
-    PCollectionView<DataGeneratorSchema> schemaView =
-        pipeline.apply("MkSchema", Create.of(schema)).apply("AsView", View.asSingleton());
-
-    int inputCount = 100;
-    PCollection<Long> output =
-        pipeline
-            .apply("Input", Create.of(buildSequence(inputCount)))
-            .apply("GenerateTicks", new GenerateTicks(100, schemaView));
-
-    PAssert.thatSingleton(output.apply("Count", org.apache.beam.sdk.transforms.Count.globally()))
-        .isEqualTo((long) inputCount * 3);
-    pipeline.run();
-  }
-
-  @Test
-  public void testScaleTicks_totalQpsLessThanBaseRateStaysBelow() {
+  public void testScaleTicks_emitsTotalQpsCopies() {
     DataGeneratorSchema schema =
         DataGeneratorSchema.builder().tables(ImmutableMap.of("A", root("A", 10))).build();
     PCollectionView<DataGeneratorSchema> schemaView =
         pipeline.apply("MkSchema", Create.of(schema)).apply("AsView", View.asSingleton());
 
-    int inputCount = 100;
+    int inputCount = 5;
     PCollection<Long> output =
         pipeline
-            .apply("Input", Create.of(buildSequence(inputCount)))
-            .apply("GenerateTicks", new GenerateTicks(100, schemaView));
+            .apply("Input", Create.of(buildInstantSequence(inputCount)))
+            .apply("GenerateTicks", new GenerateTicks(schemaView));
 
-    PAssert.that(output)
-        .satisfies(
-            iter -> {
-              int count = 0;
-              for (Long ignored : iter) {
-                count++;
-              }
-              if (count > inputCount) {
-                throw new AssertionError(
-                    "Probabilistic filter must not emit more than input; got "
-                        + count
-                        + " for "
-                        + inputCount);
-              }
-              return null;
-            });
+    PAssert.thatSingleton(output.apply("Count", org.apache.beam.sdk.transforms.Count.globally()))
+        .isEqualTo((long) inputCount * 10);
     pipeline.run();
   }
 
-  @Test
-  public void testScaleTicks_scaleUpWithRemainder_emitsAtLeastMultiplierCopies() {
-    DataGeneratorSchema schema =
-        DataGeneratorSchema.builder().tables(ImmutableMap.of("A", root("A", 250))).build();
-    PCollectionView<DataGeneratorSchema> schemaView =
-        pipeline.apply("MkSchema", Create.of(schema)).apply("AsView", View.asSingleton());
-
-    final int inputCount = 100;
-    PCollection<Long> output =
-        pipeline
-            .apply("Input", Create.of(buildSequence(inputCount)))
-            .apply("GenerateTicks", new GenerateTicks(100, schemaView));
-
-    PAssert.that(output)
-        .satisfies(
-            iter -> {
-              int count = 0;
-              for (Long ignored : iter) {
-                count++;
-              }
-              int lowerBound = 2 * inputCount;
-              int upperBound = 3 * inputCount;
-              if (count < lowerBound || count > upperBound) {
-                throw new AssertionError(
-                    "Expected output in [" + lowerBound + ", " + upperBound + "] but got " + count);
-              }
-              return null;
-            });
-    pipeline.run();
-  }
-
-  private static List<Long> buildSequence(int count) {
+  private static List<Instant> buildInstantSequence(int count) {
     if (count <= 0) {
       return Collections.emptyList();
     }
-    List<Long> out = new ArrayList<>(count);
+    List<Instant> out = new ArrayList<>(count);
     for (long i = 0; i < count; i++) {
-      out.add(i);
+      out.add(Instant.ofEpochMilli(i));
     }
     return out;
   }

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/GenerateTicksTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/GenerateTicksTest.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.templates.transforms;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import com.google.cloud.teleport.v2.templates.dofn.ScaleTicksFn;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorSchema;
@@ -101,19 +102,17 @@ public class GenerateTicksTest {
   }
 
   @Test
-  public void testScaleTicks_zeroTotalQpsEmitsNothing() {
+  public void testScaleTicks_zeroTotalQpsThrowsException() {
     DataGeneratorSchema schema =
         DataGeneratorSchema.builder().tables(ImmutableMap.of("B", child("B", "A", 42))).build();
     PCollectionView<DataGeneratorSchema> schemaView =
         pipeline.apply("MkSchema", Create.of(schema)).apply("AsView", View.asSingleton());
 
-    PCollection<Long> output =
-        pipeline
-            .apply("Input", Create.of(buildInstantSequence(50)))
-            .apply("GenerateTicks", new GenerateTicks(schemaView));
+    pipeline
+        .apply("Input", Create.of(buildInstantSequence(50)))
+        .apply("GenerateTicks", new GenerateTicks(schemaView));
 
-    PAssert.that(output).empty();
-    pipeline.run();
+    assertThrows(RuntimeException.class, () -> pipeline.run());
   }
 
   @Test


### PR DESCRIPTION
# PR Description

## Summary
This PR introduces a new mechanism to dynamically scale the data generation tick rate to match the total requested QPS for root tables defined in the schema. It adds a new `PTransform` and `DoFn` to handle both rate reduction and amplification at runtime.

## Key Changes

#### [NEW] [ScaleTicksFn.java](file:///Users/khajanchi/IdeaProjects/shreya_df/DataflowTemplates/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/ScaleTicksFn.java)
- Implemented a `DoFn` that acts as a rate converter.
- It reads the target QPS from the schema side-input and scales the input tick stream up or down to match the target rate using probabilistic and deterministic scaling.

#### [NEW] [GenerateTicks.java](file:///Users/khajanchi/IdeaProjects/shreya_df/DataflowTemplates/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/transforms/GenerateTicks.java)
- Implemented a `PTransform` that applies `ScaleTicksFn` to the input tick stream.
- Resolves the base tick rate from the configured `insertQps`.

#### [NEW] [GenerateTicksTest.java](file:///Users/khajanchi/IdeaProjects/shreya_df/DataflowTemplates/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/GenerateTicksTest.java)
- Added comprehensive unit tests to verify the rate conversion logic for various scenarios (exact match, scale up, scale down, and fallbacks).

## Verification Results
- All unit tests in `GenerateTicksTest` passed successfully.
