### PR TITLE
Adding generate primary key transform in data generator

### DIFF
--- a/v2/cdc-data-generator/pom.xml
+++ b/v2/cdc-data-generator/pom.xml
@@ -44,6 +44,11 @@
             <version>3.6.1</version>
         </dependency>
         <dependency>
+            <groupId>com.github.javafaker</groupId>
+            <artifactId>javafaker</artifactId>
+            <version>1.0.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.beam</groupId>
             <artifactId>beam-sdks-java-core</artifactId>
         </dependency>

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/GeneratePrimaryKeyFn.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/GeneratePrimaryKeyFn.java
@@ -47,11 +47,8 @@ import org.slf4j.LoggerFactory;
  * writers are reused here.
  *
  * <p>Randomness: {@link Faker} is constructed with its default no-arg constructor (which seeds
- * itself from {@code System.nanoTime()} plus a per-instance counter, not from {@code
- * /dev/urandom}), and shard-id selection uses {@link ThreadLocalRandom#current()} to avoid
- * contention under high fan-out. Duplicate-PK errors observed during earlier development were
- * caused by Beam retrying already-applied inserts, not by seed collisions across workers; the sink
- * writers now use upsert semantics, which absorbs retries cleanly.
+ * itself from {@code System.nanoTime()} plus a per-instance counter and shard-id selection uses
+ * {@link ThreadLocalRandom#current()} to avoid contention under high fan-out.
  *
  * <p>Output: {@code KV<tableName, pkRow>} so downstream transforms can shuffle by table while
  * keeping the row schema per-table.
@@ -103,8 +100,10 @@ public class GeneratePrimaryKeyFn extends DoFn<DataGeneratorTable, KV<String, Ro
     List<DataGeneratorColumn> pkColumns = primaryKeyColumns(table);
 
     if (pkColumns.isEmpty()) {
-      // A table without a PK cannot have a unique row key synthesised for it. This is a
-      // schema-definition problem, so log + skip rather than emit an empty Row (which would
+      // A table without a PK cannot have a unique row key synthesised for it. This is
+      // a
+      // schema-definition problem, so log + skip rather than emit an empty Row (which
+      // would
       // corrupt downstream joins on the PK).
       LOG.warn(
           "Table {} has no primary-key columns, or its PK list references unknown columns — "
@@ -159,9 +158,8 @@ public class GeneratePrimaryKeyFn extends DoFn<DataGeneratorTable, KV<String, Ro
   }
 
   /**
-   * Select a shard id for this row. Prefer a configured logical shard id (MySQL with shardFile),
-   * otherwise synthesise a placeholder {@code shard<N>}. Bounded at maxShards >= 1 so {@code
-   * nextInt} never throws.
+   * Select a shard id for this row. Prefer a configured logical shard id, otherwise synthesise a
+   * placeholder {@code shard<N>}. Bounded at maxShards >= 1 so {@code nextInt} never throws.
    */
   private String pickShardId() {
     ThreadLocalRandom rng = ThreadLocalRandom.current();

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/GeneratePrimaryKeyFn.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/GeneratePrimaryKeyFn.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.dofn;
+
+import com.github.javafaker.Faker;
+import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.SecretManagerAccessorImpl;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.ShardFileReader;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorColumn;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
+import com.google.cloud.teleport.v2.templates.utils.Constants;
+import com.google.cloud.teleport.v2.templates.utils.DataGeneratorUtils;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.Row;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Generates a synthetic primary-key Row for each incoming {@link DataGeneratorTable}.
+ *
+ * <p>The emitted {@link Row} has the table's PK columns followed by a synthesised logical shard
+ * id column (name controlled by {@link Constants#SHARD_ID_COLUMN_NAME}). The shard id is either
+ * sampled uniformly from {@code [0, maxShards)} or, for MySQL sinks with a shard config file,
+ * sampled uniformly from the configured logical shard ids so the same shard ids used by
+ * downstream writers are reused here.
+ *
+ * <p>Randomness: {@link Faker} is constructed with its default no-arg constructor (which seeds
+ * itself from {@code System.nanoTime()} plus a per-instance counter, not from
+ * {@code /dev/urandom}), and shard-id selection uses {@link ThreadLocalRandom#current()} to
+ * avoid contention under high fan-out. Duplicate-PK errors observed during earlier development
+ * were caused by Beam retrying already-applied inserts, not by seed collisions across workers;
+ * the sink writers now use upsert semantics, which absorbs retries cleanly.
+ *
+ * <p>Output: {@code KV<tableName, pkRow>} so downstream transforms can shuffle by table while
+ * keeping the row schema per-table.
+ */
+public class GeneratePrimaryKeyFn extends DoFn<DataGeneratorTable, KV<String, Row>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GeneratePrimaryKeyFn.class);
+
+    private final int maxShards;
+    private final String sinkOptionsPath;
+    private final String sinkType;
+
+    private transient Faker faker;
+    private transient List<String> logicalShardIds;
+    /** Per-table PK schema cache. Schemas are static per pipeline run so this is write-once. */
+    private transient Map<String, Schema> schemaCache;
+
+    public GeneratePrimaryKeyFn(int maxShards, String sinkOptionsPath, String sinkType) {
+        this.maxShards = maxShards;
+        this.sinkOptionsPath = sinkOptionsPath;
+        this.sinkType = sinkType;
+    }
+
+    @Setup
+    public void setup() {
+        faker = new Faker();
+        schemaCache = new HashMap<>();
+
+        if (Constants.SINK_TYPE_MYSQL.equalsIgnoreCase(sinkType)
+                && sinkOptionsPath != null
+                && !sinkOptionsPath.isEmpty()) {
+            try {
+                ShardFileReader shardFileReader = new ShardFileReader(new SecretManagerAccessorImpl());
+                List<Shard> shards = shardFileReader.getOrderedShardDetails(sinkOptionsPath);
+                this.logicalShardIds =
+                        shards == null || shards.isEmpty()
+                                ? null
+                                : shards.stream().map(Shard::getLogicalShardId).collect(Collectors.toList());
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to read shards from " + sinkOptionsPath, e);
+            }
+        }
+    }
+
+    @ProcessElement
+    public void processElement(
+            @Element DataGeneratorTable table, OutputReceiver<KV<String, Row>> out) {
+        List<DataGeneratorColumn> pkColumns = primaryKeyColumns(table);
+
+        if (pkColumns.isEmpty()) {
+            // A table without a PK cannot have a unique row key synthesised for it. This is a
+            // schema-definition problem, so log + skip rather than emit an empty Row (which would
+            // corrupt downstream joins on the PK).
+            LOG.warn(
+                    "Table {} has no primary-key columns, or its PK list references unknown columns — "
+                            + "skipping PK generation.",
+                    table.name());
+            return;
+        }
+
+        Schema schema = schemaCache.computeIfAbsent(table.name(), k -> buildSchema(pkColumns));
+        Row.Builder rowBuilder = Row.withSchema(schema);
+
+        for (DataGeneratorColumn column : pkColumns) {
+            rowBuilder.addValue(DataGeneratorUtils.generateValue(column, faker));
+        }
+        rowBuilder.addValue(pickShardId());
+
+        out.output(KV.of(table.name(), rowBuilder.build()));
+    }
+
+    /**
+     * Resolve the PK column list for a table.
+     */
+    @VisibleForTesting
+    public static List<DataGeneratorColumn> primaryKeyColumns(DataGeneratorTable table) {
+        if (table.primaryKeys() == null || table.primaryKeys().isEmpty()) {
+            return new ArrayList<>();
+        }
+        Map<String, DataGeneratorColumn> byName = new HashMap<>();
+        for (DataGeneratorColumn col : table.columns()) {
+            byName.put(col.name(), col);
+        }
+        List<DataGeneratorColumn> result = new ArrayList<>(table.primaryKeys().size());
+        for (String pkName : table.primaryKeys()) {
+            DataGeneratorColumn col = byName.get(pkName);
+            if (col != null) {
+                result.add(col);
+            } else {
+                LOG.warn(
+                        "PK column {} declared on table {} not present in columns list — dropping.",
+                        pkName,
+                        table.name());
+            }
+        }
+        return result;
+    }
+
+    private Schema buildSchema(List<DataGeneratorColumn> columns) {
+        Schema.Builder builder = Schema.builder();
+        for (DataGeneratorColumn col : columns) {
+            builder.addField(Schema.Field.of(col.name(), DataGeneratorUtils.mapToBeamFieldType(col)));
+        }
+        builder.addField(Schema.Field.of(Constants.SHARD_ID_COLUMN_NAME, Schema.FieldType.STRING));
+        return builder.build();
+    }
+
+    /**
+     * Select a shard id for this row. Prefer a configured logical shard id (MySQL with
+     * shardFile), otherwise synthesise a placeholder {@code shard<N>}. Bounded at maxShards >= 1
+     * so {@code nextInt} never throws.
+     */
+    private String pickShardId() {
+        ThreadLocalRandom rng = ThreadLocalRandom.current();
+        if (logicalShardIds != null && !logicalShardIds.isEmpty()) {
+            return logicalShardIds.get(rng.nextInt(logicalShardIds.size()));
+        }
+        int bound = Math.max(1, maxShards);
+        return "shard" + rng.nextInt(bound);
+    }
+}

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/GeneratePrimaryKeyFn.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/GeneratePrimaryKeyFn.java
@@ -40,136 +40,135 @@ import org.slf4j.LoggerFactory;
 /**
  * Generates a synthetic primary-key Row for each incoming {@link DataGeneratorTable}.
  *
- * <p>The emitted {@link Row} has the table's PK columns followed by a synthesised logical shard
- * id column (name controlled by {@link Constants#SHARD_ID_COLUMN_NAME}). The shard id is either
+ * <p>The emitted {@link Row} has the table's PK columns followed by a synthesised logical shard id
+ * column (name controlled by {@link Constants#SHARD_ID_COLUMN_NAME}). The shard id is either
  * sampled uniformly from {@code [0, maxShards)} or, for MySQL sinks with a shard config file,
- * sampled uniformly from the configured logical shard ids so the same shard ids used by
- * downstream writers are reused here.
+ * sampled uniformly from the configured logical shard ids so the same shard ids used by downstream
+ * writers are reused here.
  *
  * <p>Randomness: {@link Faker} is constructed with its default no-arg constructor (which seeds
- * itself from {@code System.nanoTime()} plus a per-instance counter, not from
- * {@code /dev/urandom}), and shard-id selection uses {@link ThreadLocalRandom#current()} to
- * avoid contention under high fan-out. Duplicate-PK errors observed during earlier development
- * were caused by Beam retrying already-applied inserts, not by seed collisions across workers;
- * the sink writers now use upsert semantics, which absorbs retries cleanly.
+ * itself from {@code System.nanoTime()} plus a per-instance counter, not from {@code
+ * /dev/urandom}), and shard-id selection uses {@link ThreadLocalRandom#current()} to avoid
+ * contention under high fan-out. Duplicate-PK errors observed during earlier development were
+ * caused by Beam retrying already-applied inserts, not by seed collisions across workers; the sink
+ * writers now use upsert semantics, which absorbs retries cleanly.
  *
  * <p>Output: {@code KV<tableName, pkRow>} so downstream transforms can shuffle by table while
  * keeping the row schema per-table.
  */
 public class GeneratePrimaryKeyFn extends DoFn<DataGeneratorTable, KV<String, Row>> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(GeneratePrimaryKeyFn.class);
+  private static final Logger LOG = LoggerFactory.getLogger(GeneratePrimaryKeyFn.class);
 
-    private final int maxShards;
-    private final String sinkOptionsPath;
-    private final String sinkType;
+  private final int maxShards;
+  private final String sinkOptionsPath;
+  private final String sinkType;
 
-    private transient Faker faker;
-    private transient List<String> logicalShardIds;
-    /** Per-table PK schema cache. Schemas are static per pipeline run so this is write-once. */
-    private transient Map<String, Schema> schemaCache;
+  private transient Faker faker;
+  private transient List<String> logicalShardIds;
 
-    public GeneratePrimaryKeyFn(int maxShards, String sinkOptionsPath, String sinkType) {
-        this.maxShards = maxShards;
-        this.sinkOptionsPath = sinkOptionsPath;
-        this.sinkType = sinkType;
+  /** Per-table PK schema cache. Schemas are static per pipeline run so this is write-once. */
+  private transient Map<String, Schema> schemaCache;
+
+  public GeneratePrimaryKeyFn(int maxShards, String sinkOptionsPath, String sinkType) {
+    this.maxShards = maxShards;
+    this.sinkOptionsPath = sinkOptionsPath;
+    this.sinkType = sinkType;
+  }
+
+  @Setup
+  public void setup() {
+    faker = new Faker();
+    schemaCache = new HashMap<>();
+
+    if (Constants.SINK_TYPE_MYSQL.equalsIgnoreCase(sinkType)
+        && sinkOptionsPath != null
+        && !sinkOptionsPath.isEmpty()) {
+      try {
+        ShardFileReader shardFileReader = new ShardFileReader(new SecretManagerAccessorImpl());
+        List<Shard> shards = shardFileReader.getOrderedShardDetails(sinkOptionsPath);
+        this.logicalShardIds =
+            shards == null || shards.isEmpty()
+                ? null
+                : shards.stream().map(Shard::getLogicalShardId).collect(Collectors.toList());
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to read shards from " + sinkOptionsPath, e);
+      }
+    }
+  }
+
+  @ProcessElement
+  public void processElement(
+      @Element DataGeneratorTable table, OutputReceiver<KV<String, Row>> out) {
+    List<DataGeneratorColumn> pkColumns = primaryKeyColumns(table);
+
+    if (pkColumns.isEmpty()) {
+      // A table without a PK cannot have a unique row key synthesised for it. This is a
+      // schema-definition problem, so log + skip rather than emit an empty Row (which would
+      // corrupt downstream joins on the PK).
+      LOG.warn(
+          "Table {} has no primary-key columns, or its PK list references unknown columns — "
+              + "skipping PK generation.",
+          table.name());
+      return;
     }
 
-    @Setup
-    public void setup() {
-        faker = new Faker();
-        schemaCache = new HashMap<>();
+    Schema schema = schemaCache.computeIfAbsent(table.name(), k -> buildSchema(pkColumns));
+    Row.Builder rowBuilder = Row.withSchema(schema);
 
-        if (Constants.SINK_TYPE_MYSQL.equalsIgnoreCase(sinkType)
-                && sinkOptionsPath != null
-                && !sinkOptionsPath.isEmpty()) {
-            try {
-                ShardFileReader shardFileReader = new ShardFileReader(new SecretManagerAccessorImpl());
-                List<Shard> shards = shardFileReader.getOrderedShardDetails(sinkOptionsPath);
-                this.logicalShardIds =
-                        shards == null || shards.isEmpty()
-                                ? null
-                                : shards.stream().map(Shard::getLogicalShardId).collect(Collectors.toList());
-            } catch (Exception e) {
-                throw new RuntimeException("Failed to read shards from " + sinkOptionsPath, e);
-            }
-        }
+    for (DataGeneratorColumn column : pkColumns) {
+      rowBuilder.addValue(DataGeneratorUtils.generateValue(column, faker));
     }
+    rowBuilder.addValue(pickShardId());
 
-    @ProcessElement
-    public void processElement(
-            @Element DataGeneratorTable table, OutputReceiver<KV<String, Row>> out) {
-        List<DataGeneratorColumn> pkColumns = primaryKeyColumns(table);
+    out.output(KV.of(table.name(), rowBuilder.build()));
+  }
 
-        if (pkColumns.isEmpty()) {
-            // A table without a PK cannot have a unique row key synthesised for it. This is a
-            // schema-definition problem, so log + skip rather than emit an empty Row (which would
-            // corrupt downstream joins on the PK).
-            LOG.warn(
-                    "Table {} has no primary-key columns, or its PK list references unknown columns — "
-                            + "skipping PK generation.",
-                    table.name());
-            return;
-        }
-
-        Schema schema = schemaCache.computeIfAbsent(table.name(), k -> buildSchema(pkColumns));
-        Row.Builder rowBuilder = Row.withSchema(schema);
-
-        for (DataGeneratorColumn column : pkColumns) {
-            rowBuilder.addValue(DataGeneratorUtils.generateValue(column, faker));
-        }
-        rowBuilder.addValue(pickShardId());
-
-        out.output(KV.of(table.name(), rowBuilder.build()));
+  /** Resolve the PK column list for a table. */
+  @VisibleForTesting
+  public static List<DataGeneratorColumn> primaryKeyColumns(DataGeneratorTable table) {
+    if (table.primaryKeys() == null || table.primaryKeys().isEmpty()) {
+      return new ArrayList<>();
     }
-
-    /**
-     * Resolve the PK column list for a table.
-     */
-    @VisibleForTesting
-    public static List<DataGeneratorColumn> primaryKeyColumns(DataGeneratorTable table) {
-        if (table.primaryKeys() == null || table.primaryKeys().isEmpty()) {
-            return new ArrayList<>();
-        }
-        Map<String, DataGeneratorColumn> byName = new HashMap<>();
-        for (DataGeneratorColumn col : table.columns()) {
-            byName.put(col.name(), col);
-        }
-        List<DataGeneratorColumn> result = new ArrayList<>(table.primaryKeys().size());
-        for (String pkName : table.primaryKeys()) {
-            DataGeneratorColumn col = byName.get(pkName);
-            if (col != null) {
-                result.add(col);
-            } else {
-                LOG.warn(
-                        "PK column {} declared on table {} not present in columns list — dropping.",
-                        pkName,
-                        table.name());
-            }
-        }
-        return result;
+    Map<String, DataGeneratorColumn> byName = new HashMap<>();
+    for (DataGeneratorColumn col : table.columns()) {
+      byName.put(col.name(), col);
     }
-
-    private Schema buildSchema(List<DataGeneratorColumn> columns) {
-        Schema.Builder builder = Schema.builder();
-        for (DataGeneratorColumn col : columns) {
-            builder.addField(Schema.Field.of(col.name(), DataGeneratorUtils.mapToBeamFieldType(col)));
-        }
-        builder.addField(Schema.Field.of(Constants.SHARD_ID_COLUMN_NAME, Schema.FieldType.STRING));
-        return builder.build();
+    List<DataGeneratorColumn> result = new ArrayList<>(table.primaryKeys().size());
+    for (String pkName : table.primaryKeys()) {
+      DataGeneratorColumn col = byName.get(pkName);
+      if (col != null) {
+        result.add(col);
+      } else {
+        LOG.warn(
+            "PK column {} declared on table {} not present in columns list — dropping.",
+            pkName,
+            table.name());
+      }
     }
+    return result;
+  }
 
-    /**
-     * Select a shard id for this row. Prefer a configured logical shard id (MySQL with
-     * shardFile), otherwise synthesise a placeholder {@code shard<N>}. Bounded at maxShards >= 1
-     * so {@code nextInt} never throws.
-     */
-    private String pickShardId() {
-        ThreadLocalRandom rng = ThreadLocalRandom.current();
-        if (logicalShardIds != null && !logicalShardIds.isEmpty()) {
-            return logicalShardIds.get(rng.nextInt(logicalShardIds.size()));
-        }
-        int bound = Math.max(1, maxShards);
-        return "shard" + rng.nextInt(bound);
+  private Schema buildSchema(List<DataGeneratorColumn> columns) {
+    Schema.Builder builder = Schema.builder();
+    for (DataGeneratorColumn col : columns) {
+      builder.addField(Schema.Field.of(col.name(), DataGeneratorUtils.mapToBeamFieldType(col)));
     }
+    builder.addField(Schema.Field.of(Constants.SHARD_ID_COLUMN_NAME, Schema.FieldType.STRING));
+    return builder.build();
+  }
+
+  /**
+   * Select a shard id for this row. Prefer a configured logical shard id (MySQL with shardFile),
+   * otherwise synthesise a placeholder {@code shard<N>}. Bounded at maxShards >= 1 so {@code
+   * nextInt} never throws.
+   */
+  private String pickShardId() {
+    ThreadLocalRandom rng = ThreadLocalRandom.current();
+    if (logicalShardIds != null && !logicalShardIds.isEmpty()) {
+      return logicalShardIds.get(rng.nextInt(logicalShardIds.size()));
+    }
+    int bound = Math.max(1, maxShards);
+    return "shard" + rng.nextInt(bound);
+  }
 }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/GeneratePrimaryKeyFn.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/GeneratePrimaryKeyFn.java
@@ -57,7 +57,6 @@ public class GeneratePrimaryKeyFn extends DoFn<DataGeneratorTable, KV<String, Ro
 
   private static final Logger LOG = LoggerFactory.getLogger(GeneratePrimaryKeyFn.class);
 
-  private final int maxShards;
   private final String sinkOptionsPath;
   private final String sinkType;
 
@@ -67,8 +66,7 @@ public class GeneratePrimaryKeyFn extends DoFn<DataGeneratorTable, KV<String, Ro
   /** Per-table PK schema cache. Schemas are static per pipeline run so this is write-once. */
   private transient Map<String, Schema> schemaCache;
 
-  public GeneratePrimaryKeyFn(int maxShards, String sinkOptionsPath, String sinkType) {
-    this.maxShards = maxShards;
+  public GeneratePrimaryKeyFn(String sinkOptionsPath, String sinkType) {
     this.sinkOptionsPath = sinkOptionsPath;
     this.sinkType = sinkType;
   }
@@ -166,7 +164,6 @@ public class GeneratePrimaryKeyFn extends DoFn<DataGeneratorTable, KV<String, Ro
     if (logicalShardIds != null && !logicalShardIds.isEmpty()) {
       return logicalShardIds.get(rng.nextInt(logicalShardIds.size()));
     }
-    int bound = Math.max(1, maxShards);
-    return "shard" + rng.nextInt(bound);
+    return "shard0";
   }
 }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/GeneratePrimaryKeyFn.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/GeneratePrimaryKeyFn.java
@@ -24,7 +24,8 @@ import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
 import com.google.cloud.teleport.v2.templates.utils.Constants;
 import com.google.cloud.teleport.v2.templates.utils.DataGeneratorUtils;
 import com.google.common.annotations.VisibleForTesting;
-import java.util.ArrayList;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -103,7 +104,7 @@ public class GeneratePrimaryKeyFn extends DoFn<DataGeneratorTable, KV<String, Ro
       // schema-definition problem, so log + skip rather than emit an empty Row (which
       // would
       // corrupt downstream joins on the PK).
-      LOG.warn(
+      LOG.error(
           "Table {} has no primary-key columns, or its PK list references unknown columns — "
               + "skipping PK generation.",
           table.name());
@@ -125,25 +126,26 @@ public class GeneratePrimaryKeyFn extends DoFn<DataGeneratorTable, KV<String, Ro
   @VisibleForTesting
   public static List<DataGeneratorColumn> primaryKeyColumns(DataGeneratorTable table) {
     if (table.primaryKeys() == null || table.primaryKeys().isEmpty()) {
-      return new ArrayList<>();
+      return ImmutableList.of();
     }
-    Map<String, DataGeneratorColumn> byName = new HashMap<>();
-    for (DataGeneratorColumn col : table.columns()) {
-      byName.put(col.name(), col);
-    }
-    List<DataGeneratorColumn> result = new ArrayList<>(table.primaryKeys().size());
-    for (String pkName : table.primaryKeys()) {
-      DataGeneratorColumn col = byName.get(pkName);
-      if (col != null) {
-        result.add(col);
-      } else {
-        LOG.warn(
-            "PK column {} declared on table {} not present in columns list — dropping.",
-            pkName,
-            table.name());
-      }
-    }
-    return result;
+    ImmutableMap<String, DataGeneratorColumn> byName =
+        table.columns().stream()
+            .collect(ImmutableMap.toImmutableMap(DataGeneratorColumn::name, col -> col));
+
+    return table.primaryKeys().stream()
+        .filter(
+            pkName -> {
+              if (!byName.containsKey(pkName)) {
+                LOG.error(
+                    "PK column {} declared on table {} not present in columns list — dropping.",
+                    pkName,
+                    table.name());
+                return false;
+              }
+              return true;
+            })
+        .map(byName::get)
+        .collect(Collectors.toList());
   }
 
   private Schema buildSchema(List<DataGeneratorColumn> columns) {

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/model/DataGeneratorTable.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/model/DataGeneratorTable.java
@@ -28,6 +28,7 @@ public abstract class DataGeneratorTable implements Serializable {
   public abstract String name();
 
   /** The columns of the table. */
+  // TODO(khajanchi): Consider using a map of columns instead of list
   public abstract ImmutableList<DataGeneratorColumn> columns();
 
   /** The primary key column names. */

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/model/LogicalType.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/model/LogicalType.java
@@ -26,5 +26,6 @@ public enum LogicalType {
   TIMESTAMP,
   NUMERIC,
   JSON,
+  UUID,
   // Todo: Add support for Array datatype
 }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/mysql/MySqlDataWriter.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/mysql/MySqlDataWriter.java
@@ -414,6 +414,7 @@ public class MySqlDataWriter implements DataWriter {
     switch (type) {
       case STRING:
       case JSON:
+      case UUID:
         return Types.VARCHAR;
       case INT64:
         return Types.BIGINT;

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/spanner/SpannerSchemaFetcher.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/spanner/SpannerSchemaFetcher.java
@@ -22,6 +22,7 @@ import com.google.cloud.teleport.v2.templates.model.DataGeneratorForeignKey;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorSchema;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorUniqueKey;
+import com.google.cloud.teleport.v2.templates.model.LogicalType;
 import com.google.cloud.teleport.v2.templates.sink.SinkSchemaFetcher;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -30,6 +31,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.io.FileSystems;
@@ -183,14 +185,40 @@ public class SpannerSchemaFetcher implements SinkSchemaFetcher {
       com.google.cloud.teleport.v2.spanner.ddl.Table table,
       com.google.cloud.spanner.Dialect dialect) {
 
+    LogicalType logicalType = typeMapper.getLogicalType(column.typeString(), dialect, null);
+    Long size = null;
+    Integer precision = null;
+    Integer scale = null;
+
+    if (column.size() != null) {
+      if (column.size() == -1) {
+        if (logicalType == LogicalType.STRING) {
+          size = 2621440L;
+        } else if (logicalType == LogicalType.BYTES) {
+          size = 10485760L;
+        }
+      } else {
+        size = Long.valueOf(column.size());
+      }
+    }
+
+    String typeStr = column.typeString().toUpperCase(Locale.ROOT);
+    if (typeStr.contains("BIGNUMERIC")) {
+      precision = 76;
+      scale = 38;
+    } else if (typeStr.contains("NUMERIC") || typeStr.contains("DECIMAL")) {
+      precision = 38;
+      scale = 9;
+    }
+
     return DataGeneratorColumn.builder()
         .name(column.name())
-        .logicalType(typeMapper.getLogicalType(column.typeString(), dialect, null))
+        .logicalType(logicalType)
         .isNullable(!column.notNull())
         .isGenerated(column.isGenerated())
-        .size(column.size() != null ? Long.valueOf(column.size()) : null)
-        .precision(null)
-        .scale(null)
+        .size(size)
+        .precision(precision)
+        .scale(scale)
         .build();
   }
 }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/transforms/GeneratePrimaryKey.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/transforms/GeneratePrimaryKey.java
@@ -35,29 +35,29 @@ import org.apache.beam.sdk.values.Row;
  * <ul>
  *   <li>Keep the {@code transforms/} package free of DoFn implementation details (mirrors the
  *       {@code SelectTable} / {@code SelectTableFn} split elsewhere in this module).
- *   <li>Pin the output coder. Row has no default coder so the output {@code PCollection} needs
- *       an explicit {@link KvCoder} that uses {@link SerializableCoder} for the Row half.
+ *   <li>Pin the output coder. Row has no default coder so the output {@code PCollection} needs an
+ *       explicit {@link KvCoder} that uses {@link SerializableCoder} for the Row half.
  * </ul>
  */
 public class GeneratePrimaryKey
-        extends PTransform<PCollection<DataGeneratorTable>, PCollection<KV<String, Row>>> {
+    extends PTransform<PCollection<DataGeneratorTable>, PCollection<KV<String, Row>>> {
 
-    private final int maxShards;
-    private final String sinkOptionsPath;
-    private final String sinkType;
+  private final int maxShards;
+  private final String sinkOptionsPath;
+  private final String sinkType;
 
-    public GeneratePrimaryKey(int maxShards, String sinkOptionsPath, String sinkType) {
-        this.maxShards = maxShards;
-        this.sinkOptionsPath = sinkOptionsPath;
-        this.sinkType = sinkType;
-    }
+  public GeneratePrimaryKey(int maxShards, String sinkOptionsPath, String sinkType) {
+    this.maxShards = maxShards;
+    this.sinkOptionsPath = sinkOptionsPath;
+    this.sinkType = sinkType;
+  }
 
-    @Override
-    public PCollection<KV<String, Row>> expand(PCollection<DataGeneratorTable> input) {
-        return input
-                .apply(
-                        "GeneratePrimaryKeyFn",
-                        ParDo.of(new GeneratePrimaryKeyFn(maxShards, sinkOptionsPath, sinkType)))
-                .setCoder(KvCoder.of(StringUtf8Coder.of(), SerializableCoder.of(Row.class)));
-    }
+  @Override
+  public PCollection<KV<String, Row>> expand(PCollection<DataGeneratorTable> input) {
+    return input
+        .apply(
+            "GeneratePrimaryKeyFn",
+            ParDo.of(new GeneratePrimaryKeyFn(maxShards, sinkOptionsPath, sinkType)))
+        .setCoder(KvCoder.of(StringUtf8Coder.of(), SerializableCoder.of(Row.class)));
+  }
 }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/transforms/GeneratePrimaryKey.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/transforms/GeneratePrimaryKey.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.transforms;
+
+import com.google.cloud.teleport.v2.templates.dofn.GeneratePrimaryKeyFn;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.SerializableCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+
+/**
+ * {@link PTransform} that generates synthetic primary-key {@link Row}s for each incoming {@link
+ * DataGeneratorTable}.
+ *
+ * <p>See {@link GeneratePrimaryKeyFn} for the row-building details. This wrapper exists to:
+ *
+ * <ul>
+ *   <li>Keep the {@code transforms/} package free of DoFn implementation details (mirrors the
+ *       {@code SelectTable} / {@code SelectTableFn} split elsewhere in this module).
+ *   <li>Pin the output coder. Row has no default coder so the output {@code PCollection} needs
+ *       an explicit {@link KvCoder} that uses {@link SerializableCoder} for the Row half.
+ * </ul>
+ */
+public class GeneratePrimaryKey
+        extends PTransform<PCollection<DataGeneratorTable>, PCollection<KV<String, Row>>> {
+
+    private final int maxShards;
+    private final String sinkOptionsPath;
+    private final String sinkType;
+
+    public GeneratePrimaryKey(int maxShards, String sinkOptionsPath, String sinkType) {
+        this.maxShards = maxShards;
+        this.sinkOptionsPath = sinkOptionsPath;
+        this.sinkType = sinkType;
+    }
+
+    @Override
+    public PCollection<KV<String, Row>> expand(PCollection<DataGeneratorTable> input) {
+        return input
+                .apply(
+                        "GeneratePrimaryKeyFn",
+                        ParDo.of(new GeneratePrimaryKeyFn(maxShards, sinkOptionsPath, sinkType)))
+                .setCoder(KvCoder.of(StringUtf8Coder.of(), SerializableCoder.of(Row.class)));
+    }
+}

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/transforms/GeneratePrimaryKey.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/transforms/GeneratePrimaryKey.java
@@ -42,12 +42,10 @@ import org.apache.beam.sdk.values.Row;
 public class GeneratePrimaryKey
     extends PTransform<PCollection<DataGeneratorTable>, PCollection<KV<String, Row>>> {
 
-  private final int maxShards;
   private final String sinkOptionsPath;
   private final String sinkType;
 
-  public GeneratePrimaryKey(int maxShards, String sinkOptionsPath, String sinkType) {
-    this.maxShards = maxShards;
+  public GeneratePrimaryKey(String sinkOptionsPath, String sinkType) {
     this.sinkOptionsPath = sinkOptionsPath;
     this.sinkType = sinkType;
   }
@@ -56,8 +54,7 @@ public class GeneratePrimaryKey
   public PCollection<KV<String, Row>> expand(PCollection<DataGeneratorTable> input) {
     return input
         .apply(
-            "GeneratePrimaryKeyFn",
-            ParDo.of(new GeneratePrimaryKeyFn(maxShards, sinkOptionsPath, sinkType)))
+            "GeneratePrimaryKeyFn", ParDo.of(new GeneratePrimaryKeyFn(sinkOptionsPath, sinkType)))
         .setCoder(KvCoder.of(StringUtf8Coder.of(), SerializableCoder.of(Row.class)));
   }
 }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/Constants.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/Constants.java
@@ -30,8 +30,15 @@ public final class Constants {
   // Character used to quote identifiers in MySQL (back-tick).
   public static final String MYSQL_IDENTIFIER_QUOTE = "`";
 
+  // Column name used to carry the logical shard id through the pipeline. Prefixed with `_dg_`
+  // so it cannot collide with a user-defined PK column.
+  public static final String SHARD_ID_COLUMN_NAME = "_dg_shard_id";
+
   // Keys for Spanner sink configuration JSON.
   public static final String SPANNER_CONFIG_PROJECT_ID_KEY = "projectId";
   public static final String SPANNER_CONFIG_INSTANCE_ID_KEY = "instanceId";
   public static final String SPANNER_CONFIG_DATABASE_ID_KEY = "databaseId";
+
+  public static final String SINK_TYPE_MYSQL = "MYSQL";
+  public static final String SINK_TYPE_SPANNER = "SPANNER";
 }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/DataGeneratorUtils.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/DataGeneratorUtils.java
@@ -32,173 +32,176 @@ import org.joda.time.Instant;
  * Common utilities for data generation — value synthesis and Beam type mapping.
  *
  * <p>Kept separate from the transform classes so that the generation rules can be unit-tested in
- * isolation and shared across {@code GeneratePrimaryKey}, (future) value-column generators, and
- * any other DoFn that needs to emit a synthetic value for a {@link DataGeneratorColumn}.
+ * isolation and shared across {@code GeneratePrimaryKey}, (future) value-column generators, and any
+ * other DoFn that needs to emit a synthetic value for a {@link DataGeneratorColumn}.
  */
 public final class DataGeneratorUtils {
 
-    /** Default string length when the column doesn't declare a {@code size}. */
-    @VisibleForTesting static final int DEFAULT_STRING_LENGTH = 20;
+  /** Default string length when the column doesn't declare a {@code size}. */
+  @VisibleForTesting static final int DEFAULT_STRING_LENGTH = 20;
 
-    /** Cap on string length for synthesised values. Columns wider than this use the cap. */
-    @VisibleForTesting static final int MAX_STRING_LENGTH = 1000;
+  /** Cap on string length for synthesised values. Columns wider than this use the cap. */
+  @VisibleForTesting static final int MAX_STRING_LENGTH = 1000;
 
-    /** Default precision/scale when the column doesn't declare them. */
-    @VisibleForTesting static final int DEFAULT_NUMERIC_PRECISION = 10;
+  /** Default precision/scale when the column doesn't declare them. */
+  @VisibleForTesting static final int DEFAULT_NUMERIC_PRECISION = 10;
 
-    @VisibleForTesting static final int DEFAULT_NUMERIC_SCALE = 2;
+  @VisibleForTesting static final int DEFAULT_NUMERIC_SCALE = 2;
 
-    /** INT64 sub-range. Deliberately narrow to avoid accidentally producing negative PKs. */
-    @VisibleForTesting static final long INT64_MIN = 1_000_000_000L;
+  /** INT64 sub-range. Deliberately narrow to avoid accidentally producing negative PKs. */
+  @VisibleForTesting static final long INT64_MIN = 1_000_000_000L;
 
-    @VisibleForTesting static final long INT64_MAX = 2_147_483_647L;
+  @VisibleForTesting static final long INT64_MAX = 2_147_483_647L;
 
-    /** Number of days back from today that random DATE/TIMESTAMP values can fall on. */
-    @VisibleForTesting static final int DATE_RANGE_DAYS = 365 * 2;
+  /** Number of days back from today that random DATE/TIMESTAMP values can fall on. */
+  @VisibleForTesting static final int DATE_RANGE_DAYS = 365 * 2;
 
-    private DataGeneratorUtils() {}
+  private DataGeneratorUtils() {}
 
-    /**
-     * Synthesise a value for the given column using {@code faker}. Caller is responsible for
-     * seeding the Faker instance.
-     *
-     * <p>The returned Java type matches what {@link #mapToBeamFieldType(LogicalType)} declares for
-     * the same logical type, so the value can be added directly to a {@code Row.Builder}.
-     */
-    public static Object generateValue(DataGeneratorColumn column, Faker faker) {
-        LogicalType type = column.logicalType();
-        Long size = column.size();
+  /**
+   * Synthesise a value for the given column using {@code faker}. Caller is responsible for seeding
+   * the Faker instance.
+   *
+   * <p>The returned Java type matches what {@link #mapToBeamFieldType(LogicalType)} declares for
+   * the same logical type, so the value can be added directly to a {@code Row.Builder}.
+   */
+  public static Object generateValue(DataGeneratorColumn column, Faker faker) {
+    LogicalType type = column.logicalType();
+    Long size = column.size();
 
-        switch (type) {
-            case STRING:
-                return faker.lorem().characters(clampStringLength(size));
-            case JSON:
-                // Produce valid JSON so downstream JSON-typed columns don't reject the payload. Use
-                // {@code randomNumber()} for uniqueness; the key is fixed because callers typically use
-                // JSON as an opaque blob.
-                return "{\"id\": " + faker.number().randomNumber() + "}";
-            case INT64:
-                return faker.number().numberBetween(INT64_MIN, INT64_MAX);
-            case FLOAT64:
-            {
-                int scale = column.scale() != null ? column.scale() : DEFAULT_NUMERIC_SCALE;
-                int precision =
-                        column.precision() != null ? column.precision() : DEFAULT_NUMERIC_PRECISION + 5;
-                double maxVal = Math.pow(10, precision - scale) - 1.0 / Math.pow(10, scale);
-                double minVal = -maxVal;
-                return faker.number().randomDouble(scale, (long) minVal, (long) maxVal);
-            }
-            case NUMERIC:
-                return generateNumeric(column, faker);
-            case BOOLEAN:
-                return faker.bool().bool();
-            case BYTES:
-                return faker.lorem().characters(clampStringLength(size)).getBytes(StandardCharsets.UTF_8);
-            case DATE:
-            {
-                Date pastDate = faker.date().past(DATE_RANGE_DAYS, TimeUnit.DAYS);
-                Calendar cal = Calendar.getInstance();
-                cal.setTime(pastDate);
-                // Zero the time part — DATE is day-granular and TIMESTAMP uses the TIMESTAMP branch.
-                cal.set(Calendar.HOUR_OF_DAY, 0);
-                cal.set(Calendar.MINUTE, 0);
-                cal.set(Calendar.SECOND, 0);
-                cal.set(Calendar.MILLISECOND, 0);
-                return new Instant(cal.getTimeInMillis());
-            }
-            case TIMESTAMP:
-                return new Instant(faker.date().past(DATE_RANGE_DAYS, TimeUnit.DAYS).getTime());
-            default:
-                return "unknown";
+    switch (type) {
+      case STRING:
+        return faker.lorem().characters(clampStringLength(size));
+      case JSON:
+        // Produce valid JSON so downstream JSON-typed columns don't reject the payload. Use
+        // {@code randomNumber()} for uniqueness; the key is fixed because callers typically use
+        // JSON as an opaque blob.
+        return "{\"id\": " + faker.number().randomNumber() + "}";
+      case UUID:
+        return java.util.UUID.randomUUID().toString();
+      case INT64:
+        return faker.number().numberBetween(INT64_MIN, INT64_MAX);
+      case FLOAT64:
+        {
+          int scale = column.scale() != null ? column.scale() : DEFAULT_NUMERIC_SCALE;
+          int precision =
+              column.precision() != null ? column.precision() : DEFAULT_NUMERIC_PRECISION + 5;
+          double maxVal = Math.pow(10, precision - scale) - 1.0 / Math.pow(10, scale);
+          double minVal = -maxVal;
+          return faker.number().randomDouble(scale, (long) minVal, (long) maxVal);
         }
+      case NUMERIC:
+        return generateNumeric(column, faker);
+      case BOOLEAN:
+        return faker.bool().bool();
+      case BYTES:
+        return faker.lorem().characters(clampStringLength(size)).getBytes(StandardCharsets.UTF_8);
+      case DATE:
+        {
+          Date pastDate = faker.date().past(DATE_RANGE_DAYS, TimeUnit.DAYS);
+          Calendar cal = Calendar.getInstance();
+          cal.setTime(pastDate);
+          // Zero the time part — DATE is day-granular and TIMESTAMP uses the TIMESTAMP branch.
+          cal.set(Calendar.HOUR_OF_DAY, 0);
+          cal.set(Calendar.MINUTE, 0);
+          cal.set(Calendar.SECOND, 0);
+          cal.set(Calendar.MILLISECOND, 0);
+          return new Instant(cal.getTimeInMillis());
+        }
+      case TIMESTAMP:
+        return new Instant(faker.date().past(DATE_RANGE_DAYS, TimeUnit.DAYS).getTime());
+      default:
+        return "unknown";
     }
+  }
 
-    /**
-     * Map a logical type to the matching Beam {@link Schema.FieldType}. Used to construct the Row
-     * schema for synthesised values.
-     */
-    public static Schema.FieldType mapToBeamFieldType(LogicalType logicalType) {
-        switch (logicalType) {
-            case STRING:
-            case JSON:
-                return Schema.FieldType.STRING;
-            case INT64:
-                return Schema.FieldType.INT64;
-            case FLOAT64:
-                return Schema.FieldType.DOUBLE;
-            case NUMERIC:
-                return Schema.FieldType.DECIMAL;
-            case BOOLEAN:
-                return Schema.FieldType.BOOLEAN;
-            case BYTES:
-                return Schema.FieldType.BYTES;
-            case DATE:
-            case TIMESTAMP:
-                return Schema.FieldType.DATETIME;
-            default:
-                return Schema.FieldType.STRING;
-        }
+  /**
+   * Map a logical type to the matching Beam {@link Schema.FieldType}. Used to construct the Row
+   * schema for synthesised values.
+   */
+  public static Schema.FieldType mapToBeamFieldType(LogicalType logicalType) {
+    switch (logicalType) {
+      case STRING:
+      case JSON:
+      case UUID:
+        return Schema.FieldType.STRING;
+      case INT64:
+        return Schema.FieldType.INT64;
+      case FLOAT64:
+        return Schema.FieldType.DOUBLE;
+      case NUMERIC:
+        return Schema.FieldType.DECIMAL;
+      case BOOLEAN:
+        return Schema.FieldType.BOOLEAN;
+      case BYTES:
+        return Schema.FieldType.BYTES;
+      case DATE:
+      case TIMESTAMP:
+        return Schema.FieldType.DATETIME;
+      default:
+        return Schema.FieldType.STRING;
     }
+  }
 
-    /** Convenience overload accepting the full column — kept so callers don't branch at callsite. */
-    public static Schema.FieldType mapToBeamFieldType(DataGeneratorColumn column) {
-        return mapToBeamFieldType(column.logicalType());
-    }
+  /** Convenience overload accepting the full column — kept so callers don't branch at callsite. */
+  public static Schema.FieldType mapToBeamFieldType(DataGeneratorColumn column) {
+    return mapToBeamFieldType(column.logicalType());
+  }
 
-    /**
-     * Generate a {@link BigDecimal} that fits the column's declared precision and scale. Avoids
-     * {@code new BigDecimal(faker.number().randomNumber())} which returns an unbounded integer
-     * value and overflows most DECIMAL/NUMERIC columns (e.g. {@code DECIMAL(5,2)} tops out at
-     * {@code 999.99}).
-     *
-     * <p>Defaults are precision 10 / scale 2 when the fetcher did not populate them — safe for
-     * MySQL {@code DECIMAL} (default precision is 10) and Spanner {@code NUMERIC} (up to 38
-     * precision, 9 scale).
-     */
-    @VisibleForTesting
-    static BigDecimal generateNumeric(DataGeneratorColumn column, Faker faker) {
-        int prec =
-                (column.precision() != null && column.precision() > 0)
-                        ? column.precision()
-                        : DEFAULT_NUMERIC_PRECISION;
-        int sc =
-                (column.scale() != null && column.scale() >= 0) ? column.scale() : DEFAULT_NUMERIC_SCALE;
-        if (sc > prec) {
-            sc = prec;
-        }
-        int intDigits = prec - sc;
-        // Cap to 18 digits so the randomised upper bound stays within {@code long}.
-        int capIntDigits = Math.min(intDigits, 18);
-        long maxIntPart = 1L;
-        for (int i = 0; i < capIntDigits; i++) {
-            maxIntPart *= 10L;
-        }
-        long intPart = maxIntPart <= 1L ? 0L : faker.number().numberBetween(0L, maxIntPart);
-        BigDecimal value = BigDecimal.valueOf(intPart);
-        if (sc > 0) {
-            int capScaleDigits = Math.min(sc, 18);
-            long maxFrac = 1L;
-            for (int i = 0; i < capScaleDigits; i++) {
-                maxFrac *= 10L;
-            }
-            long fracPart = maxFrac <= 1L ? 0L : faker.number().numberBetween(0L, maxFrac);
-            value = value.add(BigDecimal.valueOf(fracPart, capScaleDigits));
-        }
-        // Normalise the trailing scale so the returned value always reports the declared scale.
-        return value.setScale(sc, RoundingMode.HALF_UP);
+  /**
+   * Generate a {@link BigDecimal} that fits the column's declared precision and scale. Avoids
+   * {@code new BigDecimal(faker.number().randomNumber())} which returns an unbounded integer value
+   * and overflows most DECIMAL/NUMERIC columns (e.g. {@code DECIMAL(5,2)} tops out at {@code
+   * 999.99}).
+   *
+   * <p>Defaults are precision 10 / scale 2 when the fetcher did not populate them — safe for MySQL
+   * {@code DECIMAL} (default precision is 10) and Spanner {@code NUMERIC} (up to 38 precision, 9
+   * scale).
+   */
+  @VisibleForTesting
+  static BigDecimal generateNumeric(DataGeneratorColumn column, Faker faker) {
+    int prec =
+        (column.precision() != null && column.precision() > 0)
+            ? column.precision()
+            : DEFAULT_NUMERIC_PRECISION;
+    int sc =
+        (column.scale() != null && column.scale() >= 0) ? column.scale() : DEFAULT_NUMERIC_SCALE;
+    if (sc > prec) {
+      sc = prec;
     }
+    int intDigits = prec - sc;
+    // Cap to 18 digits so the randomised upper bound stays within {@code long}.
+    int capIntDigits = Math.min(intDigits, 18);
+    long maxIntPart = 1L;
+    for (int i = 0; i < capIntDigits; i++) {
+      maxIntPart *= 10L;
+    }
+    long intPart = maxIntPart <= 1L ? 0L : faker.number().numberBetween(0L, maxIntPart);
+    BigDecimal value = BigDecimal.valueOf(intPart);
+    if (sc > 0) {
+      int capScaleDigits = Math.min(sc, 18);
+      long maxFrac = 1L;
+      for (int i = 0; i < capScaleDigits; i++) {
+        maxFrac *= 10L;
+      }
+      long fracPart = maxFrac <= 1L ? 0L : faker.number().numberBetween(0L, maxFrac);
+      value = value.add(BigDecimal.valueOf(fracPart, capScaleDigits));
+    }
+    // Normalise the trailing scale so the returned value always reports the declared scale.
+    return value.setScale(sc, RoundingMode.HALF_UP);
+  }
 
-    /**
-     * Clamp user-supplied string lengths into a safe range. Unset / zero / absurdly-large values
-     * all fall back to a reasonable default so Faker doesn't receive a pathological input.
-     */
-    private static int clampStringLength(Long size) {
-        if (size == null || size <= 0) {
-            return DEFAULT_STRING_LENGTH;
-        }
-        if (size >= MAX_STRING_LENGTH) {
-            return MAX_STRING_LENGTH;
-        }
-        return size.intValue();
+  /**
+   * Clamp user-supplied string lengths into a safe range. Unset / zero / absurdly-large values all
+   * fall back to a reasonable default so Faker doesn't receive a pathological input.
+   */
+  private static int clampStringLength(Long size) {
+    if (size == null || size <= 0) {
+      return DEFAULT_STRING_LENGTH;
     }
+    if (size >= MAX_STRING_LENGTH) {
+      return MAX_STRING_LENGTH;
+    }
+    return size.intValue();
+  }
 }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/DataGeneratorUtils.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/DataGeneratorUtils.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.utils;
+
+import com.github.javafaker.Faker;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorColumn;
+import com.google.cloud.teleport.v2.templates.model.LogicalType;
+import com.google.common.annotations.VisibleForTesting;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import org.apache.beam.sdk.schemas.Schema;
+import org.joda.time.Instant;
+
+/**
+ * Common utilities for data generation — value synthesis and Beam type mapping.
+ *
+ * <p>Kept separate from the transform classes so that the generation rules can be unit-tested in
+ * isolation and shared across {@code GeneratePrimaryKey}, (future) value-column generators, and
+ * any other DoFn that needs to emit a synthetic value for a {@link DataGeneratorColumn}.
+ */
+public final class DataGeneratorUtils {
+
+    /** Default string length when the column doesn't declare a {@code size}. */
+    @VisibleForTesting static final int DEFAULT_STRING_LENGTH = 20;
+
+    /** Cap on string length for synthesised values. Columns wider than this use the cap. */
+    @VisibleForTesting static final int MAX_STRING_LENGTH = 1000;
+
+    /** Default precision/scale when the column doesn't declare them. */
+    @VisibleForTesting static final int DEFAULT_NUMERIC_PRECISION = 10;
+
+    @VisibleForTesting static final int DEFAULT_NUMERIC_SCALE = 2;
+
+    /** INT64 sub-range. Deliberately narrow to avoid accidentally producing negative PKs. */
+    @VisibleForTesting static final long INT64_MIN = 1_000_000_000L;
+
+    @VisibleForTesting static final long INT64_MAX = 2_147_483_647L;
+
+    /** Number of days back from today that random DATE/TIMESTAMP values can fall on. */
+    @VisibleForTesting static final int DATE_RANGE_DAYS = 365 * 2;
+
+    private DataGeneratorUtils() {}
+
+    /**
+     * Synthesise a value for the given column using {@code faker}. Caller is responsible for
+     * seeding the Faker instance.
+     *
+     * <p>The returned Java type matches what {@link #mapToBeamFieldType(LogicalType)} declares for
+     * the same logical type, so the value can be added directly to a {@code Row.Builder}.
+     */
+    public static Object generateValue(DataGeneratorColumn column, Faker faker) {
+        LogicalType type = column.logicalType();
+        Long size = column.size();
+
+        switch (type) {
+            case STRING:
+                return faker.lorem().characters(clampStringLength(size));
+            case JSON:
+                // Produce valid JSON so downstream JSON-typed columns don't reject the payload. Use
+                // {@code randomNumber()} for uniqueness; the key is fixed because callers typically use
+                // JSON as an opaque blob.
+                return "{\"id\": " + faker.number().randomNumber() + "}";
+            case INT64:
+                return faker.number().numberBetween(INT64_MIN, INT64_MAX);
+            case FLOAT64:
+            {
+                int scale = column.scale() != null ? column.scale() : DEFAULT_NUMERIC_SCALE;
+                int precision =
+                        column.precision() != null ? column.precision() : DEFAULT_NUMERIC_PRECISION + 5;
+                double maxVal = Math.pow(10, precision - scale) - 1.0 / Math.pow(10, scale);
+                double minVal = -maxVal;
+                return faker.number().randomDouble(scale, (long) minVal, (long) maxVal);
+            }
+            case NUMERIC:
+                return generateNumeric(column, faker);
+            case BOOLEAN:
+                return faker.bool().bool();
+            case BYTES:
+                return faker.lorem().characters(clampStringLength(size)).getBytes(StandardCharsets.UTF_8);
+            case DATE:
+            {
+                Date pastDate = faker.date().past(DATE_RANGE_DAYS, TimeUnit.DAYS);
+                Calendar cal = Calendar.getInstance();
+                cal.setTime(pastDate);
+                // Zero the time part — DATE is day-granular and TIMESTAMP uses the TIMESTAMP branch.
+                cal.set(Calendar.HOUR_OF_DAY, 0);
+                cal.set(Calendar.MINUTE, 0);
+                cal.set(Calendar.SECOND, 0);
+                cal.set(Calendar.MILLISECOND, 0);
+                return new Instant(cal.getTimeInMillis());
+            }
+            case TIMESTAMP:
+                return new Instant(faker.date().past(DATE_RANGE_DAYS, TimeUnit.DAYS).getTime());
+            default:
+                return "unknown";
+        }
+    }
+
+    /**
+     * Map a logical type to the matching Beam {@link Schema.FieldType}. Used to construct the Row
+     * schema for synthesised values.
+     */
+    public static Schema.FieldType mapToBeamFieldType(LogicalType logicalType) {
+        switch (logicalType) {
+            case STRING:
+            case JSON:
+                return Schema.FieldType.STRING;
+            case INT64:
+                return Schema.FieldType.INT64;
+            case FLOAT64:
+                return Schema.FieldType.DOUBLE;
+            case NUMERIC:
+                return Schema.FieldType.DECIMAL;
+            case BOOLEAN:
+                return Schema.FieldType.BOOLEAN;
+            case BYTES:
+                return Schema.FieldType.BYTES;
+            case DATE:
+            case TIMESTAMP:
+                return Schema.FieldType.DATETIME;
+            default:
+                return Schema.FieldType.STRING;
+        }
+    }
+
+    /** Convenience overload accepting the full column — kept so callers don't branch at callsite. */
+    public static Schema.FieldType mapToBeamFieldType(DataGeneratorColumn column) {
+        return mapToBeamFieldType(column.logicalType());
+    }
+
+    /**
+     * Generate a {@link BigDecimal} that fits the column's declared precision and scale. Avoids
+     * {@code new BigDecimal(faker.number().randomNumber())} which returns an unbounded integer
+     * value and overflows most DECIMAL/NUMERIC columns (e.g. {@code DECIMAL(5,2)} tops out at
+     * {@code 999.99}).
+     *
+     * <p>Defaults are precision 10 / scale 2 when the fetcher did not populate them — safe for
+     * MySQL {@code DECIMAL} (default precision is 10) and Spanner {@code NUMERIC} (up to 38
+     * precision, 9 scale).
+     */
+    @VisibleForTesting
+    static BigDecimal generateNumeric(DataGeneratorColumn column, Faker faker) {
+        int prec =
+                (column.precision() != null && column.precision() > 0)
+                        ? column.precision()
+                        : DEFAULT_NUMERIC_PRECISION;
+        int sc =
+                (column.scale() != null && column.scale() >= 0) ? column.scale() : DEFAULT_NUMERIC_SCALE;
+        if (sc > prec) {
+            sc = prec;
+        }
+        int intDigits = prec - sc;
+        // Cap to 18 digits so the randomised upper bound stays within {@code long}.
+        int capIntDigits = Math.min(intDigits, 18);
+        long maxIntPart = 1L;
+        for (int i = 0; i < capIntDigits; i++) {
+            maxIntPart *= 10L;
+        }
+        long intPart = maxIntPart <= 1L ? 0L : faker.number().numberBetween(0L, maxIntPart);
+        BigDecimal value = BigDecimal.valueOf(intPart);
+        if (sc > 0) {
+            int capScaleDigits = Math.min(sc, 18);
+            long maxFrac = 1L;
+            for (int i = 0; i < capScaleDigits; i++) {
+                maxFrac *= 10L;
+            }
+            long fracPart = maxFrac <= 1L ? 0L : faker.number().numberBetween(0L, maxFrac);
+            value = value.add(BigDecimal.valueOf(fracPart, capScaleDigits));
+        }
+        // Normalise the trailing scale so the returned value always reports the declared scale.
+        return value.setScale(sc, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * Clamp user-supplied string lengths into a safe range. Unset / zero / absurdly-large values
+     * all fall back to a reasonable default so Faker doesn't receive a pathological input.
+     */
+    private static int clampStringLength(Long size) {
+        if (size == null || size <= 0) {
+            return DEFAULT_STRING_LENGTH;
+        }
+        if (size >= MAX_STRING_LENGTH) {
+            return MAX_STRING_LENGTH;
+        }
+        return size.intValue();
+    }
+}

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/DataGeneratorUtils.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/DataGeneratorUtils.java
@@ -23,8 +23,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
-import java.util.Date;
-import java.util.concurrent.TimeUnit;
 import org.apache.beam.sdk.schemas.Schema;
 import org.joda.time.Instant;
 
@@ -40,21 +38,10 @@ public final class DataGeneratorUtils {
   /** Default string length when the column doesn't declare a {@code size}. */
   @VisibleForTesting static final int DEFAULT_STRING_LENGTH = 20;
 
-  /** Cap on string length for synthesised values. Columns wider than this use the cap. */
-  @VisibleForTesting static final int MAX_STRING_LENGTH = 1000;
-
   /** Default precision/scale when the column doesn't declare them. */
   @VisibleForTesting static final int DEFAULT_NUMERIC_PRECISION = 10;
 
   @VisibleForTesting static final int DEFAULT_NUMERIC_SCALE = 2;
-
-  /** INT64 sub-range. Deliberately narrow to avoid accidentally producing negative PKs. */
-  @VisibleForTesting static final long INT64_MIN = 1_000_000_000L;
-
-  @VisibleForTesting static final long INT64_MAX = 2_147_483_647L;
-
-  /** Number of days back from today that random DATE/TIMESTAMP values can fall on. */
-  @VisibleForTesting static final int DATE_RANGE_DAYS = 365 * 2;
 
   private DataGeneratorUtils() {}
 
@@ -73,14 +60,34 @@ public final class DataGeneratorUtils {
       case STRING:
         return faker.lorem().characters(clampStringLength(size));
       case JSON:
-        // Produce valid JSON so downstream JSON-typed columns don't reject the payload. Use
-        // {@code randomNumber()} for uniqueness; the key is fixed because callers typically use
-        // JSON as an opaque blob.
-        return "{\"id\": " + faker.number().randomNumber() + "}";
+        return "{"
+            + "\"id\": "
+            + faker.number().randomNumber()
+            + ", "
+            + "\"name\": \""
+            + faker.name().fullName()
+            + "\", "
+            + "\"isActive\": "
+            + faker.bool().bool()
+            + ", "
+            + "\"score\": "
+            + faker.number().randomDouble(2, 0, 100)
+            + ", "
+            + "\"tags\": [\""
+            + faker.lorem().word()
+            + "\", \""
+            + faker.lorem().word()
+            + "\"], "
+            + "\"address\": {\"city\": \""
+            + faker.address().city()
+            + "\", \"zip\": \""
+            + faker.address().zipCode()
+            + "\"}"
+            + "}";
       case UUID:
         return java.util.UUID.randomUUID().toString();
       case INT64:
-        return faker.number().numberBetween(INT64_MIN, INT64_MAX);
+        return (long) java.util.concurrent.ThreadLocalRandom.current().nextInt();
       case FLOAT64:
         {
           int scale = column.scale() != null ? column.scale() : DEFAULT_NUMERIC_SCALE;
@@ -98,9 +105,12 @@ public final class DataGeneratorUtils {
         return faker.lorem().characters(clampStringLength(size)).getBytes(StandardCharsets.UTF_8);
       case DATE:
         {
-          Date pastDate = faker.date().past(DATE_RANGE_DAYS, TimeUnit.DAYS);
+          long minMillis = -30610224000000L; // Year 1000
+          long maxMillis = 253402300799000L; // Year 9999
+          long randomMillis =
+              java.util.concurrent.ThreadLocalRandom.current().nextLong(minMillis, maxMillis);
           Calendar cal = Calendar.getInstance();
-          cal.setTime(pastDate);
+          cal.setTimeInMillis(randomMillis);
           // Zero the time part — DATE is day-granular and TIMESTAMP uses the TIMESTAMP branch.
           cal.set(Calendar.HOUR_OF_DAY, 0);
           cal.set(Calendar.MINUTE, 0);
@@ -109,7 +119,12 @@ public final class DataGeneratorUtils {
           return new Instant(cal.getTimeInMillis());
         }
       case TIMESTAMP:
-        return new Instant(faker.date().past(DATE_RANGE_DAYS, TimeUnit.DAYS).getTime());
+        {
+          long minMillis = -30610224000000L; // Year 1000
+          long maxMillis = 253402300799000L; // Year 9999
+          return new Instant(
+              java.util.concurrent.ThreadLocalRandom.current().nextLong(minMillis, maxMillis));
+        }
       default:
         return "unknown";
     }
@@ -169,25 +184,12 @@ public final class DataGeneratorUtils {
     if (sc > prec) {
       sc = prec;
     }
-    int intDigits = prec - sc;
-    // Cap to 18 digits so the randomised upper bound stays within {@code long}.
-    int capIntDigits = Math.min(intDigits, 18);
-    long maxIntPart = 1L;
-    for (int i = 0; i < capIntDigits; i++) {
-      maxIntPart *= 10L;
-    }
-    long intPart = maxIntPart <= 1L ? 0L : faker.number().numberBetween(0L, maxIntPart);
-    BigDecimal value = BigDecimal.valueOf(intPart);
-    if (sc > 0) {
-      int capScaleDigits = Math.min(sc, 18);
-      long maxFrac = 1L;
-      for (int i = 0; i < capScaleDigits; i++) {
-        maxFrac *= 10L;
-      }
-      long fracPart = maxFrac <= 1L ? 0L : faker.number().numberBetween(0L, maxFrac);
-      value = value.add(BigDecimal.valueOf(fracPart, capScaleDigits));
-    }
-    // Normalise the trailing scale so the returned value always reports the declared scale.
+
+    String randomDigits = faker.number().digits(prec);
+    BigDecimal value = new BigDecimal(randomDigits).movePointLeft(sc);
+
+    // Normalise the trailing scale so the returned value always reports the
+    // declared scale.
     return value.setScale(sc, RoundingMode.HALF_UP);
   }
 
@@ -195,12 +197,13 @@ public final class DataGeneratorUtils {
    * Clamp user-supplied string lengths into a safe range. Unset / zero / absurdly-large values all
    * fall back to a reasonable default so Faker doesn't receive a pathological input.
    */
-  private static int clampStringLength(Long size) {
+  @VisibleForTesting
+  static int clampStringLength(Long size) {
     if (size == null || size <= 0) {
       return DEFAULT_STRING_LENGTH;
     }
-    if (size >= MAX_STRING_LENGTH) {
-      return MAX_STRING_LENGTH;
+    if (size > Integer.MAX_VALUE) {
+      return Integer.MAX_VALUE;
     }
     return size.intValue();
   }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/DataGeneratorUtils.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/DataGeneratorUtils.java
@@ -23,6 +23,8 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import org.apache.beam.sdk.schemas.Schema;
 import org.joda.time.Instant;
 
@@ -58,7 +60,7 @@ public final class DataGeneratorUtils {
 
     switch (type) {
       case STRING:
-        return faker.lorem().characters(clampStringLength(size));
+        return faker.lorem().characters(limitStringLength(size));
       case JSON:
         return "{"
             + "\"id\": "
@@ -85,9 +87,9 @@ public final class DataGeneratorUtils {
             + "\"}"
             + "}";
       case UUID:
-        return java.util.UUID.randomUUID().toString();
+        return UUID.randomUUID().toString();
       case INT64:
-        return (long) java.util.concurrent.ThreadLocalRandom.current().nextInt();
+        return (long) ThreadLocalRandom.current().nextInt();
       case FLOAT64:
         {
           int scale = column.scale() != null ? column.scale() : DEFAULT_NUMERIC_SCALE;
@@ -102,13 +104,12 @@ public final class DataGeneratorUtils {
       case BOOLEAN:
         return faker.bool().bool();
       case BYTES:
-        return faker.lorem().characters(clampStringLength(size)).getBytes(StandardCharsets.UTF_8);
+        return faker.lorem().characters(limitStringLength(size)).getBytes(StandardCharsets.UTF_8);
       case DATE:
         {
-          long minMillis = -30610224000000L; // Year 1000
-          long maxMillis = 253402300799000L; // Year 9999
-          long randomMillis =
-              java.util.concurrent.ThreadLocalRandom.current().nextLong(minMillis, maxMillis);
+          long minMillis = -2208988800000L; // Year 1900
+          long maxMillis = 4133980799000L; // Year 2100
+          long randomMillis = ThreadLocalRandom.current().nextLong(minMillis, maxMillis);
           Calendar cal = Calendar.getInstance();
           cal.setTimeInMillis(randomMillis);
           // Zero the time part — DATE is day-granular and TIMESTAMP uses the TIMESTAMP branch.
@@ -120,10 +121,9 @@ public final class DataGeneratorUtils {
         }
       case TIMESTAMP:
         {
-          long minMillis = -30610224000000L; // Year 1000
-          long maxMillis = 253402300799000L; // Year 9999
-          return new Instant(
-              java.util.concurrent.ThreadLocalRandom.current().nextLong(minMillis, maxMillis));
+          long minMillis = -2208988800000L; // Year 1900
+          long maxMillis = 4133980799000L; // Year 2100
+          return new Instant(ThreadLocalRandom.current().nextLong(minMillis, maxMillis));
         }
       default:
         return "unknown";
@@ -194,11 +194,11 @@ public final class DataGeneratorUtils {
   }
 
   /**
-   * Clamp user-supplied string lengths into a safe range. Unset / zero / absurdly-large values all
+   * Limit user-supplied string lengths into a safe range. Unset / zero / absurdly-large values all
    * fall back to a reasonable default so Faker doesn't receive a pathological input.
    */
   @VisibleForTesting
-  static int clampStringLength(Long size) {
+  static int limitStringLength(Long size) {
     if (size == null || size <= 0) {
       return DEFAULT_STRING_LENGTH;
     }

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/mysql/MySqlDataWriterTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/mysql/MySqlDataWriterTest.java
@@ -688,6 +688,7 @@ public class MySqlDataWriterTest {
       Types.DATE,
       Types.TIMESTAMP,
       Types.NUMERIC,
+      Types.VARCHAR,
       Types.VARCHAR
     };
     LogicalType[] types = LogicalType.values();

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/GeneratePrimaryKeyTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/GeneratePrimaryKeyTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.transforms;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.teleport.v2.templates.dofn.GeneratePrimaryKeyFn;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorColumn;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
+import com.google.cloud.teleport.v2.templates.model.LogicalType;
+import com.google.cloud.teleport.v2.templates.utils.Constants;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link GeneratePrimaryKey} and its {@link GeneratePrimaryKeyFn}. */
+@RunWith(JUnit4.class)
+public class GeneratePrimaryKeyTest {
+
+  @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+
+  @Test
+  public void testPrimaryKeyColumns_emptyPkListReturnsEmpty() {
+    DataGeneratorTable table =
+        DataGeneratorTable.builder()
+            .name("T")
+            .columns(ImmutableList.of(col("id", LogicalType.STRING)))
+            .primaryKeys(ImmutableList.of())
+            .foreignKeys(ImmutableList.of())
+            .uniqueKeys(ImmutableList.of())
+            .isRoot(true)
+            .insertQps(10)
+            .updateQps(0)
+            .deleteQps(0)
+            .recordsPerTick(1.0)
+            .build();
+
+    assertTrue(GeneratePrimaryKeyFn.primaryKeyColumns(table).isEmpty());
+  }
+
+  @Test
+  public void testPrimaryKeyColumns_preservesDeclaredPkOrder() {
+    // Declared column order (a, b) differs from PK order (b, a); helper must honour the PK
+    // order so composite keys are emitted with the correct column ordering.
+    DataGeneratorColumn a = col("a", LogicalType.STRING);
+    DataGeneratorColumn b = col("b", LogicalType.INT64);
+    DataGeneratorTable table =
+        DataGeneratorTable.builder()
+            .name("T")
+            .columns(ImmutableList.of(a, b))
+            .primaryKeys(ImmutableList.of("b", "a"))
+            .foreignKeys(ImmutableList.of())
+            .uniqueKeys(ImmutableList.of())
+            .isRoot(true)
+            .insertQps(10)
+            .updateQps(0)
+            .deleteQps(0)
+            .recordsPerTick(1.0)
+            .build();
+
+    List<DataGeneratorColumn> pkCols = GeneratePrimaryKeyFn.primaryKeyColumns(table);
+    assertEquals(2, pkCols.size());
+    assertEquals("b", pkCols.get(0).name());
+    assertEquals("a", pkCols.get(1).name());
+  }
+
+  @Test
+  public void testGeneratePrimaryKey_emitsCompositeKeyAndShardId() {
+    DataGeneratorColumn id = col("id", LogicalType.STRING, 10L, null, null);
+    DataGeneratorColumn seq = col("seq", LogicalType.INT64);
+    DataGeneratorColumn payload = col("val", LogicalType.STRING); // non-PK
+    DataGeneratorTable table =
+        DataGeneratorTable.builder()
+            .name("T")
+            .columns(ImmutableList.of(id, seq, payload))
+            .primaryKeys(ImmutableList.of("id", "seq"))
+            .foreignKeys(ImmutableList.of())
+            .uniqueKeys(ImmutableList.of())
+            .isRoot(true)
+            .insertQps(10)
+            .updateQps(0)
+            .deleteQps(0)
+            .recordsPerTick(1.0)
+            .build();
+
+    PCollection<KV<String, Row>> out =
+        pipeline
+            .apply("In", Create.of(table))
+            .apply("GeneratePK", new GeneratePrimaryKey(1, null, null));
+
+    PAssert.that(out)
+        .satisfies(
+            iter -> {
+              KV<String, Row> kv = iter.iterator().next();
+              assertEquals("T", kv.getKey());
+              Row row = kv.getValue();
+              // Expect PK columns in declared PK order + shard_id. val must not appear.
+              assertEquals(3, row.getSchema().getFieldCount());
+              assertEquals("id", row.getSchema().getField(0).getName());
+              assertEquals("seq", row.getSchema().getField(1).getName());
+              assertEquals(Constants.SHARD_ID_COLUMN_NAME, row.getSchema().getField(2).getName());
+
+              assertNotNull(row.getString("id"));
+              assertTrue(row.getString("id").length() > 0);
+              assertNotNull(row.getInt64("seq"));
+              assertNotNull(row.getString(Constants.SHARD_ID_COLUMN_NAME));
+              // Default maxShards=1 → synthesised id "shard0".
+              assertEquals("shard0", row.getString(Constants.SHARD_ID_COLUMN_NAME));
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testGeneratePrimaryKey_shardIdWithinMaxShardsRange() {
+    DataGeneratorColumn id = col("id", LogicalType.STRING);
+    DataGeneratorTable table =
+        DataGeneratorTable.builder()
+            .name("T")
+            .columns(ImmutableList.of(id))
+            .primaryKeys(ImmutableList.of("id"))
+            .foreignKeys(ImmutableList.of())
+            .uniqueKeys(ImmutableList.of())
+            .isRoot(true)
+            .insertQps(10)
+            .updateQps(0)
+            .deleteQps(0)
+            .recordsPerTick(1.0)
+            .build();
+
+    PCollection<KV<String, Row>> out =
+        pipeline
+            .apply("In", Create.of(table, table, table, table, table))
+            .apply("GeneratePK", new GeneratePrimaryKey(4, null, null));
+
+    PAssert.that(out)
+        .satisfies(
+            iter -> {
+              for (KV<String, Row> kv : iter) {
+                String shard = kv.getValue().getString(Constants.SHARD_ID_COLUMN_NAME);
+                assertTrue(
+                    "Shard id should start with 'shard': " + shard, shard.startsWith("shard"));
+                int idx = Integer.parseInt(shard.substring("shard".length()));
+                assertTrue("Shard index should be in [0, 4): " + idx, idx >= 0 && idx < 4);
+              }
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testGeneratePrimaryKey_tableWithoutPkEmitsNothing() {
+    DataGeneratorColumn id = col("id", LogicalType.STRING);
+    DataGeneratorTable table =
+        DataGeneratorTable.builder()
+            .name("T")
+            .columns(ImmutableList.of(id))
+            .primaryKeys(ImmutableList.of()) // no PK
+            .foreignKeys(ImmutableList.of())
+            .uniqueKeys(ImmutableList.of())
+            .isRoot(true)
+            .insertQps(10)
+            .updateQps(0)
+            .deleteQps(0)
+            .recordsPerTick(1.0)
+            .build();
+
+    PCollection<KV<String, Row>> out =
+        pipeline
+            .apply("In", Create.of(table))
+            .apply("GeneratePK", new GeneratePrimaryKey(1, null, null));
+
+    PAssert.that(out).empty();
+    pipeline.run();
+  }
+
+  @Test
+  public void testGeneratePrimaryKey_perTableSchemaIsolation() {
+    // The fn caches PK Row schemas per table. Two tables with different PK column lists must
+    // not bleed into each other's cached schema.
+    DataGeneratorColumn id1 = col("id", LogicalType.STRING);
+    DataGeneratorColumn id2a = col("a", LogicalType.INT64);
+    DataGeneratorColumn id2b = col("b", LogicalType.STRING);
+
+    DataGeneratorTable t1 =
+        DataGeneratorTable.builder()
+            .name("T1")
+            .columns(ImmutableList.of(id1))
+            .primaryKeys(ImmutableList.of("id"))
+            .foreignKeys(ImmutableList.of())
+            .uniqueKeys(ImmutableList.of())
+            .isRoot(true)
+            .insertQps(10)
+            .updateQps(0)
+            .deleteQps(0)
+            .recordsPerTick(1.0)
+            .build();
+
+    DataGeneratorTable t2 =
+        DataGeneratorTable.builder()
+            .name("T2")
+            .columns(ImmutableList.of(id2a, id2b))
+            .primaryKeys(ImmutableList.of("a", "b"))
+            .foreignKeys(ImmutableList.of())
+            .uniqueKeys(ImmutableList.of())
+            .isRoot(true)
+            .insertQps(10)
+            .updateQps(0)
+            .deleteQps(0)
+            .recordsPerTick(1.0)
+            .build();
+
+    PCollection<KV<String, Row>> out =
+        pipeline
+            .apply("In", Create.of(t1, t2, t1))
+            .apply("GeneratePK", new GeneratePrimaryKey(1, null, null));
+
+    PAssert.that(out)
+        .satisfies(
+            iter -> {
+              int t1Rows = 0;
+              int t2Rows = 0;
+              for (KV<String, Row> kv : iter) {
+                switch (kv.getKey()) {
+                  case "T1":
+                    t1Rows++;
+                    // T1 schema: id + shard_id
+                    assertEquals(2, kv.getValue().getSchema().getFieldCount());
+                    assertEquals("id", kv.getValue().getSchema().getField(0).getName());
+                    break;
+                  case "T2":
+                    t2Rows++;
+                    // T2 schema: a, b + shard_id
+                    assertEquals(3, kv.getValue().getSchema().getFieldCount());
+                    assertEquals("a", kv.getValue().getSchema().getField(0).getName());
+                    assertEquals("b", kv.getValue().getSchema().getField(1).getName());
+                    break;
+                  default:
+                    throw new AssertionError("Unexpected table name: " + kv.getKey());
+                }
+              }
+              assertEquals(2, t1Rows);
+              assertEquals(1, t2Rows);
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  private static DataGeneratorColumn col(String name, LogicalType type) {
+    return col(name, type, null, null, null);
+  }
+
+  private static DataGeneratorColumn col(
+      String name, LogicalType type, Long size, Integer precision, Integer scale) {
+    return DataGeneratorColumn.builder()
+        .name(name)
+        .logicalType(type)
+        .isNullable(false)
+        .isSkipped(false)
+        .isGenerated(false)
+        .size(size)
+        .precision(precision)
+        .scale(scale)
+        .build();
+  }
+}

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/GeneratePrimaryKeyTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/GeneratePrimaryKeyTest.java
@@ -110,7 +110,7 @@ public class GeneratePrimaryKeyTest {
     PCollection<KV<String, Row>> out =
         pipeline
             .apply("In", Create.of(table))
-            .apply("GeneratePK", new GeneratePrimaryKey(1, null, null));
+            .apply("GeneratePK", new GeneratePrimaryKey(null, null));
 
     PAssert.that(out)
         .satisfies(
@@ -156,17 +156,14 @@ public class GeneratePrimaryKeyTest {
     PCollection<KV<String, Row>> out =
         pipeline
             .apply("In", Create.of(table, table, table, table, table))
-            .apply("GeneratePK", new GeneratePrimaryKey(4, null, null));
+            .apply("GeneratePK", new GeneratePrimaryKey(null, null));
 
     PAssert.that(out)
         .satisfies(
             iter -> {
               for (KV<String, Row> kv : iter) {
                 String shard = kv.getValue().getString(Constants.SHARD_ID_COLUMN_NAME);
-                assertTrue(
-                    "Shard id should start with 'shard': " + shard, shard.startsWith("shard"));
-                int idx = Integer.parseInt(shard.substring("shard".length()));
-                assertTrue("Shard index should be in [0, 4): " + idx, idx >= 0 && idx < 4);
+                assertEquals("shard0", shard);
               }
               return null;
             });
@@ -194,7 +191,7 @@ public class GeneratePrimaryKeyTest {
     PCollection<KV<String, Row>> out =
         pipeline
             .apply("In", Create.of(table))
-            .apply("GeneratePK", new GeneratePrimaryKey(1, null, null));
+            .apply("GeneratePK", new GeneratePrimaryKey(null, null));
 
     PAssert.that(out).empty();
     pipeline.run();
@@ -239,7 +236,7 @@ public class GeneratePrimaryKeyTest {
     PCollection<KV<String, Row>> out =
         pipeline
             .apply("In", Create.of(t1, t2, t1))
-            .apply("GeneratePK", new GeneratePrimaryKey(1, null, null));
+            .apply("GeneratePK", new GeneratePrimaryKey(null, null));
 
     PAssert.that(out)
         .satisfies(

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/utils/DataGeneratorUtilsTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/utils/DataGeneratorUtilsTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorColumn;
+import com.google.cloud.teleport.v2.templates.model.LogicalType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class DataGeneratorUtilsTest {
+
+  @Test
+  public void testClampStringLength() {
+    assertEquals(
+        DataGeneratorUtils.DEFAULT_STRING_LENGTH, DataGeneratorUtils.clampStringLength(null));
+    assertEquals(
+        DataGeneratorUtils.DEFAULT_STRING_LENGTH, DataGeneratorUtils.clampStringLength(0L));
+    assertEquals(
+        DataGeneratorUtils.DEFAULT_STRING_LENGTH, DataGeneratorUtils.clampStringLength(-1L));
+    assertEquals(50, DataGeneratorUtils.clampStringLength(50L));
+    assertEquals(Integer.MAX_VALUE, DataGeneratorUtils.clampStringLength(Long.MAX_VALUE));
+  }
+
+  @Test
+  public void testMapToBeamFieldType() {
+    assertEquals(
+        org.apache.beam.sdk.schemas.Schema.FieldType.STRING,
+        DataGeneratorUtils.mapToBeamFieldType(LogicalType.STRING));
+    assertEquals(
+        org.apache.beam.sdk.schemas.Schema.FieldType.STRING,
+        DataGeneratorUtils.mapToBeamFieldType(LogicalType.JSON));
+    assertEquals(
+        org.apache.beam.sdk.schemas.Schema.FieldType.STRING,
+        DataGeneratorUtils.mapToBeamFieldType(LogicalType.UUID));
+    assertEquals(
+        org.apache.beam.sdk.schemas.Schema.FieldType.INT64,
+        DataGeneratorUtils.mapToBeamFieldType(LogicalType.INT64));
+    assertEquals(
+        org.apache.beam.sdk.schemas.Schema.FieldType.DOUBLE,
+        DataGeneratorUtils.mapToBeamFieldType(LogicalType.FLOAT64));
+    assertEquals(
+        org.apache.beam.sdk.schemas.Schema.FieldType.DECIMAL,
+        DataGeneratorUtils.mapToBeamFieldType(LogicalType.NUMERIC));
+    assertEquals(
+        org.apache.beam.sdk.schemas.Schema.FieldType.BOOLEAN,
+        DataGeneratorUtils.mapToBeamFieldType(LogicalType.BOOLEAN));
+    assertEquals(
+        org.apache.beam.sdk.schemas.Schema.FieldType.BYTES,
+        DataGeneratorUtils.mapToBeamFieldType(LogicalType.BYTES));
+    assertEquals(
+        org.apache.beam.sdk.schemas.Schema.FieldType.DATETIME,
+        DataGeneratorUtils.mapToBeamFieldType(LogicalType.DATE));
+    assertEquals(
+        org.apache.beam.sdk.schemas.Schema.FieldType.DATETIME,
+        DataGeneratorUtils.mapToBeamFieldType(LogicalType.TIMESTAMP));
+
+    DataGeneratorColumn col =
+        DataGeneratorColumn.builder()
+            .name("c")
+            .logicalType(LogicalType.STRING)
+            .isNullable(false)
+            .isGenerated(false)
+            .build();
+    assertEquals(
+        org.apache.beam.sdk.schemas.Schema.FieldType.STRING,
+        DataGeneratorUtils.mapToBeamFieldType(col));
+  }
+
+  @Test
+  public void testGenerateNumeric() {
+    com.github.javafaker.Faker faker = new com.github.javafaker.Faker();
+
+    // Case 1: Precision and scale specified
+    DataGeneratorColumn col1 =
+        DataGeneratorColumn.builder()
+            .name("c1")
+            .logicalType(LogicalType.NUMERIC)
+            .isNullable(false)
+            .isGenerated(false)
+            .precision(5)
+            .scale(2)
+            .build();
+    java.math.BigDecimal val1 = DataGeneratorUtils.generateNumeric(col1, faker);
+    assertEquals(2, val1.scale());
+
+    // Case 2: Null precision (defaults to 10)
+    DataGeneratorColumn col2 =
+        DataGeneratorColumn.builder()
+            .name("c2")
+            .logicalType(LogicalType.NUMERIC)
+            .isNullable(false)
+            .isGenerated(false)
+            .scale(2)
+            .build();
+    java.math.BigDecimal val2 = DataGeneratorUtils.generateNumeric(col2, faker);
+    assertEquals(2, val2.scale());
+
+    // Case 3: Null scale (defaults to 2)
+    DataGeneratorColumn col3 =
+        DataGeneratorColumn.builder()
+            .name("c3")
+            .logicalType(LogicalType.NUMERIC)
+            .isNullable(false)
+            .isGenerated(false)
+            .precision(10)
+            .build();
+    java.math.BigDecimal val3 = DataGeneratorUtils.generateNumeric(col3, faker);
+    assertEquals(2, val3.scale());
+
+    // Case 4: Scale > Precision
+    DataGeneratorColumn col4 =
+        DataGeneratorColumn.builder()
+            .name("c4")
+            .logicalType(LogicalType.NUMERIC)
+            .isNullable(false)
+            .isGenerated(false)
+            .precision(5)
+            .scale(7)
+            .build();
+    java.math.BigDecimal val4 = DataGeneratorUtils.generateNumeric(col4, faker);
+    assertEquals(5, val4.scale()); // Scale should be capped at precision
+  }
+
+  @Test
+  public void testGenerateValue() {
+    com.github.javafaker.Faker faker = new com.github.javafaker.Faker();
+
+    // STRING
+    DataGeneratorColumn strCol =
+        DataGeneratorColumn.builder()
+            .name("c")
+            .logicalType(LogicalType.STRING)
+            .isNullable(false)
+            .isGenerated(false)
+            .build();
+    Object strVal = DataGeneratorUtils.generateValue(strCol, faker);
+    assertTrue(strVal instanceof String);
+
+    // JSON
+    DataGeneratorColumn jsonCol =
+        DataGeneratorColumn.builder()
+            .name("c")
+            .logicalType(LogicalType.JSON)
+            .isNullable(false)
+            .isGenerated(false)
+            .build();
+    Object jsonVal = DataGeneratorUtils.generateValue(jsonCol, faker);
+    assertTrue(jsonVal instanceof String);
+    assertTrue(((String) jsonVal).startsWith("{"));
+
+    // UUID
+    DataGeneratorColumn uuidCol =
+        DataGeneratorColumn.builder()
+            .name("c")
+            .logicalType(LogicalType.UUID)
+            .isNullable(false)
+            .isGenerated(false)
+            .build();
+    Object uuidVal = DataGeneratorUtils.generateValue(uuidCol, faker);
+    assertTrue(uuidVal instanceof String);
+
+    // INT64
+    DataGeneratorColumn intCol =
+        DataGeneratorColumn.builder()
+            .name("c")
+            .logicalType(LogicalType.INT64)
+            .isNullable(false)
+            .isGenerated(false)
+            .build();
+    Object intVal = DataGeneratorUtils.generateValue(intCol, faker);
+    assertTrue(intVal instanceof Long);
+
+    // FLOAT64
+    DataGeneratorColumn floatCol =
+        DataGeneratorColumn.builder()
+            .name("c")
+            .logicalType(LogicalType.FLOAT64)
+            .isNullable(false)
+            .isGenerated(false)
+            .build();
+    Object floatVal = DataGeneratorUtils.generateValue(floatCol, faker);
+    assertTrue(floatVal instanceof Double);
+
+    // NUMERIC
+    DataGeneratorColumn numCol =
+        DataGeneratorColumn.builder()
+            .name("c")
+            .logicalType(LogicalType.NUMERIC)
+            .isNullable(false)
+            .isGenerated(false)
+            .build();
+    Object numVal = DataGeneratorUtils.generateValue(numCol, faker);
+    assertTrue(numVal instanceof java.math.BigDecimal);
+
+    // BOOLEAN
+    DataGeneratorColumn boolCol =
+        DataGeneratorColumn.builder()
+            .name("c")
+            .logicalType(LogicalType.BOOLEAN)
+            .isNullable(false)
+            .isGenerated(false)
+            .build();
+    Object boolVal = DataGeneratorUtils.generateValue(boolCol, faker);
+    assertTrue(boolVal instanceof Boolean);
+
+    // BYTES
+    DataGeneratorColumn bytesCol =
+        DataGeneratorColumn.builder()
+            .name("c")
+            .logicalType(LogicalType.BYTES)
+            .isNullable(false)
+            .isGenerated(false)
+            .build();
+    Object bytesVal = DataGeneratorUtils.generateValue(bytesCol, faker);
+    assertTrue(bytesVal instanceof byte[]);
+
+    // DATE
+    DataGeneratorColumn dateCol =
+        DataGeneratorColumn.builder()
+            .name("c")
+            .logicalType(LogicalType.DATE)
+            .isNullable(false)
+            .isGenerated(false)
+            .build();
+    Object dateVal = DataGeneratorUtils.generateValue(dateCol, faker);
+    assertTrue(dateVal instanceof org.joda.time.Instant);
+
+    // TIMESTAMP
+    DataGeneratorColumn tsCol =
+        DataGeneratorColumn.builder()
+            .name("c")
+            .logicalType(LogicalType.TIMESTAMP)
+            .isNullable(false)
+            .isGenerated(false)
+            .build();
+    Object tsVal = DataGeneratorUtils.generateValue(tsCol, faker);
+    assertTrue(tsVal instanceof org.joda.time.Instant);
+  }
+}

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/utils/DataGeneratorUtilsTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/utils/DataGeneratorUtilsTest.java
@@ -18,8 +18,12 @@ package com.google.cloud.teleport.v2.templates.utils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.github.javafaker.Faker;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorColumn;
 import com.google.cloud.teleport.v2.templates.model.LogicalType;
+import java.math.BigDecimal;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.joda.time.Instant;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -28,49 +32,29 @@ import org.junit.runners.JUnit4;
 public class DataGeneratorUtilsTest {
 
   @Test
-  public void testClampStringLength() {
+  public void testLimitStringLength() {
     assertEquals(
-        DataGeneratorUtils.DEFAULT_STRING_LENGTH, DataGeneratorUtils.clampStringLength(null));
+        DataGeneratorUtils.DEFAULT_STRING_LENGTH, DataGeneratorUtils.limitStringLength(null));
     assertEquals(
-        DataGeneratorUtils.DEFAULT_STRING_LENGTH, DataGeneratorUtils.clampStringLength(0L));
+        DataGeneratorUtils.DEFAULT_STRING_LENGTH, DataGeneratorUtils.limitStringLength(0L));
     assertEquals(
-        DataGeneratorUtils.DEFAULT_STRING_LENGTH, DataGeneratorUtils.clampStringLength(-1L));
-    assertEquals(50, DataGeneratorUtils.clampStringLength(50L));
-    assertEquals(Integer.MAX_VALUE, DataGeneratorUtils.clampStringLength(Long.MAX_VALUE));
+        DataGeneratorUtils.DEFAULT_STRING_LENGTH, DataGeneratorUtils.limitStringLength(-1L));
+    assertEquals(50, DataGeneratorUtils.limitStringLength(50L));
+    assertEquals(Integer.MAX_VALUE, DataGeneratorUtils.limitStringLength(Long.MAX_VALUE));
   }
 
   @Test
   public void testMapToBeamFieldType() {
-    assertEquals(
-        org.apache.beam.sdk.schemas.Schema.FieldType.STRING,
-        DataGeneratorUtils.mapToBeamFieldType(LogicalType.STRING));
-    assertEquals(
-        org.apache.beam.sdk.schemas.Schema.FieldType.STRING,
-        DataGeneratorUtils.mapToBeamFieldType(LogicalType.JSON));
-    assertEquals(
-        org.apache.beam.sdk.schemas.Schema.FieldType.STRING,
-        DataGeneratorUtils.mapToBeamFieldType(LogicalType.UUID));
-    assertEquals(
-        org.apache.beam.sdk.schemas.Schema.FieldType.INT64,
-        DataGeneratorUtils.mapToBeamFieldType(LogicalType.INT64));
-    assertEquals(
-        org.apache.beam.sdk.schemas.Schema.FieldType.DOUBLE,
-        DataGeneratorUtils.mapToBeamFieldType(LogicalType.FLOAT64));
-    assertEquals(
-        org.apache.beam.sdk.schemas.Schema.FieldType.DECIMAL,
-        DataGeneratorUtils.mapToBeamFieldType(LogicalType.NUMERIC));
-    assertEquals(
-        org.apache.beam.sdk.schemas.Schema.FieldType.BOOLEAN,
-        DataGeneratorUtils.mapToBeamFieldType(LogicalType.BOOLEAN));
-    assertEquals(
-        org.apache.beam.sdk.schemas.Schema.FieldType.BYTES,
-        DataGeneratorUtils.mapToBeamFieldType(LogicalType.BYTES));
-    assertEquals(
-        org.apache.beam.sdk.schemas.Schema.FieldType.DATETIME,
-        DataGeneratorUtils.mapToBeamFieldType(LogicalType.DATE));
-    assertEquals(
-        org.apache.beam.sdk.schemas.Schema.FieldType.DATETIME,
-        DataGeneratorUtils.mapToBeamFieldType(LogicalType.TIMESTAMP));
+    assertEquals(FieldType.STRING, DataGeneratorUtils.mapToBeamFieldType(LogicalType.STRING));
+    assertEquals(FieldType.STRING, DataGeneratorUtils.mapToBeamFieldType(LogicalType.JSON));
+    assertEquals(FieldType.STRING, DataGeneratorUtils.mapToBeamFieldType(LogicalType.UUID));
+    assertEquals(FieldType.INT64, DataGeneratorUtils.mapToBeamFieldType(LogicalType.INT64));
+    assertEquals(FieldType.DOUBLE, DataGeneratorUtils.mapToBeamFieldType(LogicalType.FLOAT64));
+    assertEquals(FieldType.DECIMAL, DataGeneratorUtils.mapToBeamFieldType(LogicalType.NUMERIC));
+    assertEquals(FieldType.BOOLEAN, DataGeneratorUtils.mapToBeamFieldType(LogicalType.BOOLEAN));
+    assertEquals(FieldType.BYTES, DataGeneratorUtils.mapToBeamFieldType(LogicalType.BYTES));
+    assertEquals(FieldType.DATETIME, DataGeneratorUtils.mapToBeamFieldType(LogicalType.DATE));
+    assertEquals(FieldType.DATETIME, DataGeneratorUtils.mapToBeamFieldType(LogicalType.TIMESTAMP));
 
     DataGeneratorColumn col =
         DataGeneratorColumn.builder()
@@ -79,14 +63,12 @@ public class DataGeneratorUtilsTest {
             .isNullable(false)
             .isGenerated(false)
             .build();
-    assertEquals(
-        org.apache.beam.sdk.schemas.Schema.FieldType.STRING,
-        DataGeneratorUtils.mapToBeamFieldType(col));
+    assertEquals(FieldType.STRING, DataGeneratorUtils.mapToBeamFieldType(col));
   }
 
   @Test
   public void testGenerateNumeric() {
-    com.github.javafaker.Faker faker = new com.github.javafaker.Faker();
+    Faker faker = new Faker();
 
     // Case 1: Precision and scale specified
     DataGeneratorColumn col1 =
@@ -98,7 +80,7 @@ public class DataGeneratorUtilsTest {
             .precision(5)
             .scale(2)
             .build();
-    java.math.BigDecimal val1 = DataGeneratorUtils.generateNumeric(col1, faker);
+    BigDecimal val1 = DataGeneratorUtils.generateNumeric(col1, faker);
     assertEquals(2, val1.scale());
 
     // Case 2: Null precision (defaults to 10)
@@ -110,7 +92,7 @@ public class DataGeneratorUtilsTest {
             .isGenerated(false)
             .scale(2)
             .build();
-    java.math.BigDecimal val2 = DataGeneratorUtils.generateNumeric(col2, faker);
+    BigDecimal val2 = DataGeneratorUtils.generateNumeric(col2, faker);
     assertEquals(2, val2.scale());
 
     // Case 3: Null scale (defaults to 2)
@@ -122,7 +104,7 @@ public class DataGeneratorUtilsTest {
             .isGenerated(false)
             .precision(10)
             .build();
-    java.math.BigDecimal val3 = DataGeneratorUtils.generateNumeric(col3, faker);
+    BigDecimal val3 = DataGeneratorUtils.generateNumeric(col3, faker);
     assertEquals(2, val3.scale());
 
     // Case 4: Scale > Precision
@@ -135,13 +117,13 @@ public class DataGeneratorUtilsTest {
             .precision(5)
             .scale(7)
             .build();
-    java.math.BigDecimal val4 = DataGeneratorUtils.generateNumeric(col4, faker);
+    BigDecimal val4 = DataGeneratorUtils.generateNumeric(col4, faker);
     assertEquals(5, val4.scale()); // Scale should be capped at precision
   }
 
   @Test
   public void testGenerateValue() {
-    com.github.javafaker.Faker faker = new com.github.javafaker.Faker();
+    Faker faker = new Faker();
 
     // STRING
     DataGeneratorColumn strCol =
@@ -208,7 +190,7 @@ public class DataGeneratorUtilsTest {
             .isGenerated(false)
             .build();
     Object numVal = DataGeneratorUtils.generateValue(numCol, faker);
-    assertTrue(numVal instanceof java.math.BigDecimal);
+    assertTrue(numVal instanceof BigDecimal);
 
     // BOOLEAN
     DataGeneratorColumn boolCol =
@@ -241,7 +223,7 @@ public class DataGeneratorUtilsTest {
             .isGenerated(false)
             .build();
     Object dateVal = DataGeneratorUtils.generateValue(dateCol, faker);
-    assertTrue(dateVal instanceof org.joda.time.Instant);
+    assertTrue(dateVal instanceof Instant);
 
     // TIMESTAMP
     DataGeneratorColumn tsCol =
@@ -252,6 +234,6 @@ public class DataGeneratorUtilsTest {
             .isGenerated(false)
             .build();
     Object tsVal = DataGeneratorUtils.generateValue(tsCol, faker);
-    assertTrue(tsVal instanceof org.joda.time.Instant);
+    assertTrue(tsVal instanceof Instant);
   }
 }


### PR DESCRIPTION
This PR introduces synthetic primary key generation for the CDC Data Generator.

## High-Level Changes (New Files)
### Primary Key Generation
- **`GeneratePrimaryKey.java` & `GeneratePrimaryKeyFn.java`**: Introduced a new `PTransform` and associated `DoFn` to generate synthetic primary-key `Row`s for tables. The generated rows include the table's PK columns and a synthesised logical shard ID.
- **`GeneratePrimaryKeyTest.java`**: Added corresponding unit and pipeline tests to verify the behavior of primary key generation, including composite keys, shard ID distribution, and schema isolation.
### Data Generator Utilities
- **`DataGeneratorUtils.java`**: Added a utility class to centralize value synthesis and Beam type mapping. It supports generating random values for various supported logical types (STRING, INT64, FLOAT64, BOOLEAN, BYTES, DATE, TIMESTAMP, NUMERIC, JSON, UUID) using Java Faker and `ThreadLocalRandom`.
- **`DataGeneratorUtilsTest.java`**: Added a new test file to provide comprehensive unit tests for `DataGeneratorUtils`, covering value generation for all supported types, type mapping, and edge cases like string length clamping and numeric precision.