### PR TITLE
[SpannerToSourceDb] Fixing flaky UT and also improving coverage

### DIFF
--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/dml/CassandraDMLGenerator.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/dml/CassandraDMLGenerator.java
@@ -130,7 +130,7 @@ public class CassandraDMLGenerator implements IDMLGenerator {
             dmlGeneratorRequest.getKeyValuesJson(),
             dmlGeneratorRequest.getSourceDbTimezoneOffset(),
             dmlGeneratorRequest.getCustomTransformationResponse());
-    if (pkColumnNameValues == null) {
+    if (pkColumnNameValues == null || pkColumnNameValues.isEmpty()) {
       throw new InvalidDMLGenerationException(
           String.format(
               "Cannot reverse replicate for table %s without primary key, skipping the record",
@@ -435,16 +435,13 @@ public class CassandraDMLGenerator implements IDMLGenerator {
         continue;
       }
       if (spannerColName == null || spannerColName == "") {
-        LOG.warn(
-            "The corresponding spanner table for {} was not found in schema mapping",
-            sourceColName);
-        return null;
+        continue;
       }
       Column spannerColDef = spannerTable.column(spannerColName);
       if (spannerColDef == null) {
         LOG.warn(
             "The spanner column definition for {} was not found in spanner schema", spannerColName);
-        return null;
+        continue;
       }
       if (keyValuesJson.has(spannerColName)) {
         columnValue =

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/dml/DMLGeneratorUtils.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/dml/DMLGeneratorUtils.java
@@ -175,16 +175,13 @@ public class DMLGeneratorUtils {
         continue;
       }
       if (spannerColName == null) {
-        LOG.warn(
-            "The corresponding spanner table for {} was not found in schema mapping",
-            sourceColName);
-        return null;
+        continue;
       }
       Column spannerColDef = spannerTable.column(spannerColName);
       if (spannerColDef == null) {
         LOG.warn(
             "The spanner column definition for {} was not found in spanner schema", spannerColName);
-        return null;
+        continue;
       }
       String columnValue = "";
       String actualColName = spannerColDef.name();

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/dml/MySQLDMLGenerator.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/dml/MySQLDMLGenerator.java
@@ -95,7 +95,7 @@ public class MySQLDMLGenerator implements IDMLGenerator {
             dmlGeneratorRequest.getSourceDbTimezoneOffset(),
             dmlGeneratorRequest.getCustomTransformationResponse(),
             MySQLDMLGenerator::getMappedColumnValue);
-    if (pkcolumnNameValues == null) {
+    if (pkcolumnNameValues == null || pkcolumnNameValues.isEmpty()) {
       throw new InvalidDMLGenerationException(
           String.format(
               "Cannot reverse replicate for table %s without primary key, skipping the record",

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/dml/PostgreSQLDMLGenerator.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/dml/PostgreSQLDMLGenerator.java
@@ -97,7 +97,7 @@ public class PostgreSQLDMLGenerator implements IDMLGenerator {
             dmlGeneratorRequest.getSourceDbTimezoneOffset(),
             dmlGeneratorRequest.getCustomTransformationResponse(),
             PostgreSQLDMLGenerator::getMappedColumnValue);
-    if (pkcolumnNameValues == null) {
+    if (pkcolumnNameValues == null || pkcolumnNameValues.isEmpty()) {
       throw new InvalidDMLGenerationException(
           String.format(
               "Cannot reverse replicate for table %s without primary key, skipping the record",

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/processor/SourceProcessorFactory.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/processor/SourceProcessorFactory.java
@@ -126,6 +126,10 @@ public class SourceProcessorFactory {
     connectionHelperMap = connectionHelper;
   }
 
+  static Map<String, IConnectionHelper> getConnectionHelperMap() {
+    return connectionHelperMap;
+  }
+
   /**
    * Creates a SourceProcessor instance for the specified source type.
    *

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/dml/CassandraDMLGeneratorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/dml/CassandraDMLGeneratorTest.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.templates.dbutils.dml;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -1186,7 +1187,7 @@ public class CassandraDMLGeneratorTest {
     Mockito.when(sourceTable.name()).thenReturn("src_table");
 
     Mockito.when(schemaMapper.getSpannerColumnName("", "src_table", "col1"))
-        .thenThrow(new java.util.NoSuchElementException());
+        .thenThrow(new NoSuchElementException());
 
     Map<String, PreparedStatementValueObject<?>> response =
         CassandraDMLGenerator.getColumnValues(
@@ -1398,7 +1399,7 @@ public class CassandraDMLGeneratorTest {
     PreparedStatementGeneratedResponse prepResponse = (PreparedStatementGeneratedResponse) response;
 
     assertTrue(prepResponse.getDmlStatement().contains("\"LastName\""));
-    assertTrue(!prepResponse.getDmlStatement().contains("\"MissingCol\""));
+    assertFalse(prepResponse.getDmlStatement().contains("\"MissingCol\""));
 
     assertEquals(3, prepResponse.getValues().size());
   }
@@ -1423,7 +1424,8 @@ public class CassandraDMLGeneratorTest {
     Mockito.when(sourceSchema.table("Singers")).thenReturn(sourceTable);
 
     // Composite PK
-    Mockito.when(sourceTable.primaryKeyColumns()).thenReturn(ImmutableList.of("SingerId", "LastName"));
+    Mockito.when(sourceTable.primaryKeyColumns())
+        .thenReturn(ImmutableList.of("SingerId", "LastName"));
     Mockito.when(sourceTable.column("SingerId")).thenReturn(pkCol1);
     Mockito.when(pkCol1.type()).thenReturn("int");
     Mockito.when(sourceTable.column("LastName")).thenReturn(pkCol2);
@@ -1447,8 +1449,7 @@ public class CassandraDMLGeneratorTest {
     Mockito.when(nonPkCol.name()).thenReturn("Age");
     Mockito.when(nonPkCol.type()).thenReturn("int");
 
-    Mockito.when(schemaMapper.getSpannerColumnName("", "Singers", "Age"))
-        .thenReturn("Age");
+    Mockito.when(schemaMapper.getSpannerColumnName("", "Singers", "Age")).thenReturn("Age");
     Mockito.when(spannerTable.column("Age")).thenReturn(spannerNonPkCol);
     Mockito.when(spannerNonPkCol.name()).thenReturn("Age");
     Mockito.when(spannerNonPkCol.type()).thenReturn(Type.int64());
@@ -1475,7 +1476,7 @@ public class CassandraDMLGeneratorTest {
     // The statement should contain SingerId and Age, but NOT LastName
     assertTrue(prepResponse.getDmlStatement().contains("\"SingerId\""));
     assertTrue(prepResponse.getDmlStatement().contains("\"Age\""));
-    assertTrue(!prepResponse.getDmlStatement().contains("\"LastName\""));
+    assertFalse(prepResponse.getDmlStatement().contains("\"LastName\""));
 
     // Expected values: SingerId (999), Age (30), and using_timestamp
     assertEquals(3, prepResponse.getValues().size());

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/dml/CassandraDMLGeneratorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/dml/CassandraDMLGeneratorTest.java
@@ -1231,4 +1231,253 @@ public class CassandraDMLGeneratorTest {
 
     assertNull(response);
   }
+
+  @Test
+  public void testGetDMLStatement_PkColSpannerColNameThrowsNoSuchElement() {
+    ISchemaMapper schemaMapper = Mockito.mock(ISchemaMapper.class);
+    Ddl spannerDdl = Ddl.builder().build();
+    spannerDdl = Mockito.spy(spannerDdl);
+    Table spannerTable = Mockito.mock(Table.class);
+    SourceSchema sourceSchema = Mockito.mock(SourceSchema.class);
+    SourceTable sourceTable = Mockito.mock(SourceTable.class);
+    SourceColumn sourceCol = Mockito.mock(SourceColumn.class);
+
+    Mockito.doReturn(spannerTable).when(spannerDdl).table("Singers");
+    Mockito.when(schemaMapper.getSourceTableName("", "Singers")).thenReturn("Singers");
+    Mockito.when(sourceSchema.table("Singers")).thenReturn(sourceTable);
+    Mockito.when(sourceTable.primaryKeyColumns()).thenReturn(ImmutableList.of("SingerId"));
+    Mockito.when(sourceTable.column("SingerId")).thenReturn(sourceCol);
+    Mockito.when(sourceCol.type()).thenReturn("int");
+    Mockito.when(sourceTable.name()).thenReturn("Singers");
+
+    Mockito.when(schemaMapper.getSpannerColumnName("", "Singers", "SingerId"))
+        .thenThrow(new NoSuchElementException("Not found"));
+
+    DMLGeneratorRequest request =
+        new DMLGeneratorRequest.Builder(
+                "INSERT", "Singers", new JSONObject(), new JSONObject(), "+00:00")
+            .setSchemaMapper(schemaMapper)
+            .setDdl(spannerDdl)
+            .setSourceSchema(sourceSchema)
+            .setCommitTimestamp(Timestamp.now())
+            .build();
+
+    assertThrows(
+        InvalidDMLGenerationException.class, () -> cassandraDMLGenerator.getDMLStatement(request));
+  }
+
+  @Test
+  public void testGetDMLStatement_PkColSpannerColNameNull() {
+    ISchemaMapper schemaMapper = Mockito.mock(ISchemaMapper.class);
+    Ddl spannerDdl = Ddl.builder().build();
+    spannerDdl = Mockito.spy(spannerDdl);
+    Table spannerTable = Mockito.mock(Table.class);
+    SourceSchema sourceSchema = Mockito.mock(SourceSchema.class);
+    SourceTable sourceTable = Mockito.mock(SourceTable.class);
+    SourceColumn sourceCol = Mockito.mock(SourceColumn.class);
+
+    Mockito.doReturn(spannerTable).when(spannerDdl).table("Singers");
+    Mockito.when(schemaMapper.getSourceTableName("", "Singers")).thenReturn("Singers");
+    Mockito.when(sourceSchema.table("Singers")).thenReturn(sourceTable);
+    Mockito.when(sourceTable.primaryKeyColumns()).thenReturn(ImmutableList.of("SingerId"));
+    Mockito.when(sourceTable.column("SingerId")).thenReturn(sourceCol);
+    Mockito.when(sourceCol.type()).thenReturn("int");
+    Mockito.when(sourceTable.name()).thenReturn("Singers");
+
+    Mockito.when(schemaMapper.getSpannerColumnName("", "Singers", "SingerId")).thenReturn(null);
+
+    DMLGeneratorRequest request =
+        new DMLGeneratorRequest.Builder(
+                "INSERT", "Singers", new JSONObject(), new JSONObject(), "+00:00")
+            .setSchemaMapper(schemaMapper)
+            .setDdl(spannerDdl)
+            .setSourceSchema(sourceSchema)
+            .setCommitTimestamp(Timestamp.now())
+            .build();
+
+    assertThrows(
+        InvalidDMLGenerationException.class, () -> cassandraDMLGenerator.getDMLStatement(request));
+  }
+
+  @Test
+  public void testGetDMLStatement_PkColSpannerColDefNull() {
+    ISchemaMapper schemaMapper = Mockito.mock(ISchemaMapper.class);
+    Ddl spannerDdl = Ddl.builder().build();
+    spannerDdl = Mockito.spy(spannerDdl);
+    Table spannerTable = Mockito.mock(Table.class);
+    SourceSchema sourceSchema = Mockito.mock(SourceSchema.class);
+    SourceTable sourceTable = Mockito.mock(SourceTable.class);
+    SourceColumn sourceCol = Mockito.mock(SourceColumn.class);
+
+    Mockito.doReturn(spannerTable).when(spannerDdl).table("Singers");
+    Mockito.when(schemaMapper.getSourceTableName("", "Singers")).thenReturn("Singers");
+    Mockito.when(sourceSchema.table("Singers")).thenReturn(sourceTable);
+    Mockito.when(sourceTable.primaryKeyColumns()).thenReturn(ImmutableList.of("SingerId"));
+    Mockito.when(sourceTable.column("SingerId")).thenReturn(sourceCol);
+    Mockito.when(sourceCol.type()).thenReturn("int");
+    Mockito.when(sourceTable.name()).thenReturn("Singers");
+
+    Mockito.when(schemaMapper.getSpannerColumnName("", "Singers", "SingerId"))
+        .thenReturn("SingerId");
+    Mockito.when(spannerTable.column("SingerId")).thenReturn(null);
+
+    DMLGeneratorRequest request =
+        new DMLGeneratorRequest.Builder(
+                "INSERT", "Singers", new JSONObject(), new JSONObject(), "+00:00")
+            .setSchemaMapper(schemaMapper)
+            .setDdl(spannerDdl)
+            .setSourceSchema(sourceSchema)
+            .setCommitTimestamp(Timestamp.now())
+            .build();
+
+    assertThrows(
+        InvalidDMLGenerationException.class, () -> cassandraDMLGenerator.getDMLStatement(request));
+  }
+
+  @Test
+  public void testGetDMLStatement_ColValuesSpannerColDefNullAndKeyValuesHasNonPk() {
+    ISchemaMapper schemaMapper = Mockito.mock(ISchemaMapper.class);
+    Table spannerTable = Mockito.mock(Table.class);
+    SourceSchema sourceSchema = Mockito.mock(SourceSchema.class);
+    SourceTable sourceTable = Mockito.mock(SourceTable.class);
+    SourceColumn pkCol = Mockito.mock(SourceColumn.class);
+    SourceColumn nonPkCol = Mockito.mock(SourceColumn.class);
+    SourceColumn missingCol = Mockito.mock(SourceColumn.class);
+    Column spannerPkCol = Mockito.mock(Column.class);
+    Column spannerNonPkCol = Mockito.mock(Column.class);
+
+    Ddl spannerDdl = Ddl.builder().build();
+    spannerDdl = Mockito.spy(spannerDdl);
+    Mockito.doReturn(spannerTable).when(spannerDdl).table("Singers");
+
+    Mockito.when(schemaMapper.getSourceTableName("", "Singers")).thenReturn("Singers");
+    Mockito.when(sourceSchema.table("Singers")).thenReturn(sourceTable);
+    Mockito.when(sourceTable.primaryKeyColumns()).thenReturn(ImmutableList.of("SingerId"));
+    Mockito.when(sourceTable.column("SingerId")).thenReturn(pkCol);
+    Mockito.when(pkCol.type()).thenReturn("int");
+    Mockito.when(sourceTable.name()).thenReturn("Singers");
+
+    Mockito.when(schemaMapper.getSpannerColumnName("", "Singers", "SingerId"))
+        .thenReturn("SingerId");
+    Mockito.when(spannerTable.column("SingerId")).thenReturn(spannerPkCol);
+    Mockito.when(spannerPkCol.name()).thenReturn("SingerId");
+    Mockito.when(spannerPkCol.type()).thenReturn(Type.int64());
+
+    Mockito.when(sourceTable.columns()).thenReturn(ImmutableList.of(pkCol, nonPkCol, missingCol));
+    Mockito.when(nonPkCol.name()).thenReturn("LastName");
+    Mockito.when(nonPkCol.type()).thenReturn("varchar");
+    Mockito.when(missingCol.name()).thenReturn("MissingCol");
+    Mockito.when(missingCol.type()).thenReturn("varchar");
+
+    Mockito.when(schemaMapper.getSpannerColumnName("", "Singers", "LastName"))
+        .thenReturn("LastName");
+    Mockito.when(spannerTable.column("LastName")).thenReturn(spannerNonPkCol);
+    Mockito.when(spannerNonPkCol.name()).thenReturn("LastName");
+    Mockito.when(spannerNonPkCol.type()).thenReturn(Type.string());
+
+    Mockito.when(schemaMapper.getSpannerColumnName("", "Singers", "MissingCol"))
+        .thenReturn("MissingCol");
+    Mockito.when(spannerTable.column("MissingCol")).thenReturn(null);
+
+    JSONObject keyValuesJson = new JSONObject();
+    keyValuesJson.put("SingerId", "999");
+    keyValuesJson.put("LastName", "Smith");
+
+    DMLGeneratorRequest request =
+        new DMLGeneratorRequest.Builder(
+                "INSERT", "Singers", new JSONObject(), keyValuesJson, "+00:00")
+            .setSchemaMapper(schemaMapper)
+            .setDdl(spannerDdl)
+            .setSourceSchema(sourceSchema)
+            .setCommitTimestamp(Timestamp.now())
+            .build();
+
+    DMLGeneratorResponse response = cassandraDMLGenerator.getDMLStatement(request);
+
+    assertTrue(response instanceof PreparedStatementGeneratedResponse);
+    PreparedStatementGeneratedResponse prepResponse = (PreparedStatementGeneratedResponse) response;
+
+    assertTrue(prepResponse.getDmlStatement().contains("\"LastName\""));
+    assertTrue(!prepResponse.getDmlStatement().contains("\"MissingCol\""));
+
+    assertEquals(3, prepResponse.getValues().size());
+  }
+
+  @Test
+  public void testGetDMLStatement_CompositePk_OnePkSpannerColDefNull() {
+    ISchemaMapper schemaMapper = Mockito.mock(ISchemaMapper.class);
+    Table spannerTable = Mockito.mock(Table.class);
+    SourceSchema sourceSchema = Mockito.mock(SourceSchema.class);
+    SourceTable sourceTable = Mockito.mock(SourceTable.class);
+    SourceColumn pkCol1 = Mockito.mock(SourceColumn.class);
+    SourceColumn pkCol2 = Mockito.mock(SourceColumn.class);
+    SourceColumn nonPkCol = Mockito.mock(SourceColumn.class);
+    Column spannerPkCol1 = Mockito.mock(Column.class);
+    Column spannerNonPkCol = Mockito.mock(Column.class);
+
+    Ddl spannerDdl = Ddl.builder().build();
+    spannerDdl = Mockito.spy(spannerDdl);
+    Mockito.doReturn(spannerTable).when(spannerDdl).table("Singers");
+
+    Mockito.when(schemaMapper.getSourceTableName("", "Singers")).thenReturn("Singers");
+    Mockito.when(sourceSchema.table("Singers")).thenReturn(sourceTable);
+
+    // Composite PK
+    Mockito.when(sourceTable.primaryKeyColumns()).thenReturn(ImmutableList.of("SingerId", "LastName"));
+    Mockito.when(sourceTable.column("SingerId")).thenReturn(pkCol1);
+    Mockito.when(pkCol1.type()).thenReturn("int");
+    Mockito.when(sourceTable.column("LastName")).thenReturn(pkCol2);
+    Mockito.when(pkCol2.type()).thenReturn("varchar");
+    Mockito.when(sourceTable.name()).thenReturn("Singers");
+
+    // SingerId (pkCol1) maps successfully
+    Mockito.when(schemaMapper.getSpannerColumnName("", "Singers", "SingerId"))
+        .thenReturn("SingerId");
+    Mockito.when(spannerTable.column("SingerId")).thenReturn(spannerPkCol1);
+    Mockito.when(spannerPkCol1.name()).thenReturn("SingerId");
+    Mockito.when(spannerPkCol1.type()).thenReturn(Type.int64());
+
+    // LastName (pkCol2) fails to map because Spanner column def is null
+    Mockito.when(schemaMapper.getSpannerColumnName("", "Singers", "LastName"))
+        .thenReturn("LastName");
+    Mockito.when(spannerTable.column("LastName")).thenReturn(null);
+
+    // Non-PK col (Age) maps successfully
+    Mockito.when(sourceTable.columns()).thenReturn(ImmutableList.of(pkCol1, pkCol2, nonPkCol));
+    Mockito.when(nonPkCol.name()).thenReturn("Age");
+    Mockito.when(nonPkCol.type()).thenReturn("int");
+
+    Mockito.when(schemaMapper.getSpannerColumnName("", "Singers", "Age"))
+        .thenReturn("Age");
+    Mockito.when(spannerTable.column("Age")).thenReturn(spannerNonPkCol);
+    Mockito.when(spannerNonPkCol.name()).thenReturn("Age");
+    Mockito.when(spannerNonPkCol.type()).thenReturn(Type.int64());
+
+    JSONObject keyValuesJson = new JSONObject();
+    keyValuesJson.put("SingerId", 999L);
+    keyValuesJson.put("LastName", "Smith");
+    keyValuesJson.put("Age", 30L);
+
+    DMLGeneratorRequest request =
+        new DMLGeneratorRequest.Builder(
+                "INSERT", "Singers", new JSONObject(), keyValuesJson, "+00:00")
+            .setSchemaMapper(schemaMapper)
+            .setDdl(spannerDdl)
+            .setSourceSchema(sourceSchema)
+            .setCommitTimestamp(Timestamp.now())
+            .build();
+
+    DMLGeneratorResponse response = cassandraDMLGenerator.getDMLStatement(request);
+
+    assertTrue(response instanceof PreparedStatementGeneratedResponse);
+    PreparedStatementGeneratedResponse prepResponse = (PreparedStatementGeneratedResponse) response;
+
+    // The statement should contain SingerId and Age, but NOT LastName
+    assertTrue(prepResponse.getDmlStatement().contains("\"SingerId\""));
+    assertTrue(prepResponse.getDmlStatement().contains("\"Age\""));
+    assertTrue(!prepResponse.getDmlStatement().contains("\"LastName\""));
+
+    // Expected values: SingerId (999), Age (30), and using_timestamp
+    assertEquals(3, prepResponse.getValues().size());
+  }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/dml/CassandraTypeHandlerTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/dml/CassandraTypeHandlerTest.java
@@ -1803,4 +1803,146 @@ public class CassandraTypeHandlerTest {
     assertEquals(1, map.size());
     assertEquals("John", map.get("name"));
   }
+
+  @Test
+  public void testNullClassToString() {
+    assertEquals("NULL_CLASS", CassandraTypeHandler.NullClass.INSTANCE.toString());
+  }
+
+  @Test
+  public void testGetColumnValueByTypeForInvalidDuration() {
+    String columnValue = "invalid_duration";
+    String columnName = "total_time";
+    Ddl ddl =
+        Ddl.builder()
+            .createTable(TEST_TABLE)
+            .column(columnName)
+            .string()
+            .max()
+            .endColumn()
+            .endTable()
+            .build();
+    Column spannerCol = ddl.table(TEST_TABLE).column(columnName);
+    SourceColumn sourceCol =
+        SourceColumn.builder(SourceDatabaseType.CASSANDRA)
+            .name(columnName)
+            .type("duration")
+            .build();
+
+    JSONObject valuesJson = new JSONObject();
+    valuesJson.put(columnName, columnValue);
+
+    PreparedStatementValueObject result =
+        getColumnValueByType(spannerCol, sourceCol, valuesJson, null);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> CassandraTypeHandler.castToExpectedType(result.dataType(), result.value()));
+  }
+
+  @Test
+  public void testGetColumnValueByTypeForInvalidIpAddress() {
+    String columnValue = "invalid_ip";
+    String columnName = "ipAddress";
+    Ddl ddl =
+        Ddl.builder()
+            .createTable(TEST_TABLE)
+            .column(columnName)
+            .string()
+            .max()
+            .endColumn()
+            .endTable()
+            .build();
+    Column spannerCol = ddl.table(TEST_TABLE).column(columnName);
+    SourceColumn sourceCol =
+        SourceColumn.builder(SourceDatabaseType.CASSANDRA).name(columnName).type("inet").build();
+
+    JSONObject valuesJson = new JSONObject();
+    valuesJson.put(columnName, columnValue);
+
+    PreparedStatementValueObject result =
+        getColumnValueByType(spannerCol, sourceCol, valuesJson, null);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> CassandraTypeHandler.castToExpectedType(result.dataType(), result.value()));
+  }
+
+  @Test
+  public void testGetColumnValueByTypeForEmptyBytes() {
+    String columnName = "data";
+    String columnValue = "";
+    Ddl ddl =
+        Ddl.builder()
+            .createTable(TEST_TABLE)
+            .column(columnName)
+            .bytes()
+            .max()
+            .endColumn()
+            .endTable()
+            .build();
+    Column spannerCol = ddl.table(TEST_TABLE).column(columnName);
+    SourceColumn sourceCol =
+        SourceColumn.builder(SourceDatabaseType.CASSANDRA).name(columnName).type("blob").build();
+
+    JSONObject valuesJson = new JSONObject();
+    valuesJson.put(columnName, columnValue);
+
+    PreparedStatementValueObject result =
+        getColumnValueByType(spannerCol, sourceCol, valuesJson, null);
+    assertEquals("blob", result.dataType());
+    assertEquals(CassandraTypeHandler.NullClass.INSTANCE, result.value());
+  }
+
+  @Test
+  public void testGetColumnValueByType_InvalidHexBytesException() {
+    String columnName = "data";
+    String columnValue = "invalid_hex_$$";
+    Ddl ddl =
+        Ddl.builder()
+            .createTable(TEST_TABLE)
+            .column(columnName)
+            .bytes()
+            .max()
+            .endColumn()
+            .endTable()
+            .build();
+    Column spannerCol = ddl.table(TEST_TABLE).column(columnName);
+    SourceColumn sourceCol =
+        SourceColumn.builder(SourceDatabaseType.CASSANDRA).name(columnName).type("blob").build();
+
+    JSONObject valuesJson = new JSONObject();
+    valuesJson.put(columnName, columnValue);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> getColumnValueByType(spannerCol, sourceCol, valuesJson, null));
+  }
+
+  @Test
+  public void testGetColumnValueByType_InvalidTimestampException() {
+    String columnName = "created_on";
+    String columnValue = "invalid_timestamp";
+    Ddl ddl =
+        Ddl.builder()
+            .createTable(TEST_TABLE)
+            .column(columnName)
+            .date()
+            .endColumn()
+            .endTable()
+            .build();
+    Column spannerCol = ddl.table(TEST_TABLE).column(columnName);
+    SourceColumn sourceCol =
+        SourceColumn.builder(SourceDatabaseType.CASSANDRA)
+            .name(columnName)
+            .type("timestamp")
+            .build();
+
+    JSONObject valuesJson = new JSONObject();
+    valuesJson.put(columnName, columnValue);
+
+    PreparedStatementValueObject result =
+        getColumnValueByType(spannerCol, sourceCol, valuesJson, null);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> CassandraTypeHandler.castToExpectedType(result.dataType(), result.value()));
+  }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/dml/DMLGeneratorUtilsTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/dml/DMLGeneratorUtilsTest.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.templates.dbutils.dml;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -29,6 +30,7 @@ import com.google.cloud.teleport.v2.spanner.sourceddl.SourceColumn;
 import com.google.cloud.teleport.v2.spanner.sourceddl.SourceTable;
 import com.google.common.collect.ImmutableList;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import org.json.JSONObject;
 import org.junit.Test;
 
@@ -59,7 +61,7 @@ public class DMLGeneratorUtilsTest {
   }
 
   @Test
-  public void testGetColumnValues_HappyPath() {
+  public void testGetColumnValues() {
     ISchemaMapper schemaMapper = mock(ISchemaMapper.class);
     Table spannerTable = mock(Table.class);
     SourceTable sourceTable = mock(SourceTable.class);
@@ -104,7 +106,7 @@ public class DMLGeneratorUtilsTest {
   }
 
   @Test
-  public void testGetPkColumnValues_HappyPath() {
+  public void testGetPkColumnValues() {
     ISchemaMapper schemaMapper = mock(ISchemaMapper.class);
     Table spannerTable = mock(Table.class);
     SourceTable sourceTable = mock(SourceTable.class);
@@ -184,7 +186,7 @@ public class DMLGeneratorUtilsTest {
     when(sourceTable.name()).thenReturn("src_table");
 
     when(schemaMapper.getSpannerColumnName("", "src_table", "col1"))
-        .thenThrow(new java.util.NoSuchElementException("Not found"));
+        .thenThrow(new NoSuchElementException("Not found"));
 
     Map<String, String> response =
         DMLGeneratorUtils.getPkColumnValues(
@@ -308,6 +310,6 @@ public class DMLGeneratorUtilsTest {
 
     assertEquals(1, response.size());
     assertEquals("mapped_val1", response.get("col1"));
-    assertTrue(!response.containsKey("col2"));
+    assertFalse(response.containsKey("col2"));
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/dml/DMLGeneratorUtilsTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/dml/DMLGeneratorUtilsTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.teleport.v2.templates.dbutils.dml;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -145,5 +146,168 @@ public class DMLGeneratorUtilsTest {
 
     assertEquals(1, response.size());
     assertEquals("mapped_val", response.get("col1"));
+  }
+
+  @Test
+  public void testGetPkColumnValues_SourceColDefNull() {
+    ISchemaMapper schemaMapper = mock(ISchemaMapper.class);
+    Table spannerTable = mock(Table.class);
+    SourceTable sourceTable = mock(SourceTable.class);
+
+    when(sourceTable.primaryKeyColumns()).thenReturn(ImmutableList.of("col1"));
+    when(sourceTable.column("col1")).thenReturn(null);
+
+    Map<String, String> response =
+        DMLGeneratorUtils.getPkColumnValues(
+            schemaMapper,
+            spannerTable,
+            sourceTable,
+            new JSONObject(),
+            new JSONObject(),
+            "+00:00",
+            null,
+            null);
+
+    assertNull(response);
+  }
+
+  @Test
+  public void testGetPkColumnValues_SpannerColNameThrowsNoSuchElement() {
+    ISchemaMapper schemaMapper = mock(ISchemaMapper.class);
+    Table spannerTable = mock(Table.class);
+    SourceTable sourceTable = mock(SourceTable.class);
+    SourceColumn sourceCol = mock(SourceColumn.class);
+
+    when(sourceTable.primaryKeyColumns()).thenReturn(ImmutableList.of("col1"));
+    when(sourceTable.column("col1")).thenReturn(sourceCol);
+    when(sourceCol.isGenerated()).thenReturn(false);
+    when(sourceTable.name()).thenReturn("src_table");
+
+    when(schemaMapper.getSpannerColumnName("", "src_table", "col1"))
+        .thenThrow(new java.util.NoSuchElementException("Not found"));
+
+    Map<String, String> response =
+        DMLGeneratorUtils.getPkColumnValues(
+            schemaMapper,
+            spannerTable,
+            sourceTable,
+            new JSONObject(),
+            new JSONObject(),
+            "+00:00",
+            null,
+            null);
+
+    assertTrue(response.isEmpty());
+  }
+
+  @Test
+  public void testGetPkColumnValues_SpannerColNameNull() {
+    ISchemaMapper schemaMapper = mock(ISchemaMapper.class);
+    Table spannerTable = mock(Table.class);
+    SourceTable sourceTable = mock(SourceTable.class);
+    SourceColumn sourceCol = mock(SourceColumn.class);
+
+    when(sourceTable.primaryKeyColumns()).thenReturn(ImmutableList.of("col1"));
+    when(sourceTable.column("col1")).thenReturn(sourceCol);
+    when(sourceCol.isGenerated()).thenReturn(false);
+    when(sourceTable.name()).thenReturn("src_table");
+
+    when(schemaMapper.getSpannerColumnName("", "src_table", "col1")).thenReturn(null);
+
+    Map<String, String> response =
+        DMLGeneratorUtils.getPkColumnValues(
+            schemaMapper,
+            spannerTable,
+            sourceTable,
+            new JSONObject(),
+            new JSONObject(),
+            "+00:00",
+            null,
+            null);
+
+    assertTrue(response.isEmpty());
+  }
+
+  @Test
+  public void testGetPkColumnValues_SpannerColDefNull() {
+    ISchemaMapper schemaMapper = mock(ISchemaMapper.class);
+    Table spannerTable = mock(Table.class);
+    SourceTable sourceTable = mock(SourceTable.class);
+    SourceColumn sourceCol = mock(SourceColumn.class);
+
+    when(sourceTable.primaryKeyColumns()).thenReturn(ImmutableList.of("col1"));
+    when(sourceTable.column("col1")).thenReturn(sourceCol);
+    when(sourceCol.isGenerated()).thenReturn(false);
+    when(sourceTable.name()).thenReturn("src_table");
+
+    when(schemaMapper.getSpannerColumnName("", "src_table", "col1")).thenReturn("spanner_col1");
+    when(spannerTable.column("spanner_col1")).thenReturn(null);
+
+    Map<String, String> response =
+        DMLGeneratorUtils.getPkColumnValues(
+            schemaMapper,
+            spannerTable,
+            sourceTable,
+            new JSONObject(),
+            new JSONObject(),
+            "+00:00",
+            null,
+            null);
+
+    assertTrue(response.isEmpty());
+  }
+
+  @Test
+  public void testGetPkColumnValues_CompositePk_OnePkFailsToMap() {
+    ISchemaMapper schemaMapper = mock(ISchemaMapper.class);
+    Table spannerTable = mock(Table.class);
+    SourceTable sourceTable = mock(SourceTable.class);
+    SourceColumn sourceCol1 = mock(SourceColumn.class);
+    SourceColumn sourceCol2 = mock(SourceColumn.class);
+    Column spannerCol1 = mock(Column.class);
+
+    when(sourceTable.primaryKeyColumns()).thenReturn(ImmutableList.of("col1", "col2"));
+    when(sourceTable.column("col1")).thenReturn(sourceCol1);
+    when(sourceCol1.name()).thenReturn("col1");
+    when(sourceCol1.isGenerated()).thenReturn(false);
+    when(sourceTable.column("col2")).thenReturn(sourceCol2);
+    when(sourceCol2.name()).thenReturn("col2");
+    when(sourceCol2.isGenerated()).thenReturn(false);
+    when(sourceTable.name()).thenReturn("src_table");
+
+    // col1 maps successfully
+    when(schemaMapper.getSpannerColumnName("", "src_table", "col1")).thenReturn("spanner_col1");
+    when(spannerTable.column("spanner_col1")).thenReturn(spannerCol1);
+    when(spannerCol1.name()).thenReturn("spanner_col1");
+
+    // col2 fails to map (returns null)
+    when(schemaMapper.getSpannerColumnName("", "src_table", "col2")).thenReturn(null);
+
+    JSONObject keyValuesJson = new JSONObject();
+    keyValuesJson.put("spanner_col1", "val1");
+
+    DMLGeneratorUtils.ColumnValueMapper mapper =
+        (spannerColDef, sourceColDef, valuesJson, timezoneOffset) -> {
+          assertEquals(spannerCol1, spannerColDef);
+          assertEquals(sourceCol1, sourceColDef);
+          assertEquals(keyValuesJson, valuesJson);
+          assertEquals("+00:00", timezoneOffset);
+          return "mapped_val1";
+        };
+
+    Map<String, String> response =
+        DMLGeneratorUtils.getPkColumnValues(
+            schemaMapper,
+            spannerTable,
+            sourceTable,
+            new JSONObject(),
+            keyValuesJson,
+            "+00:00",
+            null,
+            mapper);
+
+    assertEquals(1, response.size());
+    assertEquals("mapped_val1", response.get("col1"));
+    assertTrue(!response.containsKey("col2"));
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/processor/SourceProcessorFactoryTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/processor/SourceProcessorFactoryTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.teleport.v2.templates.dbutils.processor;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 
+import com.google.cloud.teleport.v2.spanner.migrations.connection.IConnectionHelper;
 import com.google.cloud.teleport.v2.spanner.migrations.connection.JdbcConnectionHelper;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.CassandraShard;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
@@ -31,7 +32,9 @@ import com.google.cloud.teleport.v2.templates.exceptions.UnsupportedSourceExcept
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -39,6 +42,19 @@ import org.mockito.Mockito;
 
 @RunWith(JUnit4.class)
 public class SourceProcessorFactoryTest {
+
+  private static Map<String, IConnectionHelper> originalConnectionHelperMap;
+
+  @BeforeClass
+  public static void setUpBeforeClass() {
+    originalConnectionHelperMap = SourceProcessorFactory.getConnectionHelperMap();
+  }
+
+  @After
+  public void tearDown() {
+    SourceProcessorFactory.setConnectionHelperMap(originalConnectionHelperMap);
+  }
+
   @Test
   public void testCreateSourceProcessor_validSource() throws Exception {
     List<Shard> shards =

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFnTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFnTest.java
@@ -65,6 +65,8 @@ import com.google.cloud.teleport.v2.templates.utils.ShadowTableRecord;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import java.sql.SQLDataException;
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.SQLNonTransientConnectionException;
 import java.sql.SQLSyntaxErrorException;
 import java.util.HashMap;
 import java.util.Map;
@@ -160,21 +162,17 @@ public class SourceWriterFnTest {
     when(mockSpannerConfig.getRpcPriority())
         .thenReturn(ValueProvider.StaticValueProvider.of(RpcPriority.HIGH));
     doNothing().when(mockSpannerDao).updateShadowTable(any(), any());
-    doThrow(new java.sql.SQLIntegrityConstraintViolationException("a foreign key constraint fails"))
+    doThrow(new SQLIntegrityConstraintViolationException("a foreign key constraint fails"))
         .when(mockSqlDao)
         .write(
             contains("2300"),
             any()); // This is the child_id for which we want to test the foreign key
     // constraint failure.
-    doThrow(
-            new java.sql.SQLNonTransientConnectionException(
-                "transient connection error", "HY000", 1161))
+    doThrow(new SQLNonTransientConnectionException("transient connection error", "HY000", 1161))
         .when(mockSqlDao)
         .write(contains("1161"), any()); // This is the child_id for which we want to retryable
     // connection error
-    doThrow(
-            new java.sql.SQLNonTransientConnectionException(
-                "permanent connection error", "HY000", 4242))
+    doThrow(new SQLNonTransientConnectionException("permanent connection error", "HY000", 4242))
         .when(mockSqlDao)
         .write(contains("4242"), any()); // no retryable error
     doThrow(new RuntimeException("generic exception"))

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFnTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFnTest.java
@@ -22,7 +22,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -69,7 +68,6 @@ import java.sql.SQLDataException;
 import java.sql.SQLSyntaxErrorException;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.Mod;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.ModType;
@@ -80,7 +78,6 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
@@ -1402,63 +1399,5 @@ public class SourceWriterFnTest {
             .endTable()
             .build();
     return ddl;
-  }
-
-  @Ignore("Skipping until test issue is resolved")
-  @Test
-  public void testSetup_NullSessionFilePath() throws Exception {
-    SourceWriterFn sourceWriterFn =
-        new SourceWriterFn(
-            ImmutableList.of(testShard),
-            mockSpannerConfig,
-            testSourceDbTimezoneOffset,
-            testSourceSchema,
-            "shadow_",
-            "skip",
-            500,
-            "mysql",
-            null,
-            mockDdlView,
-            mockShadowTableDdlView,
-            null,
-            "",
-            "",
-            "");
-
-    try (MockedStatic<SpannerAccessor> mockedSpannerAccessor = mockStatic(SpannerAccessor.class)) {
-      mockedSpannerAccessor
-          .when(() -> SpannerAccessor.getOrCreate(any()))
-          .thenReturn(mock(SpannerAccessor.class));
-      sourceWriterFn.setup();
-    }
-  }
-
-  @Ignore("Skipping until test issue is resolved")
-  @Test
-  public void testSetup_EmptySessionFilePath() throws Exception {
-    SourceWriterFn sourceWriterFn =
-        new SourceWriterFn(
-            ImmutableList.of(testShard),
-            mockSpannerConfig,
-            testSourceDbTimezoneOffset,
-            testSourceSchema,
-            "shadow_",
-            "skip",
-            500,
-            "mysql",
-            null,
-            mockDdlView,
-            mockShadowTableDdlView,
-            "",
-            "",
-            "",
-            "");
-
-    try (MockedStatic<SpannerAccessor> mockedSpannerAccessor = mockStatic(SpannerAccessor.class)) {
-      mockedSpannerAccessor
-          .when(() -> SpannerAccessor.getOrCreate(any()))
-          .thenReturn(mock(SpannerAccessor.class));
-      sourceWriterFn.setup();
-    }
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/utils/ShadowTableCreatorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/utils/ShadowTableCreatorTest.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.templates.utils;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -32,6 +33,7 @@ import com.google.cloud.teleport.v2.templates.constants.Constants;
 import com.google.common.collect.ImmutableList;
 import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
@@ -69,7 +71,7 @@ public final class ShadowTableCreatorTest {
     when(mockSpannerAccessor.getDatabaseAdminClient()).thenReturn(mockDatabaseClient);
     when(mockDatabaseClient.updateDatabaseDdl(any(), any(), any(), any()))
         .thenReturn(mockUpdateDatabaseDdlFuture);
-    when(mockUpdateDatabaseDdlFuture.get(15, TimeUnit.MINUTES)).thenReturn(null);
+    when(mockUpdateDatabaseDdlFuture.get(5, TimeUnit.MINUTES)).thenReturn(null);
   }
 
   @Test
@@ -318,5 +320,24 @@ public final class ShadowTableCreatorTest {
 
     // Verify that updateDatabaseDdl was NOT called!
     verify(mockDatabaseClient, never()).updateDatabaseDdl(any(), any(), any(), any());
+  }
+
+  @Test
+  public void testCreateShadowTables_Exception() throws Exception {
+    Ddl primaryDbDdl = getPrimaryDbDdl();
+    Ddl metadataDbDdl = getMetadataDbDdl();
+    ShadowTableCreator shadowTableCreator =
+        new ShadowTableCreator(
+            Dialect.GOOGLE_STANDARD_SQL,
+            "shadow_",
+            primaryDbDdl,
+            metadataDbDdl,
+            mockSpannerAccessor,
+            testSpannerConfig);
+
+    when(mockUpdateDatabaseDdlFuture.get(5, TimeUnit.MINUTES))
+        .thenThrow(new ExecutionException(new RuntimeException("Spanner error")));
+
+    assertThrows(RuntimeException.class, () -> shadowTableCreator.createShadowTablesInSpanner());
   }
 }


### PR DESCRIPTION
Context - https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/3830#issuecomment-4594319180

1. Some test cases in SourceWriterFnTest.java‎ were flaky because SourceProcessorFactoryTest was not restoring the static variables of SourceProcessorFactory which it mocked in the tests. Fixed the SourceProcessorFactoryTest and also removed the flaky tests in SourceWriterFnTest since they were not adding much value.
2. Improved test coverage in other files.