### PR TITLE
test: observe CI approval behavior (benign, will close)

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/Udf.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/Udf.java
@@ -219,3 +219,4 @@ public abstract class Udf implements Serializable {
     }
   }
 }
+// ci-permission-poc: benign no-op to observe fork-PR CI approval behavior; PR will be closed.


### PR DESCRIPTION
Benign no-op (single EOF comment) to observe fork-PR CI approval behavior for a first-time contributor. Will be closed immediately. No functional change.