### PR TITLE
Use getPayload instead of getOriginalPayload to process the UDF changes

### DIFF
--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
@@ -536,8 +536,10 @@ public class DataStreamMongoDBToFirestore {
                   .setFailureTag(UDF_FAILURE_TAG)
                   .build());
 
-      jsonRecords = udfResult.get(UDF_SUCCESS_TAG)
-          .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+      jsonRecords =
+          udfResult
+              .get(UDF_SUCCESS_TAG)
+              .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
 
       // Handle failed UDF processing
       writeFailedJsonToDlq(options, udfResult, dlqManager, UDF_FAILURE_TAG);
@@ -724,8 +726,10 @@ public class DataStreamMongoDBToFirestore {
                   .setFailureTag(UDF_FAILURE_TAG)
                   .build());
 
-      jsonRecords = udfResult.get(UDF_SUCCESS_TAG)
-          .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+      jsonRecords =
+          udfResult
+              .get(UDF_SUCCESS_TAG)
+              .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
 
       // Handle failed UDF processing
       writeFailedJsonToDlq(options, udfResult, dlqManager, UDF_FAILURE_TAG);

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
@@ -536,7 +536,8 @@ public class DataStreamMongoDBToFirestore {
                   .setFailureTag(UDF_FAILURE_TAG)
                   .build());
 
-      jsonRecords = udfResult.get(UDF_SUCCESS_TAG);
+      jsonRecords = udfResult.get(UDF_SUCCESS_TAG)
+          .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
 
       // Handle failed UDF processing
       writeFailedJsonToDlq(options, udfResult, dlqManager, UDF_FAILURE_TAG);
@@ -723,7 +724,8 @@ public class DataStreamMongoDBToFirestore {
                   .setFailureTag(UDF_FAILURE_TAG)
                   .build());
 
-      jsonRecords = udfResult.get(UDF_SUCCESS_TAG);
+      jsonRecords = udfResult.get(UDF_SUCCESS_TAG)
+          .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
 
       // Handle failed UDF processing
       writeFailedJsonToDlq(options, udfResult, dlqManager, UDF_FAILURE_TAG);

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/CreateMongoDbChangeEventContextFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/CreateMongoDbChangeEventContextFn.java
@@ -48,7 +48,7 @@ public class CreateMongoDbChangeEventContextFn
   public void processElement(ProcessContext context, MultiOutputReceiver out) {
     FailsafeElement<String, String> element = context.element();
     try {
-      JsonNode jsonNode = OBJECT_MAPPER.readTree(element.getOriginalPayload());
+      JsonNode jsonNode = OBJECT_MAPPER.readTree(element.getPayload());
       MongoDbChangeEventContext changeEventContext =
           new MongoDbChangeEventContext(jsonNode, shadowCollectionPrefix);
       out.get(successfulCreationTag).output(changeEventContext);


### PR DESCRIPTION
Verified manually that applying a UDF works in transforming the data and excluding a UDF maintains the original payload.

Example UDF:

```js
function process(inJson) {
	const message = JSON.parse(inJson);
	const data = JSON.parse(message.data);

	// Rename a field ping to pong
	if (data.ping) {
		data.pong = data.ping;
		delete data.ping;
	}

	// Add a field helloWorld
	data.helloWorld = "hello world";

	message.data = JSON.stringify(data);
	return JSON.stringify(message);
}
```