### PR TITLE
Some minor bug fixes in the cdc data generator template

### DIFF
--- a/v2/cdc-data-generator/pom.xml
+++ b/v2/cdc-data-generator/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>net.datafaker</groupId>
             <artifactId>datafaker</artifactId>
-            <version>2.1.0</version>
+            <version>2.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.beam</groupId>
@@ -101,7 +101,6 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>${mysql-connector-java.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.teleport</groupId>

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/ApplyOverridesFn.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/ApplyOverridesFn.java
@@ -76,32 +76,22 @@ public class ApplyOverridesFn extends DoFn<DataGeneratorSchema, DataGeneratorSch
 
   private boolean hasValidPrimaryKey(DataGeneratorTable table) {
     if (table.primaryKeys() == null || table.primaryKeys().isEmpty()) {
-      LOG.error(
-          "Table {} has no primary-key columns, or its PK list references unknown columns — "
-              + "skipping PK generation.",
-          table.name());
+      LOG.error("Table {} has no primary-key columns defined — skipping table.", table.name());
       return false;
     }
     Map<String, DataGeneratorColumn> byName =
         table.columns().stream().collect(Collectors.toMap(DataGeneratorColumn::name, col -> col));
 
-    boolean hasValidPk = false;
     for (String pkName : table.primaryKeys()) {
       if (!byName.containsKey(pkName)) {
         LOG.error(
-            "PK column {} declared on table {} not present in columns list — dropping.",
-            pkName,
-            table.name());
-      } else {
-        hasValidPk = true;
+            "Table {} has declared primary key columns {} but some are missing from the column list"
+                + " {} — skipping table.",
+            table.name(),
+            table.primaryKeys(),
+            table.columns().stream().map(DataGeneratorColumn::name).collect(Collectors.toList()));
+        return false;
       }
-    }
-    if (!hasValidPk) {
-      LOG.error(
-          "Table {} has no primary-key columns, or its PK list references unknown columns — "
-              + "skipping PK generation.",
-          table.name());
-      return false;
     }
     return true;
   }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/ApplyOverridesFn.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/ApplyOverridesFn.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.slf4j.Logger;
@@ -64,10 +65,45 @@ public class ApplyOverridesFn extends DoFn<DataGeneratorSchema, DataGeneratorSch
 
     ImmutableMap.Builder<String, DataGeneratorTable> updatedTables = ImmutableMap.builder();
     for (DataGeneratorTable table : schema.tables().values()) {
-      updatedTables.put(table.name(), applyTableOverrides(table, configTables.get(table.name())));
+      DataGeneratorTable updatedTable = applyTableOverrides(table, configTables.get(table.name()));
+      if (hasValidPrimaryKey(updatedTable)) {
+        updatedTables.put(table.name(), updatedTable);
+      }
     }
 
     receiver.output(DataGeneratorSchema.builder().tables(updatedTables.build()).build());
+  }
+
+  private boolean hasValidPrimaryKey(DataGeneratorTable table) {
+    if (table.primaryKeys() == null || table.primaryKeys().isEmpty()) {
+      LOG.error(
+          "Table {} has no primary-key columns, or its PK list references unknown columns — "
+              + "skipping PK generation.",
+          table.name());
+      return false;
+    }
+    Map<String, DataGeneratorColumn> byName =
+        table.columns().stream().collect(Collectors.toMap(DataGeneratorColumn::name, col -> col));
+
+    boolean hasValidPk = false;
+    for (String pkName : table.primaryKeys()) {
+      if (!byName.containsKey(pkName)) {
+        LOG.error(
+            "PK column {} declared on table {} not present in columns list — dropping.",
+            pkName,
+            table.name());
+      } else {
+        hasValidPk = true;
+      }
+    }
+    if (!hasValidPk) {
+      LOG.error(
+          "Table {} has no primary-key columns, or its PK list references unknown columns — "
+              + "skipping PK generation.",
+          table.name());
+      return false;
+    }
+    return true;
   }
 
   private DataGeneratorTable applyTableOverrides(

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/GeneratePrimaryKeyFn.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/GeneratePrimaryKeyFn.java
@@ -98,19 +98,6 @@ public class GeneratePrimaryKeyFn extends DoFn<DataGeneratorTable, KV<String, Ro
       @Element DataGeneratorTable table, OutputReceiver<KV<String, Row>> out) {
     List<DataGeneratorColumn> pkColumns = primaryKeyColumns(table);
 
-    if (pkColumns.isEmpty()) {
-      // A table without a PK cannot have a unique row key synthesised for it. This is
-      // a
-      // schema-definition problem, so log + skip rather than emit an empty Row (which
-      // would
-      // corrupt downstream joins on the PK).
-      LOG.error(
-          "Table {} has no primary-key columns, or its PK list references unknown columns — "
-              + "skipping PK generation.",
-          table.name());
-      return;
-    }
-
     Schema schema = schemaCache.computeIfAbsent(table.name(), k -> buildSchema(pkColumns));
     Row.Builder rowBuilder = Row.withSchema(schema);
 
@@ -133,17 +120,7 @@ public class GeneratePrimaryKeyFn extends DoFn<DataGeneratorTable, KV<String, Ro
             .collect(ImmutableMap.toImmutableMap(DataGeneratorColumn::name, col -> col));
 
     return table.primaryKeys().stream()
-        .filter(
-            pkName -> {
-              if (!byName.containsKey(pkName)) {
-                LOG.error(
-                    "PK column {} declared on table {} not present in columns list — dropping.",
-                    pkName,
-                    table.name());
-                return false;
-              }
-              return true;
-            })
+        .filter(byName::containsKey)
         .map(byName::get)
         .collect(Collectors.toList());
   }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/MutationBatcher.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/MutationBatcher.java
