### PR TITLE
[FirestoreToFirestore] Fix default database ID for the respective API clients.

### DIFF
--- a/v2/firestore-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/FirestoreToFirestore.java
+++ b/v2/firestore-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/FirestoreToFirestore.java
@@ -169,13 +169,15 @@ public class FirestoreToFirestore {
       LOG.info("Pipeline created.");
 
       String sourceProjectId = options.getSourceProjectId();
-      String sourceDatabaseIdForFirestore = normalizeDatabaseIdForFirestore(options.getSourceDatabaseId());
+      String sourceDatabaseIdForFirestore =
+          normalizeDatabaseIdForFirestore(options.getSourceDatabaseId());
 
       String destinationProjectId =
           options.getDestinationProjectId().isEmpty()
               ? sourceProjectId
               : options.getDestinationProjectId();
-      String destinationDatabaseIdForFirestore = normalizeDatabaseIdForFirestore(options.getDestinationDatabaseId());
+      String destinationDatabaseIdForFirestore =
+          normalizeDatabaseIdForFirestore(options.getDestinationDatabaseId());
 
       int maxNumWorkers =
           options.getMaxNumWorkers() > 0 ? options.getMaxNumWorkers() : DEFAULT_MAX_NUM_WORKERS;
@@ -238,7 +240,8 @@ public class FirestoreToFirestore {
       // 5. Prepare documents for writing to the destination database
       PCollection<Write> writes =
           documents.apply(
-              ParDo.of(new PrepareWritesFn(destinationProjectId, destinationDatabaseIdForFirestore)));
+              ParDo.of(
+                  new PrepareWritesFn(destinationProjectId, destinationDatabaseIdForFirestore)));
 
       // 6. Write documents to the destination Firestore database
       writes.apply(
@@ -311,11 +314,11 @@ public class FirestoreToFirestore {
             .collect(Collectors.toList());
     return p.apply("Create Collection Groups", Create.of(collectionGroupIdsList));
   }
-  
+
   /**
    * Normalizes the database ID for use with FirestoreIO methods.
-   * 
-   * The default database ID in the Firestore API is "(default)".
+   *
+   * <p>The default database ID in the Firestore API is "(default)".
    */
   private static String normalizeDatabaseIdForFirestore(String databaseId) {
     if (databaseId.isEmpty() || FIRESTORE_DEFAULT_DATABASE.equals(databaseId)) {
@@ -326,8 +329,8 @@ public class FirestoreToFirestore {
 
   /**
    * Normalizes the database ID for use with DatastoreIO methods.
-   * 
-   * The default database ID in the Datastore API is an empty string.
+   *
+   * <p>The default database ID in the Datastore API is an empty string.
    */
   private static String normalizeDatabaseIdForDatastore(String databaseId) {
     if (databaseId.isEmpty() || FIRESTORE_DEFAULT_DATABASE.equals(databaseId)) {

--- a/v2/firestore-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/FirestoreToFirestore.java
+++ b/v2/firestore-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/FirestoreToFirestore.java
@@ -67,7 +67,8 @@ public class FirestoreToFirestore {
 
   private static final Logger LOG = LoggerFactory.getLogger(FirestoreToFirestore.class);
   private static final int DEFAULT_MAX_NUM_WORKERS = 500;
-  private static final String DEFAULT_DATABASE_ID = "(default)";
+  private static final String FIRESTORE_DEFAULT_DATABASE = "(default)";
+  private static final String DATASTORE_DEFAULT_DATABASE = "";
 
   /**
    * Options supported by the pipeline.
@@ -154,10 +155,6 @@ public class FirestoreToFirestore {
     void setReadTime(String readTime);
   }
 
-  private static String normalizeDatabaseId(String databaseId) {
-    return DEFAULT_DATABASE_ID.equals(databaseId) ? "" : databaseId;
-  }
-
   public static void main(String[] args) {
     try {
       UncaughtExceptionLogger.register();
@@ -172,13 +169,13 @@ public class FirestoreToFirestore {
       LOG.info("Pipeline created.");
 
       String sourceProjectId = options.getSourceProjectId();
-      String sourceDatabaseId = normalizeDatabaseId(options.getSourceDatabaseId());
+      String sourceDatabaseIdForFirestore = normalizeDatabaseIdForFirestore(options.getSourceDatabaseId());
 
       String destinationProjectId =
           options.getDestinationProjectId().isEmpty()
               ? sourceProjectId
               : options.getDestinationProjectId();
-      String destinationDatabaseId = normalizeDatabaseId(options.getDestinationDatabaseId());
+      String destinationDatabaseIdForFirestore = normalizeDatabaseIdForFirestore(options.getDestinationDatabaseId());
 
       int maxNumWorkers =
           options.getMaxNumWorkers() > 0 ? options.getMaxNumWorkers() : DEFAULT_MAX_NUM_WORKERS;
@@ -195,9 +192,9 @@ public class FirestoreToFirestore {
               + "destinationProjectId={}, destinationDatabaseId={}, collectionGroupIds={}, "
               + "maxNumWorkers={}, readTime={}",
           sourceProjectId,
-          sourceDatabaseId,
+          sourceDatabaseIdForFirestore,
           destinationProjectId,
-          destinationDatabaseId,
+          destinationDatabaseIdForFirestore,
           options.getCollectionGroupIds().isEmpty() ? "ALL" : options.getCollectionGroupIds(),
           maxNumWorkers,
           readTime);
@@ -206,7 +203,7 @@ public class FirestoreToFirestore {
       PCollection<PartitionQueryRequest> partitionQueryRequests =
           collectionGroupIds.apply(
               new CreatePartitionQueryRequestFn(
-                  sourceProjectId, sourceDatabaseId, maxNumWorkers, readTime));
+                  sourceProjectId, sourceDatabaseIdForFirestore, maxNumWorkers, readTime));
 
       // 2. Apply FirestoreIO to get partitions (as RunQueryRequests)
       PCollection<RunQueryRequest> partitionedQueries =
@@ -216,7 +213,7 @@ public class FirestoreToFirestore {
                   .read()
                   .partitionQuery()
                   .withProjectId(sourceProjectId)
-                  .withDatabaseId(sourceDatabaseId)
+                  .withDatabaseId(sourceDatabaseIdForFirestore)
                   .withReadTime(readTime)
                   .withRpcQosOptions(rpcQosOptions)
                   .build());
@@ -229,7 +226,7 @@ public class FirestoreToFirestore {
                   .read()
                   .runQuery()
                   .withProjectId(sourceProjectId)
-                  .withDatabaseId(sourceDatabaseId)
+                  .withDatabaseId(sourceDatabaseIdForFirestore)
                   .withReadTime(readTime)
                   .withRpcQosOptions(rpcQosOptions)
                   .build());
@@ -241,7 +238,7 @@ public class FirestoreToFirestore {
       // 5. Prepare documents for writing to the destination database
       PCollection<Write> writes =
           documents.apply(
-              ParDo.of(new PrepareWritesFn(destinationProjectId, destinationDatabaseId)));
+              ParDo.of(new PrepareWritesFn(destinationProjectId, destinationDatabaseIdForFirestore)));
 
       // 6. Write documents to the destination Firestore database
       writes.apply(
@@ -249,7 +246,7 @@ public class FirestoreToFirestore {
           FirestoreIO.v1()
               .write()
               .withProjectId(destinationProjectId)
-              .withDatabaseId(destinationDatabaseId)
+              .withDatabaseId(destinationDatabaseIdForFirestore)
               .batchWrite()
               .withRpcQosOptions(rpcQosOptions)
               .build());
@@ -283,12 +280,14 @@ public class FirestoreToFirestore {
       LOG.info("No collectionGroupIds provided. Discovering all...");
       Query query =
           Query.newBuilder().addKind(KindExpression.newBuilder().setName("__kind__")).build();
+      String sourceDatabaseIdForDatastore =
+          normalizeDatabaseIdForDatastore(options.getSourceDatabaseId());
       return p.apply(
               "Find All Collection Groups",
               DatastoreIO.v1()
                   .read()
                   .withProjectId(options.getSourceProjectId())
-                  .withDatabaseId(options.getSourceDatabaseId())
+                  .withDatabaseId(sourceDatabaseIdForDatastore)
                   .withQuery(query))
           .apply(
               "Extract Collection Group Names",
@@ -311,5 +310,29 @@ public class FirestoreToFirestore {
             .map(String::trim)
             .collect(Collectors.toList());
     return p.apply("Create Collection Groups", Create.of(collectionGroupIdsList));
+  }
+  
+  /**
+   * Normalizes the database ID for use with FirestoreIO methods.
+   * 
+   * The default database ID in the Firestore API is "(default)".
+   */
+  private static String normalizeDatabaseIdForFirestore(String databaseId) {
+    if (databaseId.isEmpty() || FIRESTORE_DEFAULT_DATABASE.equals(databaseId)) {
+      return FIRESTORE_DEFAULT_DATABASE;
+    }
+    return databaseId;
+  }
+
+  /**
+   * Normalizes the database ID for use with DatastoreIO methods.
+   * 
+   * The default database ID in the Datastore API is an empty string.
+   */
+  private static String normalizeDatabaseIdForDatastore(String databaseId) {
+    if (databaseId.isEmpty() || FIRESTORE_DEFAULT_DATABASE.equals(databaseId)) {
+      return DATASTORE_DEFAULT_DATABASE;
+    }
+    return databaseId;
   }
 }

--- a/v2/firestore-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/FirestoreToFirestoreIT.java
+++ b/v2/firestore-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/FirestoreToFirestoreIT.java
@@ -50,6 +50,7 @@ import org.apache.beam.it.gcp.firestore.FirestoreAdminResourceManager;
 import org.apache.beam.it.gcp.firestore.FirestoreResourceManager;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -288,6 +289,7 @@ public final class FirestoreToFirestoreIT extends TemplateTestBase {
     }
   }
 
+  @Ignore("Integration test project has a default database in Datastore mode.")
   @Test
   public void testFirestoreToFirestore_withDefaultSourceDatabase() throws IOException {
     String collectionId = "inputDef-" + randomString(6).toLowerCase();

--- a/v2/firestore-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/FirestoreToFirestoreIT.java
+++ b/v2/firestore-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/FirestoreToFirestoreIT.java
@@ -299,8 +299,7 @@ public final class FirestoreToFirestoreIT extends TemplateTestBase {
 
     // Act
     LaunchInfo info =
-        launchPipelineWithSourceDatabase(
-            /* testName= */ "copyFromDefault", "", "", "(default)");
+        launchPipelineWithSourceDatabase(/* testName= */ "copyFromDefault", "", "", "(default)");
     assertThatPipeline(info).isRunning();
 
     Result result = pipelineOperator().waitUntilDone(createConfig(info, Duration.ofMinutes(20)));
@@ -322,7 +321,8 @@ public final class FirestoreToFirestoreIT extends TemplateTestBase {
 
   private LaunchInfo launchPipeline(String testName, String collectionGroupIds, String readTime)
       throws IOException {
-    return launchPipelineWithSourceDatabase(testName, collectionGroupIds, readTime, sourceDatabaseId);
+    return launchPipelineWithSourceDatabase(
+        testName, collectionGroupIds, readTime, sourceDatabaseId);
   }
 
   private LaunchInfo launchPipelineWithSourceDatabase(

--- a/v2/firestore-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/FirestoreToFirestoreIT.java
+++ b/v2/firestore-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/FirestoreToFirestoreIT.java
@@ -71,6 +71,9 @@ public final class FirestoreToFirestoreIT extends TemplateTestBase {
   private FirestoreResourceManager sourceFirestoreResourceManager;
 
   private FirestoreResourceManager destinationFirestoreResourceManager;
+
+  private FirestoreResourceManager defaultSourceDatabaseFirestoreResourceManager;
+
   private Random random;
   private String sourceDatabaseId;
   private String destinationDatabaseId;
@@ -110,12 +113,19 @@ public final class FirestoreToFirestoreIT extends TemplateTestBase {
             .setDatabase(destinationDatabaseId)
             .setCredentials(TestProperties.googleCredentials())
             .build();
+    defaultSourceDatabaseFirestoreResourceManager =
+        FirestoreResourceManager.builder(testName)
+            .setProject(PROJECT)
+            .setDatabase("(default)")
+            .setCredentials(TestProperties.googleCredentials())
+            .build();
   }
 
   @After
   public void tearDown() {
     ResourceManagerUtils.cleanResources(sourceFirestoreResourceManager);
     ResourceManagerUtils.cleanResources(destinationFirestoreResourceManager);
+    ResourceManagerUtils.cleanResources(defaultSourceDatabaseFirestoreResourceManager);
     ResourceManagerUtils.cleanResources(firestoreAdminResourceManager);
   }
 
@@ -278,6 +288,30 @@ public final class FirestoreToFirestoreIT extends TemplateTestBase {
     }
   }
 
+  @Test
+  public void testFirestoreToFirestore_withDefaultSourceDatabase() throws IOException {
+    String collectionId = "inputDef-" + randomString(6).toLowerCase();
+    int numDocuments = 10;
+    Map<String, Map<String, Object>> inputData = generateTestDocuments(numDocuments);
+
+    // Populates data directly into the existing (default) database
+    defaultSourceDatabaseFirestoreResourceManager.write(collectionId, inputData);
+
+    // Act
+    LaunchInfo info =
+        launchPipelineWithSourceDatabase(
+            /* testName= */ "copyFromDefault", "", "", "(default)");
+    assertThatPipeline(info).isRunning();
+
+    Result result = pipelineOperator().waitUntilDone(createConfig(info, Duration.ofMinutes(20)));
+    assertThatResult(result).isLaunchFinished();
+
+    // Verify it successfully copied to destination database
+    List<QueryDocumentSnapshot> destDocuments =
+        destinationFirestoreResourceManager.read(collectionId);
+    assertThat(destDocuments).hasSize(numDocuments);
+  }
+
   private LaunchInfo launchPipeline(String testName) throws IOException {
     return launchPipeline(testName, /* collectionGroupIds= */ "");
   }
@@ -288,10 +322,16 @@ public final class FirestoreToFirestoreIT extends TemplateTestBase {
 
   private LaunchInfo launchPipeline(String testName, String collectionGroupIds, String readTime)
       throws IOException {
+    return launchPipelineWithSourceDatabase(testName, collectionGroupIds, readTime, sourceDatabaseId);
+  }
+
+  private LaunchInfo launchPipelineWithSourceDatabase(
+      String testName, String collectionGroupIds, String readTime, String inputSourceDatabaseId)
+      throws IOException {
     LaunchConfig.Builder options =
         LaunchConfig.builder(testName, specPath)
             .addParameter("sourceProjectId", PROJECT)
-            .addParameter("sourceDatabaseId", sourceDatabaseId)
+            .addParameter("sourceDatabaseId", inputSourceDatabaseId)
             .addParameter("destinationProjectId", PROJECT)
             .addParameter("destinationDatabaseId", destinationDatabaseId)
             .addParameter("maxNumWorkers", "10");


### PR DESCRIPTION
Firestore APIs use the string `"(default)"` to indicate the default database, while Datastore APIs use an empty string.

Either `"(default)"` or an empty string can be passed as a parameter to the template with the same effect. This fixes an issue where the same string was passed to both API clients.