### PR TITLE
Observability enhancement of DataStreamMongoDBToFirestore template 

### DIFF
--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
@@ -69,6 +69,8 @@ import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.StreamingOptions;
@@ -928,12 +930,38 @@ public class DataStreamMongoDBToFirestore {
     PCollection<FailsafeElement<String, String>> dlqJsonRecords =
         reconsumedElements
             .get(DeadLetterQueueManager.RETRYABLE_ERRORS)
-            .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+            .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))
+            .apply(
+                "Count DLQ Retries",
+                ParDo.of(
+                    new DoFn<FailsafeElement<String, String>, FailsafeElement<String, String>>() {
+                      private final Counter dlqRetries =
+                          Metrics.counter(DataStreamMongoDBToFirestore.class, "dlqRetries");
+
+                      @ProcessElement
+                      public void processElement(ProcessContext c) {
+                        dlqRetries.inc();
+                        c.output(c.element());
+                      }
+                    }));
 
     // Write non-retryable errors to DLQ
     reconsumedElements
         .get(DeadLetterQueueManager.PERMANENT_ERRORS)
         .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))
+        .apply(
+            "Count Permanent Failures",
+            ParDo.of(
+                new DoFn<FailsafeElement<String, String>, FailsafeElement<String, String>>() {
+                  private final Counter permanentFailures =
+                      Metrics.counter(DataStreamMongoDBToFirestore.class, "permanentFailures");
+
+                  @ProcessElement
+                  public void processElement(ProcessContext c) {
+                    permanentFailures.inc();
+                    c.output(c.element());
+                  }
+                }))
         .apply(
             "Write new non-retryable errors To DLQ",
             MapElements.via(new StringDeadLetterQueueSanitizer()))
