### PR TITLE
[spanner-to-sourcedb] Fail fast if MySQL destination is read-only

### DIFF
--- a/v2/gcs-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/GCSToSourceDb.java
+++ b/v2/gcs-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/GCSToSourceDb.java
@@ -21,18 +21,12 @@ import com.google.cloud.teleport.metadata.TemplateCategory;
 import com.google.cloud.teleport.metadata.TemplateParameter;
 import com.google.cloud.teleport.metadata.TemplateParameter.TemplateEnumOption;
 import com.google.cloud.teleport.v2.common.UncaughtExceptionLogger;
-import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
 import com.google.cloud.teleport.v2.spanner.migrations.transformation.CustomTransformation;
 import com.google.cloud.teleport.v2.templates.GCSToSourceDb.Options;
 import com.google.cloud.teleport.v2.templates.common.ProcessingContext;
 import com.google.cloud.teleport.v2.templates.constants.Constants;
 import com.google.cloud.teleport.v2.templates.transforms.GcsToSourceStreamer;
 import com.google.cloud.teleport.v2.templates.utils.ProcessingContextGenerator;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Map;
 import java.util.regex.Pattern;
 import org.apache.beam.sdk.Pipeline;
@@ -377,11 +371,8 @@ public class GCSToSourceDb {
             tableSuffix,
             options.getRunIdentifier(),
             isMetadataDbPostgres);
-    LOG.info("The size of  processing context is : " + processingContextMap.size());
 
-    if ("mysql".equals(options.getSourceType())) {
-      validateMySQLNotReadOnly(processingContextMap);
-    }
+    LOG.info("The size of  processing context is : " + processingContextMap.size());
 
     pipeline
         .apply(
@@ -403,33 +394,5 @@ public class GCSToSourceDb {
                     options.getSpannerProjectId())));
 
     return pipeline.run();
-  }
-
-  private static void validateMySQLNotReadOnly(
-      Map<String, ProcessingContext> processingContextMap) {
-    for (ProcessingContext context : processingContextMap.values()) {
-      Shard shard = context.getShard();
-      String sourceConnectionUrl =
-          "jdbc:mysql://" + shard.getHost() + ":" + shard.getPort() + "/" + shard.getDbName();
-      try (Connection conn =
-          DriverManager.getConnection(
-              sourceConnectionUrl, shard.getUserName(), shard.getPassword())) {
-        if (conn != null) {
-          try (Statement stmt = conn.createStatement();
-              ResultSet rs = stmt.executeQuery("SELECT @@read_only")) {
-            if (rs != null && rs.next() && rs.getInt(1) == 1) {
-              throw new RuntimeException(
-                  "MySQL destination is in read-only mode for shard: " + shard.getLogicalShardId());
-            }
-          }
-        }
-      } catch (SQLException e) {
-        LOG.error(
-            "Error checking MySQL read-only status for shard {}: {}",
-            shard.getLogicalShardId(),
-            e.getMessage());
-        throw new RuntimeException("Error checking MySQL read-only status", e);
-      }
-    }
   }
 }

--- a/v2/gcs-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/GCSToSourceDb.java
+++ b/v2/gcs-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/GCSToSourceDb.java
@@ -27,6 +27,12 @@ import com.google.cloud.teleport.v2.templates.common.ProcessingContext;
 import com.google.cloud.teleport.v2.templates.constants.Constants;
 import com.google.cloud.teleport.v2.templates.transforms.GcsToSourceStreamer;
 import com.google.cloud.teleport.v2.templates.utils.ProcessingContextGenerator;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
 import java.util.Map;
 import java.util.regex.Pattern;
 import org.apache.beam.sdk.Pipeline;
@@ -371,8 +377,11 @@ public class GCSToSourceDb {
             tableSuffix,
             options.getRunIdentifier(),
             isMetadataDbPostgres);
-
     LOG.info("The size of  processing context is : " + processingContextMap.size());
