### PR TITLE
Parsing sink config in the pipeline code rather than individual transforms

### DIFF
--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/BatchAndWriteFn.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/BatchAndWriteFn.java
@@ -20,6 +20,7 @@ import com.google.cloud.teleport.v2.templates.model.DataGeneratorSchema;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
 import com.google.cloud.teleport.v2.templates.model.GeneratedRecord;
 import com.google.cloud.teleport.v2.templates.model.LifecycleEvent;
+import com.google.cloud.teleport.v2.templates.model.SinkConfig;
 import com.google.cloud.teleport.v2.templates.sink.DataWriter;
 import com.google.cloud.teleport.v2.templates.sink.DataWriterFactory;
 import com.google.cloud.teleport.v2.templates.utils.FailureRecord;
@@ -60,7 +61,7 @@ public class BatchAndWriteFn extends DoFn<KV<Integer, GeneratedRecord>, String> 
   private static final Logger LOG = LoggerFactory.getLogger(BatchAndWriteFn.class);
 
   private final SinkType sinkType;
-  private final String sinkOptionsPath;
+  private final SinkConfig sinkConfig;
   private final int batchSize;
   private final Integer jdbcPoolSize;
   private final Integer updateInterval;
@@ -96,14 +97,14 @@ public class BatchAndWriteFn extends DoFn<KV<Integer, GeneratedRecord>, String> 
 
   public BatchAndWriteFn(
       SinkType sinkType,
-      String sinkOptionsPath,
+      SinkConfig sinkConfig,
       Integer batchSize,
       Integer jdbcPoolSize,
       Integer updateInterval,
       Integer deleteInterval,
       PCollectionView<DataGeneratorSchema> schemaView) {
     this.sinkType = sinkType;
-    this.sinkOptionsPath = sinkOptionsPath;
+    this.sinkConfig = sinkConfig;
     this.batchSize = batchSize;
     this.jdbcPoolSize = jdbcPoolSize;
     this.updateInterval = updateInterval;
@@ -116,7 +117,7 @@ public class BatchAndWriteFn extends DoFn<KV<Integer, GeneratedRecord>, String> 
     this.schema = null;
     this.insertTopoOrder = null;
     if (writer == null) {
-      writer = DataWriterFactory.createWriter(sinkType, sinkOptionsPath);
+      writer = DataWriterFactory.createWriter(sinkType, sinkConfig);
     }
     if (faker == null) {
       faker = new Faker();

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/FetchSchemaFn.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/FetchSchemaFn.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.templates.dofn;
 
 import com.google.cloud.teleport.v2.templates.CdcDataGeneratorOptions.SinkType;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorSchema;
+import com.google.cloud.teleport.v2.templates.model.SinkConfig;
 import com.google.cloud.teleport.v2.templates.mysql.MySqlSchemaFetcher;
 import com.google.cloud.teleport.v2.templates.sink.SinkSchemaFetcher;
 import com.google.cloud.teleport.v2.templates.spanner.SpannerSchemaFetcher;
@@ -38,11 +39,11 @@ public class FetchSchemaFn extends DoFn<SinkType, DataGeneratorSchema> {
           SinkType.MYSQL, MySqlSchemaFetcher::new);
 
   private final SinkType sinkType;
-  private final String sinkConfigPath;
+  private final SinkConfig sinkConfig;
 
-  public FetchSchemaFn(SinkType sinkType, String sinkConfigPath) {
+  public FetchSchemaFn(SinkType sinkType, SinkConfig sinkConfig) {
     this.sinkType = sinkType;
-    this.sinkConfigPath = sinkConfigPath;
+    this.sinkConfig = sinkConfig;
   }
 
   @ProcessElement
@@ -50,7 +51,7 @@ public class FetchSchemaFn extends DoFn<SinkType, DataGeneratorSchema> {
     try {
       SinkSchemaFetcher fetcher = createFetcher(sinkType);
 
-      fetcher.init(sinkConfigPath);
+      fetcher.init(sinkConfig);
       DataGeneratorSchema schema = fetcher.getSchema();
       LOG.info("Fetched Schema: {}", schema);
       receiver.output(schema);

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/GeneratePrimaryKeyFn.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/dofn/GeneratePrimaryKeyFn.java
@@ -16,10 +16,10 @@
 package com.google.cloud.teleport.v2.templates.dofn;
 
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
-import com.google.cloud.teleport.v2.spanner.migrations.utils.SecretManagerAccessorImpl;
-import com.google.cloud.teleport.v2.spanner.migrations.utils.ShardFileReader;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorColumn;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
+import com.google.cloud.teleport.v2.templates.model.MySqlSinkConfig;
+import com.google.cloud.teleport.v2.templates.model.SinkConfig;
 import com.google.cloud.teleport.v2.templates.utils.Constants;
 import com.google.cloud.teleport.v2.templates.utils.DataGeneratorUtils;
 import com.google.common.annotations.VisibleForTesting;
@@ -43,9 +43,8 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The emitted {@link Row} has the table's PK columns followed by a synthesised logical shard id
  * column (name controlled by {@link Constants#SHARD_ID_COLUMN_NAME}). The shard id is either
- * sampled uniformly from {@code [0, maxShards)} or, for MySQL sinks with a shard config file,
- * sampled uniformly from the configured logical shard ids so the same shard ids used by downstream
- * writers are reused here.
+ * sampled uniformly from the configured logical shard ids (for MySQL sinks with a shard config
+ * file), or defaults to {@code shard0}.
  *
  * <p>Randomness: {@link Faker} is constructed with its default no-arg constructor (which seeds
  * itself from {@code System.nanoTime()} plus a per-instance counter and shard-id selection uses
@@ -58,7 +57,7 @@ public class GeneratePrimaryKeyFn extends DoFn<DataGeneratorTable, KV<String, Ro
 
   private static final Logger LOG = LoggerFactory.getLogger(GeneratePrimaryKeyFn.class);
 
-  private final String sinkOptionsPath;
+  private final SinkConfig sinkConfig;
   private final String sinkType;
 
   private transient Faker faker;
@@ -67,8 +66,8 @@ public class GeneratePrimaryKeyFn extends DoFn<DataGeneratorTable, KV<String, Ro
   /** Per-table PK schema cache. Schemas are static per pipeline run so this is write-once. */
   private transient Map<String, Schema> schemaCache;
 
-  public GeneratePrimaryKeyFn(String sinkOptionsPath, String sinkType) {
-    this.sinkOptionsPath = sinkOptionsPath;
+  public GeneratePrimaryKeyFn(SinkConfig sinkConfig, String sinkType) {
+    this.sinkConfig = sinkConfig;
     this.sinkType = sinkType;
   }
 
@@ -77,18 +76,13 @@ public class GeneratePrimaryKeyFn extends DoFn<DataGeneratorTable, KV<String, Ro
     faker = new Faker();
     schemaCache = new HashMap<>();
 
-    if (Constants.SINK_TYPE_MYSQL.equalsIgnoreCase(sinkType)
-        && sinkOptionsPath != null
-        && !sinkOptionsPath.isEmpty()) {
-      try {
-        ShardFileReader shardFileReader = new ShardFileReader(new SecretManagerAccessorImpl());
-        List<Shard> shards = shardFileReader.getOrderedShardDetails(sinkOptionsPath);
+    if (sinkConfig instanceof MySqlSinkConfig) {
+      MySqlSinkConfig mySqlSinkConfig = (MySqlSinkConfig) sinkConfig;
+      if (mySqlSinkConfig.getShards() != null) {
         this.logicalShardIds =
-            shards == null || shards.isEmpty()
-                ? null
-                : shards.stream().map(Shard::getLogicalShardId).collect(Collectors.toList());
-      } catch (Exception e) {
-        throw new RuntimeException("Failed to read shards from " + sinkOptionsPath, e);
+            mySqlSinkConfig.getShards().stream()
+                .map(Shard::getLogicalShardId)
+                .collect(Collectors.toList());
       }
     }
   }
@@ -159,7 +153,7 @@ public class GeneratePrimaryKeyFn extends DoFn<DataGeneratorTable, KV<String, Ro
 
   /**
    * Select a shard id for this row. Prefer a configured logical shard id, otherwise synthesise a
-   * placeholder {@code shard<N>}. Bounded at maxShards >= 1 so {@code nextInt} never throws.
+   * placeholder {@code shard0}.
    */
   private String pickShardId() {
     ThreadLocalRandom rng = ThreadLocalRandom.current();

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/model/MySqlSinkConfig.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/model/MySqlSinkConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.model;
+
+import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
+import java.util.List;
+import java.util.Objects;
+
+/** Configuration for a MySQL sink, containing ordered shard details. */
+public class MySqlSinkConfig implements SinkConfig {
+
+  private List<Shard> shards;
+
+  public MySqlSinkConfig() {}
+
+  public MySqlSinkConfig(List<Shard> shards) {
+    this.shards = shards;
+  }
+
+  public List<Shard> getShards() {
+    return shards;
+  }
+
+  public void setShards(List<Shard> shards) {
+    this.shards = shards;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof MySqlSinkConfig)) {
+      return false;
+    }
+    MySqlSinkConfig that = (MySqlSinkConfig) o;
+    return Objects.equals(shards, that.shards);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(shards);
+  }
+
+  @Override
+  public String toString() {
+    return "MySqlSinkConfig{" + "shards=" + shards + '}';
+  }
+}

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/model/SinkConfig.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/model/SinkConfig.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.model;
+
+import java.io.Serializable;
+
+/**
+ * Interface representing a parsed, serializable sink configuration.
+ *
+ * <p>Architectural Note on {@link Serializable}: This interface extends {@code Serializable}
+ * because instances are stored as fields within Apache Beam {@code DoFn}s and {@code PTransform}s.
+ * Beam uses Java serialization exactly once during job submission and worker initialization to
+ * distribute the execution graph. Once initialized on worker nodes, configuration fields are
+ * accessed as warm in-memory references, incurring zero per-record serialization overhead during
+ * active data processing.
+ */
+public interface SinkConfig extends Serializable {}

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/model/SpannerSinkConfig.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/model/SpannerSinkConfig.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.model;
+
+import com.google.cloud.spanner.Dialect;
+import java.util.Objects;
+
+/**
+ * Configuration for a Cloud Spanner sink, representing both the parsed JSON config file and the
+ * pre-fetched dialect.
+ */
+public class SpannerSinkConfig implements SinkConfig {
+
+  private String projectId;
+  private String instanceId;
+  private String databaseId;
+  private Dialect dialect;
+
+  public SpannerSinkConfig() {}
+
+  public SpannerSinkConfig(
+      String projectId, String instanceId, String databaseId, Dialect dialect) {
+    this.projectId = projectId;
+    this.instanceId = instanceId;
+    this.databaseId = databaseId;
+    this.dialect = dialect;
+  }
+
+  public String getProjectId() {
+    return projectId;
+  }
+
+  public void setProjectId(String projectId) {
+    this.projectId = projectId;
+  }
+
+  public String getInstanceId() {
+    return instanceId;
+  }
+
+  public void setInstanceId(String instanceId) {
+    this.instanceId = instanceId;
+  }
+
+  public String getDatabaseId() {
+    return databaseId;
+  }
+
+  public void setDatabaseId(String databaseId) {
+    this.databaseId = databaseId;
+  }
+
+  public Dialect getDialect() {
+    return dialect;
+  }
+
+  public void setDialect(Dialect dialect) {
+    this.dialect = dialect;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SpannerSinkConfig)) {
+      return false;
+    }
+    SpannerSinkConfig that = (SpannerSinkConfig) o;
+    return Objects.equals(projectId, that.projectId)
+        && Objects.equals(instanceId, that.instanceId)
+        && Objects.equals(databaseId, that.databaseId)
+        && dialect == that.dialect;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(projectId, instanceId, databaseId, dialect);
+  }
+
+  @Override
+  public String toString() {
+    return "SpannerSinkConfig{"
+        + "projectId='"
+        + projectId
+        + '\''
+        + ", instanceId='"
+        + instanceId
+        + '\''
+        + ", databaseId='"
+        + databaseId
+        + '\''
+        + ", dialect="
+        + dialect
+        + '}';
+  }
+}

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/mysql/MySqlDataWriter.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/mysql/MySqlDataWriter.java
@@ -20,11 +20,10 @@ import com.google.cloud.teleport.v2.spanner.migrations.connection.IConnectionHel
 import com.google.cloud.teleport.v2.spanner.migrations.connection.JdbcConnectionHelper;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.ConnectionException;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
-import com.google.cloud.teleport.v2.spanner.migrations.utils.SecretManagerAccessorImpl;
-import com.google.cloud.teleport.v2.spanner.migrations.utils.ShardFileReader;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorColumn;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
 import com.google.cloud.teleport.v2.templates.model.LogicalType;
+import com.google.cloud.teleport.v2.templates.model.MySqlSinkConfig;
 import com.google.cloud.teleport.v2.templates.sink.DataWriter;
 import com.google.cloud.teleport.v2.templates.utils.Constants;
 import com.google.common.annotations.VisibleForTesting;
@@ -66,23 +65,18 @@ public class MySqlDataWriter implements DataWriter {
     DELETE
   }
 
-  private final String sinkConfigPath;
-  private final ShardFileReader shardFileReader;
+  private final MySqlSinkConfig mySqlSinkConfig;
 
   private transient IConnectionHelper<Connection> connectionHelper;
   private transient Map<String, Shard> shardsByLogicalId;
 
-  public MySqlDataWriter(String sinkConfigPath) {
-    this(sinkConfigPath, new ShardFileReader(new SecretManagerAccessorImpl()), null);
+  public MySqlDataWriter(MySqlSinkConfig mySqlSinkConfig) {
+    this(mySqlSinkConfig, null);
   }
 
   @VisibleForTesting
-  MySqlDataWriter(
-      String sinkConfigPath,
-      ShardFileReader shardFileReader,
-      IConnectionHelper<Connection> connectionHelper) {
-    this.sinkConfigPath = sinkConfigPath;
-    this.shardFileReader = shardFileReader;
+  MySqlDataWriter(MySqlSinkConfig mySqlSinkConfig, IConnectionHelper<Connection> connectionHelper) {
+    this.mySqlSinkConfig = mySqlSinkConfig;
     this.connectionHelper = connectionHelper;
   }
 
@@ -167,7 +161,11 @@ public class MySqlDataWriter implements DataWriter {
       connectionHelper = new JdbcConnectionHelper();
     }
     if (shardsByLogicalId == null) {
-      List<Shard> shards = loadShards();
+      List<Shard> shards =
+          mySqlSinkConfig != null ? mySqlSinkConfig.getShards() : Collections.emptyList();
+      if (shards.isEmpty()) {
+        throw new RuntimeException("No shards found in the provided MySQL sink configuration.");
+      }
       Map<String, Shard> byId = new LinkedHashMap<>();
       for (Shard shard : shards) {
         byId.put(shard.getLogicalShardId(), shard);
@@ -185,18 +183,6 @@ public class MySqlDataWriter implements DataWriter {
               Constants.JDBC_MYSQL_URL_PREFIX);
       connectionHelper.init(request);
     }
-  }
-
-  private List<Shard> loadShards() {
-    if (sinkConfigPath == null || sinkConfigPath.isEmpty()) {
-      throw new IllegalArgumentException(
-          "MySQL sink requires a valid shard configuration file path.");
-    }
-    List<Shard> shards = shardFileReader.getOrderedShardDetails(sinkConfigPath);
-    if (shards == null || shards.isEmpty()) {
-      throw new RuntimeException("No shards found in the provided shard file: " + sinkConfigPath);
-    }
-    return shards;
   }
 
   @VisibleForTesting

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/mysql/MySqlSchemaFetcher.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/mysql/MySqlSchemaFetcher.java
@@ -16,8 +16,6 @@
 package com.google.cloud.teleport.v2.templates.mysql;
 
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
-import com.google.cloud.teleport.v2.spanner.migrations.utils.SecretManagerAccessorImpl;
-import com.google.cloud.teleport.v2.spanner.migrations.utils.ShardFileReader;
 import com.google.cloud.teleport.v2.spanner.sourceddl.MySqlInformationSchemaScanner;
 import com.google.cloud.teleport.v2.spanner.sourceddl.SourceColumn;
 import com.google.cloud.teleport.v2.spanner.sourceddl.SourceForeignKey;
@@ -29,6 +27,8 @@ import com.google.cloud.teleport.v2.templates.model.DataGeneratorForeignKey;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorSchema;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorUniqueKey;
+import com.google.cloud.teleport.v2.templates.model.MySqlSinkConfig;
+import com.google.cloud.teleport.v2.templates.model.SinkConfig;
 import com.google.cloud.teleport.v2.templates.sink.SinkSchemaFetcher;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -55,16 +55,14 @@ public class MySqlSchemaFetcher implements SinkSchemaFetcher {
 
   private final MySqlTypeMapper typeMapper = new MySqlTypeMapper();
 
-  private final ShardFileReader shardFileReader;
   private final ConnectionProvider connectionProvider;
 
   public MySqlSchemaFetcher() {
-    this(new ShardFileReader(new SecretManagerAccessorImpl()), null);
+    this(null);
   }
 
   @VisibleForTesting
-  MySqlSchemaFetcher(ShardFileReader shardFileReader, ConnectionProvider connectionProvider) {
-    this.shardFileReader = shardFileReader;
+  MySqlSchemaFetcher(ConnectionProvider connectionProvider) {
     this.connectionProvider = connectionProvider;
   }
 
@@ -75,15 +73,14 @@ public class MySqlSchemaFetcher implements SinkSchemaFetcher {
   }
 
   @Override
-  public void init(String sinkConfigPath) {
-    if (sinkConfigPath == null || sinkConfigPath.isEmpty()) {
-      throw new IllegalArgumentException(
-          "MySQL sink requires a valid shard configuration file path.");
+  public void init(SinkConfig sinkConfig) {
+    if (sinkConfig == null) {
+      throw new IllegalArgumentException("SinkConfig cannot be null");
     }
-
-    List<Shard> shards = shardFileReader.getOrderedShardDetails(sinkConfigPath);
+    MySqlSinkConfig mySqlSinkConfig = (MySqlSinkConfig) sinkConfig;
+    List<Shard> shards = mySqlSinkConfig.getShards();
     if (shards == null || shards.isEmpty()) {
-      throw new RuntimeException("No shards found in the provided shard file: " + sinkConfigPath);
+      throw new RuntimeException("No shards found in the provided MySQL sink configuration.");
     }
     // Use the first shard to extract schema
     Shard firstShard = shards.get(0);

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/sink/DataWriterFactory.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/sink/DataWriterFactory.java
@@ -16,30 +16,34 @@
 package com.google.cloud.teleport.v2.templates.sink;
 
 import com.google.cloud.teleport.v2.templates.CdcDataGeneratorOptions.SinkType;
+import com.google.cloud.teleport.v2.templates.model.MySqlSinkConfig;
+import com.google.cloud.teleport.v2.templates.model.SinkConfig;
+import com.google.cloud.teleport.v2.templates.model.SpannerSinkConfig;
 import com.google.cloud.teleport.v2.templates.mysql.MySqlDataWriter;
 import com.google.cloud.teleport.v2.templates.spanner.SpannerDataWriter;
 
 /**
- * Factory class for creating {@link DataWriter} instances based on the configured {@link SinkType}.
+ * Factory class for creating {@link DataWriter} instances based on {@link SinkType} and {@link
+ * SinkConfig}. Provides cleaner separation of writer construction logic from the DoFn lifecycle.
  */
 public class DataWriterFactory {
 
   private DataWriterFactory() {}
 
   /**
-   * Creates a {@link DataWriter} for the specified sink type and configuration path.
+   * Creates a {@link DataWriter} instance for the specified sink type and configuration.
    *
-   * @param type the sink type to create a writer for
-   * @param configPath the path to the sink configuration document
+   * @param type the target sink type
+   * @param config the parsed sink configuration
    * @return a new {@link DataWriter} instance
    * @throws IllegalArgumentException if the sink type is unsupported
    */
-  public static DataWriter createWriter(SinkType type, String configPath) {
+  public static DataWriter createWriter(SinkType type, SinkConfig config) {
     switch (type) {
       case MYSQL:
-        return new MySqlDataWriter(configPath);
+        return new MySqlDataWriter((MySqlSinkConfig) config);
       case SPANNER:
-        return new SpannerDataWriter(configPath);
+        return new SpannerDataWriter((SpannerSinkConfig) config);
       default:
         throw new IllegalArgumentException("Unsupported sink type: " + type);
     }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/sink/SinkConfigParser.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/sink/SinkConfigParser.java
@@ -16,6 +16,8 @@
 package com.google.cloud.teleport.v2.templates.sink;
 
 import com.google.cloud.spanner.Dialect;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
 import com.google.cloud.teleport.v2.spanner.migrations.utils.SecretManagerAccessorImpl;
 import com.google.cloud.teleport.v2.spanner.migrations.utils.ShardFileReader;
@@ -24,11 +26,9 @@ import com.google.cloud.teleport.v2.templates.model.MySqlSinkConfig;
 import com.google.cloud.teleport.v2.templates.model.SinkConfig;
 import com.google.cloud.teleport.v2.templates.model.SpannerSinkConfig;
 import com.google.cloud.teleport.v2.templates.spanner.SpannerConfigFileReader;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.List;
-import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
-import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
-import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +36,24 @@ import org.slf4j.LoggerFactory;
 public class SinkConfigParser {
 
   private static final Logger LOG = LoggerFactory.getLogger(SinkConfigParser.class);
+
+  @VisibleForTesting
+  interface DialectProvider {
+    Dialect getDialect(String projectId, String instanceId, String databaseId);
+  }
+
+  private static DialectProvider dialectProvider =
+      (projectId, instanceId, databaseId) -> {
+        SpannerOptions options = SpannerOptions.newBuilder().setProjectId(projectId).build();
+        try (Spanner spanner = options.getService()) {
+          return spanner.getDatabaseAdminClient().getDatabase(instanceId, databaseId).getDialect();
+        }
+      };
+
+  @VisibleForTesting
+  static void setDialectProvider(DialectProvider provider) {
+    dialectProvider = provider;
+  }
 
   public static SinkConfig parse(SinkType sinkType, String sinkOptionsPath) throws IOException {
     if (sinkOptionsPath == null || sinkOptionsPath.isEmpty()) {
@@ -49,15 +67,7 @@ public class SinkConfigParser {
       String instanceId = config.getInstanceId();
       String databaseId = config.getDatabaseId();
 
-      SpannerConfig spannerConfig =
-          SpannerConfig.create()
-              .withProjectId(StaticValueProvider.of(projectId))
-              .withInstanceId(StaticValueProvider.of(instanceId))
-              .withDatabaseId(StaticValueProvider.of(databaseId));
-
-      SpannerAccessor accessor = SpannerAccessor.getOrCreate(spannerConfig);
-      Dialect dialect =
-          accessor.getDatabaseAdminClient().getDatabase(instanceId, databaseId).getDialect();
+      Dialect dialect = dialectProvider.getDialect(projectId, instanceId, databaseId);
       LOG.info("Pre-fetched Spanner dialect on driver: {}", dialect);
 
       config.setDialect(dialect);
@@ -67,15 +77,6 @@ public class SinkConfigParser {
       List<Shard> shards = shardFileReader.getOrderedShardDetails(sinkOptionsPath);
       if (shards == null || shards.isEmpty()) {
         throw new RuntimeException("No shards found in shard configuration: " + sinkOptionsPath);
-      }
-
-      for (int i = 0; i < shards.size(); i++) {
-        Shard shard = shards.get(i);
-        if (shard.getLogicalShardId() == null || shard.getLogicalShardId().isEmpty()) {
-          String defaultId = "shard" + i;
-          shard.setLogicalShardId(defaultId);
-          LOG.info("Assigned default logicalShardId '{}' to shard index {}", defaultId, i);
-        }
       }
 
       return new MySqlSinkConfig(shards);

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/sink/SinkConfigParser.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/sink/SinkConfigParser.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.sink;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.SecretManagerAccessorImpl;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.ShardFileReader;
+import com.google.cloud.teleport.v2.templates.CdcDataGeneratorOptions.SinkType;
+import com.google.cloud.teleport.v2.templates.model.MySqlSinkConfig;
+import com.google.cloud.teleport.v2.templates.model.SinkConfig;
+import com.google.cloud.teleport.v2.templates.model.SpannerSinkConfig;
+import com.google.cloud.teleport.v2.templates.spanner.SpannerConfigFileReader;
+import java.io.IOException;
+import java.util.List;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Utility to parse sink configuration and pre-fetch database dialect on driver JVM. */
+public class SinkConfigParser {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SinkConfigParser.class);
+
+  public static SinkConfig parse(SinkType sinkType, String sinkOptionsPath) throws IOException {
+    if (sinkOptionsPath == null || sinkOptionsPath.isEmpty()) {
+      throw new IllegalArgumentException("Sink options path must not be null or empty.");
+    }
+
+    if (sinkType == SinkType.SPANNER) {
+      SpannerConfigFileReader reader = new SpannerConfigFileReader();
+      SpannerSinkConfig config = reader.getSpannerConfig(sinkOptionsPath);
+      String projectId = config.getProjectId();
+      String instanceId = config.getInstanceId();
+      String databaseId = config.getDatabaseId();
+
+      SpannerConfig spannerConfig =
+          SpannerConfig.create()
+              .withProjectId(StaticValueProvider.of(projectId))
+              .withInstanceId(StaticValueProvider.of(instanceId))
+              .withDatabaseId(StaticValueProvider.of(databaseId));
+
+      SpannerAccessor accessor = SpannerAccessor.getOrCreate(spannerConfig);
+      Dialect dialect =
+          accessor.getDatabaseAdminClient().getDatabase(instanceId, databaseId).getDialect();
+      LOG.info("Pre-fetched Spanner dialect on driver: {}", dialect);
+
+      config.setDialect(dialect);
+      return config;
+    } else if (sinkType == SinkType.MYSQL) {
+      ShardFileReader shardFileReader = new ShardFileReader(new SecretManagerAccessorImpl());
+      List<Shard> shards = shardFileReader.getOrderedShardDetails(sinkOptionsPath);
+      if (shards == null || shards.isEmpty()) {
+        throw new RuntimeException("No shards found in shard configuration: " + sinkOptionsPath);
+      }
+
+      for (int i = 0; i < shards.size(); i++) {
+        Shard shard = shards.get(i);
+        if (shard.getLogicalShardId() == null || shard.getLogicalShardId().isEmpty()) {
+          String defaultId = "shard" + i;
+          shard.setLogicalShardId(defaultId);
+          LOG.info("Assigned default logicalShardId '{}' to shard index {}", defaultId, i);
+        }
+      }
+
+      return new MySqlSinkConfig(shards);
+    } else {
+      throw new IllegalArgumentException("Unsupported sink type: " + sinkType);
+    }
+  }
+}

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/sink/SinkSchemaFetcher.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/sink/SinkSchemaFetcher.java
@@ -16,16 +16,17 @@
 package com.google.cloud.teleport.v2.templates.sink;
 
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorSchema;
+import com.google.cloud.teleport.v2.templates.model.SinkConfig;
 import java.io.IOException;
 
 public interface SinkSchemaFetcher {
 
   /**
-   * Initializes the fetcher with the given JSON configuration.
+   * Initializes the fetcher with the given parsed configuration.
    *
-   * @param jsonData The JSON string containing configuration options specific to the sink.
+   * @param sinkConfig The parsed configuration object specific to the sink.
    */
-  void init(String sinkConfigPath);
+  void init(SinkConfig sinkConfig);
 
   /**
    * Fetches the schema definition from the sink.

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/spanner/SpannerConfigFileReader.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/spanner/SpannerConfigFileReader.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.spanner;
+
+import com.google.cloud.teleport.v2.templates.model.SpannerSinkConfig;
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.GsonBuilder;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.nio.charset.StandardCharsets;
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class to read the Cloud Spanner configuration file in GCS and convert it into a SpannerSinkConfig
+ * object.
+ */
+public class SpannerConfigFileReader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SpannerConfigFileReader.class);
+
+  public SpannerSinkConfig getSpannerConfig(String spannerConfigFilePath) {
+    try (InputStream stream =
+        Channels.newInputStream(
+            FileSystems.open(FileSystems.matchNewResource(spannerConfigFilePath, false)))) {
+
+      String result = IOUtils.toString(stream, StandardCharsets.UTF_8);
+      SpannerSinkConfig config =
+          new GsonBuilder()
+              .setFieldNamingPolicy(FieldNamingPolicy.IDENTITY)
+              .create()
+              .fromJson(result, SpannerSinkConfig.class);
+
+      if (config.getProjectId() == null || config.getProjectId().isEmpty()) {
+        throw new IllegalArgumentException(
+            "Missing projectId in Spanner configuration file: " + spannerConfigFilePath);
+      }
+      if (config.getInstanceId() == null || config.getInstanceId().isEmpty()) {
+        throw new IllegalArgumentException(
+            "Missing instanceId in Spanner configuration file: " + spannerConfigFilePath);
+      }
+      if (config.getDatabaseId() == null || config.getDatabaseId().isEmpty()) {
+        throw new IllegalArgumentException(
+            "Missing databaseId in Spanner configuration file: " + spannerConfigFilePath);
+      }
+
+      LOG.info("Read Spanner configuration: {}", config);
+      return config;
+
+    } catch (IOException e) {
+      LOG.error(
+          "Failed to read Spanner configuration file. Make sure it is ASCII or UTF-8 encoded and"
+              + " contains a well-formed JSON string.",
+          e);
+      throw new RuntimeException(
+          "Failed to read Spanner configuration file. Make sure it is ASCII or UTF-8 encoded and"
+              + " contains a well-formed JSON string.",
+          e);
+    }
+  }
+}

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/spanner/SpannerConfigFileReader.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/spanner/SpannerConfigFileReader.java
@@ -47,6 +47,11 @@ public class SpannerConfigFileReader {
               .create()
               .fromJson(result, SpannerSinkConfig.class);
 
+      if (config == null) {
+        throw new RuntimeException(
+            "Failed to parse Spanner configuration: resulting config is null.");
+      }
+
       if (config.getProjectId() == null || config.getProjectId().isEmpty()) {
         throw new IllegalArgumentException(
             "Missing projectId in Spanner configuration file: " + spannerConfigFilePath);

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/spanner/SpannerDataWriter.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/spanner/SpannerDataWriter.java
@@ -18,31 +18,24 @@ package com.google.cloud.teleport.v2.templates.spanner;
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorColumn;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
 import com.google.cloud.teleport.v2.templates.model.LogicalType;
+import com.google.cloud.teleport.v2.templates.model.SpannerSinkConfig;
 import com.google.cloud.teleport.v2.templates.sink.DataWriter;
-import com.google.cloud.teleport.v2.templates.utils.Constants;
 import com.google.common.annotations.VisibleForTesting;
-import java.io.BufferedReader;
 import java.math.BigDecimal;
-import java.nio.channels.Channels;
-import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.apache.beam.sdk.io.FileSystems;
-import org.apache.beam.sdk.io.fs.MatchResult;
-import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.values.Row;
 import org.joda.time.ReadableInstant;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,10 +47,6 @@ import org.slf4j.LoggerFactory;
  * (see {@link MutationType}) - both are translated to {@link Mutation#newInsertOrUpdateBuilder} so
  * that transient retries under {@code writeAtLeastOnce} are idempotent - and {@code DELETE} which
  * uses {@link Mutation#delete} with a key constructed from {@link DataGeneratorTable#primaryKeys}.
- *
- * <p>The Spanner connection details are loaded from a JSON configuration file with the shape {@code
- * {"projectId": ..., "instanceId": ..., "databaseId": ...}} - the same format accepted by {@link
- * SpannerSchemaFetcher}.
  */
 public class SpannerDataWriter implements DataWriter {
 
@@ -74,26 +63,26 @@ public class SpannerDataWriter implements DataWriter {
     DELETE
   }
 
-  private final String sinkConfigPath;
+  private final SpannerSinkConfig spannerSinkConfig;
   private final SpannerAccessorFactory accessorFactory;
 
   private transient SpannerConfig spannerConfig;
   private transient SpannerAccessor spannerAccessor;
-  private transient com.google.cloud.spanner.Dialect dialect;
+  private transient Dialect dialect;
 
-  public SpannerDataWriter(String sinkConfigPath) {
-    this(sinkConfigPath, SpannerAccessor::getOrCreate);
+  public SpannerDataWriter(SpannerSinkConfig spannerSinkConfig) {
+    this(spannerSinkConfig, SpannerAccessor::getOrCreate);
   }
 
   @VisibleForTesting
-  SpannerDataWriter(String sinkConfigPath, SpannerAccessorFactory accessorFactory) {
-    this.sinkConfigPath = sinkConfigPath;
+  SpannerDataWriter(SpannerSinkConfig spannerSinkConfig, SpannerAccessorFactory accessorFactory) {
+    this.spannerSinkConfig = spannerSinkConfig;
     this.accessorFactory = accessorFactory;
   }
 
   @VisibleForTesting
   SpannerDataWriter(SpannerConfig spannerConfig, SpannerAccessorFactory accessorFactory) {
-    this.sinkConfigPath = null;
+    this.spannerSinkConfig = null;
     this.accessorFactory = accessorFactory;
     this.spannerConfig = spannerConfig;
   }
@@ -146,46 +135,24 @@ public class SpannerDataWriter implements DataWriter {
   @VisibleForTesting
   synchronized void ensureInitialized() {
     if (spannerConfig == null) {
-      spannerConfig = loadSpannerConfig();
+      if (spannerSinkConfig == null) {
+        throw new IllegalArgumentException("SpannerSinkConfig cannot be null");
+      }
+      spannerConfig =
+          SpannerConfig.create()
+              .withProjectId(StaticValueProvider.of(spannerSinkConfig.getProjectId()))
+              .withInstanceId(StaticValueProvider.of(spannerSinkConfig.getInstanceId()))
+              .withDatabaseId(StaticValueProvider.of(spannerSinkConfig.getDatabaseId()));
     }
     if (spannerAccessor == null) {
       spannerAccessor = accessorFactory.getOrCreate(spannerConfig);
     }
     if (dialect == null) {
-      dialect =
-          spannerAccessor
-              .getDatabaseAdminClient()
-              .getDatabase(spannerConfig.getInstanceId().get(), spannerConfig.getDatabaseId().get())
-              .getDialect();
-      LOG.info("Detected Spanner database dialect: {}", dialect);
-    }
-  }
-
-  private SpannerConfig loadSpannerConfig() {
-    if (sinkConfigPath == null || sinkConfigPath.isEmpty()) {
-      throw new IllegalArgumentException("Spanner sink requires a valid configuration file path.");
-    }
-    try {
-      MatchResult match = FileSystems.match(sinkConfigPath);
-      if (match.metadata().isEmpty()) {
-        throw new RuntimeException("Spanner sink config file not found: " + sinkConfigPath);
+      if (spannerSinkConfig != null) {
+        dialect = spannerSinkConfig.getDialect();
+      } else {
+        dialect = Dialect.GOOGLE_STANDARD_SQL;
       }
-      ResourceId resourceId = match.metadata().get(0).resourceId();
-      ReadableByteChannel channel = FileSystems.open(resourceId);
-      String content;
-      try (BufferedReader reader = new BufferedReader(Channels.newReader(channel, "UTF-8"))) {
-        content = reader.lines().collect(Collectors.joining(System.lineSeparator()));
-      }
-      JSONObject json = new JSONObject(content);
-      return SpannerConfig.create()
-          .withProjectId(
-              StaticValueProvider.of(json.getString(Constants.SPANNER_CONFIG_PROJECT_ID_KEY)))
-          .withInstanceId(
-              StaticValueProvider.of(json.getString(Constants.SPANNER_CONFIG_INSTANCE_ID_KEY)))
-          .withDatabaseId(
-              StaticValueProvider.of(json.getString(Constants.SPANNER_CONFIG_DATABASE_ID_KEY)));
-    } catch (java.io.IOException e) {
-      throw new RuntimeException("Error reading Spanner sink config file: " + sinkConfigPath, e);
     }
   }
 

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/spanner/SpannerSchemaFetcher.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/spanner/SpannerSchemaFetcher.java
@@ -24,25 +24,20 @@ import com.google.cloud.teleport.v2.templates.model.DataGeneratorSchema;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorUniqueKey;
 import com.google.cloud.teleport.v2.templates.model.LogicalType;
+import com.google.cloud.teleport.v2.templates.model.SinkConfig;
+import com.google.cloud.teleport.v2.templates.model.SpannerSinkConfig;
 import com.google.cloud.teleport.v2.templates.sink.SinkSchemaFetcher;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.nio.channels.Channels;
-import java.nio.channels.ReadableByteChannel;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.apache.beam.sdk.io.FileSystems;
-import org.apache.beam.sdk.io.fs.MatchResult;
-import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
-import org.json.JSONObject;
 
 public class SpannerSchemaFetcher implements SinkSchemaFetcher {
 
@@ -74,25 +69,14 @@ public class SpannerSchemaFetcher implements SinkSchemaFetcher {
   }
 
   @Override
-  public void init(String sinkConfigPath) {
-    try {
-      MatchResult match = FileSystems.match(sinkConfigPath);
-      if (match.metadata().isEmpty()) {
-        throw new RuntimeException("Spanner sink config file not found: " + sinkConfigPath);
-      }
-      ResourceId resourceId = match.metadata().get(0).resourceId();
-      ReadableByteChannel channel = FileSystems.open(resourceId);
-      String content;
-      try (BufferedReader reader = new BufferedReader(Channels.newReader(channel, "UTF-8"))) {
-        content = reader.lines().collect(Collectors.joining(System.lineSeparator()));
-      }
-      JSONObject json = new JSONObject(content);
-      this.projectId = json.getString("projectId");
-      this.instanceId = json.getString("instanceId");
-      this.databaseId = json.getString("databaseId");
-    } catch (java.io.IOException e) {
-      throw new RuntimeException("Error reading Spanner sink config file: " + sinkConfigPath, e);
+  public void init(SinkConfig sinkConfig) {
+    if (sinkConfig == null) {
+      throw new IllegalArgumentException("SinkConfig cannot be null");
     }
+    SpannerSinkConfig spannerConfig = (SpannerSinkConfig) sinkConfig;
+    this.projectId = spannerConfig.getProjectId();
+    this.instanceId = spannerConfig.getInstanceId();
+    this.databaseId = spannerConfig.getDatabaseId();
   }
 
   @Override

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/transforms/GeneratePrimaryKey.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/transforms/GeneratePrimaryKey.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.templates.transforms;
 
 import com.google.cloud.teleport.v2.templates.dofn.GeneratePrimaryKeyFn;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
+import com.google.cloud.teleport.v2.templates.model.SinkConfig;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
@@ -42,19 +43,18 @@ import org.apache.beam.sdk.values.Row;
 public class GeneratePrimaryKey
     extends PTransform<PCollection<DataGeneratorTable>, PCollection<KV<String, Row>>> {
 
-  private final String sinkOptionsPath;
+  private final SinkConfig sinkConfig;
   private final String sinkType;
 
-  public GeneratePrimaryKey(String sinkOptionsPath, String sinkType) {
-    this.sinkOptionsPath = sinkOptionsPath;
+  public GeneratePrimaryKey(SinkConfig sinkConfig, String sinkType) {
+    this.sinkConfig = sinkConfig;
     this.sinkType = sinkType;
   }
 
   @Override
   public PCollection<KV<String, Row>> expand(PCollection<DataGeneratorTable> input) {
     return input
-        .apply(
-            "GeneratePrimaryKeyFn", ParDo.of(new GeneratePrimaryKeyFn(sinkOptionsPath, sinkType)))
+        .apply("GeneratePrimaryKeyFn", ParDo.of(new GeneratePrimaryKeyFn(sinkConfig, sinkType)))
         .setCoder(KvCoder.of(StringUtf8Coder.of(), SerializableCoder.of(Row.class)));
   }
 }

--- a/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SchemaLoader.java
+++ b/v2/cdc-data-generator/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SchemaLoader.java
@@ -21,6 +21,7 @@ import com.google.cloud.teleport.v2.templates.dofn.BuildSchemaDagFn;
 import com.google.cloud.teleport.v2.templates.dofn.FetchSchemaFn;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorSchema;
 import com.google.cloud.teleport.v2.templates.model.SchemaConfig;
+import com.google.cloud.teleport.v2.templates.model.SinkConfig;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
@@ -37,7 +38,7 @@ public class SchemaLoader extends PTransform<PBegin, PCollectionView<DataGenerat
 
   private static final Logger LOG = LoggerFactory.getLogger(SchemaLoader.class);
   private final SinkType sinkType;
-  private final String sinkOptionsPath;
+  private final SinkConfig sinkConfig;
   private final Integer insertQps;
   private final Integer updateQps;
   private final Integer deleteQps;
@@ -45,13 +46,13 @@ public class SchemaLoader extends PTransform<PBegin, PCollectionView<DataGenerat
 
   public SchemaLoader(
       SinkType sinkType,
-      String sinkOptionsPath,
+      SinkConfig sinkConfig,
       Integer insertQps,
       Integer updateQps,
       Integer deleteQps,
       SchemaConfig schemaConfig) {
     this.sinkType = sinkType;
-    this.sinkOptionsPath = sinkOptionsPath;
+    this.sinkConfig = sinkConfig;
     this.insertQps = insertQps;
     this.updateQps = updateQps;
     this.deleteQps = deleteQps;
@@ -62,7 +63,7 @@ public class SchemaLoader extends PTransform<PBegin, PCollectionView<DataGenerat
   public PCollectionView<DataGeneratorSchema> expand(PBegin input) {
     return input
         .apply("CreateSinkType", Create.of(sinkType))
-        .apply("FetchSchemaFromDb", ParDo.of(new FetchSchemaFn(sinkType, sinkOptionsPath)))
+        .apply("FetchSchemaFromDb", ParDo.of(new FetchSchemaFn(sinkType, sinkConfig)))
         .apply(
             "ApplyOverrides",
             ParDo.of(new ApplyOverridesFn(schemaConfig, insertQps, updateQps, deleteQps)))

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/dofn/BatchAndWriteFnTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/dofn/BatchAndWriteFnTest.java
@@ -63,14 +63,14 @@ public class BatchAndWriteFnTest {
   @Test
   public void constructor_nonPositiveBatchSize_fallsBackToDefault() {
     BatchAndWriteFn fn =
-        new BatchAndWriteFn(SinkType.SPANNER, "{}", 0, null, 10, 10, mock(PCollectionView.class));
+        new BatchAndWriteFn(SinkType.SPANNER, null, 0, null, 10, 10, mock(PCollectionView.class));
     assertNotNull(fn);
   }
 
   @Test
   public void testSetup_initializesDefaultWriterAndFaker() throws Exception {
     BatchAndWriteFn fn =
-        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+        new BatchAndWriteFn(SinkType.SPANNER, null, 1, null, 10, 10, mock(PCollectionView.class));
     fn.setup();
 
     assertNotNull(fn.getWriter());
@@ -82,7 +82,7 @@ public class BatchAndWriteFnTest {
   @Test
   public void testSetup_retainsInjectedWriterAndFaker() throws Exception {
     BatchAndWriteFn fn =
-        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+        new BatchAndWriteFn(SinkType.SPANNER, null, 1, null, 10, 10, mock(PCollectionView.class));
     DataWriter mockWriter = mock(DataWriter.class);
     Faker mockFaker = mock(Faker.class);
 
@@ -98,7 +98,7 @@ public class BatchAndWriteFnTest {
   @Test
   public void testStartBundle_callsBatcherStartBundle() throws Exception {
     BatchAndWriteFn fn =
-        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+        new BatchAndWriteFn(SinkType.SPANNER, null, 1, null, 10, 10, mock(PCollectionView.class));
     MutationBatcher mockBatcher = mock(MutationBatcher.class);
     fn.setBatcher(mockBatcher);
 
@@ -121,7 +121,7 @@ public class BatchAndWriteFnTest {
     Row row = Row.withSchema(rowSchema).addValue(1L).build();
     when(c.element()).thenReturn(KV.of(0, GeneratedRecord.create("Users", row)));
 
-    BatchAndWriteFn fn = new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, schemaView);
+    BatchAndWriteFn fn = new BatchAndWriteFn(SinkType.SPANNER, null, 1, null, 10, 10, schemaView);
     DataWriter mockWriter = mock(DataWriter.class);
     fn.setWriter(mockWriter);
     fn.setup();
@@ -156,7 +156,7 @@ public class BatchAndWriteFnTest {
     Row row = Row.withSchema(rowSchema).addValue(1L).build();
     when(c.element()).thenReturn(KV.of(0, GeneratedRecord.create("Users", row)));
 
-    BatchAndWriteFn fn = new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, schemaView);
+    BatchAndWriteFn fn = new BatchAndWriteFn(SinkType.SPANNER, null, 1, null, 10, 10, schemaView);
     DataWriter mockWriter = mock(DataWriter.class);
     fn.setWriter(mockWriter);
     fn.setup();
@@ -196,7 +196,7 @@ public class BatchAndWriteFnTest {
     Row row = Row.withSchema(rowSchema).addValue(1L).build();
     when(c.element()).thenReturn(KV.of(0, GeneratedRecord.create("Users", row)));
 
-    BatchAndWriteFn fn = new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, schemaView);
+    BatchAndWriteFn fn = new BatchAndWriteFn(SinkType.SPANNER, null, 1, null, 10, 10, schemaView);
     DataWriter mockWriter = mock(DataWriter.class);
     fn.setWriter(mockWriter);
     fn.setup();
@@ -234,7 +234,7 @@ public class BatchAndWriteFnTest {
     Row row = Row.withSchema(rowSchema).addValue(1L).build();
     when(c.element()).thenReturn(KV.of(0, GeneratedRecord.create("Users", row)));
 
-    BatchAndWriteFn fn = new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, schemaView);
+    BatchAndWriteFn fn = new BatchAndWriteFn(SinkType.SPANNER, null, 1, null, 10, 10, schemaView);
     DataWriter mockWriter = mock(DataWriter.class);
     doThrow(new RuntimeException("simulated sink failure"))
         .when(mockWriter)
@@ -257,7 +257,7 @@ public class BatchAndWriteFnTest {
   @Test
   public void testOnTimer_restoresInsertTopoOrderFromStateWhenNull() throws Exception {
     BatchAndWriteFn fn =
-        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+        new BatchAndWriteFn(SinkType.SPANNER, null, 1, null, 10, 10, mock(PCollectionView.class));
     fn.setWriter(mock(DataWriter.class));
     fn.setup();
     fn.startBundle();
@@ -284,7 +284,7 @@ public class BatchAndWriteFnTest {
   @Test
   public void testOnTimer_skipsStateReadWhenInsertTopoOrderIsPresent() throws Exception {
     BatchAndWriteFn fn =
-        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+        new BatchAndWriteFn(SinkType.SPANNER, null, 1, null, 10, 10, mock(PCollectionView.class));
     fn.setWriter(mock(DataWriter.class));
     fn.setup();
     fn.startBundle();
@@ -309,7 +309,7 @@ public class BatchAndWriteFnTest {
   @Test
   public void testOnTimer_exceptionRoutesToDlq() throws Exception {
     BatchAndWriteFn fn =
-        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+        new BatchAndWriteFn(SinkType.SPANNER, null, 1, null, 10, 10, mock(PCollectionView.class));
     fn.setWriter(mock(DataWriter.class));
     fn.setup();
     fn.startBundle();
@@ -336,7 +336,7 @@ public class BatchAndWriteFnTest {
   @Test
   public void testFinishBundle_flushesBatcherAndEmitsPendingDlq() throws Exception {
     BatchAndWriteFn fn =
-        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+        new BatchAndWriteFn(SinkType.SPANNER, null, 1, null, 10, 10, mock(PCollectionView.class));
     fn.setWriter(mock(DataWriter.class));
     fn.setup();
     fn.startBundle();
@@ -362,7 +362,7 @@ public class BatchAndWriteFnTest {
   @Test
   public void testTeardown_closesWriterSuccessfully() throws Exception {
     BatchAndWriteFn fn =
-        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+        new BatchAndWriteFn(SinkType.SPANNER, null, 1, null, 10, 10, mock(PCollectionView.class));
     DataWriter mockWriter = mock(DataWriter.class);
     fn.setWriter(mockWriter);
 
@@ -374,7 +374,7 @@ public class BatchAndWriteFnTest {
   @Test
   public void testTeardown_nullWriterDoesNothing() throws Exception {
     BatchAndWriteFn fn =
-        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+        new BatchAndWriteFn(SinkType.SPANNER, null, 1, null, 10, 10, mock(PCollectionView.class));
     fn.setWriter(null);
 
     fn.teardown();
@@ -383,7 +383,7 @@ public class BatchAndWriteFnTest {
   @Test(expected = RuntimeException.class)
   public void testTeardown_writerCloseThrowsException() throws Exception {
     BatchAndWriteFn fn =
-        new BatchAndWriteFn(SinkType.SPANNER, "{}", 1, null, 10, 10, mock(PCollectionView.class));
+        new BatchAndWriteFn(SinkType.SPANNER, null, 1, null, 10, 10, mock(PCollectionView.class));
     DataWriter mockWriter = mock(DataWriter.class);
     doThrow(new RuntimeException("simulated close error")).when(mockWriter).close();
     fn.setWriter(mockWriter);

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/model/MySqlSinkConfigTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/model/MySqlSinkConfigTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.model;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class MySqlSinkConfigTest {
+
+  @Test
+  public void testMySqlSinkConfig_gettersSettersAndConstructors() {
+    MySqlSinkConfig config1 = new MySqlSinkConfig();
+    List<Shard> shards = new ArrayList<>();
+    Shard shard = new Shard("shard1", "host", "3306", "user", "pwd", "db", null, null, "");
+    shards.add(shard);
+    config1.setShards(shards);
+
+    assertThat(config1.getShards()).hasSize(1);
+    assertThat(config1.getShards().get(0).getLogicalShardId()).isEqualTo("shard1");
+
+    MySqlSinkConfig config2 = new MySqlSinkConfig(shards);
+    assertThat(config2).isEqualTo(config1);
+    assertThat(config2.hashCode()).isEqualTo(config1.hashCode());
+    assertThat(config2.toString()).contains("shard1");
+
+    MySqlSinkConfig config3 = new MySqlSinkConfig(new ArrayList<>());
+    assertThat(config3).isNotEqualTo(config1);
+    assertThat(config1).isNotEqualTo(null);
+    assertThat(config1).isNotEqualTo("some-string");
+  }
+}

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/model/SpannerSinkConfigTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/model/SpannerSinkConfigTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.model;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.spanner.Dialect;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SpannerSinkConfigTest {
+
+  @Test
+  public void testSpannerSinkConfig_gettersSettersAndConstructors() {
+    SpannerSinkConfig config1 = new SpannerSinkConfig();
+    config1.setProjectId("projA");
+    config1.setInstanceId("instA");
+    config1.setDatabaseId("dbA");
+    config1.setDialect(Dialect.GOOGLE_STANDARD_SQL);
+
+    assertThat(config1.getProjectId()).isEqualTo("projA");
+    assertThat(config1.getInstanceId()).isEqualTo("instA");
+    assertThat(config1.getDatabaseId()).isEqualTo("dbA");
+    assertThat(config1.getDialect()).isEqualTo(Dialect.GOOGLE_STANDARD_SQL);
+
+    SpannerSinkConfig config2 =
+        new SpannerSinkConfig("projA", "instA", "dbA", Dialect.GOOGLE_STANDARD_SQL);
+    assertThat(config2).isEqualTo(config1);
+    assertThat(config2.hashCode()).isEqualTo(config1.hashCode());
+    assertThat(config2.toString()).contains("projA");
+
+    SpannerSinkConfig config3 =
+        new SpannerSinkConfig("projB", "instA", "dbA", Dialect.GOOGLE_STANDARD_SQL);
+    assertThat(config3).isNotEqualTo(config1);
+    assertThat(config1).isNotEqualTo(null);
+    assertThat(config1).isNotEqualTo("some-string");
+  }
+}

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/mysql/MySqlDataWriterTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/mysql/MySqlDataWriterTest.java
@@ -33,10 +33,10 @@ import com.google.cloud.teleport.v2.spanner.migrations.connection.ConnectionHelp
 import com.google.cloud.teleport.v2.spanner.migrations.connection.IConnectionHelper;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.ConnectionException;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
-import com.google.cloud.teleport.v2.spanner.migrations.utils.ShardFileReader;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorColumn;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
 import com.google.cloud.teleport.v2.templates.model.LogicalType;
+import com.google.cloud.teleport.v2.templates.model.MySqlSinkConfig;
 import com.google.cloud.teleport.v2.templates.utils.Constants;
 import com.google.common.collect.ImmutableList;
 import java.math.BigDecimal;
@@ -67,16 +67,12 @@ public class MySqlDataWriterTest {
 
   @Rule public final MockitoRule mockito = MockitoJUnit.rule().strictness(Strictness.LENIENT);
 
-  @Mock private ShardFileReader mockShardFileReader;
-
   @SuppressWarnings("unchecked")
   @Mock
   private IConnectionHelper<Connection> mockConnectionHelper;
 
   @Mock private Connection mockConnection;
   @Mock private PreparedStatement mockStatement;
-
-  private static final String CONFIG_PATH = "shards.json";
 
   private Shard shardA() {
     return new Shard("shardA", "hostA", "3306", "userA", "passA", "dbA", null, null, null);
@@ -88,15 +84,14 @@ public class MySqlDataWriterTest {
 
   @Before
   public void setUp() throws Exception {
-    when(mockShardFileReader.getOrderedShardDetails(anyString()))
-        .thenReturn(ImmutableList.of(shardA(), shardB()));
     when(mockConnectionHelper.isConnectionPoolInitialized()).thenReturn(false);
     when(mockConnectionHelper.getConnection(anyString())).thenReturn(mockConnection);
     when(mockConnection.prepareStatement(anyString())).thenReturn(mockStatement);
   }
 
   private MySqlDataWriter writer() {
-    return new MySqlDataWriter(CONFIG_PATH, mockShardFileReader, mockConnectionHelper);
+    return new MySqlDataWriter(
+        new MySqlSinkConfig(ImmutableList.of(shardA(), shardB())), mockConnectionHelper);
   }
 
   private DataGeneratorTable simpleTable() {
@@ -478,22 +473,16 @@ public class MySqlDataWriterTest {
   }
 
   @Test
-  public void testLoadShards_missingPathThrows() {
-    MySqlDataWriter w = new MySqlDataWriter(null, mockShardFileReader, mockConnectionHelper);
+  public void testLoadShards_missingConfigThrows() {
+    MySqlDataWriter w = new MySqlDataWriter((MySqlSinkConfig) null, mockConnectionHelper);
     assertThrows(
-        IllegalArgumentException.class,
-        () -> w.ensureInitialized(Constants.DEFAULT_JDBC_POOL_SIZE));
-
-    MySqlDataWriter w2 = new MySqlDataWriter("", mockShardFileReader, mockConnectionHelper);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> w2.ensureInitialized(Constants.DEFAULT_JDBC_POOL_SIZE));
+        RuntimeException.class, () -> w.ensureInitialized(Constants.DEFAULT_JDBC_POOL_SIZE));
   }
 
   @Test
-  public void testLoadShards_emptyShardFileThrows() {
-    when(mockShardFileReader.getOrderedShardDetails(anyString())).thenReturn(ImmutableList.of());
-    MySqlDataWriter w = writer();
+  public void testLoadShards_emptyShardsThrows() {
+    MySqlDataWriter w =
+        new MySqlDataWriter(new MySqlSinkConfig(Collections.emptyList()), mockConnectionHelper);
     assertThrows(
         RuntimeException.class, () -> w.ensureInitialized(Constants.DEFAULT_JDBC_POOL_SIZE));
   }
@@ -517,9 +506,7 @@ public class MySqlDataWriterTest {
 
   @Test
   public void testConstructor_defaultsToJdbcConnectionHelper() {
-    // Basic sanity: public constructor should not blow up even if the file doesn't exist yet.
-    MySqlDataWriter w = new MySqlDataWriter("not-used.json");
-    // Close is a no-op by contract; calling it should not throw.
+    MySqlDataWriter w = new MySqlDataWriter(new MySqlSinkConfig(ImmutableList.of(shardA())));
     w.close();
   }
 

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/mysql/MySqlSchemaFetcherTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/mysql/MySqlSchemaFetcherTest.java
@@ -17,11 +17,9 @@ package com.google.cloud.teleport.v2.templates.mysql;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
-import com.google.cloud.teleport.v2.spanner.migrations.utils.ShardFileReader;
 import com.google.cloud.teleport.v2.spanner.sourceddl.MySqlInformationSchemaScanner;
 import com.google.cloud.teleport.v2.spanner.sourceddl.SourceColumn;
 import com.google.cloud.teleport.v2.spanner.sourceddl.SourceDatabaseType;
@@ -32,6 +30,7 @@ import com.google.cloud.teleport.v2.spanner.sourceddl.SourceTable;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorColumn;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorSchema;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
+import com.google.cloud.teleport.v2.templates.model.MySqlSinkConfig;
 import com.google.cloud.teleport.v2.templates.mysql.MySqlSchemaFetcher.ConnectionProvider;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -52,7 +51,6 @@ public class MySqlSchemaFetcherTest {
 
   @Rule public final MockitoRule mockito = MockitoJUnit.rule();
 
-  @Mock private ShardFileReader mockShardFileReader;
   @Mock private ConnectionProvider mockConnectionProvider;
   @Mock private Connection mockConnection;
   @Mock private MySqlInformationSchemaScanner mockScanner;
@@ -63,7 +61,7 @@ public class MySqlSchemaFetcherTest {
   public void setUp() throws SQLException {
     when(mockConnectionProvider.get()).thenReturn(mockConnection);
     fetcher =
-        new MySqlSchemaFetcher(mockShardFileReader, mockConnectionProvider) {
+        new MySqlSchemaFetcher(mockConnectionProvider) {
           @Override
           protected MySqlInformationSchemaScanner createScanner(
               Connection connection, String databaseName) {
@@ -75,27 +73,22 @@ public class MySqlSchemaFetcherTest {
   @Test
   public void testInit_success() {
     Shard shard = new Shard("id", "host", "user", "pass", "port", "db", null, null, null);
-    when(mockShardFileReader.getOrderedShardDetails(anyString()))
-        .thenReturn(ImmutableList.of(shard));
-
-    fetcher.init("options.json");
+    fetcher.init(new MySqlSinkConfig(ImmutableList.of(shard)));
     // No exception thrown means success
   }
 
   @Test
-  public void testInit_noOptionsFile() {
+  public void testInit_nullConfig() {
     IllegalArgumentException ex =
         assertThrows(IllegalArgumentException.class, () -> fetcher.init(null));
-    assertThat(ex).hasMessageThat().contains("requires a valid shard configuration file path");
-
-    ex = assertThrows(IllegalArgumentException.class, () -> fetcher.init(""));
-    assertThat(ex).hasMessageThat().contains("requires a valid shard configuration file path");
+    assertThat(ex).hasMessageThat().contains("SinkConfig cannot be null");
   }
 
   @Test
-  public void testInit_emptyShardFile() {
-    when(mockShardFileReader.getOrderedShardDetails(anyString())).thenReturn(ImmutableList.of());
-    RuntimeException ex = assertThrows(RuntimeException.class, () -> fetcher.init("options.json"));
+  public void testInit_emptyShards() {
+    RuntimeException ex =
+        assertThrows(
+            RuntimeException.class, () -> fetcher.init(new MySqlSinkConfig(ImmutableList.of())));
     assertThat(ex).hasMessageThat().contains("No shards found");
   }
 

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/sink/DataWriterFactoryTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/sink/DataWriterFactoryTest.java
@@ -18,9 +18,14 @@ package com.google.cloud.teleport.v2.templates.sink;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
 import com.google.cloud.teleport.v2.templates.CdcDataGeneratorOptions.SinkType;
+import com.google.cloud.teleport.v2.templates.model.MySqlSinkConfig;
+import com.google.cloud.teleport.v2.templates.model.SpannerSinkConfig;
 import com.google.cloud.teleport.v2.templates.mysql.MySqlDataWriter;
 import com.google.cloud.teleport.v2.templates.spanner.SpannerDataWriter;
+import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -31,20 +36,24 @@ public class DataWriterFactoryTest {
 
   @Test
   public void testCreateWriter_mySql() {
-    DataWriter writer = DataWriterFactory.createWriter(SinkType.MYSQL, "{}");
+    Shard shard = new Shard("id", "host", "user", "pass", "port", "db", null, null, null);
+    DataWriter writer =
+        DataWriterFactory.createWriter(
+            SinkType.MYSQL, new MySqlSinkConfig(ImmutableList.of(shard)));
     assertNotNull(writer);
     assertTrue(writer instanceof MySqlDataWriter);
   }
 
   @Test
   public void testCreateWriter_spanner() {
-    DataWriter writer = DataWriterFactory.createWriter(SinkType.SPANNER, "{}");
+    SpannerSinkConfig config = new SpannerSinkConfig("p", "i", "d", Dialect.GOOGLE_STANDARD_SQL);
+    DataWriter writer = DataWriterFactory.createWriter(SinkType.SPANNER, config);
     assertNotNull(writer);
     assertTrue(writer instanceof SpannerDataWriter);
   }
 
   @Test(expected = NullPointerException.class)
   public void testCreateWriter_unsupportedThrowsException() {
-    DataWriterFactory.createWriter(null, "{}");
+    DataWriterFactory.createWriter(null, null);
   }
 }

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/sink/SinkConfigParserTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/sink/SinkConfigParserTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.sink;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.teleport.v2.templates.CdcDataGeneratorOptions.SinkType;
+import com.google.cloud.teleport.v2.templates.model.MySqlSinkConfig;
+import com.google.cloud.teleport.v2.templates.model.SinkConfig;
+import com.google.cloud.teleport.v2.templates.model.SpannerSinkConfig;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SinkConfigParserTest {
+
+  @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @After
+  public void tearDown() {
+    // Reset the static dialect provider after each test to avoid leaking mock state
+    SinkConfigParser.setDialectProvider(null);
+  }
+
+  @Test
+  public void testParse_nullOptionsPath_throwsException() {
+    assertThrows(
+        IllegalArgumentException.class, () -> SinkConfigParser.parse(SinkType.SPANNER, null));
+  }
+
+  @Test
+  public void testParse_emptyOptionsPath_throwsException() {
+    assertThrows(
+        IllegalArgumentException.class, () -> SinkConfigParser.parse(SinkType.SPANNER, ""));
+  }
+
+  @Test
+  public void testParse_unsupportedSinkType_throwsException() throws IOException {
+    File file = tempFolder.newFile("dummy.json");
+    FileUtils.writeStringToFile(file, "{}", StandardCharsets.UTF_8);
+
+    assertThrows(
+        IllegalArgumentException.class, () -> SinkConfigParser.parse(null, file.getAbsolutePath()));
+  }
+
+  @Test
+  public void testParse_spannerSink_success() throws Exception {
+    String spannerJson =
+        "{\n"
+            + "  \"projectId\": \"sp-project\",\n"
+            + "  \"instanceId\": \"sp-instance\",\n"
+            + "  \"databaseId\": \"sp-database\"\n"
+            + "}";
+    File file = tempFolder.newFile("spanner_config.json");
+    FileUtils.writeStringToFile(file, spannerJson, StandardCharsets.UTF_8);
+
+    // Use a mock DialectProvider to bypass static SpannerAccessor calls
+    SinkConfigParser.setDialectProvider((projectId, instanceId, databaseId) -> Dialect.POSTGRESQL);
+
+    SinkConfig config = SinkConfigParser.parse(SinkType.SPANNER, file.getAbsolutePath());
+
+    assertThat(config).isInstanceOf(SpannerSinkConfig.class);
+    SpannerSinkConfig spannerConfig = (SpannerSinkConfig) config;
+    assertThat(spannerConfig.getProjectId()).isEqualTo("sp-project");
+    assertThat(spannerConfig.getInstanceId()).isEqualTo("sp-instance");
+    assertThat(spannerConfig.getDatabaseId()).isEqualTo("sp-database");
+    assertThat(spannerConfig.getDialect()).isEqualTo(Dialect.POSTGRESQL);
+  }
+
+  @Test
+  public void testParse_mysqlSink_success() throws Exception {
+    String mysqlJson =
+        "[\n"
+            + "  {\n"
+            + "    \"logicalShardId\": \"shardA\",\n"
+            + "    \"host\": \"localhost\",\n"
+            + "    \"port\": \"3306\",\n"
+            + "    \"user\": \"root\",\n"
+            + "    \"password\": \"pass\",\n"
+            + "    \"dbName\": \"dbA\"\n"
+            + "  },\n"
+            + "  {\n"
+            + "    \"logicalShardId\": \"shardB\",\n"
+            + "    \"host\": \"localhost\",\n"
+            + "    \"port\": \"3306\",\n"
+            + "    \"user\": \"root\",\n"
+            + "    \"password\": \"pass\",\n"
+            + "    \"dbName\": \"dbB\"\n"
+            + "  }\n"
+            + "]";
+    File file = tempFolder.newFile("mysql_shards.json");
+    FileUtils.writeStringToFile(file, mysqlJson, StandardCharsets.UTF_8);
+
+    SinkConfig config = SinkConfigParser.parse(SinkType.MYSQL, file.getAbsolutePath());
+
+    assertThat(config).isInstanceOf(MySqlSinkConfig.class);
+    MySqlSinkConfig mysqlConfig = (MySqlSinkConfig) config;
+    assertThat(mysqlConfig.getShards()).hasSize(2);
+    assertThat(mysqlConfig.getShards().get(0).getLogicalShardId()).isEqualTo("shardA");
+    assertThat(mysqlConfig.getShards().get(1).getLogicalShardId()).isEqualTo("shardB");
+  }
+
+  @Test
+  public void testParse_mysqlSink_emptyShards_throwsException() throws IOException {
+    File file = tempFolder.newFile("empty_shards.json");
+    FileUtils.writeStringToFile(file, "[]", StandardCharsets.UTF_8);
+
+    assertThrows(
+        RuntimeException.class,
+        () -> SinkConfigParser.parse(SinkType.MYSQL, file.getAbsolutePath()));
+  }
+}

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/spanner/SpannerConfigFileReaderTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/spanner/SpannerConfigFileReaderTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates.spanner;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.spanner.Dialect;
+import com.google.cloud.teleport.v2.templates.model.SpannerSinkConfig;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SpannerConfigFileReaderTest {
+
+  @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private SpannerConfigFileReader reader;
+
+  @Before
+  public void setUp() {
+    reader = new SpannerConfigFileReader();
+  }
+
+  @Test
+  public void testGetSpannerConfig_validJson_success() throws IOException {
+    String json =
+        "{\n"
+            + "  \"projectId\": \"my-project\",\n"
+            + "  \"instanceId\": \"my-instance\",\n"
+            + "  \"databaseId\": \"my-database\",\n"
+            + "  \"dialect\": \"POSTGRESQL\"\n"
+            + "}";
+    File file = tempFolder.newFile("spanner_config.json");
+    FileUtils.writeStringToFile(file, json, StandardCharsets.UTF_8);
+
+    SpannerSinkConfig config = reader.getSpannerConfig(file.getAbsolutePath());
+
+    assertThat(config).isNotNull();
+    assertThat(config.getProjectId()).isEqualTo("my-project");
+    assertThat(config.getInstanceId()).isEqualTo("my-instance");
+    assertThat(config.getDatabaseId()).isEqualTo("my-database");
+    assertThat(config.getDialect()).isEqualTo(Dialect.POSTGRESQL);
+  }
+
+  @Test
+  public void testGetSpannerConfig_nullConfig_throwsException() throws IOException {
+    // Gson.fromJson on `"null"` returns null
+    File file = tempFolder.newFile("spanner_config_null.json");
+    FileUtils.writeStringToFile(file, "null", StandardCharsets.UTF_8);
+
+    RuntimeException ex =
+        assertThrows(RuntimeException.class, () -> reader.getSpannerConfig(file.getAbsolutePath()));
+    assertThat(ex).hasMessageThat().contains("resulting config is null");
+  }
+
+  @Test
+  public void testGetSpannerConfig_missingProjectId_throwsException() throws IOException {
+    String json =
+        "{\n"
+            + "  \"instanceId\": \"my-instance\",\n"
+            + "  \"databaseId\": \"my-database\"\n"
+            + "}";
+    File file = tempFolder.newFile("spanner_config_missing_project.json");
+    FileUtils.writeStringToFile(file, json, StandardCharsets.UTF_8);
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> reader.getSpannerConfig(file.getAbsolutePath()));
+    assertThat(ex).hasMessageThat().contains("Missing projectId");
+  }
+
+  @Test
+  public void testGetSpannerConfig_missingInstanceId_throwsException() throws IOException {
+    String json =
+        "{\n" + "  \"projectId\": \"my-project\",\n" + "  \"databaseId\": \"my-database\"\n" + "}";
+    File file = tempFolder.newFile("spanner_config_missing_instance.json");
+    FileUtils.writeStringToFile(file, json, StandardCharsets.UTF_8);
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> reader.getSpannerConfig(file.getAbsolutePath()));
+    assertThat(ex).hasMessageThat().contains("Missing instanceId");
+  }
+
+  @Test
+  public void testGetSpannerConfig_missingDatabaseId_throwsException() throws IOException {
+    String json =
+        "{\n" + "  \"projectId\": \"my-project\",\n" + "  \"instanceId\": \"my-instance\"\n" + "}";
+    File file = tempFolder.newFile("spanner_config_missing_database.json");
+    FileUtils.writeStringToFile(file, json, StandardCharsets.UTF_8);
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> reader.getSpannerConfig(file.getAbsolutePath()));
+    assertThat(ex).hasMessageThat().contains("Missing databaseId");
+  }
+
+  @Test
+  public void testGetSpannerConfig_ioError_throwsException() {
+    assertThrows(
+        RuntimeException.class, () -> reader.getSpannerConfig("/non/existent/path/config.json"));
+  }
+}

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/spanner/SpannerDataWriterTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/spanner/SpannerDataWriterTest.java
@@ -31,16 +31,13 @@ import com.google.cloud.spanner.Value;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorColumn;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
 import com.google.cloud.teleport.v2.templates.model.LogicalType;
+import com.google.cloud.teleport.v2.templates.model.SpannerSinkConfig;
 import com.google.cloud.teleport.v2.templates.spanner.SpannerDataWriter.SpannerAccessorFactory;
 import com.google.common.collect.ImmutableList;
-import java.io.File;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.List;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
-import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
-import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.values.Row;
 import org.joda.time.DateTime;
@@ -69,11 +66,14 @@ public class SpannerDataWriterTest {
 
   private SpannerAccessorFactory factory;
 
-  private SpannerConfig testConfig() {
-    return SpannerConfig.create()
-        .withProjectId(StaticValueProvider.of("project"))
-        .withInstanceId(StaticValueProvider.of("instance"))
-        .withDatabaseId(StaticValueProvider.of("database"));
+  private SpannerSinkConfig testConfig() {
+    return new SpannerSinkConfig(
+        "project", "instance", "database", com.google.cloud.spanner.Dialect.GOOGLE_STANDARD_SQL);
+  }
+
+  private SpannerSinkConfig pgConfig() {
+    return new SpannerSinkConfig(
+        "project", "instance", "database", com.google.cloud.spanner.Dialect.POSTGRESQL);
   }
 
   @Before
@@ -132,6 +132,10 @@ public class SpannerDataWriterTest {
 
   private SpannerDataWriter writer() {
     return new SpannerDataWriter(testConfig(), factory);
+  }
+
+  private SpannerDataWriter pgWriter() {
+    return new SpannerDataWriter(pgConfig(), factory);
   }
 
   @Test
@@ -280,7 +284,7 @@ public class SpannerDataWriterTest {
   public void testRowToMutation_jsonValue_pgDialect() {
     when(mockDatabase.getDialect()).thenReturn(com.google.cloud.spanner.Dialect.POSTGRESQL);
     DataGeneratorColumn c = col("j", LogicalType.JSON);
-    SpannerDataWriter w = writer();
+    SpannerDataWriter w = pgWriter();
     w.ensureInitialized();
     Mutation m =
         w.rowToMutation(
@@ -294,7 +298,7 @@ public class SpannerDataWriterTest {
   public void testRowToMutation_jsonNullValue_pgDialect() {
     when(mockDatabase.getDialect()).thenReturn(com.google.cloud.spanner.Dialect.POSTGRESQL);
     DataGeneratorColumn c = col("j", LogicalType.JSON);
-    SpannerDataWriter w = writer();
+    SpannerDataWriter w = pgWriter();
     w.ensureInitialized();
     Mutation m =
         w.rowToMutation(
@@ -308,7 +312,7 @@ public class SpannerDataWriterTest {
   public void testRowToMutation_numericValue_pgDialect() {
     when(mockDatabase.getDialect()).thenReturn(com.google.cloud.spanner.Dialect.POSTGRESQL);
     DataGeneratorColumn c = col("n", LogicalType.NUMERIC);
-    SpannerDataWriter w = writer();
+    SpannerDataWriter w = pgWriter();
     w.ensureInitialized();
     Mutation m =
         w.rowToMutation(
@@ -322,7 +326,7 @@ public class SpannerDataWriterTest {
   public void testRowToMutation_numericNullValue_pgDialect() {
     when(mockDatabase.getDialect()).thenReturn(com.google.cloud.spanner.Dialect.POSTGRESQL);
     DataGeneratorColumn c = col("n", LogicalType.NUMERIC);
-    SpannerDataWriter w = writer();
+    SpannerDataWriter w = pgWriter();
     w.ensureInitialized();
     Mutation m =
         w.rowToMutation(
@@ -617,34 +621,20 @@ public class SpannerDataWriterTest {
   }
 
   @Test
-  public void testLoadSpannerConfig_readsJsonFile() throws Exception {
-    File f = tempFolder.newFile("spanner.json");
-    String json = "{\"projectId\":\"p\",\"instanceId\":\"i\",\"databaseId\":\"d\"}";
-    Files.write(f.toPath(), json.getBytes(StandardCharsets.UTF_8));
-
-    SpannerDataWriter w = new SpannerDataWriter(f.getAbsolutePath(), factory);
+  public void testLoadSpannerConfig_usesSpannerSinkConfig() throws Exception {
+    SpannerSinkConfig config =
+        new SpannerSinkConfig("p", "i", "d", com.google.cloud.spanner.Dialect.GOOGLE_STANDARD_SQL);
+    SpannerDataWriter w = new SpannerDataWriter(config, factory);
     w.ensureInitialized();
 
-    // Force a write to prove that the loaded config was used to obtain a Spanner accessor.
     w.insert(ImmutableList.of(simpleRow(1L, "a")), simpleTable(), "", 10);
     verify(mockDatabaseClient).writeAtLeastOnce(any());
   }
 
   @Test
-  public void testLoadSpannerConfig_missingPathThrows() {
-    SpannerDataWriter w = new SpannerDataWriter((String) null, factory);
+  public void testLoadSpannerConfig_nullConfigThrows() {
+    SpannerDataWriter w = new SpannerDataWriter((SpannerSinkConfig) null, factory);
     assertThrows(IllegalArgumentException.class, w::ensureInitialized);
-
-    SpannerDataWriter w2 = new SpannerDataWriter("", factory);
-    assertThrows(IllegalArgumentException.class, w2::ensureInitialized);
-  }
-
-  @Test
-  public void testLoadSpannerConfig_missingFileThrows() {
-    SpannerDataWriter w =
-        new SpannerDataWriter(
-            new File(tempFolder.getRoot(), "does-not-exist.json").getAbsolutePath(), factory);
-    assertThrows(RuntimeException.class, w::ensureInitialized);
   }
 
   @Test

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/spanner/SpannerDataWriterTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/spanner/SpannerDataWriterTest.java
@@ -652,4 +652,35 @@ public class SpannerDataWriterTest {
         NullPointerException.class,
         () -> w.insert(ImmutableList.of(simpleRow(1L, "a")), simpleTable(), "", 10));
   }
+
+  @Test
+  public void testDirectSpannerConfigConstructor() {
+    org.apache.beam.sdk.io.gcp.spanner.SpannerConfig spannerConfig =
+        org.apache.beam.sdk.io.gcp.spanner.SpannerConfig.create()
+            .withProjectId("direct-proj")
+            .withInstanceId("direct-inst")
+            .withDatabaseId("direct-db");
+    SpannerDataWriter w = new SpannerDataWriter(spannerConfig, factory);
+    w.ensureInitialized();
+    assertThat(w).isNotNull();
+  }
+
+  @Test
+  public void testPublicConstructor() {
+    SpannerDataWriter w = new SpannerDataWriter(testConfig());
+    assertThat(w).isNotNull();
+  }
+
+  @Test
+  public void testRowToDeleteMutation_uuidValueUsesDefault() {
+    DataGeneratorColumn c = col("pk", LogicalType.UUID);
+    Mutation m =
+        writer()
+            .rowToMutation(
+                singleColTable(c),
+                rowFor("pk", Schema.FieldType.STRING, "123e4567-e89b-12d3-a456-426614174000"),
+                SpannerDataWriter.MutationType.DELETE);
+    assertThat(m.getOperation()).isEqualTo(Mutation.Op.DELETE);
+    assertThat(m.getTable()).isEqualTo("t");
+  }
 }

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/spanner/SpannerSchemaFetcherTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/spanner/SpannerSchemaFetcherTest.java
@@ -31,19 +31,15 @@ import com.google.cloud.teleport.v2.spanner.ddl.Table;
 import com.google.cloud.teleport.v2.spanner.type.Type;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorSchema;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
+import com.google.cloud.teleport.v2.templates.model.SpannerSinkConfig;
 import com.google.cloud.teleport.v2.templates.spanner.SpannerSchemaFetcher.DdlFetcher;
 import com.google.common.collect.ImmutableList;
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
@@ -54,54 +50,35 @@ import org.mockito.junit.MockitoRule;
 public class SpannerSchemaFetcherTest {
 
   @Rule public final MockitoRule mockito = MockitoJUnit.rule();
-  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
-
   @Mock private DdlFetcher mockDdlFetcher;
   @Mock private SpannerAccessor mockSpannerAccessor;
   @Mock private Ddl mockDdl;
 
   private SpannerSchemaFetcher fetcher;
-  private JSONObject defaultJson;
+  private SpannerSinkConfig defaultConfig;
 
   @Before
   public void setUp() {
     fetcher = new SpannerSchemaFetcher(mockDdlFetcher);
-    defaultJson = new JSONObject();
-    defaultJson.put("projectId", "test-project");
-    defaultJson.put("instanceId", "test-instance");
-    defaultJson.put("databaseId", "test-database");
+    defaultConfig =
+        new SpannerSinkConfig(
+            "test-project", "test-instance", "test-database", Dialect.GOOGLE_STANDARD_SQL);
   }
 
   @Test
-  public void testInit_success() throws IOException {
-    File configFile = tempFolder.newFile("config.json");
-    Files.writeString(configFile.toPath(), defaultJson.toString());
-    fetcher.init(configFile.getAbsolutePath());
+  public void testInit_success() {
+    fetcher.init(defaultConfig);
     // No assertion needed, success is no exception
   }
 
   @Test
-  public void testInit_missingFields() throws IOException {
-    File configFile = tempFolder.newFile("config.json");
-    JSONObject json = new JSONObject();
-    json.put("projectId", "test-project");
-    Files.writeString(configFile.toPath(), json.toString());
-    assertThrows(JSONException.class, () -> fetcher.init(configFile.getAbsolutePath()));
-  }
-
-  @Test
-  public void testInit_invalidJson() throws IOException {
-    File configFile = tempFolder.newFile("config.json");
-    String invalidJson = "{\"projectId\": \"test-project\",";
-    Files.writeString(configFile.toPath(), invalidJson);
-    assertThrows(JSONException.class, () -> fetcher.init(configFile.getAbsolutePath()));
+  public void testInit_nullConfig() {
+    assertThrows(IllegalArgumentException.class, () -> fetcher.init(null));
   }
 
   @Test
   public void testGetSchema_simpleTable() throws Exception {
-    File configFile = tempFolder.newFile("config.json");
-    Files.writeString(configFile.toPath(), defaultJson.toString());
-    fetcher.init(configFile.getAbsolutePath());
+    fetcher.init(defaultConfig);
 
     Table tableA = Table.builder().name("TableA").build();
     when(mockDdl.allTables()).thenReturn(ImmutableList.of(tableA));
@@ -118,9 +95,7 @@ public class SpannerSchemaFetcherTest {
 
   @Test
   public void testGetSchema_withAllFeatures() throws Exception {
-    File configFile = tempFolder.newFile("config.json");
-    Files.writeString(configFile.toPath(), defaultJson.toString());
-    fetcher.init(configFile.getAbsolutePath());
+    fetcher.init(defaultConfig);
 
     // Mock DDL components
     Table mockTableB = mock(Table.class);
@@ -177,9 +152,7 @@ public class SpannerSchemaFetcherTest {
 
   @Test
   public void testGetSchema_fetchDdlError() throws Exception {
-    File configFile = tempFolder.newFile("config.json");
-    Files.writeString(configFile.toPath(), defaultJson.toString());
-    fetcher.init(configFile.getAbsolutePath());
+    fetcher.init(defaultConfig);
     when(mockDdlFetcher.fetch(any(SpannerConfig.class)))
         .thenThrow(new RuntimeException("Failed to fetch DDL"));
 

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/GeneratePrimaryKeyTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/GeneratePrimaryKeyTest.java
@@ -19,10 +19,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
 import com.google.cloud.teleport.v2.templates.dofn.GeneratePrimaryKeyFn;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorColumn;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorTable;
 import com.google.cloud.teleport.v2.templates.model.LogicalType;
+import com.google.cloud.teleport.v2.templates.model.MySqlSinkConfig;
 import com.google.cloud.teleport.v2.templates.utils.Constants;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
@@ -128,7 +130,7 @@ public class GeneratePrimaryKeyTest {
               assertTrue(row.getString("id").length() > 0);
               assertNotNull(row.getInt64("seq"));
               assertNotNull(row.getString(Constants.SHARD_ID_COLUMN_NAME));
-              // Default maxShards=1 → synthesised id "shard0".
+              // Default synthesised id "shard0".
               assertEquals("shard0", row.getString(Constants.SHARD_ID_COLUMN_NAME));
               return null;
             });
@@ -137,7 +139,7 @@ public class GeneratePrimaryKeyTest {
   }
 
   @Test
-  public void testGeneratePrimaryKey_shardIdWithinMaxShardsRange() {
+  public void testGeneratePrimaryKey_defaultShardIdIsShard0() {
     DataGeneratorColumn id = col("id", LogicalType.STRING);
     DataGeneratorTable table =
         DataGeneratorTable.builder()
@@ -264,6 +266,45 @@ public class GeneratePrimaryKeyTest {
               }
               assertEquals(2, t1Rows);
               assertEquals(1, t2Rows);
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testGeneratePrimaryKey_usesMySqlSinkConfigShards() {
+    DataGeneratorColumn id = col("id", LogicalType.STRING);
+    DataGeneratorTable table =
+        DataGeneratorTable.builder()
+            .name("T")
+            .columns(ImmutableList.of(id))
+            .primaryKeys(ImmutableList.of("id"))
+            .foreignKeys(ImmutableList.of())
+            .uniqueKeys(ImmutableList.of())
+            .isRoot(true)
+            .insertQps(10)
+            .updateQps(0)
+            .deleteQps(0)
+            .recordsPerTick(1.0)
+            .build();
+
+    Shard shardA = new Shard("shardA", "host", "user", "pass", "port", "db", null, null, null);
+    Shard shardB = new Shard("shardB", "host", "user", "pass", "port", "db", null, null, null);
+    MySqlSinkConfig config = new MySqlSinkConfig(ImmutableList.of(shardA, shardB));
+
+    PCollection<KV<String, Row>> out =
+        pipeline
+            .apply("In", Create.of(table, table, table, table, table))
+            .apply("GeneratePK", new GeneratePrimaryKey(config, "MYSQL"));
+
+    PAssert.that(out)
+        .satisfies(
+            iter -> {
+              for (KV<String, Row> kv : iter) {
+                String shard = kv.getValue().getString(Constants.SHARD_ID_COLUMN_NAME);
+                assertTrue(shard.equals("shardA") || shard.equals("shardB"));
+              }
               return null;
             });
 

--- a/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SchemaLoaderTest.java
+++ b/v2/cdc-data-generator/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SchemaLoaderTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.teleport.v2.templates.CdcDataGeneratorOptions.SinkType;
 import com.google.cloud.teleport.v2.templates.dofn.FetchSchemaFn;
 import com.google.cloud.teleport.v2.templates.model.DataGeneratorSchema;
+import com.google.cloud.teleport.v2.templates.model.SinkConfig;
 import com.google.cloud.teleport.v2.templates.sink.SinkSchemaFetcher;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
@@ -39,13 +40,14 @@ public class SchemaLoaderTest {
   @Test
   public void testFetchSchemaFn_Spanner() throws IOException {
     final SinkSchemaFetcher mockFetcher = mock(SinkSchemaFetcher.class);
+    final SinkConfig mockConfig = mock(SinkConfig.class);
     final DataGeneratorSchema schema =
         DataGeneratorSchema.builder().tables(ImmutableMap.of()).build();
 
     when(mockFetcher.getSchema()).thenReturn(schema);
 
     FetchSchemaFn fn =
-        new FetchSchemaFn(SinkType.SPANNER, "options") {
+        new FetchSchemaFn(SinkType.SPANNER, mockConfig) {
           @Override
           protected SinkSchemaFetcher createFetcher(SinkType sinkType) {
             assertEquals(SinkType.SPANNER, sinkType);
@@ -55,19 +57,20 @@ public class SchemaLoaderTest {
 
     DoFn.OutputReceiver<DataGeneratorSchema> receiver = mock(DoFn.OutputReceiver.class);
     fn.processElement(receiver);
-    verify(mockFetcher).init("options");
+    verify(mockFetcher).init(mockConfig);
     verify(receiver).output(schema);
   }
 
   @Test
   public void testFetchSchemaFn_MySql() throws IOException {
     final SinkSchemaFetcher mockFetcher = mock(SinkSchemaFetcher.class);
+    final SinkConfig mockConfig = mock(SinkConfig.class);
     final DataGeneratorSchema schema =
         DataGeneratorSchema.builder().tables(ImmutableMap.of()).build();
     when(mockFetcher.getSchema()).thenReturn(schema);
 
     FetchSchemaFn fn =
-        new FetchSchemaFn(SinkType.MYSQL, "options") {
+        new FetchSchemaFn(SinkType.MYSQL, mockConfig) {
           @Override
           protected SinkSchemaFetcher createFetcher(SinkType sinkType) {
             assertEquals(SinkType.MYSQL, sinkType);
@@ -77,13 +80,13 @@ public class SchemaLoaderTest {
 
     DoFn.OutputReceiver<DataGeneratorSchema> receiver = mock(DoFn.OutputReceiver.class);
     fn.processElement(receiver);
-    verify(mockFetcher).init("options");
+    verify(mockFetcher).init(mockConfig);
     verify(receiver).output(schema);
   }
 
   @Test
   public void testFetchSchemaFn_Unsupported() throws IOException {
-    FetchSchemaFn fn = new FetchSchemaFn(null, "options");
+    FetchSchemaFn fn = new FetchSchemaFn(null, mock(SinkConfig.class));
 
     DoFn.OutputReceiver<DataGeneratorSchema> receiver = mock(DoFn.OutputReceiver.class);
     assertThrows(IllegalArgumentException.class, () -> fn.processElement(receiver));
@@ -92,10 +95,11 @@ public class SchemaLoaderTest {
   @Test
   public void testFetchSchemaFn_IOException() throws IOException {
     final SinkSchemaFetcher mockFetcher = mock(SinkSchemaFetcher.class);
+    final SinkConfig mockConfig = mock(SinkConfig.class);
     when(mockFetcher.getSchema()).thenThrow(new IOException("File not found"));
 
     FetchSchemaFn fn =
-        new FetchSchemaFn(SinkType.SPANNER, "options") {
+        new FetchSchemaFn(SinkType.SPANNER, mockConfig) {
           @Override
           protected SinkSchemaFetcher createFetcher(SinkType sinkType) {
             return mockFetcher;


### PR DESCRIPTION
This PR refactors the configuration handling inside the cdc-data-generator module. It shifts the responsibility of parsing sink configuration settings (for Spanner and MySQL sinks) from individual runtime transforms (DoFns) to the main pipeline driver during initialization.