### PR TITLE
[Data Validation] Add support for Custom Transformation

### DIFF
--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dofn/SourceHashFn.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dofn/SourceHashFn.java
@@ -19,6 +19,9 @@ import com.google.cloud.teleport.v2.dto.ComparisonRecord;
 import com.google.cloud.teleport.v2.mapper.ComparisonRecordMapper;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaMapper;
+import com.google.cloud.teleport.v2.spanner.migrations.transformation.CustomTransformation;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.CustomTransformationImplFetcher;
+import com.google.cloud.teleport.v2.spanner.utils.ISpannerMigrationTransformer;
 import java.util.Objects;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -30,13 +33,26 @@ public class SourceHashFn extends DoFn<GenericRecord, ComparisonRecord> {
 
   private final PCollectionView<Ddl> ddlView;
   private final SerializableFunction<Ddl, ISchemaMapper> schemaMapperProvider;
+  private final CustomTransformation customTransformation;
 
   private transient ComparisonRecordMapper comparisonRecordMapper;
+  private transient ISpannerMigrationTransformer transformer;
 
   public SourceHashFn(
-      PCollectionView<Ddl> ddlView, SerializableFunction<Ddl, ISchemaMapper> schemaMapperProvider) {
+      PCollectionView<Ddl> ddlView,
+      SerializableFunction<Ddl, ISchemaMapper> schemaMapperProvider,
+      CustomTransformation customTransformation) {
     this.ddlView = ddlView;
     this.schemaMapperProvider = schemaMapperProvider;
+    this.customTransformation = customTransformation;
+  }
+
+  @Setup
+  public void setup() {
+    if (customTransformation != null) {
+      transformer =
+          CustomTransformationImplFetcher.getCustomTransformationLogicImpl(customTransformation);
+    }
   }
 
   @ProcessElement
@@ -46,7 +62,7 @@ public class SourceHashFn extends DoFn<GenericRecord, ComparisonRecord> {
     // lazy initialization of the mapper.
     if (comparisonRecordMapper == null) {
       comparisonRecordMapper =
-          new ComparisonRecordMapper(schemaMapperProvider.apply(ddl), null, ddl);
+          new ComparisonRecordMapper(schemaMapperProvider.apply(ddl), transformer, ddl);
     }
 
     ComparisonRecord comparisonRecord =

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/templates/GCSSpannerDV.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/templates/GCSSpannerDV.java
@@ -169,7 +169,7 @@ public class GCSSpannerDV {
         example = "[{Singers, Vocalists}, {Albums, Records}]",
         helpText =
             "These are the table name overrides from source to spanner. They are written in"
-                + " thefollowing format: [{SourceTableName1, SpannerTableName1}, {SourceTableName2,"
+                + " the following format: [{SourceTableName1, SpannerTableName1}, {SourceTableName2,"
                 + " SpannerTableName2}]This example shows mapping Singers table to Vocalists and"
                 + " Albums table to Records.")
     @Default.String("")
@@ -187,7 +187,7 @@ public class GCSSpannerDV {
             "[{Singers.SingerName, Singers.TalentName}, {Albums.AlbumName, Albums.RecordName}]",
         helpText =
             "These are the column name overrides from source to spanner. They are written in"
-                + " thefollowing format: [{SourceTableName1.SourceColumnName1,"
+                + " the following format: [{SourceTableName1.SourceColumnName1,"
                 + " SourceTableName1.SpannerColumnName1}, {SourceTableName2.SourceColumnName1,"
                 + " SourceTableName2.SpannerColumnName1}]Note that the SourceTableName should"
                 + " remain the same in both the source and spanner pair. To override table names,"

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/templates/GCSSpannerDV.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/templates/GCSSpannerDV.java
@@ -138,8 +138,7 @@ public class GCSSpannerDV {
         order = 7,
         optional = true,
         description =
-            "Session File Path in Cloud Storage, to provide mapping information in the form of a"
-                + " session file",
+            "Session File Path in Cloud Storage, to provide mapping information in the form of a session file",
         helpText =
             "Session file path in Cloud Storage that contains mapping information from"
                 + " Spanner Migration Tool")
@@ -153,8 +152,7 @@ public class GCSSpannerDV {
         optional = true,
         description = "File based overrides from source to spanner",
         helpText =
-            "A file which specifies the table and the column name overrides from source to"
-                + " spanner.")
+            "A file which specifies the table and the column name overrides from source to spanner.")
     @Default.String("")
     String getSchemaOverridesFilePath();
 
@@ -168,10 +166,9 @@ public class GCSSpannerDV {
             "^\\[([[:space:]]*\\{[[:graph:]]+[[:space:]]*,[[:space:]]*[[:graph:]]+[[:space:]]*\\}[[:space:]]*(,[[:space:]]*)*)*\\]$",
         example = "[{Singers, Vocalists}, {Albums, Records}]",
         helpText =
-            "These are the table name overrides from source to spanner. They are written in"
-                + " the following format: [{SourceTableName1, SpannerTableName1}, {SourceTableName2,"
-                + " SpannerTableName2}]This example shows mapping Singers table to Vocalists and"
-                + " Albums table to Records.")
+            "These are the table name overrides from source to spanner. They are written in the"
+                + " following format: [{SourceTableName1, SpannerTableName1}, {SourceTableName2, SpannerTableName2}]"
+                + " This example shows mapping Singers table to Vocalists and Albums table to Records.")
     @Default.String("")
     String getTableOverrides();
 
@@ -286,17 +283,11 @@ public class GCSSpannerDV {
             options.getTableOverrides(),
             options.getColumnOverrides());
 
-    CustomTransformation customTransformation = null;
-    if (options.getTransformationJarPath() != null
-        && !options.getTransformationJarPath().isEmpty()
-        && options.getTransformationClassName() != null
-        && !options.getTransformationClassName().isEmpty()) {
-      customTransformation =
-          CustomTransformation.builder(
-                  options.getTransformationJarPath(), options.getTransformationClassName())
-              .setCustomParameters(options.getTransformationCustomParameters())
-              .build();
-    }
+    CustomTransformation customTransformation =
+        CustomTransformation.builder(
+                options.getTransformationJarPath(), options.getTransformationClassName())
+            .setCustomParameters(options.getTransformationCustomParameters())
+            .build();
 
     // Get Source records hashes
     PCollection<ComparisonRecord> sourceRecords =

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/templates/GCSSpannerDV.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/templates/GCSSpannerDV.java
@@ -27,6 +27,7 @@ import com.google.cloud.teleport.v2.dto.ComparisonRecord;
 import com.google.cloud.teleport.v2.fn.SchemaMapperProviderFn;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaMapper;
+import com.google.cloud.teleport.v2.spanner.migrations.transformation.CustomTransformation;
 import com.google.cloud.teleport.v2.transforms.MatchRecordsTransform;
 import com.google.cloud.teleport.v2.transforms.ReportResultsTransform;
 import com.google.cloud.teleport.v2.transforms.SourceReaderTransform;
@@ -51,7 +52,8 @@ import org.joda.time.Instant;
     category = TemplateCategory.BATCH,
     displayName = "GCS Spanner Data Validation",
     description =
-        "Batch pipeline that reads data from GCS and Spanner compares them to validate migration correctness.",
+        "Batch pipeline that reads data from GCS and Spanner compares them to validate migration"
+            + " correctness.",
     optionsClass = GCSSpannerDV.Options.class,
     flexContainerName = "gcs-spanner-dv",
     documentation =
@@ -136,7 +138,8 @@ public class GCSSpannerDV {
         order = 7,
         optional = true,
         description =
-            "Session File Path in Cloud Storage, to provide mapping information in the form of a session file",
+            "Session File Path in Cloud Storage, to provide mapping information in the form of a"
+                + " session file",
         helpText =
             "Session file path in Cloud Storage that contains mapping information from"
                 + " Spanner Migration Tool")
@@ -150,7 +153,8 @@ public class GCSSpannerDV {
         optional = true,
         description = "File based overrides from source to spanner",
         helpText =
-            "A file which specifies the table and the column name overrides from source to spanner.")
+            "A file which specifies the table and the column name overrides from source to"
+                + " spanner.")
     @Default.String("")
     String getSchemaOverridesFilePath();
 