+
+    if ("mysql".equals(options.getSourceType())) {
+      validateMySQLNotReadOnly(processingContextMap);
+    }
 
     pipeline
         .apply(
@@ -394,5 +403,33 @@ public class GCSToSourceDb {
                     options.getSpannerProjectId())));
 
     return pipeline.run();
+  }
+
+  private static void validateMySQLNotReadOnly(Map<String, ProcessingContext> processingContextMap) {
+    for (ProcessingContext context : processingContextMap.values()) {
+      Shard shard = context.getShard();
+      String sourceConnectionUrl =
+          "jdbc:mysql://" + shard.getHost() + ":" + shard.getPort() + "/" + shard.getDbName();
+      try (Connection conn =
+          DriverManager.getConnection(
+              sourceConnectionUrl, shard.getUserName(), shard.getPassword())) {
+        if (conn != null) {
+          try (Statement stmt = conn.createStatement();
+              ResultSet rs = stmt.executeQuery("SELECT @@read_only")) {
+            if (rs != null && rs.next() && rs.getInt(1) == 1) {
+              throw new RuntimeException(
+                  "MySQL destination is in read-only mode for shard: "
+                      + shard.getLogicalShardId());
+            }
+          }
+        }
+      } catch (SQLException e) {
+        LOG.error(
+            "Error checking MySQL read-only status for shard {}: {}",
+            shard.getLogicalShardId(),
+            e.getMessage());
+        throw new RuntimeException("Error checking MySQL read-only status", e);
+      }
+    }
   }
 }

--- a/v2/gcs-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/GCSToSourceDb.java
+++ b/v2/gcs-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/GCSToSourceDb.java
@@ -21,6 +21,7 @@ import com.google.cloud.teleport.metadata.TemplateCategory;
 import com.google.cloud.teleport.metadata.TemplateParameter;
 import com.google.cloud.teleport.metadata.TemplateParameter.TemplateEnumOption;
 import com.google.cloud.teleport.v2.common.UncaughtExceptionLogger;
+import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
 import com.google.cloud.teleport.v2.spanner.migrations.transformation.CustomTransformation;
 import com.google.cloud.teleport.v2.templates.GCSToSourceDb.Options;
 import com.google.cloud.teleport.v2.templates.common.ProcessingContext;
@@ -32,7 +33,6 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
 import java.util.Map;
 import java.util.regex.Pattern;
 import org.apache.beam.sdk.Pipeline;
@@ -405,7 +405,8 @@ public class GCSToSourceDb {
     return pipeline.run();
   }
 