@@ -1136,6 +1164,13 @@ public class DataStreamMongoDBToFirestore {
     private transient Map<String, MongoCollection<Document>> collectionMap;
     private transient MongoClient client;
 
+    private final Counter successfulWrites =
+        Metrics.counter(ProcessBackfillEventFn.class, "successfulWrites");
+    private final Counter retriableFailedWrites =
+        Metrics.counter(ProcessBackfillEventFn.class, "retriableFailedWrites");
+    private final Counter severeFailedWrites =
+        Metrics.counter(ProcessBackfillEventFn.class, "severeFailedWrites");
+
     public ProcessBackfillEventFn(String connectionString, String databaseName, int batchSize) {
       this.connectionString = connectionString;
       this.targetDatabaseName = databaseName;
@@ -1265,6 +1300,7 @@ public class DataStreamMongoDBToFirestore {
         // Output successful events
         for (MongoDbChangeEventContext event : events) {
           out.get(successfulWriteTag).output(event);
+          successfulWrites.inc();
         }
       } catch (MongoBulkWriteException e) {
         LOG.warn(
@@ -1284,8 +1320,10 @@ public class DataStreamMongoDBToFirestore {
           // limit)
           if (error.getCode() == ProcessChangeEventFn.INVALID_ARGUMENT) {
             out.get(severeFailedWriteTag).output(failedElement);
+            severeFailedWrites.inc();
           } else {
             out.get(failedWriteTag).output(failedElement);
+            retriableFailedWrites.inc();
           }
         }
 
@@ -1293,6 +1331,7 @@ public class DataStreamMongoDBToFirestore {
         for (int i = 0; i < events.size(); i++) {
           if (!failedIndices.contains(i)) {
             out.get(successfulWriteTag).output(events.get(i));
+            successfulWrites.inc();
           }
         }
       } catch (Exception e) {
@@ -1309,6 +1348,7 @@ public class DataStreamMongoDBToFirestore {
           failedElement.setErrorMessage(e.getMessage());
           failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
           out.get(failedWriteTag).output(failedElement);
+          retriableFailedWrites.inc();
         }
       }
 
@@ -1358,6 +1398,7 @@ public class DataStreamMongoDBToFirestore {
         // Output successful events
         for (MongoDbChangeEventContext event : events) {
           context.output(successfulWriteTag, event, Instant.now(), GlobalWindow.INSTANCE);
+          successfulWrites.inc();
         }
       } catch (MongoBulkWriteException e) {
         LOG.warn(
@@ -1378,8 +1419,10 @@ public class DataStreamMongoDBToFirestore {
           if (error.getCode() == ProcessChangeEventFn.INVALID_ARGUMENT) {
             context.output(
                 severeFailedWriteTag, failedElement, Instant.now(), GlobalWindow.INSTANCE);
+            severeFailedWrites.inc();
           } else {
             context.output(failedWriteTag, failedElement, Instant.now(), GlobalWindow.INSTANCE);
+            retriableFailedWrites.inc();
           }
         }
 
@@ -1387,6 +1430,7 @@ public class DataStreamMongoDBToFirestore {
         for (int i = 0; i < events.size(); i++) {
           if (!failedIndices.contains(i)) {
             context.output(successfulWriteTag, events.get(i), Instant.now(), GlobalWindow.INSTANCE);
+            successfulWrites.inc();
           }
         }
       } catch (Exception e) {
@@ -1403,6 +1447,7 @@ public class DataStreamMongoDBToFirestore {
           failedElement.setErrorMessage(e.getMessage());
           failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
           context.output(failedWriteTag, failedElement, Instant.now(), GlobalWindow.INSTANCE);
+          retriableFailedWrites.inc();
         }
       }
 

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/CreateMongoDbChangeEventContextFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/CreateMongoDbChangeEventContextFn.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.teleport.v2.templates.datastream.MongoDbChangeEventContext;
 import com.google.cloud.teleport.v2.values.FailsafeElement;
 import com.google.common.base.Throwables;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.values.TupleTag;
 import org.slf4j.Logger;
@@ -39,6 +41,8 @@ public class CreateMongoDbChangeEventContextFn
       new TupleTag<>("failedCreation");
 
   private final String shadowCollectionPrefix;
+  private final Counter contextCreationFailures =
+      Metrics.counter(CreateMongoDbChangeEventContextFn.class, "contextCreationFailures");
 
   public CreateMongoDbChangeEventContextFn(String shadowCollectionPrefix) {
     this.shadowCollectionPrefix = shadowCollectionPrefix;
@@ -57,6 +61,7 @@ public class CreateMongoDbChangeEventContextFn
       element.setErrorMessage(e.getMessage());
       element.setStacktrace(Throwables.getStackTraceAsString(e));
       out.get(failedCreationTag).output(element);
+      contextCreationFailures.inc();
       LOG.info("Failed element sent to DLQ");
     }
   }

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
@@ -175,9 +175,8 @@ public class ProcessChangeEventFn
         // Check if the error is permanent (e.g. code 2 for InvalidArgument when exceeding nesting
         // limit)
         boolean isPermanent = false;
-        if (e instanceof MongoWriteException) {
-          MongoWriteException mwe = (MongoWriteException) e;
-          if (mwe.getError().getCode() == INVALID_ARGUMENT) {
+        if (e instanceof MongoWriteException writeException) {
+          if (writeException.getError().getCode() == INVALID_ARGUMENT) {
             isPermanent = true;
           }
         }
@@ -198,13 +197,12 @@ public class ProcessChangeEventFn
           out.get(severeFailedWriteTag).output(failedElement);
 
           String errorIdentifier = "UnknownError";
-          if (e instanceof MongoWriteException) {
-            errorIdentifier = "WriteErrorCode_" + ((MongoWriteException) e).getError().getCode();
-          } else if (e instanceof com.mongodb.MongoCommandException) {
-            errorIdentifier =
-                "CommandErrorCode_" + ((com.mongodb.MongoCommandException) e).getCode();
-          } else if (e instanceof MongoException) {
-            errorIdentifier = e.getClass().getSimpleName();
+          if (e instanceof MongoWriteException writeException) {
+            errorIdentifier = "MongoWriteException_" + writeException.getError().getCode();
+          } else if (e instanceof com.mongodb.MongoCommandException commandException) {
+            errorIdentifier = "MongoCommandException_" + commandException.getCode();
+          } else if (e instanceof MongoException mongoException) {
+            errorIdentifier = mongoException.getClass().getSimpleName();
           }
           Metrics.counter(ProcessChangeEventFn.class, "severeFailedWrite_" + errorIdentifier).inc();
 
@@ -217,13 +215,12 @@ public class ProcessChangeEventFn
           inMemoryRetries.inc();
 
           String errorIdentifier = "UnknownError";
-          if (e instanceof MongoWriteException) {
-            errorIdentifier = "WriteErrorCode_" + ((MongoWriteException) e).getError().getCode();
-          } else if (e instanceof com.mongodb.MongoCommandException) {
-            errorIdentifier =
-                "CommandErrorCode_" + ((com.mongodb.MongoCommandException) e).getCode();
-          } else if (e instanceof MongoException) {
-            errorIdentifier = e.getClass().getSimpleName();
+          if (e instanceof MongoWriteException writeException) {
+            errorIdentifier = "MongoWriteException_" + writeException.getError().getCode();
+          } else if (e instanceof com.mongodb.MongoCommandException commandException) {
+            errorIdentifier = "MongoCommandException_" + commandException.getCode();
+          } else if (e instanceof MongoException mongoException) {
+            errorIdentifier = mongoException.getClass().getSimpleName();
           }
           Metrics.counter(ProcessChangeEventFn.class, "inMemoryRetry_" + errorIdentifier).inc();
 

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
@@ -204,7 +204,8 @@ public class ProcessChangeEventFn
           } else if (e instanceof MongoException mongoException) {
             errorIdentifier = mongoException.getClass().getSimpleName();
           }
-          Metrics.counter(ProcessChangeEventFn.class, "severeFailedWrite_" + errorIdentifier).inc();
+          Metrics.counter(ProcessChangeEventFn.class, "severeFailedWrites_" + errorIdentifier)
+              .inc();
 
           severeFailedWrites.inc();
           break; // Exit the retry loop
@@ -222,7 +223,7 @@ public class ProcessChangeEventFn
           } else if (e instanceof MongoException mongoException) {
             errorIdentifier = mongoException.getClass().getSimpleName();
           }
-          Metrics.counter(ProcessChangeEventFn.class, "inMemoryRetry_" + errorIdentifier).inc();
+          Metrics.counter(ProcessChangeEventFn.class, "inMemoryRetries_" + errorIdentifier).inc();
 
           LOG.warn(
               "Transient transaction error encountered for document ID: {}, attempt: {}. Retrying in {} ms...",

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
@@ -75,6 +75,10 @@ public class ProcessChangeEventFn
       Metrics.counter(ProcessChangeEventFn.class, "totalProcessedDocuments");
   private final Counter retriedDocuments =
       Metrics.counter(ProcessChangeEventFn.class, "retriedDocuments");
+  private final Counter inMemoryRetries =
+      Metrics.counter(ProcessChangeEventFn.class, "inMemoryRetries");
+  private final Counter outOfOrderSkips =
+      Metrics.counter(ProcessChangeEventFn.class, "outOfOrderSkips");
 
   public ProcessChangeEventFn(String connectionString, String databaseName) {
     this.connectionString = connectionString;
@@ -142,12 +146,13 @@ public class ProcessChangeEventFn
                 element.getShadowDocument(),
                 new ReplaceOptions().upsert(true));
           }
+          successfulWrites.inc();
         } else {
           // Existing document has a later timestamp, skip this event
+          outOfOrderSkips.inc();
         }
         session.commitTransaction();
         out.get(successfulWriteTag).output(element);
-        successfulWrites.inc();
         break; // Exit the retry loop on success
       } catch (Exception e) {
         lastException = e;
@@ -191,12 +196,37 @@ public class ProcessChangeEventFn
           failedElement.setErrorMessage(e.getMessage());
           failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
           out.get(severeFailedWriteTag).output(failedElement);
+
+          String errorIdentifier = "UnknownError";
+          if (e instanceof MongoWriteException) {
+            errorIdentifier = "WriteErrorCode_" + ((MongoWriteException) e).getError().getCode();
+          } else if (e instanceof com.mongodb.MongoCommandException) {
+            errorIdentifier =
+                "CommandErrorCode_" + ((com.mongodb.MongoCommandException) e).getCode();
+          } else if (e instanceof MongoException) {
+            errorIdentifier = e.getClass().getSimpleName();
+          }
+          Metrics.counter(ProcessChangeEventFn.class, "severeFailedWrite_" + errorIdentifier).inc();
+
           severeFailedWrites.inc();
           break; // Exit the retry loop
         }
 
         long backoffMs = retryDelayMs * (1 << retryCount);
         if (retryCount < maxRetries) {
+          inMemoryRetries.inc();
+
+          String errorIdentifier = "UnknownError";
+          if (e instanceof MongoWriteException) {
+            errorIdentifier = "WriteErrorCode_" + ((MongoWriteException) e).getError().getCode();
+          } else if (e instanceof com.mongodb.MongoCommandException) {
+            errorIdentifier =
+                "CommandErrorCode_" + ((com.mongodb.MongoCommandException) e).getCode();
+          } else if (e instanceof MongoException) {
+            errorIdentifier = e.getClass().getSimpleName();
+          }
+          Metrics.counter(ProcessChangeEventFn.class, "inMemoryRetry_" + errorIdentifier).inc();
+
           LOG.warn(
               "Transient transaction error encountered for document ID: {}, attempt: {}. Retrying in {} ms...",
               element.getDocumentId(),

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
@@ -31,6 +31,8 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.ReplaceOptions;
 import java.util.concurrent.TimeUnit;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.values.TupleTag;
 import org.bson.Document;
@@ -62,6 +64,18 @@ public class ProcessChangeEventFn
   // Error code 2 corresponds to BadValue/InvalidArgument, which is treated as a permanent error.
   public static final int INVALID_ARGUMENT = 2;
 
+  private final Counter successfulWrites =
+      Metrics.counter(ProcessChangeEventFn.class, "successfulWrites");
+  private final Counter retriableFailedWrites =
+      Metrics.counter(ProcessChangeEventFn.class, "retriableFailedWrites");
+  private final Counter severeFailedWrites =
+      Metrics.counter(ProcessChangeEventFn.class, "severeFailedWrites");
+  private final Counter dlqRetries = Metrics.counter(ProcessChangeEventFn.class, "dlqRetries");
+  private final Counter totalProcessedDocuments =
+      Metrics.counter(ProcessChangeEventFn.class, "totalProcessedDocuments");
+  private final Counter retriedDocuments =
+      Metrics.counter(ProcessChangeEventFn.class, "retriedDocuments");
+
   public ProcessChangeEventFn(String connectionString, String databaseName) {
     this.connectionString = connectionString;
     this.targetDatabaseName = databaseName;
@@ -76,6 +90,15 @@ public class ProcessChangeEventFn
   @ProcessElement
   public void processElement(ProcessContext context, MultiOutputReceiver out) {
     MongoDbChangeEventContext element = context.element();
+
+    totalProcessedDocuments.inc();
+    if (element.getRetryCount() > 0) {
+      retriedDocuments.inc();
+    }
+    if (element.getIsDlqReconsumed()) {
+      dlqRetries.inc();
+    }
+
     int retryCount = 0;
     Exception lastException = null;
     while (retryCount <= maxRetries) {
@@ -124,6 +147,7 @@ public class ProcessChangeEventFn
         }
         session.commitTransaction();
         out.get(successfulWriteTag).output(element);
+        successfulWrites.inc();
         break; // Exit the retry loop on success
       } catch (Exception e) {
         lastException = e;
@@ -167,18 +191,20 @@ public class ProcessChangeEventFn
           failedElement.setErrorMessage(e.getMessage());
           failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
           out.get(severeFailedWriteTag).output(failedElement);
+          severeFailedWrites.inc();
           break; // Exit the retry loop
         }
 
+        long backoffMs = retryDelayMs * (1 << retryCount);
         if (retryCount < maxRetries) {
           LOG.warn(
               "Transient transaction error encountered for document ID: {}, attempt: {}. Retrying in {} ms...",
               element.getDocumentId(),
               retryCount + 1,
-              retryDelayMs * (retryCount + 1),
+              backoffMs,
               e);
           try {
-            TimeUnit.MILLISECONDS.sleep(retryDelayMs * (retryCount + 1));
+            TimeUnit.MILLISECONDS.sleep(backoffMs);
           } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             LOG.error("Retry sleep interrupted for document ID: {}", element.getDocumentId(), ie);
@@ -187,6 +213,7 @@ public class ProcessChangeEventFn
             failedElement.setErrorMessage(ie.getMessage());
             failedElement.setStacktrace(Throwables.getStackTraceAsString(ie));
             out.get(failedWriteTag).output(failedElement);
+            retriableFailedWrites.inc();
             break; // Exit the retry loop if interrupted
           }
           retryCount++;
@@ -202,6 +229,7 @@ public class ProcessChangeEventFn
           failedElement.setErrorMessage(e.getMessage());
           failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
           out.get(failedWriteTag).output(failedElement);
+          retriableFailedWrites.inc();
           LOG.info("Failed element of id {} sent to DLQ", element.getDocumentId());
           break; // Exit the retry loop on non-transient error or max retries
         }

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
@@ -334,6 +334,27 @@ public class ProcessChangeEventFnTest {
     verify(mockReceiver).get(ProcessChangeEventFn.failedWriteTag);
     verify(mockFailureReceiver, times(1)).output(failureCaptor.capture());
     verify(mockSession, never()).commitTransaction();
+
+    MetricsContainerImpl container =
+        (MetricsContainerImpl) MetricsEnvironment.getCurrentContainer();
+    assertEquals(
+        1L,
+        (long)
+            container
+                .getCounter(MetricName.named(ProcessChangeEventFn.class, "totalProcessedDocuments"))
+                .getCumulative());
+    assertEquals(
+        3L,
+        (long)
+            container
+                .getCounter(MetricName.named(ProcessChangeEventFn.class, "inMemoryRetries"))
+                .getCumulative());
+    assertEquals(
+        1L,
+        (long)
+            container
+                .getCounter(MetricName.named(ProcessChangeEventFn.class, "retriableFailedWrites"))
+                .getCumulative());
   }
 
   @Test
@@ -352,6 +373,21 @@ public class ProcessChangeEventFnTest {
     verify(mockReceiver).get(ProcessChangeEventFn.severeFailedWriteTag);
     verify(mockSevereFailureReceiver, times(1)).output(any());
     verify(mockSession, never()).commitTransaction();
+
+    MetricsContainerImpl container =
+        (MetricsContainerImpl) MetricsEnvironment.getCurrentContainer();
+    assertEquals(
+        1L,
+        (long)
+            container
+                .getCounter(MetricName.named(ProcessChangeEventFn.class, "totalProcessedDocuments"))
+                .getCumulative());
+    assertEquals(
+        1L,
+        (long)
+            container
+                .getCounter(MetricName.named(ProcessChangeEventFn.class, "severeFailedWrites"))
+                .getCumulative());
   }
 
   @Test
@@ -372,6 +408,21 @@ public class ProcessChangeEventFnTest {
     verify(mockSession).commitTransaction();
     verify(mockReceiver).get(ProcessChangeEventFn.successfulWriteTag);
     verify(mockSuccessReceiver, times(1)).output(any());
+
+    MetricsContainerImpl container =
+        (MetricsContainerImpl) MetricsEnvironment.getCurrentContainer();
+    assertEquals(
+        1L,
+        (long)
+            container
+                .getCounter(MetricName.named(ProcessChangeEventFn.class, "totalProcessedDocuments"))
+                .getCumulative());
+    assertEquals(
+        1L,
+        (long)
+            container
+                .getCounter(MetricName.named(ProcessChangeEventFn.class, "dlqRetries"))
+                .getCumulative());
   }
 
   @Test

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.transforms;
 
 import static com.mongodb.client.model.Filters.eq;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -36,6 +37,9 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
+import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
+import org.apache.beam.sdk.metrics.MetricName;
+import org.apache.beam.sdk.metrics.MetricsEnvironment;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFn.MultiOutputReceiver;
 import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
@@ -78,6 +82,10 @@ public class ProcessChangeEventFnTest {
 
   @Before
   public void setUp() throws Exception {
+    MetricsContainerImpl container = new MetricsContainerImpl(null);
+    MetricsEnvironment.setProcessWideContainer(container);
+    MetricsEnvironment.setCurrentContainer(container);
+
     mockContext = mock(DoFn.ProcessContext.class);
     mockReceiver = mock(MultiOutputReceiver.class);
     mockSuccessReceiver = mock(OutputReceiver.class);
@@ -152,6 +160,21 @@ public class ProcessChangeEventFnTest {
     verify(mockReceiver).get(ProcessChangeEventFn.successfulWriteTag);
     verify(mockSuccessReceiver, times(1)).output(successCaptor.capture());
     verify(mockSession, never()).abortTransaction();
+
+    MetricsContainerImpl container =
+        (MetricsContainerImpl) MetricsEnvironment.getCurrentContainer();
+    assertEquals(
+        1L,
+        (long)
+            container
+                .getCounter(MetricName.named(ProcessChangeEventFn.class, "successfulWrites"))
+                .getCumulative());
+    assertEquals(
+        1L,
+        (long)
+            container
+                .getCounter(MetricName.named(ProcessChangeEventFn.class, "totalProcessedDocuments"))
+                .getCumulative());
   }
 
   @Test
@@ -191,6 +214,27 @@ public class ProcessChangeEventFnTest {
     verify(mockReceiver).get(ProcessChangeEventFn.successfulWriteTag);
     verify(mockSuccessReceiver, times(1)).output(successCaptor.capture());
     verify(mockSession, never()).abortTransaction();
+
+    MetricsContainerImpl container =
+        (MetricsContainerImpl) MetricsEnvironment.getCurrentContainer();
+    assertEquals(
+        0L,
+        (long)
+            container
+                .getCounter(MetricName.named(ProcessChangeEventFn.class, "successfulWrites"))
+                .getCumulative());
+    assertEquals(
+        1L,
+        (long)
+            container
+                .getCounter(MetricName.named(ProcessChangeEventFn.class, "totalProcessedDocuments"))
+                .getCumulative());
+    assertEquals(
+        1L,
+        (long)
+            container
+                .getCounter(MetricName.named(ProcessChangeEventFn.class, "outOfOrderSkips"))
+                .getCumulative());
   }
 
   @Test
@@ -328,5 +372,67 @@ public class ProcessChangeEventFnTest {
     verify(mockSession).commitTransaction();
     verify(mockReceiver).get(ProcessChangeEventFn.successfulWriteTag);
     verify(mockSuccessReceiver, times(1)).output(any());
+  }
+
+  @Test
+  public void testProcessElementTransientWriteError_retry() {
+    WriteError writeError = new WriteError(11000, "Duplicate key", new org.bson.BsonDocument());
+    MongoWriteException writeException =
+        new MongoWriteException(writeError, new com.mongodb.ServerAddress("localhost", 27017));
+    writeException.addLabel("TransientTransactionError");
+
+    when(mockShadowCollection.find(mockSession, LOOKUP_BY_DOC_ID))
+        .thenThrow(writeException)
+        .thenReturn(mockFindIterable);
+    when(mockFindIterable.first()).thenReturn(mockShadowDocOlder);
+
+    UpdateResult mockUpdateResult = mock(UpdateResult.class);
+    when(mockDataCollection.replaceOne(any(), any(), any(), any())).thenReturn(mockUpdateResult);
+    when(mockShadowCollection.replaceOne(any(), any(), any(), any())).thenReturn(mockUpdateResult);
+
+    processFn.processElement(mockContext, mockReceiver);
+
+    verify(mockShadowCollection, times(2)).find(mockSession, LOOKUP_BY_DOC_ID);
+    verify(mockReceiver).get(ProcessChangeEventFn.successfulWriteTag);
+  }
+
+  @Test
+  public void testProcessElementTransientCommandError_retry() {
+    org.bson.BsonDocument response = new org.bson.BsonDocument("code", new org.bson.BsonInt32(123));
+    com.mongodb.MongoCommandException commandException =
+        new com.mongodb.MongoCommandException(
+            response, new com.mongodb.ServerAddress("localhost", 27017));
+    commandException.addLabel("TransientTransactionError");
+
+    when(mockShadowCollection.find(mockSession, LOOKUP_BY_DOC_ID))
+        .thenThrow(commandException)
+        .thenReturn(mockFindIterable);
+    when(mockFindIterable.first()).thenReturn(mockShadowDocOlder);
+
+    UpdateResult mockUpdateResult = mock(UpdateResult.class);
+    when(mockDataCollection.replaceOne(any(), any(), any(), any())).thenReturn(mockUpdateResult);
+    when(mockShadowCollection.replaceOne(any(), any(), any(), any())).thenReturn(mockUpdateResult);
+
+    processFn.processElement(mockContext, mockReceiver);
+
+    verify(mockShadowCollection, times(2)).find(mockSession, LOOKUP_BY_DOC_ID);
+    verify(mockReceiver).get(ProcessChangeEventFn.successfulWriteTag);
+  }
+
+  @Test
+  public void testProcessElementSevereCommandError() {
+    org.bson.BsonDocument response = new org.bson.BsonDocument("code", new org.bson.BsonInt32(123));
+    com.mongodb.MongoCommandException commandException =
+        new com.mongodb.MongoCommandException(
+            response, new com.mongodb.ServerAddress("localhost", 27017));
+
+    when(mockShadowCollection.find(mockSession, LOOKUP_BY_DOC_ID)).thenThrow(commandException);
+
+    processFn.processElement(mockContext, mockReceiver);
+
+    verify(mockShadowCollection, times(1)).find(mockSession, LOOKUP_BY_DOC_ID);
+    verify(mockReceiver).get(ProcessChangeEventFn.severeFailedWriteTag);
+    verify(mockSevereFailureReceiver, times(1)).output(any());
+    verify(mockSession, never()).commitTransaction();
   }
 }

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
@@ -309,4 +309,24 @@ public class ProcessChangeEventFnTest {
     verify(mockSevereFailureReceiver, times(1)).output(any());
     verify(mockSession, never()).commitTransaction();
   }
+
+  @Test
+  public void testProcessElementDlqReconsumed() {
+    when(mockFindIterable.first()).thenReturn(null);
+    when(mockElement.getIsDlqReconsumed()).thenReturn(true);
+    UpdateResult mockUpdateResult = mock(UpdateResult.class);
+    when(mockDataCollection.replaceOne(
+            mockSession, LOOKUP_BY_DOC_ID, mockDataDoc, new ReplaceOptions().upsert(true)))
+        .thenReturn(mockUpdateResult);
+    when(mockShadowCollection.replaceOne(
+            mockSession, LOOKUP_BY_DOC_ID, mockShadowDocElement, new ReplaceOptions().upsert(true)))
+        .thenReturn(mockUpdateResult);
+
+    processFn.processElement(mockContext, mockReceiver);
+
+    verify(mockShadowCollection).find(mockSession, LOOKUP_BY_DOC_ID);
+    verify(mockSession).commitTransaction();
+    verify(mockReceiver).get(ProcessChangeEventFn.successfulWriteTag);
+    verify(mockSuccessReceiver, times(1)).output(any());
+  }
 }


### PR DESCRIPTION
Added counters for successful write and retry breakdown.

* `totalProcessedDocuments` counts all documents being processed, include those being skipped or being written.
* `successfulWrites` counts all the real writes that went through in the execution so far, the skipped ones are not counted.
* `outOfOrderSkips` counts the number of records skipped in write due to the order is older than the current version. This is managed by the shadow table as part of the conflict resolving.
* `inMemoryRetries` counts all the retries happened in memory. There's also a counter for each different exception and error code in format of `inMemoryRetries_<exception>_<code>` to reflect the distribution of the reason of retries.
* `severeFailedWrites` counts the non-retriable failures happened so far, similar to `inMemoryRetries`, it also has an exception + error code break down. 
* `contextCreationFailures` counts the non-retriable Json parsing errors, mostly indicates something unexpected or unsupported in the source data.
* `retriedDocuments` counts the document being written and retried via DLQ.
* `dlqRetries` counts the number of element retries performed by the DLQ.
* `permanentFailures` counts the element that exhausted all DLQ retries and goes to severe DLQ.

Example
* https://screenshot.googleplex.com/3tVgz5ukJoWSnBX (used old exception name but has the most variety of counters)
* https://screenshot.googleplex.com/7X9egw59jnLUQt2 (latest version of exception name)