### PR TITLE
Support correct YYYY-MM-DD formatting for MySQL DATE to Spanner STRING migration

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/rowmapper/provider/MysqlJdbcValueMappings.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/rowmapper/provider/MysqlJdbcValueMappings.java
@@ -89,8 +89,8 @@ public class MysqlJdbcValueMappings implements JdbcValueMappingsProvider {
    * Map {@link java.sql.Date} to <a href=https://avro.apache.org/docs/1.8.0/spec.html#Date>Date
    * LogicalType</a>.
    */
-  private static final ResultSetValueMapper<java.sql.Date> sqlDateToAvroTimestampMicros =
-      (value, schema) -> TimeUnit.DAYS.toMicros(value.toLocalDate().toEpochDay());
+  private static final ResultSetValueMapper<java.sql.Date> sqlDateToAvroDate =
+      (value, schema) -> (int) value.toLocalDate().toEpochDay();
 
   /** Map {@link java.sql.Timestamp} to {@link DateTime#SCHEMA} generic record. */
   private static final ResultSetValueMapper<java.sql.Timestamp> sqlTimestampToAvroDateTime =
@@ -229,7 +229,7 @@ public class MysqlJdbcValueMappings implements JdbcValueMappingsProvider {
            * binary data ref:
            * https://github.com/mysql/mysql-connector-j/blob/release/8.0/src/main/protocol-impl/java/com/mysql/cj/protocol/a/MysqlBinaryValueDecoder.java
            */
-          .put("DATE", utcDateExtractor, sqlDateToAvroTimestampMicros, 4)
+          .put("DATE", utcDateExtractor, sqlDateToAvroDate, 4)
           .put("DATETIME", utcTimeStampExtractor, sqlTimestampToAvroDateTime, 11)
           .put(
               "DECIMAL",

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/MysqlMappingProvider.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/MysqlMappingProvider.java
@@ -39,7 +39,7 @@ public final class MysqlMappingProvider {
           .put("BLOB", UnifiedMappingProvider.Type.STRING)
           .put("BOOL", UnifiedMappingProvider.Type.INTEGER)
           .put("CHAR", UnifiedMappingProvider.Type.STRING)
-          .put("DATE", UnifiedMappingProvider.Type.TIMESTAMP)
+          .put("DATE", UnifiedMappingProvider.Type.DATE)
           .put("DATETIME", UnifiedMappingProvider.Type.DATETIME)
           .put("DECIMAL", UnifiedMappingProvider.Type.DECIMAL)
           .put("DOUBLE", UnifiedMappingProvider.Type.DOUBLE)

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/rowmapper/JdbcSourceRowMapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/jdbc/rowmapper/JdbcSourceRowMapperTest.java
@@ -326,7 +326,7 @@ public class JdbcSourceRowMapperTest {
                 .derbyColumnType("DATE")
                 .sourceColumnType("DATE")
                 .inputValue(java.sql.Date.valueOf("2024-05-02"))
-                .mappedValue(java.sql.Date.valueOf("2024-05-02").getTime() * 1000)
+                .mappedValue((int) java.sql.Date.valueOf("2024-05-02").toLocalDate().toEpochDay())
                 .build())
         .add(
             Column.builder()

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/MysqlMappingProviderTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/reader/io/schema/typemapping/provider/MysqlMappingProviderTest.java
@@ -55,7 +55,7 @@ public class MysqlMappingProviderTest {
         .put("BLOB", "\"string\"")
         .put("BOOL", "\"int\"")
         .put("CHAR", "\"string\"")
-        .put("DATE", "{\"type\":\"long\",\"logicalType\":\"timestamp-micros\"}")
+        .put("DATE", "{\"type\":\"int\",\"logicalType\":\"date\"}")
         .put(
             "DATETIME",
             "{\"type\":\"record\","

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLDataTypesIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLDataTypesIT.java
@@ -195,10 +195,8 @@ public class MySQLDataTypesIT extends SourceDbToSpannerITBase {
     expectedData.put(
         "char", createRows("char", "a", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...", "NULL"));
     expectedData.put("date", createRows("date", "2012-09-17", "1000-01-01", "9999-12-31", "NULL"));
-    // date_to_string is commented out to avoid failing the test case; returned data has format
-    // "YYYY-MM-DDTHH:mm:SSZ" which is unexpected even if it's not necessarily incorrect
-    // expectedData.put("date_to_string", createRows("date_to_string", "2012-09-17", "1000-01-01",
-    // "9999-12-31", "NULL"));
+    expectedData.put(
+        "date_to_string", createRows("date_to_string", "2012-09-17", "1000-01-01", "9999-12-31", "NULL"));
     expectedData.put(
         "datetime",
         createRows(

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLDataTypesIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLDataTypesIT.java
@@ -196,7 +196,8 @@ public class MySQLDataTypesIT extends SourceDbToSpannerITBase {
         "char", createRows("char", "a", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...", "NULL"));
     expectedData.put("date", createRows("date", "2012-09-17", "1000-01-01", "9999-12-31", "NULL"));
     expectedData.put(
-        "date_to_string", createRows("date_to_string", "2012-09-17", "1000-01-01", "9999-12-31", "NULL"));
+        "date_to_string",
+        createRows("date_to_string", "2012-09-17", "1000-01-01", "9999-12-31", "NULL"));
     expectedData.put(
         "datetime",
         createRows(


### PR DESCRIPTION
This change updates the mapping of MySQL DATE columns to use the Avro date logical type (days since epoch) instead of timestamp-micros. This ensures that when migrating to Spanner GoogleSQL STRING columns, the values are correctly formatted as YYYY-MM-DD instead of full ISO timestamps. The date_to_string test case in MySQLDataTypesIT has also been re-enabled.

Fixes #3893

---
*PR created automatically by Jules for task [15180501333780523455](https://jules.google.com/task/15180501333780523455) started by @sm745052*