-  private static void validateMySQLNotReadOnly(Map<String, ProcessingContext> processingContextMap) {
+  private static void validateMySQLNotReadOnly(
+      Map<String, ProcessingContext> processingContextMap) {
     for (ProcessingContext context : processingContextMap.values()) {
       Shard shard = context.getShard();
       String sourceConnectionUrl =
@@ -418,8 +419,7 @@ public class GCSToSourceDb {
               ResultSet rs = stmt.executeQuery("SELECT @@read_only")) {
             if (rs != null && rs.next() && rs.getInt(1) == 1) {
               throw new RuntimeException(
-                  "MySQL destination is in read-only mode for shard: "
-                      + shard.getLogicalShardId());
+                  "MySQL destination is in read-only mode for shard: " + shard.getLogicalShardId());
             }
           }
         }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
@@ -66,7 +66,10 @@ import com.google.common.base.Strings;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -657,6 +660,11 @@ public class SpannerToSourceDb {
       LOG.info("Cassandra config is: {}", shards.get(0));
       shardingMode = Constants.SHARDING_MODE_SINGLE_SHARD;
     }
+
+    if (MYSQL_SOURCE_TYPE.equals(options.getSourceType())) {
+      validateMySQLNotReadOnly(shards);
+    }
+
     SourceSchema sourceSchema = fetchSourceSchema(options, shards);
     LOG.info("Source schema: {}", sourceSchema);
 
@@ -991,6 +999,33 @@ public class SpannerToSourceDb {
         CassandraDriverConfigLoader.fromOptionsMap(cassandraShard.getOptionsMap());
     builder.withConfigLoader(configLoader);
     return builder.build();
+  }
+
+  private static void validateMySQLNotReadOnly(List<Shard> shards) {
+    for (Shard shard : shards) {
+      String sourceConnectionUrl =
+          "jdbc:mysql://" + shard.getHost() + ":" + shard.getPort() + "/" + shard.getDbName();
+      try (Connection conn =
+          DriverManager.getConnection(
+              sourceConnectionUrl, shard.getUserName(), shard.getPassword())) {
+        if (conn != null) {
+          try (Statement stmt = conn.createStatement();
+              ResultSet rs = stmt.executeQuery("SELECT @@read_only")) {
+            if (rs != null && rs.next() && rs.getInt(1) == 1) {
+              throw new RuntimeException(
+                  "MySQL destination is in read-only mode for shard: "
+                      + shard.getLogicalShardId());
+            }
+          }
+        }
+      } catch (SQLException e) {
+        LOG.error(
+            "Error checking MySQL read-only status for shard {}: {}",
+            shard.getLogicalShardId(),
+            e.getMessage());
+        throw new RuntimeException("Error checking MySQL read-only status", e);
+      }
+    }
   }
 
   private static SourceSchema fetchSourceSchema(Options options, List<Shard> shards) {

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
@@ -1013,8 +1013,7 @@ public class SpannerToSourceDb {
               ResultSet rs = stmt.executeQuery("SELECT @@read_only")) {
             if (rs != null && rs.next() && rs.getInt(1) == 1) {
               throw new RuntimeException(
-                  "MySQL destination is in read-only mode for shard: "
-                      + shard.getLogicalShardId());
+                  "MySQL destination is in read-only mode for shard: " + shard.getLogicalShardId());
             }
           }
         }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
@@ -66,7 +66,6 @@ import com.google.common.base.Strings;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -1003,11 +1002,8 @@ public class SpannerToSourceDb {
 
   private static void validateMySQLNotReadOnly(List<Shard> shards) {
     for (Shard shard : shards) {
-      String sourceConnectionUrl =
-          "jdbc:mysql://" + shard.getHost() + ":" + shard.getPort() + "/" + shard.getDbName();
       try (Connection conn =
-          DriverManager.getConnection(
-              sourceConnectionUrl, shard.getUserName(), shard.getPassword())) {
+          createJdbcConnection(shard, "com.mysql.cj.jdbc.Driver", "jdbc:mysql://")) {
         if (conn != null) {
           try (Statement stmt = conn.createStatement();
               ResultSet rs = stmt.executeQuery("SELECT @@read_only")) {


### PR DESCRIPTION
fixes b/414507198

Adds a pre-launch check to ensure destination MySQL shards are not in read-only mode in SpannerToSourceDb template. This prevents pipeline failures later during execution.

TESTED: 
Confirmed fail-fast behavior with error: MySQL** destination is in read-only* mode.
```
com.google.cloud.teleport.v2.common.UncaughtExceptionLogger - The template launch failed.
java.lang.RuntimeException: MySQL destination is in read-only mode for shard: shard1
	at com.google.cloud.teleport.v2.templates.SpannerToSourceDb.validateMySQLNotReadOnly(SpannerToSourceDb.java:1017)
	at com.google.cloud.teleport.v2.templates.SpannerToSourceDb.run(SpannerToSourceDb.java:665)
	at com.google.cloud.teleport.v2.templates.SpannerToSourceDb.main(SpannerToSourceDb.java:563)
```

_*Read only mode was achieved using `gcloud sql instances patch [instance] --database-flags=read_only=on`_ 
_**Tested on MySQL 8.0 and 5.7_
