### PR TITLE
feat(datastream): support more _id types in Datastream to Firestore template

### DIFF
--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContext.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContext.java
@@ -117,18 +117,22 @@ public class MongoDbChangeEventContext implements Serializable {
     if (changeEvent.has(DatastreamConstants.MONGODB_DOCUMENT_ID)) {
       JsonNode docIdVal =
           OBJECT_MAPPER.readTree(changeEvent.get(DatastreamConstants.MONGODB_DOCUMENT_ID).asText());
-      if (docIdVal.isIntegralNumber()) {
+      if (docIdVal.isInt()) {
+        this.documentId = docIdVal.asInt();
+      } else if (docIdVal.isIntegralNumber()) {
         this.documentId = docIdVal.asLong();
-        if (this.documentId.equals(0L)) {
-          LOG.error("Unsupported _id value of _id {}.", docIdVal);
-          throw new IllegalArgumentException("Unsupported _id value.");
-        }
+      } else if (docIdVal.isFloatingPointNumber()) {
+        this.documentId = docIdVal.asDouble();
       } else if (docIdVal.isTextual()) {
         this.documentId = docIdVal.asText();
-      } else if (docIdVal.isObject()
-          && docIdVal.has(OID_FIELD_NAME)
-          && docIdVal.get(OID_FIELD_NAME).isTextual()) {
-        this.documentId = new ObjectId(docIdVal.get(OID_FIELD_NAME).asText());
+      } else if (docIdVal.isObject()) {
+        if (docIdVal.has(OID_FIELD_NAME) && docIdVal.get(OID_FIELD_NAME).isTextual()) {
+          this.documentId = new ObjectId(docIdVal.get(OID_FIELD_NAME).asText());
+        } else {
+          // Support for generic Object-typed IDs or other complex BSON types (e.g., Binary)
+          Document wrapper = Document.parse("{ \"val\": " + docIdVal.toString() + " }");
+          this.documentId = wrapper.get("val");
+        }
       } else {
         LOG.error("Unsupported _id type of _id {}.", docIdVal);
         throw new IllegalArgumentException("Unsupported _id type.");

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContext.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContext.java
@@ -252,13 +252,7 @@ public class MongoDbChangeEventContext implements Serializable {
       // Add other important fields
       jsonNode.put("dataCollection", this.dataCollection);
       jsonNode.put("shadowCollection", this.shadowCollection);
-      if (this.documentId instanceof ObjectId) {
-        ObjectNode objectIdNode = OBJECT_MAPPER.createObjectNode();
-        objectIdNode.put(OID_FIELD_NAME, this.documentId.toString());
-        jsonNode.put("documentId", objectIdNode);
-      } else {
-        jsonNode.putPOJO("documentId", this.documentId);
-      }
+      jsonNode.put("documentId", Utils.documentIdToString(this.documentId));
       jsonNode.put("isDeleteEvent", this.isDeleteEvent);
 
       // Convert timestamp document to JSON

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/Utils.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/Utils.java
@@ -54,4 +54,18 @@ public final class Utils {
     rawDoc.put(MongoDbChangeEventContext.DOC_ID_COL, documentId);
     return rawDoc;
   }
+
+  public static String documentIdToString(Object documentId) {
+    if (documentId == null) {
+      return "null";
+    }
+    if (documentId instanceof org.bson.types.Binary) {
+      org.bson.types.Binary binary = (org.bson.types.Binary) documentId;
+      return java.util.Base64.getEncoder().encodeToString(binary.getData());
+    }
+    if (documentId instanceof Document) {
+      return ((Document) documentId).toJson();
+    }
+    return documentId.toString();
+  }
 }

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContextTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContextTest.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.teleport.v2.transforms.Utils;
 import com.google.common.collect.ImmutableMap;
 import org.bson.Document;
+import org.bson.types.Binary;
 import org.bson.types.ObjectId;
 import org.junit.Before;
 import org.junit.Test;
@@ -277,6 +278,161 @@ public class MongoDbChangeEventContextTest {
     assertNotNull(context.getDocumentId());
     assertTrue(context.getDocumentId() instanceof String);
     assertEquals("test_id", context.getDocumentId());
+  }
+
+  @Test
+  public void testConstructorDoubleId() throws JsonProcessingException {
+    JsonNode eventWithDoubleId =
+        OBJECT_MAPPER.readTree(
+            """
+                {
+                  "_metadata_source": {
+                    "collection": "test_collection"
+                  },
+                  "_id": "123.456",
+                  "data": {
+                    "field1": "updated_value"
+                  },
+                  "_metadata_timestamp_seconds": 1683782270,
+                  "_metadata_timestamp_nanos": 123456789
+                }""");
+    MongoDbChangeEventContext context =
+        new MongoDbChangeEventContext(eventWithDoubleId, SHADOW_PREFIX);
+    assertNotNull(context.getDocumentId());
+    assertTrue(context.getDocumentId() instanceof Double);
+    assertEquals(123.456, (Double) context.getDocumentId(), 0.001);
+  }
+
+  @Test
+  public void testConstructorZeroId() throws JsonProcessingException {
+    JsonNode eventWithZeroId =
+        OBJECT_MAPPER.readTree(
+            """
+                {
+                  "_metadata_source": {
+                    "collection": "test_collection"
+                  },
+                  "_id": "0",
+                  "data": {
+                    "field1": "updated_value"
+                  },
+                  "_metadata_timestamp_seconds": 1683782270,
+                  "_metadata_timestamp_nanos": 123456789
+                }""");
+    MongoDbChangeEventContext context =
+        new MongoDbChangeEventContext(eventWithZeroId, SHADOW_PREFIX);
+    assertNotNull(context.getDocumentId());
+    assertEquals(0, context.getDocumentId());
+  }
+
+  @Test
+  public void testConstructorGenericObjectId() throws JsonProcessingException {
+    JsonNode eventWithGenericObjectId =
+        OBJECT_MAPPER.readTree(
+            """
+                {
+                  "_metadata_source": {
+                    "collection": "test_collection"
+                  },
+                  "_id": "{\\\"a\\\": 1, \\\"b\\\": \\\"test\\\"}",
+                  "data": {
+                    "field1": "updated_value"
+                  },
+                  "_metadata_timestamp_seconds": 1683782270,
+                  "_metadata_timestamp_nanos": 123456789
+                }""");
+    MongoDbChangeEventContext context =
+        new MongoDbChangeEventContext(eventWithGenericObjectId, SHADOW_PREFIX);
+    assertNotNull(context.getDocumentId());
+    assertTrue(context.getDocumentId() instanceof Document);
+    Document docId = (Document) context.getDocumentId();
+    assertEquals(1, docId.get("a"));
+    assertEquals("test", docId.get("b"));
+  }
+
+  @Test
+  public void testConstructorIntId() throws JsonProcessingException {
+    JsonNode eventWithIntId =
+        OBJECT_MAPPER.readTree(
+            """
+                {
+                  "_metadata_source": {
+                    "collection": "test_collection"
+                  },
+                  "_id": 123,
+                  "data": {
+                    "field1": "updated_value"
+                  },
+                  "_metadata_timestamp_seconds": 1683782270,
+                  "_metadata_timestamp_nanos": 123456789
+                }""");
+    MongoDbChangeEventContext context =
+        new MongoDbChangeEventContext(eventWithIntId, SHADOW_PREFIX);
+    assertNotNull(context.getDocumentId());
+    assertTrue(context.getDocumentId() instanceof Integer);
+    assertEquals(123, context.getDocumentId());
+  }
+
+  @Test
+  public void testConstructorBinaryId() throws JsonProcessingException {
+    JsonNode eventWithBinaryId =
+        OBJECT_MAPPER.readTree(
+            """
+                {
+                  "_metadata_source": {
+                    "collection": "test_collection"
+                  },
+                  "_id": "{\\\"$binary\\\": {\\\"base64\\\": \\\"AQID\\\", \\\"subType\\\": \\\"00\\\"}}",
+                  "data": {
+                    "field1": "updated_value"
+                  },
+                  "_metadata_timestamp_seconds": 1683782270,
+                  "_metadata_timestamp_nanos": 123456789
+                }""");
+    MongoDbChangeEventContext context =
+        new MongoDbChangeEventContext(eventWithBinaryId, SHADOW_PREFIX);
+    assertNotNull(context.getDocumentId());
+    assertTrue(context.getDocumentId() instanceof Binary);
+    Binary binaryId = (Binary) context.getDocumentId();
+    assertEquals(0, binaryId.getType());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConstructorArrayIdThrows() throws JsonProcessingException {
+    JsonNode eventWithArrayId =
+        OBJECT_MAPPER.readTree(
+            """
+                {
+                  "_metadata_source": {
+                    "collection": "test_collection"
+                  },
+                  "_id": "[1, 2, 3]",
+                  "data": {
+                    "field1": "updated_value"
+                  },
+                  "_metadata_timestamp_seconds": 1683782270,
+                  "_metadata_timestamp_nanos": 123456789
+                }""");
+    new MongoDbChangeEventContext(eventWithArrayId, SHADOW_PREFIX);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConstructorNullIdThrows() throws JsonProcessingException {
+    JsonNode eventWithNullId =
+        OBJECT_MAPPER.readTree(
+            """
+                {
+                  "_metadata_source": {
+                    "collection": "test_collection"
+                  },
+                  "_id": "null",
+                  "data": {
+                    "field1": "updated_value"
+                  },
+                  "_metadata_timestamp_seconds": 1683782270,
+                  "_metadata_timestamp_nanos": 123456789
+                }""");
+    new MongoDbChangeEventContext(eventWithNullId, SHADOW_PREFIX);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/UtilsTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/UtilsTest.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.v2.transforms;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -138,5 +139,23 @@ public class UtilsTest {
             .toJson()
             .equals(
                 "{\"_id\": 1, \"arrayField\": [\"hello\", 10], \"dateField\": {\"$date\": \"2019-08-11T17:54:14.692Z\"}, \"dateBefore1970\": {\"$date\": {\"$numberLong\": \"-1577923200000\"}}, \"decimal128Field\": {\"$numberDecimal\": \"10.99\"}, \"documentField\": {\"a\": \"hello\"}, \"doubleField\": 10.5, \"infiniteNumber\": {\"$numberDouble\": \"Infinity\"}, \"int32field\": 10, \"int64Field\": 50, \"minKeyField\": {\"$minKey\": 1}, \"maxKeyField\": {\"$maxKey\": 1}, \"regexField\": {\"$regularExpression\": {\"pattern\": \"^H\", \"options\": \"i\"}}, \"timestampField\": {\"$timestamp\": {\"t\": 1565545664, \"i\": 1}}, \"uuid\": {\"$binary\": {\"base64\": \"OyQRAeK7QlWMr0E2xWapYg==\", \"subType\": \"04\"}}}"));
+  }
+
+  @Test
+  public void testDocumentIdToString() {
+    assertEquals("test_id", Utils.documentIdToString("test_id"));
+    assertEquals("123", Utils.documentIdToString(123L));
+    assertEquals("123.456", Utils.documentIdToString(123.456));
+    assertEquals("true", Utils.documentIdToString(true));
+    assertEquals("null", Utils.documentIdToString(null));
+
+    org.bson.types.ObjectId objectId = new org.bson.types.ObjectId("645c9a7e7b8b1a0e9c0f8b3a");
+    assertEquals("645c9a7e7b8b1a0e9c0f8b3a", Utils.documentIdToString(objectId));
+
+    org.bson.types.Binary binary = new org.bson.types.Binary(new byte[] {1, 2, 3});
+    assertEquals("AQID", Utils.documentIdToString(binary));
+
+    Document doc = new Document("a", 1).append("b", "test");
+    assertEquals("{\"a\": 1, \"b\": \"test\"}", Utils.documentIdToString(doc));
   }
 }


### PR DESCRIPTION
- Update MongoDbChangeEventContext.java to support Double, Integer, and complex BSON types like Binary.
- Remove restriction on 0L values.
- Add comprehensive unit tests covering valid, invalid, and unsupported types.