### PR TITLE
Fix batch failures and excessive retries for permanent errors in MongoDB to Firestore template

### DIFF
--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
@@ -607,7 +607,8 @@ public class DataStreamMongoDBToFirestore {
                   ParDo.of(new ProcessChangeEventFn(connectionString, options.getDatabaseName()))
                       .withOutputTags(
                           ProcessChangeEventFn.successfulWriteTag,
-                          TupleTagList.of(ProcessChangeEventFn.failedWriteTag).and(ProcessChangeEventFn.severeFailedWriteTag)));
+                          TupleTagList.of(ProcessChangeEventFn.failedWriteTag)
+                              .and(ProcessChangeEventFn.severeFailedWriteTag)));
     } else {
       // Process backfill without shadow tables
       backfillResult =
@@ -620,7 +621,8 @@ public class DataStreamMongoDBToFirestore {
                               connectionString, options.getDatabaseName(), options.getBatchSize()))
                       .withOutputTags(
                           ProcessBackfillEventFn.successfulWriteTag,
-                          TupleTagList.of(ProcessBackfillEventFn.failedWriteTag).and(ProcessBackfillEventFn.severeFailedWriteTag)));
+                          TupleTagList.of(ProcessBackfillEventFn.failedWriteTag)
+                              .and(ProcessBackfillEventFn.severeFailedWriteTag)));
     }
 
     // Set coders for backfill results
@@ -678,7 +680,8 @@ public class DataStreamMongoDBToFirestore {
                 ParDo.of(new ProcessChangeEventFn(connectionString, options.getDatabaseName()))
                     .withOutputTags(
                         ProcessChangeEventFn.successfulWriteTag,
-                        TupleTagList.of(ProcessChangeEventFn.failedWriteTag).and(ProcessChangeEventFn.severeFailedWriteTag)));
+                        TupleTagList.of(ProcessChangeEventFn.failedWriteTag)
+                            .and(ProcessChangeEventFn.severeFailedWriteTag)));
 
     // Set coders for CDC results
     cdcResult
@@ -701,7 +704,8 @@ public class DataStreamMongoDBToFirestore {
     // Handle failed CDC writes with DLQ
     writeFailedEventsToDlq(options, cdcResult, dlqManager, ProcessChangeEventFn.failedWriteTag);
     // Write severe CDC failures directly to severe DLQ
-    writeSevereEventsToDlq(options, cdcResult, dlqManager, ProcessChangeEventFn.severeFailedWriteTag);
+    writeSevereEventsToDlq(
+        options, cdcResult, dlqManager, ProcessChangeEventFn.severeFailedWriteTag);
 
     // Execute the pipeline
     LOG.info("Executing pipeline");
@@ -810,7 +814,8 @@ public class DataStreamMongoDBToFirestore {
                 ParDo.of(new ProcessChangeEventFn(connectionString, options.getDatabaseName()))
                     .withOutputTags(
                         ProcessChangeEventFn.successfulWriteTag,
-                        TupleTagList.of(ProcessChangeEventFn.failedWriteTag).and(ProcessChangeEventFn.severeFailedWriteTag)));
+                        TupleTagList.of(ProcessChangeEventFn.failedWriteTag)
+                            .and(ProcessChangeEventFn.severeFailedWriteTag)));
 
     /* Set coder for successful writes */
     writeResult
