### PR TITLE
[sourcedb-to-spanner] Fix GCS Avro Export flow

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/AvroDestination.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/AvroDestination.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.templates;
 
 import java.util.Objects;
+import org.apache.avro.reflect.Nullable;
 import org.apache.beam.sdk.coders.DefaultCoder;
 import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
 
@@ -23,7 +24,7 @@ import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
 public class AvroDestination {
   public String name;
   public String jsonSchema;
-  @org.apache.avro.reflect.Nullable public String shardId;
+  @Nullable public String shardId;
 
   // Needed for serialization
   public AvroDestination() {}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/AvroDestination.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/AvroDestination.java
@@ -23,7 +23,7 @@ import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
 public class AvroDestination {
   public String name;
   public String jsonSchema;
-  public String shardId;
+  @org.apache.avro.reflect.Nullable public String shardId;
 
   // Needed for serialization
   public AvroDestination() {}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/MigrateTableTransform.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/MigrateTableTransform.java
@@ -162,9 +162,7 @@ public class MigrateTableTransform extends PTransform<PBegin, PCollection<Void>>
             .by(
                 (record) ->
                     AvroDestination.of(
-                        record.shardId(),
-                        record.tableName(),
-                        record.getPayload().getSchema().toString()))
+                        record.shardId(), record.tableName(), record.gcsSchema().toString()))
             .via(
                 Contextful.fn(
                     record -> {

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MigrateTableTransformTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MigrateTableTransformTest.java
@@ -22,13 +22,21 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.teleport.v2.options.SourceDbToSpannerOptions;
 import com.google.cloud.teleport.v2.source.reader.ReaderImpl;
 import com.google.cloud.teleport.v2.source.reader.io.row.SourceRow;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SchemaTestUtils;
+import com.google.cloud.teleport.v2.source.reader.io.schema.SourceTableSchema;
+import com.google.cloud.teleport.v2.source.reader.io.schema.typemapping.UnifiedTypeMapper;
 import com.google.cloud.teleport.v2.source.reader.io.transform.ReaderTransform;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaMapper;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.Compression;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
@@ -37,13 +45,16 @@ import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.TupleTag;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Test class for {@link MigrateTableTransform}. */
 @RunWith(JUnit4.class)
 public class MigrateTableTransformTest {
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
   /** Tests that metric names are correctly generated, optionally including the shard ID. */
   @Test
@@ -131,5 +142,75 @@ public class MigrateTableTransformTest {
     // This avoids the need to mock execution-time dependencies like SpannerWriter.
     Pipeline p = Pipeline.create();
     migrateTableTransform.expand(PBegin.in(p));
+  }
+
+  /**
+   * Tests the writeToGCS method end-to-end to ensure that records are serialized correctly using
+   * the wrapper schema without throwing UnresolvedUnionException.
+   */
+  @Test
+  public void testWriteToGCS() throws Exception {
+    TestPipeline pipeline = TestPipeline.create().enableAbandonedNodeEnforcement(false);
+
+    final String testTable = "table1";
+    final String shardId = "id1";
+    final long testReadTime = 1712751118L;
+    var schemaRef = SchemaTestUtils.generateSchemaReference("public", "mydb");
+    var schema =
+        SourceTableSchema.builder(UnifiedTypeMapper.MapperType.MYSQL)
+            .setTableName(testTable)
+            .addSourceColumnNameToSourceColumnType(
+                "id", new SourceColumnType("INTEGER", new Long[] {}, null))
+            .addSourceColumnNameToSourceColumnType(
+                "firstName", new SourceColumnType("varchar", new Long[] {20L}, null))
+            .build();
+    SourceRow sourceRow =
+        SourceRow.builder(schemaRef, schema, shardId, testReadTime)
+            .setField("id", 123)
+            .setField("firstName", "abc")
+            .build();
+
+    PCollection<SourceRow> sourceRows = pipeline.apply(Create.of(sourceRow));
+    String tempDirPath = tempFolder.getRoot().getAbsolutePath();
+
+    SourceDbToSpannerOptions options = PipelineOptionsFactory.as(SourceDbToSpannerOptions.class);
+    options.setSourceDbDialect("MYSQL");
+    options.setGcsOutputDirectory(tempDirPath);
+
+    SpannerConfig mockSpannerConfig = mock(SpannerConfig.class);
+    Ddl mockDdl = mock(Ddl.class);
+    ISchemaMapper mockSchemaMapper = mock(ISchemaMapper.class);
+    ReaderImpl mockReader = mock(ReaderImpl.class);
+
+    MigrateTableTransform migrateTableTransform =
+        new MigrateTableTransform(
+            options, mockSpannerConfig, mockDdl, mockSchemaMapper, mockReader);
+
+    migrateTableTransform.writeToGCS(sourceRows, tempDirPath);
+
+    // Run the pipeline to execute the Avro write logic on actual data
+    pipeline.run().waitUntilFinish();
+
+    // Verify Avro File was written and matches wrapper schema
+    java.io.File avroSubDir = new java.io.File(tempDirPath, "table1/id1");
+    java.io.File[] avroFiles = avroSubDir.listFiles((dir, name) -> name.endsWith(".avro"));
+    org.junit.Assert.assertNotNull(avroFiles);
+    org.junit.Assert.assertEquals(1, avroFiles.length);
+    java.io.File avroFile = avroFiles[0];
+
+    try (DataFileReader<GenericRecord> fileReader =
+        new DataFileReader<>(avroFile, new GenericDatumReader<>())) {
+      org.junit.Assert.assertTrue(fileReader.hasNext());
+      GenericRecord record = fileReader.next();
+
+      org.junit.Assert.assertEquals("table1", record.get("tableName").toString());
+      org.junit.Assert.assertEquals("id1", record.get("shardId").toString());
+
+      GenericRecord payloadRecord = (GenericRecord) record.get("payload");
+      org.junit.Assert.assertEquals(123, payloadRecord.get("id"));
+      org.junit.Assert.assertEquals("abc", payloadRecord.get("firstName").toString());
+
+      org.junit.Assert.assertFalse(fileReader.hasNext());
+    }
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MigrateTableTransformTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MigrateTableTransformTest.java
@@ -146,14 +146,26 @@ public class MigrateTableTransformTest {
 
   /**
    * Tests the writeToGCS method end-to-end to ensure that records are serialized correctly using
-   * the wrapper schema without throwing UnresolvedUnionException.
+   * the wrapper schema in a non-sharded flow, where shardId is null.
    */
   @Test
-  public void testWriteToGCS() throws Exception {
+  public void testWriteToGCSForNonShardedFlow() throws Exception {
+    runGcsWriteTest(null, "table1");
+  }
+
+  /**
+   * Tests the writeToGCS method end-to-end to ensure that records are serialized correctly using
+   * the wrapper schema in a sharded flow, where shardId is present.
+   */
+  @Test
+  public void testWriteToGCSForShardedFlow() throws Exception {
+    runGcsWriteTest("shard1", "table1/shard1");
+  }
+
+  private void runGcsWriteTest(String shardId, String expectedRelativeSubDir) throws Exception {
     TestPipeline pipeline = TestPipeline.create().enableAbandonedNodeEnforcement(false);
 
     final String testTable = "table1";
-    final String shardId = null;
     final long testReadTime = 1712751118L;
     var schemaRef = SchemaTestUtils.generateSchemaReference("public", "mydb");
     var schema =
@@ -192,7 +204,7 @@ public class MigrateTableTransformTest {
     pipeline.run().waitUntilFinish();
 
     // Verify Avro File was written and matches wrapper schema
-    java.io.File avroSubDir = new java.io.File(tempDirPath, "table1");
+    java.io.File avroSubDir = new java.io.File(tempDirPath, expectedRelativeSubDir);
     java.io.File[] avroFiles = avroSubDir.listFiles((dir, name) -> name.endsWith(".avro"));
     assertThat(avroFiles).isNotNull();
     assertThat(avroFiles).hasLength(1);
@@ -204,7 +216,11 @@ public class MigrateTableTransformTest {
       GenericRecord record = fileReader.next();
 
       assertThat(record.get("tableName").toString()).isEqualTo("table1");
-      assertThat(record.get("shardId")).isNull();
+      if (shardId == null) {
+        assertThat(record.get("shardId")).isNull();
+      } else {
+        assertThat(record.get("shardId").toString()).isEqualTo(shardId);
+      }
 
       GenericRecord payloadRecord = (GenericRecord) record.get("payload");
       assertThat(payloadRecord.get("id")).isEqualTo(123);

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MigrateTableTransformTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MigrateTableTransformTest.java
@@ -153,7 +153,7 @@ public class MigrateTableTransformTest {
     TestPipeline pipeline = TestPipeline.create().enableAbandonedNodeEnforcement(false);
 
     final String testTable = "table1";
-    final String shardId = "id1";
+    final String shardId = null;
     final long testReadTime = 1712751118L;
     var schemaRef = SchemaTestUtils.generateSchemaReference("public", "mydb");
     var schema =
@@ -192,25 +192,25 @@ public class MigrateTableTransformTest {
     pipeline.run().waitUntilFinish();
 
     // Verify Avro File was written and matches wrapper schema
-    java.io.File avroSubDir = new java.io.File(tempDirPath, "table1/id1");
+    java.io.File avroSubDir = new java.io.File(tempDirPath, "table1");
     java.io.File[] avroFiles = avroSubDir.listFiles((dir, name) -> name.endsWith(".avro"));
-    org.junit.Assert.assertNotNull(avroFiles);
-    org.junit.Assert.assertEquals(1, avroFiles.length);
+    assertThat(avroFiles).isNotNull();
+    assertThat(avroFiles).hasLength(1);
     java.io.File avroFile = avroFiles[0];
 
     try (DataFileReader<GenericRecord> fileReader =
         new DataFileReader<>(avroFile, new GenericDatumReader<>())) {
-      org.junit.Assert.assertTrue(fileReader.hasNext());
+      assertThat(fileReader.hasNext()).isTrue();
       GenericRecord record = fileReader.next();
 
-      org.junit.Assert.assertEquals("table1", record.get("tableName").toString());
-      org.junit.Assert.assertEquals("id1", record.get("shardId").toString());
+      assertThat(record.get("tableName").toString()).isEqualTo("table1");
+      assertThat(record.get("shardId")).isNull();
 
       GenericRecord payloadRecord = (GenericRecord) record.get("payload");
-      org.junit.Assert.assertEquals(123, payloadRecord.get("id"));
-      org.junit.Assert.assertEquals("abc", payloadRecord.get("firstName").toString());
+      assertThat(payloadRecord.get("id")).isEqualTo(123);
+      assertThat(payloadRecord.get("firstName").toString()).isEqualTo("abc");
 
-      org.junit.Assert.assertFalse(fileReader.hasNext());
+      assertThat(fileReader.hasNext()).isFalse();
     }
   }
 }


### PR DESCRIPTION
https://b.corp.google.com/issues/515646503

## 1. Issues
When migrating data using the `Sourcedb_to_Spanner_Flex` batch Dataflow template with the optional GCS export feature enabled (`gcsOutputDirectory` parameter specified), the Dataflow job fails with two distinct serialization errors depending on the shard configuration:

### Issue 1 (Dynamic Avro Serialization)
For all migrations, successfully migrated records fail to write to GCS with an `UnresolvedUnionException`:
```
org.apache.avro.file.DataFileWriter$AppendWriteException: org.apache.avro.UnresolvedUnionException: Not in union ["null","int"]: table1_transform_fail (field=id)
```

### Issue 2 (Reflect Coder Nullability)
For non-sharded migrations (where `shardId` is null), the job fails with a `NullPointerException` inside the Beam pipeline runner stages:
```
java.lang.NullPointerException: null in string in field shardId
	org.apache.avro.generic.GenericDatumWriter.npe(GenericDatumWriter.java:208)
	org.apache.avro.reflect.ReflectDatumWriter.write(ReflectDatumWriter.java:173)
	org.apache.beam.sdk.extensions.avro.coders.AvroCoder.encode(AvroCoder.java:466)
```

---

## 2. Causes

### Cause 1 (Index Mismatch in `writeToGCS()`)
In `MigrateTableTransform.java`, the dynamic Avro writer's schema given to the sink was incorrectly configured using:
`record.getPayload().getSchema().toString()` (e.g., database row schema `"table1"` with fields `id` and `firstName`).
However, the elements passed to the writer in the pipeline were the metadata wrapper records:
`record.toGcsRecord()` (schema `SourceRowWithMetadata` with fields `tableName`, `shardId`, `primaryKeys`, and `payload`).

During serialization, Avro's `GenericDatumWriter` evaluated fields by index. For the first field `id` (at index `0` of the writer's schema), it called `datum.get(0)` on the provided `SourceRowWithMetadata` record. Since index `0` of `SourceRowWithMetadata` is the `tableName` field, it returned the String `"table1"`. Attempting to write this String into the integer `id` field threw the `UnresolvedUnionException`.

> [!NOTE]
> The original unit test went undetected because the test table defined only `VARCHAR` (String) columns. By pure coincidence, both the wrapper metadata fields (`tableName`, `shardId`) and the database columns were Strings, causing Avro to silently serialize metadata into database columns.

### Cause 2 (Null `shardId` Serialization in `AvroDestination`)
At the end of the `WriteFiles` stage, Beam serializes a collection of `FileResult<AvroDestination>` metadata records using `AvroCoder.of(AvroDestination.class)`.
In `AvroDestination.java`, the `shardId` field was defined as a raw Java `String` without any nullability annotations. Under Avro reflection, a raw `String` is treated as non-nullable. For standard bulk migrations without sharding, `shardId` is `null`, leading to a `NullPointerException` when the reflection coder attempted to encode it.

---

## 3. Fixes

### Fix 1: Corrected dynamic writer schema
Modified the dynamic Avro destination builder in MigrateTableTransform.java to utilize the wrapper schema:
`record.gcsSchema().toString()))`

This aligns the writer's schema with the actual wrapper schema.

### Fix 2: Annotated `shardId` in `AvroDestination`
Modified [AvroDestination.java](file:///usr/local/google/home/aasthabharill/DataflowTemplates/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/AvroDestination.java) to annotate the `shardId` field with Avro's `@org.apache.avro.reflect.Nullable` annotation:
`@org.apache.avro.reflect.Nullable public String shardId;`

This instructs Avro's reflection engine to allow `null` values for the field by mapping it to a `["null", "string"]` union type.

---

## 4. Verification
#### Unit Test
I implemented a comprehensive, unit test `testWriteToGCS()` in MigrateTableTransformTest.java

* **Reproducing production scenarios**: It sets `shardId` to `null` to replicate non-sharded migrations.
* **Type Validation**: It configures a schema with an **`INTEGER id`** field at index `0`, ensuring that any index mismatch instantly fails with `UnresolvedUnionException`.
* **Assertions**: Post-pipeline execution, the test reads the generated `.avro` file back from disk using Avro's `DataFileReader` and asserts that:
  * The schema is correctly structured.
  * The `tableName` matches `"table1"`.
  * The `shardId` is successfully serialized as `null`.
  * The nested payload correctly holds the integer `id` (`123`) and the `firstName` string (`"abc"`).

This test executes locally in sub-second time and compiles and passes successfully.

#### Manual test
Built modified template: gs://ea-functional-tests/templates-aastha-2026-05-22/flex/Sourcedb_to_Spanner_Flex
Job was a success: https://pantheon.corp.google.com/dataflow/jobs/us-central1/2026-05-22_03_10_50-3991903184278937362;graphView=1?project=span-cloud-ck-testing-external&e=PangolinKitchenLaunch::PangolinKitchenEnabled&mods=logs_tg_staging&pageState=(%22dfTime%22:(%22l%22:%22dfJobMaxTime%22))