### PR TITLE
[CassandraIOTest] add retry logic for embedded Cassandra startup in CassandraIOTest

### DIFF
--- a/v2/sourcedb-to-spanner/src/test/java/org/apache/beam/sdk/io/localcassandra/CassandraIOTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/org/apache/beam/sdk/io/localcassandra/CassandraIOTest.java
@@ -111,7 +111,19 @@ public class CassandraIOTest implements Serializable {
    */
   @BeforeClass
   public static void beforeClass() throws Exception {
-    embeddedCassandra = new EmbeddedCassandra("/CassandraUT/beamUTConfig.yaml", null, false);
+    int maxRetries = 3;
+    for (int i = 0; i < maxRetries; i++) {
+      try {
+        embeddedCassandra = new EmbeddedCassandra("/CassandraUT/beamUTConfig.yaml", null, false);
+        break;
+      } catch (Exception e) {
+        LOG.warn("Failed to start Embedded Cassandra on attempt {}. Retrying...", i + 1, e);
+        if (i == maxRetries - 1) {
+          throw e;
+        }
+        Thread.sleep(1000);
+      }
+    }
     jmxPort = NetworkTestHelper.getAvailableLocalPort();
     cassandraInetSocketAddress = embeddedCassandra.getContactPoints().get(0);
     cassandraHost = cassandraInetSocketAddress.getHostString();

--- a/v2/sourcedb-to-spanner/src/test/java/org/apache/beam/sdk/io/localcassandra/CassandraIOTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/org/apache/beam/sdk/io/localcassandra/CassandraIOTest.java
@@ -83,6 +83,8 @@ import org.slf4j.LoggerFactory;
 })
 public class CassandraIOTest implements Serializable {
   private static final long NUM_ROWS = 22L;
+  private static final int MAX_RETRIES = 3;
+  private static final int RETRY_DELAY_MS = 1000;
   private static final String CASSANDRA_KEYSPACE = "beam_ks";
   private static String cassandraHost = "127.0.0.1";
   private static InetSocketAddress cassandraInetSocketAddress;
@@ -111,17 +113,17 @@ public class CassandraIOTest implements Serializable {
    */
   @BeforeClass
   public static void beforeClass() throws Exception {
-    int maxRetries = 3;
-    for (int i = 0; i < maxRetries; i++) {
+    for (int i = 0; i < MAX_RETRIES; i++) {
       try {
         embeddedCassandra = new EmbeddedCassandra("/CassandraUT/beamUTConfig.yaml", null, false);
         break;
       } catch (Exception e) {
-        LOG.warn("Failed to start Embedded Cassandra on attempt {}. Retrying...", i + 1, e);
-        if (i == maxRetries - 1) {
+        if (i == MAX_RETRIES - 1) {
+          LOG.error("Failed to start Embedded Cassandra on final attempt.", e);
           throw e;
         }
-        Thread.sleep(1000);
+        LOG.warn("Failed to start Embedded Cassandra on attempt {}. Retrying...", i + 1, e);
+        Thread.sleep(RETRY_DELAY_MS);
       }
     }
     jmxPort = NetworkTestHelper.getAvailableLocalPort();


### PR DESCRIPTION
This PR adds a retry mechanism to the embedded Cassandra startup in CassandraIOTest to mitigate test flakiness caused by transient port conflicts.

When running tests that spin up embedded services, port collisions can occur if a previously used port is still in TIME_WAIT or if another process briefly claims a randomly selected port. This change attempts to start the embedded Cassandra instance up to 3 times before failing the test.

The workflow example where the failure occurred: https://github.com/GoogleCloudPlatform/DataflowTemplates/actions/runs/25410517913/job/74531124148

The failure stacktrace:
```
Error:  Errors: 
Error:  org.apache.beam.sdk.io.localcassandra.CassandraIOTest.<beforeAll>
Error:    Run 1: CassandraIOTest.beforeClass:114 » Cassandra Unable to await DefaultCassandra{name='cassandra-6', version='5.0.6'}. Caused by: java.io.IOException: 'UnixCassandraDatabase{process=Process[pid=3742779, exitValue=1]}' is not alive. Please see logs for more details.
```

```
ERROR [main] 2026-05-06 00:59:26,803 CassandraDaemon.java:887 - Fatal configuration error
org.apache.cassandra.exceptions.ConfigurationException: localhost/127.0.0.1:41489 is in use by another process.  Change listen_address:storage_port in cassandra.yaml to values that do not conflict with other services
	at org.apache.cassandra.net.InboundConnectionInitiator.bind(InboundConnectionInitiator.java:193)
	at org.apache.cassandra.net.InboundConnectionInitiator.bind(InboundConnectionInitiator.java:213)
	at org.apache.cassandra.net.InboundSockets$InboundSocket.open(InboundSockets.java:103)
	at org.apache.cassandra.net.InboundSockets$InboundSocket.open(InboundSockets.java:90)
	at org.apache.cassandra.net.InboundSockets.open(InboundSockets.java:261)
	at org.apache.cassandra.net.MessagingService.listen(MessagingService.java:696)
	at org.apache.cassandra.service.StorageService.prepareToJoin(StorageService.java:1153)
	at org.apache.cassandra.service.StorageService.initServer(StorageService.java:1017)
	at org.apache.cassandra.service.StorageService.initServer(StorageService.java:947)
	at org.apache.cassandra.service.CassandraDaemon.setup(CassandraDaemon.java:383)
	at org.apache.cassandra.service.CassandraDaemon.activate(CassandraDaemon.java:727)
	at org.apache.cassandra.service.CassandraDaemon.main(CassandraDaemon.java:865)
```