@@ -164,9 +168,10 @@ public class GCSSpannerDV {
             "^\\[([[:space:]]*\\{[[:graph:]]+[[:space:]]*,[[:space:]]*[[:graph:]]+[[:space:]]*\\}[[:space:]]*(,[[:space:]]*)*)*\\]$",
         example = "[{Singers, Vocalists}, {Albums, Records}]",
         helpText =
-            "These are the table name overrides from source to spanner. They are written in the"
-                + "following format: [{SourceTableName1, SpannerTableName1}, {SourceTableName2, SpannerTableName2}]"
-                + "This example shows mapping Singers table to Vocalists and Albums table to Records.")
+            "These are the table name overrides from source to spanner. They are written in"
+                + " thefollowing format: [{SourceTableName1, SpannerTableName1}, {SourceTableName2,"
+                + " SpannerTableName2}]This example shows mapping Singers table to Vocalists and"
+                + " Albums table to Records.")
     @Default.String("")
     String getTableOverrides();
 
@@ -181,10 +186,13 @@ public class GCSSpannerDV {
         example =
             "[{Singers.SingerName, Singers.TalentName}, {Albums.AlbumName, Albums.RecordName}]",
         helpText =
-            "These are the column name overrides from source to spanner. They are written in the"
-                + "following format: [{SourceTableName1.SourceColumnName1, SourceTableName1.SpannerColumnName1}, {SourceTableName2.SourceColumnName1, SourceTableName2.SpannerColumnName1}]"
-                + "Note that the SourceTableName should remain the same in both the source and spanner pair. To override table names, use tableOverrides."
-                + "The example shows mapping SingerName to TalentName and AlbumName to RecordName in Singers and Albums table respectively.")
+            "These are the column name overrides from source to spanner. They are written in"
+                + " thefollowing format: [{SourceTableName1.SourceColumnName1,"
+                + " SourceTableName1.SpannerColumnName1}, {SourceTableName2.SourceColumnName1,"
+                + " SourceTableName2.SpannerColumnName1}]Note that the SourceTableName should"
+                + " remain the same in both the source and spanner pair. To override table names,"
+                + " use tableOverrides.The example shows mapping SingerName to TalentName and"
+                + " AlbumName to RecordName in Singers and Albums table respectively.")
     @Default.String("")
     String getColumnOverrides();
 
