### PR TITLE
Adding mutation batcher and row assembler in cdc data generator

### DIFF
--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/MutationBatcher.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/MutationBatcher.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.dofn;
+
+import com.google.cloud.teleport.v2.templates.model.BufferKey;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
+import com.google.cloud.teleport.v2.templates.sink.DataWriter;
+import com.google.cloud.teleport.v2.templates.utils.Constants;
+import com.google.cloud.teleport.v2.templates.utils.FailureRecord;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.values.Row;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Collects, groups, and buffers generated records in transient worker memory, chunking mutations
+ * into batches based on size thresholds before executing database sink writes.
+ *
+ * <p>Crucially, the configured {@code batchSize} threshold from pipeline options is applied <b>per
+ * table</b> (specifically partitioned by {@link BufferKey} groups of table, shard, and operation
+ * type). This prevents large tables from starving smaller ones or forcing premature cross-table
+ * flushes, ensuring maximum throughput and proper database transactional sizing.
+ */
+public class MutationBatcher implements Serializable {
+  private static final Logger LOG = LoggerFactory.getLogger(MutationBatcher.class);
+
+  public static final String MUTATION_INSERT = "INSERT";
+  public static final String MUTATION_UPDATE = "UPDATE";
+  public static final String MUTATION_DELETE = "DELETE";
+
+  private final int batchSize;
+  private final Integer jdbcPoolSize;
+  private final DataWriter writer;
+
+  private transient Map<BufferKey, BufferValue> buffers;
+  private transient List<String> pendingDlq;
+
+  private final Counter batchesWritten = Metrics.counter(MutationBatcher.class, "batchesWritten");
+  private final Counter recordsWritten = Metrics.counter(MutationBatcher.class, "recordsWritten");
+  private final Counter writeFailures = Metrics.counter(MutationBatcher.class, "writeFailures");
+
+  public MutationBatcher(int batchSize, Integer jdbcPoolSize, DataWriter writer) {
+    this.batchSize = batchSize;
+    this.jdbcPoolSize = jdbcPoolSize;
+    this.writer = writer;
+  }
+
+  public void startBundle() {
+    this.buffers = new HashMap<>();
+    this.pendingDlq = new ArrayList<>();
+  }
+
+  public List<String> getPendingDlq() {
+    return pendingDlq;
+  }
+
+  public void clearDlq() {
+    if (this.pendingDlq != null) {
+      this.pendingDlq.clear();
+    }
+  }
+
+  public void bufferRow(
+      String tableName,
+      Row row,
+      String operation,
+      DataGeneratorTable table,
+      String shardIdHint,
+      List<String> insertTopoOrder) {
+    String shardId = shardIdHint == null ? "" : shardIdHint;
+    if (shardId.isEmpty() && row.getSchema().hasField(Constants.SHARD_ID_COLUMN_NAME)) {
+      shardId = row.getString(Constants.SHARD_ID_COLUMN_NAME);
+    }
+    BufferKey bufferKey = BufferKey.create(tableName, shardId, operation);
+    buffers.computeIfAbsent(bufferKey, k -> new BufferValue(table)).rows.add(row);
+
+    if (buffers.get(bufferKey).rows.size() >= batchSize) {
+      if (MUTATION_INSERT.equals(operation)) {
+        flushInsertsInTopoOrder(insertTopoOrder);
+      } else if (MUTATION_DELETE.equals(operation)) {
+        flushDeletesInReverseTopoOrder(insertTopoOrder);
+      } else {
+        flush(bufferKey);
+      }
+    }
+  }
+
+  public void flushInsertsInTopoOrder(List<String> insertTopoOrder) {
+    if (buffers == null || buffers.isEmpty()) {
+      return;
+    }
+    List<String> order = insertTopoOrder != null ? insertTopoOrder : Collections.emptyList();
+    for (String table : order) {
+      flushByTableAndOp(table, MUTATION_INSERT);
+    }
+  }
+
+  public void flushDeletesInReverseTopoOrder(List<String> insertTopoOrder) {
+    if (buffers == null || buffers.isEmpty()) {
+      return;
+    }
+    List<String> order = insertTopoOrder != null ? insertTopoOrder : Collections.emptyList();
+    for (int i = order.size() - 1; i >= 0; i--) {
+      flushByTableAndOp(order.get(i), MUTATION_DELETE);
+    }
+  }
+
+  public void flushUpdates() {
+    if (buffers == null || buffers.isEmpty()) {
+      return;
+    }
+    for (BufferKey bufferKey : new ArrayList<>(buffers.keySet())) {
+      if (MUTATION_UPDATE.equals(bufferKey.operation())) {
+        flush(bufferKey);
+      }
+    }
+  }
+
+  private void flushByTableAndOp(String tableName, String op) {
+    for (BufferKey bufferKey : new ArrayList<>(buffers.keySet())) {
+      if (bufferKey.tableName().equals(tableName) && bufferKey.operation().equals(op)) {
+        flush(bufferKey);
+      }
+    }
+  }
+
+  private void flush(BufferKey key) {
+    String tableName = key.tableName();
+    String shardId = key.shardId();
+    String operation = key.operation();
+
+    BufferValue bv = buffers.get(key);
+    List<Row> batch = bv != null ? bv.rows : null;
+    DataGeneratorTable table = bv != null ? bv.table : null;
+    if (batch == null || batch.isEmpty()) {
+      if (bv != null && bv.rows.isEmpty()) {
+        buffers.remove(key);
+      }
+      return;
+    }
+
+    int maxShardConnections =
+        (this.jdbcPoolSize != null && this.jdbcPoolSize > 0)
+            ? this.jdbcPoolSize
+            : Constants.DEFAULT_JDBC_POOL_SIZE;
+    try {
+      switch (operation) {
+        case MUTATION_INSERT:
+          writer.insert(batch, table, shardId, maxShardConnections);
+          break;
+        case MUTATION_UPDATE:
+          writer.update(batch, table, shardId, maxShardConnections);
+          break;
+        case MUTATION_DELETE:
+          writer.delete(batch, table, shardId, maxShardConnections);
+          break;
+        default:
+          throw new IllegalStateException("Unknown operation: " + operation);
+      }
+      batchesWritten.inc();
+      recordsWritten.inc(batch.size());
+      if (!shardId.isEmpty()) {
+        Metrics.counter(MutationBatcher.class, "recordsWritten_" + shardId).inc(batch.size());
+      }
+      Metrics.counter(MutationBatcher.class, operation.toLowerCase() + "_" + tableName)
+          .inc(batch.size());
+    } catch (Exception writeError) {
+      LOG.error(
+          "Sink write failed for table {} ({}); {} rows routed to DLQ",
+          tableName,
+          operation,
+          batch.size(),
+          writeError);
+      writeFailures.inc(batch.size());
+      for (Row r : batch) {
+        pendingDlq.add(FailureRecord.toJson(tableName, operation, r, writeError));
+      }
+    } finally {
+      batch.clear();
+      buffers.remove(key);
+    }
+  }
+
+  private static final class BufferValue {
+    final DataGeneratorTable table;
+    final List<Row> rows;
+
+    BufferValue(DataGeneratorTable table) {
+      this.table = table;
+      this.rows = new ArrayList<>();
+    }
+  }
+}

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/MutationBatcher.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/MutationBatcher.java
@@ -20,7 +20,6 @@ import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
 import com.google.cloud.teleport.v2.templates.sink.DataWriter;
 import com.google.cloud.teleport.v2.templates.utils.Constants;
 import com.google.cloud.teleport.v2.templates.utils.FailureRecord;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -41,19 +40,19 @@ import org.slf4j.LoggerFactory;
  * type). This prevents large tables from starving smaller ones or forcing premature cross-table
  * flushes, ensuring maximum throughput and proper database transactional sizing.
  */
