### PR TITLE
Add postgres float 4 to pg dialect float4 support in bulk migration

### DIFF
--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroToValueMapper.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroToValueMapper.java
@@ -216,6 +216,9 @@ public class AvroToValueMapper {
         Type.pgFloat8(),
         (recordValue, fieldSchema) -> Value.float64(avroFieldToDouble(recordValue, fieldSchema)));
     pgFunctions.put(
+        Type.pgFloat4(),
+        (recordValue, fieldSchema) -> Value.float32(avroFieldToFloat32(recordValue, fieldSchema)));
+    pgFunctions.put(
         Type.pgVarchar(),
         (recordValue, fieldSchema) -> Value.string(avroFieldToString(recordValue, fieldSchema)));
     pgFunctions.put(


### PR DESCRIPTION
Add support for mapping `pgFloat4` type in bulk migrations targeting Spanner. This correctly maps Avro to value mapping.

---
*PR created automatically by Jules for task [9270526303072825437](https://jules.google.com/task/9270526303072825437) started by @sm745052*