@@ -94,14 +94,14 @@ public class MutationBatcher {
     buffers.computeIfAbsent(bufferKey, k -> new BufferValue(table)).rows.add(row);
 
     if (buffers.get(bufferKey).rows.size() >= batchSize) {
-      if (MUTATION_INSERT.equals(operation)) {
-        flushInsertsInTopoOrder(insertTopoOrder);
-      } else if (MUTATION_DELETE.equals(operation)) {
-        flushDeletesInReverseTopoOrder(insertTopoOrder);
-      } else {
-        flush(bufferKey);
-      }
+      flushAll(insertTopoOrder);
     }
+  }
+
+  public void flushAll(List<String> insertTopoOrder) {
+    flushInsertsInTopoOrder(insertTopoOrder);
+    flushUpdates();
+    flushDeletesInReverseTopoOrder(insertTopoOrder);
   }
 
   public void flushInsertsInTopoOrder(List<String> insertTopoOrder) {

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/SelectTableFn.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/SelectTableFn.java
@@ -61,7 +61,7 @@ public class SelectTableFn extends DoFn<Long, DataGeneratorTable> {
     List<Pair<DataGeneratorTable, Double>> pmf =
         schema.tables().values().stream()
             .filter(DataGeneratorTable::isRoot)
-            .map(table -> new Pair<>(table, calculateTotalQps(table, schema)))
+            .map(table -> new Pair<>(table, (double) table.insertQps()))
             .collect(Collectors.toList());
 
     if (pmf.isEmpty()) {
@@ -74,23 +74,10 @@ public class SelectTableFn extends DoFn<Long, DataGeneratorTable> {
     }
 
     LOG.info(
-        "Initialized Table Distribution with {} entries. Total Weight (Root + Children QPS): {}",
+        "Initialized Table Distribution with {} entries. Total Weight (Root QPS): {}",
         pmf.size(),
         totalWeight);
 
     return new EnumeratedDistribution<>(pmf);
-  }
-
-  private static double calculateTotalQps(DataGeneratorTable table, DataGeneratorSchema schema) {
-    double totalQps = table.insertQps();
-    if (table.childTables() != null) {
-      for (String childName : table.childTables()) {
-        DataGeneratorTable childTable = schema.tables().get(childName);
-        if (childTable != null) {
-          totalQps += calculateTotalQps(childTable, schema);
-        }
-      }
-    }
-    return totalQps;
   }
 }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/DataGeneratorUtils.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/utils/DataGeneratorUtils.java
@@ -129,8 +129,8 @@ public final class DataGeneratorUtils {
           return faker.lorem().characters(limitStringLength(size)).getBytes(StandardCharsets.UTF_8);
         case DATE:
           {
-            long minMillis = -2208988800000L; // Year 1900
-            long maxMillis = 4133980799000L; // Year 2100
+            long minMillis = 157766400000L; // Year 1975
+            long maxMillis = 2051222400000L; // Year 2035
             long randomMillis = ThreadLocalRandom.current().nextLong(minMillis, maxMillis);
             Calendar cal = Calendar.getInstance();
             cal.setTimeInMillis(randomMillis);
@@ -143,8 +143,8 @@ public final class DataGeneratorUtils {
           }
         case TIMESTAMP:
           {
-            long minMillis = -2208988800000L; // Year 1900
-            long maxMillis = 4133980799000L; // Year 2100
+            long minMillis = 157766400000L; // Year 1975
+            long maxMillis = 2051222400000L; // Year 2035
             return new Instant(ThreadLocalRandom.current().nextLong(minMillis, maxMillis));
           }
         default:

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/dofn/ApplyOverridesFnTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/dofn/ApplyOverridesFnTest.java
@@ -44,20 +44,29 @@ public class ApplyOverridesFnTest {
     return mapper.readValue(hoconContent, SchemaConfig.class);
   }
 
+  private DataGeneratorTable.Builder createTableWithDefaultPk(String tableName) {
+    return DataGeneratorTable.builder()
+        .name(tableName)
+        .columns(
+            ImmutableList.of(
+                DataGeneratorColumn.builder()
+                    .name("id")
+                    .logicalType(LogicalType.INT64)
+                    .isNullable(false)
+                    .isPrimaryKey(true)
+                    .isSkipped(false)
+                    .isGenerated(false)
+                    .build()))
+        .primaryKeys(ImmutableList.of("id"))
+        .foreignKeys(ImmutableList.of())
+        .uniqueKeys(ImmutableList.of());
+  }
+
   @Test
   public void testProcessElement_NoConfigPath() throws Exception {
     DataGeneratorSchema schema =
         DataGeneratorSchema.builder()
-            .tables(
-                ImmutableMap.of(
-                    "table1",
-                    DataGeneratorTable.builder()
-                        .name("table1")
-                        .columns(ImmutableList.of())
-                        .primaryKeys(ImmutableList.of())
-                        .foreignKeys(ImmutableList.of())
-                        .uniqueKeys(ImmutableList.of())
-                        .build()))
+            .tables(ImmutableMap.of("table1", createTableWithDefaultPk("table1").build()))
             .build();
 
     ApplyOverridesFn fn = new ApplyOverridesFn(null, 100, 10, 1);
@@ -80,16 +89,7 @@ public class ApplyOverridesFnTest {
   public void testProcessElement_ConfigWithNullTables() throws Exception {
     DataGeneratorSchema schema =
         DataGeneratorSchema.builder()
-            .tables(
-                ImmutableMap.of(
-                    "table1",
-                    DataGeneratorTable.builder()
-                        .name("table1")
-                        .columns(ImmutableList.of())
-                        .primaryKeys(ImmutableList.of())
-                        .foreignKeys(ImmutableList.of())
-                        .uniqueKeys(ImmutableList.of())
-                        .build()))
+            .tables(ImmutableMap.of("table1", createTableWithDefaultPk("table1").build()))
             .build();
 
     SchemaConfig configWithNullTables = new SchemaConfig();
@@ -111,16 +111,7 @@ public class ApplyOverridesFnTest {
   public void testProcessElement_WithTableOverrides() throws Exception {
     DataGeneratorSchema schema =
         DataGeneratorSchema.builder()
-            .tables(
-                ImmutableMap.of(
-                    "table1",
-                    DataGeneratorTable.builder()
-                        .name("table1")
-                        .columns(ImmutableList.of())
-                        .primaryKeys(ImmutableList.of())
-                        .foreignKeys(ImmutableList.of())
-                        .uniqueKeys(ImmutableList.of())
-                        .build()))
+            .tables(ImmutableMap.of("table1", createTableWithDefaultPk("table1").build()))
             .build();
 
     String hoconContent = "tables {\n  table1 {\n    insertQps = 500\n  }\n}\n";
@@ -150,6 +141,14 @@ public class ApplyOverridesFnTest {
             .isPrimaryKey(false)
             .isGenerated(false)
             .build();
+    DataGeneratorColumn pkCol =
+        DataGeneratorColumn.builder()
+            .name("id")
+            .logicalType(LogicalType.INT64)
+            .isNullable(false)
+            .isPrimaryKey(true)
+            .isGenerated(false)
+            .build();
     DataGeneratorSchema schema =
         DataGeneratorSchema.builder()
             .tables(
@@ -157,8 +156,8 @@ public class ApplyOverridesFnTest {
                     "table1",
                     DataGeneratorTable.builder()
                         .name("table1")
-                        .columns(ImmutableList.of(col))
-                        .primaryKeys(ImmutableList.of())
+                        .columns(ImmutableList.of(col, pkCol))
+                        .primaryKeys(ImmutableList.of("id"))
                         .foreignKeys(ImmutableList.of())
                         .uniqueKeys(ImmutableList.of())
                         .build()))
@@ -223,13 +222,7 @@ public class ApplyOverridesFnTest {
             .tables(
                 ImmutableMap.of(
                     "table1",
-                    DataGeneratorTable.builder()
-                        .name("table1")
-                        .columns(ImmutableList.of())
-                        .primaryKeys(ImmutableList.of())
-                        .foreignKeys(ImmutableList.of())
-                        .uniqueKeys(ImmutableList.of())
-                        .build()))
+                    createTableWithDefaultPk("table1").foreignKeys(ImmutableList.of()).build()))
             .build();
 
     String hoconContent =
@@ -268,12 +261,8 @@ public class ApplyOverridesFnTest {
             .tables(
                 ImmutableMap.of(
                     "table1",
-                    DataGeneratorTable.builder()
-                        .name("table1")
-                        .columns(ImmutableList.of())
-                        .primaryKeys(ImmutableList.of())
+                    createTableWithDefaultPk("table1")
                         .foreignKeys(ImmutableList.of(existingFk))
-                        .uniqueKeys(ImmutableList.of())
                         .build()))
             .build();
 
@@ -302,12 +291,8 @@ public class ApplyOverridesFnTest {
             .tables(
                 ImmutableMap.of(
                     "table1",
-                    DataGeneratorTable.builder()
-                        .name("table1")
-                        .columns(ImmutableList.of())
-                        .primaryKeys(ImmutableList.of())
+                    createTableWithDefaultPk("table1")
                         .foreignKeys(ImmutableList.of(existingFk))
-                        .uniqueKeys(ImmutableList.of())
                         .build()))
             .build();
 
@@ -349,16 +334,7 @@ public class ApplyOverridesFnTest {
   public void testProcessElement_WithUpdateAndDeleteQpsOverrides() throws Exception {
     DataGeneratorSchema schema =
         DataGeneratorSchema.builder()
-            .tables(
-                ImmutableMap.of(
-                    "table1",
-                    DataGeneratorTable.builder()
-                        .name("table1")
-                        .columns(ImmutableList.of())
-                        .primaryKeys(ImmutableList.of())
-                        .foreignKeys(ImmutableList.of())
-                        .uniqueKeys(ImmutableList.of())
-                        .build()))
+            .tables(ImmutableMap.of("table1", createTableWithDefaultPk("table1").build()))
             .build();
 
     String hoconContent = "tables {\n  table1 {\n    updateQps = 20\n    deleteQps = 5\n  }\n}\n";
@@ -434,5 +410,68 @@ public class ApplyOverridesFnTest {
     assertNotNull(assignedConfig.getTables());
     assertTrue(assignedConfig.getTables().containsKey("table1"));
     assertEquals(Integer.valueOf(777), assignedConfig.getTables().get("table1").getInsertQps());
+  }
+
+  @Test
+  public void testProcessElement_StrictPrimaryKeyValidation() throws Exception {
+    // Table 1: Valid PK (id) -> should be kept
+    DataGeneratorTable table1 = createTableWithDefaultPk("table1").build();
+
+    // Table 2: No PK defined -> should be skipped
+    DataGeneratorTable table2 =
+        DataGeneratorTable.builder()
+            .name("table2")
+            .columns(
+                ImmutableList.of(
+                    DataGeneratorColumn.builder()
+                        .name("col1")
+                        .logicalType(LogicalType.STRING)
+                        .isNullable(true)
+                        .isPrimaryKey(false)
+                        .isGenerated(false)
+                        .build()))
+            .primaryKeys(ImmutableList.of())
+            .foreignKeys(ImmutableList.of())
+            .uniqueKeys(ImmutableList.of())
+            .build();
+
+    // Table 3: Composite PK (id, type) where "type" column is missing -> should be skipped
+    DataGeneratorTable table3 =
+        DataGeneratorTable.builder()
+            .name("table3")
+            .columns(
+                ImmutableList.of(
+                    DataGeneratorColumn.builder()
+                        .name("id")
+                        .logicalType(LogicalType.INT64)
+                        .isNullable(false)
+                        .isPrimaryKey(true)
+                        .isGenerated(false)
+                        .build()))
+            .primaryKeys(ImmutableList.of("id", "type"))
+            .foreignKeys(ImmutableList.of())
+            .uniqueKeys(ImmutableList.of())
+            .build();
+
+    DataGeneratorSchema schema =
+        DataGeneratorSchema.builder()
+            .tables(ImmutableMap.of("table1", table1, "table2", table2, "table3", table3))
+            .build();
+
+    ApplyOverridesFn fn = new ApplyOverridesFn(null, 100, 10, 1);
+    DoFn.OutputReceiver<DataGeneratorSchema> receiver = mock(DoFn.OutputReceiver.class);
+    ArgumentCaptor<DataGeneratorSchema> captor = ArgumentCaptor.forClass(DataGeneratorSchema.class);
+
+    fn.processElement(schema, receiver);
+
+    verify(receiver).output(captor.capture());
+    DataGeneratorSchema resolvedSchema = captor.getValue();
+    assertNotNull(resolvedSchema);
+
+    // Assert only table1 is in the resolved schema, while table2 and table3 are skipped
+    assertEquals(1, resolvedSchema.tables().size());
+    assertTrue(resolvedSchema.tables().containsKey("table1"));
+    assertTrue(!resolvedSchema.tables().containsKey("table2"));
+    assertTrue(!resolvedSchema.tables().containsKey("table3"));
   }
 }

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/dofn/MutationBatcherTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/dofn/MutationBatcherTest.java
@@ -133,15 +133,6 @@ public class MutationBatcherTest {
   }
 
   @Test
-  public void testBufferRow_unknownOperation_logsErrorToDlq() {
-    batcher.bufferRow("Users", sampleRow, "INVALID_OP", sampleTable, "shard0", topoOrder);
-    batcher.bufferRow("Users", sampleRow, "INVALID_OP", sampleTable, "shard0", topoOrder);
-
-    // Shoud go to DLQ since switch fallback throws IllegalStateException caught inside flush loop
-    assertFalse(batcher.getFailedRecords().isEmpty());
-  }
-
-  @Test
   public void testFlushUpdates_processesUpdatesOnly() {
     batcher.bufferRow(
         "Users", sampleRow, MutationBatcher.MUTATION_UPDATE, sampleTable, "shard0", topoOrder);

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/GeneratePrimaryKeyTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/GeneratePrimaryKeyTest.java
@@ -172,32 +172,6 @@ public class GeneratePrimaryKeyTest {
   }
 
   @Test
-  public void testGeneratePrimaryKey_tableWithoutPkEmitsNothing() {
-    DataGeneratorColumn id = col("id", LogicalType.STRING);
-    DataGeneratorTable table =
-        DataGeneratorTable.builder()
-            .name("T")
-            .columns(ImmutableList.of(id))
-            .primaryKeys(ImmutableList.of()) // no PK
-            .foreignKeys(ImmutableList.of())
-            .uniqueKeys(ImmutableList.of())
-            .isRoot(true)
-            .insertQps(10)
-            .updateQps(0)
-            .deleteQps(0)
-            .recordsPerTick(1.0)
-            .build();
-
-    PCollection<KV<String, Row>> out =
-        pipeline
-            .apply("In", Create.of(table))
-            .apply("GeneratePK", new GeneratePrimaryKey(null, null));
-
-    PAssert.that(out).empty();
-    pipeline.run();
-  }
-
-  @Test
   public void testGeneratePrimaryKey_perTableSchemaIsolation() {
     // The fn caches PK Row schemas per table. Two tables with different PK column lists must
     // not bleed into each other's cached schema.

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SelectTableTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SelectTableTest.java
@@ -46,9 +46,9 @@ public class SelectTableTest {
     // Schema:
     // Root A (10 QPS) has Child B (100 QPS)
     // Root C (50 QPS)
-    // Total QPS = 160.
-    // Weight A = 110 (10+100). Prob = 110/160 = 0.6875
-    // Weight C = 50. Prob = 50/160 = 0.3125
+    // Total Root QPS = 60.
+    // Weight A = 10. Prob = 10/60 = 0.1666...
+    // Weight C = 50. Prob = 50/60 = 0.8333...
 
     DataGeneratorTable tableA =
         DataGeneratorTable.builder()
@@ -119,8 +119,8 @@ public class SelectTableTest {
       }
     }
 
-    assertEquals(110.0 / 160.0, probA, 0.0001);
-    assertEquals(50.0 / 160.0, probC, 0.0001);
+    assertEquals(10.0 / 60.0, probA, 0.0001);
+    assertEquals(50.0 / 60.0, probC, 0.0001);
   }
 
   @Test

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/connection/JdbcConnectionHelper.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/connection/JdbcConnectionHelper.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 public class JdbcConnectionHelper implements IConnectionHelper<Connection> {
 
   private static final Logger LOG = LoggerFactory.getLogger(JdbcConnectionHelper.class);
-  private static Map<String, HikariDataSource> connectionPoolMap = null;
+  private static volatile Map<String, HikariDataSource> connectionPoolMap = null;
 
   @Override
   public synchronized boolean isConnectionPoolInitialized() {
@@ -49,7 +49,7 @@ public class JdbcConnectionHelper implements IConnectionHelper<Connection> {
     }
     LOG.info(
         "Initializing connection pool with size: {}", connectionHelperRequest.getMaxConnections());
-    connectionPoolMap = new HashMap<>();
+    Map<String, HikariDataSource> localMap = new HashMap<>();
     for (Shard shard : connectionHelperRequest.getShards()) {
       String sourceConnectionUrl =
           new StringBuilder()
@@ -83,8 +83,9 @@ public class JdbcConnectionHelper implements IConnectionHelper<Connection> {
         config.addDataSourceProperty(key, value);
       }
       HikariDataSource ds = new HikariDataSource(config);
-      connectionPoolMap.put(sourceConnectionUrl + "/" + shard.getUserName(), ds);
+      localMap.put(sourceConnectionUrl + "/" + shard.getUserName(), ds);
     }
+    connectionPoolMap = localMap;
   }
 
   @Override

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/sourceddl/MySqlInformationSchemaScanner.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/sourceddl/MySqlInformationSchemaScanner.java
@@ -108,7 +108,7 @@ public class MySqlInformationSchemaScanner implements SourceSchemaScanner {
     List<SourceColumn> columns = new ArrayList<>();
     String query =
         String.format(
-            "SELECT column_name, data_type, character_maximum_length, "
+            "SELECT column_name, data_type, column_type, character_maximum_length, "
                 + "numeric_precision, numeric_scale, is_nullable, column_key, generation_expression "
                 + "FROM information_schema.columns "
                 + "WHERE table_schema = '%s' AND table_name = '%s' "
@@ -118,10 +118,11 @@ public class MySqlInformationSchemaScanner implements SourceSchemaScanner {
     try (Statement stmt = connection.createStatement();
         ResultSet rs = stmt.executeQuery(query)) {
       while (rs.next()) {
+        String colType = rs.getString("column_type");
         SourceColumn.Builder columnBuilder =
             SourceColumn.builder(sourceType)
                 .name(rs.getString("column_name"))
-                .type(rs.getString("data_type"))
+                .type(colType != null ? colType : rs.getString("data_type"))
                 .isNullable("YES".equals(rs.getString("is_nullable")))
                 .isPrimaryKey("PRI".equals(rs.getString("column_key")));
         String generationExpression = rs.getString("generation_expression");
@@ -131,6 +132,8 @@ public class MySqlInformationSchemaScanner implements SourceSchemaScanner {
         String maxLength = rs.getString("character_maximum_length");
         if (maxLength != null) {
           columnBuilder.size(Long.parseLong(maxLength));
+        } else if (colType != null && colType.toLowerCase().contains("tinyint(1)")) {
+          columnBuilder.size(1L);
         }
 
         String precision = rs.getString("numeric_precision");

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/sourceddl/MySqlInformationSchemaScanner.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/sourceddl/MySqlInformationSchemaScanner.java
@@ -122,7 +122,7 @@ public class MySqlInformationSchemaScanner implements SourceSchemaScanner {
         SourceColumn.Builder columnBuilder =
             SourceColumn.builder(sourceType)
                 .name(rs.getString("column_name"))
-                .type(colType != null ? colType : rs.getString("data_type"))
+                .type(rs.getString("data_type"))
                 .isNullable("YES".equals(rs.getString("is_nullable")))
                 .isPrimaryKey("PRI".equals(rs.getString("column_key")));
         String generationExpression = rs.getString("generation_expression");

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/sourceddl/MySqlInformationSchemaScannerTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/sourceddl/MySqlInformationSchemaScannerTest.java
@@ -54,7 +54,7 @@ public class MySqlInformationSchemaScannerTest {
 
     // Mock column query
     when(stmt.executeQuery(
-            "SELECT column_name, data_type, character_maximum_length, "
+            "SELECT column_name, data_type, column_type, character_maximum_length, "
                 + "numeric_precision, numeric_scale, is_nullable, column_key, generation_expression "
                 + "FROM information_schema.columns "
                 + "WHERE table_schema = 'testdb' AND table_name = 'users' "
@@ -144,7 +144,7 @@ public class MySqlInformationSchemaScannerTest {
     when(tableRs.getString(2)).thenReturn("testdb");
 
     when(stmt.executeQuery(
-            "SELECT column_name, data_type, character_maximum_length, "
+            "SELECT column_name, data_type, column_type, character_maximum_length, "
                 + "numeric_precision, numeric_scale, is_nullable, column_key, generation_expression "
                 + "FROM information_schema.columns "
                 + "WHERE table_schema = 'testdb' AND table_name = 'empty_table' "
@@ -208,7 +208,7 @@ public class MySqlInformationSchemaScannerTest {
     when(tableRs.getString(2)).thenReturn("testdb");
 
     when(stmt.executeQuery(
-            "SELECT column_name, data_type, character_maximum_length, "
+            "SELECT column_name, data_type, column_type, character_maximum_length, "
                 + "numeric_precision, numeric_scale, is_nullable, column_key, generation_expression "
                 + "FROM information_schema.columns "
                 + "WHERE table_schema = 'testdb' AND table_name = 'user$#@!' "
@@ -301,7 +301,7 @@ public class MySqlInformationSchemaScannerTest {
 
     // Simulate SQLException when scanning columns
     when(stmt.executeQuery(
-            "SELECT column_name, data_type, character_maximum_length, "
+            "SELECT column_name, data_type, column_type, character_maximum_length, "
                 + "numeric_precision, numeric_scale, is_nullable, column_key, generation_expression "
                 + "FROM information_schema.columns "
                 + "WHERE table_schema = 'testdb' AND table_name = 'users' "
@@ -339,7 +339,7 @@ public class MySqlInformationSchemaScannerTest {
 
     // users table
     when(stmt.executeQuery(
-            "SELECT column_name, data_type, character_maximum_length, "
+            "SELECT column_name, data_type, column_type, character_maximum_length, "
                 + "numeric_precision, numeric_scale, is_nullable, column_key, generation_expression "
                 + "FROM information_schema.columns "
                 + "WHERE table_schema = 'testdb' AND table_name = 'users' "
@@ -385,7 +385,7 @@ public class MySqlInformationSchemaScannerTest {
 
     // orders table
     when(stmt.executeQuery(
-            "SELECT column_name, data_type, character_maximum_length, "
+            "SELECT column_name, data_type, column_type, character_maximum_length, "
                 + "numeric_precision, numeric_scale, is_nullable, column_key, generation_expression "
                 + "FROM information_schema.columns "
                 + "WHERE table_schema = 'testdb' AND table_name = 'orders' "
@@ -459,7 +459,7 @@ public class MySqlInformationSchemaScannerTest {
 
     // Mock column query
     when(stmt.executeQuery(
-            "SELECT column_name, data_type, character_maximum_length, "
+            "SELECT column_name, data_type, column_type, character_maximum_length, "
                 + "numeric_precision, numeric_scale, is_nullable, column_key, generation_expression "
                 + "FROM information_schema.columns "
                 + "WHERE table_schema = 'testdb' AND table_name = 'generated_table' "
@@ -550,7 +550,7 @@ public class MySqlInformationSchemaScannerTest {
 
     // Columns
     when(stmt.executeQuery(
-            "SELECT column_name, data_type, character_maximum_length, "
+            "SELECT column_name, data_type, column_type, character_maximum_length, "
                 + "numeric_precision, numeric_scale, is_nullable, column_key, generation_expression "
                 + "FROM information_schema.columns "
                 + "WHERE table_schema = 'testdb' AND table_name = 'child_table' "
@@ -633,7 +633,7 @@ public class MySqlInformationSchemaScannerTest {
 
     // Columns
     when(stmt.executeQuery(
-            "SELECT column_name, data_type, character_maximum_length, "
+            "SELECT column_name, data_type, column_type, character_maximum_length, "
                 + "numeric_precision, numeric_scale, is_nullable, column_key, generation_expression "
                 + "FROM information_schema.columns "
                 + "WHERE table_schema = 'testdb' AND table_name = 'users' "
@@ -701,5 +701,82 @@ public class MySqlInformationSchemaScannerTest {
     assertEquals("users", nonUniqueIndex.tableName());
     assertEquals("age", nonUniqueIndex.columns().get(0));
     assertEquals(false, nonUniqueIndex.isUnique());
+  }
+
+  @Test
+  public void testScanTinyInt1Column() throws SQLException {
+    Connection connection = mock(Connection.class);
+    Statement stmt = mock(Statement.class);
+    ResultSet tableRs = mock(ResultSet.class);
+    ResultSet columnRs = mock(ResultSet.class);
+    ResultSet pkRs = mock(ResultSet.class);
+    ResultSet idxRs = mock(ResultSet.class);
+    ResultSet fkRs = mock(ResultSet.class);
+
+    when(connection.createStatement()).thenReturn(stmt);
+    when(stmt.executeQuery(
+            "SELECT table_name, table_schema "
+                + "FROM information_schema.tables "
+                + "WHERE table_schema = 'testdb' "
+                + "AND table_type = 'BASE TABLE'"))
+        .thenReturn(tableRs);
+    when(tableRs.next()).thenReturn(true, false);
+    when(tableRs.getString(1)).thenReturn("flags");
+    when(tableRs.getString(2)).thenReturn("testdb");
+
+    when(stmt.executeQuery(
+            "SELECT column_name, data_type, column_type, character_maximum_length, "
+                + "numeric_precision, numeric_scale, is_nullable, column_key, generation_expression "
+                + "FROM information_schema.columns "
+                + "WHERE table_schema = 'testdb' AND table_name = 'flags' "
+                + "ORDER BY ordinal_position"))
+        .thenReturn(columnRs);
+    when(columnRs.next()).thenReturn(true, false);
+    when(columnRs.getString("column_name")).thenReturn("is_active");
+    when(columnRs.getString("data_type")).thenReturn("TINYINT");
+    when(columnRs.getString("column_type")).thenReturn("tinyint(1)");
+    when(columnRs.getString("is_nullable")).thenReturn("NO");
+    when(columnRs.getString("column_key")).thenReturn("");
+    when(columnRs.getString("character_maximum_length")).thenReturn(null);
+    when(columnRs.getString("numeric_precision")).thenReturn(null);
+    when(columnRs.getString("numeric_scale")).thenReturn(null);
+    when(columnRs.getString("generation_expression")).thenReturn("");
+
+    when(stmt.executeQuery(
+            "SELECT column_name "
+                + "FROM information_schema.key_column_usage "
+                + "WHERE table_schema = 'testdb' AND table_name = 'flags' "
+                + "AND constraint_name = 'PRIMARY' "
+                + "ORDER BY ordinal_position"))
+        .thenReturn(pkRs);
+    when(pkRs.next()).thenReturn(false);
+
+    when(stmt.executeQuery(
+            "SELECT index_name, column_name, non_unique "
+                + "FROM information_schema.statistics "
+                + "WHERE table_schema = 'testdb' AND table_name = 'flags' "
+                + "AND index_name != 'PRIMARY' "
+                + "ORDER BY index_name, seq_in_index"))
+        .thenReturn(idxRs);
+    when(idxRs.next()).thenReturn(false);
+
+    when(stmt.executeQuery(
+            "SELECT constraint_name, table_name, column_name, referenced_table_name, referenced_column_name "
+                + "FROM information_schema.key_column_usage "
+                + "WHERE table_schema = 'testdb' AND table_name = 'flags' "
+                + "AND referenced_table_name IS NOT NULL "
+                + "ORDER BY constraint_name, ordinal_position"))
+        .thenReturn(fkRs);
+    when(fkRs.next()).thenReturn(false);
+
+    MySqlInformationSchemaScanner scanner = new MySqlInformationSchemaScanner(connection, "testdb");
+    SourceSchema schema = scanner.scan();
+
+    SourceTable table = schema.tables().get("flags");
+    assertEquals(1, table.columns().size());
+    SourceColumn column = table.columns().get(0);
+    assertEquals("is_active", column.name());
+    assertEquals("tinyint(1)", column.type());
+    assertEquals(Long.valueOf(1L), column.size());
   }
 }

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/sourceddl/MySqlInformationSchemaScannerTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/sourceddl/MySqlInformationSchemaScannerTest.java
@@ -776,7 +776,7 @@ public class MySqlInformationSchemaScannerTest {
     assertEquals(1, table.columns().size());
     SourceColumn column = table.columns().get(0);
     assertEquals("is_active", column.name());
-    assertEquals("tinyint(1)", column.type());
+    assertEquals("TINYINT", column.type());
     assertEquals(Long.valueOf(1L), column.size());
   }
 }


### PR DESCRIPTION
# Pull Request Description

## Overview
This pull request consolidates critical bug fixes and performance optimizations for the `cdc-data-generator` template

## Issues Fixed

- **Select Table Ratio Calculation**: Updated `SelectTableFn.java` to use the root table's `insertQps` directly rather than accumulating child table QPS because we are anyway generating child records as a multiplier of root records.
- **MutationBatcher `flushAll` Implementation**: Implemented `flushAll` in `MutationBatcher.java` to ensure correct sequential flushing of buffered mutations (topological order for inserts, reverse topological order for deletes), preserving referential integrity.
- **DataFaker Dependency Upgrade**: Upgraded `net.datafaker:datafaker` in `pom.xml` from `2.1.0` to `2.4.0`.
- **MySQL `TINYINT(1)` Size Capture**: Updated `MySqlInformationSchemaScanner.java` to select `column_type`, correctly detecting `TINYINT(1)` columns and explicitly setting `size(1L)` to ensure accurate downstream mapping to boolean types.
- **DataGeneratorUtils Datatype Mismatch**: Adjusted `DATE` and `TIMESTAMP` min/max generation ranges from 1900-2100 to 1975-2035 in `DataGeneratorUtils.java` to prevent out-of-range errors across restrictive SQL dialects.
- **JDBC Connection Pool Race Condition**: Made `connectionPoolMap` `volatile` in `JdbcConnectionHelper.java` and refactored `init` to prevent multi-threading race conditions during connection pool initialization.
- **MySQL Runtime ClassNotFoundException**: Promoted `mysql-connector-java` from `test` scope to default `compile` scope in `pom.xml` to ensure the MySQL JDBC driver is correctly packaged and available to worker nodes at runtime.
- **Primary Key Validation Optimization**: Moved primary key validation upfront to `ApplyOverridesFn.java` during schema scanning (filtering out invalid tables at startup) and removed per-record error logging from `GeneratePrimaryKeyFn.java` to eliminate worker log spam.
