### PR TITLE
upgrade activemq to 5.19.2 to match beam

### DIFF
--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -45,9 +45,9 @@
         <astra-sdk.version>2.2.0</astra-sdk.version>
         <astra-io.version>4.18.1</astra-io.version>
         <dataplex.api.version>v1-rev20251113-2.0.0</dataplex.api.version>
-        <!-- ActiveMQ uses JMS 1.1 for versions < 5.18.0 -->
-        <!-- This can only be upgraded after Beam moves to JMS 2.0 -->
-        <activemq.version>5.17.7</activemq.version>
+        <!-- ActiveMQ version 5.19.2 uses JMS 2.0 but retains javax.jms compatibility. -->
+        <!-- Upgrade to 6.x requires Beam/templates to transition to the Jakarta Messaging API (jakarta.jms). -->
+        <activemq.version>5.19.2</activemq.version>
         <licenseHeaderFile>../JAVA_LICENSE_HEADER</licenseHeaderFile>
     </properties>
 


### PR DESCRIPTION
Get partially the way to 6.2 version - https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/3858

Replaces https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/3637