### PR TITLE
Ensure that failed events sent to the DLQ can be successfully reconsumed.

### DIFF
--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestore.java
@@ -1456,13 +1456,6 @@ public class DataStreamMongoDBToFirestore {
         // Handle events wrapped in a changeEvent field (common for reconsumed DLQ records)
         Document innerDoc = Utils.extractInnerEvent(doc);
 
-        // Skip UDF if it has already been processed (e.g. on DLQ retry)
-        Boolean udfProcessed = innerDoc.getBoolean("_metadata_udf_processed");
-        if (udfProcessed != null && udfProcessed) {
-          c.output(BYPASS_UDF_TAG, element);
-          return;
-        }
-
         String changeType = innerDoc.getString(DatastreamConstants.EVENT_CHANGE_TYPE_KEY);
         if (changeType == null) {
           changeType = "";
@@ -1516,10 +1509,17 @@ public class DataStreamMongoDBToFirestore {
         // This ensures we don't write invalid data to the destination.
         Document.parse(transformedData);
 
-        ((ObjectNode) fullEventNode).put(MongoDbChangeEventContext.DATA_COL, transformedData);
+        // Merge the transformed data back into the full event JSON.
+        // The payload of the output FailsafeElement will contain this modified event JSON,
+        // which is used by downstream steps (like writing to Firestore) to process the update.
+        // The originalPayload remains the raw event for safety and DLQ purposes.
+        JsonNode targetNode = Utils.extractInnerEvent(fullEventNode);
+        ((ObjectNode) targetNode).put(MongoDbChangeEventContext.DATA_COL, transformedData);
 
         String modifiedEventJson = OBJECT_MAPPER.writeValueAsString(fullEventNode);
-        c.output(FailsafeElement.of(modifiedEventJson, modifiedEventJson));
+        // Output the element with the preserved original payload and the modified event JSON
+        // containing UDF output.
+        c.output(FailsafeElement.of(element.getOriginalPayload(), modifiedEventJson));
       } catch (Exception e) {
         LOG.error("Error restoring UDF output, exception: {}", e.getMessage(), e);
         FailsafeElement<String, String> failedElement =
@@ -1527,22 +1527,6 @@ public class DataStreamMongoDBToFirestore {
         failedElement.setErrorMessage(e.getMessage());
         failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
         c.output(RESTORE_FAILURE_TAG, failedElement);
-      }
-    }
-  }
-
-  public static class MarkUdfProcessedFn
-      extends DoFn<FailsafeElement<String, String>, FailsafeElement<String, String>> {
-    @ProcessElement
-    public void processElement(ProcessContext c) {
-      FailsafeElement<String, String> element = c.element();
-      try {
-        JsonNode node = OBJECT_MAPPER.readTree(element.getPayload());
-        ((ObjectNode) node).put("_metadata_udf_processed", true);
-        String json = OBJECT_MAPPER.writeValueAsString(node);
-        c.output(FailsafeElement.of(json, json));
-      } catch (Exception e) {
-        throw new RuntimeException(e);
       }
     }
   }
@@ -1613,13 +1597,9 @@ public class DataStreamMongoDBToFirestore {
               .get(UDF_SUCCESS_TAG)
               .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
 
-      // Mark as UDF processed to avoid re-processing on DLQ retries
-      PCollection<FailsafeElement<String, String>> markedOutput =
-          restoredOutput.apply("Mark UDF Processed", ParDo.of(new MarkUdfProcessedFn()));
-
       // Merge the restored UDF output with the events that bypassed the UDF.
       // Both streams now contain the full event JSON in the required format for downstream steps.
-      return PCollectionList.of(markedOutput)
+      return PCollectionList.of(restoredOutput)
           .and(bypassedElements)
           .apply("Merge Streams", Flatten.pCollections());
     }

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContext.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContext.java
@@ -50,6 +50,7 @@ public class MongoDbChangeEventContext implements Serializable {
   public static final String OID_FIELD_NAME = "$oid";
 
   private final JsonNode changeEvent;
+  private final JsonNode originalChangeEvent;
   private final String dataCollection;
   private final String shadowCollection;
   private final Object documentId;
@@ -87,7 +88,16 @@ public class MongoDbChangeEventContext implements Serializable {
 
   public MongoDbChangeEventContext(JsonNode payload, String shadowCollectionPrefix)
       throws JsonProcessingException {
+    this(payload, payload, shadowCollectionPrefix);
+  }
+
+  public MongoDbChangeEventContext(
+      JsonNode payload, JsonNode originalPayload, String shadowCollectionPrefix)
+      throws JsonProcessingException {
+    // Extracts the actual change event. If wrapped in a DLQ structure like {"changeEvent": {...}},
+    // it extracts the inner object.
     this.changeEvent = Utils.extractInnerEvent(payload);
+    this.originalChangeEvent = Utils.extractInnerEvent(originalPayload);
 
     this.retryCount =
         changeEvent.has(DatastreamConstants.RETRY_COUNT)
@@ -196,6 +206,10 @@ public class MongoDbChangeEventContext implements Serializable {
 
   public JsonNode getChangeEvent() {
     return changeEvent;
+  }
+
+  public JsonNode getOriginalChangeEvent() {
+    return originalChangeEvent;
   }
 
   public String getDataCollection() {

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/CreateMongoDbChangeEventContextFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/CreateMongoDbChangeEventContextFn.java
@@ -52,9 +52,10 @@ public class CreateMongoDbChangeEventContextFn
   public void processElement(ProcessContext context, MultiOutputReceiver out) {
     FailsafeElement<String, String> element = context.element();
     try {
-      JsonNode jsonNode = OBJECT_MAPPER.readTree(element.getOriginalPayload());
+      JsonNode jsonNode = OBJECT_MAPPER.readTree(element.getPayload());
+      JsonNode originalNode = OBJECT_MAPPER.readTree(element.getOriginalPayload());
       MongoDbChangeEventContext changeEventContext =
-          new MongoDbChangeEventContext(jsonNode, shadowCollectionPrefix);
+          new MongoDbChangeEventContext(jsonNode, originalNode, shadowCollectionPrefix);
       out.get(successfulCreationTag).output(changeEventContext);
     } catch (Exception e) {
       LOG.error("Error creating MongoDbChangeEventContext, exception: {}, element: {}", e, element);

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbEventDeadLetterQueueSanitizer.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbEventDeadLetterQueueSanitizer.java
@@ -44,8 +44,10 @@ public class MongoDbEventDeadLetterQueueSanitizer
       // Serialize the change event to JSON
       ObjectNode jsonNode = OBJECT_MAPPER.createObjectNode();
 
-      // Add the original change event JSON
-      jsonNode.set("changeEvent", changeEvent.getChangeEvent());
+      // Add the original change event JSON. This preserves the raw source data in the
+      // DLQ, ensuring that retry attempts can re-apply updated UDF logic to the original
+      // payload.
+      jsonNode.set("changeEvent", changeEvent.getOriginalChangeEvent());
 
       // Add other important fields
       jsonNode.put("dataCollection", changeEvent.getDataCollection());

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestoreTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamMongoDBToFirestoreTest.java
@@ -207,6 +207,60 @@ public final class DataStreamMongoDBToFirestoreTest {
   }
 
   @Test
+  public void prepareUdfInputFn_wrappedPayload() {
+    // Test that PrepareUdfInputFn correctly extracts the inner event from a wrapped DLQ payload.
+    // This simulates an event that has failed before and is being retried from the Dead Letter
+    // Queue.
+    // The structure contains the event under "changeEvent" and metadata like "dataCollection".
+    String fullEventJson =
+        "{\"changeEvent\":{\"data\":\"{\\\"name\\\":\\\"John\\\"}\"},\"dataCollection\":\"test\"}";
+
+    // We pass the fullEventJson as both payload and originalPayload, which is typical for the start
+    // of a retry flow.
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "PrepareUdfInput",
+                ParDo.of(new DataStreamMongoDBToFirestore.PrepareUdfInputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(SUCCESS_TAG))
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              // Verify that the original payload is preserved intact for DLQ purposes.
+              assertEquals(fullEventJson, element.getOriginalPayload());
+              try {
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode node = mapper.readTree(element.getPayload());
+                // Verify that PrepareUdfInputFn successfully extracted the inner "data" field
+                // from the wrapped "changeEvent", rather than passing the whole wrapper to UDF.
+                assertEquals("John", node.get("name").asText());
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
   public void prepareUdfInputFn_missingData_routesToDlq() {
     String fullEventJson = "{\"op\":\"u\"}";
     FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, fullEventJson);
@@ -372,47 +426,6 @@ public final class DataStreamMongoDBToFirestoreTest {
   }
 
   @Test
-  public void prepareUdfInputFn_alreadyProcessed_bypassesUdf() {
-    String processedJson = "{\"_metadata_udf_processed\": true, \"data\": \"{}\"}";
-    FailsafeElement<String, String> input = FailsafeElement.of(processedJson, processedJson);
-
-    PCollectionTuple result =
-        pipeline
-            .apply(
-                "CreateInput",
-                Create.of(input)
-                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-            .apply(
-                "PrepareUdfInput",
-                ParDo.of(new DataStreamMongoDBToFirestore.PrepareUdfInputFn())
-                    .withOutputTags(
-                        SUCCESS_TAG,
-                        TupleTagList.of(DataStreamMongoDBToFirestore.BYPASS_UDF_TAG)
-                            .and(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)));
-
-    result
-        .get(SUCCESS_TAG)
-        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
-    result
-        .get(DataStreamMongoDBToFirestore.BYPASS_UDF_TAG)
-        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
-    result
-        .get(DataStreamMongoDBToFirestore.PREPARE_FAILURE_TAG)
-        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
-
-    PAssert.that(result.get(DataStreamMongoDBToFirestore.BYPASS_UDF_TAG))
-        .satisfies(
-            iterable -> {
-              FailsafeElement<String, String> element = iterable.iterator().next();
-              assertEquals(processedJson, element.getOriginalPayload());
-              assertEquals(processedJson, element.getPayload());
-              return null;
-            });
-
-    pipeline.run();
-  }
-
-  @Test
   public void prepareUdfInputFn_invalidJson_routesToDlq() {
     String invalidJson = "{invalid}";
     FailsafeElement<String, String> input = FailsafeElement.of(invalidJson, invalidJson);
@@ -483,7 +496,6 @@ public final class DataStreamMongoDBToFirestoreTest {
               try {
                 ObjectMapper mapper = new ObjectMapper();
                 JsonNode node = mapper.readTree(element.getPayload());
-                assertFalse(node.has("_metadata_udf_processed"));
                 assertEquals("{\"name\":\"John\"}", node.get("data").asText());
               } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -573,11 +585,70 @@ public final class DataStreamMongoDBToFirestoreTest {
                 JsonNode dataNode = mapper.readTree(dataStr);
                 assertEquals("Jane", dataNode.get("name").asText());
 
-                // Verify that originalPayload is ALSO overwritten with the transformed data
+                // Verify that originalPayload is PRESERVED and not overwritten
                 JsonNode originalNode = mapper.readTree(element.getOriginalPayload());
-                String originalDataStr = originalNode.get("data").asText();
+                JsonNode originalDataNode = originalNode.get("data");
+                assertEquals("John", originalDataNode.get("name").asText());
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void restoreUdfOutputFn_wrappedPayload() {
+    // Test that RestoreUdfOutputFn correctly merges transformed data back into the wrapped event
+    // (DLQ format). This ensures that when we retry an event from DLQ and apply UDF, the result
+    // is correctly placed back into the wrapped structure for further processing.
+    String fullEventJson =
+        "{\"changeEvent\":{\"data\":\"{\\\"name\\\":\\\"John\\\"}\"},\"dataCollection\":\"test\"}";
+    String transformedData = "{\"name\":\"Jane\"}";
+    FailsafeElement<String, String> input = FailsafeElement.of(fullEventJson, transformedData);
+
+    PCollectionTuple result =
+        pipeline
+            .apply(
+                "CreateInput",
+                Create.of(input)
+                    .withCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
+            .apply(
+                "RestoreUdfOutput",
+                ParDo.of(new DataStreamMongoDBToFirestore.RestoreUdfOutputFn())
+                    .withOutputTags(
+                        SUCCESS_TAG,
+                        TupleTagList.of(DataStreamMongoDBToFirestore.RESTORE_FAILURE_TAG)));
+
+    result
+        .get(SUCCESS_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+    result
+        .get(DataStreamMongoDBToFirestore.RESTORE_FAILURE_TAG)
+        .setCoder(FailsafeElementCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
+
+    PAssert.that(result.get(SUCCESS_TAG))
+        .satisfies(
+            iterable -> {
+              FailsafeElement<String, String> element = iterable.iterator().next();
+              try {
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode node = mapper.readTree(element.getPayload());
+
+                // Verify that the inner changeEvent has the updated data after UDF application.
+                JsonNode innerEvent = node.get("changeEvent");
+                String dataStr = innerEvent.get("data").asText();
+                JsonNode dataNode = mapper.readTree(dataStr);
+                assertEquals("Jane", dataNode.get("name").asText());
+
+                // Verify that originalPayload is PRESERVED as the original wrapped event,
+                // ensuring auditability and safety for further retries.
+                JsonNode originalNode = mapper.readTree(element.getOriginalPayload());
+                JsonNode originalInnerEvent = originalNode.get("changeEvent");
+                String originalDataStr = originalInnerEvent.get("data").asText();
                 JsonNode originalDataNode = mapper.readTree(originalDataStr);
-                assertEquals("Jane", originalDataNode.get("name").asText());
+                assertEquals("John", originalDataNode.get("name").asText());
               } catch (Exception e) {
                 throw new RuntimeException(e);
               }
@@ -974,12 +1045,6 @@ public final class DataStreamMongoDBToFirestoreTest {
               assertTrue(eventMap.containsKey("DELETE"));
               assertTrue(eventMap.containsKey("UPDATE"));
               assertTrue(eventMap.containsKey("READ"));
-
-              // Verify UDF processed flag
-              assertTrue(eventMap.get("INSERT").has("_metadata_udf_processed"));
-              assertTrue(eventMap.get("UPDATE").has("_metadata_udf_processed"));
-              assertTrue(eventMap.get("READ").has("_metadata_udf_processed"));
-              assertFalse(eventMap.get("DELETE").has("_metadata_udf_processed"));
 
               try {
                 // Verify UDF was applied to INSERT, UPDATE, READ

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContextTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContextTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertTrue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.cloud.teleport.v2.transforms.Utils;
 import com.google.common.collect.ImmutableMap;
 import org.bson.Document;
@@ -571,5 +572,53 @@ public class MongoDbChangeEventContextTest {
             + "\"isDlqReconsumed\":false,\"_metadata_retry_count\":0}";
 
     assertEquals(jsonString, expectedJson);
+  }
+
+  @Test
+  public void testConstructorWithOriginalEvent() throws JsonProcessingException {
+    // Test that the 3-argument constructor correctly stores separate instances for
+    // the current change event and the original change event.
+    JsonNode originalEvent = insertEvent.deepCopy();
+    ((ObjectNode) insertEvent).put("modified", true);
+
+    MongoDbChangeEventContext context =
+        new MongoDbChangeEventContext(insertEvent, originalEvent, SHADOW_PREFIX);
+
+    // Verify that both current and original events are preserved as passed.
+    assertEquals(insertEvent, context.getChangeEvent());
+    assertEquals(originalEvent, context.getOriginalChangeEvent());
+  }
+
+  @Test
+  public void test2ArgumentConstructorSetsOriginalSameAsCurrent() throws JsonProcessingException {
+    // Test that the 2-argument constructor falls back to setting the original event
+    // to be the same as the current event when no separate original event is provided.
+    MongoDbChangeEventContext context = new MongoDbChangeEventContext(insertEvent, SHADOW_PREFIX);
+
+    assertEquals(insertEvent, context.getChangeEvent());
+    assertEquals(insertEvent, context.getOriginalChangeEvent());
+  }
+
+  @Test
+  public void testConstructorWithWrappedPayload() throws JsonProcessingException {
+    // Test that the constructor correctly detects and unwraps events that are
+    // wrapped in a DLQ structure (containing "changeEvent" and "dataCollection").
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode wrappedPayload =
+        mapper.readTree(
+            "{\"changeEvent\":{\"_id\":\"{\\\"$oid\\\": \\\"645c9a7e7b8b1a0e9c0f8b3a\\\"}\",\"op\":\"i\",\"data\":\"{\\\"name\\\":\\\"John\\\"}\",\"_metadata_source\":{\"collection\":\"test_collection\"},\"_metadata_timestamp_seconds\":1683782270,\"_metadata_timestamp_nanos\":123456789},\"dataCollection\":\"test\"}");
+
+    MongoDbChangeEventContext context =
+        new MongoDbChangeEventContext(wrappedPayload, SHADOW_PREFIX);
+
+    // Verify that it successfully extracted and unwrapped the inner event.
+    JsonNode extractedEvent = context.getChangeEvent();
+    assertEquals("i", extractedEvent.get("op").asText());
+    assertEquals(
+        "test_collection", extractedEvent.get("_metadata_source").get("collection").asText());
+
+    // Verify that originalChangeEvent is also correctly extracted and unwrapped.
+    JsonNode originalExtractedEvent = context.getOriginalChangeEvent();
+    assertEquals("i", originalExtractedEvent.get("op").asText());
   }
 }

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbEventDeadLetterQueueSanitizerTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbEventDeadLetterQueueSanitizerTest.java
@@ -45,7 +45,7 @@ public class MongoDbEventDeadLetterQueueSanitizerTest {
     mockContext.setErrorMessage("MongoDbChangeEventContext processing error");
     mockChangeEvent = OBJECT_MAPPER.readTree("{\"key\": \"value\"}");
 
-    when(mockChangeEventContext.getChangeEvent()).thenReturn(mockChangeEvent);
+    when(mockChangeEventContext.getOriginalChangeEvent()).thenReturn(mockChangeEvent);
     when(mockChangeEventContext.getDataCollection()).thenReturn("test_collection");
     when(mockChangeEventContext.getShadowCollection()).thenReturn("shadow_test_collection");
     when(mockChangeEventContext.getDocumentId()).thenReturn("test_id");
@@ -67,8 +67,8 @@ public class MongoDbEventDeadLetterQueueSanitizerTest {
 
   @Test
   public void testGetJsonMessageEmptyChangeEvent() throws Exception {
-    // Simulate JsonProcessingException by making getChangeEvent return null
-    when(mockContext.getOriginalPayload().getChangeEvent()).thenReturn(null);
+    // Simulate JsonProcessingException by making getOriginalChangeEvent return null
+    when(mockContext.getOriginalPayload().getOriginalChangeEvent()).thenReturn(null);
 
     String expectedJson =
         "{\"changeEvent\":null,"
@@ -107,7 +107,7 @@ public class MongoDbEventDeadLetterQueueSanitizerTest {
         OBJECT_MAPPER.readTree(
             "{\"_id\": {\"$oid\": \"645c9a7e7b8b1a0e9c0f8b3a\"}, \"data\": {\"field1\": \"value1\","
                 + " \"field2\": 123}}");
-    when(mockContext.getOriginalPayload().getChangeEvent()).thenReturn(complexChangeEvent);
+    when(mockContext.getOriginalPayload().getOriginalChangeEvent()).thenReturn(complexChangeEvent);
 
     String expectedJson =
         "{\"changeEvent\":{\"_id\":{\"$oid\":\"645c9a7e7b8b1a0e9c0f8b3a\"},\"data\":{\"field1\":\"value1\",\"field2\":123}},"


### PR DESCRIPTION
Updated MongoDbEventDeadLetterQueueSanitizer to store the original, unmodified event in the DLQ (under a changeEvent wrapper), ensuring that retry attempts have access to the initial event.

MongoDbChangeEventContext changed to accept and track both current and original payloads.

Updated PrepareUdfInputFn to extract the inner event from DLQ payloads for UDF processing, and RestoreUdfOutputFn to merge UDF results back into the correct inner structure.
