### PR TITLE
bump io.netty:netty-bom from 4.2.12.Final to 4.2.15.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <surefire.version>3.5.5</surefire.version>
     <testcontainers.version>1.21.4</testcontainers.version>
     <truth.version>1.4.5</truth.version>
-    <netty.version>4.2.12.Final</netty.version>
+    <netty.version>4.2.15.Final</netty.version>
     <zookeeper.version>3.9.5</zookeeper.version>
     <sqladmin-api.version>v1beta4-rev20240115-2.0.0</sqladmin-api.version>
 


### PR DESCRIPTION
Bump the netty version to address various transitive CVEs