### PR TITLE
Set watermark to range end_ts for latency improvement.

### DIFF
--- a/python/src/main/python/bigquery-anomaly-detection/src/bqmonitor/cdc.py
+++ b/python/src/main/python/bigquery-anomaly-detection/src/bqmonitor/cdc.py
@@ -519,7 +519,6 @@ class _PollChangeHistoryFn(beam.DoFn, beam.transforms.core.RestrictionProvider):
     Metrics.counter('BigQueryChangeHistory', 'polls').inc()
 
     watermark_estimator.advance_poll_cursor(end_ts)
-    watermark_estimator.set_watermark(start_ts)
     _LOGGER.info(
         '[Poll] Watermark=%s (start_ts), cursor=%s (end_ts)',
         _utc(start_ts),
@@ -528,6 +527,7 @@ class _PollChangeHistoryFn(beam.DoFn, beam.transforms.core.RestrictionProvider):
     for chunk_start, chunk_end in ranges:
       yield TimestampedValue(
           _QueryRange(chunk_start=chunk_start, chunk_end=chunk_end), start_ts)
+    watermark_estimator.set_watermark(end_ts)
 
   @beam.DoFn.unbounded_per_element()
   def process(


### PR DESCRIPTION
Previous watermark was held back to the start of the query range which was overly conservative and causing data to be delayed by poll_duration.