### PR TITLE
Resolve race when staging multiple classic templates at the same time

### DIFF
--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
@@ -337,8 +337,7 @@ public abstract class TemplateTestBase {
 
       String identifier = flex ? template.flexContainerName() : templateMetadata.name();
 
-      stagedTemplates.get(
-          identifier,
+      java.util.concurrent.Callable<String> stageCallable =
           () -> {
             LOG.info("Preparing test for {} ({})", templateMetadata.name(), dataflowTemplateClass);
 
@@ -376,7 +375,15 @@ public abstract class TemplateTestBase {
             } catch (Exception e) {
               throw new IllegalArgumentException("Error staging template", e);
             }
-          });
+          };
+
+      if (!flex) {
+        synchronized (stagedTemplates) {
+          stagedTemplates.get(identifier, stageCallable);
+        }
+      } else {
+        stagedTemplates.get(identifier, stageCallable);
+      }
       return stagePath;
     }
   }


### PR DESCRIPTION
context: https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/3833#issuecomment-4502649406

There is a racing condition when multiple classic templates get staged, jars are overwrittened by each other. gcsio correctly handles this race, but unfortunately, it's printing an log triggering a JDK bug.