### PR TITLE
feat: Add PostgreSQL REAL/FLOAT4 support to Sourcedb to Spanner template

### DIFF
--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesPGDialectIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesPGDialectIT.java
@@ -228,12 +228,12 @@ public class PostgreSQLDataTypesPGDialectIT extends SourceDbToSpannerITBase {
         "float4",
         createRows(
             "-1.9876542E38", "1.9876542E38", "NaN", "-Infinity", "Infinity", "2.34", "NULL"));
-    // float4_to_float32 is commented out to avoid failing the test case; data is not migrated at
-    // all
-    // result.put(
-    //     "float4_to_float32",
-    //     createRows(
-    //         "-1.9876542E38", "1.9876542E38", "NaN", "-Infinity", "Infinity", "2.34", "NULL"));
+    float4_to_float32 is commented out to avoid failing the test case; data is not migrated at
+    all
+    result.put(
+        "float4_to_float32",
+        createRows(
+            "-1.9876542E38", "1.9876542E38", "NaN", "-Infinity", "Infinity", "2.34", "NULL"));
     result.put(
         "float4_to_string",
         createRows(
@@ -302,12 +302,12 @@ public class PostgreSQLDataTypesPGDialectIT extends SourceDbToSpannerITBase {
         "real",
         createRows(
             "-1.9876542E38", "1.9876542E38", "NaN", "-Infinity", "Infinity", "5.67", "NULL"));
-    // float4_to_float32 is commented out to avoid failing the test case; data is not migrated at
-    // all
-    // result.put(
-    //     "real_to_float32",
-    //     createRows(
-    //         "-1.9876542E38", "1.9876542E38", "NaN", "-Infinity", "Infinity", "5.67", "NULL"));
+    float4_to_float32 is commented out to avoid failing the test case; data is not migrated at
+    all
+    result.put(
+        "real_to_float32",
+        createRows(
+            "-1.9876542E38", "1.9876542E38", "NaN", "-Infinity", "Infinity", "5.67", "NULL"));
     result.put(
         "real_to_string",
         createRows(

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesPGDialectIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesPGDialectIT.java
@@ -228,8 +228,8 @@ public class PostgreSQLDataTypesPGDialectIT extends SourceDbToSpannerITBase {
         "float4",
         createRows(
             "-1.9876542E38", "1.9876542E38", "NaN", "-Infinity", "Infinity", "2.34", "NULL"));
-    float4_to_float32 is commented out to avoid failing the test case; data is not migrated at
-    all
+    // float4_to_float32 is commented out to avoid failing the test case; data is not migrated at
+    // all
     result.put(
         "float4_to_float32",
         createRows(
@@ -302,8 +302,8 @@ public class PostgreSQLDataTypesPGDialectIT extends SourceDbToSpannerITBase {
         "real",
         createRows(
             "-1.9876542E38", "1.9876542E38", "NaN", "-Infinity", "Infinity", "5.67", "NULL"));
-    float4_to_float32 is commented out to avoid failing the test case; data is not migrated at
-    all
+    // float4_to_float32 is commented out to avoid failing the test case; data is not migrated at
+    // all
     result.put(
         "real_to_float32",
         createRows(

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesPGDialectIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesPGDialectIT.java
@@ -228,8 +228,6 @@ public class PostgreSQLDataTypesPGDialectIT extends SourceDbToSpannerITBase {
         "float4",
         createRows(
             "-1.9876542E38", "1.9876542E38", "NaN", "-Infinity", "Infinity", "2.34", "NULL"));
-    // float4_to_float32 is commented out to avoid failing the test case; data is not migrated at
-    // all
     result.put(
         "float4_to_float32",
         createRows(
@@ -302,8 +300,6 @@ public class PostgreSQLDataTypesPGDialectIT extends SourceDbToSpannerITBase {
         "real",
         createRows(
             "-1.9876542E38", "1.9876542E38", "NaN", "-Infinity", "Infinity", "5.67", "NULL"));
-    // float4_to_float32 is commented out to avoid failing the test case; data is not migrated at
-    // all
     result.put(
         "real_to_float32",
         createRows(

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroToValueMapper.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroToValueMapper.java
@@ -213,6 +213,9 @@ public class AvroToValueMapper {
         Type.pgInt8(),
         (recordValue, fieldSchema) -> Value.int64(avroFieldToLong(recordValue, fieldSchema)));
     pgFunctions.put(
+        Type.pgFloat4(),
+        (recordValue, fieldSchema) -> Value.float32(avroFieldToFloat32(recordValue, fieldSchema)));
+    pgFunctions.put(
         Type.pgFloat8(),
         (recordValue, fieldSchema) -> Value.float64(avroFieldToDouble(recordValue, fieldSchema)));
     pgFunctions.put(

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroToValueMapperTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroToValueMapperTest.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.spanner.migrations.avro;
 
 import static com.google.cloud.teleport.v2.spanner.migrations.avro.AvroToValueMapper.avroArrayFieldToSpannerArray;
 import static com.google.cloud.teleport.v2.spanner.migrations.avro.AvroToValueMapper.getGsqlMap;
+import static com.google.cloud.teleport.v2.spanner.migrations.avro.AvroToValueMapper.getPgMap;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroToValueMapperTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroToValueMapperTest.java
@@ -198,9 +198,15 @@ public class AvroToValueMapperTest {
         AvroToValueMapper.avroFieldToFloat32((Double) 3.14, SchemaBuilder.builder().floatType());
     assertEquals("Test float input", (Float) 3.14f, result);
 
+    // Test a valid GSQL float32 to float32 mapping
     Value value =
         getGsqlMap().get(Type.float32()).apply(3.14f, SchemaBuilder.builder().floatType());
     assertEquals("Test float input", Value.float32(3.14f), value);
+
+    // Test a valid PostgreSQL float4/real to float32 mapping
+    Value pgValue =
+        getPgMap().get(Type.pgFloat4()).apply(5.75f, SchemaBuilder.builder().floatType());
+    assertEquals("Test float input", Value.float32(5.75f), pgValue);
 
     result = AvroToValueMapper.avroFieldToFloat32("456.346", SchemaBuilder.builder().doubleType());
     assertEquals("Test string input", (Float) 456.346f, result);


### PR DESCRIPTION
The `Sourcedb_to_Spanner_Flex` template previously lacked support for migrating data from PostgreSQL `REAL` (aliased as `FLOAT4`) columns when using the Spanner PostgreSQL dialect. This resulted in data not being populated in the target Spanner tables for columns of type `FLOAT4` (Spanner's single-precision float type), causing failures in `PostgreSQLDataTypesPGDialectIT` for these type tests.

This PR addresses this by:

1.  **Adding Type Mapping:** Introduced a type conversion mapping for `Type.pgFloat4()` in `AvroToValueMapper.getPgMap()`. This mapping utilizes the existing `avroFieldToFloat32` function to correctly convert incoming Avro values (originating from PostgreSQL `REAL` columns) to Spanner `Value.float32()`.
2.  **Unit Tests:** Added new unit tests to `AvroToValueMapperTest.java` to specifically validate the `Dialect.POSTGRESQL` map entries for `Type.pgFloat4()`, ensuring the conversion logic is correctly wired.
3.  **Integration Tests:** Re-enabled the integration test cases for `REAL` data types within `PostgreSQLDataTypesPGDialectIT.java` that were previously commented out. These tests now pass, confirming end-to-end functionality.

With these changes, the template now correctly handles PostgreSQL `REAL`/`FLOAT4` types, mapping them to Spanner's `float4` type in the PostgreSQL dialect.

Fixes: b/516973815