@@ -207,11 +215,48 @@ public class GCSSpannerDV {
         regexes = {"^[^ ;]*$"},
         description = "Run ID for the validation job",
         helpText =
-            "A unique identifier for the validation run. If not provided, the Dataflow Job Name will be used.",
+            "A unique identifier for the validation run. If not provided, the Dataflow Job Name"
+                + " will be used.",
         example = "run_20230101_120000")
     String getRunId();
 
     void setRunId(String value);
+
+    @TemplateParameter.GcsReadFile(
+        order = 13,
+        optional = true,
+        description = "Custom jar location in Cloud Storage",
+        helpText =
+            "Custom jar location in Cloud Storage that contains the custom transformation logic for"
+                + " processing records.")
+    @Default.String("")
+    String getTransformationJarPath();
+
+    void setTransformationJarPath(String value);
+
+    @TemplateParameter.Text(
+        order = 14,
+        optional = true,
+        description = "Custom class name",
+        helpText =
+            "Fully qualified class name having the custom transformation logic. It is a"
+                + " mandatory field in case transformationJarPath is specified")
+    @Default.String("")
+    String getTransformationClassName();
+
+    void setTransformationClassName(String value);
+
+    @TemplateParameter.Text(
+        order = 15,
+        optional = true,
+        description = "Custom parameters for transformation",
+        helpText =
+            "String containing any custom parameters to be passed to the custom transformation"
+                + " class.")
+    @Default.String("")
+    String getTransformationCustomParameters();
+
+    void setTransformationCustomParameters(String value);
   }
 
   public static void main(String[] args) {
@@ -241,12 +286,27 @@ public class GCSSpannerDV {
             options.getTableOverrides(),
             options.getColumnOverrides());
 
+    CustomTransformation customTransformation = null;
+    if (options.getTransformationJarPath() != null
+        && !options.getTransformationJarPath().isEmpty()
+        && options.getTransformationClassName() != null
+        && !options.getTransformationClassName().isEmpty()) {
+      customTransformation =
+          CustomTransformation.builder(
+                  options.getTransformationJarPath(), options.getTransformationClassName())
+              .setCustomParameters(options.getTransformationCustomParameters())
+              .build();
+    }
+
     // Get Source records hashes
     PCollection<ComparisonRecord> sourceRecords =
         pipeline.apply(
             "ReadSourceRecords",
             new SourceReaderTransform(
-                options.getGcsInputDirectory(), ddlView, schemaMapperProvider));
+                options.getGcsInputDirectory(),
+                ddlView,
+                schemaMapperProvider,
+                customTransformation));
 
     // Get Spanner records hashes
     PCollection<ComparisonRecord> spannerRecords =

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/transforms/SourceReaderTransform.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/transforms/SourceReaderTransform.java
@@ -21,6 +21,7 @@ import com.google.cloud.teleport.v2.dto.ComparisonRecord;
 import com.google.cloud.teleport.v2.fn.IdentityGenericRecordFn;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaMapper;
+import com.google.cloud.teleport.v2.spanner.migrations.transformation.CustomTransformation;
 import org.apache.beam.sdk.extensions.avro.io.AvroIO;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
