### PR TITLE
Skip UPDATE events with null data field in PrepareUdfInputFn and bypass DELETEs

### DIFF
--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
@@ -141,6 +141,7 @@ public class DataStreamMongoDBToFirestore {
   static final TupleTag<FailsafeElement<String, String>> UDF_FAILURE_TAG = new TupleTag<>();
   static final TupleTag<FailsafeElement<String, String>> PREPARE_FAILURE_TAG = new TupleTag<>();
   static final TupleTag<FailsafeElement<String, String>> RESTORE_FAILURE_TAG = new TupleTag<>();
+  static final TupleTag<FailsafeElement<String, String>> BYPASS_UDF_TAG = new TupleTag<>();
   private static final String AVRO_SUFFIX = "avro";
   private static final String JSON_SUFFIX = "json";
   public static final Set<String> MAPPER_IGNORE_FIELDS =
@@ -1442,18 +1443,54 @@ public class DataStreamMongoDBToFirestore {
 
   public static class PrepareUdfInputFn
       extends DoFn<FailsafeElement<String, String>, FailsafeElement<String, String>> {
+
+    private final Counter skippedUpdates =
+        Metrics.counter(PrepareUdfInputFn.class, "skippedUpdatesWithNullData");
+
     @ProcessElement
     public void processElement(ProcessContext c) {
       FailsafeElement<String, String> element = c.element();
       try {
         String fullEventJson = element.getPayload();
-        String canonicalJson = Utils.getCanonicalJsonOfDataField(fullEventJson);
-        if (canonicalJson != null) {
-          c.output(FailsafeElement.of(fullEventJson, canonicalJson));
-        } else {
+        Document doc = Document.parse(fullEventJson);
+        // Handle events wrapped in a changeEvent field (common for reconsumed DLQ records)
+        Document innerDoc = Utils.extractInnerEvent(doc);
+
+        // Skip UDF if it has already been processed (e.g. on DLQ retry)
+        Boolean udfProcessed = innerDoc.getBoolean("_metadata_udf_processed");
+        if (udfProcessed != null && udfProcessed) {
+          c.output(BYPASS_UDF_TAG, element);
+          return;
+        }
+
+        String changeType = innerDoc.getString(DatastreamConstants.EVENT_CHANGE_TYPE_KEY);
+        if (changeType == null) {
+          changeType = "";
+        }
+
+        Object dataVal = innerDoc.get(MongoDbChangeEventContext.DATA_COL);
+
+        // Delete events don't have a 'data' field to transform, so we bypass the UDF.
+        if ("DELETE".equalsIgnoreCase(changeType)) {
+          c.output(BYPASS_UDF_TAG, element);
+          return;
+        }
+
+        // Update events with null data occurs when an updated document is later
+        // deleted. In this case, we skip the UDF transformation.
+        if ("UPDATE".equalsIgnoreCase(changeType) && dataVal == null) {
+          skippedUpdates.inc();
+          return; // Skip by not outputting anything
+        }
+
+        // Extract and canonicalize the 'data' field for UDF input.
+        String canonicalJson = Utils.getCanonicalJsonOfDataField(innerDoc);
+        if (canonicalJson == null) {
           throw new IllegalArgumentException(
               "Missing data field in event or unsupported data field type");
         }
+
+        c.output(FailsafeElement.of(fullEventJson, canonicalJson));
       } catch (Exception e) {
         LOG.error("Error preparing UDF input, exception: {}", e.getMessage(), e);
         FailsafeElement<String, String> failedElement =
@@ -1475,6 +1512,10 @@ public class DataStreamMongoDBToFirestore {
 
       try {
         JsonNode fullEventNode = OBJECT_MAPPER.readTree(fullEventJson);
+        // Validate that the UDF output is a valid BSON document before proceeding.
+        // This ensures we don't write invalid data to the destination.
+        Document.parse(transformedData);
+
         ((ObjectNode) fullEventNode).put(MongoDbChangeEventContext.DATA_COL, transformedData);
 
         String modifiedEventJson = OBJECT_MAPPER.writeValueAsString(fullEventNode);
@@ -1486,6 +1527,22 @@ public class DataStreamMongoDBToFirestore {
         failedElement.setErrorMessage(e.getMessage());
         failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
         c.output(RESTORE_FAILURE_TAG, failedElement);
+      }
+    }
+  }
+
+  public static class MarkUdfProcessedFn
+      extends DoFn<FailsafeElement<String, String>, FailsafeElement<String, String>> {
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      FailsafeElement<String, String> element = c.element();
+      try {
+        JsonNode node = OBJECT_MAPPER.readTree(element.getPayload());
+        ((ObjectNode) node).put("_metadata_udf_processed", true);
+        String json = OBJECT_MAPPER.writeValueAsString(node);
+        c.output(FailsafeElement.of(json, json));
+      } catch (Exception e) {
+        throw new RuntimeException(e);
       }
     }
   }
@@ -1510,7 +1567,8 @@ public class DataStreamMongoDBToFirestore {
           input.apply(
               "Prepare UDF Input",
               ParDo.of(new PrepareUdfInputFn())
-                  .withOutputTags(UDF_SUCCESS_TAG, TupleTagList.of(PREPARE_FAILURE_TAG)));
+                  .withOutputTags(
+                      UDF_SUCCESS_TAG, TupleTagList.of(PREPARE_FAILURE_TAG).and(BYPASS_UDF_TAG)));
 
       // Handle failed preparation
       writeFailedJsonToDlq(options, preparedResult, dlqManager, PREPARE_FAILURE_TAG);
@@ -1518,6 +1576,11 @@ public class DataStreamMongoDBToFirestore {
       PCollection<FailsafeElement<String, String>> preparedInput =
           preparedResult
               .get(UDF_SUCCESS_TAG)
+              .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+      PCollection<FailsafeElement<String, String>> bypassedElements =
+          preparedResult
+              .get(BYPASS_UDF_TAG)
               .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
 
       PCollectionTuple udfResult =
@@ -1545,9 +1608,20 @@ public class DataStreamMongoDBToFirestore {
 
       writeFailedJsonToDlq(options, restoreResult, dlqManager, RESTORE_FAILURE_TAG);
 
-      return restoreResult
-          .get(UDF_SUCCESS_TAG)
-          .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+      PCollection<FailsafeElement<String, String>> restoredOutput =
+          restoreResult
+              .get(UDF_SUCCESS_TAG)
+              .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+      // Mark as UDF processed to avoid re-processing on DLQ retries
+      PCollection<FailsafeElement<String, String>> markedOutput =
+          restoredOutput.apply("Mark UDF Processed", ParDo.of(new MarkUdfProcessedFn()));
+
+      // Merge the restored UDF output with the events that bypassed the UDF.
+      // Both streams now contain the full event JSON in the required format for downstream steps.
+      return PCollectionList.of(markedOutput)
+          .and(bypassedElements)
+          .apply("Merge Streams", Flatten.pCollections());
     }
   }
 }

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContext.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContext.java
@@ -87,10 +87,7 @@ public class MongoDbChangeEventContext implements Serializable {
 
   public MongoDbChangeEventContext(JsonNode payload, String shadowCollectionPrefix)
       throws JsonProcessingException {
-    this.changeEvent =
-        payload.has(DatastreamConstants.CHANGE_EVENT)
-            ? payload.get(DatastreamConstants.CHANGE_EVENT)
-            : payload;
+    this.changeEvent = Utils.extractInnerEvent(payload);
 
     this.retryCount =
         changeEvent.has(DatastreamConstants.RETRY_COUNT)

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/Utils.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/Utils.java
@@ -17,6 +17,8 @@ package com.google.cloud.teleport.v2.transforms;
 
 import static com.google.cloud.teleport.v2.templates.datastream.MongoDbChangeEventContext.DATA_COL;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.cloud.teleport.v2.templates.datastream.DatastreamConstants;
 import com.google.cloud.teleport.v2.templates.datastream.MongoDbChangeEventContext;
 import java.util.Base64;
 import java.util.Set;
@@ -76,8 +78,7 @@ public final class Utils {
     return documentId.toString();
   }
 
-  public static String getCanonicalJsonOfDataField(String jsonString) {
-    Document fullEvent = Document.parse(jsonString);
+  public static String getCanonicalJsonOfDataField(Document fullEvent) {
     Object dataVal = fullEvent.get(DATA_COL);
     if (dataVal == null) {
       return null;
@@ -89,5 +90,21 @@ public final class Utils {
       return dataDoc.toJson(CANONICAL_JSON_SETTINGS);
     }
     throw new IllegalArgumentException("Unsupported data field type: " + dataVal.getClass());
+  }
+
+  public static String getCanonicalJsonOfDataField(String jsonString) {
+    return getCanonicalJsonOfDataField(Document.parse(jsonString));
+  }
+
+  public static Document extractInnerEvent(Document doc) {
+    return doc.containsKey(DatastreamConstants.CHANGE_EVENT)
+        ? (Document) doc.get(DatastreamConstants.CHANGE_EVENT)
+        : doc;
+  }
+
+  public static JsonNode extractInnerEvent(JsonNode payload) {
+    return payload.has(DatastreamConstants.CHANGE_EVENT)
+        ? payload.get(DatastreamConstants.CHANGE_EVENT)
+        : payload;
   }
 }

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestoreTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestoreTest.java
@@ -16,7 +16,10 @@
 package com.google.cloud.teleport.v2.templates;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,7 +29,11 @@ import com.google.cloud.teleport.v2.values.FailsafeElement;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.metrics.MetricNameFilter;
+import org.apache.beam.sdk.metrics.MetricQueryResults;
+import org.apache.beam.sdk.metrics.MetricsFilter;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
@@ -240,6 +247,172 @@ public final class DataStreamMongoDBToFirestoreTest {
   }
 
   @Test
+  public void prepareUdfInputFn_updateWithNullData_skipsEvent() {
+    String fullEventJson = "{\"_metadata_change_type\":\"UPDATE\"}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "PrepareUdfInput",
+                ParDo.of(new DataStreamMongoDBToFirestore.PrepareUdfInputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(SUCCESS_TAG)).empty();
+    PAssert.that(result.get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)).empty();
+
+    PipelineResult pipelineResult = pipeline.run();
+
+    MetricQueryResults metrics =
+        pipelineResult
+            .metrics()
+            .queryMetrics(
+                MetricsFilter.builder()
+                    .addNameFilter(
+                        MetricNameFilter.named(
+                            DataStreamMongoDBToFirestore.PrepareUdfInputFn.class,
+                            "skippedUpdatesWithNullData"))
+                    .build());
+
+    long count = 0;
+    if (metrics.getCounters().iterator().hasNext()) {
+      count = metrics.getCounters().iterator().next().getAttempted();
+    }
+    assertEquals(1L, count);
+  }
+
+  @Test
+  public void prepareUdfInputFn_insertWithNullData_routesToDlq() {
+    String fullEventJson = "{\"_metadata_change_type\":\"INSERT\"}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "PrepareUdfInput",
+                ParDo.of(new DataStreamMongoDBToFirestore.PrepareUdfInputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG))
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              assertEquals(fullEventJson, element.getOriginalPayload());
+              assertEquals(
+                  "Missing data field in event or unsupported data field type",
+                  element.getErrorMessage());
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void prepareUdfInputFn_wrappedEvent_succeeds() {
+    String fullEventJson =
+        "{\"changeEvent\":{\"_metadata_change_type\":\"UPDATE\",\"data\":{\"field\":\"value\"}}}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "PrepareUdfInput",
+                ParDo.of(new DataStreamMongoDBToFirestore.PrepareUdfInputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(SUCCESS_TAG))
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              assertEquals(fullEventJson, element.getOriginalPayload());
+              assertTrue(element.getPayload().contains("\"field\": \"value\""));
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void prepareUdfInputFn_alreadyProcessed_bypassesUdf() {
+    String processedJson = "{\"_metadata_udf_processed\": true, \"data\": \"{}\"}";
+    FailsafeElement<String, String> input = FailsafeElement.of(processedJson, processedJson);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "PrepareUdfInput",
+                ParDo.of(new DataStreamMongoDBToFirestore.PrepareUdfInputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.BYPASS_UDF_TAG)
+                            .and(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.BYPASS_UDF_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(DataStreamMongoDBToFirestore.BYPASS_UDF_TAG))
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              assertEquals(processedJson, element.getOriginalPayload());
+              assertEquals(processedJson, element.getPayload());
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
   public void prepareUdfInputFn_invalidJson_routesToDlq() {
     String invalidJson = "{invalid}";
     FailsafeElement<String, String> input = FailsafeElement.of(invalidJson, invalidJson);
@@ -303,15 +476,68 @@ public final class DataStreamMongoDBToFirestoreTest {
         .get(DataStreamMongoDBToFirestore.RESTORE_FAILURE_TAG)
         .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
 
-    FailsafeElement<String, String> expectedOutput =
-        FailsafeElement.of(fullEventJson, fullEventJson);
-    PAssert.that(result.get(SUCCESS_TAG)).containsInAnyOrder(expectedOutput);
+    PAssert.that(result.get(SUCCESS_TAG))
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              try {
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode node = mapper.readTree(element.getPayload());
+                assertFalse(node.has("_metadata_udf_processed"));
+                assertEquals("{\"name\":\"John\"}", node.get("data").asText());
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void restoreUdfOutputFn_invalidTransformedData_routesToDlq() {
+    String fullEventJson = "{\"data\":\"{\\\"name\\\":\\\"John\\\"}\"}";
+    String invalidTransformedData = "invalid json";
+    FailsafeElement<String, String> input =
+        FailsafeElement.of(fullEventJson, invalidTransformedData);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "RestoreUdfOutput",
+                ParDo.of(new DataStreamMongoDBToFirestore.RestoreUdfOutputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.RESTORE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.RESTORE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(DataStreamMongoDBToFirestore.RESTORE_FAILURE_TAG))
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              assertEquals(fullEventJson, element.getOriginalPayload());
+              assertEquals(invalidTransformedData, element.getPayload());
+              assertNotNull(element.getErrorMessage());
+              return null;
+            });
 
     pipeline.run();
   }
 
   @Test
   public void restoreUdfOutputFn_changedPayload() {
+    // Test that RestoreUdfOutputFn correctly merges transformed data back into the full event
+    // and overwrites BOTH originalPayload and payload with the modified event JSON.
     String fullEventJson = "{\"data\":{\"name\":\"John\"}}";
     String transformedData = "{\"name\":\"Jane\"}";
     FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, transformedData);
@@ -346,6 +572,12 @@ public final class DataStreamMongoDBToFirestoreTest {
                 String dataStr = node.get("data").asText();
                 JsonNode dataNode = mapper.readTree(dataStr);
                 assertEquals("Jane", dataNode.get("name").asText());
+
+                // Verify that originalPayload is ALSO overwritten with the transformed data
+                JsonNode originalNode = mapper.readTree(element.getOriginalPayload());
+                String originalDataStr = originalNode.get("data").asText();
+                JsonNode originalDataNode = mapper.readTree(originalDataStr);
+                assertEquals("Jane", originalDataNode.get("name").asText());
               } catch (Exception e) {
                 throw new RuntimeException(e);
               }
@@ -418,6 +650,7 @@ public final class DataStreamMongoDBToFirestoreTest {
     String udfCode =
         "function transform(inJson) {\n"
             + "  var obj = JSON.parse(inJson);\n"
+            + "  obj.processed = true;\n"
             + "  return JSON.stringify(obj);\n"
             + "}";
     Path udfFile = Files.createTempFile("test-udf-special", ".js");
@@ -437,7 +670,7 @@ public final class DataStreamMongoDBToFirestoreTest {
     DeadLetterQueueManager dlqManager = DeadLetterQueueManager.create("/tmp/dlq", 3);
 
     String fullEventJson =
-        "{\"data\":{\"nan\":{\"$numberDouble\":\"NaN\"},\"inf\":{\"$numberDouble\":\"Infinity\"},\"negInf\":{\"$numberDouble\":\"-Infinity\"},\"dbl\":3.14,\"lng\":{\"$numberLong\":\"1234567890\"}}}";
+        "{\"data\":{\"_id\":{\"$oid\":\"507f1f77bcf86cd799439011\"},\"nan\":{\"$numberDouble\":\"NaN\"},\"inf\":{\"$numberDouble\":\"Infinity\"},\"negInf\":{\"$numberDouble\":\"-Infinity\"},\"dbl\":3.14,\"lng\":{\"$numberLong\":\"1234567890\"},\"ts\":{\"$timestamp\":{\"t\":123,\"i\":456}}}}";
     FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
 
     PCollection<FailsafeElement<String, String>> result =
@@ -466,10 +699,310 @@ public final class DataStreamMongoDBToFirestoreTest {
                 assertEquals(Double.NEGATIVE_INFINITY, doc.getDouble("negInf"), 0.0);
                 assertEquals(3.14, doc.getDouble("dbl"), 0.0);
                 assertEquals(1234567890L, doc.getLong("lng").longValue());
+                assertEquals(
+                    new org.bson.types.ObjectId("507f1f77bcf86cd799439011"),
+                    doc.getObjectId("_id"));
+                assertEquals(
+                    new org.bson.BsonTimestamp(123, 456),
+                    doc.get("ts", org.bson.BsonTimestamp.class));
+                assertEquals(true, doc.getBoolean("processed"));
 
               } catch (Exception e) {
                 throw new RuntimeException(e);
               }
+              return null;
+            });
+
+    pipeline.run();
+
+    Files.delete(udfFile);
+  }
+
+  @Test
+  public void applyUdfToDataField_updateWithNullData_skipsEvent() throws IOException {
+    String udfCode =
+        "function transform(inJson) {\n"
+            + "  var obj = JSON.parse(inJson);\n"
+            + "  obj.processed = true;\n"
+            + "  return JSON.stringify(obj);\n"
+            + "}";
+    Path udfFile = Files.createTempFile("test-udf-skip", ".js");
+    Files.write(udfFile, udfCode.getBytes());
+
+    String[] args =
+        new String[] {
+          "--javascriptTextTransformGcsPath=" + udfFile.toAbsolutePath().toString(),
+          "--javascriptTextTransformFunctionName=transform",
+          "--deadLetterQueueDirectory=/tmp/dlq"
+        };
+    DataStreamMongoDBToFirestore.Options options =
+        PipelineOptionsFactory.fromArgs(args)
+            .withValidation()
+            .as(DataStreamMongoDBToFirestore.Options.class);
+
+    DeadLetterQueueManager dlqManager = DeadLetterQueueManager.create("/tmp/dlq", 3);
+
+    String fullEventJson = "{\"_metadata_change_type\":\"UPDATE\"}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollection<FailsafeElement<String, String>> result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "ApplyUdf",
+                new DataStreamMongoDBToFirestore.ApplyUdfToDataField(options, dlqManager));
+
+    PAssert.that(result).empty();
+
+    pipeline.run();
+
+    Files.delete(udfFile);
+  }
+
+  @Test
+  public void applyUdfToDataField_udfFails_emitsEmptyResult() throws IOException {
+    String udfCode =
+        "function transform(inJson) {\n" + "  throw new Error(\"UDF failed\");\n" + "}";
+    Path udfFile = Files.createTempFile("test-udf-fail", ".js");
+    Files.write(udfFile, udfCode.getBytes());
+
+    String[] args =
+        new String[] {
+          "--javascriptTextTransformGcsPath=" + udfFile.toAbsolutePath().toString(),
+          "--javascriptTextTransformFunctionName=transform",
+          "--deadLetterQueueDirectory=/tmp/dlq"
+        };
+    DataStreamMongoDBToFirestore.Options options =
+        PipelineOptionsFactory.fromArgs(args)
+            .withValidation()
+            .as(DataStreamMongoDBToFirestore.Options.class);
+
+    DeadLetterQueueManager dlqManager = DeadLetterQueueManager.create("/tmp/dlq", 3);
+
+    String fullEventJson = "{\"data\":{\"name\":\"john\"}}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollection<FailsafeElement<String, String>> result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "ApplyUdf",
+                new DataStreamMongoDBToFirestore.ApplyUdfToDataField(options, dlqManager));
+
+    // The result should be empty because the event failed UDF and went to DLQ
+    PAssert.that(result).empty();
+
+    pipeline.run();
+
+    Files.delete(udfFile);
+  }
+
+  @Test
+  public void applyUdfToDataField_udfReturnsNonBson_emitsEmptyResult() throws IOException {
+    String udfCode = "function transform(inJson) {\n" + "  return \"invalid json\";\n" + "}";
+    Path udfFile = Files.createTempFile("test-udf-non-bson", ".js");
+    Files.write(udfFile, udfCode.getBytes());
+
+    String[] args =
+        new String[] {
+          "--javascriptTextTransformGcsPath=" + udfFile.toAbsolutePath().toString(),
+          "--javascriptTextTransformFunctionName=transform",
+          "--deadLetterQueueDirectory=/tmp/dlq"
+        };
+    DataStreamMongoDBToFirestore.Options options =
+        PipelineOptionsFactory.fromArgs(args)
+            .withValidation()
+            .as(DataStreamMongoDBToFirestore.Options.class);
+
+    DeadLetterQueueManager dlqManager = DeadLetterQueueManager.create("/tmp/dlq", 3);
+
+    String fullEventJson = "{\"data\":{\"name\":\"john\"}}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollection<FailsafeElement<String, String>> result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "ApplyUdf",
+                new DataStreamMongoDBToFirestore.ApplyUdfToDataField(options, dlqManager));
+
+    // If we expect it to be DLQed, the successful result should be empty!
+    PAssert.that(result).empty();
+
+    pipeline.run();
+
+    Files.delete(udfFile);
+  }
+
+  @Test
+  public void applyUdfToDataField_deleteEvent_bypassesUdf() throws IOException {
+    String udfCode =
+        "function transform(inJson) {\n"
+            + "  var obj = JSON.parse(inJson);\n"
+            + "  obj.processed = true;\n"
+            + "  return JSON.stringify(obj);\n"
+            + "}";
+    Path udfFile = Files.createTempFile("test-udf-delete", ".js");
+    Files.write(udfFile, udfCode.getBytes());
+
+    String[] args =
+        new String[] {
+          "--javascriptTextTransformGcsPath=" + udfFile.toAbsolutePath().toString(),
+          "--javascriptTextTransformFunctionName=transform",
+          "--deadLetterQueueDirectory=/tmp/dlq"
+        };
+    DataStreamMongoDBToFirestore.Options options =
+        PipelineOptionsFactory.fromArgs(args)
+            .withValidation()
+            .as(DataStreamMongoDBToFirestore.Options.class);
+
+    DeadLetterQueueManager dlqManager = DeadLetterQueueManager.create("/tmp/dlq", 3);
+
+    String fullEventJson = "{\"_metadata_change_type\":\"DELETE\",\"data\":{\"name\":\"John\"}}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollection<FailsafeElement<String, String>> result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "ApplyUdf",
+                new DataStreamMongoDBToFirestore.ApplyUdfToDataField(options, dlqManager));
+
+    PAssert.that(result)
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              try {
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode node = mapper.readTree(element.getPayload());
+                assertEquals("DELETE", node.get("_metadata_change_type").asText());
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              return null;
+            });
+
+    pipeline.run();
+
+    Files.delete(udfFile);
+  }
+
+  @Test
+  public void applyUdfToDataField_mixedEvents_correctlyProcessed() throws IOException {
+    String udfCode =
+        "function transform(inJson) {\n"
+            + "  var obj = JSON.parse(inJson);\n"
+            + "  obj.processed = true;\n"
+            + "  return JSON.stringify(obj);\n"
+            + "}";
+    Path udfFile = Files.createTempFile("test-udf-mixed", ".js");
+    Files.write(udfFile, udfCode.getBytes());
+
+    String[] args =
+        new String[] {
+          "--javascriptTextTransformGcsPath=" + udfFile.toAbsolutePath().toString(),
+          "--javascriptTextTransformFunctionName=transform",
+          "--deadLetterQueueDirectory=/tmp/dlq"
+        };
+    DataStreamMongoDBToFirestore.Options options =
+        PipelineOptionsFactory.fromArgs(args)
+            .withValidation()
+            .as(DataStreamMongoDBToFirestore.Options.class);
+
+    DeadLetterQueueManager dlqManager = DeadLetterQueueManager.create("/tmp/dlq", 3);
+
+    String insertJson = "{\"_metadata_change_type\":\"INSERT\",\"data\":{\"name\":\"inv1\"}}";
+    String deleteJson = "{\"_metadata_change_type\":\"DELETE\",\"data\":{\"name\":\"del1\"}}";
+    String updateWithDataJson =
+        "{\"_metadata_change_type\":\"UPDATE\",\"data\":{\"name\":\"upd1\"}}";
+    String updateNullDataJson = "{\"_metadata_change_type\":\"UPDATE\"}";
+    String readJson = "{\"_metadata_change_type\":\"READ\",\"data\":{\"name\":\"rd1\"}}";
+
+    java.util.List<FailsafeElement<String, String>> inputs =
+        java.util.Arrays.asList(
+            FailsafeElement.of(insertJson, insertJson),
+            FailsafeElement.of(deleteJson, deleteJson),
+            FailsafeElement.of(updateWithDataJson, updateWithDataJson),
+            FailsafeElement.of(updateNullDataJson, updateNullDataJson),
+            FailsafeElement.of(readJson, readJson));
+
+    PCollection<FailsafeElement<String, String>> result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(inputs)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "ApplyUdf",
+                new DataStreamMongoDBToFirestore.ApplyUdfToDataField(options, dlqManager));
+
+    PAssert.that(result)
+        .satisfies(
+            iterable -> {
+              java.util.List<FailsafeElement<String, String>> elements =
+                  new java.util.ArrayList<>();
+              iterable.forEach(elements::add);
+
+              assertEquals(4, elements.size());
+
+              java.util.Map<String, JsonNode> eventMap = new java.util.HashMap<>();
+              ObjectMapper mapper = new ObjectMapper();
+
+              for (FailsafeElement<String, String> element : elements) {
+                try {
+                  JsonNode node = mapper.readTree(element.getPayload());
+                  String type = node.get("_metadata_change_type").asText();
+                  eventMap.put(type, node);
+                } catch (Exception e) {
+                  throw new RuntimeException(e);
+                }
+              }
+
+              assertTrue(eventMap.containsKey("INSERT"));
+              assertTrue(eventMap.containsKey("DELETE"));
+              assertTrue(eventMap.containsKey("UPDATE"));
+              assertTrue(eventMap.containsKey("READ"));
+
+              // Verify UDF processed flag
+              assertTrue(eventMap.get("INSERT").has("_metadata_udf_processed"));
+              assertTrue(eventMap.get("UPDATE").has("_metadata_udf_processed"));
+              assertTrue(eventMap.get("READ").has("_metadata_udf_processed"));
+              assertFalse(eventMap.get("DELETE").has("_metadata_udf_processed"));
+
+              try {
+                // Verify UDF was applied to INSERT, UPDATE, READ
+                String insertDataStr = eventMap.get("INSERT").get("data").asText();
+                JsonNode insertDataNode = mapper.readTree(insertDataStr);
+                assertTrue(insertDataNode.has("processed"));
+
+                String updateDataStr = eventMap.get("UPDATE").get("data").asText();
+                JsonNode updateDataNode = mapper.readTree(updateDataStr);
+                assertTrue(updateDataNode.has("processed"));
+
+                String readDataStr = eventMap.get("READ").get("data").asText();
+                JsonNode readDataNode = mapper.readTree(readDataStr);
+                assertTrue(readDataNode.has("processed"));
+
+                // Verify UDF was NOT applied to DELETE
+                JsonNode deleteDataNode = eventMap.get("DELETE").get("data");
+                assertFalse(deleteDataNode.has("processed"));
+
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+
               return null;
             });
 

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/ProcessBackfillEventFnTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/ProcessBackfillEventFnTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.teleport.v2.templates;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -171,5 +172,76 @@ public class ProcessBackfillEventFnTest {
     FailsafeElement failedElement = failureCaptor.getValue();
     assertEquals(event2, failedElement.getOriginalPayload());
     assertEquals("Some other error", failedElement.getErrorMessage());
+  }
+
+  @Test
+  public void testProcessBatch_success() {
+    MongoDbChangeEventContext event1 = mock(MongoDbChangeEventContext.class);
+    MongoDbChangeEventContext event2 = mock(MongoDbChangeEventContext.class);
+
+    when(event1.getDataCollection()).thenReturn(COLLECTION_NAME);
+    when(event2.getDataCollection()).thenReturn(COLLECTION_NAME);
+    when(event1.getDocumentId()).thenReturn("id1");
+    when(event2.getDocumentId()).thenReturn("id2");
+    when(event1.getDataAsJsonString()).thenReturn("{\"data\": {\"_id\":\"id1\"}}");
+    when(event2.getDataAsJsonString()).thenReturn("{\"data\": {\"_id\":\"id2\"}}");
+
+    when(mockContext.element()).thenReturn(event1).thenReturn(event2);
+
+    // Process first element
+    fn.processElement(mockContext, mockReceiver);
+
+    // Process second element, should trigger batch processing
+    com.mongodb.bulk.BulkWriteResult mockResult = mock(com.mongodb.bulk.BulkWriteResult.class);
+    when(mockResult.getInsertedCount()).thenReturn(2);
+    when(mockResult.getModifiedCount()).thenReturn(0);
+    when(mockResult.getUpserts()).thenReturn(Collections.emptyList());
+    when(mockResult.getDeletedCount()).thenReturn(0);
+
+    when(mockCollection.bulkWrite(anyList(), any())).thenReturn(mockResult);
+
+    fn.processElement(mockContext, mockReceiver);
+
+    // Verify output
+    verify(mockSuccessReceiver, times(1)).output(event1);
+    verify(mockSuccessReceiver, times(1)).output(event2);
+  }
+
+  @Test
+  public void testFinishBundle_processesRemainingEvents() {
+    MongoDbChangeEventContext event1 = mock(MongoDbChangeEventContext.class);
+
+    when(event1.getDataCollection()).thenReturn(COLLECTION_NAME);
+    when(event1.getDocumentId()).thenReturn("id1");
+    when(event1.getDataAsJsonString()).thenReturn("{\"data\": {\"_id\":\"id1\"}}");
+
+    when(mockContext.element()).thenReturn(event1);
+
+    // Process element, but don't reach batch size (batch size is 2)
+    fn.processElement(mockContext, mockReceiver);
+
+    // Verify no output yet
+    verify(mockSuccessReceiver, times(0)).output(any());
+
+    // Finish bundle
+    com.mongodb.bulk.BulkWriteResult mockResult = mock(com.mongodb.bulk.BulkWriteResult.class);
+    when(mockResult.getInsertedCount()).thenReturn(1);
+    when(mockResult.getModifiedCount()).thenReturn(0);
+    when(mockResult.getUpserts()).thenReturn(Collections.emptyList());
+    when(mockResult.getDeletedCount()).thenReturn(0);
+
+    when(mockCollection.bulkWrite(anyList(), any())).thenReturn(mockResult);
+
+    DoFn.FinishBundleContext mockFinishBundleContext = mock(DoFn.FinishBundleContext.class);
+
+    fn.finishBundle(mockFinishBundleContext);
+
+    // Verify output in finishBundle
+    verify(mockFinishBundleContext, times(1))
+        .output(
+            eq(DataStreamMongoDBToFirestore.ProcessBackfillEventFn.successfulWriteTag),
+            eq(event1),
+            any(org.joda.time.Instant.class),
+            any(org.apache.beam.sdk.transforms.windowing.GlobalWindow.class));
   }
 }

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/UtilsTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/UtilsTest.java
@@ -19,6 +19,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.cloud.teleport.v2.templates.datastream.DatastreamConstants;
 import com.google.cloud.teleport.v2.templates.datastream.MongoDbChangeEventContext;
 import java.util.HashSet;
 import java.util.Set;
@@ -210,5 +214,39 @@ public class UtilsTest {
     assertTrue(result.contains("\"infiniteNumber\": {\"$numberDouble\": \"Infinity\"}"));
     assertTrue(result.contains("\"negativeInfiniteNumber\": {\"$numberDouble\": \"-Infinity\"}"));
     assertTrue(result.contains("\"int64Field\": {\"$numberLong\": \"50\"}"));
+  }
+
+  @Test
+  public void testJsonToDocument_fallbackCase() {
+    // data is an object, not a string
+    String jsonString = "{\"data\": {\"name\": \"John\"}}";
+    Document result = Utils.jsonToDocument(jsonString, "id1");
+
+    assertEquals("John", result.get("name"));
+    assertEquals("id1", result.get("_id"));
+  }
+
+  @Test
+  public void testExtractInnerEvent_Document() {
+    // Test case where the document is wrapped in a "changeEvent" field (common for DLQ records)
+    Document inner = new Document("field", "value");
+    Document wrapped = new Document(DatastreamConstants.CHANGE_EVENT, inner);
+
+    assertEquals(inner, Utils.extractInnerEvent(wrapped));
+    // Test case where the document is NOT wrapped
+    assertEquals(inner, Utils.extractInnerEvent(inner));
+  }
+
+  @Test
+  public void testExtractInnerEvent_JsonNode() throws Exception {
+    // Test case where the JSON node is wrapped in a "changeEvent" field
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode inner = mapper.readTree("{\"field\":\"value\"}");
+    ObjectNode wrapped = mapper.createObjectNode();
+    wrapped.set(DatastreamConstants.CHANGE_EVENT, inner);
+
+    assertEquals(inner, Utils.extractInnerEvent(wrapped));
+    // Test case where the JSON node is NOT wrapped
+    assertEquals(inner, Utils.extractInnerEvent(inner));
   }
 }


### PR DESCRIPTION
Skip UPDATE events with null data in PrepareUdfInputFn to handle cases where an updated document is later deleted. Bypass UDF transformation for DELETE events since they lack a data field. Combine bypassed and successfully transformed results to the next step.