@@ -836,7 +841,8 @@ public class DataStreamMongoDBToFirestore {
     LOG.info("Setting up DLQ handling for failed writes");
     writeFailedEventsToDlq(options, writeResult, dlqManager, ProcessChangeEventFn.failedWriteTag);
     // Write severe failures directly to severe DLQ
-    writeSevereEventsToDlq(options, writeResult, dlqManager, ProcessChangeEventFn.severeFailedWriteTag);
+    writeSevereEventsToDlq(
+        options, writeResult, dlqManager, ProcessChangeEventFn.severeFailedWriteTag);
 
     // Execute the pipeline and return the result.
     LOG.info("Executing pipeline");
@@ -1054,7 +1060,8 @@ public class DataStreamMongoDBToFirestore {
             "Write Severe Events Failures To DLQ",
             DLQWriteTransform.WriteDLQ.newBuilder()
                 .withDlqDirectory(dlqManager.getSevereDlqDirectoryWithDateTime())
-                .withTmpDirectory(options.getDeadLetterQueueDirectory() + "/tmp_severe_mongo_event/")
+                .withTmpDirectory(
+                    options.getDeadLetterQueueDirectory() + "/tmp_severe_mongo_event/")
                 .setIncludePaneInfo(true)
                 .build());
     LOG.info("Severe DLQ setup completed");
@@ -1136,7 +1143,8 @@ public class DataStreamMongoDBToFirestore {
     }
 
     @com.google.common.annotations.VisibleForTesting
-    public ProcessBackfillEventFn(com.mongodb.client.MongoClient client, String databaseName, int batchSize) {
+    public ProcessBackfillEventFn(
+        com.mongodb.client.MongoClient client, String databaseName, int batchSize) {
       this.client = client;
       this.targetDatabaseName = databaseName;
       this.batchSize = batchSize;
@@ -1246,7 +1254,8 @@ public class DataStreamMongoDBToFirestore {
         }
 
         // Execute bulk write with ordered(false) to isolate failed documents
-        BulkWriteResult result = collection.bulkWrite(bulkOperations, new BulkWriteOptions().ordered(false));
+        BulkWriteResult result =
+            collection.bulkWrite(bulkOperations, new BulkWriteOptions().ordered(false));
         LOG.debug(
             "Bulk write completed for collection {}: {} inserts/updates, {} deletes",
             collectionName,
@@ -1259,9 +1268,7 @@ public class DataStreamMongoDBToFirestore {
         }
       } catch (MongoBulkWriteException e) {
         LOG.warn(
-            "Bulk write partially failed for collection {}: {}",
-            collectionName,
-            e.getMessage());
+            "Bulk write partially failed for collection {}: {}", collectionName, e.getMessage());
 
         // Identify failed documents and route them to appropriate tag
         Set<Integer> failedIndices = new HashSet<>();
@@ -1272,8 +1279,9 @@ public class DataStreamMongoDBToFirestore {
               FailsafeElement.of(event, event);
           failedElement.setErrorMessage(error.getMessage());
           failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
-          
-          // Check if the error is permanent (e.g. code 2 for InvalidArgument when exceeding nesting limit)
+
+          // Check if the error is permanent (e.g. code 2 for InvalidArgument when exceeding nesting
+          // limit)
           if (error.getCode() == ProcessChangeEventFn.INVALID_ARGUMENT) {
             out.get(severeFailedWriteTag).output(failedElement);
           } else {
@@ -1339,7 +1347,8 @@ public class DataStreamMongoDBToFirestore {
         }
 
         // Execute bulk write with ordered(false) to isolate failed documents
-        BulkWriteResult result = collection.bulkWrite(bulkOperations, new BulkWriteOptions().ordered(false));
+        BulkWriteResult result =
+            collection.bulkWrite(bulkOperations, new BulkWriteOptions().ordered(false));
         LOG.debug(
             "Bulk write completed for collection {}: {} inserts/updates, {} deletes",
             collectionName,
@@ -1352,9 +1361,7 @@ public class DataStreamMongoDBToFirestore {
         }
       } catch (MongoBulkWriteException e) {
         LOG.warn(
-            "Bulk write partially failed for collection {}: {}",
-            collectionName,
-            e.getMessage());
+            "Bulk write partially failed for collection {}: {}", collectionName, e.getMessage());
 
         // Identify failed documents and route them to appropriate tag
         Set<Integer> failedIndices = new HashSet<>();
@@ -1365,10 +1372,12 @@ public class DataStreamMongoDBToFirestore {
               FailsafeElement.of(event, event);
           failedElement.setErrorMessage(error.getMessage());
           failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
-          
-          // Check if the error is permanent (e.g. code 2 for InvalidArgument when exceeding nesting limit)
+
+          // Check if the error is permanent (e.g. code 2 for InvalidArgument when exceeding nesting
+          // limit)
           if (error.getCode() == ProcessChangeEventFn.INVALID_ARGUMENT) {
-            context.output(severeFailedWriteTag, failedElement, Instant.now(), GlobalWindow.INSTANCE);
+            context.output(
+                severeFailedWriteTag, failedElement, Instant.now(), GlobalWindow.INSTANCE);
           } else {
             context.output(failedWriteTag, failedElement, Instant.now(), GlobalWindow.INSTANCE);
           }

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
@@ -40,12 +40,15 @@ import com.google.cloud.teleport.v2.transforms.ProcessChangeEventFn;
 import com.google.cloud.teleport.v2.transforms.Utils;
 import com.google.cloud.teleport.v2.values.FailsafeElement;
 import com.google.common.base.Strings;
+import com.mongodb.MongoBulkWriteException;
 import com.mongodb.MongoClientSettings;
+import com.mongodb.bulk.BulkWriteError;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.BulkWriteOptions;
 import com.mongodb.client.model.DeleteOneModel;
 import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.ReplaceOptions;
@@ -603,7 +606,7 @@ public class DataStreamMongoDBToFirestore {
                   ParDo.of(new ProcessChangeEventFn(connectionString, options.getDatabaseName()))
                       .withOutputTags(
                           ProcessChangeEventFn.successfulWriteTag,
-                          TupleTagList.of(ProcessChangeEventFn.failedWriteTag)));
+                          TupleTagList.of(ProcessChangeEventFn.failedWriteTag).and(ProcessChangeEventFn.severeFailedWriteTag)));
     } else {
       // Process backfill without shadow tables
       backfillResult =
@@ -636,6 +639,15 @@ public class DataStreamMongoDBToFirestore {
                 SerializableCoder.of(MongoDbChangeEventContext.class),
                 SerializableCoder.of(MongoDbChangeEventContext.class)));
 
+    if (options.getUseShadowTablesForBackfill()) {
+      backfillResult
+          .get(ProcessChangeEventFn.severeFailedWriteTag)
+          .setCoder(
+              FailsafeElementCoder.of(
+                  SerializableCoder.of(MongoDbChangeEventContext.class),
+                  SerializableCoder.of(MongoDbChangeEventContext.class)));
+    }
+
     // Handle failed backfill writes with DLQ
     writeFailedEventsToDlq(
         options,
@@ -644,6 +656,14 @@ public class DataStreamMongoDBToFirestore {
         options.getUseShadowTablesForBackfill()
             ? ProcessChangeEventFn.failedWriteTag
             : ProcessBackfillEventFn.failedWriteTag);
+
+    if (options.getUseShadowTablesForBackfill()) {
+      writeSevereEventsToDlq(
+          options,
+          backfillResult,
+          dlqManager,
+          ProcessChangeEventFn.severeFailedWriteTag);
+    }
 
     // Stage 5: Process CDC events
     LOG.info("Processing CDC events");
@@ -655,7 +675,7 @@ public class DataStreamMongoDBToFirestore {
                 ParDo.of(new ProcessChangeEventFn(connectionString, options.getDatabaseName()))
                     .withOutputTags(
                         ProcessChangeEventFn.successfulWriteTag,
-                        TupleTagList.of(ProcessChangeEventFn.failedWriteTag)));
+                        TupleTagList.of(ProcessChangeEventFn.failedWriteTag).and(ProcessChangeEventFn.severeFailedWriteTag)));
 
     // Set coders for CDC results
     cdcResult
@@ -668,8 +688,16 @@ public class DataStreamMongoDBToFirestore {
                 SerializableCoder.of(MongoDbChangeEventContext.class),
                 SerializableCoder.of(MongoDbChangeEventContext.class)));
 
+    cdcResult
+        .get(ProcessChangeEventFn.severeFailedWriteTag)
+        .setCoder(
+            FailsafeElementCoder.of(
+                SerializableCoder.of(MongoDbChangeEventContext.class),
+                SerializableCoder.of(MongoDbChangeEventContext.class)));
+
     // Handle failed CDC writes with DLQ
     writeFailedEventsToDlq(options, cdcResult, dlqManager, ProcessChangeEventFn.failedWriteTag);
+    writeSevereEventsToDlq(options, cdcResult, dlqManager, ProcessChangeEventFn.severeFailedWriteTag);
 
     // Execute the pipeline
     LOG.info("Executing pipeline");
@@ -778,7 +806,7 @@ public class DataStreamMongoDBToFirestore {
                 ParDo.of(new ProcessChangeEventFn(connectionString, options.getDatabaseName()))
                     .withOutputTags(
                         ProcessChangeEventFn.successfulWriteTag,
-                        TupleTagList.of(ProcessChangeEventFn.failedWriteTag)));
+                        TupleTagList.of(ProcessChangeEventFn.failedWriteTag).and(ProcessChangeEventFn.severeFailedWriteTag)));
 
     /* Set coder for successful writes */
     writeResult
@@ -793,9 +821,17 @@ public class DataStreamMongoDBToFirestore {
                 SerializableCoder.of(MongoDbChangeEventContext.class),
                 SerializableCoder.of(MongoDbChangeEventContext.class)));
 
+    writeResult
+        .get(ProcessChangeEventFn.severeFailedWriteTag)
+        .setCoder(
+            FailsafeElementCoder.of(
+                SerializableCoder.of(MongoDbChangeEventContext.class),
+                SerializableCoder.of(MongoDbChangeEventContext.class)));
+
     /* Handle failed writes with DLQ */
     LOG.info("Setting up DLQ handling for failed writes");
     writeFailedEventsToDlq(options, writeResult, dlqManager, ProcessChangeEventFn.failedWriteTag);
+    writeSevereEventsToDlq(options, writeResult, dlqManager, ProcessChangeEventFn.severeFailedWriteTag);
 
     // Execute the pipeline and return the result.
     LOG.info("Executing pipeline");
@@ -993,6 +1029,32 @@ public class DataStreamMongoDBToFirestore {
     LOG.info("DLQ setup completed for failed MongoDB event processing");
   }
 