@@ -36,14 +37,17 @@ public class SourceReaderTransform
   private final String gcsInputDirectory;
   private final PCollectionView<Ddl> ddlView;
   private final SerializableFunction<Ddl, ISchemaMapper> schemaMapperProvider;
+  private final CustomTransformation customTransformation;
 
   public SourceReaderTransform(
       String gcsInputDirectory,
       PCollectionView<Ddl> ddlView,
-      SerializableFunction<Ddl, ISchemaMapper> schemaMapperProvider) {
+      SerializableFunction<Ddl, ISchemaMapper> schemaMapperProvider,
+      CustomTransformation customTransformation) {
     this.gcsInputDirectory = gcsInputDirectory;
     this.ddlView = ddlView;
     this.schemaMapperProvider = schemaMapperProvider;
+    this.customTransformation = customTransformation;
   }
 
   @Override
@@ -57,7 +61,8 @@ public class SourceReaderTransform
                 .withHintMatchesManyFiles())
         .apply(
             "CalculateSourceRecordsHash",
-            ParDo.of(new SourceHashFn(ddlView, schemaMapperProvider)).withSideInputs(ddlView));
+            ParDo.of(new SourceHashFn(ddlView, schemaMapperProvider, customTransformation))
+                .withSideInputs(ddlView));
   }
 
   private static String createAvroFilePattern(String inputPath) {

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/dofn/SourceHashFnTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/dofn/SourceHashFnTest.java
@@ -112,7 +112,7 @@ public class SourceHashFnTest {
     when(table.primaryKeys()).thenReturn(ImmutableList.of(pkColumn));
 
     // Execute
-    SourceHashFn fn = new SourceHashFn(ddlView, schemaMapperProvider);
+    SourceHashFn fn = new SourceHashFn(ddlView, schemaMapperProvider, null);
     fn.processElement(context);
     fn.processElement(context);
 

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperBasicTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperBasicTest.java
@@ -281,4 +281,75 @@ public class ComparisonRecordMapperBasicTest {
     ComparisonRecord record = mapper.mapFrom(avroRecord);
     assertNotNull(record);
   }
+
+  @Test
+  public void testMapFromAvroRecord_WithCustomTransformation() throws Exception {
+    Schema payloadSchema = Schema.createRecord("Payload", null, "ns", false);
+    payloadSchema.setFields(
+        Arrays.asList(
+            new Schema.Field("id", Schema.create(Schema.Type.LONG), null, null),
+            new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null)));
+
+    Schema avroSchema = Schema.createRecord("SourceRow", null, "ns", false);
+    avroSchema.setFields(
+        Arrays.asList(
+            new Schema.Field("tableName", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("shardId", Schema.create(Schema.Type.STRING), null, null),
+            new Schema.Field("payload", payloadSchema, null, null)));
+
+    GenericRecord payload = new GenericData.Record(payloadSchema);
+    payload.put("id", 1L);
+    payload.put("name", "Alice");
+
+    GenericRecord avroRecord = new GenericData.Record(avroSchema);
+    avroRecord.put("tableName", "public.Users");
+    avroRecord.put("shardId", "shard1");
+    avroRecord.put("payload", payload);
+
+    String cleanTableName = "Users";
+    when(mockSchemaMapper.getSpannerTableName(anyString(), anyString())).thenReturn("public.Users");
+    when(mockSchemaMapper.getSpannerColumnName(anyString(), anyString(), anyString()))
+        .thenAnswer(invocation -> invocation.getArgument(2));
+
+    when(mockSchemaMapper.getDialect()).thenReturn(Dialect.GOOGLE_STANDARD_SQL);
+    when(mockSchemaMapper.getSpannerColumns(anyString(), anyString()))
+        .thenReturn(Arrays.asList("id", "name"));
+    when(mockSchemaMapper.getSourceColumnName(anyString(), anyString(), anyString()))
+        .thenAnswer(invocation -> invocation.getArgument(2));
+    when(mockSchemaMapper.getSpannerColumnType(
+            anyString(), anyString(), org.mockito.ArgumentMatchers.eq("id")))
+        .thenReturn(Type.int64());
+    when(mockSchemaMapper.getSpannerColumnType(
+            anyString(), anyString(), org.mockito.ArgumentMatchers.eq("name")))
+        .thenReturn(Type.string());
+    when(mockSchemaMapper.colExistsAtSource(anyString(), anyString(), anyString()))
+        .thenReturn(true);
+
+    Table mockTable = mock(Table.class);
+    when(mockDdl.table(cleanTableName)).thenReturn(mockTable);
+    IndexColumn pkCol = IndexColumn.create("id", IndexColumn.Order.ASC);
+    when(mockTable.primaryKeys()).thenReturn(com.google.common.collect.ImmutableList.of(pkCol));
+
+    MigrationTransformationResponse mockResponse = mock(MigrationTransformationResponse.class);
+    when(mockResponse.isEventFiltered()).thenReturn(false);
+
+    // Custom transformation modifies 'id' from 1L to 2L and keeps 'name' unmodified as 'Alice'
+    java.util.Map<String, Object> responseRow = new java.util.HashMap<>();
+    responseRow.put("id", 2L);
+    responseRow.put("name", "Alice");
+    when(mockResponse.getResponseRow()).thenReturn(responseRow);
+
+    when(mockTransformer.toSpannerRow(org.mockito.ArgumentMatchers.any())).thenReturn(mockResponse);
+
+    ComparisonRecord record = mapper.mapFrom(avroRecord);
+
+    assertNotNull(record);
+    assertEquals(cleanTableName, record.getTableName());
+    assertEquals("public", record.getSchemaName());
+
+    // Verify that the primary key value is indeed modified by the transformer (from 1 to 2)
+    assertEquals(1, record.getPrimaryKeyColumns().size());
+    assertEquals("id", record.getPrimaryKeyColumns().get(0).getColName());
+    assertEquals("2", record.getPrimaryKeyColumns().get(0).getColValue());
+  }
 }

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/transforms/SourceReaderTransformTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/transforms/SourceReaderTransformTest.java
@@ -80,7 +80,7 @@ public class SourceReaderTransformTest implements Serializable {
     // FileIO in beam support a variety of paths dynamically, such as GCS, S3 and TempFolder
     // This allows us to pass a tempFolder into the same transform that accepts a GCS path
     SourceReaderTransform transform =
-        new SourceReaderTransform(inputPath, ddlView, IdentityMapper::new);
+        new SourceReaderTransform(inputPath, ddlView, IdentityMapper::new, null);
 
     PCollection<ComparisonRecord> output = pipeline.apply(transform);
 
@@ -123,7 +123,7 @@ public class SourceReaderTransformTest implements Serializable {
     // 2. Run Pipeline with input path that has no avro files
     String inputPath = tempFolder.getRoot().getAbsolutePath();
     SourceReaderTransform transform =
-        new SourceReaderTransform(inputPath, ddlView, IdentityMapper::new);
+        new SourceReaderTransform(inputPath, ddlView, IdentityMapper::new, null);
 
     pipeline.apply(transform);
 
@@ -162,7 +162,7 @@ public class SourceReaderTransformTest implements Serializable {
     // 3. Run Pipeline
     String inputPath = tempFolder.getRoot().getAbsolutePath();
     SourceReaderTransform transform =
-        new SourceReaderTransform(inputPath, ddlView, IdentityMapper::new);
+        new SourceReaderTransform(inputPath, ddlView, IdentityMapper::new, null);
 
     pipeline.apply(transform);
 
@@ -204,7 +204,7 @@ public class SourceReaderTransformTest implements Serializable {
     // 3. Run Pipeline
     String inputPath = tempFolder.getRoot().getAbsolutePath();
     SourceReaderTransform transform =
-        new SourceReaderTransform(inputPath, ddlView, IdentityMapper::new);
+        new SourceReaderTransform(inputPath, ddlView, IdentityMapper::new, null);
 
     PCollection<ComparisonRecord> output = pipeline.apply(transform);
 


### PR DESCRIPTION
b/519845738 

Adds support for Custom Transformation in Data Validation pipeline. 

#### Follow up work:
- Handle exceptions/errors returned by Transformation gracefully (b/519845805)

#### Testing:
Built custom flex template and tested these cases:
1. Happy Path: Transformed Row at spanner was correctly validated with the original row at source
2. Data Mismatch: Corresponding Spanner row didn't have correctly transformed values - was flagged as a mismatch by validation pipeline
3. NULL Handling: NULL values in row handled correctly without throwing error
4. Filtered Rows: Row was dropped from Spanner after transformation, but the original row was NOT flagged with `MISSING_IN_DESTINATION` tag during validation
5. PK Transform: Transformed Row at spanner had a transformed Primary key value but was correctly validated with the original row at source
6. Data type casting: Transformation casted STRING to INT but validation pipeline was able handle this and compare the rows correctly. 

Note: Error scenario was also tested which crashed the pipeline - but since this requires a bigger effort, it's created as a follow up bug as mentioned above. 