-public class MutationBatcher implements Serializable {
+public class MutationBatcher {
   private static final Logger LOG = LoggerFactory.getLogger(MutationBatcher.class);
 
   public static final String MUTATION_INSERT = "INSERT";
   public static final String MUTATION_UPDATE = "UPDATE";
   public static final String MUTATION_DELETE = "DELETE";
 
-  private final int batchSize;
+  private final Integer batchSize;
   private final Integer jdbcPoolSize;
   private final DataWriter writer;
 
   private transient Map<BufferKey, BufferValue> buffers;
-  private transient List<String> pendingDlq;
+  private transient List<String> failedRecords;
 
   private final Counter batchesWritten = Metrics.counter(MutationBatcher.class, "batchesWritten");
   private final Counter recordsWritten = Metrics.counter(MutationBatcher.class, "recordsWritten");
@@ -67,16 +66,16 @@ public class MutationBatcher implements Serializable {
 
   public void startBundle() {
     this.buffers = new HashMap<>();
-    this.pendingDlq = new ArrayList<>();
+    this.failedRecords = new ArrayList<>();
   }
 
-  public List<String> getPendingDlq() {
-    return pendingDlq;
+  public List<String> getFailedRecords() {
+    return failedRecords;
   }
 
   public void clearDlq() {
-    if (this.pendingDlq != null) {
-      this.pendingDlq.clear();
+    if (this.failedRecords != null) {
+      this.failedRecords.clear();
     }
   }
 
@@ -193,7 +192,7 @@ public class MutationBatcher implements Serializable {
           writeError);
       writeFailures.inc(batch.size());
       for (Row r : batch) {
-        pendingDlq.add(FailureRecord.toJson(tableName, operation, r, writeError));
+        failedRecords.add(FailureRecord.toJson(tableName, operation, r, writeError));
       }
     } finally {
       batch.clear();

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/RowAssembler.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/RowAssembler.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.dofn;
+
+import com.github.javafaker.Faker;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorColumn;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorForeignKey;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorUniqueKey;
+import com.google.cloud.teleport.v2.templates.utils.Constants;
+import com.google.cloud.teleport.v2.templates.utils.DataGeneratorUtils;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.values.Row;
+
+/**
+ * Pure-function helpers for assembling Beam {@link Row}s from a {@link DataGeneratorTable}, plus
+ * primary-key utilities used to drive state-keying inside {@code BatchAndWriteFn}.
+ *
+ * <p>This class has no Beam runtime state and no I/O. It exists to keep {@code BatchAndWriteFn}
+ * focused on lifecycle / state / batching concerns while the row-construction details live here.
+ */
+final class RowAssembler {
+
+  private static final Map<DataGeneratorTable, Set<String>> UNIQUE_COLUMNS_CACHE =
+      new ConcurrentHashMap<>();
+  private static final Map<DataGeneratorTable, Set<String>> FK_COLUMNS_CACHE =
+      new ConcurrentHashMap<>();
+
+  private RowAssembler() {}
+
+  /** Returns the names of all columns covered by any unique key on {@code table}. */
+  static Set<String> uniqueColumnNames(DataGeneratorTable table) {
+    Set<String> uniqueColumns = new HashSet<>();
+    if (table.uniqueKeys() != null) {
+      for (DataGeneratorUniqueKey uk : table.uniqueKeys()) {
+        uniqueColumns.addAll(uk.columns());
+      }
+    }
+    return uniqueColumns;
+  }
+
+  /** Returns the names of every column referenced by any foreign key on {@code table}. */
+  static Set<String> foreignKeyColumns(DataGeneratorTable table) {
+    Set<String> fkColumns = new HashSet<>();
+    if (table.foreignKeys() != null) {
+      for (DataGeneratorForeignKey fk : table.foreignKeys()) {
+        fkColumns.addAll(fk.keyColumns());
+      }
+    }
+    return fkColumns;
+  }
+
+  /**
+   * Builds a row for an UPDATE event. Primary keys come from {@code pkValues}; foreign keys and
+   * unique columns are preserved from {@code originalRow} so they don't churn between updates;
+   * everything else is freshly generated.
+   *
+   * <p>{@code col.isSkipped()} columns are omitted from the row schema entirely so the sink writes
+   * its DEFAULT (or NULL) for them.
+   */
+  static Row generateUpdateRow(
+      LinkedHashMap<String, Object> pkValues,
+      DataGeneratorTable table,
+      Row originalRow,
+      Faker faker) {
+    Schema.Builder schemaBuilder = Schema.builder();
+    List<Object> values = new ArrayList<>();
+    Set<String> pkSet = new HashSet<>(table.primaryKeys());
+    Set<String> fkColumns = FK_COLUMNS_CACHE.computeIfAbsent(table, k -> foreignKeyColumns(table));
+    Set<String> uniqueColumns =
+        UNIQUE_COLUMNS_CACHE.computeIfAbsent(table, k -> uniqueColumnNames(table));
+
+    for (DataGeneratorColumn col : table.columns()) {
+      if (col.isSkipped()) {
+        continue;
+      }
+      schemaBuilder.addField(
+          Schema.Field.of(col.name(), DataGeneratorUtils.mapToBeamFieldType(col.logicalType())));
+      if (pkSet.contains(col.name())) {
+        values.add(pkValues.get(col.name()));
+      } else if (uniqueColumns.contains(col.name())) {
+        // Unique columns must NOT churn on UPDATE. Preserve the original inserted value from
+        // state — re-deriving would either collide with another row's existing value or change
+        // the row's logical identity between updates. createReducedRow guarantees every unique
+        // column is captured at INSERT time.
+        Object originalVal =
+            (originalRow != null && originalRow.getSchema().hasField(col.name()))
+                ? originalRow.getValue(col.name())
+                : null;
+        values.add(originalVal);
+      } else if (fkColumns.contains(col.name())) {
+        Object val =
+            (originalRow != null && originalRow.getSchema().hasField(col.name()))
+                ? originalRow.getValue(col.name())
+                : DataGeneratorUtils.generateValue(col, faker);
+        values.add(val);
+      } else {
+        values.add(DataGeneratorUtils.generateValue(col, faker));
+      }
+    }
+    return Row.withSchema(schemaBuilder.build()).addValues(values).build();
+  }
+
+  /**
+   * Builds a row for a DELETE event. Only the primary-key columns carry values; everything else is
+   * a nullable {@code null}. {@code isSkipped()} columns are omitted entirely.
+   */
+  static Row generateDeleteRow(LinkedHashMap<String, Object> pkValues, DataGeneratorTable table) {
+    Schema.Builder schemaBuilder = Schema.builder();
+    List<Object> values = new ArrayList<>();
+    Set<String> pkSet = new HashSet<>(table.primaryKeys());
+
+    for (DataGeneratorColumn col : table.columns()) {
+      if (col.isSkipped()) {
+        continue;
+      }
+      Schema.FieldType fieldType = DataGeneratorUtils.mapToBeamFieldType(col.logicalType());
+      if (pkSet.contains(col.name())) {
+        schemaBuilder.addField(Schema.Field.of(col.name(), fieldType));
+        values.add(pkValues.get(col.name()));
+      } else {
+        schemaBuilder.addField(Schema.Field.nullable(col.name(), fieldType));
+        values.add(null);
+      }
+    }
+    return Row.withSchema(schemaBuilder.build()).addValues(values).build();
+  }
+
+  /**
+   * Captures only the columns a future UPDATE/DELETE follow-up will need: PK + FK + unique columns,
+   * plus the synthetic shard id when present. {@code isSkipped()} columns are omitted.
+   */
+  static Row createReducedRow(Row fullRow, DataGeneratorTable table) {
+    Schema.Builder schemaBuilder = Schema.builder();
+    List<Object> values = new ArrayList<>();
+    Set<String> pkSet = new HashSet<>(table.primaryKeys());
+    Set<String> fkColumns = FK_COLUMNS_CACHE.computeIfAbsent(table, k -> foreignKeyColumns(table));
+    Set<String> uniqueColumns =
+        UNIQUE_COLUMNS_CACHE.computeIfAbsent(table, k -> uniqueColumnNames(table));
+
+    for (DataGeneratorColumn col : table.columns()) {
+      if (col.isSkipped()) {
+        continue;
+      }
+      if (pkSet.contains(col.name())
+          || fkColumns.contains(col.name())
+          || uniqueColumns.contains(col.name())) {
+        schemaBuilder.addField(
+            Schema.Field.of(col.name(), DataGeneratorUtils.mapToBeamFieldType(col.logicalType())));
+        values.add(fullRow.getValue(col.name()));
+      }
+    }
+    if (fullRow.getSchema().hasField(Constants.SHARD_ID_COLUMN_NAME)) {
+      schemaBuilder.addField(
+          Schema.Field.of(Constants.SHARD_ID_COLUMN_NAME, Schema.FieldType.STRING));
+      values.add(fullRow.getString(Constants.SHARD_ID_COLUMN_NAME));
+    }
+    return Row.withSchema(schemaBuilder.build()).addValues(values).build();
+  }
+
+  /**
+   * Completes a partial row by generating any missing columns through {@link
+   * DataGeneratorUtils#generateValue}. {@code isSkipped()} columns are omitted from the assembled
+   * row so the sink writes its DEFAULT.
+   *
+   * <p>If {@code partialRow} already contains every non-skipped column, it is returned unchanged.
+   */
+  static Row completeRow(DataGeneratorTable table, Row partialRow, Faker faker) {
+    boolean hasAllColumns = true;
+    for (DataGeneratorColumn col : table.columns()) {
+      if (col.isSkipped()) {
+        continue;
+      }
+      if (!partialRow.getSchema().hasField(col.name())) {
+        hasAllColumns = false;
+        break;
+      }
+    }
+    if (hasAllColumns) {
+      return partialRow;
+    }
+
+    Schema.Builder schemaBuilder = Schema.builder();
+    List<Object> values = new ArrayList<>();
+    for (DataGeneratorColumn col : table.columns()) {
+      if (col.isSkipped()) {
+        continue;
+      }
+      Object val =
+          partialRow.getSchema().hasField(col.name())
+              ? partialRow.getValue(col.name())
+              : DataGeneratorUtils.generateValue(col, faker);
+      schemaBuilder.addField(
+          Schema.Field.of(col.name(), DataGeneratorUtils.mapToBeamFieldType(col.logicalType())));
+      values.add(val);
+    }
+
+    if (partialRow.getSchema().hasField(Constants.SHARD_ID_COLUMN_NAME)) {
+      String shardId = partialRow.getString(Constants.SHARD_ID_COLUMN_NAME);
+      schemaBuilder.addField(
+          Schema.Field.of(Constants.SHARD_ID_COLUMN_NAME, Schema.FieldType.STRING));
+      values.add(shardId);
+    }
+
+    return Row.withSchema(schemaBuilder.build()).addValues(values).build();
+  }
+}

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/model/BufferKey.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/model/BufferKey.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.model;
+
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+
+/** Type-safe buffering key object for grouping row mutation lists. */
+@AutoValue
+public abstract class BufferKey implements Serializable {
+  public abstract String tableName();
+
+  public abstract String shardId();
+
+  public abstract String operation();
+
+  public static BufferKey create(String tableName, String shardId, String operation) {
+    return new AutoValue_BufferKey(tableName, shardId, operation);
+  }
+}

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/DataGeneratorUtils.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/DataGeneratorUtils.java
@@ -23,11 +23,13 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Calendar;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.beam.sdk.schemas.Schema;
 import org.joda.time.Instant;
+import org.json.JSONObject;
 
 /**
  * Common utilities for data generation — value synthesis and Beam type mapping.
@@ -211,31 +213,19 @@ public final class DataGeneratorUtils {
 
   public static Object canonicalizeValue(Object v) {
     if (v == null) {
-      return null;
+      return JSONObject.NULL;
     }
-    if (v instanceof byte[]) {
-      return "0x" + bytesToHex((byte[]) v);
-    }
-    if (v instanceof ByteBuffer) {
-      ByteBuffer bb = ((ByteBuffer) v).duplicate();
-      byte[] bytes = new byte[bb.remaining()];
-      bb.get(bytes);
-      return "0x" + bytesToHex(bytes);
-    }
-    if (v instanceof Number || v instanceof Boolean || v instanceof String) {
-      return v;
-    }
-    return v.toString();
-  }
 
-  public static String bytesToHex(byte[] bytes) {
-    char[] hex = "0123456789abcdef".toCharArray();
-    char[] out = new char[bytes.length * 2];
-    for (int i = 0; i < bytes.length; i++) {
-      int b = bytes[i] & 0xff;
-      out[i * 2] = hex[b >>> 4];
-      out[i * 2 + 1] = hex[b & 0x0f];
+    // Convert byte[] to standard Base64 string
+    if (v instanceof byte[] bytes) {
+      return Base64.getEncoder().encodeToString(bytes);
     }
-    return new String(out);
+
+    // Safely extract bytes from ByteBuffer and convert to Base64
+    if (v instanceof ByteBuffer bb) {
+      return Base64.getEncoder().encodeToString(bb.array());
+    }
+
+    return JSONObject.wrap(v);
   }
 }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/DataGeneratorUtils.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/DataGeneratorUtils.java
@@ -21,6 +21,7 @@ import com.google.cloud.teleport.v2.templates.model.LogicalType;
 import com.google.common.annotations.VisibleForTesting;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
 import java.util.UUID;
@@ -206,5 +207,35 @@ public final class DataGeneratorUtils {
       return Integer.MAX_VALUE;
     }
     return size.intValue();
+  }
+
+  public static Object canonicalizeValue(Object v) {
+    if (v == null) {
+      return null;
+    }
+    if (v instanceof byte[]) {
+      return "0x" + bytesToHex((byte[]) v);
+    }
+    if (v instanceof ByteBuffer) {
+      ByteBuffer bb = ((ByteBuffer) v).duplicate();
+      byte[] bytes = new byte[bb.remaining()];
+      bb.get(bytes);
+      return "0x" + bytesToHex(bytes);
+    }
+    if (v instanceof Number || v instanceof Boolean || v instanceof String) {
+      return v;
+    }
+    return v.toString();
+  }
+
+  public static String bytesToHex(byte[] bytes) {
+    char[] hex = "0123456789abcdef".toCharArray();
+    char[] out = new char[bytes.length * 2];
+    for (int i = 0; i < bytes.length; i++) {
+      int b = bytes[i] & 0xff;
+      out[i * 2] = hex[b >>> 4];
+      out[i * 2 + 1] = hex[b & 0x0f];
+    }
+    return new String(out);
   }
 }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/FailureRecord.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/FailureRecord.java
@@ -73,7 +73,7 @@ public final class FailureRecord {
         raw = "<unreadable: " + e.getClass().getSimpleName() + ">";
       }
       Object val = DataGeneratorUtils.canonicalizeValue(raw);
-      obj.put(field.getName(), val == null ? JSONObject.NULL : val);
+      obj.put(field.getName(), val);
     }
     return obj;
   }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/FailureRecord.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/FailureRecord.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.utils;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.values.Row;
+import org.json.JSONObject;
+
+/**
+ * Helper for serialising data-generator failures into newline-delimited JSON for the dead-letter
+ * queue.
+ *
+ * <p>Each record is a flat JSON object with a stable schema so downstream tools (e.g. BigQuery
+ * external tables, ad-hoc {@code jq} pipelines) can rely on the field names. Unprintable values
+ * (byte arrays, {@link ByteBuffer}s) are hex-encoded; everything else falls back to {@link
+ * Object#toString} to keep the failure record self-contained even when the underlying value isn't
+ * natively JSON-representable.
+ */
+public final class FailureRecord {
+
+  /** Operation tag used when the failure happened during row generation, before any sink call. */
+  public static final String OPERATION_GENERATION = "GENERATION";
+
+  private FailureRecord() {}
+
+  /**
+   * Builds a JSON failure record for a row that could not be generated or written.
+   *
+   * @param tableName logical table the row belongs to
+   * @param operation the in-flight operation: INSERT / UPDATE / DELETE / GENERATION
+   * @param row the row that failed; may be {@code null} when the failure happened before the row
+   *     could be assembled
+   * @param error the throwable that aborted the operation; must not be null
+   */
+  public static String toJson(String tableName, String operation, Row row, Throwable error) {
+    JSONObject obj = new JSONObject();
+    obj.put("timestamp", Instant.now().toString());
+    obj.put("table", tableName == null ? JSONObject.NULL : tableName);
+    obj.put("operation", operation == null ? JSONObject.NULL : operation);
+    obj.put("row", rowToJson(row));
+    obj.put("error", error == null ? JSONObject.NULL : describeError(error));
+    return obj.toString();
+  }
+
+  private static Object rowToJson(Row row) {
+    if (row == null) {
+      return JSONObject.NULL;
+    }
+    JSONObject obj = new JSONObject();
+    Schema schema = row.getSchema();
+    for (Schema.Field field : schema.getFields()) {
+      Object raw;
+      try {
+        raw = row.getValue(field.getName());
+      } catch (Exception e) {
+        raw = "<unreadable: " + e.getClass().getSimpleName() + ">";
+      }
+      Object val = DataGeneratorUtils.canonicalizeValue(raw);
+      obj.put(field.getName(), val == null ? JSONObject.NULL : val);
+    }
+    return obj;
+  }
+
+  private static JSONObject describeError(Throwable error) {
+    JSONObject obj = new JSONObject();
+    obj.put("class", error.getClass().getName());
+    obj.put("message", error.getMessage() == null ? "" : error.getMessage());
+    StringWriter sw = new StringWriter();
+    error.printStackTrace(new PrintWriter(sw));
+    obj.put("stackTrace", sw.toString());
+    return obj;
+  }
+}

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/dofn/MutationBatcherTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/dofn/MutationBatcherTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.dofn;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
+import com.google.cloud.teleport.v2.templates.sink.DataWriter;
+import com.google.cloud.teleport.v2.templates.utils.Constants;
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.values.Row;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class MutationBatcherTest {
+
+  private DataWriter mockWriter;
+  private MutationBatcher batcher;
+  private DataGeneratorTable sampleTable;
+  private Schema rowSchema;
+  private Row sampleRow;
+  private List<String> topoOrder;
+
+  @Before
+  public void setUp() {
+    mockWriter = mock(DataWriter.class);
+    batcher = new MutationBatcher(2, 10, mockWriter);
+    batcher.startBundle();
+
+    sampleTable =
+        DataGeneratorTable.builder()
+            .name("Users")
+            .columns(ImmutableList.of())
+            .primaryKeys(ImmutableList.of())
+            .foreignKeys(ImmutableList.of())
+            .uniqueKeys(ImmutableList.of())
+            .insertQps(10)
+            .updateQps(0)
+            .deleteQps(0)
+            .isRoot(true)
+            .recordsPerTick(1.0)
+            .build();
+
+    rowSchema = Schema.builder().addInt64Field("id").build();
+    sampleRow = Row.withSchema(rowSchema).addValue(1L).build();
+    topoOrder = Arrays.asList("Users");
+  }
+
+  @Test
+  public void testBufferRow_triggersFlushOnThreshold() {
+    // Threshold is set to 2. Inserting 1st row should not trigger writer.
+    batcher.bufferRow(
+        "Users", sampleRow, MutationBatcher.MUTATION_INSERT, sampleTable, "shard0", topoOrder);
+    verify(mockWriter, times(0)).insert(any(), any(), anyString(), anyInt());
+
+    // Inserting 2nd row should cross threshold and flush inserts in topo order.
+    batcher.bufferRow(
+        "Users", sampleRow, MutationBatcher.MUTATION_INSERT, sampleTable, "shard0", topoOrder);
+    verify(mockWriter, times(1)).insert(any(), any(), anyString(), anyInt());
+  }
+
+  @Test
+  public void testBufferRow_sinkErrorRoutesToDlq() {
+    doThrow(new RuntimeException("Sink error simulation"))
+        .when(mockWriter)
+        .insert(any(), any(), anyString(), anyInt());
+
+    assertTrue(batcher.getPendingDlq().isEmpty());
+
+    // Push two rows to force threshold trip and catch error routing
+    batcher.bufferRow(
+        "Users", sampleRow, MutationBatcher.MUTATION_INSERT, sampleTable, "shard0", topoOrder);
+    batcher.bufferRow(
+        "Users", sampleRow, MutationBatcher.MUTATION_INSERT, sampleTable, "shard0", topoOrder);
+
+    assertFalse(batcher.getPendingDlq().isEmpty());
+    assertEquals(2, batcher.getPendingDlq().size());
+  }
+
+  @Test
+  public void testBufferRow_withShardIdFromRowSchema() {
+    Schema schemaWithShard =
+        Schema.builder().addInt64Field("id").addStringField(Constants.SHARD_ID_COLUMN_NAME).build();
+    Row rowWithShard = Row.withSchema(schemaWithShard).addValues(1L, "shard-from-row").build();
+
+    // Tripping threshold with null/empty shard hint argument, should pull shard-from-row
+    batcher.bufferRow(
+        "Users", rowWithShard, MutationBatcher.MUTATION_INSERT, sampleTable, null, topoOrder);
+    batcher.bufferRow(
+        "Users", rowWithShard, MutationBatcher.MUTATION_INSERT, sampleTable, "", topoOrder);
+
+    verify(mockWriter, times(1))
+        .insert(any(), any(), org.mockito.Mockito.eq("shard-from-row"), anyInt());
+  }
+
+  @Test
+  public void testBufferRow_mutationDelete_flushesInReverseTopoOrder() {
+    List<String> extendedTopo = Arrays.asList("Companies", "Users");
+    batcher.bufferRow(
+        "Users", sampleRow, MutationBatcher.MUTATION_DELETE, sampleTable, "shard0", extendedTopo);
+    batcher.bufferRow(
+        "Users", sampleRow, MutationBatcher.MUTATION_DELETE, sampleTable, "shard0", extendedTopo);
+
+    verify(mockWriter, times(1)).delete(any(), any(), anyString(), anyInt());
+  }
+
+  @Test
+  public void testBufferRow_unknownOperation_logsErrorToDlq() {
+    batcher.bufferRow("Users", sampleRow, "INVALID_OP", sampleTable, "shard0", topoOrder);
+    batcher.bufferRow("Users", sampleRow, "INVALID_OP", sampleTable, "shard0", topoOrder);
+
+    // Shoud go to DLQ since switch fallback throws IllegalStateException caught inside flush loop
+    assertFalse(batcher.getPendingDlq().isEmpty());
+  }
+
+  @Test
+  public void testFlushUpdates_processesUpdatesOnly() {
+    batcher.bufferRow(
+        "Users", sampleRow, MutationBatcher.MUTATION_UPDATE, sampleTable, "shard0", topoOrder);
+    verify(mockWriter, times(0)).update(any(), any(), anyString(), anyInt());
+
+    batcher.flushUpdates();
+    verify(mockWriter, times(1)).update(any(), any(), anyString(), anyInt());
+  }
+
+  @Test
+  public void testFlush_emptyBatch_returnsSafely() {
+    // Forcing direct call on table and operation with empty buffer
+    batcher.flushInsertsInTopoOrder(topoOrder);
+    batcher.flushDeletesInReverseTopoOrder(topoOrder);
+    verify(mockWriter, times(0)).insert(any(), any(), anyString(), anyInt());
+  }
+
+  @Test
+  public void testFlush_customJdbcPoolSize_honorsPoolLimits() {
+    MutationBatcher customBatcher = new MutationBatcher(1, 45, mockWriter);
+    customBatcher.startBundle();
+    customBatcher.bufferRow(
+        "Users", sampleRow, MutationBatcher.MUTATION_INSERT, sampleTable, "shard0", topoOrder);
+
+    verify(mockWriter, times(1)).insert(any(), any(), anyString(), org.mockito.Mockito.eq(45));
+  }
+}

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/dofn/MutationBatcherTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/dofn/MutationBatcherTest.java
@@ -93,7 +93,7 @@ public class MutationBatcherTest {
         .when(mockWriter)
         .insert(any(), any(), anyString(), anyInt());
 
-    assertTrue(batcher.getPendingDlq().isEmpty());
+    assertTrue(batcher.getFailedRecords().isEmpty());
 
     // Push two rows to force threshold trip and catch error routing
     batcher.bufferRow(
@@ -101,8 +101,8 @@ public class MutationBatcherTest {
     batcher.bufferRow(
         "Users", sampleRow, MutationBatcher.MUTATION_INSERT, sampleTable, "shard0", topoOrder);
 
-    assertFalse(batcher.getPendingDlq().isEmpty());
-    assertEquals(2, batcher.getPendingDlq().size());
+    assertFalse(batcher.getFailedRecords().isEmpty());
+    assertEquals(2, batcher.getFailedRecords().size());
   }
 
   @Test
@@ -138,7 +138,7 @@ public class MutationBatcherTest {
     batcher.bufferRow("Users", sampleRow, "INVALID_OP", sampleTable, "shard0", topoOrder);
 
     // Shoud go to DLQ since switch fallback throws IllegalStateException caught inside flush loop
-    assertFalse(batcher.getPendingDlq().isEmpty());
+    assertFalse(batcher.getFailedRecords().isEmpty());
   }
 
   @Test

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/dofn/RowAssemblerTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/dofn/RowAssemblerTest.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.dofn;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.github.javafaker.Faker;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorColumn;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorForeignKey;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorUniqueKey;
+import com.google.cloud.teleport.v2.templates.model.LogicalType;
+import com.google.cloud.teleport.v2.templates.utils.Constants;
+import com.google.common.collect.ImmutableList;
+import java.util.LinkedHashMap;
+import java.util.Random;
+import java.util.Set;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.values.Row;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Pure-function tests for {@link RowAssembler}. */
+@RunWith(JUnit4.class)
+public class RowAssemblerTest {
+
+  /** Deterministic Faker so generated values don't make tests flaky. */
+  private final Faker faker = new Faker(new Random(42L));
+
+  // ===========================================================================
+  // uniqueColumnNames + foreignKeyColumns
+  // ===========================================================================
+
+  @Test
+  public void uniqueColumnNames_aggregatesAcrossUniqueKeys() {
+    DataGeneratorUniqueKey uk1 =
+        DataGeneratorUniqueKey.builder().name("uk1").columns(ImmutableList.of("email")).build();
+    DataGeneratorUniqueKey uk2 =
+        DataGeneratorUniqueKey.builder()
+            .name("uk2")
+            .columns(ImmutableList.of("phone", "country"))
+            .build();
+    DataGeneratorTable table =
+        baseTable("Users", ImmutableList.of("id"))
+            .columns(ImmutableList.of(intColumn("id")))
+            .uniqueKeys(ImmutableList.of(uk1, uk2))
+            .build();
+    Set<String> names = RowAssembler.uniqueColumnNames(table);
+    assertThat(names).containsExactly("email", "phone", "country");
+  }
+
+  @Test
+  public void uniqueColumnNames_emptyWhenNoUniqueKeys() {
+    DataGeneratorTable table =
+        baseTable("Users", ImmutableList.of("id"))
+            .columns(ImmutableList.of(intColumn("id")))
+            .build();
+    assertThat(RowAssembler.uniqueColumnNames(table)).isEmpty();
+  }
+
+  @Test
+  public void foreignKeyColumns_aggregatesAcrossForeignKeys() {
+    DataGeneratorForeignKey fk1 =
+        DataGeneratorForeignKey.builder()
+            .name("fk1")
+            .referencedTable("Other")
+            .keyColumns(ImmutableList.of("a", "b"))
+            .referencedColumns(ImmutableList.of("x", "y"))
+            .build();
+    DataGeneratorForeignKey fk2 =
+        DataGeneratorForeignKey.builder()
+            .name("fk2")
+            .referencedTable("Third")
+            .keyColumns(ImmutableList.of("c"))
+            .referencedColumns(ImmutableList.of("z"))
+            .build();
+    DataGeneratorTable table =
+        baseTable("Users", ImmutableList.of("id"))
+            .columns(ImmutableList.of(intColumn("id")))
+            .foreignKeys(ImmutableList.of(fk1, fk2))
+            .build();
+    Set<String> cols = RowAssembler.foreignKeyColumns(table);
+    assertThat(cols).containsExactly("a", "b", "c");
+  }
+
+  // ===========================================================================
+  // generateUpdateRow
+  // ===========================================================================
+
+  @Test
+  public void generateUpdateRow_pkPreservedFromArgument() {
+    DataGeneratorTable table =
+        baseTable("T", ImmutableList.of("id"))
+            .columns(ImmutableList.of(intColumn("id"), stringColumn("name", false)))
+            .build();
+    LinkedHashMap<String, Object> pk = new LinkedHashMap<>();
+    pk.put("id", 99L);
+    Row update = RowAssembler.generateUpdateRow(pk, table, /* originalRow= */ null, faker);
+    assertThat((Long) update.getValue("id")).isEqualTo(99L);
+    assertThat(update.getString("name")).isNotEmpty();
+  }
+
+  @Test
+  public void generateUpdateRow_skippedColumnsOmittedFromSchema() {
+    DataGeneratorColumn skipped =
+        DataGeneratorColumn.builder()
+            .name("ghost")
+            .logicalType(LogicalType.STRING)
+            .isGenerated(false)
+            .isNullable(true)
+            .isSkipped(true)
+            .size(null)
+            .precision(null)
+            .scale(null)
+            .build();
+    DataGeneratorTable table =
+        baseTable("T", ImmutableList.of("id"))
+            .columns(ImmutableList.of(intColumn("id"), skipped))
+            .build();
+    LinkedHashMap<String, Object> pk = new LinkedHashMap<>();
+    pk.put("id", 1L);
+    Row update = RowAssembler.generateUpdateRow(pk, table, null, faker);
+    assertThat(update.getSchema().hasField("ghost")).isFalse();
+    assertThat(update.getSchema().hasField("id")).isTrue();
+  }
+
+  @Test
+  public void generateUpdateRow_uniqueColumnsPreservedFromOriginal() {
+    DataGeneratorUniqueKey uk =
+        DataGeneratorUniqueKey.builder().name("uk").columns(ImmutableList.of("email")).build();
+    DataGeneratorTable table =
+        baseTable("T", ImmutableList.of("id"))
+            .columns(ImmutableList.of(intColumn("id"), stringColumn("email", false)))
+            .uniqueKeys(ImmutableList.of(uk))
+            .build();
+
+    Schema origSchema = Schema.builder().addInt64Field("id").addStringField("email").build();
+    Row original = Row.withSchema(origSchema).addValues(1L, "alice@example.com").build();
+
+    LinkedHashMap<String, Object> pk = new LinkedHashMap<>();
+    pk.put("id", 1L);
+    Row update = RowAssembler.generateUpdateRow(pk, table, original, faker);
+    assertThat(update.getString("email")).isEqualTo("alice@example.com");
+  }
+
+  // ===========================================================================
+  // generateDeleteRow
+  // ===========================================================================
+
+  @Test
+  public void generateDeleteRow_pkSetAndOtherColsNull() {
+    DataGeneratorTable table =
+        baseTable("T", ImmutableList.of("id"))
+            .columns(ImmutableList.of(intColumn("id"), stringColumn("name", true)))
+            .build();
+    LinkedHashMap<String, Object> pk = new LinkedHashMap<>();
+    pk.put("id", 5L);
+    Row del = RowAssembler.generateDeleteRow(pk, table);
+    assertThat((Long) del.getValue("id")).isEqualTo(5L);
+    assertThat((Object) del.getValue("name")).isNull();
+  }
+
+  @Test
+  public void generateDeleteRow_skippedColumnOmitted() {
+    DataGeneratorColumn skipped =
+        DataGeneratorColumn.builder()
+            .name("ghost")
+            .logicalType(LogicalType.STRING)
+            .isNullable(true)
+            .isSkipped(true)
+            .isGenerated(false)
+            .size(null)
+            .precision(null)
+            .scale(null)
+            .build();
+    DataGeneratorTable table =
+        baseTable("T", ImmutableList.of("id"))
+            .columns(ImmutableList.of(intColumn("id"), skipped))
+            .build();
+    LinkedHashMap<String, Object> pk = new LinkedHashMap<>();
+    pk.put("id", 5L);
+    Row del = RowAssembler.generateDeleteRow(pk, table);
+    assertThat(del.getSchema().hasField("ghost")).isFalse();
+  }
+
+  // ===========================================================================
+  // createReducedRow
+  // ===========================================================================
+
+  @Test
+  public void createReducedRow_keepsPkFkUniqueAndShardOnly() {
+    DataGeneratorForeignKey fk =
+        DataGeneratorForeignKey.builder()
+            .name("fk1")
+            .referencedTable("P")
+            .keyColumns(ImmutableList.of("parent_id"))
+            .referencedColumns(ImmutableList.of("id"))
+            .build();
+    DataGeneratorUniqueKey uk =
+        DataGeneratorUniqueKey.builder().name("uk").columns(ImmutableList.of("email")).build();
+    DataGeneratorTable table =
+        baseTable("Users", ImmutableList.of("id"))
+            .columns(
+                ImmutableList.of(
+                    intColumn("id"),
+                    intColumn("parent_id"),
+                    stringColumn("email", false),
+                    stringColumn("name", false)))
+            .foreignKeys(ImmutableList.of(fk))
+            .uniqueKeys(ImmutableList.of(uk))
+            .build();
+    Schema fullSchema =
+        Schema.builder()
+            .addInt64Field("id")
+            .addInt64Field("parent_id")
+            .addStringField("email")
+            .addStringField("name")
+            .addStringField(Constants.SHARD_ID_COLUMN_NAME)
+            .build();
+    Row full = Row.withSchema(fullSchema).addValues(1L, 99L, "x@y", "Alice", "shardA").build();
+
+    Row reduced = RowAssembler.createReducedRow(full, table);
+    assertThat(reduced.getSchema().getFieldNames())
+        .containsExactly("id", "parent_id", "email", Constants.SHARD_ID_COLUMN_NAME)
+        .inOrder();
+    assertThat(reduced.getString(Constants.SHARD_ID_COLUMN_NAME)).isEqualTo("shardA");
+    assertThat(reduced.getString("email")).isEqualTo("x@y");
+  }
+
+  @Test
+  public void createReducedRow_omitsShardIdWhenAbsent() {
+    DataGeneratorTable table =
+        baseTable("Users", ImmutableList.of("id"))
+            .columns(ImmutableList.of(intColumn("id")))
+            .build();
+    Schema schema = Schema.builder().addInt64Field("id").build();
+    Row row = Row.withSchema(schema).addValue(1L).build();
+    Row reduced = RowAssembler.createReducedRow(row, table);
+    assertThat(reduced.getSchema().hasField(Constants.SHARD_ID_COLUMN_NAME)).isFalse();
+  }
+
+  // ===========================================================================
+  // completeRow
+  // ===========================================================================
+
+  @Test
+  public void completeRow_returnsSameRowWhenAllColumnsPresent() {
+    DataGeneratorTable table =
+        baseTable("T", ImmutableList.of("id"))
+            .columns(ImmutableList.of(intColumn("id"), stringColumn("name", false)))
+            .build();
+    Schema schema = Schema.builder().addInt64Field("id").addStringField("name").build();
+    Row complete = Row.withSchema(schema).addValues(1L, "Alice").build();
+    Row result = RowAssembler.completeRow(table, complete, faker);
+    assertThat((Long) result.getValue("id")).isEqualTo(1L);
+    assertThat(result.getString("name")).isEqualTo("Alice");
+  }
+
+  @Test
+  public void completeRow_fillsMissingColumnsAndPreservesProvided() {
+    DataGeneratorTable table =
+        baseTable("T", ImmutableList.of("id"))
+            .columns(ImmutableList.of(intColumn("id"), stringColumn("name", false)))
+            .build();
+    Schema partialSchema = Schema.builder().addInt64Field("id").build();
+    Row partial = Row.withSchema(partialSchema).addValue(7L).build();
+    Row full = RowAssembler.completeRow(table, partial, faker);
+    assertThat((Long) full.getValue("id")).isEqualTo(7L);
+    assertThat(full.getString("name")).isNotNull();
+  }
+
+  @Test
+  public void completeRow_preservesShardIdWhenPresent() {
+    DataGeneratorTable table =
+        baseTable("T", ImmutableList.of("id"))
+            .columns(ImmutableList.of(intColumn("id"), stringColumn("name", false)))
+            .build();
+    Schema partialSchema =
+        Schema.builder().addInt64Field("id").addStringField(Constants.SHARD_ID_COLUMN_NAME).build();
+    Row partial = Row.withSchema(partialSchema).addValues(1L, "shardX").build();
+    Row full = RowAssembler.completeRow(table, partial, faker);
+    assertThat(full.getSchema().hasField(Constants.SHARD_ID_COLUMN_NAME)).isTrue();
+    assertThat(full.getString(Constants.SHARD_ID_COLUMN_NAME)).isEqualTo("shardX");
+  }
+
+  @Test
+  public void completeRow_skippedColumnsExcludedFromOutput() {
+    DataGeneratorColumn skipped =
+        DataGeneratorColumn.builder()
+            .name("ghost")
+            .logicalType(LogicalType.STRING)
+            .isNullable(true)
+            .isSkipped(true)
+            .isGenerated(false)
+            .size(null)
+            .precision(null)
+            .scale(null)
+            .build();
+    DataGeneratorTable table =
+        baseTable("T", ImmutableList.of("id"))
+            .columns(ImmutableList.of(intColumn("id"), skipped))
+            .build();
+    Schema partialSchema = Schema.builder().addInt64Field("id").build();
+    Row partial = Row.withSchema(partialSchema).addValue(1L).build();
+    Row full = RowAssembler.completeRow(table, partial, faker);
+    assertThat(full.getSchema().hasField("ghost")).isFalse();
+  }
+
+  // ===========================================================================
+  // helpers
+  // ===========================================================================
+
+  private static DataGeneratorTable.Builder baseTable(String name, ImmutableList<String> pks) {
+    return DataGeneratorTable.builder()
+        .name(name)
+        .columns(ImmutableList.of())
+        .primaryKeys(pks)
+        .foreignKeys(ImmutableList.of())
+        .uniqueKeys(ImmutableList.of())
+        .insertQps(1)
+        .updateQps(0)
+        .deleteQps(0)
+        .isRoot(true)
+        .recordsPerTick(1.0);
+  }
+
+  private static DataGeneratorColumn intColumn(String name) {
+    return DataGeneratorColumn.builder()
+        .name(name)
+        .logicalType(LogicalType.INT64)
+        .isNullable(false)
+        .isSkipped(false)
+        .isGenerated(false)
+        .size(null)
+        .precision(null)
+        .scale(null)
+        .build();
+  }
+
+  private static DataGeneratorColumn stringColumn(String name, boolean nullable) {
+    return DataGeneratorColumn.builder()
+        .name(name)
+        .logicalType(LogicalType.STRING)
+        .isNullable(nullable)
+        .isSkipped(false)
+        .isGenerated(false)
+        .size(20L)
+        .precision(null)
+        .scale(null)
+        .build();
+  }
+}

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/utils/FailureRecordTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/utils/FailureRecordTest.java
@@ -55,14 +55,16 @@ public class FailureRecordTest {
 
   @Test
   public void toJson_primitiveRowFields() {
-    Schema schema = Schema.builder()
-        .addStringField("name")
-        .addInt64Field("age")
-        .addBooleanField("active")
-        .build();
+    Schema schema =
+        Schema.builder()
+            .addStringField("name")
+            .addInt64Field("age")
+            .addBooleanField("active")
+            .build();
     Row row = Row.withSchema(schema).addValues("Alice", 30L, true).build();
 
-    JSONObject obj = new JSONObject(FailureRecord.toJson("T", "UPDATE", row, new RuntimeException("e")));
+    JSONObject obj =
+        new JSONObject(FailureRecord.toJson("T", "UPDATE", row, new RuntimeException("e")));
     JSONObject rowJson = obj.getJSONObject("row");
     assertThat(rowJson.getString("name")).isEqualTo("Alice");
     assertThat(rowJson.getLong("age")).isEqualTo(30L);
@@ -72,9 +74,10 @@ public class FailureRecordTest {
   @Test
   public void toJson_byteArrayFieldHexEncoded() {
     Schema schema = Schema.builder().addByteArrayField("payload").build();
-    Row row = Row.withSchema(schema).addValue(new byte[] { 0x00, 0x0a, (byte) 0xff }).build();
+    Row row = Row.withSchema(schema).addValue(new byte[] {0x00, 0x0a, (byte) 0xff}).build();
 
-    JSONObject obj = new JSONObject(FailureRecord.toJson("T", "INSERT", row, new RuntimeException("e")));
+    JSONObject obj =
+        new JSONObject(FailureRecord.toJson("T", "INSERT", row, new RuntimeException("e")));
     String hex = obj.getJSONObject("row").getString("payload");
     assertThat(hex).isEqualTo("0x000aff");
   }
@@ -82,9 +85,10 @@ public class FailureRecordTest {
   @Test
   public void toJson_byteBufferFieldHexEncoded() {
     Schema schema = Schema.builder().addField("payload", Schema.FieldType.BYTES).build();
-    Row row = Row.withSchema(schema).addValue(ByteBuffer.wrap(new byte[] { 1, 2, 3 })).build();
+    Row row = Row.withSchema(schema).addValue(ByteBuffer.wrap(new byte[] {1, 2, 3})).build();
 
-    JSONObject obj = new JSONObject(FailureRecord.toJson("T", "INSERT", row, new RuntimeException("e")));
+    JSONObject obj =
+        new JSONObject(FailureRecord.toJson("T", "INSERT", row, new RuntimeException("e")));
     String hex = obj.getJSONObject("row").getString("payload");
     assertThat(hex).startsWith("0x");
     assertThat(hex).contains("010203");
@@ -95,7 +99,8 @@ public class FailureRecordTest {
     Schema schema = Schema.builder().addNullableField("name", Schema.FieldType.STRING).build();
     Row row = Row.withSchema(schema).addValue(null).build();
 
-    JSONObject obj = new JSONObject(FailureRecord.toJson("T", "INSERT", row, new RuntimeException("e")));
+    JSONObject obj =
+        new JSONObject(FailureRecord.toJson("T", "INSERT", row, new RuntimeException("e")));
     assertThat(obj.getJSONObject("row").isNull("name")).isTrue();
   }
 
@@ -104,7 +109,8 @@ public class FailureRecordTest {
     Schema schema = Schema.builder().build();
     Row row = Row.withSchema(schema).build();
 
-    JSONObject obj = new JSONObject(FailureRecord.toJson("T", "INSERT", row, new RuntimeException("e")));
+    JSONObject obj =
+        new JSONObject(FailureRecord.toJson("T", "INSERT", row, new RuntimeException("e")));
     JSONObject rowJson = obj.getJSONObject("row");
     assertThat(rowJson.length()).isEqualTo(0);
   }
@@ -138,9 +144,10 @@ public class FailureRecordTest {
 
   @Test
   public void toJson_generationOperation() {
-    JSONObject obj = new JSONObject(
-        FailureRecord.toJson(
-            "T", FailureRecord.OPERATION_GENERATION, null, new RuntimeException("e")));
+    JSONObject obj =
+        new JSONObject(
+            FailureRecord.toJson(
+                "T", FailureRecord.OPERATION_GENERATION, null, new RuntimeException("e")));
     assertThat(obj.getString("operation")).isEqualTo("GENERATION");
   }
 }

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/utils/FailureRecordTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/utils/FailureRecordTest.java
@@ -72,26 +72,25 @@ public class FailureRecordTest {
   }
 
   @Test
-  public void toJson_byteArrayFieldHexEncoded() {
+  public void toJson_byteArrayFieldBase64Encoded() {
     Schema schema = Schema.builder().addByteArrayField("payload").build();
     Row row = Row.withSchema(schema).addValue(new byte[] {0x00, 0x0a, (byte) 0xff}).build();
 
     JSONObject obj =
         new JSONObject(FailureRecord.toJson("T", "INSERT", row, new RuntimeException("e")));
-    String hex = obj.getJSONObject("row").getString("payload");
-    assertThat(hex).isEqualTo("0x000aff");
+    String base64 = obj.getJSONObject("row").getString("payload");
+    assertThat(base64).isEqualTo("AAr/");
   }
 
   @Test
-  public void toJson_byteBufferFieldHexEncoded() {
+  public void toJson_byteBufferFieldBase64Encoded() {
     Schema schema = Schema.builder().addField("payload", Schema.FieldType.BYTES).build();
     Row row = Row.withSchema(schema).addValue(ByteBuffer.wrap(new byte[] {1, 2, 3})).build();
 
     JSONObject obj =
         new JSONObject(FailureRecord.toJson("T", "INSERT", row, new RuntimeException("e")));
-    String hex = obj.getJSONObject("row").getString("payload");
-    assertThat(hex).startsWith("0x");
-    assertThat(hex).contains("010203");
+    String base64 = obj.getJSONObject("row").getString("payload");
+    assertThat(base64).isEqualTo("AQID");
   }
 
   @Test

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/utils/FailureRecordTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/utils/FailureRecordTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.utils;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.nio.ByteBuffer;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.values.Row;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link FailureRecord}. */
+@RunWith(JUnit4.class)
+public class FailureRecordTest {
+
+  @Test
+  public void toJson_topLevelKeys() {
+    String json = FailureRecord.toJson("Users", "INSERT", null, new RuntimeException("boom"));
+    JSONObject obj = new JSONObject(json);
+    assertThat(obj.keySet()).containsExactly("timestamp", "table", "operation", "row", "error");
+    assertThat(obj.getString("table")).isEqualTo("Users");
+    assertThat(obj.getString("operation")).isEqualTo("INSERT");
+  }
+
+  @Test
+  public void toJson_nullRowFlowsThroughAsJsonNull() {
+    String json = FailureRecord.toJson("Users", "INSERT", null, new RuntimeException("err"));
+    JSONObject obj = new JSONObject(json);
+    assertThat(obj.isNull("row")).isTrue();
+  }
+
+  @Test
+  public void toJson_nullTableAndOperation() {
+    String json = FailureRecord.toJson(null, null, null, new RuntimeException("err"));
+    JSONObject obj = new JSONObject(json);
+    assertThat(obj.isNull("table")).isTrue();
+    assertThat(obj.isNull("operation")).isTrue();
+  }
+
+  @Test
+  public void toJson_primitiveRowFields() {
+    Schema schema = Schema.builder()
+        .addStringField("name")
+        .addInt64Field("age")
+        .addBooleanField("active")
+        .build();
+    Row row = Row.withSchema(schema).addValues("Alice", 30L, true).build();
+
+    JSONObject obj = new JSONObject(FailureRecord.toJson("T", "UPDATE", row, new RuntimeException("e")));
+    JSONObject rowJson = obj.getJSONObject("row");
+    assertThat(rowJson.getString("name")).isEqualTo("Alice");
+    assertThat(rowJson.getLong("age")).isEqualTo(30L);
+    assertThat(rowJson.getBoolean("active")).isTrue();
+  }
+
+  @Test
+  public void toJson_byteArrayFieldHexEncoded() {
+    Schema schema = Schema.builder().addByteArrayField("payload").build();
+    Row row = Row.withSchema(schema).addValue(new byte[] { 0x00, 0x0a, (byte) 0xff }).build();
+
+    JSONObject obj = new JSONObject(FailureRecord.toJson("T", "INSERT", row, new RuntimeException("e")));
+    String hex = obj.getJSONObject("row").getString("payload");
+    assertThat(hex).isEqualTo("0x000aff");
+  }
+
+  @Test
+  public void toJson_byteBufferFieldHexEncoded() {
+    Schema schema = Schema.builder().addField("payload", Schema.FieldType.BYTES).build();
+    Row row = Row.withSchema(schema).addValue(ByteBuffer.wrap(new byte[] { 1, 2, 3 })).build();
+
+    JSONObject obj = new JSONObject(FailureRecord.toJson("T", "INSERT", row, new RuntimeException("e")));
+    String hex = obj.getJSONObject("row").getString("payload");
+    assertThat(hex).startsWith("0x");
+    assertThat(hex).contains("010203");
+  }
+
+  @Test
+  public void toJson_nullField() {
+    Schema schema = Schema.builder().addNullableField("name", Schema.FieldType.STRING).build();
+    Row row = Row.withSchema(schema).addValue(null).build();
+
+    JSONObject obj = new JSONObject(FailureRecord.toJson("T", "INSERT", row, new RuntimeException("e")));
+    assertThat(obj.getJSONObject("row").isNull("name")).isTrue();
+  }
+
+  @Test
+  public void toJson_emptyRow() {
+    Schema schema = Schema.builder().build();
+    Row row = Row.withSchema(schema).build();
+
+    JSONObject obj = new JSONObject(FailureRecord.toJson("T", "INSERT", row, new RuntimeException("e")));
+    JSONObject rowJson = obj.getJSONObject("row");
+    assertThat(rowJson.length()).isEqualTo(0);
+  }
+
+  @Test
+  public void toJson_errorIncludesClassMessageAndStack() {
+    RuntimeException ex = new RuntimeException("something failed");
+    JSONObject obj = new JSONObject(FailureRecord.toJson("T", "INSERT", null, ex));
+    JSONObject err = obj.getJSONObject("error");
+    assertThat(err.getString("class")).isEqualTo("java.lang.RuntimeException");
+    assertThat(err.getString("message")).isEqualTo("something failed");
+    assertThat(err.getString("stackTrace")).contains("FailureRecordTest");
+  }
+
+  @Test
+  public void toJson_errorWithNullMessageRendersEmptyString() {
+    RuntimeException ex = new RuntimeException();
+    JSONObject obj = new JSONObject(FailureRecord.toJson("T", "INSERT", null, ex));
+    assertThat(obj.getJSONObject("error").getString("message")).isEmpty();
+  }
+
+  @Test
+  public void toJson_errorWithCausePropagatesStackTrace() {
+    Throwable cause = new IllegalStateException("inner");
+    RuntimeException ex = new RuntimeException("outer", cause);
+    JSONObject obj = new JSONObject(FailureRecord.toJson("T", "INSERT", null, ex));
+    String stack = obj.getJSONObject("error").getString("stackTrace");
+    assertThat(stack).contains("Caused by");
+    assertThat(stack).contains("IllegalStateException");
+  }
+
+  @Test
+  public void toJson_generationOperation() {
+    JSONObject obj = new JSONObject(
+        FailureRecord.toJson(
+            "T", FailureRecord.OPERATION_GENERATION, null, new RuntimeException("e")));
+    assertThat(obj.getString("operation")).isEqualTo("GENERATION");
+  }
+}


### PR DESCRIPTION
## 📝 Description
This PR introduces the `MutationBatcher` and `RowAssembler` components into the `v2/cdc-data-generator` module, separating row synthesis from transient buffering logic. It accumulates and chunks mutations in worker memory based on size limits partitioned per table, shard, and operation type (`INSERT`, `UPDATE`, `DELETE`). 

Additionally, it implements `FailureRecord` to uniformly format serialization/writer errors into JSON lines for dead-letter queue (DLQ) storage.

## Changes

### Core Production Classes
* **`BufferKey.java`** [NEW]: AutoValue key structure for buffer group partitioning.
* **`MutationBatcher.java`** [NEW]: Accumulates rows, drives local thresholds, and manages transactional flushes.
* **`RowAssembler.java`** [NEW]: Pure-function helpers for updating and deleting Beam `Row` assembly.
* **`FailureRecord.java`** [NEW]: Uniform serialization wrapper for DLQ errors.
* **`DataGeneratorUtils.java`** [MODIFY]: Embedded hex conversion helpers (`canonicalizeValue`, `bytesToHex`).

### Unit Test Suites
* **`MutationBatcherTest.java`** [NEW]: Validates batch thresholds, selective update flushes, and custom connection constraints.
* **`RowAssemblerTest.java`** [NEW]: Asserts field schema mapping rules.
* **`FailureRecordTest.java`** [NEW]: Verifies JSON conversion attributes across raw byte arrays and nulls.
