### PR TITLE
fix(datastream-to-bigquery): Added support to read SQLServer Primary keys from replication_index to support Merge operation (Issue #3805)

### DIFF
--- a/.github/workflows/spanner-load-tests.yml
+++ b/.github/workflows/spanner-load-tests.yml
@@ -32,7 +32,7 @@ permissions: write-all
 jobs:
   load_tests:
     name: Spanner Dataflow Templates Load tests
-    timeout-minutes: 1440 # 1 day
+    timeout-minutes: 2100 # 35 hours
     # Run on any runner that matches all the specified runs-on values.
     runs-on: [ self-hosted, perf ]
     steps:

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlShardOrchestrator.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/CloudSqlShardOrchestrator.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.teleport.v2.templates.loadtesting;
+package org.apache.beam.it.gcp.cloudsql;
 
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
@@ -27,7 +27,6 @@ import com.google.api.services.sqladmin.model.User;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.BlobInfo;
-import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.SQLDialect;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -39,9 +38,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.apache.beam.it.gcp.artifacts.GcsArtifact;
-import org.apache.beam.it.gcp.cloudsql.CloudMySQLResourceManager;
-import org.apache.beam.it.gcp.cloudsql.CloudPostgresResourceManager;
-import org.apache.beam.it.gcp.cloudsql.CloudSqlResourceManager;
 import org.apache.beam.it.gcp.storage.GcsResourceManager;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -72,7 +68,12 @@ public class CloudSqlShardOrchestrator {
   public static final String MYSQL_8_0 = "MYSQL_8_0";
   public static final String POSTGRES_14 = "POSTGRES_14";
 
-  protected final SQLDialect sqlDialect;
+  public enum DatabaseType {
+    MYSQL,
+    POSTGRESQL
+  }
+
+  protected final DatabaseType databaseType;
   protected final String dbVersion;
   protected final int port;
   protected final String project;
@@ -80,21 +81,22 @@ public class CloudSqlShardOrchestrator {
   protected final String username;
   protected final String password;
   protected final GcsResourceManager gcsResourceManager;
-  protected final Map<String, CloudSqlResourceManager> managers;
+  public final Map<String, CloudSqlResourceManager> managers;
   protected final Map<String, String> instanceIpMap;
-  protected Map<String, List<String>> requestedShardMap;
+  public Map<String, List<String>> requestedShardMap;
   protected final SQLAdmin sqlAdmin;
 
   /**
    * Constructs a new orchestrator for the specified database dialect.
    *
-   * @param dbType The dialect of the source database (e.g., MYSQL, POSTGRESQL).
+   * @param dbType The type of the source database (MYSQL or POSTGRESQL).
+   * @param dbVersion The version of the database.
    * @param project The GCP project ID.
    * @param region The GCP region for Cloud SQL instances.
    * @param gcsResourceManager The GCS resource manager for uploading configuration artifacts.
    */
   public CloudSqlShardOrchestrator(
-      SQLDialect dbType,
+      DatabaseType dbType,
       String dbVersion,
       String project,
       String region,
@@ -106,7 +108,7 @@ public class CloudSqlShardOrchestrator {
         region,
         gcsResourceManager,
         System.getProperty(
-            "cloudProxyUsername", (dbType == SQLDialect.MYSQL) ? "root" : "postgres"),
+            "cloudProxyUsername", (dbType == DatabaseType.MYSQL) ? "root" : "postgres"),
         System.getProperty("cloudProxyPassword", ""),
         null);
   }
@@ -114,7 +116,8 @@ public class CloudSqlShardOrchestrator {
   /**
    * Constructs a new orchestrator with explicit credentials.
    *
-   * @param sqlDialect The dialect of the source database.
+   * @param databaseType The type of the source database.
+   * @param dbVersion The version of the database.
    * @param project The GCP project ID.
    * @param region The GCP region.
    * @param gcsResourceManager The GCS resource manager.
@@ -123,7 +126,7 @@ public class CloudSqlShardOrchestrator {
    * @param credentials The GCP credentials to use.
    */
   public CloudSqlShardOrchestrator(
-      SQLDialect sqlDialect,
+      DatabaseType databaseType,
       String dbVersion,
       String project,
       String region,
@@ -131,8 +134,8 @@ public class CloudSqlShardOrchestrator {
       String username,
       String password,
       GoogleCredentials credentials) {
-    checkVersionCompatibility(sqlDialect, dbVersion);
-    this.sqlDialect = sqlDialect;
+    checkVersionCompatibility(databaseType, dbVersion);
+    this.databaseType = databaseType;
     this.dbVersion = dbVersion;
     this.project = project;
     this.region = region;
@@ -158,14 +161,14 @@ public class CloudSqlShardOrchestrator {
       LOG.error("Exception while initializing SQL Admin", e);
       throw new RuntimeException("Failed to initialize SQLAdmin client", e);
     }
-    port = (sqlDialect == SQLDialect.MYSQL) ? 3306 : 5432;
+    port = (databaseType == DatabaseType.MYSQL) ? 3306 : 5432;
   }
 
   @VisibleForTesting
-  protected static void checkVersionCompatibility(SQLDialect sqlDialect, String dbVersion) {
+  protected static void checkVersionCompatibility(DatabaseType databaseType, String dbVersion) {
     Preconditions.checkArgument(
-        (sqlDialect == SQLDialect.MYSQL && dbVersion.toLowerCase().startsWith("mysql"))
-            || (sqlDialect == SQLDialect.POSTGRESQL
+        (databaseType == DatabaseType.MYSQL && dbVersion.toLowerCase().startsWith("mysql"))
+            || (databaseType == DatabaseType.POSTGRESQL
                 && dbVersion.toLowerCase().startsWith("postgres")));
   }
 
@@ -265,7 +268,7 @@ public class CloudSqlShardOrchestrator {
     User user = new User().setName(username).setPassword(password);
 
     // MySQL requires a '%' host for connections from any IP within the VPC.
-    if (sqlDialect == SQLDialect.MYSQL) {
+    if (databaseType == DatabaseType.MYSQL) {
       user.setHost("%");
     }
 
@@ -273,7 +276,7 @@ public class CloudSqlShardOrchestrator {
     // These are passed as query parameters in the Update request.
     SQLAdmin.Users.Update request = sqlAdmin.users().update(project, instanceName, user);
     request.setName(username);
-    if (sqlDialect == SQLDialect.MYSQL) {
+    if (databaseType == DatabaseType.MYSQL) {
       // In MySQL, host is part of the primary key for a user. '%' allows the user to connect from
       // any VPC IP.
       request.setHost("%");
@@ -319,7 +322,9 @@ public class CloudSqlShardOrchestrator {
 
   protected void createPhysicalInstance(String instanceName)
       throws IOException, InterruptedException {
-    String tier = sqlDialect == SQLDialect.MYSQL ? "db-n1-standard-2" : "db-custom-2-7680";
+    String defaultTier =
+        databaseType == DatabaseType.MYSQL ? "db-n1-standard-2" : "db-custom-2-7680";
+    String tier = System.getProperty("cloudSqlInstanceTier", defaultTier);
     DatabaseInstance instance =
         new DatabaseInstance()
             .setName(instanceName)
@@ -370,19 +375,19 @@ public class CloudSqlShardOrchestrator {
 
   protected CloudSqlResourceManager createManager(String instanceName) {
     String ip = instanceIpMap.get(instanceName);
-    if (sqlDialect == SQLDialect.MYSQL) {
+    if (databaseType == DatabaseType.MYSQL) {
       return (CloudSqlResourceManager)
           CloudMySQLResourceManager.builder(instanceName)
               .maybeUseStaticInstance(ip, port, username, password)
               .build();
-    } else if (sqlDialect == SQLDialect.POSTGRESQL) {
+    } else if (databaseType == DatabaseType.POSTGRESQL) {
       return (CloudSqlResourceManager)
           CloudPostgresResourceManager.builder(instanceName)
               .maybeUseStaticInstance(ip, port, username, password)
               .setDatabaseName("postgres")
               .build();
     } else {
-      throw new IllegalArgumentException("Unsupported database type: " + sqlDialect);
+      throw new IllegalArgumentException("Unsupported database type: " + databaseType);
     }
   }
 
@@ -400,6 +405,11 @@ public class CloudSqlShardOrchestrator {
                 CloudSqlResourceManager manager = createManager(instanceName);
                 managers.put(instanceName, manager);
                 for (String dbName : dbNames) {
+                  try {
+                    manager.runSQLUpdate("DROP DATABASE IF EXISTS " + dbName);
+                  } catch (Exception e) {
+                    LOG.warn("Failed to drop pre-existing database {} if it existed", dbName, e);
+                  }
                   manager.createDatabase(dbName);
                 }
               }));

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/ShardOrchestrationException.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/cloudsql/ShardOrchestrationException.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.teleport.v2.templates.loadtesting;
+package org.apache.beam.it.gcp.cloudsql;
 
 /** Exception thrown when Cloud SQL shard orchestration fails. */
 public class ShardOrchestrationException extends RuntimeException {

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudSqlShardOrchestratorTest.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/cloudsql/CloudSqlShardOrchestratorTest.java
@@ -13,11 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.teleport.v2.templates.loadtesting;
+package org.apache.beam.it.gcp.cloudsql;
 
-import static com.google.cloud.teleport.v2.templates.loadtesting.CloudSqlShardOrchestrator.MYSQL_8_0;
-import static com.google.cloud.teleport.v2.templates.loadtesting.CloudSqlShardOrchestrator.POSTGRES_14;
 import static com.google.common.truth.Truth.assertThat;
+import static org.apache.beam.it.gcp.cloudsql.CloudSqlShardOrchestrator.MYSQL_8_0;
+import static org.apache.beam.it.gcp.cloudsql.CloudSqlShardOrchestrator.POSTGRES_14;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -41,7 +41,6 @@ import com.google.api.services.sqladmin.model.Operation;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobInfo;
-import com.google.cloud.teleport.v2.source.reader.io.jdbc.iowrapper.config.SQLDialect;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 import java.util.Arrays;
@@ -50,8 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import org.apache.beam.it.gcp.artifacts.GcsArtifact;
-import org.apache.beam.it.gcp.cloudsql.CloudMySQLResourceManager;
-import org.apache.beam.it.gcp.cloudsql.CloudPostgresResourceManager;
+import org.apache.beam.it.gcp.cloudsql.CloudSqlShardOrchestrator.DatabaseType;
 import org.apache.beam.it.gcp.storage.GcsResourceManager;
 import org.junit.Before;
 import org.junit.Test;
@@ -88,13 +86,13 @@ public class CloudSqlShardOrchestratorTest {
   /** Helper subclass to inject mock SQLAdmin and synchronous executor. */
   private static class TestCloudSqlShardOrchestrator extends CloudSqlShardOrchestrator {
     public TestCloudSqlShardOrchestrator(
-        SQLDialect sqlDialect,
+        DatabaseType databaseType,
         String dbVersion,
         String project,
         String region,
         GcsResourceManager gcsResourceManager,
         SQLAdmin sqlAdmin) {
-      super(sqlDialect, dbVersion, project, region, gcsResourceManager);
+      super(databaseType, dbVersion, project, region, gcsResourceManager);
       // Overwrite the real sqlAdmin created in super constructor
       try {
         java.lang.reflect.Field field =
@@ -138,7 +136,7 @@ public class CloudSqlShardOrchestratorTest {
   public void testInitialize_provisionsAndSetsUpCorrectly() throws Exception {
     TestCloudSqlShardOrchestrator orchestrator =
         new TestCloudSqlShardOrchestrator(
-            SQLDialect.MYSQL, MYSQL_8_0, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
+            DatabaseType.MYSQL, MYSQL_8_0, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
 
     // Mock Stage 1: Physical Provisioning
     DatabaseInstance instance =
@@ -189,7 +187,7 @@ public class CloudSqlShardOrchestratorTest {
   public void testInitialize_createsInstance_whenMissing() throws Exception {
     TestCloudSqlShardOrchestrator orchestrator =
         new TestCloudSqlShardOrchestrator(
-            SQLDialect.MYSQL, MYSQL_8_0, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
+            DatabaseType.MYSQL, MYSQL_8_0, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
 
     // Mock 404 for first call, then 200 for refresh
     when(sqlAdmin.instances().get(PROJECT_ID, INSTANCE_NAME).execute())
@@ -228,7 +226,7 @@ public class CloudSqlShardOrchestratorTest {
   public void testCleanup_delegatesToManagers() throws Exception {
     TestCloudSqlShardOrchestrator orchestrator =
         new TestCloudSqlShardOrchestrator(
-            SQLDialect.MYSQL, MYSQL_8_0, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
+            DatabaseType.MYSQL, MYSQL_8_0, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
 
     // Mock successful initialization to populate managers map
     when(sqlAdmin.instances().get(PROJECT_ID, INSTANCE_NAME).execute())
@@ -272,7 +270,7 @@ public class CloudSqlShardOrchestratorTest {
 
       CloudSqlShardOrchestrator orchestrator =
           new CloudSqlShardOrchestrator(
-              SQLDialect.MYSQL, MYSQL_8_0, PROJECT_ID, REGION, gcsResourceManager);
+              DatabaseType.MYSQL, MYSQL_8_0, PROJECT_ID, REGION, gcsResourceManager);
 
       assertThat(orchestrator.project).isEqualTo(PROJECT_ID);
     }
@@ -282,7 +280,7 @@ public class CloudSqlShardOrchestratorTest {
   public void testInitialize_provisionsAndSetsUpPostgresCorrectly() throws Exception {
     TestCloudSqlShardOrchestrator orchestrator =
         new TestCloudSqlShardOrchestrator(
-            SQLDialect.POSTGRESQL, POSTGRES_14, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
+            DatabaseType.POSTGRESQL, POSTGRES_14, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
 
     DatabaseInstance instance =
         new DatabaseInstance()
@@ -318,20 +316,19 @@ public class CloudSqlShardOrchestratorTest {
   public void testInitialize_throwsOnFailure() throws Exception {
     TestCloudSqlShardOrchestrator orchestrator =
         new TestCloudSqlShardOrchestrator(
-            SQLDialect.MYSQL, MYSQL_8_0, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
+            DatabaseType.MYSQL, MYSQL_8_0, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
 
     when(sqlAdmin.instances().get(anyString(), anyString()).execute())
         .thenThrow(new IOException("API Error"));
 
-    assertThrows(
-        ShardOrchestrationException.class, () -> orchestrator.initialize(shardMap, "shards.json"));
+    assertThrows(RuntimeException.class, () -> orchestrator.initialize(shardMap, "shards.json"));
   }
 
   @Test
   public void testExecuteWithRetries_retriesOn409() throws Exception {
     TestCloudSqlShardOrchestrator orchestrator =
         new TestCloudSqlShardOrchestrator(
-            SQLDialect.MYSQL, MYSQL_8_0, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
+            DatabaseType.MYSQL, MYSQL_8_0, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
 
     com.google.api.client.googleapis.services.AbstractGoogleClientRequest<DatabaseInstance>
         mockRequest =
@@ -355,7 +352,7 @@ public class CloudSqlShardOrchestratorTest {
   public void testWaitForOperation_throwsOnOpError() throws Exception {
     TestCloudSqlShardOrchestrator orchestrator =
         new TestCloudSqlShardOrchestrator(
-            SQLDialect.MYSQL, MYSQL_8_0, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
+            DatabaseType.MYSQL, MYSQL_8_0, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
 
     Operation op = mock(Operation.class, Answers.RETURNS_DEEP_STUBS);
     when(op.getName()).thenReturn("op-error");
@@ -373,7 +370,7 @@ public class CloudSqlShardOrchestratorTest {
   public void testCleanup_handlesDropDatabaseError() throws Exception {
     TestCloudSqlShardOrchestrator orchestrator =
         new TestCloudSqlShardOrchestrator(
-            SQLDialect.MYSQL, MYSQL_8_0, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
+            DatabaseType.MYSQL, MYSQL_8_0, PROJECT_ID, REGION, gcsResourceManager, sqlAdmin);
 
     // Mock successful initialization
     DatabaseInstance instance =
@@ -411,13 +408,14 @@ public class CloudSqlShardOrchestratorTest {
   public void testVersionCompatability() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> CloudSqlShardOrchestrator.checkVersionCompatibility(SQLDialect.MYSQL, POSTGRES_14));
+        () -> CloudSqlShardOrchestrator.checkVersionCompatibility(DatabaseType.MYSQL, POSTGRES_14));
     assertThrows(
         IllegalArgumentException.class,
         () ->
-            CloudSqlShardOrchestrator.checkVersionCompatibility(SQLDialect.POSTGRESQL, MYSQL_8_0));
+            CloudSqlShardOrchestrator.checkVersionCompatibility(
+                DatabaseType.POSTGRESQL, MYSQL_8_0));
 
-    CloudSqlShardOrchestrator.checkVersionCompatibility(SQLDialect.MYSQL, MYSQL_8_0);
-    CloudSqlShardOrchestrator.checkVersionCompatibility(SQLDialect.POSTGRESQL, POSTGRES_14);
+    CloudSqlShardOrchestrator.checkVersionCompatibility(DatabaseType.MYSQL, MYSQL_8_0);
+    CloudSqlShardOrchestrator.checkVersionCompatibility(DatabaseType.POSTGRESQL, POSTGRES_14);
   }
 }

--- a/python/src/main/python/job-builder-util-transforms/pyproject.toml
+++ b/python/src/main/python/job-builder-util-transforms/pyproject.toml
@@ -9,7 +9,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.11,<4.0"
-apache-beam = {extras = ["gcp", "yaml"], version = "^2.72.0"}
+apache-beam = {extras = ["gcp", "yaml", "aws"], version = "^2.72.0"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.4"

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/BatchAndWriteFn.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/BatchAndWriteFn.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.dofn;
+
+import com.google.cloud.teleport.v2.templates.CdcDataGeneratorOptions.SinkType;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorSchema;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
+import com.google.cloud.teleport.v2.templates.model.GeneratedRecord;
+import com.google.cloud.teleport.v2.templates.model.LifecycleEvent;
+import com.google.cloud.teleport.v2.templates.sink.DataWriter;
+import com.google.cloud.teleport.v2.templates.sink.DataWriterFactory;
+import com.google.cloud.teleport.v2.templates.utils.FailureRecord;
+import com.google.cloud.teleport.v2.templates.utils.SchemaUtils;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.List;
+import java.util.function.Consumer;
+import net.datafaker.Faker;
+import org.apache.beam.sdk.coders.ListCoder;
+import org.apache.beam.sdk.coders.SerializableCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.VarLongCoder;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.state.MapState;
+import org.apache.beam.sdk.state.StateSpec;
+import org.apache.beam.sdk.state.StateSpecs;
+import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.state.Timer;
+import org.apache.beam.sdk.state.TimerSpec;
+import org.apache.beam.sdk.state.TimerSpecs;
+import org.apache.beam.sdk.state.ValueState;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.Row;
+import org.joda.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Stateful {@link DoFn} that manages persistence lifecycles, state fields, and timers, delegating
+ * core traversal to {@link DataGeneratorEngine} and mutation batch writing to {@link
+ * MutationBatcher}.
+ */
+public class BatchAndWriteFn extends DoFn<KV<Integer, GeneratedRecord>, String> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BatchAndWriteFn.class);
+
+  private final SinkType sinkType;
+  private final String sinkOptionsPath;
+  private final int batchSize;
+  private final Integer jdbcPoolSize;
+  private final Integer updateInterval;
+  private final Integer deleteInterval;
+  private final PCollectionView<DataGeneratorSchema> schemaView;
+
+  private transient DataWriter writer;
+  private transient Faker faker;
+  private transient volatile DataGeneratorSchema schema;
+  private transient volatile List<String> insertTopoOrder;
+
+  private transient DataGeneratorEngine dataGeneratorEngine;
+  private transient MutationBatcher batcher;
+
+  @StateId("eventQueue")
+  private final StateSpec<MapState<Long, List<LifecycleEvent>>> eventQueueSpec =
+      StateSpecs.map(VarLongCoder.of(), ListCoder.of(SerializableCoder.of(LifecycleEvent.class)));
+
+  @StateId("activeTimestamps")
+  private final StateSpec<ValueState<List<Long>>> activeTimestampsSpec =
+      StateSpecs.value(ListCoder.of(VarLongCoder.of()));
+
+  @StateId("tableMapState")
+  private final StateSpec<MapState<String, DataGeneratorTable>> tableMapSpec =
+      StateSpecs.map(StringUtf8Coder.of(), SerializableCoder.of(DataGeneratorTable.class));
+
+  @StateId("insertTopoOrderState")
+  private final StateSpec<ValueState<List<String>>> insertTopoOrderSpec =
+      StateSpecs.value(ListCoder.of(StringUtf8Coder.of()));
+
+  @TimerId("eventTimer")
+  private final TimerSpec eventTimerSpec = TimerSpecs.timer(TimeDomain.PROCESSING_TIME);
+
+  public BatchAndWriteFn(
+      SinkType sinkType,
+      String sinkOptionsPath,
+      Integer batchSize,
+      Integer jdbcPoolSize,
+      Integer updateInterval,
+      Integer deleteInterval,
+      PCollectionView<DataGeneratorSchema> schemaView) {
+    this.sinkType = sinkType;
+    this.sinkOptionsPath = sinkOptionsPath;
+    this.batchSize = batchSize;
+    this.jdbcPoolSize = jdbcPoolSize;
+    this.updateInterval = updateInterval;
+    this.deleteInterval = deleteInterval;
+    this.schemaView = schemaView;
+  }
+
+  @Setup
+  public void setup() {
+    this.schema = null;
+    this.insertTopoOrder = null;
+    if (writer == null) {
+      writer = DataWriterFactory.createWriter(sinkType, sinkOptionsPath);
+    }
+    if (faker == null) {
+      faker = new Faker();
+    }
+
+    this.batcher = new MutationBatcher(batchSize, jdbcPoolSize, writer);
+    this.dataGeneratorEngine = new DataGeneratorEngine(updateInterval, deleteInterval, faker);
+  }
+
+  @StartBundle
+  public void startBundle() {
+    this.batcher.startBundle();
+  }
+
+  @ProcessElement
+  public void processElement(
+      ProcessContext c,
+      @StateId("eventQueue") MapState<Long, List<LifecycleEvent>> eventQueueState,
+      @StateId("activeTimestamps") ValueState<List<Long>> activeTimestamps,
+      @StateId("tableMapState") MapState<String, DataGeneratorTable> tableMapState,
+      @StateId("insertTopoOrderState") ValueState<List<String>> insertTopoOrderState,
+      @TimerId("eventTimer") Timer eventTimer) {
+
+    ensureSchemaInitialized(c, insertTopoOrderState);
+
+    GeneratedRecord record = c.element().getValue();
+    String tableName = record.tableName();
+    Row pkValues = record.primaryKeyValues();
+
+    try {
+      dataGeneratorEngine.processRecord(
+          tableName,
+          pkValues,
+          eventQueueState,
+          activeTimestamps,
+          tableMapState,
+          eventTimer,
+          schema,
+          batcher,
+          insertTopoOrder);
+    } catch (Exception genError) {
+      LOG.error("Generation failed for table {}", tableName, genError);
+      Metrics.counter(BatchAndWriteFn.class, "generationFailures").inc();
+      batcher
+          .getFailedRecords()
+          .add(
+              FailureRecord.toJson(
+                  tableName, FailureRecord.OPERATION_GENERATION, pkValues, genError));
+    }
+
+    writeFailedRecords(c::output);
+  }
+
+  @OnTimer("eventTimer")
+  public void onTimer(
+      OnTimerContext c,
+      @StateId("eventQueue") MapState<Long, List<LifecycleEvent>> eventQueueState,
+      @StateId("activeTimestamps") ValueState<List<Long>> activeTimestamps,
+      @StateId("tableMapState") MapState<String, DataGeneratorTable> tableMapState,
+      @StateId("insertTopoOrderState") ValueState<List<String>> insertTopoOrderState,
+      @TimerId("eventTimer") Timer eventTimer) {
+
+    if (this.insertTopoOrder == null) {
+      this.insertTopoOrder = insertTopoOrderState.read();
+    }
+
+    try {
+      dataGeneratorEngine.processScheduledEvents(
+          eventQueueState,
+          activeTimestamps,
+          tableMapState,
+          eventTimer,
+          batcher,
+          batcher.getFailedRecords(),
+          this.insertTopoOrder);
+    } catch (Exception timerError) {
+      LOG.error("Scheduled events generation failed during timer processing", timerError);
+      Metrics.counter(BatchAndWriteFn.class, "generationFailures").inc();
+      batcher.getFailedRecords().add(FailureRecord.toJson("UNKNOWN_TABLE", null, null, timerError));
+    }
+
+    writeFailedRecords(c::output);
+  }
+
+  @FinishBundle
+  public void finishBundle(FinishBundleContext c) {
+    batcher.flushInsertsInTopoOrder(insertTopoOrder);
+    batcher.flushUpdates();
+    batcher.flushDeletesInReverseTopoOrder(insertTopoOrder);
+
+    List<String> pendingDlq = batcher.getFailedRecords();
+    if (pendingDlq != null && !pendingDlq.isEmpty()) {
+      Instant now = Instant.now();
+      for (String record : pendingDlq) {
+        c.output(record, now, GlobalWindow.INSTANCE);
+      }
+      batcher.clearDlq();
+    }
+  }
+
+  @Teardown
+  public void teardown() {
+    if (writer != null) {
+      try {
+        writer.close();
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to close writer", e);
+      }
+    }
+  }
+
+  private void ensureSchemaInitialized(
+      ProcessContext c, ValueState<List<String>> insertTopoOrderState) {
+    if (schema != null && insertTopoOrder != null) {
+      return;
+    }
+    DataGeneratorSchema loaded = c.sideInput(schemaView);
+    this.insertTopoOrder = SchemaUtils.buildInsertTopoOrder(loaded);
+    insertTopoOrderState.write(this.insertTopoOrder);
+    this.schema = loaded;
+  }
+
+  private void writeFailedRecords(Consumer<String> sink) {
+    List<String> dlq = batcher.getFailedRecords();
+    if (dlq == null || dlq.isEmpty()) {
+      return;
+    }
+    for (String record : dlq) {
+      sink.accept(record);
+    }
+    batcher.clearDlq();
+  }
+
+  @VisibleForTesting
+  DataWriter getWriter() {
+    return writer;
+  }
+
+  @VisibleForTesting
+  void setWriter(DataWriter writer) {
+    this.writer = writer;
+  }
+
+  @VisibleForTesting
+  Faker getFaker() {
+    return faker;
+  }
+
+  @VisibleForTesting
+  void setFaker(Faker faker) {
+    this.faker = faker;
+  }
+
+  @VisibleForTesting
+  DataGeneratorSchema getSchema() {
+    return schema;
+  }
+
+  @VisibleForTesting
+  void setSchema(DataGeneratorSchema schema) {
+    this.schema = schema;
+  }
+
+  @VisibleForTesting
+  List<String> getInsertTopoOrder() {
+    return insertTopoOrder;
+  }
+
+  @VisibleForTesting
+  void setInsertTopoOrder(List<String> insertTopoOrder) {
+    this.insertTopoOrder = insertTopoOrder;
+  }
+
+  @VisibleForTesting
+  DataGeneratorEngine getDataGeneratorEngine() {
+    return dataGeneratorEngine;
+  }
+
+  @VisibleForTesting
+  void setDataGeneratorEngine(DataGeneratorEngine dataGeneratorEngine) {
+    this.dataGeneratorEngine = dataGeneratorEngine;
+  }
+
+  @VisibleForTesting
+  MutationBatcher getBatcher() {
+    return batcher;
+  }
+
+  @VisibleForTesting
+  void setBatcher(MutationBatcher batcher) {
+    this.batcher = batcher;
+  }
+}

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/model/GeneratedRecord.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/model/GeneratedRecord.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.model;
+
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+import org.apache.beam.sdk.values.Row;
+
+/** Type-safe container wrapping table names and primary key values. */
+@AutoValue
+public abstract class GeneratedRecord implements Serializable {
+  public abstract String tableName();
+
+  public abstract Row primaryKeyValues();
+
+  public static GeneratedRecord create(String tableName, Row primaryKeyValues) {
+    return new AutoValue_GeneratedRecord(tableName, primaryKeyValues);
+  }
+}

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/sink/DataWriterFactory.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/sink/DataWriterFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.sink;
+
+import com.google.cloud.teleport.v2.templates.CdcDataGeneratorOptions.SinkType;
+import com.google.cloud.teleport.v2.templates.mysql.MySqlDataWriter;
+import com.google.cloud.teleport.v2.templates.spanner.SpannerDataWriter;
+
+/**
+ * Factory class for creating {@link DataWriter} instances based on the configured {@link SinkType}.
+ */
+public class DataWriterFactory {
+
+  private DataWriterFactory() {}
+
+  /**
+   * Creates a {@link DataWriter} for the specified sink type and configuration path.
+   *
+   * @param type the sink type to create a writer for
+   * @param configPath the path to the sink configuration document
+   * @return a new {@link DataWriter} instance
+   * @throws IllegalArgumentException if the sink type is unsupported
+   */
+  public static DataWriter createWriter(SinkType type, String configPath) {
+    switch (type) {
+      case MYSQL:
+        return new MySqlDataWriter(configPath);
+      case SPANNER:
+        return new SpannerDataWriter(configPath);
+      default:
+        throw new IllegalArgumentException("Unsupported sink type: " + type);
+    }
+  }
+}

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/dofn/BatchAndWriteFnTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/dofn/BatchAndWriteFnTest.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.dofn;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.teleport.v2.templates.CdcDataGeneratorOptions.SinkType;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorColumn;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorSchema;
+import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
+import com.google.cloud.teleport.v2.templates.model.GeneratedRecord;
+import com.google.cloud.teleport.v2.templates.model.LogicalType;
+import com.google.cloud.teleport.v2.templates.sink.DataWriter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import net.datafaker.Faker;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.state.MapState;
+import org.apache.beam.sdk.state.Timer;
+import org.apache.beam.sdk.state.ValueState;
+import org.apache.beam.sdk.transforms.DoFn.FinishBundleContext;
+import org.apache.beam.sdk.transforms.DoFn.OnTimerContext;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.Row;
+import org.joda.time.Instant;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Comprehensive unit tests covering code paths and lifecycle of {@link BatchAndWriteFn}. */
+@RunWith(JUnit4.class)
+@SuppressWarnings("unchecked")
+public class BatchAndWriteFnTest {
+
+  @Test
+  public void constructor_nonPositiveBatchSize_fallsBackToDefault() {
+    BatchAndWriteFn fn =
+        new BatchAndWriteFn(SinkType.SPANNER, "{}", 0, null, 10, 10, mock(PCollectionView.class));
+    assertNotNull(fn);
+  }
+
+  @Test
+  public void testSetup_initializesDefaultWriterAndFaker() throws Exception {
+    BatchAndWriteFn fn =
+        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+    fn.setup();
+
+    assertNotNull(fn.getWriter());
+    assertNotNull(fn.getFaker());
+    assertNotNull(fn.getBatcher());
+    assertNotNull(fn.getDataGeneratorEngine());
+  }
+
+  @Test
+  public void testSetup_retainsInjectedWriterAndFaker() throws Exception {
+    BatchAndWriteFn fn =
+        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+    DataWriter mockWriter = mock(DataWriter.class);
+    Faker mockFaker = mock(Faker.class);
+
+    fn.setWriter(mockWriter);
+    fn.setFaker(mockFaker);
+
+    fn.setup();
+
+    assertEquals(mockWriter, fn.getWriter());
+    assertEquals(mockFaker, fn.getFaker());
+  }
+
+  @Test
+  public void testStartBundle_callsBatcherStartBundle() throws Exception {
+    BatchAndWriteFn fn =
+        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+    MutationBatcher mockBatcher = mock(MutationBatcher.class);
+    fn.setBatcher(mockBatcher);
+
+    fn.startBundle();
+
+    verify(mockBatcher).startBundle();
+  }
+
+  @Test
+  public void testProcessElement_initializesSchemaWhenNull() throws Exception {
+    DataGeneratorTable users = simpleUsersTable();
+    DataGeneratorSchema schema =
+        DataGeneratorSchema.builder().tables(ImmutableMap.of(users.name(), users)).build();
+
+    PCollectionView<DataGeneratorSchema> schemaView = mock(PCollectionView.class);
+    ProcessContext c = mock(ProcessContext.class);
+    when(c.sideInput(schemaView)).thenReturn(schema);
+
+    Schema rowSchema = Schema.builder().addInt64Field("id").build();
+    Row row = Row.withSchema(rowSchema).addValue(1L).build();
+    when(c.element()).thenReturn(KV.of(0, GeneratedRecord.create("Users", row)));
+
+    BatchAndWriteFn fn = new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, schemaView);
+    DataWriter mockWriter = mock(DataWriter.class);
+    fn.setWriter(mockWriter);
+    fn.setup();
+    fn.startBundle();
+
+    ValueState<List<String>> mockInsertTopoOrderState = mock(ValueState.class);
+
+    fn.processElement(
+        c,
+        mock(MapState.class),
+        mock(ValueState.class),
+        mock(MapState.class),
+        mockInsertTopoOrderState,
+        mock(Timer.class));
+
+    verify(c).sideInput(schemaView);
+    verify(mockInsertTopoOrderState).write(any(List.class));
+    verify(mockWriter).insert(any(), eq(users), any(), anyInt());
+  }
+
+  @Test
+  public void testProcessElement_skipsSchemaInitializationWhenAlreadyLoaded() throws Exception {
+    DataGeneratorTable users = simpleUsersTable();
+    DataGeneratorSchema schema =
+        DataGeneratorSchema.builder().tables(ImmutableMap.of(users.name(), users)).build();
+
+    PCollectionView<DataGeneratorSchema> schemaView = mock(PCollectionView.class);
+    ProcessContext c = mock(ProcessContext.class);
+    when(c.sideInput(schemaView)).thenReturn(schema);
+
+    Schema rowSchema = Schema.builder().addInt64Field("id").build();
+    Row row = Row.withSchema(rowSchema).addValue(1L).build();
+    when(c.element()).thenReturn(KV.of(0, GeneratedRecord.create("Users", row)));
+
+    BatchAndWriteFn fn = new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, schemaView);
+    DataWriter mockWriter = mock(DataWriter.class);
+    fn.setWriter(mockWriter);
+    fn.setup();
+    fn.startBundle();
+
+    // Pre-populate schema and insertTopoOrder
+    fn.setSchema(schema);
+    fn.setInsertTopoOrder(ImmutableList.of("Users"));
+
+    ValueState<List<String>> mockInsertTopoOrderState = mock(ValueState.class);
+
+    fn.processElement(
+        c,
+        mock(MapState.class),
+        mock(ValueState.class),
+        mock(MapState.class),
+        mockInsertTopoOrderState,
+        mock(Timer.class));
+
+    // verify sideInput was never called since schema was already initialized
+    verify(c, never()).sideInput(any());
+    verify(mockInsertTopoOrderState, never()).write(any());
+    verify(mockWriter).insert(any(), eq(users), any(), anyInt());
+  }
+
+  @Test
+  public void testProcessElement_normalExecution_flushesDlqWhenPresent() throws Exception {
+    DataGeneratorTable users = simpleUsersTable();
+    DataGeneratorSchema schema =
+        DataGeneratorSchema.builder().tables(ImmutableMap.of(users.name(), users)).build();
+
+    PCollectionView<DataGeneratorSchema> schemaView = mock(PCollectionView.class);
+    ProcessContext c = mock(ProcessContext.class);
+    when(c.sideInput(schemaView)).thenReturn(schema);
+
+    Schema rowSchema = Schema.builder().addInt64Field("id").build();
+    Row row = Row.withSchema(rowSchema).addValue(1L).build();
+    when(c.element()).thenReturn(KV.of(0, GeneratedRecord.create("Users", row)));
+
+    BatchAndWriteFn fn = new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, schemaView);
+    DataWriter mockWriter = mock(DataWriter.class);
+    fn.setWriter(mockWriter);
+    fn.setup();
+    fn.startBundle();
+
+    MutationBatcher mockBatcher = mock(MutationBatcher.class);
+    List<String> dlq = new ArrayList<>();
+    dlq.add("dlq_record_1");
+    when(mockBatcher.getFailedRecords()).thenReturn(dlq);
+    fn.setBatcher(mockBatcher);
+
+    fn.processElement(
+        c,
+        mock(MapState.class),
+        mock(ValueState.class),
+        mock(MapState.class),
+        mock(ValueState.class),
+        mock(Timer.class));
+
+    verify(c).output(eq("dlq_record_1"));
+    verify(mockBatcher).clearDlq();
+  }
+
+  @Test
+  public void testProcessElement_engineFailure_catchesAndOutputsToDlq() throws Exception {
+    DataGeneratorTable users = simpleUsersTable();
+    DataGeneratorSchema schema =
+        DataGeneratorSchema.builder().tables(ImmutableMap.of(users.name(), users)).build();
+
+    PCollectionView<DataGeneratorSchema> schemaView = mock(PCollectionView.class);
+    ProcessContext c = mock(ProcessContext.class);
+    when(c.sideInput(schemaView)).thenReturn(schema);
+
+    Schema rowSchema = Schema.builder().addInt64Field("id").build();
+    Row row = Row.withSchema(rowSchema).addValue(1L).build();
+    when(c.element()).thenReturn(KV.of(0, GeneratedRecord.create("Users", row)));
+
+    BatchAndWriteFn fn = new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, schemaView);
+    DataWriter mockWriter = mock(DataWriter.class);
+    doThrow(new RuntimeException("simulated sink failure"))
+        .when(mockWriter)
+        .insert(any(), any(), any(), anyInt());
+    fn.setWriter(mockWriter);
+    fn.setup();
+    fn.startBundle();
+
+    fn.processElement(
+        c,
+        mock(MapState.class),
+        mock(ValueState.class),
+        mock(MapState.class),
+        mock(ValueState.class),
+        mock(Timer.class));
+
+    verify(c).output(any(String.class));
+  }
+
+  @Test
+  public void testOnTimer_restoresInsertTopoOrderFromStateWhenNull() throws Exception {
+    BatchAndWriteFn fn =
+        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+    fn.setWriter(mock(DataWriter.class));
+    fn.setup();
+    fn.startBundle();
+
+    fn.setDataGeneratorEngine(mock(DataGeneratorEngine.class));
+    // ensure insertTopoOrder is null in memory
+    fn.setInsertTopoOrder(null);
+
+    ValueState<List<String>> mockInsertTopoOrderState = mock(ValueState.class);
+    when(mockInsertTopoOrderState.read()).thenReturn(ImmutableList.of("TableA", "TableB"));
+
+    fn.onTimer(
+        mock(OnTimerContext.class),
+        mock(MapState.class),
+        mock(ValueState.class),
+        mock(MapState.class),
+        mockInsertTopoOrderState,
+        mock(Timer.class));
+
+    verify(mockInsertTopoOrderState).read();
+    assertEquals(ImmutableList.of("TableA", "TableB"), fn.getInsertTopoOrder());
+  }
+
+  @Test
+  public void testOnTimer_skipsStateReadWhenInsertTopoOrderIsPresent() throws Exception {
+    BatchAndWriteFn fn =
+        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+    fn.setWriter(mock(DataWriter.class));
+    fn.setup();
+    fn.startBundle();
+
+    fn.setDataGeneratorEngine(mock(DataGeneratorEngine.class));
+    // Pre-populate insertTopoOrder in memory
+    fn.setInsertTopoOrder(ImmutableList.of("TableA"));
+
+    ValueState<List<String>> mockInsertTopoOrderState = mock(ValueState.class);
+
+    fn.onTimer(
+        mock(OnTimerContext.class),
+        mock(MapState.class),
+        mock(ValueState.class),
+        mock(MapState.class),
+        mockInsertTopoOrderState,
+        mock(Timer.class));
+
+    verify(mockInsertTopoOrderState, never()).read();
+  }
+
+  @Test
+  public void testOnTimer_exceptionRoutesToDlq() throws Exception {
+    BatchAndWriteFn fn =
+        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+    fn.setWriter(mock(DataWriter.class));
+    fn.setup();
+    fn.startBundle();
+
+    DataGeneratorEngine mockEngine = mock(DataGeneratorEngine.class);
+    doThrow(new RuntimeException("timer failure"))
+        .when(mockEngine)
+        .processScheduledEvents(any(), any(), any(), any(), any(), any(), any());
+    fn.setDataGeneratorEngine(mockEngine);
+
+    OnTimerContext c = mock(OnTimerContext.class);
+
+    fn.onTimer(
+        c,
+        mock(MapState.class),
+        mock(ValueState.class),
+        mock(MapState.class),
+        mock(ValueState.class),
+        mock(Timer.class));
+
+    verify(c).output(any(String.class));
+  }
+
+  @Test
+  public void testFinishBundle_flushesBatcherAndEmitsPendingDlq() throws Exception {
+    BatchAndWriteFn fn =
+        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+    fn.setWriter(mock(DataWriter.class));
+    fn.setup();
+    fn.startBundle();
+
+    List<String> topoOrder = ImmutableList.of("TableA", "TableB");
+    fn.setInsertTopoOrder(topoOrder);
+
+    MutationBatcher mockBatcher = mock(MutationBatcher.class);
+    when(mockBatcher.getFailedRecords()).thenReturn(Arrays.asList("dlq_record_1"));
+    fn.setBatcher(mockBatcher);
+
+    FinishBundleContext context = mock(FinishBundleContext.class);
+
+    fn.finishBundle(context);
+
+    verify(mockBatcher).flushInsertsInTopoOrder(eq(topoOrder));
+    verify(mockBatcher).flushUpdates();
+    verify(mockBatcher).flushDeletesInReverseTopoOrder(eq(topoOrder));
+    verify(context).output(eq("dlq_record_1"), any(Instant.class), eq(GlobalWindow.INSTANCE));
+    verify(mockBatcher).clearDlq();
+  }
+
+  @Test
+  public void testTeardown_closesWriterSuccessfully() throws Exception {
+    BatchAndWriteFn fn =
+        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+    DataWriter mockWriter = mock(DataWriter.class);
+    fn.setWriter(mockWriter);
+
+    fn.teardown();
+
+    verify(mockWriter).close();
+  }
+
+  @Test
+  public void testTeardown_nullWriterDoesNothing() throws Exception {
+    BatchAndWriteFn fn =
+        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+    fn.setWriter(null);
+
+    fn.teardown();
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testTeardown_writerCloseThrowsException() throws Exception {
+    BatchAndWriteFn fn =
+        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+    DataWriter mockWriter = mock(DataWriter.class);
+    doThrow(new RuntimeException("simulated close error")).when(mockWriter).close();
+    fn.setWriter(mockWriter);
+
+    fn.teardown();
+  }
+
+  // ===========================================================================
+  // Helpers
+  // ===========================================================================
+
+  private static DataGeneratorTable simpleUsersTable() {
+    return DataGeneratorTable.builder()
+        .name("Users")
+        .columns(ImmutableList.of(intColumn("id")))
+        .primaryKeys(ImmutableList.of("id"))
+        .foreignKeys(ImmutableList.of())
+        .uniqueKeys(ImmutableList.of())
+        .insertQps(1)
+        .updateQps(0)
+        .deleteQps(0)
+        .isRoot(true)
+        .recordsPerTick(1.0)
+        .build();
+  }
+
+  private static DataGeneratorColumn intColumn(String name) {
+    return DataGeneratorColumn.builder()
+        .name(name)
+        .logicalType(LogicalType.INT64)
+        .isPrimaryKey(false)
+        .isNullable(false)
+        .isSkipped(false)
+        .isGenerated(false)
+        .size(null)
+        .precision(null)
+        .scale(null)
+        .build();
+  }
+}

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/sink/DataWriterFactoryTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/sink/DataWriterFactoryTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.sink;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.teleport.v2.templates.CdcDataGeneratorOptions.SinkType;
+import com.google.cloud.teleport.v2.templates.mysql.MySqlDataWriter;
+import com.google.cloud.teleport.v2.templates.spanner.SpannerDataWriter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Comprehensive unit tests for {@link DataWriterFactory}. */
+@RunWith(JUnit4.class)
+public class DataWriterFactoryTest {
+
+  @Test
+  public void testCreateWriter_mySql() {
+    DataWriter writer = DataWriterFactory.createWriter(SinkType.MYSQL, "{}");
+    assertNotNull(writer);
+    assertTrue(writer instanceof MySqlDataWriter);
+  }
+
+  @Test
+  public void testCreateWriter_spanner() {
+    DataWriter writer = DataWriterFactory.createWriter(SinkType.SPANNER, "{}");
+    assertNotNull(writer);
+    assertTrue(writer instanceof SpannerDataWriter);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testCreateWriter_unsupportedThrowsException() {
+    DataWriterFactory.createWriter(null, "{}");
+  }
+}

--- a/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamJsonToJson.java
+++ b/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamJsonToJson.java
@@ -245,13 +245,13 @@ public final class FormatDatastreamJsonToJson
 
     // Try primary_keys first (MySQL, Oracle, PostgreSQL)
     JsonNode primaryKeys = md.get("primary_keys");
-    if (primaryKeys != null) {
+    if (primaryKeys != null && !primaryKeys.isNull()) {
       return primaryKeys;
     }
 
     // Fallback to replication_index for SQL Server
     JsonNode replicationIndex = md.get("replication_index");
-    if (replicationIndex != null) {
+    if (replicationIndex != null && !replicationIndex.isNull()) {
       return replicationIndex;
     }
 

--- a/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamJsonToJson.java
+++ b/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamJsonToJson.java
@@ -243,7 +243,19 @@ public final class FormatDatastreamJsonToJson
       return null;
     }
 
-    return md.get("primary_keys");
+    // Try primary_keys first (MySQL, Oracle, PostgreSQL)
+    JsonNode primaryKeys = md.get("primary_keys");
+    if (primaryKeys != null) {
+      return primaryKeys;
+    }
+
+    // Fallback to replication_index for SQL Server
+    JsonNode replicationIndex = md.get("replication_index");
+    if (replicationIndex != null) {
+      return replicationIndex;
+    }
+
+    return null;
   }
 
   private Long getSourceMetadataAsLong(JsonNode record, String fieldName) {

--- a/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamRecordToJson.java
+++ b/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamRecordToJson.java
@@ -285,20 +285,20 @@ public class FormatDatastreamRecordToJson
 
   private JsonNode getPrimaryKeys(GenericRecord record) {
     GenericRecord sourceMetadata = (GenericRecord) record.get("source_metadata");
-    JsonNode dataInput = getSourceMetadataJson(record);
+    if (sourceMetadata == null) {
+      return null;
+    }
 
     // Try primary_keys first (MySQL, Oracle, PostgreSQL)
     if (sourceMetadata.getSchema().getField("primary_keys") != null
         && sourceMetadata.get("primary_keys") != null) {
-      JsonNode primaryKeys = dataInput.get("primary_keys");
-      return primaryKeys;
+      return getSourceMetadataJson(record).get("primary_keys");
     }
 
     // Fallback to replication_index for SQL Server
     if (sourceMetadata.getSchema().getField("replication_index") != null
         && sourceMetadata.get("replication_index") != null) {
-      JsonNode replicationIndex = dataInput.get("replication_index");
-      return replicationIndex;
+      return getSourceMetadataJson(record).get("replication_index");
     }
 
     return null;

--- a/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamRecordToJson.java
+++ b/v2/datastream-common/src/main/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamRecordToJson.java
@@ -285,13 +285,23 @@ public class FormatDatastreamRecordToJson
 
   private JsonNode getPrimaryKeys(GenericRecord record) {
     GenericRecord sourceMetadata = (GenericRecord) record.get("source_metadata");
-    if (sourceMetadata.getSchema().getField("primary_keys") == null
-        || sourceMetadata.get("primary_keys") == null) {
-      return null;
+    JsonNode dataInput = getSourceMetadataJson(record);
+
+    // Try primary_keys first (MySQL, Oracle, PostgreSQL)
+    if (sourceMetadata.getSchema().getField("primary_keys") != null
+        && sourceMetadata.get("primary_keys") != null) {
+      JsonNode primaryKeys = dataInput.get("primary_keys");
+      return primaryKeys;
     }
 
-    JsonNode dataInput = getSourceMetadataJson(record);
-    return dataInput.get("primary_keys");
+    // Fallback to replication_index for SQL Server
+    if (sourceMetadata.getSchema().getField("replication_index") != null
+        && sourceMetadata.get("replication_index") != null) {
+      JsonNode replicationIndex = dataInput.get("replication_index");
+      return replicationIndex;
+    }
+
+    return null;
   }
 
   private String getUUID() {

--- a/v2/datastream-common/src/test/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamJsonToJsonTest.java
+++ b/v2/datastream-common/src/test/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamJsonToJsonTest.java
@@ -194,6 +194,132 @@ public class FormatDatastreamJsonToJsonTest {
     pipeline.run();
   }
 
+  private static final String SQLSERVER_JSON_WITH_REPLICATION_INDEX =
+      "{\"uuid\":\"test-uuid-ri\","
+          + "\"read_timestamp\":\"2021-12-25 05:42:04.408\","
+          + "\"source_timestamp\":\"2021-12-25T05:42:04.408\","
+          + "\"object\":\"dbo_ORDERS\","
+          + "\"read_method\":\"sqlserver-cdc\","
+          + "\"stream_name\":\"projects/123/locations/us-central1/streams/s\","
+          + "\"source_metadata\":{"
+          + "\"schema\":\"dbo\","
+          + "\"table\":\"ORDERS\","
+          + "\"database\":\"mydb\","
+          + "\"is_deleted\":false,"
+          + "\"change_type\":\"INSERT\","
+          + "\"replication_index\":[\"order_id\"]},"
+          + "\"payload\":{\"ORDER_ID\":1}}";
+
+  private static final String ORACLE_JSON_WITH_NO_KEYS =
+      "{\"uuid\":\"test-uuid-none\","
+          + "\"read_timestamp\":\"2021-12-25 05:42:04.408\","
+          + "\"source_timestamp\":\"2021-12-25T05:42:04.408\","
+          + "\"object\":\"HR_EMPLOYEES\","
+          + "\"read_method\":\"oracle-backfill\","
+          + "\"stream_name\":\"projects/123/locations/us-central1/streams/s\","
+          + "\"sort_keys\":[1640410924408,0,\"\",0],"
+          + "\"source_metadata\":{"
+          + "\"schema\":\"HR\","
+          + "\"table\":\"EMPLOYEES\","
+          + "\"database\":\"XE\","
+          + "\"is_deleted\":false,"
+          + "\"change_type\":\"INSERT\"},"
+          + "\"payload\":{\"EMP_ID\":1}}";
+
+  private static final String JSON_WITH_BOTH_KEYS =
+      "{\"uuid\":\"test-uuid-both\","
+          + "\"read_timestamp\":\"2021-12-25 05:42:04.408\","
+          + "\"source_timestamp\":\"2021-12-25T05:42:04.408\","
+          + "\"object\":\"dbo_ITEMS\","
+          + "\"read_method\":\"sqlserver-cdc\","
+          + "\"stream_name\":\"projects/123/locations/us-central1/streams/s\","
+          + "\"source_metadata\":{"
+          + "\"schema\":\"dbo\","
+          + "\"table\":\"ITEMS\","
+          + "\"database\":\"mydb\","
+          + "\"is_deleted\":false,"
+          + "\"change_type\":\"INSERT\","
+          + "\"primary_keys\":[\"id\"],"
+          + "\"replication_index\":[\"repl_col\"]},"
+          + "\"payload\":{\"ID\":1}}";
+
+  @Test
+  public void testGetPrimaryKeys_sqlServerReplicationIndexFallback() {
+    FailsafeElementCoder<String, String> coder =
+        FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of());
+
+    PCollection<String> primaryKeys =
+        pipeline
+            .apply("CreateInput", Create.of(SQLSERVER_JSON_WITH_REPLICATION_INDEX))
+            .apply(
+                "Format",
+                ParDo.of(
+                    (FormatDatastreamJsonToJson)
+                        FormatDatastreamJsonToJson.create()
+                            .withStreamName("my-stream")
+                            .withLowercaseSourceColumns(false)))
+            .setCoder(coder)
+            .apply("ExtractKeys", ParDo.of(new ExtractPrimaryKeysFn()));
+
+    PAssert.that(primaryKeys).containsInAnyOrder("[\"order_id\"]");
+    pipeline.run();
+  }
+
+  @Test
+  public void testGetPrimaryKeys_nullWhenNeitherFieldPresent() {
+    FailsafeElementCoder<String, String> coder =
+        FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of());
+
+    PCollection<String> primaryKeys =
+        pipeline
+            .apply("CreateInput", Create.of(ORACLE_JSON_WITH_NO_KEYS))
+            .apply(
+                "Format",
+                ParDo.of(
+                    (FormatDatastreamJsonToJson)
+                        FormatDatastreamJsonToJson.create()
+                            .withStreamName("my-stream")
+                            .withLowercaseSourceColumns(false)))
+            .setCoder(coder)
+            .apply("ExtractKeys", ParDo.of(new ExtractPrimaryKeysFn()));
+
+    PAssert.that(primaryKeys).containsInAnyOrder("null");
+    pipeline.run();
+  }
+
+  @Test
+  public void testGetPrimaryKeys_prefersPrimaryKeysWhenBothPresent() {
+    FailsafeElementCoder<String, String> coder =
+        FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of());
+
+    PCollection<String> primaryKeys =
+        pipeline
+            .apply("CreateInput", Create.of(JSON_WITH_BOTH_KEYS))
+            .apply(
+                "Format",
+                ParDo.of(
+                    (FormatDatastreamJsonToJson)
+                        FormatDatastreamJsonToJson.create()
+                            .withStreamName("my-stream")
+                            .withLowercaseSourceColumns(false)))
+            .setCoder(coder)
+            .apply("ExtractKeys", ParDo.of(new ExtractPrimaryKeysFn()));
+
+    PAssert.that(primaryKeys).containsInAnyOrder("[\"id\"]");
+    pipeline.run();
+  }
+
+  static class ExtractPrimaryKeysFn extends DoFn<FailsafeElement<String, String>, String> {
+    @ProcessElement
+    public void processElement(
+        @Element FailsafeElement<String, String> element, OutputReceiver<String> out)
+        throws JsonProcessingException {
+      JsonNode changeEvent = new ObjectMapper().readTree(element.getPayload());
+      JsonNode primaryKeys = changeEvent.get("_metadata_primary_keys");
+      out.output(primaryKeys != null ? primaryKeys.toString() : "null");
+    }
+  }
+
   // Static nested DoFn class to remove timestamp property
   static class RemoveTimestampPropertyFn
       extends DoFn<FailsafeElement<String, String>, FailsafeElement<String, String>> {

--- a/v2/datastream-common/src/test/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamRecordToJsonTest.java
+++ b/v2/datastream-common/src/test/java/com/google/cloud/teleport/v2/datastream/transforms/FormatDatastreamRecordToJsonTest.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.List;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
@@ -327,6 +328,218 @@ public class FormatDatastreamRecordToJsonTest {
     genericRecord.put("seconds", seconds);
     genericRecord.put("nanos", nanos);
     return genericRecord;
+  }
+
+  @Test
+  public void testGetPrimaryKeys_primaryKeysField() throws IOException {
+    Schema arraySchema = Schema.createArray(Schema.create(Schema.Type.STRING));
+    Schema sourceMetadataSchema =
+        SchemaBuilder.record("source_metadata_pk")
+            .fields()
+            .name("schema")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("database")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("table")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("change_type")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("is_deleted")
+            .type()
+            .booleanType()
+            .noDefault()
+            .name("primary_keys")
+            .type(arraySchema)
+            .noDefault()
+            .endRecord();
+    GenericRecord sourceMetadata = new GenericData.Record(sourceMetadataSchema);
+    sourceMetadata.put("schema", "mydb");
+    sourceMetadata.put("database", "mydb");
+    sourceMetadata.put("table", "users");
+    sourceMetadata.put("change_type", "INSERT");
+    sourceMetadata.put("is_deleted", false);
+    sourceMetadata.put("primary_keys", new GenericData.Array<>(arraySchema, List.of("id")));
+
+    GenericRecord record = buildOuterRecord(sourceMetadata, "mysql-cdc-binlog");
+    String json = FormatDatastreamRecordToJson.create().apply(record).getOriginalPayload();
+    JsonNode output = new ObjectMapper().readTree(json);
+
+    assertEquals("[\"id\"]", output.get("_metadata_primary_keys").toString());
+  }
+
+  @Test
+  public void testGetPrimaryKeys_sqlServerReplicationIndexFallback() throws IOException {
+    Schema arraySchema = Schema.createArray(Schema.create(Schema.Type.STRING));
+    Schema sourceMetadataSchema =
+        SchemaBuilder.record("source_metadata_ri")
+            .fields()
+            .name("schema")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("table")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("change_type")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("is_deleted")
+            .type()
+            .booleanType()
+            .noDefault()
+            .name("replication_index")
+            .type(arraySchema)
+            .noDefault()
+            .endRecord();
+    GenericRecord sourceMetadata = new GenericData.Record(sourceMetadataSchema);
+    sourceMetadata.put("schema", "dbo");
+    sourceMetadata.put("table", "orders");
+    sourceMetadata.put("change_type", "INSERT");
+    sourceMetadata.put("is_deleted", false);
+    sourceMetadata.put(
+        "replication_index", new GenericData.Array<>(arraySchema, List.of("order_id")));
+
+    GenericRecord record = buildOuterRecord(sourceMetadata, "sqlserver-cdc-logbased");
+    String json = FormatDatastreamRecordToJson.create().apply(record).getOriginalPayload();
+    JsonNode output = new ObjectMapper().readTree(json);
+
+    assertEquals("[\"order_id\"]", output.get("_metadata_primary_keys").toString());
+  }
+
+  @Test
+  public void testGetPrimaryKeys_nullWhenNeitherFieldPresent() throws IOException {
+    Schema sourceMetadataSchema =
+        SchemaBuilder.record("source_metadata_none")
+            .fields()
+            .name("schema")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("table")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("change_type")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("is_deleted")
+            .type()
+            .booleanType()
+            .noDefault()
+            .endRecord();
+    GenericRecord sourceMetadata = new GenericData.Record(sourceMetadataSchema);
+    sourceMetadata.put("schema", "HR");
+    sourceMetadata.put("table", "employees");
+    sourceMetadata.put("change_type", "INSERT");
+    sourceMetadata.put("is_deleted", false);
+
+    GenericRecord record = buildOuterRecord(sourceMetadata, "oracle-dump");
+    String json = FormatDatastreamRecordToJson.create().apply(record).getOriginalPayload();
+    JsonNode output = new ObjectMapper().readTree(json);
+
+    assertTrue(output.get("_metadata_primary_keys").isNull());
+  }
+
+  @Test
+  public void testGetPrimaryKeys_prefersPrimaryKeysWhenBothPresent() throws IOException {
+    Schema arraySchema = Schema.createArray(Schema.create(Schema.Type.STRING));
+    Schema sourceMetadataSchema =
+        SchemaBuilder.record("source_metadata_both")
+            .fields()
+            .name("schema")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("database")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("table")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("change_type")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("is_deleted")
+            .type()
+            .booleanType()
+            .noDefault()
+            .name("primary_keys")
+            .type(arraySchema)
+            .noDefault()
+            .name("replication_index")
+            .type(arraySchema)
+            .noDefault()
+            .endRecord();
+    GenericRecord sourceMetadata = new GenericData.Record(sourceMetadataSchema);
+    sourceMetadata.put("schema", "dbo");
+    sourceMetadata.put("database", "dbo");
+    sourceMetadata.put("table", "items");
+    sourceMetadata.put("change_type", "UPDATE");
+    sourceMetadata.put("is_deleted", false);
+    sourceMetadata.put("primary_keys", new GenericData.Array<>(arraySchema, List.of("id")));
+    sourceMetadata.put(
+        "replication_index", new GenericData.Array<>(arraySchema, List.of("repl_col")));
+
+    GenericRecord record = buildOuterRecord(sourceMetadata, "mysql-cdc-binlog");
+    String json = FormatDatastreamRecordToJson.create().apply(record).getOriginalPayload();
+    JsonNode output = new ObjectMapper().readTree(json);
+
+    assertEquals("[\"id\"]", output.get("_metadata_primary_keys").toString());
+  }
+
+  private GenericRecord buildOuterRecord(GenericRecord sourceMetadata, String readMethod) {
+    Schema payloadSchema = SchemaBuilder.record("payload").fields().endRecord();
+    GenericRecord payload = new GenericData.Record(payloadSchema);
+
+    Schema outerSchema =
+        SchemaBuilder.record("test_record")
+            .fields()
+            .name("stream_name")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("read_timestamp")
+            .type()
+            .longType()
+            .noDefault()
+            .name("source_timestamp")
+            .type()
+            .longType()
+            .noDefault()
+            .name("read_method")
+            .type()
+            .stringType()
+            .noDefault()
+            .name("source_metadata")
+            .type(sourceMetadata.getSchema())
+            .noDefault()
+            .name("payload")
+            .type(payloadSchema)
+            .noDefault()
+            .endRecord();
+
+    GenericRecord record = new GenericData.Record(outerSchema);
+    record.put("stream_name", "test-stream");
+    record.put("read_timestamp", 1000000L);
+    record.put("source_timestamp", 1000000L);
+    record.put("read_method", readMethod);
+    record.put("source_metadata", sourceMetadata);
+    record.put("payload", payload);
+    return record;
   }
 
   private Schema generateIntervalNanosSchema() {

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
@@ -1456,13 +1456,6 @@ public class DataStreamMongoDBToFirestore {
         // Handle events wrapped in a changeEvent field (common for reconsumed DLQ records)
         Document innerDoc = Utils.extractInnerEvent(doc);
 
-        // Skip UDF if it has already been processed (e.g. on DLQ retry)
-        Boolean udfProcessed = innerDoc.getBoolean("_metadata_udf_processed");
-        if (udfProcessed != null && udfProcessed) {
-          c.output(BYPASS_UDF_TAG, element);
-          return;
-        }
-
         String changeType = innerDoc.getString(DatastreamConstants.EVENT_CHANGE_TYPE_KEY);
         if (changeType == null) {
           changeType = "";
@@ -1516,10 +1509,17 @@ public class DataStreamMongoDBToFirestore {
         // This ensures we don't write invalid data to the destination.
         Document.parse(transformedData);
 
-        ((ObjectNode) fullEventNode).put(MongoDbChangeEventContext.DATA_COL, transformedData);
+        // Merge the transformed data back into the full event JSON.
+        // The payload of the output FailsafeElement will contain this modified event JSON,
+        // which is used by downstream steps (like writing to Firestore) to process the update.
+        // The originalPayload remains the raw event for safety and DLQ purposes.
+        JsonNode targetNode = Utils.extractInnerEvent(fullEventNode);
+        ((ObjectNode) targetNode).put(MongoDbChangeEventContext.DATA_COL, transformedData);
 
         String modifiedEventJson = OBJECT_MAPPER.writeValueAsString(fullEventNode);
-        c.output(FailsafeElement.of(modifiedEventJson, modifiedEventJson));
+        // Output the element with the preserved original payload and the modified event JSON
+        // containing UDF output.
+        c.output(FailsafeElement.of(element.getOriginalPayload(), modifiedEventJson));
       } catch (Exception e) {
         LOG.error("Error restoring UDF output, exception: {}", e.getMessage(), e);
         FailsafeElement<String, String> failedElement =
@@ -1527,22 +1527,6 @@ public class DataStreamMongoDBToFirestore {
         failedElement.setErrorMessage(e.getMessage());
         failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
         c.output(RESTORE_FAILURE_TAG, failedElement);
-      }
-    }
-  }
-
-  public static class MarkUdfProcessedFn
-      extends DoFn<FailsafeElement<String, String>, FailsafeElement<String, String>> {
-    @ProcessElement
-    public void processElement(ProcessContext c) {
-      FailsafeElement<String, String> element = c.element();
-      try {
-        JsonNode node = OBJECT_MAPPER.readTree(element.getPayload());
-        ((ObjectNode) node).put("_metadata_udf_processed", true);
-        String json = OBJECT_MAPPER.writeValueAsString(node);
-        c.output(FailsafeElement.of(json, json));
-      } catch (Exception e) {
-        throw new RuntimeException(e);
       }
     }
   }
@@ -1613,13 +1597,9 @@ public class DataStreamMongoDBToFirestore {
               .get(UDF_SUCCESS_TAG)
               .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
 
-      // Mark as UDF processed to avoid re-processing on DLQ retries
-      PCollection<FailsafeElement<String, String>> markedOutput =
-          restoredOutput.apply("Mark UDF Processed", ParDo.of(new MarkUdfProcessedFn()));
-
       // Merge the restored UDF output with the events that bypassed the UDF.
       // Both streams now contain the full event JSON in the required format for downstream steps.
-      return PCollectionList.of(markedOutput)
+      return PCollectionList.of(restoredOutput)
           .and(bypassedElements)
           .apply("Merge Streams", Flatten.pCollections());
     }

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
@@ -141,6 +141,7 @@ public class DataStreamMongoDBToFirestore {
   static final TupleTag<FailsafeElement<String, String>> UDF_FAILURE_TAG = new TupleTag<>();
   static final TupleTag<FailsafeElement<String, String>> PREPARE_FAILURE_TAG = new TupleTag<>();
   static final TupleTag<FailsafeElement<String, String>> RESTORE_FAILURE_TAG = new TupleTag<>();
+  static final TupleTag<FailsafeElement<String, String>> BYPASS_UDF_TAG = new TupleTag<>();
   private static final String AVRO_SUFFIX = "avro";
   private static final String JSON_SUFFIX = "json";
   public static final Set<String> MAPPER_IGNORE_FIELDS =
@@ -1442,18 +1443,54 @@ public class DataStreamMongoDBToFirestore {
 
   public static class PrepareUdfInputFn
       extends DoFn<FailsafeElement<String, String>, FailsafeElement<String, String>> {
+
+    private final Counter skippedUpdates =
+        Metrics.counter(PrepareUdfInputFn.class, "skippedUpdatesWithNullData");
+
     @ProcessElement
     public void processElement(ProcessContext c) {
       FailsafeElement<String, String> element = c.element();
       try {
         String fullEventJson = element.getPayload();
-        String canonicalJson = Utils.getCanonicalJsonOfDataField(fullEventJson);
-        if (canonicalJson != null) {
-          c.output(FailsafeElement.of(fullEventJson, canonicalJson));
-        } else {
+        Document doc = Document.parse(fullEventJson);
+        // Handle events wrapped in a changeEvent field (common for reconsumed DLQ records)
+        Document innerDoc = Utils.extractInnerEvent(doc);
+
+        // Skip UDF if it has already been processed (e.g. on DLQ retry)
+        Boolean udfProcessed = innerDoc.getBoolean("_metadata_udf_processed");
+        if (udfProcessed != null && udfProcessed) {
+          c.output(BYPASS_UDF_TAG, element);
+          return;
+        }
+
+        String changeType = innerDoc.getString(DatastreamConstants.EVENT_CHANGE_TYPE_KEY);
+        if (changeType == null) {
+          changeType = "";
+        }
+
+        Object dataVal = innerDoc.get(MongoDbChangeEventContext.DATA_COL);
+
+        // Delete events don't have a 'data' field to transform, so we bypass the UDF.
+        if ("DELETE".equalsIgnoreCase(changeType)) {
+          c.output(BYPASS_UDF_TAG, element);
+          return;
+        }
+
+        // Update events with null data occurs when an updated document is later
+        // deleted. In this case, we skip the UDF transformation.
+        if ("UPDATE".equalsIgnoreCase(changeType) && dataVal == null) {
+          skippedUpdates.inc();
+          return; // Skip by not outputting anything
+        }
+
+        // Extract and canonicalize the 'data' field for UDF input.
+        String canonicalJson = Utils.getCanonicalJsonOfDataField(innerDoc);
+        if (canonicalJson == null) {
           throw new IllegalArgumentException(
               "Missing data field in event or unsupported data field type");
         }
+
+        c.output(FailsafeElement.of(fullEventJson, canonicalJson));
       } catch (Exception e) {
         LOG.error("Error preparing UDF input, exception: {}", e.getMessage(), e);
         FailsafeElement<String, String> failedElement =
@@ -1475,6 +1512,10 @@ public class DataStreamMongoDBToFirestore {
 
       try {
         JsonNode fullEventNode = OBJECT_MAPPER.readTree(fullEventJson);
+        // Validate that the UDF output is a valid BSON document before proceeding.
+        // This ensures we don't write invalid data to the destination.
+        Document.parse(transformedData);
+
         ((ObjectNode) fullEventNode).put(MongoDbChangeEventContext.DATA_COL, transformedData);
 
         String modifiedEventJson = OBJECT_MAPPER.writeValueAsString(fullEventNode);
@@ -1486,6 +1527,22 @@ public class DataStreamMongoDBToFirestore {
         failedElement.setErrorMessage(e.getMessage());
         failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
         c.output(RESTORE_FAILURE_TAG, failedElement);
+      }
+    }
+  }
+
+  public static class MarkUdfProcessedFn
+      extends DoFn<FailsafeElement<String, String>, FailsafeElement<String, String>> {
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      FailsafeElement<String, String> element = c.element();
+      try {
+        JsonNode node = OBJECT_MAPPER.readTree(element.getPayload());
+        ((ObjectNode) node).put("_metadata_udf_processed", true);
+        String json = OBJECT_MAPPER.writeValueAsString(node);
+        c.output(FailsafeElement.of(json, json));
+      } catch (Exception e) {
+        throw new RuntimeException(e);
       }
     }
   }
@@ -1510,7 +1567,8 @@ public class DataStreamMongoDBToFirestore {
           input.apply(
               "Prepare UDF Input",
               ParDo.of(new PrepareUdfInputFn())
-                  .withOutputTags(UDF_SUCCESS_TAG, TupleTagList.of(PREPARE_FAILURE_TAG)));
+                  .withOutputTags(
+                      UDF_SUCCESS_TAG, TupleTagList.of(PREPARE_FAILURE_TAG).and(BYPASS_UDF_TAG)));
 
       // Handle failed preparation
       writeFailedJsonToDlq(options, preparedResult, dlqManager, PREPARE_FAILURE_TAG);
@@ -1518,6 +1576,11 @@ public class DataStreamMongoDBToFirestore {
       PCollection<FailsafeElement<String, String>> preparedInput =
           preparedResult
               .get(UDF_SUCCESS_TAG)
+              .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+      PCollection<FailsafeElement<String, String>> bypassedElements =
+          preparedResult
+              .get(BYPASS_UDF_TAG)
               .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
 
       PCollectionTuple udfResult =
@@ -1545,9 +1608,20 @@ public class DataStreamMongoDBToFirestore {
 
       writeFailedJsonToDlq(options, restoreResult, dlqManager, RESTORE_FAILURE_TAG);
 
-      return restoreResult
-          .get(UDF_SUCCESS_TAG)
-          .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+      PCollection<FailsafeElement<String, String>> restoredOutput =
+          restoreResult
+              .get(UDF_SUCCESS_TAG)
+              .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+      // Mark as UDF processed to avoid re-processing on DLQ retries
+      PCollection<FailsafeElement<String, String>> markedOutput =
+          restoredOutput.apply("Mark UDF Processed", ParDo.of(new MarkUdfProcessedFn()));
+
+      // Merge the restored UDF output with the events that bypassed the UDF.
+      // Both streams now contain the full event JSON in the required format for downstream steps.
+      return PCollectionList.of(markedOutput)
+          .and(bypassedElements)
+          .apply("Merge Streams", Flatten.pCollections());
     }
   }
 }

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContext.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContext.java
@@ -87,10 +87,7 @@ public class MongoDbChangeEventContext implements Serializable {
 
   public MongoDbChangeEventContext(JsonNode payload, String shadowCollectionPrefix)
       throws JsonProcessingException {
-    this.changeEvent =
-        payload.has(DatastreamConstants.CHANGE_EVENT)
-            ? payload.get(DatastreamConstants.CHANGE_EVENT)
-            : payload;
+    this.changeEvent = Utils.extractInnerEvent(payload);
 
     this.retryCount =
         changeEvent.has(DatastreamConstants.RETRY_COUNT)

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContext.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContext.java
@@ -50,6 +50,7 @@ public class MongoDbChangeEventContext implements Serializable {
   public static final String OID_FIELD_NAME = "$oid";
 
   private final JsonNode changeEvent;
+  private final JsonNode originalChangeEvent;
   private final String dataCollection;
   private final String shadowCollection;
   private final Object documentId;
@@ -87,7 +88,16 @@ public class MongoDbChangeEventContext implements Serializable {
 
   public MongoDbChangeEventContext(JsonNode payload, String shadowCollectionPrefix)
       throws JsonProcessingException {
+    this(payload, payload, shadowCollectionPrefix);
+  }
+
+  public MongoDbChangeEventContext(
+      JsonNode payload, JsonNode originalPayload, String shadowCollectionPrefix)
+      throws JsonProcessingException {
+    // Extracts the actual change event. If wrapped in a DLQ structure like {"changeEvent": {...}},
+    // it extracts the inner object.
     this.changeEvent = Utils.extractInnerEvent(payload);
+    this.originalChangeEvent = Utils.extractInnerEvent(originalPayload);
 
     this.retryCount =
         changeEvent.has(DatastreamConstants.RETRY_COUNT)
@@ -196,6 +206,10 @@ public class MongoDbChangeEventContext implements Serializable {
 
   public JsonNode getChangeEvent() {
     return changeEvent;
+  }
+
+  public JsonNode getOriginalChangeEvent() {
+    return originalChangeEvent;
   }
 
   public String getDataCollection() {

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/CreateMongoDbChangeEventContextFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/CreateMongoDbChangeEventContextFn.java
@@ -52,9 +52,10 @@ public class CreateMongoDbChangeEventContextFn
   public void processElement(ProcessContext context, MultiOutputReceiver out) {
     FailsafeElement<String, String> element = context.element();
     try {
-      JsonNode jsonNode = OBJECT_MAPPER.readTree(element.getOriginalPayload());
+      JsonNode jsonNode = OBJECT_MAPPER.readTree(element.getPayload());
+      JsonNode originalNode = OBJECT_MAPPER.readTree(element.getOriginalPayload());
       MongoDbChangeEventContext changeEventContext =
-          new MongoDbChangeEventContext(jsonNode, shadowCollectionPrefix);
+          new MongoDbChangeEventContext(jsonNode, originalNode, shadowCollectionPrefix);
       out.get(successfulCreationTag).output(changeEventContext);
     } catch (Exception e) {
       LOG.error("Error creating MongoDbChangeEventContext, exception: {}, element: {}", e, element);

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbEventDeadLetterQueueSanitizer.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbEventDeadLetterQueueSanitizer.java
@@ -44,8 +44,10 @@ public class MongoDbEventDeadLetterQueueSanitizer
       // Serialize the change event to JSON
       ObjectNode jsonNode = OBJECT_MAPPER.createObjectNode();
 
-      // Add the original change event JSON
-      jsonNode.set("changeEvent", changeEvent.getChangeEvent());
+      // Add the original change event JSON. This preserves the raw source data in the
+      // DLQ, ensuring that retry attempts can re-apply updated UDF logic to the original
+      // payload.
+      jsonNode.set("changeEvent", changeEvent.getOriginalChangeEvent());
 
       // Add other important fields
       jsonNode.put("dataCollection", changeEvent.getDataCollection());

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/Utils.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/Utils.java
@@ -17,6 +17,8 @@ package com.google.cloud.teleport.v2.transforms;
 
 import static com.google.cloud.teleport.v2.templates.datastream.MongoDbChangeEventContext.DATA_COL;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.cloud.teleport.v2.templates.datastream.DatastreamConstants;
 import com.google.cloud.teleport.v2.templates.datastream.MongoDbChangeEventContext;
 import java.util.Base64;
 import java.util.Set;
@@ -76,8 +78,7 @@ public final class Utils {
     return documentId.toString();
   }
 
-  public static String getCanonicalJsonOfDataField(String jsonString) {
-    Document fullEvent = Document.parse(jsonString);
+  public static String getCanonicalJsonOfDataField(Document fullEvent) {
     Object dataVal = fullEvent.get(DATA_COL);
     if (dataVal == null) {
       return null;
@@ -89,5 +90,21 @@ public final class Utils {
       return dataDoc.toJson(CANONICAL_JSON_SETTINGS);
     }
     throw new IllegalArgumentException("Unsupported data field type: " + dataVal.getClass());
+  }
+
+  public static String getCanonicalJsonOfDataField(String jsonString) {
+    return getCanonicalJsonOfDataField(Document.parse(jsonString));
+  }
+
+  public static Document extractInnerEvent(Document doc) {
+    return doc.containsKey(DatastreamConstants.CHANGE_EVENT)
+        ? (Document) doc.get(DatastreamConstants.CHANGE_EVENT)
+        : doc;
+  }
+
+  public static JsonNode extractInnerEvent(JsonNode payload) {
+    return payload.has(DatastreamConstants.CHANGE_EVENT)
+        ? payload.get(DatastreamConstants.CHANGE_EVENT)
+        : payload;
   }
 }

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestoreTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestoreTest.java
@@ -16,7 +16,10 @@
 package com.google.cloud.teleport.v2.templates;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,7 +29,11 @@ import com.google.cloud.teleport.v2.values.FailsafeElement;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.metrics.MetricNameFilter;
+import org.apache.beam.sdk.metrics.MetricQueryResults;
+import org.apache.beam.sdk.metrics.MetricsFilter;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
@@ -240,6 +247,172 @@ public final class DataStreamMongoDBToFirestoreTest {
   }
 
   @Test
+  public void prepareUdfInputFn_updateWithNullData_skipsEvent() {
+    String fullEventJson = "{\"_metadata_change_type\":\"UPDATE\"}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "PrepareUdfInput",
+                ParDo.of(new DataStreamMongoDBToFirestore.PrepareUdfInputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(SUCCESS_TAG)).empty();
+    PAssert.that(result.get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)).empty();
+
+    PipelineResult pipelineResult = pipeline.run();
+
+    MetricQueryResults metrics =
+        pipelineResult
+            .metrics()
+            .queryMetrics(
+                MetricsFilter.builder()
+                    .addNameFilter(
+                        MetricNameFilter.named(
+                            DataStreamMongoDBToFirestore.PrepareUdfInputFn.class,
+                            "skippedUpdatesWithNullData"))
+                    .build());
+
+    long count = 0;
+    if (metrics.getCounters().iterator().hasNext()) {
+      count = metrics.getCounters().iterator().next().getAttempted();
+    }
+    assertEquals(1L, count);
+  }
+
+  @Test
+  public void prepareUdfInputFn_insertWithNullData_routesToDlq() {
+    String fullEventJson = "{\"_metadata_change_type\":\"INSERT\"}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "PrepareUdfInput",
+                ParDo.of(new DataStreamMongoDBToFirestore.PrepareUdfInputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG))
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              assertEquals(fullEventJson, element.getOriginalPayload());
+              assertEquals(
+                  "Missing data field in event or unsupported data field type",
+                  element.getErrorMessage());
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void prepareUdfInputFn_wrappedEvent_succeeds() {
+    String fullEventJson =
+        "{\"changeEvent\":{\"_metadata_change_type\":\"UPDATE\",\"data\":{\"field\":\"value\"}}}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "PrepareUdfInput",
+                ParDo.of(new DataStreamMongoDBToFirestore.PrepareUdfInputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(SUCCESS_TAG))
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              assertEquals(fullEventJson, element.getOriginalPayload());
+              assertTrue(element.getPayload().contains("\"field\": \"value\""));
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void prepareUdfInputFn_alreadyProcessed_bypassesUdf() {
+    String processedJson = "{\"_metadata_udf_processed\": true, \"data\": \"{}\"}";
+    FailsafeElement<String, String> input = FailsafeElement.of(processedJson, processedJson);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "PrepareUdfInput",
+                ParDo.of(new DataStreamMongoDBToFirestore.PrepareUdfInputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.BYPASS_UDF_TAG)
+                            .and(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.BYPASS_UDF_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(DataStreamMongoDBToFirestore.BYPASS_UDF_TAG))
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              assertEquals(processedJson, element.getOriginalPayload());
+              assertEquals(processedJson, element.getPayload());
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
   public void prepareUdfInputFn_invalidJson_routesToDlq() {
     String invalidJson = "{invalid}";
     FailsafeElement<String, String> input = FailsafeElement.of(invalidJson, invalidJson);
@@ -303,15 +476,68 @@ public final class DataStreamMongoDBToFirestoreTest {
         .get(DataStreamMongoDBToFirestore.RESTORE_FAILURE_TAG)
         .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
 
-    FailsafeElement<String, String> expectedOutput =
-        FailsafeElement.of(fullEventJson, fullEventJson);
-    PAssert.that(result.get(SUCCESS_TAG)).containsInAnyOrder(expectedOutput);
+    PAssert.that(result.get(SUCCESS_TAG))
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              try {
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode node = mapper.readTree(element.getPayload());
+                assertFalse(node.has("_metadata_udf_processed"));
+                assertEquals("{\"name\":\"John\"}", node.get("data").asText());
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void restoreUdfOutputFn_invalidTransformedData_routesToDlq() {
+    String fullEventJson = "{\"data\":\"{\\\"name\\\":\\\"John\\\"}\"}";
+    String invalidTransformedData = "invalid json";
+    FailsafeElement<String, String> input =
+        FailsafeElement.of(fullEventJson, invalidTransformedData);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "RestoreUdfOutput",
+                ParDo.of(new DataStreamMongoDBToFirestore.RestoreUdfOutputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.RESTORE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.RESTORE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(DataStreamMongoDBToFirestore.RESTORE_FAILURE_TAG))
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              assertEquals(fullEventJson, element.getOriginalPayload());
+              assertEquals(invalidTransformedData, element.getPayload());
+              assertNotNull(element.getErrorMessage());
+              return null;
+            });
 
     pipeline.run();
   }
 
   @Test
   public void restoreUdfOutputFn_changedPayload() {
+    // Test that RestoreUdfOutputFn correctly merges transformed data back into the full event
+    // and overwrites BOTH originalPayload and payload with the modified event JSON.
     String fullEventJson = "{\"data\":{\"name\":\"John\"}}";
     String transformedData = "{\"name\":\"Jane\"}";
     FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, transformedData);
@@ -346,6 +572,12 @@ public final class DataStreamMongoDBToFirestoreTest {
                 String dataStr = node.get("data").asText();
                 JsonNode dataNode = mapper.readTree(dataStr);
                 assertEquals("Jane", dataNode.get("name").asText());
+
+                // Verify that originalPayload is ALSO overwritten with the transformed data
+                JsonNode originalNode = mapper.readTree(element.getOriginalPayload());
+                String originalDataStr = originalNode.get("data").asText();
+                JsonNode originalDataNode = mapper.readTree(originalDataStr);
+                assertEquals("Jane", originalDataNode.get("name").asText());
               } catch (Exception e) {
                 throw new RuntimeException(e);
               }
@@ -418,6 +650,7 @@ public final class DataStreamMongoDBToFirestoreTest {
     String udfCode =
         "function transform(inJson) {\n"
             + "  var obj = JSON.parse(inJson);\n"
+            + "  obj.processed = true;\n"
             + "  return JSON.stringify(obj);\n"
             + "}";
     Path udfFile = Files.createTempFile("test-udf-special", ".js");
@@ -437,7 +670,7 @@ public final class DataStreamMongoDBToFirestoreTest {
     DeadLetterQueueManager dlqManager = DeadLetterQueueManager.create("/tmp/dlq", 3);
 
     String fullEventJson =
-        "{\"data\":{\"nan\":{\"$numberDouble\":\"NaN\"},\"inf\":{\"$numberDouble\":\"Infinity\"},\"negInf\":{\"$numberDouble\":\"-Infinity\"},\"dbl\":3.14,\"lng\":{\"$numberLong\":\"1234567890\"}}}";
+        "{\"data\":{\"_id\":{\"$oid\":\"507f1f77bcf86cd799439011\"},\"nan\":{\"$numberDouble\":\"NaN\"},\"inf\":{\"$numberDouble\":\"Infinity\"},\"negInf\":{\"$numberDouble\":\"-Infinity\"},\"dbl\":3.14,\"lng\":{\"$numberLong\":\"1234567890\"},\"ts\":{\"$timestamp\":{\"t\":123,\"i\":456}}}}";
     FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
 
     PCollection<FailsafeElement<String, String>> result =
@@ -466,10 +699,310 @@ public final class DataStreamMongoDBToFirestoreTest {
                 assertEquals(Double.NEGATIVE_INFINITY, doc.getDouble("negInf"), 0.0);
                 assertEquals(3.14, doc.getDouble("dbl"), 0.0);
                 assertEquals(1234567890L, doc.getLong("lng").longValue());
+                assertEquals(
+                    new org.bson.types.ObjectId("507f1f77bcf86cd799439011"),
+                    doc.getObjectId("_id"));
+                assertEquals(
+                    new org.bson.BsonTimestamp(123, 456),
+                    doc.get("ts", org.bson.BsonTimestamp.class));
+                assertEquals(true, doc.getBoolean("processed"));
 
               } catch (Exception e) {
                 throw new RuntimeException(e);
               }
+              return null;
+            });
+
+    pipeline.run();
+
+    Files.delete(udfFile);
+  }
+
+  @Test
+  public void applyUdfToDataField_updateWithNullData_skipsEvent() throws IOException {
+    String udfCode =
+        "function transform(inJson) {\n"
+            + "  var obj = JSON.parse(inJson);\n"
+            + "  obj.processed = true;\n"
+            + "  return JSON.stringify(obj);\n"
+            + "}";
+    Path udfFile = Files.createTempFile("test-udf-skip", ".js");
+    Files.write(udfFile, udfCode.getBytes());
+
+    String[] args =
+        new String[] {
+          "--javascriptTextTransformGcsPath=" + udfFile.toAbsolutePath().toString(),
+          "--javascriptTextTransformFunctionName=transform",
+          "--deadLetterQueueDirectory=/tmp/dlq"
+        };
+    DataStreamMongoDBToFirestore.Options options =
+        PipelineOptionsFactory.fromArgs(args)
+            .withValidation()
+            .as(DataStreamMongoDBToFirestore.Options.class);
+
+    DeadLetterQueueManager dlqManager = DeadLetterQueueManager.create("/tmp/dlq", 3);
+
+    String fullEventJson = "{\"_metadata_change_type\":\"UPDATE\"}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollection<FailsafeElement<String, String>> result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "ApplyUdf",
+                new DataStreamMongoDBToFirestore.ApplyUdfToDataField(options, dlqManager));
+
+    PAssert.that(result).empty();
+
+    pipeline.run();
+
+    Files.delete(udfFile);
+  }
+
+  @Test
+  public void applyUdfToDataField_udfFails_emitsEmptyResult() throws IOException {
+    String udfCode =
+        "function transform(inJson) {\n" + "  throw new Error(\"UDF failed\");\n" + "}";
+    Path udfFile = Files.createTempFile("test-udf-fail", ".js");
+    Files.write(udfFile, udfCode.getBytes());
+
+    String[] args =
+        new String[] {
+          "--javascriptTextTransformGcsPath=" + udfFile.toAbsolutePath().toString(),
+          "--javascriptTextTransformFunctionName=transform",
+          "--deadLetterQueueDirectory=/tmp/dlq"
+        };
+    DataStreamMongoDBToFirestore.Options options =
+        PipelineOptionsFactory.fromArgs(args)
+            .withValidation()
+            .as(DataStreamMongoDBToFirestore.Options.class);
+
+    DeadLetterQueueManager dlqManager = DeadLetterQueueManager.create("/tmp/dlq", 3);
+
+    String fullEventJson = "{\"data\":{\"name\":\"john\"}}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollection<FailsafeElement<String, String>> result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "ApplyUdf",
+                new DataStreamMongoDBToFirestore.ApplyUdfToDataField(options, dlqManager));
+
+    // The result should be empty because the event failed UDF and went to DLQ
+    PAssert.that(result).empty();
+
+    pipeline.run();
+
+    Files.delete(udfFile);
+  }
+
+  @Test
+  public void applyUdfToDataField_udfReturnsNonBson_emitsEmptyResult() throws IOException {
+    String udfCode = "function transform(inJson) {\n" + "  return \"invalid json\";\n" + "}";
+    Path udfFile = Files.createTempFile("test-udf-non-bson", ".js");
+    Files.write(udfFile, udfCode.getBytes());
+
+    String[] args =
+        new String[] {
+          "--javascriptTextTransformGcsPath=" + udfFile.toAbsolutePath().toString(),
+          "--javascriptTextTransformFunctionName=transform",
+          "--deadLetterQueueDirectory=/tmp/dlq"
+        };
+    DataStreamMongoDBToFirestore.Options options =
+        PipelineOptionsFactory.fromArgs(args)
+            .withValidation()
+            .as(DataStreamMongoDBToFirestore.Options.class);
+
+    DeadLetterQueueManager dlqManager = DeadLetterQueueManager.create("/tmp/dlq", 3);
+
+    String fullEventJson = "{\"data\":{\"name\":\"john\"}}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollection<FailsafeElement<String, String>> result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "ApplyUdf",
+                new DataStreamMongoDBToFirestore.ApplyUdfToDataField(options, dlqManager));
+
+    // If we expect it to be DLQed, the successful result should be empty!
+    PAssert.that(result).empty();
+
+    pipeline.run();
+
+    Files.delete(udfFile);
+  }
+
+  @Test
+  public void applyUdfToDataField_deleteEvent_bypassesUdf() throws IOException {
+    String udfCode =
+        "function transform(inJson) {\n"
+            + "  var obj = JSON.parse(inJson);\n"
+            + "  obj.processed = true;\n"
+            + "  return JSON.stringify(obj);\n"
+            + "}";
+    Path udfFile = Files.createTempFile("test-udf-delete", ".js");
+    Files.write(udfFile, udfCode.getBytes());
+
+    String[] args =
+        new String[] {
+          "--javascriptTextTransformGcsPath=" + udfFile.toAbsolutePath().toString(),
+          "--javascriptTextTransformFunctionName=transform",
+          "--deadLetterQueueDirectory=/tmp/dlq"
+        };
+    DataStreamMongoDBToFirestore.Options options =
+        PipelineOptionsFactory.fromArgs(args)
+            .withValidation()
+            .as(DataStreamMongoDBToFirestore.Options.class);
+
+    DeadLetterQueueManager dlqManager = DeadLetterQueueManager.create("/tmp/dlq", 3);
+
+    String fullEventJson = "{\"_metadata_change_type\":\"DELETE\",\"data\":{\"name\":\"John\"}}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollection<FailsafeElement<String, String>> result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "ApplyUdf",
+                new DataStreamMongoDBToFirestore.ApplyUdfToDataField(options, dlqManager));
+
+    PAssert.that(result)
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              try {
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode node = mapper.readTree(element.getPayload());
+                assertEquals("DELETE", node.get("_metadata_change_type").asText());
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              return null;
+            });
+
+    pipeline.run();
+
+    Files.delete(udfFile);
+  }
+
+  @Test
+  public void applyUdfToDataField_mixedEvents_correctlyProcessed() throws IOException {
+    String udfCode =
+        "function transform(inJson) {\n"
+            + "  var obj = JSON.parse(inJson);\n"
+            + "  obj.processed = true;\n"
+            + "  return JSON.stringify(obj);\n"
+            + "}";
+    Path udfFile = Files.createTempFile("test-udf-mixed", ".js");
+    Files.write(udfFile, udfCode.getBytes());
+
+    String[] args =
+        new String[] {
+          "--javascriptTextTransformGcsPath=" + udfFile.toAbsolutePath().toString(),
+          "--javascriptTextTransformFunctionName=transform",
+          "--deadLetterQueueDirectory=/tmp/dlq"
+        };
+    DataStreamMongoDBToFirestore.Options options =
+        PipelineOptionsFactory.fromArgs(args)
+            .withValidation()
+            .as(DataStreamMongoDBToFirestore.Options.class);
+
+    DeadLetterQueueManager dlqManager = DeadLetterQueueManager.create("/tmp/dlq", 3);
+
+    String insertJson = "{\"_metadata_change_type\":\"INSERT\",\"data\":{\"name\":\"inv1\"}}";
+    String deleteJson = "{\"_metadata_change_type\":\"DELETE\",\"data\":{\"name\":\"del1\"}}";
+    String updateWithDataJson =
+        "{\"_metadata_change_type\":\"UPDATE\",\"data\":{\"name\":\"upd1\"}}";
+    String updateNullDataJson = "{\"_metadata_change_type\":\"UPDATE\"}";
+    String readJson = "{\"_metadata_change_type\":\"READ\",\"data\":{\"name\":\"rd1\"}}";
+
+    java.util.List<FailsafeElement<String, String>> inputs =
+        java.util.Arrays.asList(
+            FailsafeElement.of(insertJson, insertJson),
+            FailsafeElement.of(deleteJson, deleteJson),
+            FailsafeElement.of(updateWithDataJson, updateWithDataJson),
+            FailsafeElement.of(updateNullDataJson, updateNullDataJson),
+            FailsafeElement.of(readJson, readJson));
+
+    PCollection<FailsafeElement<String, String>> result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(inputs)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "ApplyUdf",
+                new DataStreamMongoDBToFirestore.ApplyUdfToDataField(options, dlqManager));
+
+    PAssert.that(result)
+        .satisfies(
+            iterable -> {
+              java.util.List<FailsafeElement<String, String>> elements =
+                  new java.util.ArrayList<>();
+              iterable.forEach(elements::add);
+
+              assertEquals(4, elements.size());
+
+              java.util.Map<String, JsonNode> eventMap = new java.util.HashMap<>();
+              ObjectMapper mapper = new ObjectMapper();
+
+              for (FailsafeElement<String, String> element : elements) {
+                try {
+                  JsonNode node = mapper.readTree(element.getPayload());
+                  String type = node.get("_metadata_change_type").asText();
+                  eventMap.put(type, node);
+                } catch (Exception e) {
+                  throw new RuntimeException(e);
+                }
+              }
+
+              assertTrue(eventMap.containsKey("INSERT"));
+              assertTrue(eventMap.containsKey("DELETE"));
+              assertTrue(eventMap.containsKey("UPDATE"));
+              assertTrue(eventMap.containsKey("READ"));
+
+              // Verify UDF processed flag
+              assertTrue(eventMap.get("INSERT").has("_metadata_udf_processed"));
+              assertTrue(eventMap.get("UPDATE").has("_metadata_udf_processed"));
+              assertTrue(eventMap.get("READ").has("_metadata_udf_processed"));
+              assertFalse(eventMap.get("DELETE").has("_metadata_udf_processed"));
+
+              try {
+                // Verify UDF was applied to INSERT, UPDATE, READ
+                String insertDataStr = eventMap.get("INSERT").get("data").asText();
+                JsonNode insertDataNode = mapper.readTree(insertDataStr);
+                assertTrue(insertDataNode.has("processed"));
+
+                String updateDataStr = eventMap.get("UPDATE").get("data").asText();
+                JsonNode updateDataNode = mapper.readTree(updateDataStr);
+                assertTrue(updateDataNode.has("processed"));
+
+                String readDataStr = eventMap.get("READ").get("data").asText();
+                JsonNode readDataNode = mapper.readTree(readDataStr);
+                assertTrue(readDataNode.has("processed"));
+
+                // Verify UDF was NOT applied to DELETE
+                JsonNode deleteDataNode = eventMap.get("DELETE").get("data");
+                assertFalse(deleteDataNode.has("processed"));
+
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+
               return null;
             });
 

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestoreTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestoreTest.java
@@ -207,6 +207,60 @@ public final class DataStreamMongoDBToFirestoreTest {
   }
 
   @Test
+  public void prepareUdfInputFn_wrappedPayload() {
+    // Test that PrepareUdfInputFn correctly extracts the inner event from a wrapped DLQ payload.
+    // This simulates an event that has failed before and is being retried from the Dead Letter
+    // Queue.
+    // The structure contains the event under "changeEvent" and metadata like "dataCollection".
+    String fullEventJson =
+        "{\"changeEvent\":{\"data\":\"{\\\"name\\\":\\\"John\\\"}\"},\"dataCollection\":\"test\"}";
+
+    // We pass the fullEventJson as both payload and originalPayload, which is typical for the start
+    // of a retry flow.
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "PrepareUdfInput",
+                ParDo.of(new DataStreamMongoDBToFirestore.PrepareUdfInputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(SUCCESS_TAG))
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              // Verify that the original payload is preserved intact for DLQ purposes.
+              assertEquals(fullEventJson, element.getOriginalPayload());
+              try {
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode node = mapper.readTree(element.getPayload());
+                // Verify that PrepareUdfInputFn successfully extracted the inner "data" field
+                // from the wrapped "changeEvent", rather than passing the whole wrapper to UDF.
+                assertEquals("John", node.get("name").asText());
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
   public void prepareUdfInputFn_missingData_routesToDlq() {
     String fullEventJson = "{\"op\":\"u\"}";
     FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
@@ -372,47 +426,6 @@ public final class DataStreamMongoDBToFirestoreTest {
   }
 
   @Test
-  public void prepareUdfInputFn_alreadyProcessed_bypassesUdf() {
-    String processedJson = "{\"_metadata_udf_processed\": true, \"data\": \"{}\"}";
-    FailsafeElement<String, String> input = FailsafeElement.of(processedJson, processedJson);
-
-    PCollectionTuple result =
-        pipeline
-            .apply(
-                "CreateInput",
-                Create.of(input)
-                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-            .apply(
-                "PrepareUdfInput",
-                ParDo.of(new DataStreamMongoDBToFirestore.PrepareUdfInputFn())
-                    .withOutputTags(
-                        SUCCESS_TAG,
-                        TupleTagList.of(DataStreamMongoDBToFirestore.BYPASS_UDF_TAG)
-                            .and(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)));
-
-    result
-        .get(SUCCESS_TAG)
-        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
-    result
-        .get(DataStreamMongoDBToFirestore.BYPASS_UDF_TAG)
-        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
-    result
-        .get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)
-        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
-
-    PAssert.that(result.get(DataStreamMongoDBToFirestore.BYPASS_UDF_TAG))
-        .satisfies(
-            iterable -> {
-              FailsafeElement<String, String> element = iterable.iterator().next();
-              assertEquals(processedJson, element.getOriginalPayload());
-              assertEquals(processedJson, element.getPayload());
-              return null;
-            });
-
-    pipeline.run();
-  }
-
-  @Test
   public void prepareUdfInputFn_invalidJson_routesToDlq() {
     String invalidJson = "{invalid}";
     FailsafeElement<String, String> input = FailsafeElement.of(invalidJson, invalidJson);
@@ -483,7 +496,6 @@ public final class DataStreamMongoDBToFirestoreTest {
               try {
                 ObjectMapper mapper = new ObjectMapper();
                 JsonNode node = mapper.readTree(element.getPayload());
-                assertFalse(node.has("_metadata_udf_processed"));
                 assertEquals("{\"name\":\"John\"}", node.get("data").asText());
               } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -573,11 +585,70 @@ public final class DataStreamMongoDBToFirestoreTest {
                 JsonNode dataNode = mapper.readTree(dataStr);
                 assertEquals("Jane", dataNode.get("name").asText());
 
-                // Verify that originalPayload is ALSO overwritten with the transformed data
+                // Verify that originalPayload is PRESERVED and not overwritten
                 JsonNode originalNode = mapper.readTree(element.getOriginalPayload());
-                String originalDataStr = originalNode.get("data").asText();
+                JsonNode originalDataNode = originalNode.get("data");
+                assertEquals("John", originalDataNode.get("name").asText());
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void restoreUdfOutputFn_wrappedPayload() {
+    // Test that RestoreUdfOutputFn correctly merges transformed data back into the wrapped event
+    // (DLQ format). This ensures that when we retry an event from DLQ and apply UDF, the result
+    // is correctly placed back into the wrapped structure for further processing.
+    String fullEventJson =
+        "{\"changeEvent\":{\"data\":\"{\\\"name\\\":\\\"John\\\"}\"},\"dataCollection\":\"test\"}";
+    String transformedData = "{\"name\":\"Jane\"}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, transformedData);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "RestoreUdfOutput",
+                ParDo.of(new DataStreamMongoDBToFirestore.RestoreUdfOutputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.RESTORE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.RESTORE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(SUCCESS_TAG))
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              try {
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode node = mapper.readTree(element.getPayload());
+
+                // Verify that the inner changeEvent has the updated data after UDF application.
+                JsonNode innerEvent = node.get("changeEvent");
+                String dataStr = innerEvent.get("data").asText();
+                JsonNode dataNode = mapper.readTree(dataStr);
+                assertEquals("Jane", dataNode.get("name").asText());
+
+                // Verify that originalPayload is PRESERVED as the original wrapped event,
+                // ensuring auditability and safety for further retries.
+                JsonNode originalNode = mapper.readTree(element.getOriginalPayload());
+                JsonNode originalInnerEvent = originalNode.get("changeEvent");
+                String originalDataStr = originalInnerEvent.get("data").asText();
                 JsonNode originalDataNode = mapper.readTree(originalDataStr);
-                assertEquals("Jane", originalDataNode.get("name").asText());
+                assertEquals("John", originalDataNode.get("name").asText());
               } catch (Exception e) {
                 throw new RuntimeException(e);
               }
@@ -974,12 +1045,6 @@ public final class DataStreamMongoDBToFirestoreTest {
               assertTrue(eventMap.containsKey("DELETE"));
               assertTrue(eventMap.containsKey("UPDATE"));
               assertTrue(eventMap.containsKey("READ"));
-
-              // Verify UDF processed flag
-              assertTrue(eventMap.get("INSERT").has("_metadata_udf_processed"));
-              assertTrue(eventMap.get("UPDATE").has("_metadata_udf_processed"));
-              assertTrue(eventMap.get("READ").has("_metadata_udf_processed"));
-              assertFalse(eventMap.get("DELETE").has("_metadata_udf_processed"));
 
               try {
                 // Verify UDF was applied to INSERT, UPDATE, READ

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/ProcessBackfillEventFnTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/ProcessBackfillEventFnTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.teleport.v2.templates;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -171,5 +172,76 @@ public class ProcessBackfillEventFnTest {
     FailsafeElement failedElement = failureCaptor.getValue();
     assertEquals(event2, failedElement.getOriginalPayload());
     assertEquals("Some other error", failedElement.getErrorMessage());
+  }
+
+  @Test
+  public void testProcessBatch_success() {
+    MongoDbChangeEventContext event1 = mock(MongoDbChangeEventContext.class);
+    MongoDbChangeEventContext event2 = mock(MongoDbChangeEventContext.class);
+
+    when(event1.getDataCollection()).thenReturn(COLLECTION_NAME);
+    when(event2.getDataCollection()).thenReturn(COLLECTION_NAME);
+    when(event1.getDocumentId()).thenReturn("id1");
+    when(event2.getDocumentId()).thenReturn("id2");
+    when(event1.getDataAsJsonString()).thenReturn("{\"data\": {\"_id\":\"id1\"}}");
+    when(event2.getDataAsJsonString()).thenReturn("{\"data\": {\"_id\":\"id2\"}}");
+
+    when(mockContext.element()).thenReturn(event1).thenReturn(event2);
+
+    // Process first element
+    fn.processElement(mockContext, mockReceiver);
+
+    // Process second element, should trigger batch processing
+    com.mongodb.bulk.BulkWriteResult mockResult = mock(com.mongodb.bulk.BulkWriteResult.class);
+    when(mockResult.getInsertedCount()).thenReturn(2);
+    when(mockResult.getModifiedCount()).thenReturn(0);
+    when(mockResult.getUpserts()).thenReturn(Collections.emptyList());
+    when(mockResult.getDeletedCount()).thenReturn(0);
+
+    when(mockCollection.bulkWrite(anyList(), any())).thenReturn(mockResult);
+
+    fn.processElement(mockContext, mockReceiver);
+
+    // Verify output
+    verify(mockSuccessReceiver, times(1)).output(event1);
+    verify(mockSuccessReceiver, times(1)).output(event2);
+  }
+
+  @Test
+  public void testFinishBundle_processesRemainingEvents() {
+    MongoDbChangeEventContext event1 = mock(MongoDbChangeEventContext.class);
+
+    when(event1.getDataCollection()).thenReturn(COLLECTION_NAME);
+    when(event1.getDocumentId()).thenReturn("id1");
+    when(event1.getDataAsJsonString()).thenReturn("{\"data\": {\"_id\":\"id1\"}}");
+
+    when(mockContext.element()).thenReturn(event1);
+
+    // Process element, but don't reach batch size (batch size is 2)
+    fn.processElement(mockContext, mockReceiver);
+
+    // Verify no output yet
+    verify(mockSuccessReceiver, times(0)).output(any());
+
+    // Finish bundle
+    com.mongodb.bulk.BulkWriteResult mockResult = mock(com.mongodb.bulk.BulkWriteResult.class);
+    when(mockResult.getInsertedCount()).thenReturn(1);
+    when(mockResult.getModifiedCount()).thenReturn(0);
+    when(mockResult.getUpserts()).thenReturn(Collections.emptyList());
+    when(mockResult.getDeletedCount()).thenReturn(0);
+
+    when(mockCollection.bulkWrite(anyList(), any())).thenReturn(mockResult);
+
+    DoFn.FinishBundleContext mockFinishBundleContext = mock(DoFn.FinishBundleContext.class);
+
+    fn.finishBundle(mockFinishBundleContext);
+
+    // Verify output in finishBundle
+    verify(mockFinishBundleContext, times(1))
+        .output(
+            eq(DataStreamMongoDBToFirestore.ProcessBackfillEventFn.successfulWriteTag),
+            eq(event1),
+            any(org.joda.time.Instant.class),
+            any(org.apache.beam.sdk.transforms.windowing.GlobalWindow.class));
   }
 }

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContextTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContextTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertTrue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.cloud.teleport.v2.transforms.Utils;
 import com.google.common.collect.ImmutableMap;
 import org.bson.Document;
@@ -571,5 +572,53 @@ public class MongoDbChangeEventContextTest {
             + "\"isDlqReconsumed\":false,\"_metadata_retry_count\":0}";
 
     assertEquals(jsonString, expectedJson);
+  }
+
+  @Test
+  public void testConstructorWithOriginalEvent() throws JsonProcessingException {
+    // Test that the 3-argument constructor correctly stores separate instances for
+    // the current change event and the original change event.
+    JsonNode originalEvent = insertEvent.deepCopy();
+    ((ObjectNode) insertEvent).put("modified", true);
+
+    MongoDbChangeEventContext context =
+        new MongoDbChangeEventContext(insertEvent, originalEvent, SHADOW_PREFIX);
+
+    // Verify that both current and original events are preserved as passed.
+    assertEquals(insertEvent, context.getChangeEvent());
+    assertEquals(originalEvent, context.getOriginalChangeEvent());
+  }
+
+  @Test
+  public void test2ArgumentConstructorSetsOriginalSameAsCurrent() throws JsonProcessingException {
+    // Test that the 2-argument constructor falls back to setting the original event
+    // to be the same as the current event when no separate original event is provided.
+    MongoDbChangeEventContext context = new MongoDbChangeEventContext(insertEvent, SHADOW_PREFIX);
+
+    assertEquals(insertEvent, context.getChangeEvent());
+    assertEquals(insertEvent, context.getOriginalChangeEvent());
+  }
+
+  @Test
+  public void testConstructorWithWrappedPayload() throws JsonProcessingException {
+    // Test that the constructor correctly detects and unwraps events that are
+    // wrapped in a DLQ structure (containing "changeEvent" and "dataCollection").
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode wrappedPayload =
+        mapper.readTree(
+            "{\"changeEvent\":{\"_id\":\"{\\\"$oid\\\": \\\"645c9a7e7b8b1a0e9c0f8b3a\\\"}\",\"op\":\"i\",\"data\":\"{\\\"name\\\":\\\"John\\\"}\",\"_metadata_source\":{\"collection\":\"test_collection\"},\"_metadata_timestamp_seconds\":1683782270,\"_metadata_timestamp_nanos\":123456789},\"dataCollection\":\"test\"}");
+
+    MongoDbChangeEventContext context =
+        new MongoDbChangeEventContext(wrappedPayload, SHADOW_PREFIX);
+
+    // Verify that it successfully extracted and unwrapped the inner event.
+    JsonNode extractedEvent = context.getChangeEvent();
+    assertEquals("i", extractedEvent.get("op").asText());
+    assertEquals(
+        "test_collection", extractedEvent.get("_metadata_source").get("collection").asText());
+
+    // Verify that originalChangeEvent is also correctly extracted and unwrapped.
+    JsonNode originalExtractedEvent = context.getOriginalChangeEvent();
+    assertEquals("i", originalExtractedEvent.get("op").asText());
   }
 }

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbEventDeadLetterQueueSanitizerTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbEventDeadLetterQueueSanitizerTest.java
@@ -45,7 +45,7 @@ public class MongoDbEventDeadLetterQueueSanitizerTest {
     mockContext.setErrorMessage("MongoDbChangeEventContext processing error");
     mockChangeEvent = OBJECT_MAPPER.readTree("{\"key\": \"value\"}");
 
-    when(mockChangeEventContext.getChangeEvent()).thenReturn(mockChangeEvent);
+    when(mockChangeEventContext.getOriginalChangeEvent()).thenReturn(mockChangeEvent);
     when(mockChangeEventContext.getDataCollection()).thenReturn("test_collection");
     when(mockChangeEventContext.getShadowCollection()).thenReturn("shadow_test_collection");
     when(mockChangeEventContext.getDocumentId()).thenReturn("test_id");
@@ -67,8 +67,8 @@ public class MongoDbEventDeadLetterQueueSanitizerTest {
 
   @Test
   public void testGetJsonMessageEmptyChangeEvent() throws Exception {
-    // Simulate JsonProcessingException by making getChangeEvent return null
-    when(mockContext.getOriginalPayload().getChangeEvent()).thenReturn(null);
+    // Simulate JsonProcessingException by making getOriginalChangeEvent return null
+    when(mockContext.getOriginalPayload().getOriginalChangeEvent()).thenReturn(null);
 
     String expectedJson =
         "{\"changeEvent\":null,"
@@ -107,7 +107,7 @@ public class MongoDbEventDeadLetterQueueSanitizerTest {
         OBJECT_MAPPER.readTree(
             "{\"_id\": {\"$oid\": \"645c9a7e7b8b1a0e9c0f8b3a\"}, \"data\": {\"field1\": \"value1\","
                 + " \"field2\": 123}}");
-    when(mockContext.getOriginalPayload().getChangeEvent()).thenReturn(complexChangeEvent);
+    when(mockContext.getOriginalPayload().getOriginalChangeEvent()).thenReturn(complexChangeEvent);
 
     String expectedJson =
         "{\"changeEvent\":{\"_id\":{\"$oid\":\"645c9a7e7b8b1a0e9c0f8b3a\"},\"data\":{\"field1\":\"value1\",\"field2\":123}},"

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/UtilsTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/UtilsTest.java
@@ -19,6 +19,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.cloud.teleport.v2.templates.datastream.DatastreamConstants;
 import com.google.cloud.teleport.v2.templates.datastream.MongoDbChangeEventContext;
 import java.util.HashSet;
 import java.util.Set;
@@ -210,5 +214,39 @@ public class UtilsTest {
     assertTrue(result.contains("\"infiniteNumber\": {\"$numberDouble\": \"Infinity\"}"));
     assertTrue(result.contains("\"negativeInfiniteNumber\": {\"$numberDouble\": \"-Infinity\"}"));
     assertTrue(result.contains("\"int64Field\": {\"$numberLong\": \"50\"}"));
+  }
+
+  @Test
+  public void testJsonToDocument_fallbackCase() {
+    // data is an object, not a string
+    String jsonString = "{\"data\": {\"name\": \"John\"}}";
+    Document result = Utils.jsonToDocument(jsonString, "id1");
+
+    assertEquals("John", result.get("name"));
+    assertEquals("id1", result.get("_id"));
+  }
+
+  @Test
+  public void testExtractInnerEvent_Document() {
+    // Test case where the document is wrapped in a "changeEvent" field (common for DLQ records)
+    Document inner = new Document("field", "value");
+    Document wrapped = new Document(DatastreamConstants.CHANGE_EVENT, inner);
+
+    assertEquals(inner, Utils.extractInnerEvent(wrapped));
+    // Test case where the document is NOT wrapped
+    assertEquals(inner, Utils.extractInnerEvent(inner));
+  }
+
+  @Test
+  public void testExtractInnerEvent_JsonNode() throws Exception {
+    // Test case where the JSON node is wrapped in a "changeEvent" field
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode inner = mapper.readTree("{\"field\":\"value\"}");
+    ObjectNode wrapped = mapper.createObjectNode();
+    wrapped.set(DatastreamConstants.CHANGE_EVENT, inner);
+
+    assertEquals(inner, Utils.extractInnerEvent(wrapped));
+    // Test case where the JSON node is NOT wrapped
+    assertEquals(inner, Utils.extractInnerEvent(inner));
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/MySQLMultiSharded1024ShardsLT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/MySQLMultiSharded1024ShardsLT.java
@@ -15,8 +15,8 @@
  */
 package com.google.cloud.teleport.v2.templates.loadtesting;
 
-import static com.google.cloud.teleport.v2.templates.loadtesting.CloudSqlShardOrchestrator.MYSQL_8_0;
 import static com.google.common.truth.Truth.assertThat;
+import static org.apache.beam.it.gcp.cloudsql.CloudSqlShardOrchestrator.MYSQL_8_0;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
 
 import com.google.cloud.spanner.Struct;
@@ -45,6 +45,8 @@ import org.apache.beam.it.common.PipelineOperator;
 import org.apache.beam.it.common.utils.ResourceManagerUtils;
 import org.apache.beam.it.gcp.artifacts.GcsArtifact;
 import org.apache.beam.it.gcp.cloudsql.CloudSqlResourceManager;
+import org.apache.beam.it.gcp.cloudsql.CloudSqlShardOrchestrator;
+import org.apache.beam.it.gcp.cloudsql.CloudSqlShardOrchestrator.DatabaseType;
 import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -101,7 +103,7 @@ public class MySQLMultiSharded1024ShardsLT extends SourceDbToSpannerLTBase {
 
     orchestrator =
         new CloudSqlShardOrchestrator(
-            SQLDialect.MYSQL, MYSQL_8_0, project, region, gcsResourceManager);
+            DatabaseType.MYSQL, MYSQL_8_0, project, region, gcsResourceManager);
   }
 
   @After

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/PostgreSQLMultiSharded1024ShardsLT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/PostgreSQLMultiSharded1024ShardsLT.java
@@ -15,8 +15,8 @@
  */
 package com.google.cloud.teleport.v2.templates.loadtesting;
 
-import static com.google.cloud.teleport.v2.templates.loadtesting.CloudSqlShardOrchestrator.POSTGRES_14;
 import static com.google.common.truth.Truth.assertThat;
+import static org.apache.beam.it.gcp.cloudsql.CloudSqlShardOrchestrator.POSTGRES_14;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
 
 import com.google.cloud.spanner.Struct;
@@ -45,6 +45,8 @@ import org.apache.beam.it.common.PipelineOperator;
 import org.apache.beam.it.common.utils.ResourceManagerUtils;
 import org.apache.beam.it.gcp.artifacts.GcsArtifact;
 import org.apache.beam.it.gcp.cloudsql.CloudSqlResourceManager;
+import org.apache.beam.it.gcp.cloudsql.CloudSqlShardOrchestrator;
+import org.apache.beam.it.gcp.cloudsql.CloudSqlShardOrchestrator.DatabaseType;
 import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -102,7 +104,7 @@ public class PostgreSQLMultiSharded1024ShardsLT extends SourceDbToSpannerLTBase 
 
     orchestrator =
         new CloudSqlShardOrchestrator(
-            SQLDialect.POSTGRESQL, POSTGRES_14, project, region, gcsResourceManager);
+            DatabaseType.POSTGRESQL, POSTGRES_14, project, region, gcsResourceManager);
   }
 
   @After

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDbLTBase.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDbLTBase.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import org.apache.beam.it.common.PipelineLauncher;
 import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
 import org.apache.beam.it.common.PipelineLauncher.LaunchInfo;
@@ -39,6 +40,7 @@ import org.apache.beam.it.common.TestProperties;
 import org.apache.beam.it.common.utils.IORedirectUtil;
 import org.apache.beam.it.common.utils.ResourceManagerUtils;
 import org.apache.beam.it.gcp.TemplateLoadTestBase;
+import org.apache.beam.it.gcp.TestConstants;
 import org.apache.beam.it.gcp.artifacts.utils.ArtifactUtils;
 import org.apache.beam.it.gcp.pubsub.PubsubResourceManager;
 import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
@@ -152,10 +154,57 @@ public class SpannerToSourceDbLTBase extends TemplateLoadTestBase {
   }
 
   public SpannerResourceManager createSpannerMetadataDatabase() throws IOException {
-    SpannerResourceManager spannerMetadataResourceManager =
-        SpannerResourceManager.builder("rr-meta-" + testName, project, region)
-            .maybeUseStaticInstance()
-            .build();
+    String metadataInstanceId = System.getProperty("spannerMetadataInstanceId");
+    SpannerResourceManager.Builder builder =
+        SpannerResourceManager.builder("rr-meta-" + testName, project, region);
+
+    if (metadataInstanceId != null && !metadataInstanceId.isEmpty()) {
+      builder.setInstanceId(metadataInstanceId).useStaticInstance();
+    } else {
+      builder.maybeUseStaticInstance();
+    }
+
+    SpannerResourceManager spannerMetadataResourceManager = builder.build();
+
+    // Collision Detection and Auto-Avoidance
+    if (spannerResourceManager != null
+        && spannerMetadataResourceManager
+            .getInstanceId()
+            .equals(spannerResourceManager.getInstanceId())) {
+
+      String spannerInstanceId =
+          System.getProperty("spannerInstanceId"); // check if it was a user defined instance
+      boolean isTestProject =
+          java.util.Objects.equals(project, "cloud-teleport-testing")
+              || java.util.Objects.equals(project, "span-cloud-teleport-testing");
+      boolean shouldPickRandomInstance =
+          com.google.common.base.Strings.isNullOrEmpty(spannerInstanceId)
+              || java.util.Objects.equals(spannerInstanceId, "teleport");
+
+      if (isTestProject && shouldPickRandomInstance) {
+        List<String> staticInstanceList = new ArrayList<>(TestConstants.SPANNER_TEST_INSTANCES);
+        // Avoid picking the same instance
+        staticInstanceList.remove(spannerResourceManager.getInstanceId());
+        if (!staticInstanceList.isEmpty()) {
+          String newMetadataInstanceId =
+              staticInstanceList.get(new Random().nextInt(staticInstanceList.size()));
+          LOG.info(
+              "Spanner collision detected. Re-selecting metadata instance to: {}",
+              newMetadataInstanceId);
+          spannerMetadataResourceManager =
+              SpannerResourceManager.builder("rr-meta-" + testName, project, region)
+                  .setInstanceId(newMetadataInstanceId)
+                  .useStaticInstance()
+                  .build();
+        }
+      } else {
+        LOG.warn(
+            "WARNING: Both primary and metadata Spanner resource managers are configured to use the same instance: {}. "
+                + "To isolate resources, consider specifying '-DspannerInstanceId' and '-DspannerMetadataInstanceId' separately.",
+            spannerResourceManager.getInstanceId());
+      }
+    }
+
     String dummy = "CREATE TABLE IF NOT EXISTS t1(id INT64 ) primary key(id)";
     spannerMetadataResourceManager.executeDdlStatement(dummy);
     return spannerMetadataResourceManager;

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDbLargeBacklogLT.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDbLargeBacklogLT.java
@@ -1,0 +1,620 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates;
+
+import static org.apache.beam.it.common.TestProperties.getProperty;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.spanner.Instance;
+import com.google.cloud.spanner.InstanceAdminClient;
+import com.google.cloud.spanner.InstanceId;
+import com.google.cloud.spanner.InstanceInfo;
+import com.google.cloud.spanner.InstanceInfo.InstanceField;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerOptions;
+import com.google.cloud.teleport.metadata.TemplateLoadTest;
+import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
+import com.google.common.base.MoreObjects;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import java.io.IOException;
+import java.text.ParseException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.beam.it.common.PipelineLauncher;
+import org.apache.beam.it.common.PipelineOperator;
+import org.apache.beam.it.common.TestProperties;
+import org.apache.beam.it.conditions.ConditionCheck;
+import org.apache.beam.it.gcp.cloudsql.CloudSqlResourceManager;
+import org.apache.beam.it.gcp.cloudsql.CloudSqlShardOrchestrator;
+import org.apache.beam.it.gcp.cloudsql.CloudSqlShardOrchestrator.DatabaseType;
+import org.apache.beam.it.gcp.dataflow.ClassicTemplateClient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Performance / Load test for {@link SpannerToSourceDb} template.
+ *
+ * <p>Objective: Validate if Reverse Replication pipeline can successfully process a massive backlog
+ * of 1 Billion rows (1 Terabyte of data) generated and imported into Spanner.
+ */
+@Category(TemplateLoadTest.class)
+@TemplateLoadTest(SpannerToSourceDb.class)
+@RunWith(JUnit4.class)
+public class SpannerToSourceDbLargeBacklogLT extends SpannerToSourceDbLTBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SpannerToSourceDbLargeBacklogLT.class);
+
+  private static final String TEMPLATE_SPEC_PATH =
+      MoreObjects.firstNonNull(
+          TestProperties.specPath(), "gs://dataflow-templates/latest/flex/Spanner_to_SourceDb");
+
+  private static final String SPANNER_DDL_RESOURCE =
+      "SpannerToSourceDbLargeBacklogLT/spanner-schema.sql";
+  private static final String SESSION_FILE_RESOURCE =
+      "SpannerToSourceDbLargeBacklogLT/session.json";
+  private static final String TABLE = "MigrationLoadTest";
+
+  private static final String DEFAULT_PHYSICAL_SHARD_1 = "nokill-high-resources-backlog-shard1";
+  private static final String DEFAULT_PHYSICAL_SHARD_2 = "nokill-high-resources-backlog-shard2";
+  private static final String DEFAULT_SPANNER_SCALE_NODES = "25";
+  private static final String DEFAULT_AVRO_INPUT_DIR =
+      "gs://nokill-spanner-to-sourcedb-load/data/avro/";
+  private static final String DEFAULT_EXPECTED_SPANNER_COUNT = "1000000000";
+  private static final String DEFAULT_IMPORT_TIMEOUT_MINUTES = "120";
+  private static final String DEFAULT_SPANNER_DOWNSCALE_NODES = "5";
+  private static final String DEFAULT_METADATA_SCALE_NODES = "20";
+  private static final String DEFAULT_REVERSE_TIMEOUT_MINUTES = "600";
+  private static final String DEFAULT_MAX_SHARD_CONNECTIONS = "2000";
+  private static final String DEFAULT_NUM_WORKERS = "200";
+  private static final String DEFAULT_MAX_WORKERS = "200";
+  private static final String DEFAULT_MACHINE_TYPE = "n2-highmem-8";
+  private static final String DEFAULT_EXPECTED_SHARD_COUNT = "250000000";
+  private static final String DEFAULT_METRIC_THRESHOLD = "1000000000";
+  private static final String DEFAULT_VERIFICATION_TIMEOUT_MINUTES = "30";
+
+  private CloudSqlShardOrchestrator orchestrator;
+  private CloudSqlResourceManager manager1;
+  private CloudSqlResourceManager manager2;
+  private Integer originalSpannerNodeCount = null;
+  private Integer originalSpannerMetadataNodeCount = null;
+
+  @Before
+  public void setup() throws IOException {
+    setupResourceManagers(SPANNER_DDL_RESOURCE, SESSION_FILE_RESOURCE);
+
+    orchestrator =
+        new CloudSqlShardOrchestrator(
+            DatabaseType.MYSQL,
+            CloudSqlShardOrchestrator.MYSQL_8_0,
+            project,
+            region,
+            gcsResourceManager);
+
+    // The CloudSQL setup consists of 2 physical shards with 2 logical shards each
+    String physicalShard1 =
+        getProperty("physicalShard1", DEFAULT_PHYSICAL_SHARD_1, TestProperties.Type.PROPERTY);
+    String physicalShard2 =
+        getProperty("physicalShard2", DEFAULT_PHYSICAL_SHARD_2, TestProperties.Type.PROPERTY);
+
+    Map<String, List<String>> shardMap = new HashMap<>();
+    shardMap.put(physicalShard1, List.of("shard0", "shard1"));
+    shardMap.put(physicalShard2, List.of("shard2", "shard3"));
+
+    // Initialize the physical instances (reusing existing ones) and logical schemas
+    orchestrator.initialize(shardMap, "orchestrator_shards_bulk.json");
+    manager1 = (CloudSqlResourceManager) orchestrator.managers.get(physicalShard1);
+    manager2 = (CloudSqlResourceManager) orchestrator.managers.get(physicalShard2);
+
+    LOG.info("Creating logical schemas on MySQL shards...");
+    createLogicalTableSchema(manager1, "shard0");
+    createLogicalTableSchema(manager1, "shard1");
+    createLogicalTableSchema(manager2, "shard2");
+    createLogicalTableSchema(manager2, "shard3");
+
+    LOG.info("Generating and uploading sharding configuration to GCS...");
+    createAndUploadShardConfigToGcs();
+
+    // Store original node counts for cleanup
+    originalSpannerNodeCount = getSpannerNodeCount(spannerResourceManager.getInstanceId());
+    originalSpannerMetadataNodeCount =
+        getSpannerNodeCount(spannerMetadataResourceManager.getInstanceId());
+  }
+
+  @After
+  public void tearDown() {
+    LOG.info("Cleaning up resources...");
+
+    // Reset Spanner instance to its original node count if it was modified
+    if (originalSpannerNodeCount != null && spannerResourceManager != null) {
+      try {
+        updateSpannerNodeCount(spannerResourceManager.getInstanceId(), originalSpannerNodeCount);
+      } catch (Exception e) {
+        LOG.warn("Failed to reset Spanner node count during teardown: ", e);
+      }
+    }
+    // Reset Spanner Metadata instance to its original node count if it was modified
+    if (originalSpannerMetadataNodeCount != null && spannerMetadataResourceManager != null) {
+      try {
+        updateSpannerNodeCount(
+            spannerMetadataResourceManager.getInstanceId(), originalSpannerMetadataNodeCount);
+      } catch (Exception e) {
+        LOG.warn("Failed to reset Spanner Metadata node count during teardown: ", e);
+      }
+    }
+
+    cleanupResourceManagers();
+    if (orchestrator != null) {
+      orchestrator.cleanup();
+    }
+  }
+
+  @Test
+  public void reverseReplicationBacklogLoadTest()
+      throws IOException, ParseException, InterruptedException {
+
+    // -------------------------------------------------------------
+    // PHASE 1: Import 1 billion rows to Spanner
+    // -------------------------------------------------------------
+    LOG.info("PHASE 1: Import 1 billion rows to Spanner");
+
+    // Record UTC start timestamp before import begins (to serve as start timestamp to reverse
+    // replication job)
+    String startTimestamp = java.time.Instant.now().toString();
+    LOG.info("Recorded UTC start timestamp for Reverse Replication Job: {}", startTimestamp);
+
+    // Node count taken from manual test results available in go/reverse-backlog-manual-tests
+    int scaleNodes =
+        Integer.parseInt(
+            getProperty(
+                "spannerScaleNodes", DEFAULT_SPANNER_SCALE_NODES, TestProperties.Type.PROPERTY));
+    updateSpannerNodeCount(spannerResourceManager.getInstanceId(), scaleNodes);
+
+    // Verify scale-up - it is critical that the Spanner instance is scaled up, otherwise the
+    // pipeline might run out of resources or face bottleneck issues.
+    int currentNodeCount = getSpannerNodeCount(spannerResourceManager.getInstanceId());
+    assertEquals(
+        "Spanner instance node count mismatch after scale-up", scaleNodes, currentNodeCount);
+
+    // Run Avro Import with complete dataset (1 billion rows)
+    String avroInputDir =
+        getProperty("avroInputDir", DEFAULT_AVRO_INPUT_DIR, TestProperties.Type.PROPERTY);
+    long expectedSpannerCount =
+        Long.parseLong(
+            getProperty(
+                "expectedSpannerCount",
+                DEFAULT_EXPECTED_SPANNER_COUNT,
+                TestProperties.Type.PROPERTY));
+    int importTimeoutMinutes =
+        Integer.parseInt(
+            getProperty(
+                "importTimeoutMinutes",
+                DEFAULT_IMPORT_TIMEOUT_MINUTES,
+                TestProperties.Type.PROPERTY));
+
+    // Ensure avroInputDir ends with a trailing slash for the classic import template
+    if (!avroInputDir.endsWith("/")) {
+      avroInputDir = avroInputDir + "/";
+    }
+
+    LOG.info("Avro Input Directory: {}", avroInputDir);
+    LOG.info("Expected Spanner count: {}", expectedSpannerCount);
+
+    PipelineLauncher.LaunchInfo importJobInfo = launchImportJob(avroInputDir);
+    assertThatPipeline(importJobInfo).isRunning();
+
+    PipelineOperator.Result importResult =
+        pipelineOperator.waitUntilDone(
+            createConfig(importJobInfo, Duration.ofMinutes(importTimeoutMinutes)));
+    assertThatResult(importResult).isLaunchFinished();
+
+    long spannerCount = spannerResourceManager.getRowCount(TABLE);
+    assertEquals("Spanner database row count mismatch", expectedSpannerCount, spannerCount);
+    LOG.info("Import Phase successful! Imported {} rows.", spannerCount);
+
+    // -------------------------------------------------------------
+    // PHASE 2: Reverse Replication E2E Verification
+    // -------------------------------------------------------------
+    // Downscale main Spanner instance to 5 nodes and upscale metadata Spanner instance to 20 nodes
+    // (go/reverse-backlog-manual-tests)
+    int spannerDownscaleNodes =
+        Integer.parseInt(
+            getProperty(
+                "spannerDownscaleNodes",
+                DEFAULT_SPANNER_DOWNSCALE_NODES,
+                TestProperties.Type.PROPERTY));
+    int metadataScaleNodes =
+        Integer.parseInt(
+            getProperty(
+                "metadataScaleNodes", DEFAULT_METADATA_SCALE_NODES, TestProperties.Type.PROPERTY));
+
+    LOG.info(
+        "Downscaling main Spanner instance to {} nodes and upscaling metadata instance to {} nodes before starting replication...",
+        spannerDownscaleNodes,
+        metadataScaleNodes);
+    updateSpannerNodeCount(spannerResourceManager.getInstanceId(), spannerDownscaleNodes);
+    updateSpannerNodeCount(spannerMetadataResourceManager.getInstanceId(), metadataScaleNodes);
+
+    int reverseTimeoutMinutes =
+        Integer.parseInt(
+            getProperty(
+                "reverseTimeoutMinutes",
+                DEFAULT_REVERSE_TIMEOUT_MINUTES,
+                TestProperties.Type.PROPERTY));
+    int maxShardConnections =
+        Integer.parseInt(
+            getProperty(
+                "maxShardConnections",
+                DEFAULT_MAX_SHARD_CONNECTIONS,
+                TestProperties.Type.PROPERTY));
+    int numWorkers =
+        Integer.parseInt(
+            getProperty("numWorkers", DEFAULT_NUM_WORKERS, TestProperties.Type.PROPERTY));
+    int maxWorkers =
+        Integer.parseInt(
+            getProperty("maxWorkers", DEFAULT_MAX_WORKERS, TestProperties.Type.PROPERTY));
+    String machineType =
+        getProperty("machineType", DEFAULT_MACHINE_TYPE, TestProperties.Type.PROPERTY);
+
+    PipelineLauncher.LaunchInfo reverseJobInfo =
+        launchReverseReplicationJob(
+            startTimestamp, numWorkers, maxWorkers, machineType, maxShardConnections);
+    assertThatPipeline(reverseJobInfo).isRunning();
+
+    // This is a long running test (7-8 hours) and we don't expect the SQL count queries to pass
+    // the assertion for the first few hours (when the replication backlog is being processed).
+    // Asserting on direct database counts during early stages would be highly inefficient and put
+    // unnecessary resource contention on the database shards. Thus, we poll the
+    // "success_record_count" metric and only start asserting on SQL counts once the metric
+    // threshold is met.
+    // Note that the above metric can NOT act as a reliable source of truth for the success of a
+    // replication pipeline. It is ONLY used as an indicator to start the SQL count verification.
+
+    long expectedShardCount =
+        Long.parseLong(
+            getProperty(
+                "expectedShardCount", DEFAULT_EXPECTED_SHARD_COUNT, TestProperties.Type.PROPERTY));
+    long metricThreshold =
+        Long.parseLong(
+            getProperty("metricThreshold", DEFAULT_METRIC_THRESHOLD, TestProperties.Type.PROPERTY));
+
+    long startTimeMillis = System.currentTimeMillis();
+    int numShards = 4;
+
+    ConditionCheck successRecordsCheck =
+        new ConditionCheck() {
+          @Override
+          protected String getDescription() {
+            return String.format(
+                "Check if Dataflow metric success_record_count reaches %d", metricThreshold);
+          }
+
+          @Override
+          protected CheckResult check() {
+            try {
+              Double successRecordsCount =
+                  pipelineLauncher.getMetric(
+                      project, region, reverseJobInfo.jobId(), "success_record_count");
+              long polledCount = successRecordsCount != null ? successRecordsCount.longValue() : 0;
+
+              LOG.info("--- PIPELINE PROGRESS UPDATE ---");
+              LOG.info(
+                  "Time Elapsed: {} minutes / {} minutes",
+                  (System.currentTimeMillis() - startTimeMillis) / 60000,
+                  reverseTimeoutMinutes);
+              LOG.info(
+                  "Polled success_record_count: {} / Target: {}", polledCount, metricThreshold);
+              LOG.info("---------------------------------");
+
+              if (polledCount >= metricThreshold) {
+                return new CheckResult(true, String.format("Threshold reached: %d", polledCount));
+              }
+              return new CheckResult(
+                  false, String.format("Current progress: %d rows", polledCount));
+            } catch (Exception e) {
+              return new CheckResult(false, "Failed to retrieve job metrics: " + e.getMessage());
+            }
+          }
+        };
+
+    PipelineOperator.Result result =
+        pipelineOperator.waitForCondition(
+            createConfig(
+                reverseJobInfo,
+                Duration.ofMinutes(reverseTimeoutMinutes), // total timeout
+                Duration.ofMinutes(
+                    15)), // Poll every 15 minutes. Since the test runs for 7-8 hours, 15-minute
+            // intervals
+            // print exactly 4 logs per hour, preventing clutter and API call costs.
+            successRecordsCheck);
+
+    assertThatResult(result).meetsConditions();
+
+    // Verify database parity on MySQL shards with a retry loop to handle minor replication
+    // synchronization lag
+    LOG.info(
+        "Replication threshold reached. Verifying logical databases row counts on CloudSQL with a catch-up retry loop...");
+    long verificationStartTime = System.currentTimeMillis();
+    int verificationTimeoutMinutes =
+        Integer.parseInt(
+            getProperty(
+                "verificationTimeoutMinutes",
+                DEFAULT_VERIFICATION_TIMEOUT_MINUTES,
+                TestProperties.Type.PROPERTY));
+    long verificationTimeoutMs =
+        verificationTimeoutMinutes
+            * 60
+            * 1000; // Configurable minutes timeout for final parity catch-up
+    boolean parityAchieved = false;
+    long count0 = 0, count1 = 0, count2 = 0, count3 = 0;
+
+    // We execute the logical database row counts using a parallel thread pool instead of running
+    // them sequentially. At 1-billion row scale, executing sequential SELECT COUNT(*) on 4 massive
+    // MySQL database shards sequentially takes around 12 minutes per iteration, causing the
+    // catch-up verification timeout to exhaust after only two/three iterations. Running in parallel
+    // reduces
+    // the query round-trip time to the slowest single shard query (~3 minutes), ensuring the loop
+    // has
+    // ample opportunities to poll and catch up.
+    ExecutorService executor = Executors.newFixedThreadPool(4);
+    try {
+      while (System.currentTimeMillis() - verificationStartTime < verificationTimeoutMs) {
+        CompletableFuture<Long> f0 =
+            CompletableFuture.supplyAsync(
+                () -> getLogicalDatabaseRowCount(manager1, "shard0"), executor);
+        CompletableFuture<Long> f1 =
+            CompletableFuture.supplyAsync(
+                () -> getLogicalDatabaseRowCount(manager1, "shard1"), executor);
+        CompletableFuture<Long> f2 =
+            CompletableFuture.supplyAsync(
+                () -> getLogicalDatabaseRowCount(manager2, "shard2"), executor);
+        CompletableFuture<Long> f3 =
+            CompletableFuture.supplyAsync(
+                () -> getLogicalDatabaseRowCount(manager2, "shard3"), executor);
+
+        // Block and wait for all parallel database count queries to resolve and return their values
+        // - neccessary for the subsequent if block to compute correctly
+        count0 = f0.join();
+        count1 = f1.join();
+        count2 = f2.join();
+        count3 = f3.join();
+
+        LOG.info(
+            "Polled replicated row counts: shard0={}, shard1={}, shard2={}, shard3={} (Target: {})",
+            count0,
+            count1,
+            count2,
+            count3,
+            expectedShardCount);
+
+        if (count0 == expectedShardCount
+            && count1 == expectedShardCount
+            && count2 == expectedShardCount
+            && count3 == expectedShardCount) {
+          parityAchieved = true;
+          break;
+        }
+
+        LOG.info(
+            "Database counts have not reached exact target parity yet. Retrying in 1 minute...");
+        Thread.sleep(60000); // Polling retry interval of 1 minute
+      }
+    } finally {
+      executor.shutdown();
+    }
+
+    assertTrue(
+        String.format(
+            "Logical database row count mismatch after replication verification timeout. Replicated: shard0=%d, shard1=%d, shard2=%d, shard3=%d (Expected: %d each)",
+            count0, count1, count2, count3, expectedShardCount),
+        parityAchieved);
+
+    LOG.info("All sharded replication backlog counts successfully verified. Cancelling job...");
+    PipelineOperator.Result cancelResult =
+        pipelineOperator.cancelJobAndFinish(createConfig(reverseJobInfo, Duration.ofMinutes(20)));
+    assertThatResult(cancelResult).isLaunchFinished();
+    exportMetrics(reverseJobInfo, numShards);
+  }
+
+  private void createLogicalTableSchema(CloudSqlResourceManager manager, String dbName) {
+    manager.runSQLUpdate(
+        "CREATE TABLE IF NOT EXISTS "
+            + dbName
+            + "."
+            + TABLE
+            + " ("
+            + "Id VARCHAR(36) NOT NULL,"
+            + "Payload LONGTEXT NOT NULL,"
+            + "PRIMARY KEY (Id)"
+            + ") ENGINE=InnoDB");
+  }
+
+  private void createAndUploadShardConfigToGcs() throws IOException {
+    JsonArray ja = new JsonArray();
+    ja.add(createShardConfig("shard_0", "shard0", manager1));
+    ja.add(createShardConfig("shard_1", "shard1", manager1));
+    ja.add(createShardConfig("shard_2", "shard2", manager2));
+    ja.add(createShardConfig("shard_3", "shard3", manager2));
+
+    String shardFileContents = ja.toString();
+    LOG.info("Shard file contents: {}", shardFileContents);
+    gcsResourceManager.createArtifact(SOURCE_SHARDS_FILE_NAME, shardFileContents);
+  }
+
+  private JsonObject createShardConfig(
+      String logicalShardId, String dbName, CloudSqlResourceManager manager) {
+    Shard shard = new Shard();
+    shard.setLogicalShardId(logicalShardId);
+    shard.setUser(manager.getUsername());
+    shard.setHost(manager.getHost());
+    shard.setPassword(manager.getPassword());
+    shard.setPort(String.valueOf(manager.getPort()));
+    shard.setDbName(dbName);
+    JsonObject jsObj = (JsonObject) new Gson().toJsonTree(shard).getAsJsonObject();
+    jsObj.remove("secretManagerUri");
+    return jsObj;
+  }
+
+  private PipelineLauncher.LaunchInfo launchImportJob(String inputDir) throws IOException {
+    ClassicTemplateClient classicClient = ClassicTemplateClient.builder(CREDENTIALS).build();
+
+    Map<String, String> params = new HashMap<>();
+    params.put("instanceId", spannerResourceManager.getInstanceId());
+    params.put("databaseId", spannerResourceManager.getDatabaseId());
+    params.put("inputDir", inputDir);
+
+    PipelineLauncher.LaunchConfig options =
+        PipelineLauncher.LaunchConfig.builder(
+                "spanner-avro-import-backlog",
+                "gs://dataflow-templates/latest/GCS_Avro_to_Cloud_Spanner")
+            .setParameters(params)
+            .addEnvironment("numWorkers", 80)
+            .addEnvironment("maxWorkers", 120)
+            .addEnvironment("machineType", "n2-highmem-8")
+            .build();
+
+    return classicClient.launch(project, region, options);
+  }
+
+  private PipelineLauncher.LaunchInfo launchReverseReplicationJob(
+      String startTimestamp,
+      int numWorkers,
+      int maxWorkers,
+      String machineType,
+      int maxShardConnections)
+      throws IOException {
+
+    Map<String, String> params = new HashMap<>();
+    params.put("changeStreamName", "MigrationStream");
+    params.put("instanceId", spannerResourceManager.getInstanceId());
+    params.put("databaseId", spannerResourceManager.getDatabaseId());
+    params.put("spannerProjectId", project);
+    params.put("metadataInstance", spannerMetadataResourceManager.getInstanceId());
+    params.put("metadataDatabase", spannerMetadataResourceManager.getDatabaseId());
+    params.put("sourceShardsFilePath", getGcsPath(SOURCE_SHARDS_FILE_NAME, gcsResourceManager));
+    params.put("deadLetterQueueDirectory", getGcsPath("dlq", gcsResourceManager));
+    params.put("startTimestamp", startTimestamp);
+    params.put("maxShardConnections", String.valueOf(maxShardConnections));
+    params.put("sessionFilePath", getGcsPath(SESSION_FILE_NAME, gcsResourceManager));
+    params.put("workerMachineType", machineType);
+
+    PipelineLauncher.LaunchConfig.Builder options =
+        PipelineLauncher.LaunchConfig.builder(getClass().getSimpleName(), TEMPLATE_SPEC_PATH);
+    options
+        .addEnvironment("maxWorkers", maxWorkers)
+        .addEnvironment("numWorkers", numWorkers)
+        .addEnvironment("machineType", machineType)
+        .addEnvironment(
+            "additionalExperiments", java.util.Collections.singletonList("use_runner_v2"));
+
+    options.setParameters(params);
+    return pipelineLauncher.launch(project, region, options.build());
+  }
+
+  private long getLogicalDatabaseRowCount(CloudSqlResourceManager manager, String dbName) {
+    // We use the InnoDB Optimizer hint 'SET_VAR(innodb_parallel_read_threads=94)' to explicitly
+    // instruct
+    // MySQL to leverage parallel read threads for the COUNT(*) operation. On massive shards
+    // containing
+    // 250 million rows, this utilizes multiple CPU cores of the high-resource Cloud SQL instance,
+    // accelerating the full-table scan from over 10 minutes down to 2 minutes.
+    String query =
+        "SELECT /*+ SET_VAR(innodb_parallel_read_threads=94) */ COUNT(*) FROM "
+            + dbName
+            + "."
+            + TABLE;
+    List<Map<String, Object>> result = manager.runSQLQuery(query);
+    if (result != null && !result.isEmpty()) {
+      Map<String, Object> row = result.get(0);
+      for (Object val : row.values()) {
+        if (val instanceof Number) {
+          return ((Number) val).longValue();
+        }
+      }
+    }
+    return 0;
+  }
+
+  public void updateSpannerNodeCount(String instanceId, int nodeCount) {
+    SpannerOptions options = SpannerOptions.newBuilder().setProjectId(project).build();
+    try (Spanner spanner = options.getService()) {
+      InstanceAdminClient instanceAdminClient = spanner.getInstanceAdminClient();
+
+      InstanceInfo instanceInfo =
+          InstanceInfo.newBuilder(InstanceId.of(project, instanceId))
+              .setNodeCount(nodeCount)
+              .build();
+
+      int maxRetries = 3;
+      long backoffMs = 10000; // 10 seconds initial backoff
+      for (int attempt = 1; attempt <= maxRetries; attempt++) {
+        try {
+          LOG.info(
+              "Updating Spanner instance {} node count to {}... (Attempt {}/{})",
+              instanceId,
+              nodeCount,
+              attempt,
+              maxRetries);
+          instanceAdminClient.updateInstance(instanceInfo, InstanceField.NODE_COUNT).get();
+          LOG.info(
+              "Successfully updated Spanner instance {} node count to {}.", instanceId, nodeCount);
+          return;
+        } catch (Exception e) {
+          if (attempt == maxRetries) {
+            throw e;
+          }
+          LOG.warn(
+              "Failed to update Spanner instance node count on attempt {}. Retrying in {} ms...",
+              attempt,
+              backoffMs,
+              e);
+          Thread.sleep(backoffMs);
+          backoffMs *= 2; // Exponential backoff
+        }
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to update Spanner instance node count after retries.", e);
+      throw new RuntimeException("Failed to update Spanner node count", e);
+    }
+  }
+
+  public int getSpannerNodeCount(String instanceId) {
+    SpannerOptions options = SpannerOptions.newBuilder().setProjectId(project).build();
+    try (Spanner spanner = options.getService()) {
+      InstanceAdminClient instanceAdminClient = spanner.getInstanceAdminClient();
+      Instance instance = instanceAdminClient.getInstance(instanceId);
+      return instance.getNodeCount();
+    } catch (Exception e) {
+      LOG.error("Failed to retrieve Spanner instance node count.", e);
+      throw new RuntimeException("Failed to get Spanner node count", e);
+    }
+  }
+}

--- a/v2/spanner-to-sourcedb/src/test/resources/SpannerToSourceDbLargeBacklogLT/session.json
+++ b/v2/spanner-to-sourcedb/src/test/resources/SpannerToSourceDbLargeBacklogLT/session.json
@@ -1,0 +1,313 @@
+{
+  "SpSchema": {
+    "t1": {
+      "Name": "MigrationLoadTest",
+      "ColIds": [
+        "c2",
+        "c3",
+        "c4"
+      ],
+      "ShardIdColumn": "c4",
+      "ColDefs": {
+        "c2": {
+          "Name": "Id",
+          "T": {
+            "Name": "STRING",
+            "Len": 36,
+            "IsArray": false
+          },
+          "NotNull": true,
+          "Comment": "From: Id varchar(36)",
+          "Id": "c2",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        },
+        "c3": {
+          "Name": "Payload",
+          "T": {
+            "Name": "STRING",
+            "Len": 9223372036854775807,
+            "IsArray": false
+          },
+          "NotNull": true,
+          "Comment": "From: Payload longtext(4294967295)",
+          "Id": "c3",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        },
+        "c4": {
+          "Name": "migration_shard_id",
+          "T": {
+            "Name": "STRING",
+            "Len": 50,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "",
+          "Id": "c4",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        }
+      },
+      "PrimaryKeys": [
+        {
+          "ColId": "c2",
+          "Desc": false,
+          "Order": 2
+        },
+        {
+          "ColId": "c4",
+          "Desc": false,
+          "Order": 1
+        }
+      ],
+      "ForeignKeys": null,
+      "Indexes": null,
+      "ParentTable": {
+        "Id": "",
+        "OnDelete": "",
+        "InterleaveType": ""
+      },
+      "CheckConstraints": null,
+      "Comment": "Spanner schema for source table MigrationLoadTest",
+      "Id": "t1"
+    }
+  },
+  "SyntheticPKeys": {},
+  "SrcSchema": {
+    "t1": {
+      "Name": "MigrationLoadTest",
+      "Schema": "shard0",
+      "ColIds": [
+        "c2",
+        "c3"
+      ],
+      "ColDefs": {
+        "c2": {
+          "Name": "Id",
+          "Type": {
+            "Name": "varchar",
+            "Mods": [
+              36
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": true,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c2",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          }
+        },
+        "c3": {
+          "Name": "Payload",
+          "Type": {
+            "Name": "longtext",
+            "Mods": [
+              4294967295
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": true,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c3",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          }
+        }
+      },
+      "PrimaryKeys": [
+        {
+          "ColId": "c2",
+          "Desc": false,
+          "Order": 1
+        }
+      ],
+      "ForeignKeys": null,
+      "CheckConstraints": null,
+      "Indexes": null,
+      "Id": "t1"
+    }
+  },
+  "SchemaIssues": {
+    "t1": {
+      "ColumnLevelIssues": {
+        "c4": [
+          29
+        ]
+      },
+      "TableLevelIssues": null
+    }
+  },
+  "InvalidCheckExp": null,
+  "ToSpanner": {
+    "MigrationLoadTest": {
+      "Name": "MigrationLoadTest",
+      "Cols": {
+        "Id": "Id",
+        "Payload": "Payload"
+      }
+    }
+  },
+  "Location": {},
+  "TimezoneOffset": "+00:00",
+  "SpDialect": "google_standard_sql",
+  "UniquePKey": {},
+  "Rules": [
+    {
+      "Id": "r5",
+      "Name": "r5",
+      "Type": "add_shard_id_primary_key",
+      "ObjectType": "",
+      "AssociatedObjects": "All Tables",
+      "Enabled": true,
+      "Data": {
+        "AddedAtTheStart": true
+      },
+      "AddedOn": null
+    }
+  ],
+  "IsSharded": true,
+  "SpRegion": "",
+  "ResourceValidation": false,
+  "UI": true,
+  "SpSequences": {},
+  "SrcSequences": {},
+  "SpProjectId": "span-cloud-ck-testing-external",
+  "SpInstanceId": "ea-functional-tests",
+  "Source": "mysql",
+  "DatabaseOptions": {
+    "DbName": "",
+    "DefaultTimezone": ""
+  },
+  "DefaultIdentityOptions": {
+    "SkipRangeMin": "",
+    "SkipRangeMax": "",
+    "StartCounterWith": ""
+  }
+}

--- a/v2/spanner-to-sourcedb/src/test/resources/SpannerToSourceDbLargeBacklogLT/spanner-schema.sql
+++ b/v2/spanner-to-sourcedb/src/test/resources/SpannerToSourceDbLargeBacklogLT/spanner-schema.sql
@@ -1,0 +1,12 @@
+CREATE TABLE MigrationLoadTest (
+  Id STRING(36) NOT NULL,
+  Payload STRING(MAX) NOT NULL,
+  migration_shard_id STRING(50),
+) PRIMARY KEY (migration_shard_id, Id);
+
+CREATE CHANGE STREAM MigrationStream
+FOR MigrationLoadTest
+OPTIONS (
+  retention_period = '7d',
+  value_capture_type = 'OLD_AND_NEW_VALUES'
+);


### PR DESCRIPTION
This is to address the correct reading of SQL Server primary keys from "replication_index" metadata field, if the primary key is not found in the default metadata field "primary_keys".

This is to address the issue reported in the bug - https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/3805