### PR TITLE
Adds a package that includes utility transforms for Job builder

### DIFF
--- a/.github/workflows/upload-python-package.yml
+++ b/.github/workflows/upload-python-package.yml
@@ -40,6 +40,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install poetry
 
+      - name: Install project dependencies
+        working-directory: python/src/main/python/job-builder-util-transforms
+        run: poetry install
+
+      - name: Run Tests
+        working-directory: python/src/main/python/job-builder-util-transforms
+        run: poetry run pytest ../../../test/python/job-builder-util-transforms/
+
       - name: Build Package
         working-directory: python/src/main/python/job-builder-util-transforms
         run: poetry build

--- a/.github/workflows/upload-python-package.yml
+++ b/.github/workflows/upload-python-package.yml
@@ -1,0 +1,51 @@
+# ====================================================================================
+# Purpose:
+#   This workflow builds and uploads the job-builder-util-transforms Python package to Google Cloud Storage (GCS).
+#   It is designed to distribute the utility transforms package for use in Dataflow jobs.
+#   The workflow:
+#     1. Sets up Python and installs build dependencies.
+#     2. Builds the Python package (wheel and sdist).
+#     3. Uploads the built artifacts to a specified GCS bucket.
+#
+# How to Run:
+#   This workflow is triggered manually via GitHub Actions `workflow_dispatch`.
+#   Required Inputs:
+#     - bucket_path: The GCS bucket destination (e.g., gs://my-bucket/path).
+# ====================================================================================
+
+name: Build and Upload Python Package for Job Builder
+
+on:
+  workflow_dispatch:
+    inputs:
+      bucket_path:
+        description: 'GCS bucket path (e.g., gs://my-bucket/path)'
+        required: true
+
+jobs:
+  build-and-upload:
+    runs-on: [self-hosted, release]
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+
+      - name: Build Package
+        working-directory: python/src/main/python/job-builder-util-transforms
+        run: poetry build
+
+      - name: Upload to GCS
+        env:
+          BUCKET_PATH: ${{ github.event.inputs.bucket_path }}
+        run: |
+          gcloud storage cp python/src/main/python/job-builder-util-transforms/dist/* "$BUCKET_PATH"

--- a/python/src/main/python/job-builder-util-transforms/copy_files_to_gcs.py
+++ b/python/src/main/python/job-builder-util-transforms/copy_files_to_gcs.py
@@ -1,0 +1,89 @@
+"""Module containing transforms to copy files to Google Cloud Storage (GCS)."""
+
+import apache_beam as beam
+from apache_beam import Row
+from apache_beam.transforms import DoFn
+from apache_beam.transforms import ParDo
+from apache_beam.transforms import PTransform
+from apache_beam.io.filesystems import FileSystems
+from apache_beam.typehints.row_type import RowTypeConstraint
+import shutil
+import secrets
+
+class CopyFilesToGCSDoFn(DoFn):
+  """A DoFn that copies input files to a GCS destination.
+  
+  It skips files that are already on GCS (starting with 'gs://').
+  It uses a bundle-level random prefix to avoid duplicate writes on retries.
+  """
+  COPY_BUFFER_SIZE = 16*1024*1024  # 16MB
+  JOB_LEVEL_PREFIX = 'migrated-data-'  # 16MB
+  
+  def __init__(self, job_level_gcs_prefix):
+    """Initializes the DoFn.
+    
+    Args:
+      job_level_gcs_prefix: The job-level GCS prefix to use for copying files.
+    """
+    self.job_level_gcs_prefix = job_level_gcs_prefix
+
+  def start_bundle(self):
+    """Starts a bundle. Generates a unique bundle-level prefix if a job-level prefix is set."""
+    # Generating a random string to be added to the path during bundle startup
+    # so that we do not write duplicate data due to bundle retries by the runner.
+    if self.job_level_gcs_prefix:
+      self.bundle_level_gcs_prefix = self.job_level_gcs_prefix + secrets.token_urlsafe(32) + '/'
+    else:
+      self.bundle_level_gcs_prefix = None
+
+  def process(self, input_file):
+    """Processes an input file.
+    
+    Args:
+      input_file: A `Row` object with a `path` attribute representing the file path.
+      
+    Yields:
+      A `Row` object containing the new path of the file on GCS, or the original path if it was already on GCS.
+    """
+    if input_file.path.startswith('gs://'):
+      # No need to copy over GCS files.
+      yield input_file
+      return
+
+    if not self.bundle_level_gcs_prefix:
+      raise ValueError(f"Encountered non-GCS file {input_file.path} but no gcs_file_path was provided to copy to.")
+
+    file_name = input_file.path.split('/')[-1]
+    gcs_file_path = self.bundle_level_gcs_prefix + file_name
+    with FileSystems.open(input_file.path, 'application/octet-stream') as s3_file:
+      with FileSystems.create(gcs_file_path, 'application/octet-stream') as gcs_file:
+        shutil.copyfileobj(s3_file, gcs_file, length=CopyFilesToGCSDoFn.COPY_BUFFER_SIZE)
+
+    yield Row(path=gcs_file_path)
+
+
+class CopyFilesToGCS(PTransform):
+  """A PTransform that copies files to GCS.
+  
+  It takes a PCollection of objects with a `path` attribute and copies non-GCS files to the specified GCS destination.
+  """
+  def __init__(self, gcs_file_path):
+    """Initializes the transform.
+    
+    Args:
+      gcs_file_path: The base GCS path where files should be copied.
+    """
+    self.gcs_file_path = gcs_file_path
+
+  def expand(self, pcoll):
+    """Expands the transform.
+    
+    Generates a job-level random prefix and applies `CopyFilesToGCSDoFn`.
+    """
+    if self.gcs_file_path:
+      gcs_file_path = self.gcs_file_path if self.gcs_file_path.endswith('/') else self.gcs_file_path + '/'
+      # Generating a job level random prefix so that files copied in a single job can be easily identified.
+      job_level_gcs_prefix = gcs_file_path + secrets.token_urlsafe(32) + '/'
+    else:
+      job_level_gcs_prefix = None
+    return pcoll | ParDo(CopyFilesToGCSDoFn(job_level_gcs_prefix)).with_output_types(RowTypeConstraint.from_fields([('path', str)]))

--- a/python/src/main/python/job-builder-util-transforms/copy_files_to_gcs.py
+++ b/python/src/main/python/job-builder-util-transforms/copy_files_to_gcs.py
@@ -30,7 +30,8 @@ class CopyFilesToGCSDoFn(DoFn):
   def start_bundle(self):
     """Starts a bundle. Generates a unique bundle-level prefix if a job-level prefix is set."""
     # Generating a random string to be added to the path during bundle startup
-    # so that we do not write duplicate data due to bundle retries by the runner.
+    # so that subquent steps only consider elements from succeessful bundles executions
+    # in case of a bundle retry by the runner.
     if self.job_level_gcs_prefix:
       self.bundle_level_gcs_prefix = self.job_level_gcs_prefix + secrets.token_urlsafe(32) + '/'
     else:
@@ -55,9 +56,9 @@ class CopyFilesToGCSDoFn(DoFn):
 
     file_name = input_file.path.split('/')[-1]
     gcs_file_path = self.bundle_level_gcs_prefix + file_name
-    with FileSystems.open(input_file.path, 'application/octet-stream') as s3_file:
+    with FileSystems.open(input_file.path, 'application/octet-stream') as external_file:
       with FileSystems.create(gcs_file_path, 'application/octet-stream') as gcs_file:
-        shutil.copyfileobj(s3_file, gcs_file, length=CopyFilesToGCSDoFn.COPY_BUFFER_SIZE)
+        shutil.copyfileobj(external_file, gcs_file, length=CopyFilesToGCSDoFn.COPY_BUFFER_SIZE)
 
     yield Row(path=gcs_file_path)
 
@@ -66,6 +67,11 @@ class CopyFilesToGCS(PTransform):
   """A PTransform that copies files to GCS.
   
   It takes a PCollection of objects with a `path` attribute and copies non-GCS files to the specified GCS destination.
+
+  This returns a PCollection of `Row` objects with the new path of the file on GCS, or the original path if it was already on GCS.
+
+  In case of a bundle retry by the runner, this makes sure to only produce elements of successful bundles.
+  Failed bundles may leave temporary files behind that should not be considered as part of the pipeline output.
   """
   def __init__(self, gcs_file_path):
     """Initializes the transform.

--- a/python/src/main/python/job-builder-util-transforms/pyproject.toml
+++ b/python/src/main/python/job-builder-util-transforms/pyproject.toml
@@ -1,0 +1,35 @@
+[tool.poetry]
+name = "job-builder-util-transforms"
+version = "0.1.0"
+description = "Utility transforms for job builder"
+authors = ["Google Cloud Platform"]
+packages = [
+    { include = "copy_files_to_gcs.py" },
+]
+
+[tool.poetry.dependencies]
+python = ">=3.11,<4.0"
+apache-beam = {extras = ["gcp", "yaml"], version = "2.72.0"}
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.3.4"
+yapf = "^0.43.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.yapf]
+indent_width = 2
+continuation_indent_width = 4
+column_limit = 80
+allow_split_before_dict_value = false
+blank_line_before_module_docstring = true
+coalesce_brackets = true
+each_dict_entry_on_separate_line = true
+split_all_top_level_comma_separated_values = true
+split_arguments_when_comma_terminated = true
+split_before_expression_after_opening_paren = true
+split_before_first_argument = true
+split_before_logical_operator = false
+

--- a/python/src/test/python/job-builder-util-transforms/copy_files_to_gcs_test.py
+++ b/python/src/test/python/job-builder-util-transforms/copy_files_to_gcs_test.py
@@ -1,0 +1,71 @@
+import unittest
+import os
+import shutil
+import tempfile
+import apache_beam as beam
+from apache_beam import Row
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that
+from apache_beam.typehints.row_type import RowTypeConstraint
+
+from copy_files_to_gcs import CopyFilesToGCSDoFn
+from copy_files_to_gcs import CopyFilesToGCS as CopyFilesToGCSImpl
+
+class TransformsTest(unittest.TestCase):
+
+  def test_copy_files_to_gcs_dofn_gcs_input(self):
+    dofn = CopyFilesToGCSDoFn(job_level_gcs_prefix='gs://bucket/job/')
+    dofn.start_bundle()
+    
+    input_row = Row(path='gs://bucket/source/file.txt')
+    outputs = list(dofn.process(input_row))
+    
+    self.assertEqual(len(outputs), 1)
+    self.assertEqual(outputs[0], input_row)
+
+  def test_copy_files_to_gcs_dofn_local_input(self):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      src_file = os.path.join(tmp_dir, 'src.txt')
+      with open(src_file, 'w') as f:
+        f.write('hello world')
+        
+      dest_prefix = os.path.join(tmp_dir, 'dest') + '/'
+      
+      dofn = CopyFilesToGCSDoFn(job_level_gcs_prefix=dest_prefix)
+      dofn.start_bundle()
+      
+      input_row = Row(path=src_file)
+      outputs = list(dofn.process(input_row))
+      
+      self.assertEqual(len(outputs), 1)
+      out_path = outputs[0].path
+      self.assertTrue(out_path.startswith(dest_prefix))
+      self.assertTrue(out_path.endswith('src.txt'))
+      
+      # Verify file was copied
+      self.assertTrue(os.path.exists(out_path))
+      with open(out_path, 'r') as f:
+        self.assertEqual(f.read(), 'hello world')
+
+  def test_copy_files_to_gcs_transform(self):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      src_file = os.path.join(tmp_dir, 'src.txt')
+      with open(src_file, 'w') as f:
+        f.write('hello world')
+        
+      dest_prefix = os.path.join(tmp_dir, 'dest') + '/'
+      
+      with TestPipeline() as p:
+        input_rows = p | beam.Create([Row(path=src_file)])
+        output = input_rows | CopyFilesToGCSImpl(gcs_file_path=dest_prefix)
+        
+        def check_output(elements):
+          self.assertEqual(len(elements), 1)
+          element = elements[0]
+          self.assertTrue(hasattr(element, 'path'))
+          self.assertTrue(element.path.startswith(dest_prefix))
+          
+        assert_that(output, check_output)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/python/src/test/python/job-builder-util-transforms/copy_files_to_gcs_test.py
+++ b/python/src/test/python/job-builder-util-transforms/copy_files_to_gcs_test.py
@@ -1,15 +1,15 @@
 import unittest
+from unittest.mock import patch
 import os
-import shutil
 import tempfile
 import apache_beam as beam
 from apache_beam import Row
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
-from apache_beam.typehints.row_type import RowTypeConstraint
+from apache_beam.testing.util import equal_to
 
 from copy_files_to_gcs import CopyFilesToGCSDoFn
-from copy_files_to_gcs import CopyFilesToGCS as CopyFilesToGCSImpl
+from copy_files_to_gcs import CopyFilesToGCS
 
 class TransformsTest(unittest.TestCase):
 
@@ -55,17 +55,13 @@ class TransformsTest(unittest.TestCase):
         
       dest_prefix = os.path.join(tmp_dir, 'dest') + '/'
       
-      with TestPipeline() as p:
-        input_rows = p | beam.Create([Row(path=src_file)])
-        output = input_rows | CopyFilesToGCSImpl(gcs_file_path=dest_prefix)
-        
-        def check_output(elements):
-          self.assertEqual(len(elements), 1)
-          element = elements[0]
-          self.assertTrue(hasattr(element, 'path'))
-          self.assertTrue(element.path.startswith(dest_prefix))
+      with patch('copy_files_to_gcs.secrets.token_urlsafe', return_value='fixed_token'):
+        with TestPipeline() as p:
+          input_rows = p | beam.Create([Row(path=src_file)])
+          output = input_rows | CopyFilesToGCS(gcs_file_path=dest_prefix)
           
-        assert_that(output, check_output)
+          expected_path = dest_prefix + 'fixed_token/' + 'fixed_token/' + 'src.txt'
+          assert_that(output, equal_to([Row(path=expected_path)]))
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This will include utility transforms that wii be used by Job builder via a Python provider. Adding them here (instead of directly in Job builder makes such transforms better testable).

Also adds a Github workflow for pushing a package that includes such transforms to GCS.