+  private static void writeSevereEventsToDlq(
+      Options options,
+      PCollectionTuple results,
+      DeadLetterQueueManager dlqManager,
+      TupleTag<FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext>> failedTag) {
+    LOG.info("Setting up Severe DLQ for failed MongoDB event processing");
+    results
+        .get(failedTag)
+        .setCoder(
+            FailsafeElementCoder.of(
+                SerializableCoder.of(MongoDbChangeEventContext.class),
+                SerializableCoder.of(MongoDbChangeEventContext.class)))
+        .apply(
+            "DLQ: Write Severe Events Failures to GCS",
+            MapElements.via(new MongoDbEventDeadLetterQueueSanitizer()))
+        .setCoder(StringUtf8Coder.of())
+        .apply(
+            "Write Severe Events Failures To DLQ",
+            DLQWriteTransform.WriteDLQ.newBuilder()
+                .withDlqDirectory(dlqManager.getSevereDlqDirectoryWithDateTime())
+                .withTmpDirectory(options.getDeadLetterQueueDirectory() + "/tmp_severe_mongo_event/")
+                .setIncludePaneInfo(true)
+                .build());
+    LOG.info("Severe DLQ setup completed");
+  }
+
   /** DoFn to split events into backfill and CDC streams. */
   public static class SplitBackfillAndCdcEventsFn
       extends DoFn<MongoDbChangeEventContext, MongoDbChangeEventContext> {
@@ -1066,23 +1128,33 @@ public class DataStreamMongoDBToFirestore {
       this.batchSize = batchSize;
     }
 
+    @com.google.common.annotations.VisibleForTesting
+    public ProcessBackfillEventFn(com.mongodb.client.MongoClient client, String databaseName, int batchSize) {
+      this.client = client;
+      this.targetDatabaseName = databaseName;
+      this.batchSize = batchSize;
+      this.connectionString = "";
+    }
+
     @Setup
     public void setup() {
       LOG.info("Setting up MongoDB client for backfill processing with batch size: {}", batchSize);
-      MongoClientSettings settings =
-          MongoClientSettings.builder()
-              .applyConnectionString(new com.mongodb.ConnectionString(connectionString))
-              .applyToSocketSettings(
-                  builder -> {
-                    // How long the driver will wait to establish a connection
-                    builder.connectTimeout(60, TimeUnit.SECONDS);
-                    builder.readTimeout(60, TimeUnit.SECONDS); // Example: 60 seconds
-                  })
-              .applyToClusterSettings(
-                  builder -> builder.serverSelectionTimeout(10, TimeUnit.MINUTES))
-              .uuidRepresentation(UuidRepresentation.STANDARD)
-              .build();
-      client = MongoClients.create(settings);
+      if (client == null) {
+        com.mongodb.MongoClientSettings settings =
+            com.mongodb.MongoClientSettings.builder()
+                .applyConnectionString(new com.mongodb.ConnectionString(connectionString))
+                .applyToSocketSettings(
+                    builder -> {
+                      // How long the driver will wait to establish a connection
+                      builder.connectTimeout(60, TimeUnit.SECONDS);
+                      builder.readTimeout(60, TimeUnit.SECONDS); // Example: 60 seconds
+                    })
+                .applyToClusterSettings(
+                    builder -> builder.serverSelectionTimeout(10, TimeUnit.MINUTES))
+                .uuidRepresentation(org.bson.UuidRepresentation.STANDARD)
+                .build();
+        client = com.mongodb.client.MongoClients.create(settings);
+      }
       bufferedEvents = new HashMap<>();
       collectionMap = new HashMap<>();
     }
@@ -1167,7 +1239,7 @@ public class DataStreamMongoDBToFirestore {
         }
 
         // Execute bulk write
-        BulkWriteResult result = collection.bulkWrite(bulkOperations);
+        BulkWriteResult result = collection.bulkWrite(bulkOperations, new BulkWriteOptions().ordered(false));
         LOG.debug(
             "Bulk write completed for collection {}: {} inserts/updates, {} deletes",
             collectionName,
@@ -1177,6 +1249,29 @@ public class DataStreamMongoDBToFirestore {
         // Output successful events
         for (MongoDbChangeEventContext event : events) {
           out.get(successfulWriteTag).output(event);
+        }
+      } catch (MongoBulkWriteException e) {
+        LOG.warn(
+            "Bulk write partially failed for collection {}: {}",
+            collectionName,
+            e.getMessage());
+
+        Set<Integer> failedIndices = new HashSet<>();
+        for (BulkWriteError error : e.getWriteErrors()) {
+          failedIndices.add(error.getIndex());
+          MongoDbChangeEventContext event = events.get(error.getIndex());
+          FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext> failedElement =
+              FailsafeElement.of(event, event);
+          failedElement.setErrorMessage(error.getMessage());
+          failedElement.setStacktrace(Arrays.deepToString(e.getStackTrace()));
+          out.get(failedWriteTag).output(failedElement);
+        }
+
+        // Output successful events
+        for (int i = 0; i < events.size(); i++) {
+          if (!failedIndices.contains(i)) {
+            out.get(successfulWriteTag).output(events.get(i));
+          }
         }
       } catch (Exception e) {
         LOG.error(
@@ -1230,7 +1325,7 @@ public class DataStreamMongoDBToFirestore {
         }
 
         // Execute bulk write
-        BulkWriteResult result = collection.bulkWrite(bulkOperations);
+        BulkWriteResult result = collection.bulkWrite(bulkOperations, new BulkWriteOptions().ordered(false));
         LOG.debug(
             "Bulk write completed for collection {}: {} inserts/updates, {} deletes",
             collectionName,
@@ -1240,6 +1335,29 @@ public class DataStreamMongoDBToFirestore {
         // Output successful events
         for (MongoDbChangeEventContext event : events) {
           context.output(successfulWriteTag, event, Instant.now(), GlobalWindow.INSTANCE);
+        }
+      } catch (MongoBulkWriteException e) {
+        LOG.warn(
+            "Bulk write partially failed for collection {}: {}",
+            collectionName,
+            e.getMessage());
+
+        Set<Integer> failedIndices = new HashSet<>();
+        for (BulkWriteError error : e.getWriteErrors()) {
+          failedIndices.add(error.getIndex());
+          MongoDbChangeEventContext event = events.get(error.getIndex());
+          FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext> failedElement =
+              FailsafeElement.of(event, event);
+          failedElement.setErrorMessage(error.getMessage());
+          failedElement.setStacktrace(Arrays.deepToString(e.getStackTrace()));
+          context.output(failedWriteTag, failedElement, Instant.now(), GlobalWindow.INSTANCE);
+        }
+
+        // Output successful events
+        for (int i = 0; i < events.size(); i++) {
+          if (!failedIndices.contains(i)) {
+            context.output(successfulWriteTag, events.get(i), Instant.now(), GlobalWindow.INSTANCE);
+          }
         }
       } catch (Exception e) {
         LOG.error(

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
@@ -657,6 +657,7 @@ public class DataStreamMongoDBToFirestore {
             ? ProcessChangeEventFn.failedWriteTag
             : ProcessBackfillEventFn.failedWriteTag);
 
+    // Write severe backfill failures directly to severe DLQ
     if (options.getUseShadowTablesForBackfill()) {
       writeSevereEventsToDlq(
           options,
@@ -697,6 +698,7 @@ public class DataStreamMongoDBToFirestore {
 
     // Handle failed CDC writes with DLQ
     writeFailedEventsToDlq(options, cdcResult, dlqManager, ProcessChangeEventFn.failedWriteTag);
+    // Write severe CDC failures directly to severe DLQ
     writeSevereEventsToDlq(options, cdcResult, dlqManager, ProcessChangeEventFn.severeFailedWriteTag);
 
     // Execute the pipeline
@@ -831,6 +833,7 @@ public class DataStreamMongoDBToFirestore {
     /* Handle failed writes with DLQ */
     LOG.info("Setting up DLQ handling for failed writes");
     writeFailedEventsToDlq(options, writeResult, dlqManager, ProcessChangeEventFn.failedWriteTag);
+    // Write severe failures directly to severe DLQ
     writeSevereEventsToDlq(options, writeResult, dlqManager, ProcessChangeEventFn.severeFailedWriteTag);
 
     // Execute the pipeline and return the result.
@@ -1238,7 +1241,7 @@ public class DataStreamMongoDBToFirestore {
           }
         }
 
-        // Execute bulk write
+        // Execute bulk write with ordered(false) to isolate failed documents
         BulkWriteResult result = collection.bulkWrite(bulkOperations, new BulkWriteOptions().ordered(false));
         LOG.debug(
             "Bulk write completed for collection {}: {} inserts/updates, {} deletes",
@@ -1256,6 +1259,7 @@ public class DataStreamMongoDBToFirestore {
             collectionName,
             e.getMessage());
 
+        // Identify failed documents and route them to failedWriteTag
         Set<Integer> failedIndices = new HashSet<>();
         for (BulkWriteError error : e.getWriteErrors()) {
           failedIndices.add(error.getIndex());
@@ -1267,7 +1271,7 @@ public class DataStreamMongoDBToFirestore {
           out.get(failedWriteTag).output(failedElement);
         }
 
-        // Output successful events
+        // Output successful events that were not part of the failed indices
         for (int i = 0; i < events.size(); i++) {
           if (!failedIndices.contains(i)) {
             out.get(successfulWriteTag).output(events.get(i));
@@ -1324,7 +1328,7 @@ public class DataStreamMongoDBToFirestore {
           }
         }
 
-        // Execute bulk write
+        // Execute bulk write with ordered(false) to isolate failed documents
         BulkWriteResult result = collection.bulkWrite(bulkOperations, new BulkWriteOptions().ordered(false));
         LOG.debug(
             "Bulk write completed for collection {}: {} inserts/updates, {} deletes",
@@ -1342,6 +1346,7 @@ public class DataStreamMongoDBToFirestore {
             collectionName,
             e.getMessage());
 
+        // Identify failed documents and route them to failedWriteTag
         Set<Integer> failedIndices = new HashSet<>();
         for (BulkWriteError error : e.getWriteErrors()) {
           failedIndices.add(error.getIndex());
@@ -1353,7 +1358,7 @@ public class DataStreamMongoDBToFirestore {
           context.output(failedWriteTag, failedElement, Instant.now(), GlobalWindow.INSTANCE);
         }
 
-        // Output successful events
+        // Output successful events that were not part of the failed indices
         for (int i = 0; i < events.size(); i++) {
           if (!failedIndices.contains(i)) {
             context.output(successfulWriteTag, events.get(i), Instant.now(), GlobalWindow.INSTANCE);

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
@@ -619,7 +619,7 @@ public class DataStreamMongoDBToFirestore {
                               connectionString, options.getDatabaseName(), options.getBatchSize()))
                       .withOutputTags(
                           ProcessBackfillEventFn.successfulWriteTag,
-                          TupleTagList.of(ProcessBackfillEventFn.failedWriteTag)));
+                          TupleTagList.of(ProcessBackfillEventFn.failedWriteTag).and(ProcessBackfillEventFn.severeFailedWriteTag)));
     }
 
     // Set coders for backfill results
@@ -639,14 +639,15 @@ public class DataStreamMongoDBToFirestore {
                 SerializableCoder.of(MongoDbChangeEventContext.class),
                 SerializableCoder.of(MongoDbChangeEventContext.class)));
 
-    if (options.getUseShadowTablesForBackfill()) {
-      backfillResult
-          .get(ProcessChangeEventFn.severeFailedWriteTag)
-          .setCoder(
-              FailsafeElementCoder.of(
-                  SerializableCoder.of(MongoDbChangeEventContext.class),
-                  SerializableCoder.of(MongoDbChangeEventContext.class)));
-    }
+    backfillResult
+        .get(
+            options.getUseShadowTablesForBackfill()
+                ? ProcessChangeEventFn.severeFailedWriteTag
+                : ProcessBackfillEventFn.severeFailedWriteTag)
+        .setCoder(
+            FailsafeElementCoder.of(
+                SerializableCoder.of(MongoDbChangeEventContext.class),
+                SerializableCoder.of(MongoDbChangeEventContext.class)));
 
     // Handle failed backfill writes with DLQ
     writeFailedEventsToDlq(
@@ -658,13 +659,13 @@ public class DataStreamMongoDBToFirestore {
             : ProcessBackfillEventFn.failedWriteTag);
 
     // Write severe backfill failures directly to severe DLQ
-    if (options.getUseShadowTablesForBackfill()) {
-      writeSevereEventsToDlq(
-          options,
-          backfillResult,
-          dlqManager,
-          ProcessChangeEventFn.severeFailedWriteTag);
-    }
+    writeSevereEventsToDlq(
+        options,
+        backfillResult,
+        dlqManager,
+        options.getUseShadowTablesForBackfill()
+            ? ProcessChangeEventFn.severeFailedWriteTag
+            : ProcessBackfillEventFn.severeFailedWriteTag);
 
     // Stage 5: Process CDC events
     LOG.info("Processing CDC events");
@@ -1115,6 +1116,8 @@ public class DataStreamMongoDBToFirestore {
         new TupleTag<>("backfillSuccessfulWrite");
     public static TupleTag<FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext>>
         failedWriteTag = new TupleTag<>("backfillFailedWrite");
+    public static TupleTag<FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext>>
+        severeFailedWriteTag = new TupleTag<>("backfillSevereFailedWrite");
 
     private final String connectionString;
     private final String targetDatabaseName;
@@ -1259,7 +1262,7 @@ public class DataStreamMongoDBToFirestore {
             collectionName,
             e.getMessage());
 
-        // Identify failed documents and route them to failedWriteTag
+        // Identify failed documents and route them to appropriate tag
         Set<Integer> failedIndices = new HashSet<>();
         for (BulkWriteError error : e.getWriteErrors()) {
           failedIndices.add(error.getIndex());
@@ -1268,7 +1271,13 @@ public class DataStreamMongoDBToFirestore {
               FailsafeElement.of(event, event);
           failedElement.setErrorMessage(error.getMessage());
           failedElement.setStacktrace(Arrays.deepToString(e.getStackTrace()));
-          out.get(failedWriteTag).output(failedElement);
+          
+          // Check if the error is permanent (e.g. code 2 for InvalidArgument when exceeding nesting limit)
+          if (error.getCode() == 2) {
+            out.get(severeFailedWriteTag).output(failedElement);
+          } else {
+            out.get(failedWriteTag).output(failedElement);
+          }
         }
 
         // Output successful events that were not part of the failed indices
@@ -1346,7 +1355,7 @@ public class DataStreamMongoDBToFirestore {
             collectionName,
             e.getMessage());
 
-        // Identify failed documents and route them to failedWriteTag
+        // Identify failed documents and route them to appropriate tag
         Set<Integer> failedIndices = new HashSet<>();
         for (BulkWriteError error : e.getWriteErrors()) {
           failedIndices.add(error.getIndex());
@@ -1355,7 +1364,13 @@ public class DataStreamMongoDBToFirestore {
               FailsafeElement.of(event, event);
           failedElement.setErrorMessage(error.getMessage());
           failedElement.setStacktrace(Arrays.deepToString(e.getStackTrace()));
-          context.output(failedWriteTag, failedElement, Instant.now(), GlobalWindow.INSTANCE);
+          
+          // Check if the error is permanent (e.g. code 2 for InvalidArgument when exceeding nesting limit)
+          if (error.getCode() == 2) {
+            context.output(severeFailedWriteTag, failedElement, Instant.now(), GlobalWindow.INSTANCE);
+          } else {
+            context.output(failedWriteTag, failedElement, Instant.now(), GlobalWindow.INSTANCE);
+          }
         }
 
         // Output successful events that were not part of the failed indices

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
@@ -40,6 +40,7 @@ import com.google.cloud.teleport.v2.transforms.ProcessChangeEventFn;
 import com.google.cloud.teleport.v2.transforms.Utils;
 import com.google.cloud.teleport.v2.values.FailsafeElement;
 import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
 import com.mongodb.MongoBulkWriteException;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.bulk.BulkWriteError;
@@ -1270,7 +1271,7 @@ public class DataStreamMongoDBToFirestore {
           FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext> failedElement =
               FailsafeElement.of(event, event);
           failedElement.setErrorMessage(error.getMessage());
-          failedElement.setStacktrace(Arrays.deepToString(e.getStackTrace()));
+          failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
           
           // Check if the error is permanent (e.g. code 2 for InvalidArgument when exceeding nesting limit)
           if (error.getCode() == 2) {
@@ -1298,7 +1299,7 @@ public class DataStreamMongoDBToFirestore {
           FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext> failedElement =
               FailsafeElement.of(event, event);
           failedElement.setErrorMessage(e.getMessage());
-          failedElement.setStacktrace(Arrays.deepToString(e.getStackTrace()));
+          failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
           out.get(failedWriteTag).output(failedElement);
         }
       }
@@ -1363,7 +1364,7 @@ public class DataStreamMongoDBToFirestore {
           FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext> failedElement =
               FailsafeElement.of(event, event);
           failedElement.setErrorMessage(error.getMessage());
-          failedElement.setStacktrace(Arrays.deepToString(e.getStackTrace()));
+          failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
           
           // Check if the error is permanent (e.g. code 2 for InvalidArgument when exceeding nesting limit)
           if (error.getCode() == 2) {
@@ -1391,7 +1392,7 @@ public class DataStreamMongoDBToFirestore {
           FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext> failedElement =
               FailsafeElement.of(event, event);
           failedElement.setErrorMessage(e.getMessage());
-          failedElement.setStacktrace(Arrays.deepToString(e.getStackTrace()));
+          failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
           context.output(failedWriteTag, failedElement, Instant.now(), GlobalWindow.INSTANCE);
         }
       }

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
@@ -1274,7 +1274,7 @@ public class DataStreamMongoDBToFirestore {
           failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
           
           // Check if the error is permanent (e.g. code 2 for InvalidArgument when exceeding nesting limit)
-          if (error.getCode() == 2) {
+          if (error.getCode() == ProcessChangeEventFn.INVALID_ARGUMENT) {
             out.get(severeFailedWriteTag).output(failedElement);
           } else {
             out.get(failedWriteTag).output(failedElement);
@@ -1367,7 +1367,7 @@ public class DataStreamMongoDBToFirestore {
           failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
           
           // Check if the error is permanent (e.g. code 2 for InvalidArgument when exceeding nesting limit)
-          if (error.getCode() == 2) {
+          if (error.getCode() == ProcessChangeEventFn.INVALID_ARGUMENT) {
             context.output(severeFailedWriteTag, failedElement, Instant.now(), GlobalWindow.INSTANCE);
           } else {
             context.output(failedWriteTag, failedElement, Instant.now(), GlobalWindow.INSTANCE);

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/CreateMongoDbChangeEventContextFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/CreateMongoDbChangeEventContextFn.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.teleport.v2.templates.datastream.MongoDbChangeEventContext;
 import com.google.cloud.teleport.v2.values.FailsafeElement;
+import com.google.common.base.Throwables;
 import java.util.Arrays;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.values.TupleTag;
@@ -55,7 +56,7 @@ public class CreateMongoDbChangeEventContextFn
     } catch (Exception e) {
       LOG.error("Error creating MongoDbChangeEventContext, exception: {}, element: {}", e, element);
       element.setErrorMessage(e.getMessage());
-      element.setStacktrace(Arrays.deepToString(e.getStackTrace()));
+      element.setStacktrace(Throwables.getStackTraceAsString(e));
       out.get(failedCreationTag).output(element);
       LOG.info("Failed element sent to DLQ");
     }

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/CreateMongoDbChangeEventContextFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/CreateMongoDbChangeEventContextFn.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.teleport.v2.templates.datastream.MongoDbChangeEventContext;
 import com.google.cloud.teleport.v2.values.FailsafeElement;
 import com.google.common.base.Throwables;
-import java.util.Arrays;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.values.TupleTag;
 import org.slf4j.Logger;

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
@@ -59,6 +59,9 @@ public class ProcessChangeEventFn
   public static TupleTag<FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext>>
       severeFailedWriteTag = new TupleTag<>("severeFailedWrite");
 
+  // Error code 2 corresponds to BadValue/InvalidArgument, which is treated as a permanent error.
+  public static final int INVALID_ARGUMENT = 2;
+
   public ProcessChangeEventFn(String connectionString, String databaseName) {
     this.connectionString = connectionString;
     this.targetDatabaseName = databaseName;
@@ -144,7 +147,7 @@ public class ProcessChangeEventFn
         boolean isPermanent = false;
         if (e instanceof MongoWriteException) {
           MongoWriteException mwe = (MongoWriteException) e;
-          if (mwe.getError().getCode() == 2) {
+          if (mwe.getError().getCode() == INVALID_ARGUMENT) {
             isPermanent = true;
           }
         }

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
@@ -54,6 +54,7 @@ public class ProcessChangeEventFn
       new TupleTag<>("successfulWrite");
   public static TupleTag<FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext>>
       failedWriteTag = new TupleTag<>("failedWrite");
+  // Tag for severe failures that should not be retried (e.g. permanent errors or non-transient transaction errors)
   public static TupleTag<FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext>>
       severeFailedWriteTag = new TupleTag<>("severeFailedWrite");
 
@@ -138,6 +139,7 @@ public class ProcessChangeEventFn
           }
         }
 
+        // Check if the error is permanent (e.g. code 2 for InvalidArgument when exceeding nesting limit)
         boolean isPermanent = false;
         if (e instanceof MongoWriteException) {
           MongoWriteException mwe = (MongoWriteException) e;
@@ -146,8 +148,10 @@ public class ProcessChangeEventFn
           }
         }
 
+        // Check if the error is transient and safe to retry
         boolean isTransient = isTransientTransactionError(e);
 
+        // If it's a permanent error or not transient, fail fast and route to severe DLQ
         if (isPermanent || !isTransient) {
           LOG.error(
               "Permanent or non-retryable error for document ID: {}: {}",

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
@@ -20,6 +20,7 @@ import static com.mongodb.client.model.Filters.eq;
 import com.google.cloud.teleport.v2.templates.datastream.MongoDbChangeEventContext;
 import com.google.cloud.teleport.v2.values.FailsafeElement;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoException;
 import com.mongodb.MongoWriteException;
@@ -160,7 +161,7 @@ public class ProcessChangeEventFn
           FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext> failedElement =
               FailsafeElement.of(element, element);
           failedElement.setErrorMessage(e.getMessage());
-          failedElement.setStacktrace(Arrays.deepToString(e.getStackTrace()));
+          failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
           out.get(severeFailedWriteTag).output(failedElement);
           break; // Exit the retry loop
         }
@@ -180,7 +181,7 @@ public class ProcessChangeEventFn
             FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext> failedElement =
                 FailsafeElement.of(element, element);
             failedElement.setErrorMessage(ie.getMessage());
-            failedElement.setStacktrace(Arrays.deepToString(ie.getStackTrace()));
+            failedElement.setStacktrace(Throwables.getStackTraceAsString(ie));
             out.get(failedWriteTag).output(failedElement);
             break; // Exit the retry loop if interrupted
           }
@@ -195,7 +196,7 @@ public class ProcessChangeEventFn
           FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext> failedElement =
               FailsafeElement.of(element, element);
           failedElement.setErrorMessage(e.getMessage());
-          failedElement.setStacktrace(Arrays.deepToString(e.getStackTrace()));
+          failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
           out.get(failedWriteTag).output(failedElement);
           LOG.info("Failed element of id {} sent to DLQ", element.getDocumentId());
           break; // Exit the retry loop on non-transient error or max retries

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
@@ -54,7 +54,8 @@ public class ProcessChangeEventFn
       new TupleTag<>("successfulWrite");
   public static TupleTag<FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext>>
       failedWriteTag = new TupleTag<>("failedWrite");
-  // Tag for severe failures that should not be retried (e.g. permanent errors or non-transient transaction errors)
+  // Tag for severe failures that should not be retried (e.g. permanent errors or non-transient
+  // transaction errors)
   public static TupleTag<FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext>>
       severeFailedWriteTag = new TupleTag<>("severeFailedWrite");
 
@@ -142,7 +143,8 @@ public class ProcessChangeEventFn
           }
         }
 
-        // Check if the error is permanent (e.g. code 2 for InvalidArgument when exceeding nesting limit)
+        // Check if the error is permanent (e.g. code 2 for InvalidArgument when exceeding nesting
+        // limit)
         boolean isPermanent = false;
         if (e instanceof MongoWriteException) {
           MongoWriteException mwe = (MongoWriteException) e;

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
@@ -30,7 +30,6 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.ReplaceOptions;
-import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.values.TupleTag;

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
@@ -22,6 +22,7 @@ import com.google.cloud.teleport.v2.values.FailsafeElement;
 import com.google.common.annotations.VisibleForTesting;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoException;
+import com.mongodb.MongoWriteException;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
@@ -53,6 +54,8 @@ public class ProcessChangeEventFn
       new TupleTag<>("successfulWrite");
   public static TupleTag<FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext>>
       failedWriteTag = new TupleTag<>("failedWrite");
+  public static TupleTag<FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext>>
+      severeFailedWriteTag = new TupleTag<>("severeFailedWrite");
 
   public ProcessChangeEventFn(String connectionString, String databaseName) {
     this.connectionString = connectionString;
@@ -134,8 +137,31 @@ public class ProcessChangeEventFn
                 abortException);
           }
         }
+
+        boolean isPermanent = false;
+        if (e instanceof MongoWriteException) {
+          MongoWriteException mwe = (MongoWriteException) e;
+          if (mwe.getError().getCode() == 2) {
+            isPermanent = true;
+          }
+        }
+
+        boolean isTransient = isTransientTransactionError(e);
+
+        if (isPermanent || !isTransient) {
+          LOG.error(
+              "Permanent or non-retryable error for document ID: {}: {}",
+              element.getDocumentId(),
+              e.getMessage());
+          FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext> failedElement =
+              FailsafeElement.of(element, element);
+          failedElement.setErrorMessage(e.getMessage());
+          failedElement.setStacktrace(Arrays.deepToString(e.getStackTrace()));
+          out.get(severeFailedWriteTag).output(failedElement);
+          break; // Exit the retry loop
+        }
+
         if (retryCount < maxRetries) {
-          // Retry regardless of error types till maxRetries before thrown to dlq.
           LOG.warn(
               "Transient transaction error encountered for document ID: {}, attempt: {}. Retrying in {} ms...",
               element.getDocumentId(),

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/ProcessBackfillEventFnTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/ProcessBackfillEventFnTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.teleport.v2.templates;
 
 import static org.junit.Assert.assertEquals;
@@ -53,11 +68,16 @@ public class ProcessBackfillEventFnTest {
 
     when(mockClient.getDatabase(DATABASE_NAME)).thenReturn(mockDatabase);
     when(mockDatabase.getCollection(COLLECTION_NAME)).thenReturn(mockCollection);
-    when(mockReceiver.get(DataStreamMongoDBToFirestore.ProcessBackfillEventFn.successfulWriteTag)).thenReturn(mockSuccessReceiver);
-    when(mockReceiver.get(DataStreamMongoDBToFirestore.ProcessBackfillEventFn.failedWriteTag)).thenReturn(mockFailureReceiver);
-    when(mockReceiver.get(DataStreamMongoDBToFirestore.ProcessBackfillEventFn.severeFailedWriteTag)).thenReturn(mockSevereFailureReceiver);
+    when(mockReceiver.get(DataStreamMongoDBToFirestore.ProcessBackfillEventFn.successfulWriteTag))
+        .thenReturn(mockSuccessReceiver);
+    when(mockReceiver.get(DataStreamMongoDBToFirestore.ProcessBackfillEventFn.failedWriteTag))
+        .thenReturn(mockFailureReceiver);
+    when(mockReceiver.get(DataStreamMongoDBToFirestore.ProcessBackfillEventFn.severeFailedWriteTag))
+        .thenReturn(mockSevereFailureReceiver);
 
-    fn = new DataStreamMongoDBToFirestore.ProcessBackfillEventFn(mockClient, DATABASE_NAME, BATCH_SIZE);
+    fn =
+        new DataStreamMongoDBToFirestore.ProcessBackfillEventFn(
+            mockClient, DATABASE_NAME, BATCH_SIZE);
     fn.setup();
     fn.startBundle();
   }
@@ -78,16 +98,21 @@ public class ProcessBackfillEventFnTest {
 
     // Process first element
     fn.processElement(mockContext, mockReceiver);
-    
+
     // Process second element, should trigger batch processing
-    com.mongodb.bulk.BulkWriteError error = new com.mongodb.bulk.BulkWriteError(2, "At most 20 nested array/entity values are supported.", new org.bson.BsonDocument(), 1);
-    com.mongodb.MongoBulkWriteException exception = new com.mongodb.MongoBulkWriteException(
-        mock(com.mongodb.bulk.BulkWriteResult.class),
-        Collections.singletonList(error),
-        mock(com.mongodb.bulk.WriteConcernError.class),
-        new com.mongodb.ServerAddress(),
-        Collections.emptySet()
-    );
+    com.mongodb.bulk.BulkWriteError error =
+        new com.mongodb.bulk.BulkWriteError(
+            2,
+            "At most 20 nested array/entity values are supported.",
+            new org.bson.BsonDocument(),
+            1);
+    com.mongodb.MongoBulkWriteException exception =
+        new com.mongodb.MongoBulkWriteException(
+            mock(com.mongodb.bulk.BulkWriteResult.class),
+            Collections.singletonList(error),
+            mock(com.mongodb.bulk.WriteConcernError.class),
+            new com.mongodb.ServerAddress(),
+            Collections.emptySet());
 
     when(mockCollection.bulkWrite(anyList(), any())).thenThrow(exception);
 
@@ -95,13 +120,14 @@ public class ProcessBackfillEventFnTest {
 
     // Verify output
     verify(mockSuccessReceiver, times(1)).output(event1);
-    
+
     ArgumentCaptor<FailsafeElement> failureCaptor = ArgumentCaptor.forClass(FailsafeElement.class);
     verify(mockSevereFailureReceiver, times(1)).output(failureCaptor.capture());
-    
+
     FailsafeElement failedElement = failureCaptor.getValue();
     assertEquals(event2, failedElement.getOriginalPayload());
-    assertEquals("At most 20 nested array/entity values are supported.", failedElement.getErrorMessage());
+    assertEquals(
+        "At most 20 nested array/entity values are supported.", failedElement.getErrorMessage());
   }
 
   @Test
@@ -120,16 +146,17 @@ public class ProcessBackfillEventFnTest {
 
     // Process first element
     fn.processElement(mockContext, mockReceiver);
-    
+
     // Process second element, should trigger batch processing
-    com.mongodb.bulk.BulkWriteError error = new com.mongodb.bulk.BulkWriteError(1, "Some other error", new org.bson.BsonDocument(), 1);
-    com.mongodb.MongoBulkWriteException exception = new com.mongodb.MongoBulkWriteException(
-        mock(com.mongodb.bulk.BulkWriteResult.class),
-        Collections.singletonList(error),
-        mock(com.mongodb.bulk.WriteConcernError.class),
-        new com.mongodb.ServerAddress(),
-        Collections.emptySet()
-    );
+    com.mongodb.bulk.BulkWriteError error =
+        new com.mongodb.bulk.BulkWriteError(1, "Some other error", new org.bson.BsonDocument(), 1);
+    com.mongodb.MongoBulkWriteException exception =
+        new com.mongodb.MongoBulkWriteException(
+            mock(com.mongodb.bulk.BulkWriteResult.class),
+            Collections.singletonList(error),
+            mock(com.mongodb.bulk.WriteConcernError.class),
+            new com.mongodb.ServerAddress(),
+            Collections.emptySet());
 
     when(mockCollection.bulkWrite(anyList(), any())).thenThrow(exception);
 
@@ -137,10 +164,10 @@ public class ProcessBackfillEventFnTest {
 
     // Verify output
     verify(mockSuccessReceiver, times(1)).output(event1);
-    
+
     ArgumentCaptor<FailsafeElement> failureCaptor = ArgumentCaptor.forClass(FailsafeElement.class);
     verify(mockFailureReceiver, times(1)).output(failureCaptor.capture());
-    
+
     FailsafeElement failedElement = failureCaptor.getValue();
     assertEquals(event2, failedElement.getOriginalPayload());
     assertEquals("Some other error", failedElement.getErrorMessage());

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/ProcessBackfillEventFnTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/ProcessBackfillEventFnTest.java
@@ -37,6 +37,7 @@ public class ProcessBackfillEventFnTest {
   private MultiOutputReceiver mockReceiver;
   private OutputReceiver mockSuccessReceiver;
   private OutputReceiver mockFailureReceiver;
+  private OutputReceiver mockSevereFailureReceiver;
   private DoFn.ProcessContext mockContext;
 
   @Before
@@ -47,12 +48,14 @@ public class ProcessBackfillEventFnTest {
     mockReceiver = mock(MultiOutputReceiver.class);
     mockSuccessReceiver = mock(OutputReceiver.class);
     mockFailureReceiver = mock(OutputReceiver.class);
+    mockSevereFailureReceiver = mock(OutputReceiver.class);
     mockContext = mock(DoFn.ProcessContext.class);
 
     when(mockClient.getDatabase(DATABASE_NAME)).thenReturn(mockDatabase);
     when(mockDatabase.getCollection(COLLECTION_NAME)).thenReturn(mockCollection);
     when(mockReceiver.get(DataStreamMongoDBToFirestore.ProcessBackfillEventFn.successfulWriteTag)).thenReturn(mockSuccessReceiver);
     when(mockReceiver.get(DataStreamMongoDBToFirestore.ProcessBackfillEventFn.failedWriteTag)).thenReturn(mockFailureReceiver);
+    when(mockReceiver.get(DataStreamMongoDBToFirestore.ProcessBackfillEventFn.severeFailedWriteTag)).thenReturn(mockSevereFailureReceiver);
 
     fn = new DataStreamMongoDBToFirestore.ProcessBackfillEventFn(mockClient, DATABASE_NAME, BATCH_SIZE);
     fn.setup();
@@ -94,10 +97,52 @@ public class ProcessBackfillEventFnTest {
     verify(mockSuccessReceiver, times(1)).output(event1);
     
     ArgumentCaptor<FailsafeElement> failureCaptor = ArgumentCaptor.forClass(FailsafeElement.class);
-    verify(mockFailureReceiver, times(1)).output(failureCaptor.capture());
+    verify(mockSevereFailureReceiver, times(1)).output(failureCaptor.capture());
     
     FailsafeElement failedElement = failureCaptor.getValue();
     assertEquals(event2, failedElement.getOriginalPayload());
     assertEquals("At most 20 nested array/entity values are supported.", failedElement.getErrorMessage());
+  }
+
+  @Test
+  public void testProcessBatch_nonPermanentFailure() {
+    MongoDbChangeEventContext event1 = mock(MongoDbChangeEventContext.class);
+    MongoDbChangeEventContext event2 = mock(MongoDbChangeEventContext.class);
+
+    when(event1.getDataCollection()).thenReturn(COLLECTION_NAME);
+    when(event2.getDataCollection()).thenReturn(COLLECTION_NAME);
+    when(event1.getDocumentId()).thenReturn("id1");
+    when(event2.getDocumentId()).thenReturn("id2");
+    when(event1.getDataAsJsonString()).thenReturn("{\"data\": {\"_id\":\"id1\"}}");
+    when(event2.getDataAsJsonString()).thenReturn("{\"data\": {\"_id\":\"id2\"}}");
+
+    when(mockContext.element()).thenReturn(event1).thenReturn(event2);
+
+    // Process first element
+    fn.processElement(mockContext, mockReceiver);
+    
+    // Process second element, should trigger batch processing
+    com.mongodb.bulk.BulkWriteError error = new com.mongodb.bulk.BulkWriteError(1, "Some other error", new org.bson.BsonDocument(), 1);
+    com.mongodb.MongoBulkWriteException exception = new com.mongodb.MongoBulkWriteException(
+        mock(com.mongodb.bulk.BulkWriteResult.class),
+        Collections.singletonList(error),
+        mock(com.mongodb.bulk.WriteConcernError.class),
+        new com.mongodb.ServerAddress(),
+        Collections.emptySet()
+    );
+
+    when(mockCollection.bulkWrite(anyList(), any())).thenThrow(exception);
+
+    fn.processElement(mockContext, mockReceiver);
+
+    // Verify output
+    verify(mockSuccessReceiver, times(1)).output(event1);
+    
+    ArgumentCaptor<FailsafeElement> failureCaptor = ArgumentCaptor.forClass(FailsafeElement.class);
+    verify(mockFailureReceiver, times(1)).output(failureCaptor.capture());
+    
+    FailsafeElement failedElement = failureCaptor.getValue();
+    assertEquals(event2, failedElement.getOriginalPayload());
+    assertEquals("Some other error", failedElement.getErrorMessage());
   }
 }

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/ProcessBackfillEventFnTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/ProcessBackfillEventFnTest.java
@@ -1,0 +1,103 @@
+package com.google.cloud.teleport.v2.templates;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.teleport.v2.templates.datastream.MongoDbChangeEventContext;
+import com.google.cloud.teleport.v2.values.FailsafeElement;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import java.util.Collections;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.MultiOutputReceiver;
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+
+@RunWith(JUnit4.class)
+public class ProcessBackfillEventFnTest {
+  private static final String DATABASE_NAME = "test_db";
+  private static final String COLLECTION_NAME = "test_col";
+  private static final int BATCH_SIZE = 2;
+
+  private DataStreamMongoDBToFirestore.ProcessBackfillEventFn fn;
+  private MongoClient mockClient;
+  private MongoDatabase mockDatabase;
+  private MongoCollection<Document> mockCollection;
+  private MultiOutputReceiver mockReceiver;
+  private OutputReceiver mockSuccessReceiver;
+  private OutputReceiver mockFailureReceiver;
+  private DoFn.ProcessContext mockContext;
+
+  @Before
+  public void setUp() {
+    mockClient = mock(MongoClient.class);
+    mockDatabase = mock(MongoDatabase.class);
+    mockCollection = mock(MongoCollection.class);
+    mockReceiver = mock(MultiOutputReceiver.class);
+    mockSuccessReceiver = mock(OutputReceiver.class);
+    mockFailureReceiver = mock(OutputReceiver.class);
+    mockContext = mock(DoFn.ProcessContext.class);
+
+    when(mockClient.getDatabase(DATABASE_NAME)).thenReturn(mockDatabase);
+    when(mockDatabase.getCollection(COLLECTION_NAME)).thenReturn(mockCollection);
+    when(mockReceiver.get(DataStreamMongoDBToFirestore.ProcessBackfillEventFn.successfulWriteTag)).thenReturn(mockSuccessReceiver);
+    when(mockReceiver.get(DataStreamMongoDBToFirestore.ProcessBackfillEventFn.failedWriteTag)).thenReturn(mockFailureReceiver);
+
+    fn = new DataStreamMongoDBToFirestore.ProcessBackfillEventFn(mockClient, DATABASE_NAME, BATCH_SIZE);
+    fn.setup();
+    fn.startBundle();
+  }
+
+  @Test
+  public void testProcessBatch_partialFailure() {
+    MongoDbChangeEventContext event1 = mock(MongoDbChangeEventContext.class);
+    MongoDbChangeEventContext event2 = mock(MongoDbChangeEventContext.class);
+
+    when(event1.getDataCollection()).thenReturn(COLLECTION_NAME);
+    when(event2.getDataCollection()).thenReturn(COLLECTION_NAME);
+    when(event1.getDocumentId()).thenReturn("id1");
+    when(event2.getDocumentId()).thenReturn("id2");
+    when(event1.getDataAsJsonString()).thenReturn("{\"data\": {\"_id\":\"id1\"}}");
+    when(event2.getDataAsJsonString()).thenReturn("{\"data\": {\"_id\":\"id2\"}}");
+
+    when(mockContext.element()).thenReturn(event1).thenReturn(event2);
+
+    // Process first element
+    fn.processElement(mockContext, mockReceiver);
+    
+    // Process second element, should trigger batch processing
+    com.mongodb.bulk.BulkWriteError error = new com.mongodb.bulk.BulkWriteError(2, "At most 20 nested array/entity values are supported.", new org.bson.BsonDocument(), 1);
+    com.mongodb.MongoBulkWriteException exception = new com.mongodb.MongoBulkWriteException(
+        mock(com.mongodb.bulk.BulkWriteResult.class),
+        Collections.singletonList(error),
+        mock(com.mongodb.bulk.WriteConcernError.class),
+        new com.mongodb.ServerAddress(),
+        Collections.emptySet()
+    );
+
+    when(mockCollection.bulkWrite(anyList(), any())).thenThrow(exception);
+
+    fn.processElement(mockContext, mockReceiver);
+
+    // Verify output
+    verify(mockSuccessReceiver, times(1)).output(event1);
+    
+    ArgumentCaptor<FailsafeElement> failureCaptor = ArgumentCaptor.forClass(FailsafeElement.class);
+    verify(mockFailureReceiver, times(1)).output(failureCaptor.capture());
+    
+    FailsafeElement failedElement = failureCaptor.getValue();
+    assertEquals(event2, failedElement.getOriginalPayload());
+    assertEquals("At most 20 nested array/entity values are supported.", failedElement.getErrorMessage());
+  }
+}

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
@@ -127,7 +127,8 @@ public class ProcessChangeEventFnTest {
     // Mock the MultiOutputReceiver's get() method
     when(mockReceiver.get(ProcessChangeEventFn.successfulWriteTag)).thenReturn(mockSuccessReceiver);
     when(mockReceiver.get(ProcessChangeEventFn.failedWriteTag)).thenReturn(mockFailureReceiver);
-    when(mockReceiver.get(ProcessChangeEventFn.severeFailedWriteTag)).thenReturn(mockSevereFailureReceiver);
+    when(mockReceiver.get(ProcessChangeEventFn.severeFailedWriteTag))
+        .thenReturn(mockSevereFailureReceiver);
   }
 
   @Test
@@ -293,9 +294,12 @@ public class ProcessChangeEventFnTest {
 
   @Test
   public void testProcessElementPermanentError_Code2() {
-    WriteError writeError = new WriteError(2, "At most 20 nested array/entity values are supported.", new org.bson.BsonDocument());
-    MongoWriteException permanentError = new MongoWriteException(writeError, new com.mongodb.ServerAddress());
-    
+    WriteError writeError =
+        new WriteError(
+            2, "At most 20 nested array/entity values are supported.", new org.bson.BsonDocument());
+    MongoWriteException permanentError =
+        new MongoWriteException(writeError, new com.mongodb.ServerAddress());
+
     when(mockShadowCollection.find(mockSession, LOOKUP_BY_DOC_ID)).thenThrow(permanentError);
 
     processFn.processElement(mockContext, mockReceiver);

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.teleport.v2.templates.datastream.MongoDbChangeEventContext;
 import com.mongodb.MongoException;
+import com.mongodb.MongoWriteException;
+import com.mongodb.WriteError;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoClient;
@@ -59,6 +61,7 @@ public class ProcessChangeEventFnTest {
   private MultiOutputReceiver mockReceiver;
   private OutputReceiver mockSuccessReceiver;
   private OutputReceiver mockFailureReceiver;
+  private OutputReceiver mockSevereFailureReceiver;
   private MongoClient mockClient;
   private MongoDatabase mockDatabase;
   private ClientSession mockSession;
@@ -79,6 +82,7 @@ public class ProcessChangeEventFnTest {
     mockReceiver = mock(MultiOutputReceiver.class);
     mockSuccessReceiver = mock(OutputReceiver.class);
     mockFailureReceiver = mock(OutputReceiver.class);
+    mockSevereFailureReceiver = mock(OutputReceiver.class);
     mockClient = mock(MongoClient.class);
     mockDatabase = mock(MongoDatabase.class);
     mockSession = mock(ClientSession.class);
@@ -123,6 +127,7 @@ public class ProcessChangeEventFnTest {
     // Mock the MultiOutputReceiver's get() method
     when(mockReceiver.get(ProcessChangeEventFn.successfulWriteTag)).thenReturn(mockSuccessReceiver);
     when(mockReceiver.get(ProcessChangeEventFn.failedWriteTag)).thenReturn(mockFailureReceiver);
+    when(mockReceiver.get(ProcessChangeEventFn.severeFailedWriteTag)).thenReturn(mockSevereFailureReceiver);
   }
 
   @Test
@@ -262,17 +267,18 @@ public class ProcessChangeEventFnTest {
 
     processFn.processElement(mockContext, mockReceiver);
 
-    verify(mockShadowCollection, times(4)).find(mockSession, LOOKUP_BY_DOC_ID);
+    verify(mockShadowCollection, times(2)).find(mockSession, LOOKUP_BY_DOC_ID);
     ArgumentCaptor<MongoDbChangeEventContext> failureCaptor =
         ArgumentCaptor.forClass(MongoDbChangeEventContext.class);
-    verify(mockReceiver).get(ProcessChangeEventFn.failedWriteTag);
-    verify(mockFailureReceiver, times(1)).output(failureCaptor.capture());
+    verify(mockReceiver).get(ProcessChangeEventFn.severeFailedWriteTag);
+    verify(mockSevereFailureReceiver, times(1)).output(failureCaptor.capture());
     verify(mockSession, never()).commitTransaction();
   }
 
   @Test
   public void testProcessElementTransientError_retryTillMaximum() {
     MongoException randomError = new MongoException("Fake transient error.");
+    randomError.addLabel("TransientTransactionError");
     when(mockShadowCollection.find(mockSession, LOOKUP_BY_DOC_ID)).thenThrow(randomError);
 
     processFn.processElement(mockContext, mockReceiver);
@@ -282,6 +288,21 @@ public class ProcessChangeEventFnTest {
         ArgumentCaptor.forClass(MongoDbChangeEventContext.class);
     verify(mockReceiver).get(ProcessChangeEventFn.failedWriteTag);
     verify(mockFailureReceiver, times(1)).output(failureCaptor.capture());
+    verify(mockSession, never()).commitTransaction();
+  }
+
+  @Test
+  public void testProcessElementPermanentError_Code2() {
+    WriteError writeError = new WriteError(2, "At most 20 nested array/entity values are supported.", new org.bson.BsonDocument());
+    MongoWriteException permanentError = new MongoWriteException(writeError, new com.mongodb.ServerAddress());
+    
+    when(mockShadowCollection.find(mockSession, LOOKUP_BY_DOC_ID)).thenThrow(permanentError);
+
+    processFn.processElement(mockContext, mockReceiver);
+
+    verify(mockShadowCollection, times(1)).find(mockSession, LOOKUP_BY_DOC_ID);
+    verify(mockReceiver).get(ProcessChangeEventFn.severeFailedWriteTag);
+    verify(mockSevereFailureReceiver, times(1)).output(any());
     verify(mockSession, never()).commitTransaction();
   }
 }


### PR DESCRIPTION
This Pull Request addresses suboptimal error handling in the **Datastream MongoDB to Firestore** template, specifically regarding permanent Firestore limitations such as the 20-level nesting limit. These changes prevent valid data from being delayed by invalid documents and reduce operational costs by suppressing futile retry attempts.

#### **Key Improvements:**
*   **Isolate Batch Failures in Backfill:** Updated `ProcessBackfillEventFn` to use **unordered bulk writes**. By catching `MongoBulkWriteException`, the template now identifies specific failed indices, allowing successful documents in a batch to proceed while routing only the truly failed ones to the DLQ.
*   **Fail-Fast for Permanent Errors:** Implemented detection for permanent error codes (specifically **Code 2** for `InvalidArgument`) in `ProcessChangeEventFn`. When a permanent error is identified, the code now skips internal retries and routes the record immediately to the failure path.
*   **Severe DLQ Routing:** Introduced a `severeFailedWriteTag` to route non-retryable failures to a dedicated **severe DLQ partition**. This prevents these records from being re-consumed and retried hundreds of times by the standard DLQ manager.
*   **Enhanced Testing:** Added `ProcessBackfillEventFnTest` to verify partial batch success and updated `ProcessChangeEventFnTest` to validate the new permanent error routing logic.

**Related Bug:** [b/507644443](https://buganizer.corp.google.com/issues/507644443)