### PR TITLE
Support specifying runtime dependencies for YAML template

### DIFF
--- a/python/src/main/python/yaml-template/main.py
+++ b/python/src/main/python/yaml-template/main.py
@@ -15,13 +15,40 @@
 
 
 import argparse
+import tempfile
 
 from apache_beam.yaml import main
+
+# A list of default runtime dependencies that will be installed when running jobs using the
+# YAML template. These will only be installed if the caller do not provide a
+# `requirements_file` option.
+DEFAULT_DEPENDENCIES = [
+    'boto3',
+    'botocore',
+    # When updating this, also update the container dependency in `python/default_base_yaml_requirements.txt`
+    'https://storage.googleapis.com/dataflow-templates/extra-python-packages/2026-05-02/job_builder_util_transforms-0.1.1.tar.gz',
+]
 
 
 def run(argv=None):
   parser = argparse.ArgumentParser()
   _, args = parser.parse_known_args(argv)
+
+  has_req_file = False
+  for arg in args:
+    if arg == '--requirements_file' or arg.startswith('--requirements_file='):
+      has_req_file = True
+      break
+
+  if not has_req_file:
+    # Create a temporary requirements.txt file with default dependencies.
+    # We use delete=False because the file needs to exist during pipeline execution.
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', prefix='requirements_', delete=False) as f:
+      for dep in DEFAULT_DEPENDENCIES:
+        f.write(f'{dep}\n')
+      temp_requirements_path = f.name
+    args.append(f'--requirements_file={temp_requirements_path}')
+
   main.run(args)
 
 

--- a/python/src/test/python/yaml-template/main_test.py
+++ b/python/src/test/python/yaml-template/main_test.py
@@ -1,0 +1,104 @@
+# Copyright (C) 2023 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import unittest
+from unittest.mock import patch
+import os
+
+import main
+
+
+class MainTest(unittest.TestCase):
+
+  def test_run_adds_requirements_file_if_not_present(self):
+    argv = ['--yaml_pipeline=path/to/pipeline.yaml']
+
+    with patch('main.main.run') as mock_run:
+      main.run(argv)
+
+      # Verify main.run was called
+      mock_run.assert_called_once()
+      called_args = mock_run.call_args[0][0]
+
+      # Verify --requirements_file was added
+      req_file_arg = None
+      for arg in called_args:
+        if arg.startswith('--requirements_file='):
+          req_file_arg = arg
+          break
+
+      self.assertIsNotNone(req_file_arg)
+      temp_path = req_file_arg.split('=', 1)[1]
+      self.assertTrue(os.path.exists(temp_path))
+
+      # Read content of the temp requirements file
+      with open(temp_path, 'r') as f:
+        content = f.read().splitlines()
+
+      self.assertEqual(content, ['boto3', 'botocore'])
+
+      # Clean up the temp file
+      os.remove(temp_path)
+
+  def test_run_does_not_override_existing_requirements_file(self):
+    custom_req_path = 'custom/requirements.txt'
+    argv = [
+        '--yaml_pipeline=path/to/pipeline.yaml',
+        f'--requirements_file={custom_req_path}',
+    ]
+
+    with patch('main.main.run') as mock_run:
+      main.run(argv)
+
+      mock_run.assert_called_once()
+      called_args = mock_run.call_args[0][0]
+
+      # Verify --requirements_file was not changed or duplicated
+      req_file_args = [
+          arg
+          for arg in called_args
+          if arg.startswith('--requirements_file=')
+          or arg == '--requirements_file'
+      ]
+      self.assertEqual(len(req_file_args), 1)
+      self.assertEqual(
+          req_file_args[0], f'--requirements_file={custom_req_path}'
+      )
+
+  def test_run_does_not_override_existing_requirements_file_separated(self):
+    custom_req_path = 'custom/requirements.txt'
+    argv = [
+        '--yaml_pipeline=path/to/pipeline.yaml',
+        '--requirements_file',
+        custom_req_path,
+    ]
+
+    with patch('main.main.run') as mock_run:
+      main.run(argv)
+
+      mock_run.assert_called_once()
+      called_args = mock_run.call_args[0][0]
+
+      # Verify --requirements_file was not changed or duplicated
+      self.assertIn('--requirements_file', called_args)
+      self.assertIn(custom_req_path, called_args)
+      # Verify no other requirements_file arg was added
+      req_file_args = [
+          arg for arg in called_args if arg.startswith('--requirements_file=')
+      ]
+      self.assertEqual(len(req_file_args), 0)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Currently includes the util package (that includes custom job builder transforms) and AWS dependencies. 

Removing the job builder util package from the template containers (job submission).

This fixes https://github.com/GoogleCloudPlatform/DataflowTemplates/issues/3818.
