### PR TITLE
[googlecloud-to-googlecloud] Add Spanner Capture Type: NEW_ROW_AND_OLD_VALUES for AVRO files 

### DIFF
--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToAvro.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/transforms/WriteDataChangeRecordsToAvro.java
@@ -210,6 +210,8 @@ public class WriteDataChangeRecordsToAvro {
         return com.google.cloud.teleport.v2.ValueCaptureType.OLD_AND_NEW_VALUES;
       case NEW_ROW:
         return com.google.cloud.teleport.v2.ValueCaptureType.NEW_ROW;
+      case NEW_ROW_AND_OLD_VALUES:
+        return com.google.cloud.teleport.v2.ValueCaptureType.NEW_ROW_AND_OLD_VALUES;
       default:
         return com.google.cloud.teleport.v2.ValueCaptureType.NEW_VALUES;
     }

--- a/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/datachangerecord.avsc
+++ b/v2/googlecloud-to-googlecloud/src/main/resources/schema/avro/datachangerecord.avsc
@@ -61,7 +61,7 @@
       "type" : {
         "name": "ValueCaptureType",
         "type": "enum",
-        "symbols": ["OLD_AND_NEW_VALUES", "NEW_ROW", "NEW_VALUES"]
+        "symbols": ["OLD_AND_NEW_VALUES", "NEW_ROW", "NEW_VALUES", "NEW_ROW_AND_OLD_VALUES"]
       }
     },
     { "name" : "numberOfRecordsInTransaction", "type" : "long"},


### PR DESCRIPTION
The capture type NEW_ROW_AND_OLD_VALUES is mapped as NEW_VALUES when generating avro files for Spanner Change Stream. This PR is target to correct the mapping, and use NEW_ROW_AND_OLD_VALUES as is in the generated avro file.