### PR TITLE
Updates the job builder util package workflow to also publish a YAML provider listing

### DIFF
--- a/.github/workflows/upload-python-package.yml
+++ b/.github/workflows/upload-python-package.yml
@@ -29,6 +29,10 @@ on:
         required: false
         type: boolean
         default: false
+      date_override:
+        description: 'Optional date string to use instead of generating one'
+        required: false
+        type: string
 
 jobs:
   build-and-upload:
@@ -65,8 +69,9 @@ jobs:
           BUCKET_PATH: ${{ github.event.inputs.bucket_path }}
           VERSION: ${{ github.event.inputs.version }}
           ONLY_UPLOAD_LISTING: ${{ github.event.inputs.only_upload_listing }}
+          DATE_OVERRIDE: ${{ github.event.inputs.date_override }}
         run: |
-          DATE=$(date +'%Y-%m-%d')
+          DATE="${DATE_OVERRIDE:-$(date +'%Y-%m-%d')}"
           GCS_PACKAGE_PATH="$BUCKET_PATH/$DATE/job_builder_util_transforms-$VERSION.tar.gz"
           if [ "$ONLY_UPLOAD_LISTING" != "true" ]; then
             gcloud storage cp python/src/main/python/job-builder-util-transforms/dist/job_builder_util_transforms-*.tar.gz "$GCS_PACKAGE_PATH"

--- a/.github/workflows/upload-python-package.yml
+++ b/.github/workflows/upload-python-package.yml
@@ -5,7 +5,7 @@
 #   The workflow:
 #     1. Sets up Python and installs build dependencies.
 #     2. Builds the Python package (wheel and sdist).
-#     3. Uploads the built artifacts to a specified GCS bucket.
+#     3. Uploads the built artifacts and Beam YAML provider listing to a specified GCS bucket.
 #
 # How to Run:
 #   This workflow is triggered manually via GitHub Actions `workflow_dispatch`.
@@ -24,6 +24,11 @@ on:
       version:
         description: 'Version number for the package (e.g., 0.1.0)'
         required: true
+      only_upload_listing:
+        description: 'If true, skips uploading the Python package to GCS and only uploads the provider listing'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-and-upload:
@@ -59,6 +64,13 @@ jobs:
         env:
           BUCKET_PATH: ${{ github.event.inputs.bucket_path }}
           VERSION: ${{ github.event.inputs.version }}
+          ONLY_UPLOAD_LISTING: ${{ github.event.inputs.only_upload_listing }}
         run: |
           DATE=$(date +'%Y-%m-%d')
-          gcloud storage cp python/src/main/python/job-builder-util-transforms/dist/job_builder_util_transforms-*.tar.gz "$BUCKET_PATH/$DATE/job_builder_util_transforms-$VERSION.tar.gz"
+          GCS_PACKAGE_PATH="$BUCKET_PATH/$DATE/job_builder_util_transforms-$VERSION.tar.gz"
+          if [ "$ONLY_UPLOAD_LISTING" != "true" ]; then
+            gcloud storage cp python/src/main/python/job-builder-util-transforms/dist/job_builder_util_transforms-*.tar.gz "$GCS_PACKAGE_PATH"
+          fi
+          PACKAGE_PATH_NO_GS="${GCS_PACKAGE_PATH#gs://}"
+          sed "s|<package_path>|$PACKAGE_PATH_NO_GS|g" python/src/main/python/job-builder-util-transforms/provider_listing_template.yaml > "python/src/main/python/job-builder-util-transforms/yaml_provider_listing_$VERSION.yaml"
+          gcloud storage cp "python/src/main/python/job-builder-util-transforms/yaml_provider_listing_$VERSION.yaml" "$BUCKET_PATH/$DATE/yaml_provider_listing_$VERSION.yaml"

--- a/python/src/main/python/job-builder-util-transforms/provider_listing_template.yaml
+++ b/python/src/main/python/job-builder-util-transforms/provider_listing_template.yaml
@@ -1,0 +1,6 @@
+- type: pythonPackage
+  config:
+    packages:
+      - https://storage.googleapis.com/<package_path>
+  transforms:
+    CopyFilesToGCS: "copy_files_to_gcs.CopyFilesToGCS"


### PR DESCRIPTION
Updates the job builder util package workflow to also publish a YAML provider listing.

Also adds several new Github actions configs.
* only_upload_listing - can be used to perform corrections to the provider listing without regenerating the artifact.
* date_override - can be used to generate/regenerate the provider listing for old artifacts.