### PR TITLE
Add AWS dependencies to the YAML template

### DIFF
--- a/python/default_base_yaml_requirements.txt
+++ b/python/default_base_yaml_requirements.txt
@@ -1,2 +1,2 @@
-apache-beam[dataframe,gcp,test,yaml]
+apache-beam[dataframe,gcp,test,yaml,aws]
 setuptools


### PR DESCRIPTION
This will be useful for YAML and Dataflow Job builder when executing pipelines that connect to AWS (for example, reading from S3).