### PR TITLE
ci: declare contents: read on three workflows

### DIFF
--- a/.github/workflows/spanner-terraform-validator.yml
+++ b/.github/workflows/spanner-terraform-validator.yml
@@ -15,6 +15,9 @@ on:
       - 'v2/sourcedb-to-spanner/terraform/samples/**'
       - 'v2/spanner-to-sourcedb/terraform/samples/**'
 
+permissions:
+  contents: read
+
 jobs:
   verify-terraform-samples:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-jar.yml
+++ b/.github/workflows/upload-jar.yml
@@ -30,6 +30,9 @@ on:
         required: true
 
 
+permissions:
+  contents: read
+
 jobs:
   build-and-upload:
     runs-on:  [self-hosted, release]

--- a/.github/workflows/upload-python-package.yml
+++ b/.github/workflows/upload-python-package.yml
@@ -25,6 +25,9 @@ on:
         description: 'Version number for the package (e.g., 0.1.0)'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build-and-upload:
     runs-on: [self-hosted, release]


### PR DESCRIPTION
Three workflows currently without explicit permissions:

- `spanner-terraform-validator` — PR-time `terraform fmt -check`, `terraform validate`, README convention check.
- `upload-jar` / `upload-python-package` — manual `workflow_dispatch` jobs that build artifacts and upload to GCS. GCS auth uses the self-hosted runner`s preconfigured gcloud credentials, not GITHUB_TOKEN.

All three only need `contents: read` from the GitHub token for `actions/checkout`. The DataflowTemplates repo has 26 workflows total; 23 already declare permissions explicitly. This brings the remaining three in line.