### PR TITLE
Update UDF pipeline to only process the data field of an event

### DIFF
--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
@@ -18,6 +18,8 @@ package com.google.cloud.teleport.v2.templates;
 import static com.mongodb.client.model.Filters.eq;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.cloud.teleport.metadata.Template;
 import com.google.cloud.teleport.metadata.TemplateCategory;
 import com.google.cloud.teleport.metadata.TemplateParameter;
@@ -77,6 +79,7 @@ import org.apache.beam.sdk.options.StreamingOptions;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Flatten;
 import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Reshuffle;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
@@ -134,8 +137,10 @@ import org.slf4j.LoggerFactory;
 public class DataStreamMongoDBToFirestore {
 
   private static final Logger LOG = LoggerFactory.getLogger(DataStreamMongoDBToFirestore.class);
-  private static final TupleTag<FailsafeElement<String, String>> UDF_SUCCESS_TAG = new TupleTag<>();
-  private static final TupleTag<FailsafeElement<String, String>> UDF_FAILURE_TAG = new TupleTag<>();
+  static final TupleTag<FailsafeElement<String, String>> UDF_SUCCESS_TAG = new TupleTag<>();
+  static final TupleTag<FailsafeElement<String, String>> UDF_FAILURE_TAG = new TupleTag<>();
+  static final TupleTag<FailsafeElement<String, String>> PREPARE_FAILURE_TAG = new TupleTag<>();
+  static final TupleTag<FailsafeElement<String, String>> RESTORE_FAILURE_TAG = new TupleTag<>();
   private static final String AVRO_SUFFIX = "avro";
   private static final String JSON_SUFFIX = "json";
   public static final Set<String> MAPPER_IGNORE_FIELDS =
@@ -530,25 +535,9 @@ public class DataStreamMongoDBToFirestore {
     // Optional Stage 1.5: Apply Javascript UDF for JSON transformation
     if (!Strings.isNullOrEmpty(options.getJavascriptTextTransformGcsPath())) {
       LOG.info("Applying Javascript UDF for JSON transformation");
-      PCollectionTuple udfResult =
-          jsonRecords.apply(
-              "Run UDF",
-              FailsafeJavascriptUdf.<String>newBuilder()
-                  .setFileSystemPath(options.getJavascriptTextTransformGcsPath())
-                  .setFunctionName(options.getJavascriptTextTransformFunctionName())
-                  .setReloadIntervalMinutes(
-                      options.getJavascriptTextTransformReloadIntervalMinutes())
-                  .setSuccessTag(UDF_SUCCESS_TAG)
-                  .setFailureTag(UDF_FAILURE_TAG)
-                  .build());
-
       jsonRecords =
-          udfResult
-              .get(UDF_SUCCESS_TAG)
-              .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
-
-      // Handle failed UDF processing
-      writeFailedJsonToDlq(options, udfResult, dlqManager, UDF_FAILURE_TAG);
+          jsonRecords.apply(
+              "Apply UDF To Data Field", new ApplyUdfToDataField(options, dlqManager));
     }
 
     // Stage 2: Create MongoDbChangeEventContext objects
@@ -752,25 +741,9 @@ public class DataStreamMongoDBToFirestore {
      * Optional Stage 1.5: Apply Javascript UDF to transform JSON strings
      */
     if (!Strings.isNullOrEmpty(options.getJavascriptTextTransformGcsPath())) {
-      PCollectionTuple udfResult =
-          jsonRecords.apply(
-              "Run UDF",
-              FailsafeJavascriptUdf.<String>newBuilder()
-                  .setFileSystemPath(options.getJavascriptTextTransformGcsPath())
-                  .setFunctionName(options.getJavascriptTextTransformFunctionName())
-                  .setReloadIntervalMinutes(
-                      options.getJavascriptTextTransformReloadIntervalMinutes())
-                  .setSuccessTag(UDF_SUCCESS_TAG)
-                  .setFailureTag(UDF_FAILURE_TAG)
-                  .build());
-
       jsonRecords =
-          udfResult
-              .get(UDF_SUCCESS_TAG)
-              .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
-
-      // Handle failed UDF processing
-      writeFailedJsonToDlq(options, udfResult, dlqManager, UDF_FAILURE_TAG);
+          jsonRecords.apply(
+              "Apply UDF To Data Field", new ApplyUdfToDataField(options, dlqManager));
     }
 
     LOG.info("Stage 1: Completed ingestion of data from GCS");
@@ -1028,11 +1001,11 @@ public class DataStreamMongoDBToFirestore {
         .get(failedTag)
         .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))
         .apply(
-            "DLQ: Write Retryable Json Failures to GCS",
+            "DLQ: Write Retryable Json Failures to GCS - " + failedTag.getId(),
             MapElements.via(new StringDeadLetterQueueSanitizer()))
         .setCoder(StringUtf8Coder.of())
         .apply(
-            "Write Failed Json To DLQ",
+            "Write Failed Json To DLQ - " + failedTag.getId(),
             DLQWriteTransform.WriteDLQ.newBuilder()
                 .withDlqDirectory(dlqManager.getSevereDlqDirectoryWithDateTime())
                 .withTmpDirectory(options.getDeadLetterQueueDirectory() + "/tmp_non_retry_json/")
@@ -1462,6 +1435,124 @@ public class DataStreamMongoDBToFirestore {
         client.close();
         client = null;
       }
+    }
+  }
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  public static class PrepareUdfInputFn
+      extends DoFn<FailsafeElement<String, String>, FailsafeElement<String, String>> {
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      FailsafeElement<String, String> element = c.element();
+      try {
+        String fullEventJson = element.getPayload();
+        String canonicalJson = Utils.getCanonicalJsonOfDataField(fullEventJson);
+        if (canonicalJson != null) {
+          c.output(FailsafeElement.of(fullEventJson, canonicalJson));
+        } else {
+          throw new IllegalArgumentException(
+              "Missing data field in event or unsupported data field type");
+        }
+      } catch (Exception e) {
+        LOG.error("Error preparing UDF input, exception: {}", e.getMessage(), e);
+        FailsafeElement<String, String> failedElement =
+            FailsafeElement.of(element.getOriginalPayload(), element.getPayload());
+        failedElement.setErrorMessage(e.getMessage());
+        failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
+        c.output(PREPARE_FAILURE_TAG, failedElement);
+      }
+    }
+  }
+
+  public static class RestoreUdfOutputFn
+      extends DoFn<FailsafeElement<String, String>, FailsafeElement<String, String>> {
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      FailsafeElement<String, String> element = c.element();
+      String fullEventJson = element.getOriginalPayload();
+      String transformedData = element.getPayload();
+
+      try {
+        JsonNode fullEventNode = OBJECT_MAPPER.readTree(fullEventJson);
+        if (transformedData.equals(fullEventJson)) {
+          c.output(element);
+          return;
+        }
+
+        ((ObjectNode) fullEventNode).put(MongoDbChangeEventContext.DATA_COL, transformedData);
+
+        String modifiedEventJson = OBJECT_MAPPER.writeValueAsString(fullEventNode);
+        c.output(FailsafeElement.of(modifiedEventJson, modifiedEventJson));
+      } catch (Exception e) {
+        LOG.error("Error restoring UDF output, exception: {}", e.getMessage(), e);
+        FailsafeElement<String, String> failedElement =
+            FailsafeElement.of(element.getOriginalPayload(), element.getPayload());
+        failedElement.setErrorMessage(e.getMessage());
+        failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
+        c.output(RESTORE_FAILURE_TAG, failedElement);
+      }
+    }
+  }
+
+  public static class ApplyUdfToDataField
+      extends PTransform<
+          PCollection<FailsafeElement<String, String>>,
+          PCollection<FailsafeElement<String, String>>> {
+    private final Options options;
+    private final DeadLetterQueueManager dlqManager;
+
+    public ApplyUdfToDataField(Options options, DeadLetterQueueManager dlqManager) {
+      this.options = options;
+      this.dlqManager = dlqManager;
+    }
+
+    @Override
+    public PCollection<FailsafeElement<String, String>> expand(
+        PCollection<FailsafeElement<String, String>> input) {
+
+      PCollectionTuple preparedResult =
+          input.apply(
+              "Prepare UDF Input",
+              ParDo.of(new PrepareUdfInputFn())
+                  .withOutputTags(UDF_SUCCESS_TAG, TupleTagList.of(PREPARE_FAILURE_TAG)));
+
+      // Handle failed preparation
+      writeFailedJsonToDlq(options, preparedResult, dlqManager, PREPARE_FAILURE_TAG);
+
+      PCollection<FailsafeElement<String, String>> preparedInput =
+          preparedResult
+              .get(UDF_SUCCESS_TAG)
+              .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+      PCollectionTuple udfResult =
+          preparedInput.apply(
+              "Run UDF",
+              FailsafeJavascriptUdf.<String>newBuilder()
+                  .setFileSystemPath(options.getJavascriptTextTransformGcsPath())
+                  .setFunctionName(options.getJavascriptTextTransformFunctionName())
+                  .setReloadIntervalMinutes(
+                      options.getJavascriptTextTransformReloadIntervalMinutes())
+                  .setSuccessTag(UDF_SUCCESS_TAG)
+                  .setFailureTag(UDF_FAILURE_TAG)
+                  .build());
+
+      writeFailedJsonToDlq(options, udfResult, dlqManager, UDF_FAILURE_TAG);
+
+      PCollectionTuple restoreResult =
+          udfResult
+              .get(UDF_SUCCESS_TAG)
+              .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))
+              .apply(
+                  "Restore UDF Output",
+                  ParDo.of(new RestoreUdfOutputFn())
+                      .withOutputTags(UDF_SUCCESS_TAG, TupleTagList.of(RESTORE_FAILURE_TAG)));
+
+      writeFailedJsonToDlq(options, restoreResult, dlqManager, RESTORE_FAILURE_TAG);
+
+      return restoreResult
+          .get(UDF_SUCCESS_TAG)
+          .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
     }
   }
 }

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
@@ -1475,11 +1475,6 @@ public class DataStreamMongoDBToFirestore {
 
       try {
         JsonNode fullEventNode = OBJECT_MAPPER.readTree(fullEventJson);
-        if (transformedData.equals(fullEventJson)) {
-          c.output(element);
-          return;
-        }
-
         ((ObjectNode) fullEventNode).put(MongoDbChangeEventContext.DATA_COL, transformedData);
 
         String modifiedEventJson = OBJECT_MAPPER.writeValueAsString(fullEventNode);

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
@@ -226,7 +226,8 @@ public class ProcessChangeEventFn
           Metrics.counter(ProcessChangeEventFn.class, "inMemoryRetries_" + errorIdentifier).inc();
 
           LOG.warn(
-              "Transient transaction error encountered for document ID: {}, attempt: {}. Retrying in {} ms...",
+              "Transient transaction error encountered for document ID: {}, attempt: {}. Retrying"
+                  + " in {} ms...",
               element.getDocumentId(),
               retryCount + 1,
               backoffMs,

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/Utils.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/Utils.java
@@ -21,6 +21,8 @@ import com.google.cloud.teleport.v2.templates.datastream.MongoDbChangeEventConte
 import java.util.Base64;
 import java.util.Set;
 import org.bson.Document;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
 import org.bson.types.Binary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +30,9 @@ import org.slf4j.LoggerFactory;
 /** Utils used by the Datastream-mongodb-to-mongodb pipeline. */
 public final class Utils {
   private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
+
+  private static final JsonWriterSettings CANONICAL_JSON_SETTINGS =
+      JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
 
   public static void removeTableRowFields(Document doc, Set<String> ignoreFields) {
     for (String ignoreField : ignoreFields) {
@@ -69,5 +74,20 @@ public final class Utils {
       return ((Document) documentId).toJson();
     }
     return documentId.toString();
+  }
+
+  public static String getCanonicalJsonOfDataField(String jsonString) {
+    Document fullEvent = Document.parse(jsonString);
+    Object dataVal = fullEvent.get(DATA_COL);
+    if (dataVal == null) {
+      return null;
+    }
+    if (dataVal instanceof Document) {
+      return ((Document) dataVal).toJson(CANONICAL_JSON_SETTINGS);
+    } else if (dataVal instanceof String) {
+      Document dataDoc = Document.parse((String) dataVal);
+      return dataDoc.toJson(CANONICAL_JSON_SETTINGS);
+    }
+    throw new IllegalArgumentException("Unsupported data field type: " + dataVal.getClass());
   }
 }

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestoreTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestoreTest.java
@@ -279,8 +279,9 @@ public final class DataStreamMongoDBToFirestoreTest {
 
   @Test
   public void restoreUdfOutputFn_unchangedPayload() {
-    String fullEventJson = "{\"data\":{\"name\":\"John\"}}";
-    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+    String fullEventJson = "{\"data\":\"{\\\"name\\\":\\\"John\\\"}\"}";
+    String canonicalJson = "{\"name\":\"John\"}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, canonicalJson);
 
     PCollectionTuple result =
         pipeline
@@ -302,7 +303,8 @@ public final class DataStreamMongoDBToFirestoreTest {
         .get(DataStreamMongoDBToFirestore.RESTORE_FAILURE_TAG)
         .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
 
-    PAssert.that(result.get(SUCCESS_TAG)).containsInAnyOrder(input);
+    FailsafeElement<String, String> expectedOutput = FailsafeElement.of(fullEventJson, fullEventJson);
+    PAssert.that(result.get(SUCCESS_TAG)).containsInAnyOrder(expectedOutput);
 
     pipeline.run();
   }
@@ -409,4 +411,68 @@ public final class DataStreamMongoDBToFirestoreTest {
 
     Files.delete(udfFile);
   }
+  @Test
+  public void applyUdfToDataField_specialValues() throws IOException {
+    String udfCode =
+        "function transform(inJson) {\n"
+            + "  var obj = JSON.parse(inJson);\n"
+            + "  return JSON.stringify(obj);\n"
+            + "}";
+    Path udfFile = Files.createTempFile("test-udf-special", ".js");
+    Files.write(udfFile, udfCode.getBytes());
+
+    String[] args =
+        new String[] {
+          "--javascriptTextTransformGcsPath=" + udfFile.toAbsolutePath().toString(),
+          "--javascriptTextTransformFunctionName=transform",
+          "--deadLetterQueueDirectory=/tmp/dlq"
+        };
+    DataStreamMongoDBToFirestore.Options options =
+        PipelineOptionsFactory.fromArgs(args)
+            .withValidation()
+            .as(DataStreamMongoDBToFirestore.Options.class);
+
+    DeadLetterQueueManager dlqManager = DeadLetterQueueManager.create("/tmp/dlq", 3);
+
+    String fullEventJson = "{\"data\":{\"nan\":{\"$numberDouble\":\"NaN\"},\"inf\":{\"$numberDouble\":\"Infinity\"},\"negInf\":{\"$numberDouble\":\"-Infinity\"},\"dbl\":3.14,\"lng\":{\"$numberLong\":\"1234567890\"}}}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollection<FailsafeElement<String, String>> result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "ApplyUdf",
+                new DataStreamMongoDBToFirestore.ApplyUdfToDataField(options, dlqManager));
+
+    PAssert.that(result)
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              try {
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode node = mapper.readTree(element.getPayload());
+                String dataStr = node.get("data").asText();
+                
+                org.bson.Document doc = org.bson.Document.parse(dataStr);
+                
+                assertEquals(Double.NaN, doc.getDouble("nan"), 0.0);
+                assertEquals(Double.POSITIVE_INFINITY, doc.getDouble("inf"), 0.0);
+                assertEquals(Double.NEGATIVE_INFINITY, doc.getDouble("negInf"), 0.0);
+                assertEquals(3.14, doc.getDouble("dbl"), 0.0);
+                assertEquals(1234567890L, doc.getLong("lng").longValue());
+                
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              return null;
+            });
+
+    pipeline.run();
+
+    Files.delete(udfFile);
+  }
 }
+

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestoreTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestoreTest.java
@@ -18,13 +18,36 @@ package com.google.cloud.teleport.v2.templates;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.teleport.v2.cdc.dlq.DeadLetterQueueManager;
+import com.google.cloud.teleport.v2.coders.FailsafeElementCoder;
+import com.google.cloud.teleport.v2.values.FailsafeElement;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.TupleTagList;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public final class DataStreamMongoDBToFirestoreTest {
+
+  @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+
+  private static final TupleTag<FailsafeElement<String, String>> SUCCESS_TAG =
+      new TupleTag<FailsafeElement<String, String>>() {};
 
   @Test
   public void inputArgs_inputFilePattern() {
@@ -131,5 +154,259 @@ public final class DataStreamMongoDBToFirestoreTest {
     String functionName = options.getJavascriptTextTransformFunctionName();
 
     assertEquals(functionName, "myTransform");
+  }
+
+  @Test
+  public void prepareUdfInputFn_validJsonWithData() {
+    String fullEventJson = "{\"data\":{\"name\":\"John\"}}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "PrepareUdfInput",
+                ParDo.of(new DataStreamMongoDBToFirestore.PrepareUdfInputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(SUCCESS_TAG))
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              assertEquals(fullEventJson, element.getOriginalPayload());
+              try {
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode node = mapper.readTree(element.getPayload());
+                assertEquals("John", node.get("name").asText());
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void prepareUdfInputFn_missingData_routesToDlq() {
+    String fullEventJson = "{\"op\":\"u\"}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "PrepareUdfInput",
+                ParDo.of(new DataStreamMongoDBToFirestore.PrepareUdfInputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG))
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              assertEquals(fullEventJson, element.getOriginalPayload());
+              assertEquals(fullEventJson, element.getPayload());
+              assertEquals(
+                  "Missing data field in event or unsupported data field type",
+                  element.getErrorMessage());
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void prepareUdfInputFn_invalidJson_routesToDlq() {
+    String invalidJson = "{invalid}";
+    FailsafeElement<String, String> input = FailsafeElement.of(invalidJson, invalidJson);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "PrepareUdfInput",
+                ParDo.of(new DataStreamMongoDBToFirestore.PrepareUdfInputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG))
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              assertEquals(invalidJson, element.getOriginalPayload());
+              assertEquals(invalidJson, element.getPayload());
+              org.junit.Assert.assertNotNull(element.getErrorMessage());
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void restoreUdfOutputFn_unchangedPayload() {
+    String fullEventJson = "{\"data\":{\"name\":\"John\"}}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "RestoreUdfOutput",
+                ParDo.of(new DataStreamMongoDBToFirestore.RestoreUdfOutputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.RESTORE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.RESTORE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(SUCCESS_TAG)).containsInAnyOrder(input);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void restoreUdfOutputFn_changedPayload() {
+    String fullEventJson = "{\"data\":{\"name\":\"John\"}}";
+    String transformedData = "{\"name\":\"Jane\"}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, transformedData);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "RestoreUdfOutput",
+                ParDo.of(new DataStreamMongoDBToFirestore.RestoreUdfOutputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.RESTORE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.RESTORE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(SUCCESS_TAG))
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              try {
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode node = mapper.readTree(element.getPayload());
+                String dataStr = node.get("data").asText();
+                JsonNode dataNode = mapper.readTree(dataStr);
+                assertEquals("Jane", dataNode.get("name").asText());
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void applyUdfToDataField_fullTransform() throws IOException {
+    String udfCode =
+        "function transform(inJson) {\n"
+            + "  var obj = JSON.parse(inJson);\n"
+            + "  obj.name = obj.name.toUpperCase();\n"
+            + "  return JSON.stringify(obj);\n"
+            + "}";
+    Path udfFile = Files.createTempFile("test-udf", ".js");
+    Files.write(udfFile, udfCode.getBytes());
+
+    String[] args =
+        new String[] {
+          "--javascriptTextTransformGcsPath=" + udfFile.toAbsolutePath().toString(),
+          "--javascriptTextTransformFunctionName=transform",
+          "--deadLetterQueueDirectory=/tmp/dlq"
+        };
+    DataStreamMongoDBToFirestore.Options options =
+        PipelineOptionsFactory.fromArgs(args)
+            .withValidation()
+            .as(DataStreamMongoDBToFirestore.Options.class);
+
+    DeadLetterQueueManager dlqManager = DeadLetterQueueManager.create("/tmp/dlq", 3);
+
+    String fullEventJson = "{\"data\":{\"name\":\"john\"}}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollection<FailsafeElement<String, String>> result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "ApplyUdf",
+                new DataStreamMongoDBToFirestore.ApplyUdfToDataField(options, dlqManager));
+
+    PAssert.that(result)
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              try {
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode node = mapper.readTree(element.getPayload());
+                String dataStr = node.get("data").asText();
+                JsonNode dataNode = mapper.readTree(dataStr);
+                assertEquals("JOHN", dataNode.get("name").asText());
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              return null;
+            });
+
+    pipeline.run();
+
+    Files.delete(udfFile);
   }
 }

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestoreTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestoreTest.java
@@ -303,7 +303,8 @@ public final class DataStreamMongoDBToFirestoreTest {
         .get(DataStreamMongoDBToFirestore.RESTORE_FAILURE_TAG)
         .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
 
-    FailsafeElement<String, String> expectedOutput = FailsafeElement.of(fullEventJson, fullEventJson);
+    FailsafeElement<String, String> expectedOutput =
+        FailsafeElement.of(fullEventJson, fullEventJson);
     PAssert.that(result.get(SUCCESS_TAG)).containsInAnyOrder(expectedOutput);
 
     pipeline.run();
@@ -411,6 +412,7 @@ public final class DataStreamMongoDBToFirestoreTest {
 
     Files.delete(udfFile);
   }
+
   @Test
   public void applyUdfToDataField_specialValues() throws IOException {
     String udfCode =
@@ -434,7 +436,8 @@ public final class DataStreamMongoDBToFirestoreTest {
 
     DeadLetterQueueManager dlqManager = DeadLetterQueueManager.create("/tmp/dlq", 3);
 
-    String fullEventJson = "{\"data\":{\"nan\":{\"$numberDouble\":\"NaN\"},\"inf\":{\"$numberDouble\":\"Infinity\"},\"negInf\":{\"$numberDouble\":\"-Infinity\"},\"dbl\":3.14,\"lng\":{\"$numberLong\":\"1234567890\"}}}";
+    String fullEventJson =
+        "{\"data\":{\"nan\":{\"$numberDouble\":\"NaN\"},\"inf\":{\"$numberDouble\":\"Infinity\"},\"negInf\":{\"$numberDouble\":\"-Infinity\"},\"dbl\":3.14,\"lng\":{\"$numberLong\":\"1234567890\"}}}";
     FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
 
     PCollection<FailsafeElement<String, String>> result =
@@ -455,15 +458,15 @@ public final class DataStreamMongoDBToFirestoreTest {
                 ObjectMapper mapper = new ObjectMapper();
                 JsonNode node = mapper.readTree(element.getPayload());
                 String dataStr = node.get("data").asText();
-                
+
                 org.bson.Document doc = org.bson.Document.parse(dataStr);
-                
+
                 assertEquals(Double.NaN, doc.getDouble("nan"), 0.0);
                 assertEquals(Double.POSITIVE_INFINITY, doc.getDouble("inf"), 0.0);
                 assertEquals(Double.NEGATIVE_INFINITY, doc.getDouble("negInf"), 0.0);
                 assertEquals(3.14, doc.getDouble("dbl"), 0.0);
                 assertEquals(1234567890L, doc.getLong("lng").longValue());
-                
+
               } catch (Exception e) {
                 throw new RuntimeException(e);
               }
@@ -475,4 +478,3 @@ public final class DataStreamMongoDBToFirestoreTest {
     Files.delete(udfFile);
   }
 }
-

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContextTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContextTest.java
@@ -60,85 +60,91 @@ public class MongoDbChangeEventContextTest {
     insertEvent =
         OBJECT_MAPPER.readTree(
             """
-                {
-                  "_metadata_source": {
-                    "collection": "test_collection"
-                  },
-                  "_id": "{\\\"$oid\\\": \\\"645c9a7e7b8b1a0e9c0f8b3a\\\"}",
-                  "data": {
-                    "field1": "value1",
-                    "field2": 123
-                  },
-                  "_metadata_timestamp_seconds": 1683782270,
-                  "_metadata_timestamp_nanos": 123456789,
-                  "op": "i"
-                }""");
+            {
+              "_metadata_source": {
+                "collection": "test_collection"
+              },
+              "_id": "{\\\"$oid\\\": \\\"645c9a7e7b8b1a0e9c0f8b3a\\\"}",
+              "data": {
+                "field1": "value1",
+                "field2": 123
+              },
+              "_metadata_timestamp_seconds": 1683782270,
+              "_metadata_timestamp_nanos": 123456789,
+              "op": "i"
+            }\
+            """);
 
     deleteEvent =
         OBJECT_MAPPER.readTree(
             """
-                {
-                  "_metadata_source": {
-                    "collection": "test_collection"
-                  },
-                  "_id": "{\\\"$oid\\\": \\\"645c9a7e7b8b1a0e9c0f8b3a\\\"}",
-                  "_metadata_timestamp_seconds": 1683782270,
-                  "_metadata_timestamp_nanos": 123456789,
-                  "op": "d",
-                  "_metadata_change_type": "DELETE"
-                }""");
+            {
+              "_metadata_source": {
+                "collection": "test_collection"
+              },
+              "_id": "{\\\"$oid\\\": \\\"645c9a7e7b8b1a0e9c0f8b3a\\\"}",
+              "_metadata_timestamp_seconds": 1683782270,
+              "_metadata_timestamp_nanos": 123456789,
+              "op": "d",
+              "_metadata_change_type": "DELETE"
+            }\
+            """);
 
     updateEvent =
         OBJECT_MAPPER.readTree(
             """
-                {
-                  "_metadata_source": {
-                    "collection": "test_collection"
-                  },
-                  "_id": "{\\\"$oid\\\": \\\"645c9a7e7b8b1a0e9c0f8b3a\\\"}",
-                  "data": {
-                    "field1": "updated_value",
-                    "field2": 456
-                  },
-                  "_metadata_timestamp_seconds": 1683782270,
-                  "_metadata_timestamp_nanos": 123456789,
-                  "op": "u"
-                }""");
+            {
+              "_metadata_source": {
+                "collection": "test_collection"
+              },
+              "_id": "{\\\"$oid\\\": \\\"645c9a7e7b8b1a0e9c0f8b3a\\\"}",
+              "data": {
+                "field1": "updated_value",
+                "field2": 456
+              },
+              "_metadata_timestamp_seconds": 1683782270,
+              "_metadata_timestamp_nanos": 123456789,
+              "op": "u"
+            }\
+            """);
 
     invalidEventMissingMetadata = OBJECT_MAPPER.readTree("{}");
 
     invalidEventMissingId =
         OBJECT_MAPPER.readTree(
             """
-                {
-                  "_metadata_source": {
-                    "collection": "test_collection"
-                  },
-                  "_metadata_timestamp_seconds": 1683782270,
-                  "_metadata_timestamp_nanos": 123456789
-                }""");
+            {
+              "_metadata_source": {
+                "collection": "test_collection"
+              },
+              "_metadata_timestamp_seconds": 1683782270,
+              "_metadata_timestamp_nanos": 123456789
+            }\
+            """);
 
     invalidEventUnsupportedIdType =
         OBJECT_MAPPER.readTree(
             """
-                {
-                  "_metadata_source": {
-                    "collection": "test_collection"
-                  },
-                  "_id": "[1, 2, 3]",
-                  "_metadata_timestamp_seconds": 1683782270,
-                  "_metadata_timestamp_nanos": 123456789
-                }""");
+            {
+              "_metadata_source": {
+                "collection": "test_collection"
+              },
+              "_id": "[1, 2, 3]",
+              "_metadata_timestamp_seconds": 1683782270,
+              "_metadata_timestamp_nanos": 123456789
+            }\
+            """);
 
     invalidEventMissingTimestamp =
         OBJECT_MAPPER.readTree(
             """
-                {
-                  "_metadata_source": {
-                    "collection": "test_collection"
-                  },
-                  "_id": "{\\\"$oid\\\": \\\"645c9a7e7b8b1a0e9c0f8b3a\\\"}"
-                }""");
+            {
+              "_metadata_source": {
+                "collection": "test_collection"
+              },
+              "_id": "{\\\"$oid\\\": \\\"645c9a7e7b8b1a0e9c0f8b3a\\\"}"
+            }\
+            """);
   }
 
   @Test
@@ -213,18 +219,19 @@ public class MongoDbChangeEventContextTest {
     JsonNode eventWithObjectId =
         OBJECT_MAPPER.readTree(
             """
-                {
-                  "_metadata_source": {
-                    "collection": "test_collection"
-                  },
-                  "_id": "{ \\\"$oid\\\": \\\"645c9a7e7b8b1a0e9c0f8b3a\\\"}",
-                  "data": {
-                    "field1": "updated_value",
-                    "field2": 456
-                  },
-                  "_metadata_timestamp_seconds": 1683782270,
-                  "_metadata_timestamp_nanos": 123456789
-                }""");
+            {
+              "_metadata_source": {
+                "collection": "test_collection"
+              },
+              "_id": "{ \\\"$oid\\\": \\\"645c9a7e7b8b1a0e9c0f8b3a\\\"}",
+              "data": {
+                "field1": "updated_value",
+                "field2": 456
+              },
+              "_metadata_timestamp_seconds": 1683782270,
+              "_metadata_timestamp_nanos": 123456789
+            }\
+            """);
     MongoDbChangeEventContext context =
         new MongoDbChangeEventContext(eventWithObjectId, SHADOW_PREFIX);
     assertNotNull(context.getDocumentId());
@@ -237,18 +244,19 @@ public class MongoDbChangeEventContextTest {
     JsonNode eventWithLongId =
         OBJECT_MAPPER.readTree(
             """
-                {
-                  "_metadata_source": {
-                    "collection": "test_collection"
-                  },
-                  "_id": 9223372036854775806,
-                  "data": {
-                    "field1": "updated_value",
-                    "field2": 456
-                  },
-                  "_metadata_timestamp_seconds": 1683782270,
-                  "_metadata_timestamp_nanos": 123456789
-                }""");
+            {
+              "_metadata_source": {
+                "collection": "test_collection"
+              },
+              "_id": 9223372036854775806,
+              "data": {
+                "field1": "updated_value",
+                "field2": 456
+              },
+              "_metadata_timestamp_seconds": 1683782270,
+              "_metadata_timestamp_nanos": 123456789
+            }\
+            """);
     MongoDbChangeEventContext context =
         new MongoDbChangeEventContext(eventWithLongId, SHADOW_PREFIX);
     assertNotNull(context.getDocumentId());
@@ -261,18 +269,19 @@ public class MongoDbChangeEventContextTest {
     JsonNode eventWithStringId =
         OBJECT_MAPPER.readTree(
             """
-                {
-                  "_metadata_source": {
-                    "collection": "test_collection"
-                  },
-                  "_id": "\\\"test_id\\\"",
-                  "data": {
-                    "field1": "updated_value",
-                    "field2": 456
-                  },
-                  "_metadata_timestamp_seconds": 1683782270,
-                  "_metadata_timestamp_nanos": 123456789
-                }""");
+            {
+              "_metadata_source": {
+                "collection": "test_collection"
+              },
+              "_id": "\\\"test_id\\\"",
+              "data": {
+                "field1": "updated_value",
+                "field2": 456
+              },
+              "_metadata_timestamp_seconds": 1683782270,
+              "_metadata_timestamp_nanos": 123456789
+            }\
+            """);
     MongoDbChangeEventContext context =
         new MongoDbChangeEventContext(eventWithStringId, SHADOW_PREFIX);
     assertNotNull(context.getDocumentId());
@@ -285,17 +294,18 @@ public class MongoDbChangeEventContextTest {
     JsonNode eventWithDoubleId =
         OBJECT_MAPPER.readTree(
             """
-                {
-                  "_metadata_source": {
-                    "collection": "test_collection"
-                  },
-                  "_id": "123.456",
-                  "data": {
-                    "field1": "updated_value"
-                  },
-                  "_metadata_timestamp_seconds": 1683782270,
-                  "_metadata_timestamp_nanos": 123456789
-                }""");
+            {
+              "_metadata_source": {
+                "collection": "test_collection"
+              },
+              "_id": "123.456",
+              "data": {
+                "field1": "updated_value"
+              },
+              "_metadata_timestamp_seconds": 1683782270,
+              "_metadata_timestamp_nanos": 123456789
+            }\
+            """);
     MongoDbChangeEventContext context =
         new MongoDbChangeEventContext(eventWithDoubleId, SHADOW_PREFIX);
     assertNotNull(context.getDocumentId());
@@ -308,17 +318,18 @@ public class MongoDbChangeEventContextTest {
     JsonNode eventWithZeroId =
         OBJECT_MAPPER.readTree(
             """
-                {
-                  "_metadata_source": {
-                    "collection": "test_collection"
-                  },
-                  "_id": "0",
-                  "data": {
-                    "field1": "updated_value"
-                  },
-                  "_metadata_timestamp_seconds": 1683782270,
-                  "_metadata_timestamp_nanos": 123456789
-                }""");
+            {
+              "_metadata_source": {
+                "collection": "test_collection"
+              },
+              "_id": "0",
+              "data": {
+                "field1": "updated_value"
+              },
+              "_metadata_timestamp_seconds": 1683782270,
+              "_metadata_timestamp_nanos": 123456789
+            }\
+            """);
     MongoDbChangeEventContext context =
         new MongoDbChangeEventContext(eventWithZeroId, SHADOW_PREFIX);
     assertNotNull(context.getDocumentId());
@@ -330,17 +341,18 @@ public class MongoDbChangeEventContextTest {
     JsonNode eventWithGenericObjectId =
         OBJECT_MAPPER.readTree(
             """
-                {
-                  "_metadata_source": {
-                    "collection": "test_collection"
-                  },
-                  "_id": "{\\\"a\\\": 1, \\\"b\\\": \\\"test\\\"}",
-                  "data": {
-                    "field1": "updated_value"
-                  },
-                  "_metadata_timestamp_seconds": 1683782270,
-                  "_metadata_timestamp_nanos": 123456789
-                }""");
+            {
+              "_metadata_source": {
+                "collection": "test_collection"
+              },
+              "_id": "{\\\"a\\\": 1, \\\"b\\\": \\\"test\\\"}",
+              "data": {
+                "field1": "updated_value"
+              },
+              "_metadata_timestamp_seconds": 1683782270,
+              "_metadata_timestamp_nanos": 123456789
+            }\
+            """);
     MongoDbChangeEventContext context =
         new MongoDbChangeEventContext(eventWithGenericObjectId, SHADOW_PREFIX);
     assertNotNull(context.getDocumentId());
@@ -355,17 +367,18 @@ public class MongoDbChangeEventContextTest {
     JsonNode eventWithIntId =
         OBJECT_MAPPER.readTree(
             """
-                {
-                  "_metadata_source": {
-                    "collection": "test_collection"
-                  },
-                  "_id": 123,
-                  "data": {
-                    "field1": "updated_value"
-                  },
-                  "_metadata_timestamp_seconds": 1683782270,
-                  "_metadata_timestamp_nanos": 123456789
-                }""");
+            {
+              "_metadata_source": {
+                "collection": "test_collection"
+              },
+              "_id": 123,
+              "data": {
+                "field1": "updated_value"
+              },
+              "_metadata_timestamp_seconds": 1683782270,
+              "_metadata_timestamp_nanos": 123456789
+            }\
+            """);
     MongoDbChangeEventContext context =
         new MongoDbChangeEventContext(eventWithIntId, SHADOW_PREFIX);
     assertNotNull(context.getDocumentId());
@@ -378,17 +391,18 @@ public class MongoDbChangeEventContextTest {
     JsonNode eventWithBinaryId =
         OBJECT_MAPPER.readTree(
             """
-                {
-                  "_metadata_source": {
-                    "collection": "test_collection"
-                  },
-                  "_id": "{\\\"$binary\\\": {\\\"base64\\\": \\\"AQID\\\", \\\"subType\\\": \\\"00\\\"}}",
-                  "data": {
-                    "field1": "updated_value"
-                  },
-                  "_metadata_timestamp_seconds": 1683782270,
-                  "_metadata_timestamp_nanos": 123456789
-                }""");
+            {
+              "_metadata_source": {
+                "collection": "test_collection"
+              },
+              "_id": "{\\\"$binary\\\": {\\\"base64\\\": \\\"AQID\\\", \\\"subType\\\": \\\"00\\\"}}",
+              "data": {
+                "field1": "updated_value"
+              },
+              "_metadata_timestamp_seconds": 1683782270,
+              "_metadata_timestamp_nanos": 123456789
+            }\
+            """);
     MongoDbChangeEventContext context =
         new MongoDbChangeEventContext(eventWithBinaryId, SHADOW_PREFIX);
     assertNotNull(context.getDocumentId());
@@ -402,17 +416,18 @@ public class MongoDbChangeEventContextTest {
     JsonNode eventWithArrayId =
         OBJECT_MAPPER.readTree(
             """
-                {
-                  "_metadata_source": {
-                    "collection": "test_collection"
-                  },
-                  "_id": "[1, 2, 3]",
-                  "data": {
-                    "field1": "updated_value"
-                  },
-                  "_metadata_timestamp_seconds": 1683782270,
-                  "_metadata_timestamp_nanos": 123456789
-                }""");
+            {
+              "_metadata_source": {
+                "collection": "test_collection"
+              },
+              "_id": "[1, 2, 3]",
+              "data": {
+                "field1": "updated_value"
+              },
+              "_metadata_timestamp_seconds": 1683782270,
+              "_metadata_timestamp_nanos": 123456789
+            }\
+            """);
     new MongoDbChangeEventContext(eventWithArrayId, SHADOW_PREFIX);
   }
 
@@ -421,17 +436,18 @@ public class MongoDbChangeEventContextTest {
     JsonNode eventWithNullId =
         OBJECT_MAPPER.readTree(
             """
-                {
-                  "_metadata_source": {
-                    "collection": "test_collection"
-                  },
-                  "_id": "null",
-                  "data": {
-                    "field1": "updated_value"
-                  },
-                  "_metadata_timestamp_seconds": 1683782270,
-                  "_metadata_timestamp_nanos": 123456789
-                }""");
+            {
+              "_metadata_source": {
+                "collection": "test_collection"
+              },
+              "_id": "null",
+              "data": {
+                "field1": "updated_value"
+              },
+              "_metadata_timestamp_seconds": 1683782270,
+              "_metadata_timestamp_nanos": 123456789
+            }\
+            """);
     new MongoDbChangeEventContext(eventWithNullId, SHADOW_PREFIX);
   }
 
@@ -546,14 +562,13 @@ public class MongoDbChangeEventContextTest {
     String jsonString = context.toString();
 
     String expectedJson =
-        "{\"changeEvent\":{\"_metadata_source\":{\"collection\":\"test_collection\"},\"_id\":\"{\\\"$oid\\\": \\\"645c9a7e7b8b1a0e9c0f8b3a\\\"}\",\"data\":{\"field1\":\"value1\",\"field2\":123},\"_metadata_timestamp_seconds\":1683782270,\"_metadata_timestamp_nanos\":123456789,\"op\":\"i\"},"
+        "{\"changeEvent\":{\"_metadata_source\":{\"collection\":\"test_collection\"},\"_id\":\"{\\\"$oid\\\":"
+            + " \\\"645c9a7e7b8b1a0e9c0f8b3a\\\"}\",\"data\":{\"field1\":\"value1\",\"field2\":123},\"_metadata_timestamp_seconds\":1683782270,\"_metadata_timestamp_nanos\":123456789,\"op\":\"i\"},"
             + "\"dataCollection\":\"test_collection\","
             + "\"shadowCollection\":\"shadow_test_collection\","
-            + "\"documentId\":{\"$oid\":\"645c9a7e7b8b1a0e9c0f8b3a\"},"
-            + "\"isDeleteEvent\":false,"
+            + "\"documentId\":{\"$oid\":\"645c9a7e7b8b1a0e9c0f8b3a\"},\"isDeleteEvent\":false,"
             + "\"timestamp\":{\"seconds\":1683782270,\"nanos\":123456789},"
-            + "\"isDlqReconsumed\":false,"
-            + "\"_metadata_retry_count\":0}";
+            + "\"isDlqReconsumed\":false,\"_metadata_retry_count\":0}";
 
     assertEquals(jsonString, expectedJson);
   }

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/CreateMongoDbChangeEventContextFnTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/CreateMongoDbChangeEventContextFnTest.java
@@ -67,17 +67,18 @@ public class CreateMongoDbChangeEventContextFnTest {
 
     String validPayload =
         """
-            {
-              "_metadata_source": {
-                "collection": "test_collection"
-              },
-              "_id": "{\\\"$oid\\\": \\\"645c9a7e7b8b1a0e9c0f8b3a\\\"}",
-              "data": {
-                "field1": "testString"
-              },
-              "_metadata_timestamp_seconds": 1683782270,
-              "_metadata_timestamp_nanos": 123456789
-            }""";
+        {
+          "_metadata_source": {
+            "collection": "test_collection"
+          },
+          "_id": "{\\\"$oid\\\": \\\"645c9a7e7b8b1a0e9c0f8b3a\\\"}",
+          "data": {
+            "field1": "testString"
+          },
+          "_metadata_timestamp_seconds": 1683782270,
+          "_metadata_timestamp_nanos": 123456789
+        }\
+        """;
     successElement = FailsafeElement.of(validPayload, validPayload);
     when(mockContext.element()).thenReturn(successElement);
     validJsonNode = OBJECT_MAPPER.readTree(validPayload);

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbEventDeadLetterQueueSanitizerTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbEventDeadLetterQueueSanitizerTest.java
@@ -96,7 +96,8 @@ public class MongoDbEventDeadLetterQueueSanitizerTest {
     when(mockContext.getOriginalPayload().getDataCollection()).thenReturn(null);
 
     assertEquals(
-        "{\"errorType\":\"MongoDbChangeEventContext processing error\",\"documentId\":\"test_id\",\"collection\":null}",
+        "{\"errorType\":\"MongoDbChangeEventContext processing"
+            + " error\",\"documentId\":\"test_id\",\"collection\":null}",
         sanitizer.getErrorMessageJson(mockContext));
   }
 
@@ -104,17 +105,15 @@ public class MongoDbEventDeadLetterQueueSanitizerTest {
   public void testGetJsonMessageWithComplexChangeEvent() throws Exception {
     JsonNode complexChangeEvent =
         OBJECT_MAPPER.readTree(
-            "{\"_id\": {\"$oid\": \"645c9a7e7b8b1a0e9c0f8b3a\"}, \"data\": {\"field1\": \"value1\", \"field2\": 123}}");
+            "{\"_id\": {\"$oid\": \"645c9a7e7b8b1a0e9c0f8b3a\"}, \"data\": {\"field1\": \"value1\","
+                + " \"field2\": 123}}");
     when(mockContext.getOriginalPayload().getChangeEvent()).thenReturn(complexChangeEvent);
 
     String expectedJson =
         "{\"changeEvent\":{\"_id\":{\"$oid\":\"645c9a7e7b8b1a0e9c0f8b3a\"},\"data\":{\"field1\":\"value1\",\"field2\":123}},"
             + "\"dataCollection\":\"test_collection\","
-            + "\"shadowCollection\":\"shadow_test_collection\","
-            + "\"documentId\":\"test_id\","
-            + "\"isDeleteEvent\":false,"
-            + "\"isDlqReconsumed\":true,"
-            + "\"_metadata_retry_count\":1}";
+            + "\"shadowCollection\":\"shadow_test_collection\",\"documentId\":\"test_id\","
+            + "\"isDeleteEvent\":false,\"isDlqReconsumed\":true,\"_metadata_retry_count\":1}";
     assertEquals(expectedJson, sanitizer.getJsonMessage(mockContext));
   }
 

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/UtilsTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/UtilsTest.java
@@ -134,13 +134,36 @@ public class UtilsTest {
   @Test
   public void testJsonToDocument() {
     String jsonString =
-        "{\"_id\":\"{\\\"$oid\\\": \\\"6811235eaf8583310cb9d2e9\\\"}\",\"data\":\"{\\\"_id\\\": {\\\"$oid\\\": \\\"6811235eaf8583310cb9d2e9\\\"},\\\"arrayField\\\": [\\\"hello\\\",10],\\\"dateField\\\": {\\\"$date\\\": 1565546054692},\\\"dateBefore1970\\\": {\\\"$date\\\": -1577923200000},\\\"decimal128Field\\\": {\\\"$numberDecimal\\\": \\\"10.99\\\"},\\\"documentField\\\": {\\\"a\\\": \\\"hello\\\"},\\\"doubleField\\\": 10.5,\\\"infiniteNumber\\\": Infinity,\\\"int32field\\\": 10,\\\"int64Field\\\": {\\\"$numberLong\\\": \\\"50\\\"},\\\"minKeyField\\\": {\\\"$minKey\\\": 1},\\\"maxKeyField\\\": {\\\"$maxKey\\\": 1},\\\"regexField\\\": {\\\"$regex\\\": \\\"^H\\\",\\\"$options\\\": \\\"i\\\"},\\\"timestampField\\\": {\\\"$timestamp\\\": {\\\"t\\\": 1565545664,\\\"i\\\": 1}},\\\"uuid\\\": {\\\"$binary\\\": \\\"OyQRAeK7QlWMr0E2xWapYg==\\\",\\\"$type\\\": \\\"04\\\"}}\",\"_metadata_stream\":\"extended-types-test\",\"_metadata_timestamp\":1745957556,\"_metadata_read_timestamp\":1745957556,\"_metadata_dataflow_timestamp\":1745963670,\"_metadata_read_method\":\"backfill\",\"_metadata_source_type\":\"backfill\",\"_metadata_deleted\":false,\"_metadata_table\":null,\"_metadata_change_type\":\"READ\",\"_metadata_primary_keys\":null,\"_metadata_uuid\":\"2a9cf8eb-4f35-433c-899a-39921d4c8587\",\"_metadata_timestamp_seconds\":\"1745957556\",\"_metadata_timestamp_nanos\":\"184498000\",\"_metadata_source\":{\"database\":\"extended_types\",\"collection\":\"mycol\",\"change_type\":\"READ\",\"is_deleted\":false,\"primary_key\":[\"_id\"]},\"_metadata_error\":null,\"_metadata_retry_count\":116}";
+        "{\"_id\":\"{\\\"$oid\\\": \\\"6811235eaf8583310cb9d2e9\\\"}\",\"data\":\"{\\\"_id\\\":"
+            + " {\\\"$oid\\\": \\\"6811235eaf8583310cb9d2e9\\\"},\\\"arrayField\\\":"
+            + " [\\\"hello\\\",10],\\\"dateField\\\": {\\\"$date\\\":"
+            + " 1565546054692},\\\"dateBefore1970\\\": {\\\"$date\\\":"
+            + " -1577923200000},\\\"decimal128Field\\\": {\\\"$numberDecimal\\\":"
+            + " \\\"10.99\\\"},\\\"documentField\\\": {\\\"a\\\":"
+            + " \\\"hello\\\"},\\\"doubleField\\\": 10.5,\\\"infiniteNumber\\\":"
+            + " Infinity,\\\"int32field\\\": 10,\\\"int64Field\\\": {\\\"$numberLong\\\":"
+            + " \\\"50\\\"},\\\"minKeyField\\\": {\\\"$minKey\\\": 1},\\\"maxKeyField\\\":"
+            + " {\\\"$maxKey\\\": 1},\\\"regexField\\\": {\\\"$regex\\\":"
+            + " \\\"^H\\\",\\\"$options\\\": \\\"i\\\"},\\\"timestampField\\\":"
+            + " {\\\"$timestamp\\\": {\\\"t\\\": 1565545664,\\\"i\\\": 1}},\\\"uuid\\\":"
+            + " {\\\"$binary\\\": \\\"OyQRAeK7QlWMr0E2xWapYg==\\\",\\\"$type\\\":"
+            + " \\\"04\\\"}}\",\"_metadata_stream\":\"extended-types-test\",\"_metadata_timestamp\":1745957556,\"_metadata_read_timestamp\":1745957556,\"_metadata_dataflow_timestamp\":1745963670,\"_metadata_read_method\":\"backfill\",\"_metadata_source_type\":\"backfill\",\"_metadata_deleted\":false,\"_metadata_table\":null,\"_metadata_change_type\":\"READ\",\"_metadata_primary_keys\":null,\"_metadata_uuid\":\"2a9cf8eb-4f35-433c-899a-39921d4c8587\",\"_metadata_timestamp_seconds\":\"1745957556\",\"_metadata_timestamp_nanos\":\"184498000\",\"_metadata_source\":{\"database\":\"extended_types\",\"collection\":\"mycol\",\"change_type\":\"READ\",\"is_deleted\":false,\"primary_key\":[\"_id\"]},\"_metadata_error\":null,\"_metadata_retry_count\":116}";
     Document result = Utils.jsonToDocument(jsonString, 1L);
     assertTrue(
         result
             .toJson()
             .equals(
-                "{\"_id\": 1, \"arrayField\": [\"hello\", 10], \"dateField\": {\"$date\": \"2019-08-11T17:54:14.692Z\"}, \"dateBefore1970\": {\"$date\": {\"$numberLong\": \"-1577923200000\"}}, \"decimal128Field\": {\"$numberDecimal\": \"10.99\"}, \"documentField\": {\"a\": \"hello\"}, \"doubleField\": 10.5, \"infiniteNumber\": {\"$numberDouble\": \"Infinity\"}, \"int32field\": 10, \"int64Field\": 50, \"minKeyField\": {\"$minKey\": 1}, \"maxKeyField\": {\"$maxKey\": 1}, \"regexField\": {\"$regularExpression\": {\"pattern\": \"^H\", \"options\": \"i\"}}, \"timestampField\": {\"$timestamp\": {\"t\": 1565545664, \"i\": 1}}, \"uuid\": {\"$binary\": {\"base64\": \"OyQRAeK7QlWMr0E2xWapYg==\", \"subType\": \"04\"}}}"));
+                "{\"_id\": 1, \"arrayField\": [\"hello\", 10], \"dateField\": {\"$date\":"
+                    + " \"2019-08-11T17:54:14.692Z\"}, \"dateBefore1970\": {\"$date\":"
+                    + " {\"$numberLong\": \"-1577923200000\"}}, \"decimal128Field\":"
+                    + " {\"$numberDecimal\": \"10.99\"}, \"documentField\": {\"a\": \"hello\"},"
+                    + " \"doubleField\": 10.5, \"infiniteNumber\": {\"$numberDouble\":"
+                    + " \"Infinity\"}, \"int32field\": 10, \"int64Field\": 50, \"minKeyField\":"
+                    + " {\"$minKey\": 1}, \"maxKeyField\": {\"$maxKey\": 1}, \"regexField\":"
+                    + " {\"$regularExpression\": {\"pattern\": \"^H\", \"options\": \"i\"}},"
+                    + " \"timestampField\": {\"$timestamp\": {\"t\": 1565545664, \"i\": 1}},"
+                    + " \"uuid\": {\"$binary\": {\"base64\": \"OyQRAeK7QlWMr0E2xWapYg==\","
+                    + " \"subType\": \"04\"}}}"));
   }
 
   @Test
@@ -159,5 +182,33 @@ public class UtilsTest {
 
     Document doc = new Document("a", 1).append("b", "test");
     assertEquals("{\"a\": 1, \"b\": \"test\"}", Utils.documentIdToString(doc));
+  }
+
+  @Test
+  public void testGetCanonicalJsonOfDataField_StringInput() {
+    String jsonString =
+        "{\"data\":\"{\\\"doubleField\\\": 10.5, \\\"infiniteNumber\\\": Infinity,"
+            + " \\\"negativeInfiniteNumber\\\": -Infinity, \\\"nanNumber\\\": NaN,"
+            + " \\\"int64Field\\\": {\\\"$numberLong\\\": \\\"50\\\"}}\"}";
+    String result = Utils.getCanonicalJsonOfDataField(jsonString);
+
+    assertTrue(result.contains("\"doubleField\": {\"$numberDouble\": \"10.5\"}"));
+    assertTrue(result.contains("\"infiniteNumber\": {\"$numberDouble\": \"Infinity\"}"));
+    assertTrue(result.contains("\"negativeInfiniteNumber\": {\"$numberDouble\": \"-Infinity\"}"));
+    assertTrue(result.contains("\"nanNumber\": {\"$numberDouble\": \"NaN\"}"));
+    assertTrue(result.contains("\"int64Field\": {\"$numberLong\": \"50\"}"));
+  }
+
+  @Test
+  public void testGetCanonicalJsonOfDataField_ObjectInput() {
+    String jsonString =
+        "{\"data\":{\"doubleField\": 10.5, \"infiniteNumber\": Infinity,"
+            + " \"negativeInfiniteNumber\": -Infinity, \"int64Field\": {\"$numberLong\": \"50\"}}}";
+    String result = Utils.getCanonicalJsonOfDataField(jsonString);
+
+    assertTrue(result.contains("\"doubleField\": {\"$numberDouble\": \"10.5\"}"));
+    assertTrue(result.contains("\"infiniteNumber\": {\"$numberDouble\": \"Infinity\"}"));
+    assertTrue(result.contains("\"negativeInfiniteNumber\": {\"$numberDouble\": \"-Infinity\"}"));
+    assertTrue(result.contains("\"int64Field\": {\"$numberLong\": \"50\"}"));
   }
 }


### PR DESCRIPTION
This PR adds JavaScript UDF support to the DataStreamMongoDBToFirestore template. Instead of a single stage applying the UDF to the full event, we use a 3-stage approach to simplify UDF creation and protect metadata.

## The 3-Stage UDF Transform
To avoid requiring users to parse full event JSON in their UDFs, we split the process into three stages:

Stage 1: Prepare UDF Input (PrepareUdfInputFn)
Responsibility: Extracts the data field from the full event and converts it to canonical JSON. Routes missing/invalid data events to DLQ.

Stage 2: Run UDF (FailsafeJavascriptUdf)
Responsibility: Executes the JavaScript UDF on the extracted payload. Users only need to transform the document data, not the full event structure.

Stage 3: Restore UDF Output (RestoreUdfOutputFn)
Responsibility: Injects the transformed payload back into the data field of the original full event, preserving metadata for downstream writing.
