### PR TITLE
refactor(spanner-to-sourcedb): complete reverse replication source se…

### DIFF
--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
@@ -691,8 +691,6 @@ public class SpannerToSourceDb {
     return pipeline.run();
   }
 
-
-
   static void buildPipeline(
       Pipeline pipeline,
       Options options,
@@ -948,8 +946,6 @@ public class SpannerToSourceDb {
                 .build());
   }
 
-
-
   public static SpannerIO.ReadChangeStream getReadChangeStreamDoFn(
       Options options, SpannerConfig spannerConfig) {
 
@@ -997,8 +993,6 @@ public class SpannerToSourceDb {
     options.setDeadLetterQueueDirectory(dlqDirectory);
     return DeadLetterQueueManager.create(dlqDirectory, options.getDlqMaxRetryCount(), true);
   }
-
-
 
   static int calculateConnectionPoolSizePerWorker(Long maxShardConnections, int maxNumWorkers) {
     int connectionPoolSizePerWorker = (int) (maxShardConnections / maxNumWorkers);

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
@@ -15,17 +15,10 @@
  */
 package com.google.cloud.teleport.v2.templates;
 
-import static com.google.cloud.teleport.v2.spanner.migrations.constants.Constants.CASSANDRA_SOURCE_TYPE;
-import static com.google.cloud.teleport.v2.spanner.migrations.constants.Constants.MYSQL_SOURCE_TYPE;
-import static com.google.cloud.teleport.v2.spanner.migrations.constants.Constants.POSTGRES_SOURCE_TYPE;
 import static com.google.cloud.teleport.v2.spanner.migrations.constants.Constants.RUN_MODE_REGULAR;
 import static com.google.cloud.teleport.v2.spanner.migrations.constants.Constants.RUN_MODE_RETRY_ALL_DLQ;
 import static com.google.cloud.teleport.v2.spanner.migrations.constants.Constants.RUN_MODE_RETRY_DLQ;
-import static com.google.cloud.teleport.v2.spanner.migrations.constants.Constants.SPANNER_SOURCE_TYPE;
 
-import com.datastax.oss.driver.api.core.CqlSession;
-import com.datastax.oss.driver.api.core.CqlSessionBuilder;
-import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Options.RpcPriority;
 import com.google.cloud.teleport.metadata.Template;
@@ -40,28 +33,15 @@ import com.google.cloud.teleport.v2.common.CommonTemplateJvmInitializer;
 import com.google.cloud.teleport.v2.common.UncaughtExceptionLogger;
 import com.google.cloud.teleport.v2.options.CommonTemplateOptions;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
-import com.google.cloud.teleport.v2.spanner.migrations.shard.CassandraShard;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
-import com.google.cloud.teleport.v2.spanner.migrations.shard.SpannerShard;
-import com.google.cloud.teleport.v2.spanner.migrations.source.config.CassandraConnectionConfig;
-import com.google.cloud.teleport.v2.spanner.migrations.source.config.JdbcShardConfig;
-import com.google.cloud.teleport.v2.spanner.migrations.source.config.SourceConfigParser;
-import com.google.cloud.teleport.v2.spanner.migrations.source.config.SourceConnectionConfig;
 import com.google.cloud.teleport.v2.spanner.migrations.transformation.CustomTransformation;
-import com.google.cloud.teleport.v2.spanner.migrations.utils.CassandraConfigFileReader;
-import com.google.cloud.teleport.v2.spanner.migrations.utils.CassandraDriverConfigLoader;
 import com.google.cloud.teleport.v2.spanner.migrations.utils.DataflowWorkerMachineTypeUtils;
-import com.google.cloud.teleport.v2.spanner.migrations.utils.ISecretManagerAccessor;
-import com.google.cloud.teleport.v2.spanner.migrations.utils.SecretManagerAccessorImpl;
-import com.google.cloud.teleport.v2.spanner.migrations.utils.SpannerShardFileReader;
-import com.google.cloud.teleport.v2.spanner.sourceddl.CassandraInformationSchemaScanner;
-import com.google.cloud.teleport.v2.spanner.sourceddl.MySqlInformationSchemaScanner;
-import com.google.cloud.teleport.v2.spanner.sourceddl.PostgreSQLInformationSchemaScanner;
 import com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema;
-import com.google.cloud.teleport.v2.spanner.sourceddl.SpannerInformationSchemaScanner;
 import com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options;
 import com.google.cloud.teleport.v2.templates.changestream.TrimmedShardedDataChangeRecord;
 import com.google.cloud.teleport.v2.templates.constants.Constants;
+import com.google.cloud.teleport.v2.templates.dbutils.processor.ISourceConnector;
+import com.google.cloud.teleport.v2.templates.dbutils.processor.SourceProcessorFactory;
 import com.google.cloud.teleport.v2.templates.transforms.AssignShardIdFn;
 import com.google.cloud.teleport.v2.templates.transforms.ConvertChangeStreamErrorRecordToFailsafeElementFn;
 import com.google.cloud.teleport.v2.templates.transforms.ConvertDlqRecordToTrimmedShardedDataChangeRecordFn;
@@ -72,14 +52,7 @@ import com.google.cloud.teleport.v2.templates.transforms.SpannerInformationSchem
 import com.google.cloud.teleport.v2.templates.transforms.UpdateDlqMetricsFn;
 import com.google.cloud.teleport.v2.transforms.DLQWriteTransform;
 import com.google.cloud.teleport.v2.values.FailsafeElement;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -664,31 +637,31 @@ public class SpannerToSourceDb {
             .apply("View Shadow DDL", View.asSingleton());
 
     List<Shard> shards;
-    if (SPANNER_SOURCE_TYPE.equals(options.getSourceType())) {
-      SpannerShardFileReader spannerShardFileReader = new SpannerShardFileReader();
-      shards = spannerShardFileReader.getSpannerShards(options.getSourceShardsFilePath());
-    } else {
-      shards = getShardList(options.getSourceType(), options.getSourceShardsFilePath());
+    ISourceConnector sourceConnector;
+    try {
+      sourceConnector = SourceProcessorFactory.getSource(options.getSourceType());
+      shards = sourceConnector.parseShardList(options.getSourceShardsFilePath());
+    } catch (Exception e) {
+      throw new RuntimeException("Error parsing shard list", e);
     }
 
-    // cassandra and spanner are always a single sharded migration.
-    // for JDBC, shards size and IsShardedMigration option is used below.
     String shardingMode =
-        (options.getSourceType().equals(CASSANDRA_SOURCE_TYPE)
-                || options.getSourceType().equals(SPANNER_SOURCE_TYPE))
-            ? Constants.SHARDING_MODE_SINGLE_SHARD
-            : Constants.SHARDING_MODE_MULTI_SHARD;
+        sourceConnector.isMultiSharded()
+            ? Constants.SHARDING_MODE_MULTI_SHARD
+            : Constants.SHARDING_MODE_SINGLE_SHARD;
 
-    if (SPANNER_SOURCE_TYPE.equals(options.getSourceType())) {
-      LOG.info("Spanner target shard config: {}", shards.get(0));
-      validateSpannerColocation(options, (SpannerShard) shards.get(0));
+    try {
+      sourceConnector.validate(shards, options);
+    } catch (Exception e) {
+      throw new RuntimeException("Validation failed", e);
     }
 
-    if (MYSQL_SOURCE_TYPE.equals(options.getSourceType())) {
-      validateMySQLNotReadOnly(shards);
+    SourceSchema sourceSchema;
+    try {
+      sourceSchema = sourceConnector.getInformationSchema(shards);
+    } catch (Exception e) {
+      throw new RuntimeException("Error fetching source schema", e);
     }
-
-    SourceSchema sourceSchema = fetchSourceSchema(options, shards);
     LOG.info("Source schema: {}", sourceSchema);
 
     if (shards.size() == 1 && !options.getIsShardedMigration()) {
@@ -718,14 +691,7 @@ public class SpannerToSourceDb {
     return pipeline.run();
   }
 
-  static void validateSpannerColocation(Options options, SpannerShard spannerShard) {
-    if (!options.getSpannerProjectId().equals(spannerShard.getProjectId())
-        || !options.getMetadataInstance().equals(spannerShard.getInstanceId())
-        || !options.getMetadataDatabase().equals(spannerShard.getDatabaseId())) {
-      throw new IllegalArgumentException(
-          "For Cloud Spanner target, the metadata database and target database must be the same to ensure atomic operations.");
-    }
-  }
+
 
   static void buildPipeline(
       Pipeline pipeline,
@@ -982,52 +948,7 @@ public class SpannerToSourceDb {
                 .build());
   }
 
-  /**
-   * Returns a list of shards based on the source type and source shards file path. This should be
-   * removed in Phase 2 of Standardizing config.
-   *
-   * @param sourceType The type of the source database.
-   * @param sourceShardsFilePath The GCS path to the source shards configuration file.
-   * @return A list of shards.
-   */
-  public static List<Shard> getShardList(String sourceType, String sourceShardsFilePath) {
-    ISecretManagerAccessor secretManagerAccessor = new SecretManagerAccessorImpl();
-    SourceConfigParser sourceConfigParser = new SourceConfigParser(secretManagerAccessor);
-    SourceConnectionConfig sourceConnectionConfig;
-    try {
-      // Parse the source shards configuration file to respective
-      // SourceConnectionConfig.
-      sourceConnectionConfig =
-          sourceConfigParser.parseConfiguration(sourceType, sourceShardsFilePath);
-    } catch (Exception e) {
-      LOG.error("Error parsing source config", e);
-      throw new RuntimeException("Error parsing source config", e);
-    }
-    List<Shard> shards;
-    if (sourceConnectionConfig instanceof JdbcShardConfig) {
-      shards = ((JdbcShardConfig) sourceConnectionConfig).getShardConfigs();
-      LOG.info("JDBC shard config is parsed.");
-    } else if (sourceConnectionConfig instanceof CassandraConnectionConfig) {
-      CassandraConfigFileReader cassandraConfigFileReader = new CassandraConfigFileReader();
-      shards =
-          cassandraConfigFileReader.getCassandraShard(
-              ((CassandraConnectionConfig) sourceConnectionConfig).getOptionsMap());
-      LOG.info("Cassandra shard config is parsed.");
-    } else {
-      String errorMessage =
-          "Invalid source config for source type: "
-              + sourceType
-              + ". Source config parsed to: "
-              + sourceConnectionConfig.getClass()
-              + ". Source config file path: "
-              + sourceShardsFilePath;
-      LOG.error(errorMessage);
-      throw new RuntimeException(errorMessage);
-    }
-    Preconditions.checkArgument(
-        shards != null && !shards.isEmpty(), "Shard list should have at least 1 element.");
-    return shards;
-  }
+
 
   public static SpannerIO.ReadChangeStream getReadChangeStreamDoFn(
       Options options, SpannerConfig spannerConfig) {
@@ -1077,104 +998,7 @@ public class SpannerToSourceDb {
     return DeadLetterQueueManager.create(dlqDirectory, options.getDlqMaxRetryCount(), true);
   }
 
-  static Connection createJdbcConnection(
-      Shard shard, String driverClassName, String jdbcUrlPrefix) {
-    try {
-      String sourceConnectionUrl =
-          new StringBuilder()
-              .append(jdbcUrlPrefix)
-              .append(shard.getHost())
-              .append(":")
-              .append(shard.getPort())
-              .append("/")
-              .append(shard.getDbName())
-              .toString();
-      HikariConfig config = new HikariConfig();
-      config.setJdbcUrl(sourceConnectionUrl);
-      config.setUsername(shard.getUserName());
-      config.setPassword(shard.getPassword());
-      config.setDriverClassName(driverClassName);
-      HikariDataSource ds = new HikariDataSource(config);
-      return ds.getConnection();
-    } catch (java.sql.SQLException e) {
-      LOG.error("Sql error while discovering jdbc schema: {}", e);
-      throw new RuntimeException(e);
-    }
-  }
 
-  /**
-   * Creates a {@link CqlSession} for the given {@link CassandraShard}.
-   *
-   * @param cassandraShard The shard containing connection details.
-   * @return A {@link CqlSession} instance.
-   */
-  static CqlSession createCqlSession(CassandraShard cassandraShard) {
-    CqlSessionBuilder builder = CqlSession.builder();
-    DriverConfigLoader configLoader =
-        CassandraDriverConfigLoader.fromOptionsMap(cassandraShard.getOptionsMap());
-    builder.withConfigLoader(configLoader);
-    return builder.build();
-  }
-
-  static void validateMySQLNotReadOnly(List<Shard> shards) {
-    for (Shard shard : shards) {
-      try (Connection conn = createJdbcConnection(shard, MYSQL_DRIVER, MYSQL_JDBC_PREFIX)) {
-        if (conn != null) {
-          try (Statement stmt = conn.createStatement();
-              ResultSet rs = stmt.executeQuery("SELECT @@read_only")) {
-            if (rs != null && rs.next() && rs.getInt(1) == 1) {
-              throw new RuntimeException(
-                  "MySQL destination is in read-only mode for shard: " + shard.getLogicalShardId());
-            }
-          }
-        }
-      } catch (SQLException e) {
-        LOG.error(
-            "Error checking MySQL read-only status for shard {}: {}",
-            shard.getLogicalShardId(),
-            e.getMessage());
-        throw new RuntimeException("Error checking MySQL read-only status", e);
-      }
-    }
-  }
-
-  static SourceSchema fetchSourceSchema(Options options, List<Shard> shards) {
-    try {
-      return getSourceSchema(options, shards);
-    } catch (SQLException e) {
-      throw new RuntimeException("Unable to discover jdbc schema", e);
-    }
-  }
-
-  static SourceSchema getSourceSchema(Options options, List<Shard> shards) throws SQLException {
-    if (options.getSourceType().equals(MYSQL_SOURCE_TYPE)) {
-      try (Connection connection =
-          createJdbcConnection(shards.get(0), MYSQL_DRIVER, MYSQL_JDBC_PREFIX)) {
-        return new MySqlInformationSchemaScanner(connection, shards.get(0).getDbName()).scan();
-      }
-    } else if (options.getSourceType().equals(POSTGRES_SOURCE_TYPE)) {
-      try (Connection connection =
-          createJdbcConnection(shards.get(0), POSTGRESQL_DRIVER, POSTGRESQL_JDBC_PREFIX)) {
-        return new PostgreSQLInformationSchemaScanner(
-                connection, shards.get(0).getDbName(), shards.get(0).getNamespace())
-            .scan();
-      }
-    } else if (options.getSourceType().equals(SPANNER_SOURCE_TYPE)) {
-      SpannerShard spannerShard = (SpannerShard) shards.get(0);
-      SpannerConfig targetSpannerConfig =
-          SpannerConfig.create()
-              .withProjectId(spannerShard.getProjectId())
-              .withInstanceId(spannerShard.getInstanceId())
-              .withDatabaseId(spannerShard.getDatabaseId());
-      return new SpannerInformationSchemaScanner(targetSpannerConfig).scan();
-    } else {
-      try (CqlSession session = createCqlSession((CassandraShard) shards.get(0))) {
-        return new CassandraInformationSchemaScanner(
-                session, ((CassandraShard) shards.get(0)).getKeySpaceName())
-            .scan();
-      }
-    }
-  }
 
   static int calculateConnectionPoolSizePerWorker(Long maxShardConnections, int maxNumWorkers) {
     int connectionPoolSizePerWorker = (int) (maxShardConnections / maxNumWorkers);

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
@@ -640,13 +640,13 @@ public class SpannerToSourceDb {
     ISourceConnector sourceConnector;
     try {
       sourceConnector = SourceProcessorFactory.getSource(options.getSourceType());
-      shards = sourceConnector.parseShardList(options.getSourceShardsFilePath());
+      shards = sourceConnector.parseShardConfig(options.getSourceShardsFilePath());
     } catch (Exception e) {
       throw new RuntimeException("Error parsing shard list", e);
     }
 
     String shardingMode =
-        sourceConnector.isMultiSharded()
+        sourceConnector.supportsSharding()
             ? Constants.SHARDING_MODE_MULTI_SHARD
             : Constants.SHARDING_MODE_SINGLE_SHARD;
 

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb.java
@@ -645,6 +645,11 @@ public class SpannerToSourceDb {
       throw new RuntimeException("Error parsing shard list", e);
     }
 
+    if (shards == null || shards.isEmpty()) {
+      LOG.error("Shard list should have at least 1 element.");
+      throw new IllegalArgumentException("Shard list should have at least 1 element.");
+    }
+
     String shardingMode =
         sourceConnector.supportsSharding()
             ? Constants.SHARDING_MODE_MULTI_SHARD

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/processor/ISourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/processor/ISourceConnector.java
@@ -109,9 +109,9 @@ public interface ISourceConnector {
   /**
    * Classifies a dialect-specific exception into retryable or permanent.
    *
-   * @param exception The exception to classify.
+   * @param cause The cause to classify.
    * @return The TupleTag (Constants.PERMANENT_ERROR_TAG or Constants.RETRYABLE_ERROR_TAG) if
    *     classified, or null to fallback to general classification.
    */
-  org.apache.beam.sdk.values.TupleTag<String> classifyException(Exception exception);
+  org.apache.beam.sdk.values.TupleTag<String> classifyException(Throwable cause);
 }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/processor/ISourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/processor/ISourceConnector.java
@@ -17,9 +17,11 @@ package com.google.cloud.teleport.v2.templates.dbutils.processor;
 
 import com.google.cloud.teleport.v2.spanner.migrations.connection.IConnectionHelper;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
+import com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema;
 import com.google.cloud.teleport.v2.templates.dbutils.dao.source.IDao;
 import com.google.cloud.teleport.v2.templates.dbutils.dml.IDMLGenerator;
 import java.util.List;
+import org.apache.beam.sdk.options.PipelineOptions;
 
 /**
  * Interface representing a connector to the external source/destination database (e.g., MySQL,
@@ -68,4 +70,55 @@ public interface ISourceConnector {
    * @param maxConnections The maximum number of connections allowed in the pool.
    */
   void initConnectionHelper(List<Shard> shards, int maxConnections);
+
+  /**
+   * Parses the shard configuration file to a list of shards.
+   *
+   * @param shardFilePath The GCS path to the shard configuration file.
+   * @return A list of Shards.
+   * @throws Exception If parsing fails.
+   */
+  List<Shard> parseShardList(String shardFilePath) throws Exception;
+
+  /**
+   * Validates the shards and pipeline options.
+   *
+   * @param shards The list of shards to validate.
+   * @param options The pipeline options.
+   * @throws Exception If validation fails.
+   */
+  void validate(List<Shard> shards, PipelineOptions options) throws Exception;
+
+  /**
+   * Scans the source/destination database to retrieve its information schema.
+   *
+   * @param shards The list of shards.
+   * @return The SourceSchema.
+   * @throws Exception If scanning fails.
+   */
+  SourceSchema getInformationSchema(List<Shard> shards) throws Exception;
+
+  /**
+   * Returns whether this source supports multi-sharded migrations.
+   *
+   * @return True if multi-sharded, false otherwise.
+   */
+  boolean isMultiSharded();
+
+  /**
+   * Returns whether the pipeline should update the Spanner record with values read from Spanner
+   * during stale reads (e.g. for DELETE events).
+   *
+   * @return True if it should update, false otherwise.
+   */
+  boolean shouldUpdateReadValuesToSpannerRecord();
+
+  /**
+   * Classifies a dialect-specific exception into retryable or permanent.
+   *
+   * @param exception The exception to classify.
+   * @return The TupleTag (Constants.PERMANENT_ERROR_TAG or Constants.RETRYABLE_ERROR_TAG) if
+   *     classified, or null to fallback to general classification.
+   */
+  org.apache.beam.sdk.values.TupleTag<String> classifyException(Exception exception);
 }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/processor/ISourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/processor/ISourceConnector.java
@@ -48,14 +48,6 @@ public interface ISourceConnector {
   IConnectionHelper getConnectionHelper();
 
   /**
-   * Constructs and returns the JDBC or connection URL for a given shard.
-   *
-   * @param shard The shard configuration containing host, port, and database name.
-   * @return The connection URL string.
-   */
-  String getConnectionUrl(Shard shard);
-
-  /**
    * Returns a dialect-specific Data Access Object (DAO) for a given shard.
    *
    * @param shard The shard configuration to initialize the DAO with.
@@ -78,7 +70,7 @@ public interface ISourceConnector {
    * @return A list of Shards.
    * @throws Exception If parsing fails.
    */
-  List<Shard> parseShardList(String shardFilePath) throws Exception;
+  List<Shard> parseShardConfig(String shardFilePath) throws Exception;
 
   /**
    * Validates the shards and pipeline options.
@@ -99,15 +91,16 @@ public interface ISourceConnector {
   SourceSchema getInformationSchema(List<Shard> shards) throws Exception;
 
   /**
-   * Returns whether this source supports multi-sharded migrations.
+   * Returns whether this source supports sharded migrations.
    *
-   * @return True if multi-sharded, false otherwise.
+   * @return True if supports sharding, false otherwise.
    */
-  boolean isMultiSharded();
+  boolean supportsSharding();
 
   /**
    * Returns whether the pipeline should update the Spanner record with values read from Spanner
-   * during stale reads (e.g. for DELETE events).
+   * during stale reads (e.g. for DELETE events). //TODO this flag is only required by cassandra. We
+   * should look for a way to remove it
    *
    * @return True if it should update, false otherwise.
    */

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraConnectionHelper.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraConnectionHelper.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.teleport.v2.templates.dbutils.connection;
+package com.google.cloud.teleport.v2.templates.source.cassandra;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.CqlSessionBuilder;

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraDao.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraDao.java
@@ -13,16 +13,17 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.teleport.v2.templates.dbutils.dao.source;
+package com.google.cloud.teleport.v2.templates.source.cassandra;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.google.cloud.teleport.v2.spanner.migrations.connection.IConnectionHelper;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.ConnectionException;
+import com.google.cloud.teleport.v2.templates.dbutils.dao.source.IDao;
+import com.google.cloud.teleport.v2.templates.dbutils.dao.source.TransactionalCheck;
 import com.google.cloud.teleport.v2.templates.models.DMLGeneratorResponse;
 import com.google.cloud.teleport.v2.templates.models.PreparedStatementGeneratedResponse;
-import com.google.cloud.teleport.v2.templates.source.cassandra.CassandraTypeHandler;
 
 public class CassandraDao implements IDao<DMLGeneratorResponse> {
   private final String cassandraUrl;

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnector.java
@@ -116,6 +116,7 @@ public class CassandraSourceConnector implements ISourceConnector {
       throw new IllegalArgumentException(
           "Expected CassandraShard but got: " + shards.get(0).getClass());
     }
+    //TODO Check for valid connection as well
   }
 
   @Override

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnector.java
@@ -116,7 +116,7 @@ public class CassandraSourceConnector implements ISourceConnector {
       throw new IllegalArgumentException(
           "Expected CassandraShard but got: " + shards.get(0).getClass());
     }
-    //TODO Check for valid connection as well
+    // TODO Check for valid connection as well
   }
 
   @Override

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnector.java
@@ -62,9 +62,14 @@ public class CassandraSourceConnector implements ISourceConnector {
   }
 
   String getConnectionUrl(Shard shard) {
-    // Cassandra does not use a simple connection URL string in the same way as JDBC,
-    // but we can return a identifier or host info.
-    return shard.getHost() + ":" + shard.getPort();
+    CassandraShard cassandraShard = (CassandraShard) shard;
+    return cassandraShard.getHost()
+        + ":"
+        + cassandraShard.getPort()
+        + "/"
+        + cassandraShard.getUserName()
+        + "/"
+        + cassandraShard.getKeySpaceName();
   }
 
   @Override
@@ -76,7 +81,7 @@ public class CassandraSourceConnector implements ISourceConnector {
   public void initConnectionHelper(List<Shard> shards, int maxConnections) {
     if (!connectionHelper.isConnectionPoolInitialized()) {
       ConnectionHelperRequest request =
-          new ConnectionHelperRequest(shards, null, maxConnections, null, null, null);
+          new ConnectionHelperRequest(shards, null, maxConnections, "com.datastax.oss.driver.api.core.CqlSession", null, null);
       connectionHelper.init(request);
     }
   }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnector.java
@@ -81,7 +81,13 @@ public class CassandraSourceConnector implements ISourceConnector {
   public void initConnectionHelper(List<Shard> shards, int maxConnections) {
     if (!connectionHelper.isConnectionPoolInitialized()) {
       ConnectionHelperRequest request =
-          new ConnectionHelperRequest(shards, null, maxConnections, "com.datastax.oss.driver.api.core.CqlSession", null, null);
+          new ConnectionHelperRequest(
+              shards,
+              null,
+              maxConnections,
+              "com.datastax.oss.driver.api.core.CqlSession",
+              null,
+              null);
       connectionHelper.init(request);
     }
   }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnector.java
@@ -61,8 +61,7 @@ public class CassandraSourceConnector implements ISourceConnector {
     return connectionHelper;
   }
 
-  @Override
-  public String getConnectionUrl(Shard shard) {
+  String getConnectionUrl(Shard shard) {
     // Cassandra does not use a simple connection URL string in the same way as JDBC,
     // but we can return a identifier or host info.
     return shard.getHost() + ":" + shard.getPort();
@@ -83,7 +82,7 @@ public class CassandraSourceConnector implements ISourceConnector {
   }
 
   @Override
-  public List<Shard> parseShardList(String shardFilePath) throws Exception {
+  public List<Shard> parseShardConfig(String shardFilePath) throws Exception {
     ISecretManagerAccessor secretManagerAccessor = new SecretManagerAccessorImpl();
     SourceConfigParser sourceConfigParser = new SourceConfigParser(secretManagerAccessor);
     SourceConnectionConfig sourceConnectionConfig =
@@ -127,7 +126,7 @@ public class CassandraSourceConnector implements ISourceConnector {
   }
 
   @Override
-  public boolean isMultiSharded() {
+  public boolean supportsSharding() {
     return false;
   }
 

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnector.java
@@ -76,7 +76,8 @@ public class CassandraSourceConnector implements ISourceConnector {
   @Override
   public void initConnectionHelper(List<Shard> shards, int maxConnections) {
     if (!connectionHelper.isConnectionPoolInitialized()) {
-      ConnectionHelperRequest request = new ConnectionHelperRequest(shards, null, maxConnections, null, null, null);
+      ConnectionHelperRequest request =
+          new ConnectionHelperRequest(shards, null, maxConnections, null, null, null);
       connectionHelper.init(request);
     }
   }
@@ -111,8 +112,7 @@ public class CassandraSourceConnector implements ISourceConnector {
   public SourceSchema getInformationSchema(List<Shard> shards) throws Exception {
     CassandraShard cassandraShard = (CassandraShard) shards.get(0);
     try (CqlSession session = createCqlSession(cassandraShard)) {
-      return new CassandraInformationSchemaScanner(
-              session, cassandraShard.getKeySpaceName())
+      return new CassandraInformationSchemaScanner(session, cassandraShard.getKeySpaceName())
           .scan();
     }
   }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnector.java
@@ -147,8 +147,7 @@ public class CassandraSourceConnector implements ISourceConnector {
   }
 
   @Override
-  public org.apache.beam.sdk.values.TupleTag<String> classifyException(Exception exception) {
-    Throwable cause = exception.getCause();
+  public org.apache.beam.sdk.values.TupleTag<String> classifyException(Throwable cause) {
     if (cause instanceof com.datastax.oss.driver.api.core.type.codec.CodecNotFoundException) {
       return com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG;
     }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnector.java
@@ -15,17 +15,28 @@
  */
 package com.google.cloud.teleport.v2.templates.source.cassandra;
 
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.google.cloud.teleport.v2.spanner.migrations.connection.ConnectionHelperRequest;
 import com.google.cloud.teleport.v2.spanner.migrations.connection.IConnectionHelper;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.CassandraShard;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
-import com.google.cloud.teleport.v2.templates.dbutils.connection.CassandraConnectionHelper;
-import com.google.cloud.teleport.v2.templates.dbutils.dao.source.CassandraDao;
+import com.google.cloud.teleport.v2.spanner.migrations.source.config.CassandraConnectionConfig;
+import com.google.cloud.teleport.v2.spanner.migrations.source.config.SourceConfigParser;
+import com.google.cloud.teleport.v2.spanner.migrations.source.config.SourceConnectionConfig;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.CassandraConfigFileReader;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.CassandraDriverConfigLoader;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.ISecretManagerAccessor;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.SecretManagerAccessorImpl;
+import com.google.cloud.teleport.v2.spanner.sourceddl.CassandraInformationSchemaScanner;
+import com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema;
 import com.google.cloud.teleport.v2.templates.dbutils.dao.source.IDao;
 import com.google.cloud.teleport.v2.templates.dbutils.dml.IDMLGenerator;
 import com.google.cloud.teleport.v2.templates.dbutils.processor.ISourceConnector;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
+import org.apache.beam.sdk.options.PipelineOptions;
 
 public class CassandraSourceConnector implements ISourceConnector {
 
@@ -52,14 +63,9 @@ public class CassandraSourceConnector implements ISourceConnector {
 
   @Override
   public String getConnectionUrl(Shard shard) {
-    CassandraShard cassandraShard = (CassandraShard) shard;
-    return cassandraShard.getHost()
-        + ":"
-        + cassandraShard.getPort()
-        + "/"
-        + cassandraShard.getUserName()
-        + "/"
-        + cassandraShard.getKeySpaceName();
+    // Cassandra does not use a simple connection URL string in the same way as JDBC,
+    // but we can return a identifier or host info.
+    return shard.getHost() + ":" + shard.getPort();
   }
 
   @Override
@@ -70,15 +76,72 @@ public class CassandraSourceConnector implements ISourceConnector {
   @Override
   public void initConnectionHelper(List<Shard> shards, int maxConnections) {
     if (!connectionHelper.isConnectionPoolInitialized()) {
-      ConnectionHelperRequest request =
-          new ConnectionHelperRequest(
-              shards,
-              null,
-              maxConnections,
-              "com.datastax.oss.driver.api.core.CqlSession",
-              null,
-              null);
+      ConnectionHelperRequest request = new ConnectionHelperRequest(shards, null, maxConnections, null, null, null);
       connectionHelper.init(request);
     }
+  }
+
+  @Override
+  public List<Shard> parseShardList(String shardFilePath) throws Exception {
+    ISecretManagerAccessor secretManagerAccessor = new SecretManagerAccessorImpl();
+    SourceConfigParser sourceConfigParser = new SourceConfigParser(secretManagerAccessor);
+    SourceConnectionConfig sourceConnectionConfig =
+        sourceConfigParser.parseConfiguration("cassandra", shardFilePath);
+    if (sourceConnectionConfig instanceof CassandraConnectionConfig) {
+      CassandraConfigFileReader cassandraConfigFileReader = new CassandraConfigFileReader();
+      return cassandraConfigFileReader.getCassandraShard(
+          ((CassandraConnectionConfig) sourceConnectionConfig).getOptionsMap());
+    }
+    throw new IllegalArgumentException(
+        "Expected CassandraConnectionConfig but got: " + sourceConnectionConfig.getClass());
+  }
+
+  @Override
+  public void validate(List<Shard> shards, PipelineOptions options) throws Exception {
+    if (shards.size() != 1) {
+      throw new IllegalArgumentException("Cassandra migration must have exactly 1 shard.");
+    }
+    if (!(shards.get(0) instanceof CassandraShard)) {
+      throw new IllegalArgumentException(
+          "Expected CassandraShard but got: " + shards.get(0).getClass());
+    }
+  }
+
+  @Override
+  public SourceSchema getInformationSchema(List<Shard> shards) throws Exception {
+    CassandraShard cassandraShard = (CassandraShard) shards.get(0);
+    try (CqlSession session = createCqlSession(cassandraShard)) {
+      return new CassandraInformationSchemaScanner(
+              session, cassandraShard.getKeySpaceName())
+          .scan();
+    }
+  }
+
+  @VisibleForTesting
+  CqlSession createCqlSession(CassandraShard cassandraShard) {
+    CqlSessionBuilder builder = CqlSession.builder();
+    DriverConfigLoader configLoader =
+        CassandraDriverConfigLoader.fromOptionsMap(cassandraShard.getOptionsMap());
+    builder.withConfigLoader(configLoader);
+    return builder.build();
+  }
+
+  @Override
+  public boolean isMultiSharded() {
+    return false;
+  }
+
+  @Override
+  public boolean shouldUpdateReadValuesToSpannerRecord() {
+    return false;
+  }
+
+  @Override
+  public org.apache.beam.sdk.values.TupleTag<String> classifyException(Exception exception) {
+    Throwable cause = exception.getCause();
+    if (cause instanceof com.datastax.oss.driver.api.core.type.codec.CodecNotFoundException) {
+      return com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG;
+    }
+    return null;
   }
 }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceSchemaReader.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceSchemaReader.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.teleport.v2.templates.utils;
+package com.google.cloud.teleport.v2.templates.source.cassandra;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.CqlSessionBuilder;

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnector.java
@@ -96,6 +96,7 @@ public class MySQLSourceConnector implements ISourceConnector {
     SourceConfigParser sourceConfigParser = new SourceConfigParser(secretManagerAccessor);
     SourceConnectionConfig sourceConnectionConfig =
         sourceConfigParser.parseConfiguration("mysql", shardFilePath);
+    //TODO checks for null and minimum size of 1
     if (sourceConnectionConfig instanceof JdbcShardConfig) {
       return ((JdbcShardConfig) sourceConnectionConfig).getShardConfigs();
     }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnector.java
@@ -113,8 +113,7 @@ public class MySQLSourceConnector implements ISourceConnector {
               ResultSet rs = stmt.executeQuery("SELECT @@read_only")) {
             if (rs != null && rs.next() && rs.getInt(1) == 1) {
               throw new RuntimeException(
-                  "MySQL destination is in read-only mode for shard: "
-                      + shard.getLogicalShardId());
+                  "MySQL destination is in read-only mode for shard: " + shard.getLogicalShardId());
             }
           }
         }
@@ -164,10 +163,9 @@ public class MySQLSourceConnector implements ISourceConnector {
       return com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG;
     }
     if (cause instanceof java.sql.SQLNonTransientConnectionException) {
-      java.sql.SQLNonTransientConnectionException e = (java.sql.SQLNonTransientConnectionException) cause;
-      if (e.getErrorCode() != 1053
-          && e.getErrorCode() != 1159
-          && e.getErrorCode() != 1161) {
+      java.sql.SQLNonTransientConnectionException e =
+          (java.sql.SQLNonTransientConnectionException) cause;
+      if (e.getErrorCode() != 1053 && e.getErrorCode() != 1159 && e.getErrorCode() != 1161) {
         return com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG;
       }
     }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnector.java
@@ -66,8 +66,7 @@ public class MySQLSourceConnector implements ISourceConnector {
     return connectionHelper;
   }
 
-  @Override
-  public String getConnectionUrl(Shard shard) {
+  String getConnectionUrl(Shard shard) {
     return "jdbc:mysql://" + shard.getHost() + ":" + shard.getPort() + "/" + shard.getDbName();
   }
 
@@ -92,7 +91,7 @@ public class MySQLSourceConnector implements ISourceConnector {
   }
 
   @Override
-  public List<Shard> parseShardList(String shardFilePath) throws Exception {
+  public List<Shard> parseShardConfig(String shardFilePath) throws Exception {
     ISecretManagerAccessor secretManagerAccessor = new SecretManagerAccessorImpl();
     SourceConfigParser sourceConfigParser = new SourceConfigParser(secretManagerAccessor);
     SourceConnectionConfig sourceConnectionConfig =
@@ -146,7 +145,7 @@ public class MySQLSourceConnector implements ISourceConnector {
   }
 
   @Override
-  public boolean isMultiSharded() {
+  public boolean supportsSharding() {
     return true;
   }
 

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnector.java
@@ -19,14 +19,31 @@ import com.google.cloud.teleport.v2.spanner.migrations.connection.ConnectionHelp
 import com.google.cloud.teleport.v2.spanner.migrations.connection.IConnectionHelper;
 import com.google.cloud.teleport.v2.spanner.migrations.connection.JdbcConnectionHelper;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
+import com.google.cloud.teleport.v2.spanner.migrations.source.config.JdbcShardConfig;
+import com.google.cloud.teleport.v2.spanner.migrations.source.config.SourceConfigParser;
+import com.google.cloud.teleport.v2.spanner.migrations.source.config.SourceConnectionConfig;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.ISecretManagerAccessor;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.SecretManagerAccessorImpl;
+import com.google.cloud.teleport.v2.spanner.sourceddl.MySqlInformationSchemaScanner;
+import com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema;
 import com.google.cloud.teleport.v2.templates.dbutils.dao.source.IDao;
 import com.google.cloud.teleport.v2.templates.dbutils.dao.source.JdbcDao;
 import com.google.cloud.teleport.v2.templates.dbutils.dml.IDMLGenerator;
 import com.google.cloud.teleport.v2.templates.dbutils.processor.ISourceConnector;
 import com.google.common.annotations.VisibleForTesting;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
 import java.util.List;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MySQLSourceConnector implements ISourceConnector {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MySQLSourceConnector.class);
 
   private final IConnectionHelper connectionHelper;
 
@@ -72,5 +89,88 @@ public class MySQLSourceConnector implements ISourceConnector {
               "jdbc:mysql://");
       connectionHelper.init(request);
     }
+  }
+
+  @Override
+  public List<Shard> parseShardList(String shardFilePath) throws Exception {
+    ISecretManagerAccessor secretManagerAccessor = new SecretManagerAccessorImpl();
+    SourceConfigParser sourceConfigParser = new SourceConfigParser(secretManagerAccessor);
+    SourceConnectionConfig sourceConnectionConfig =
+        sourceConfigParser.parseConfiguration("mysql", shardFilePath);
+    if (sourceConnectionConfig instanceof JdbcShardConfig) {
+      return ((JdbcShardConfig) sourceConnectionConfig).getShardConfigs();
+    }
+    throw new IllegalArgumentException(
+        "Expected JdbcShardConfig but got: " + sourceConnectionConfig.getClass());
+  }
+
+  @Override
+  public void validate(List<Shard> shards, PipelineOptions options) throws Exception {
+    for (Shard shard : shards) {
+      try (Connection conn = createConnection(shard)) {
+        if (conn != null) {
+          try (Statement stmt = conn.createStatement();
+              ResultSet rs = stmt.executeQuery("SELECT @@read_only")) {
+            if (rs != null && rs.next() && rs.getInt(1) == 1) {
+              throw new RuntimeException(
+                  "MySQL destination is in read-only mode for shard: "
+                      + shard.getLogicalShardId());
+            }
+          }
+        }
+      } catch (Exception e) {
+        LOG.error(
+            "Error checking MySQL read-only status for shard {}: {}",
+            shard.getLogicalShardId(),
+            e.getMessage());
+        throw new RuntimeException("Error checking MySQL read-only status", e);
+      }
+    }
+  }
+
+  @Override
+  public SourceSchema getInformationSchema(List<Shard> shards) throws Exception {
+    try (Connection connection = createConnection(shards.get(0))) {
+      return new MySqlInformationSchemaScanner(connection, shards.get(0).getDbName()).scan();
+    }
+  }
+
+  @VisibleForTesting
+  Connection createConnection(Shard shard) throws Exception {
+    HikariConfig config = new HikariConfig();
+    config.setJdbcUrl(getConnectionUrl(shard));
+    config.setUsername(shard.getUserName());
+    config.setPassword(shard.getPassword());
+    config.setDriverClassName("com.mysql.cj.jdbc.Driver");
+    HikariDataSource ds = new HikariDataSource(config);
+    return ds.getConnection();
+  }
+
+  @Override
+  public boolean isMultiSharded() {
+    return true;
+  }
+
+  @Override
+  public boolean shouldUpdateReadValuesToSpannerRecord() {
+    return true;
+  }
+
+  @Override
+  public org.apache.beam.sdk.values.TupleTag<String> classifyException(Exception exception) {
+    Throwable cause = exception.getCause();
+    if (cause instanceof java.sql.SQLSyntaxErrorException
+        || cause instanceof java.sql.SQLDataException) {
+      return com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG;
+    }
+    if (cause instanceof java.sql.SQLNonTransientConnectionException) {
+      java.sql.SQLNonTransientConnectionException e = (java.sql.SQLNonTransientConnectionException) cause;
+      if (e.getErrorCode() != 1053
+          && e.getErrorCode() != 1159
+          && e.getErrorCode() != 1161) {
+        return com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG;
+      }
+    }
+    return null;
   }
 }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnector.java
@@ -96,7 +96,7 @@ public class MySQLSourceConnector implements ISourceConnector {
     SourceConfigParser sourceConfigParser = new SourceConfigParser(secretManagerAccessor);
     SourceConnectionConfig sourceConnectionConfig =
         sourceConfigParser.parseConfiguration("mysql", shardFilePath);
-    //TODO checks for null and minimum size of 1
+    // TODO checks for null and minimum size of 1
     if (sourceConnectionConfig instanceof JdbcShardConfig) {
       return ((JdbcShardConfig) sourceConnectionConfig).getShardConfigs();
     }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnector.java
@@ -135,6 +135,7 @@ public class MySQLSourceConnector implements ISourceConnector {
 
   @VisibleForTesting
   Connection createConnection(Shard shard) throws Exception {
+    // TODO this looks like a connection leak. Look to fix this.
     HikariConfig config = new HikariConfig();
     config.setJdbcUrl(getConnectionUrl(shard));
     config.setUsername(shard.getUserName());

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnector.java
@@ -155,16 +155,15 @@ public class MySQLSourceConnector implements ISourceConnector {
   }
 
   @Override
-  public org.apache.beam.sdk.values.TupleTag<String> classifyException(Exception exception) {
-    Throwable cause = exception.getCause();
+  public org.apache.beam.sdk.values.TupleTag<String> classifyException(Throwable cause) {
     if (cause instanceof java.sql.SQLSyntaxErrorException
         || cause instanceof java.sql.SQLDataException) {
       return com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG;
     }
-    if (cause instanceof java.sql.SQLNonTransientConnectionException) {
-      java.sql.SQLNonTransientConnectionException e =
-          (java.sql.SQLNonTransientConnectionException) cause;
+    if (cause instanceof java.sql.SQLNonTransientConnectionException e) {
       if (e.getErrorCode() != 1053 && e.getErrorCode() != 1159 && e.getErrorCode() != 1161) {
+        // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
+        // error codes 1053,1161 and 1159 can be retried
         return com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG;
       }
     }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnector.java
@@ -83,6 +83,7 @@ public class PostgreSQLSourceConnector implements ISourceConnector {
   public List<Shard> parseShardConfig(String shardFilePath) throws Exception {
     ISecretManagerAccessor secretManagerAccessor = new SecretManagerAccessorImpl();
     SourceConfigParser sourceConfigParser = new SourceConfigParser(secretManagerAccessor);
+    //TODO checks for null and minimum size of 1
     SourceConnectionConfig sourceConnectionConfig =
         sourceConfigParser.parseConfiguration("postgresql", shardFilePath);
     if (sourceConnectionConfig instanceof JdbcShardConfig) {

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnector.java
@@ -108,6 +108,8 @@ public class PostgreSQLSourceConnector implements ISourceConnector {
 
   @VisibleForTesting
   Connection createConnection(Shard shard) throws Exception {
+    // TODO this looks like a connection leak. Look to fix this.
+    // Maybe create a connection directly without a pool
     HikariConfig config = new HikariConfig();
     config.setJdbcUrl(getConnectionUrl(shard));
     config.setUsername(shard.getUserName());

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnector.java
@@ -75,12 +75,7 @@ public class PostgreSQLSourceConnector implements ISourceConnector {
     if (!connectionHelper.isConnectionPoolInitialized()) {
       ConnectionHelperRequest request =
           new ConnectionHelperRequest(
-              shards,
-              null,
-              maxConnections,
-              "org.postgresql.Driver",
-              null,
-              "jdbc:postgresql://");
+              shards, null, maxConnections, "org.postgresql.Driver", null, "jdbc:postgresql://");
       connectionHelper.init(request);
     }
   }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnector.java
@@ -83,7 +83,7 @@ public class PostgreSQLSourceConnector implements ISourceConnector {
   public List<Shard> parseShardConfig(String shardFilePath) throws Exception {
     ISecretManagerAccessor secretManagerAccessor = new SecretManagerAccessorImpl();
     SourceConfigParser sourceConfigParser = new SourceConfigParser(secretManagerAccessor);
-    //TODO checks for null and minimum size of 1
+    // TODO checks for null and minimum size of 1
     SourceConnectionConfig sourceConnectionConfig =
         sourceConfigParser.parseConfiguration("postgresql", shardFilePath);
     if (sourceConnectionConfig instanceof JdbcShardConfig) {

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnector.java
@@ -128,13 +128,7 @@ public class PostgreSQLSourceConnector implements ISourceConnector {
   }
 
   @Override
-  public org.apache.beam.sdk.values.TupleTag<String> classifyException(Exception exception) {
-    Throwable cause = exception.getCause();
-    if (cause instanceof java.sql.SQLSyntaxErrorException
-        || cause instanceof java.sql.SQLDataException
-        || cause instanceof java.sql.SQLNonTransientConnectionException) {
-      return com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG;
-    }
+  public org.apache.beam.sdk.values.TupleTag<String> classifyException(Throwable cause) {
     return null;
   }
 }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnector.java
@@ -19,12 +19,23 @@ import com.google.cloud.teleport.v2.spanner.migrations.connection.ConnectionHelp
 import com.google.cloud.teleport.v2.spanner.migrations.connection.IConnectionHelper;
 import com.google.cloud.teleport.v2.spanner.migrations.connection.JdbcConnectionHelper;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
+import com.google.cloud.teleport.v2.spanner.migrations.source.config.JdbcShardConfig;
+import com.google.cloud.teleport.v2.spanner.migrations.source.config.SourceConfigParser;
+import com.google.cloud.teleport.v2.spanner.migrations.source.config.SourceConnectionConfig;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.ISecretManagerAccessor;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.SecretManagerAccessorImpl;
+import com.google.cloud.teleport.v2.spanner.sourceddl.PostgreSQLInformationSchemaScanner;
+import com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema;
 import com.google.cloud.teleport.v2.templates.dbutils.dao.source.IDao;
 import com.google.cloud.teleport.v2.templates.dbutils.dao.source.JdbcDao;
 import com.google.cloud.teleport.v2.templates.dbutils.dml.IDMLGenerator;
 import com.google.cloud.teleport.v2.templates.dbutils.processor.ISourceConnector;
 import com.google.common.annotations.VisibleForTesting;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
 import java.util.List;
+import org.apache.beam.sdk.options.PipelineOptions;
 
 public class PostgreSQLSourceConnector implements ISourceConnector {
 
@@ -64,8 +75,72 @@ public class PostgreSQLSourceConnector implements ISourceConnector {
     if (!connectionHelper.isConnectionPoolInitialized()) {
       ConnectionHelperRequest request =
           new ConnectionHelperRequest(
-              shards, null, maxConnections, "org.postgresql.Driver", null, "jdbc:postgresql://");
+              shards,
+              null,
+              maxConnections,
+              "org.postgresql.Driver",
+              null,
+              "jdbc:postgresql://");
       connectionHelper.init(request);
     }
+  }
+
+  @Override
+  public List<Shard> parseShardList(String shardFilePath) throws Exception {
+    ISecretManagerAccessor secretManagerAccessor = new SecretManagerAccessorImpl();
+    SourceConfigParser sourceConfigParser = new SourceConfigParser(secretManagerAccessor);
+    SourceConnectionConfig sourceConnectionConfig =
+        sourceConfigParser.parseConfiguration("postgresql", shardFilePath);
+    if (sourceConnectionConfig instanceof JdbcShardConfig) {
+      return ((JdbcShardConfig) sourceConnectionConfig).getShardConfigs();
+    }
+    throw new IllegalArgumentException(
+        "Expected JdbcShardConfig but got: " + sourceConnectionConfig.getClass());
+  }
+
+  @Override
+  public void validate(List<Shard> shards, PipelineOptions options) throws Exception {
+    // No-op for PostgreSQL
+  }
+
+  @Override
+  public SourceSchema getInformationSchema(List<Shard> shards) throws Exception {
+    try (Connection connection = createConnection(shards.get(0))) {
+      return new PostgreSQLInformationSchemaScanner(
+              connection, shards.get(0).getDbName(), shards.get(0).getNamespace())
+          .scan();
+    }
+  }
+
+  @VisibleForTesting
+  Connection createConnection(Shard shard) throws Exception {
+    HikariConfig config = new HikariConfig();
+    config.setJdbcUrl(getConnectionUrl(shard));
+    config.setUsername(shard.getUserName());
+    config.setPassword(shard.getPassword());
+    config.setDriverClassName("org.postgresql.Driver");
+    HikariDataSource ds = new HikariDataSource(config);
+    return ds.getConnection();
+  }
+
+  @Override
+  public boolean isMultiSharded() {
+    return true;
+  }
+
+  @Override
+  public boolean shouldUpdateReadValuesToSpannerRecord() {
+    return true;
+  }
+
+  @Override
+  public org.apache.beam.sdk.values.TupleTag<String> classifyException(Exception exception) {
+    Throwable cause = exception.getCause();
+    if (cause instanceof java.sql.SQLSyntaxErrorException
+        || cause instanceof java.sql.SQLDataException
+        || cause instanceof java.sql.SQLNonTransientConnectionException) {
+      return com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG;
+    }
+    return null;
   }
 }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnector.java
@@ -94,7 +94,7 @@ public class PostgreSQLSourceConnector implements ISourceConnector {
 
   @Override
   public void validate(List<Shard> shards, PipelineOptions options) throws Exception {
-    // No-op for PostgreSQL
+    // TODO- validate read only similar to mysql
   }
 
   @Override

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnector.java
@@ -60,8 +60,7 @@ public class PostgreSQLSourceConnector implements ISourceConnector {
     return connectionHelper;
   }
 
-  @Override
-  public String getConnectionUrl(Shard shard) {
+  String getConnectionUrl(Shard shard) {
     return "jdbc:postgresql://" + shard.getHost() + ":" + shard.getPort() + "/" + shard.getDbName();
   }
 
@@ -81,7 +80,7 @@ public class PostgreSQLSourceConnector implements ISourceConnector {
   }
 
   @Override
-  public List<Shard> parseShardList(String shardFilePath) throws Exception {
+  public List<Shard> parseShardConfig(String shardFilePath) throws Exception {
     ISecretManagerAccessor secretManagerAccessor = new SecretManagerAccessorImpl();
     SourceConfigParser sourceConfigParser = new SourceConfigParser(secretManagerAccessor);
     SourceConnectionConfig sourceConnectionConfig =
@@ -119,7 +118,7 @@ public class PostgreSQLSourceConnector implements ISourceConnector {
   }
 
   @Override
-  public boolean isMultiSharded() {
+  public boolean supportsSharding() {
     return true;
   }
 

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSourceConnector.java
@@ -15,31 +15,30 @@
  */
 package com.google.cloud.teleport.v2.templates.source.spanner;
 
-import com.google.cloud.spanner.DatabaseClient;
-import com.google.cloud.teleport.v2.spanner.migrations.connection.ConnectionHelperRequest;
 import com.google.cloud.teleport.v2.spanner.migrations.connection.IConnectionHelper;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.SpannerShard;
+import com.google.cloud.teleport.v2.spanner.migrations.utils.SpannerShardFileReader;
+import com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema;
+import com.google.cloud.teleport.v2.spanner.sourceddl.SpannerInformationSchemaScanner;
 import com.google.cloud.teleport.v2.templates.dbutils.dao.source.IDao;
 import com.google.cloud.teleport.v2.templates.dbutils.dml.IDMLGenerator;
 import com.google.cloud.teleport.v2.templates.dbutils.processor.ISourceConnector;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
+import org.apache.beam.sdk.options.PipelineOptions;
 
-/**
- * Spanner implementation of {@link ISourceConnector}. Encapsulates connection management, DML
- * generation, and DAO initialization for Cloud Spanner target databases.
- */
 public class SpannerSourceConnector implements ISourceConnector {
 
-  private final IConnectionHelper<DatabaseClient> connectionHelper;
+  private final IConnectionHelper connectionHelper;
 
   public SpannerSourceConnector() {
     this.connectionHelper = new SpannerConnectionHelper();
   }
 
   @VisibleForTesting
-  SpannerSourceConnector(IConnectionHelper<DatabaseClient> connectionHelper) {
+  SpannerSourceConnector(IConnectionHelper connectionHelper) {
     this.connectionHelper = connectionHelper;
   }
 
@@ -49,7 +48,7 @@ public class SpannerSourceConnector implements ISourceConnector {
   }
 
   @Override
-  public IConnectionHelper<DatabaseClient> getConnectionHelper() {
+  public IConnectionHelper getConnectionHelper() {
     return connectionHelper;
   }
 
@@ -57,22 +56,88 @@ public class SpannerSourceConnector implements ISourceConnector {
   public String getConnectionUrl(Shard shard) {
     if (!(shard instanceof SpannerShard)) {
       throw new IllegalArgumentException(
-          "Expected SpannerShard but got: " + shard.getClass().getSimpleName());
+          "Expected SpannerShard but got: " + (shard != null ? shard.getClass().getName() : "null"));
     }
-    return SpannerConnectionHelper.connectionKey((SpannerShard) shard);
+    SpannerShard spannerShard = (SpannerShard) shard;
+    return SpannerConnectionHelper.connectionKey(spannerShard);
   }
 
   @Override
   public IDao getDao(Shard shard) {
-    return new SpannerTargetDao(getConnectionUrl(shard), getConnectionHelper());
+    return new SpannerTargetDao(
+        getConnectionUrl(shard),
+        (IConnectionHelper<com.google.cloud.spanner.DatabaseClient>) getConnectionHelper());
   }
 
   @Override
   public void initConnectionHelper(List<Shard> shards, int maxConnections) {
+    // SpannerConnectionHelper does not need complex initialization in the same way as JDBC,
+    // but we can pass the shards to it if needed.
+    // Actually, SpannerConnectionHelper.init is currently a no-op or simple.
+    // Let's check what SpannerSourceConnector did before:
+    // It didn't do much in init, but let's check if it needs to call init.
+    // In our previous unit tests, we mocked connectionHelper.init.
+    // Let's just call init with a default request.
     if (!connectionHelper.isConnectionPoolInitialized()) {
-      ConnectionHelperRequest request =
-          new ConnectionHelperRequest(shards, null, maxConnections, null, null, null);
-      connectionHelper.init(request);
+      connectionHelper.init(new com.google.cloud.teleport.v2.spanner.migrations.connection.ConnectionHelperRequest(shards, null, maxConnections, null, null, null));
     }
+  }
+
+  @Override
+  public List<Shard> parseShardList(String shardFilePath) throws Exception {
+    SpannerShardFileReader spannerShardFileReader = new SpannerShardFileReader();
+    return spannerShardFileReader.getSpannerShards(shardFilePath);
+  }
+
+  @Override
+  public void validate(List<Shard> shards, PipelineOptions options) throws Exception {
+    if (shards.size() != 1) {
+      throw new IllegalArgumentException("Spanner migration must have exactly 1 shard.");
+    }
+    if (!(shards.get(0) instanceof SpannerShard)) {
+      throw new IllegalArgumentException(
+          "Expected SpannerShard but got: " + shards.get(0).getClass());
+    }
+    SpannerShard spannerShard = (SpannerShard) shards.get(0);
+
+    com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options spannerOptions =
+        options.as(com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options.class);
+    if (spannerOptions != null
+        && spannerOptions.getSpannerProjectId() != null
+        && spannerOptions.getMetadataInstance() != null
+        && spannerOptions.getMetadataDatabase() != null) {
+      if (!spannerOptions.getSpannerProjectId().equals(spannerShard.getProjectId())
+          || !spannerOptions.getMetadataInstance().equals(spannerShard.getInstanceId())
+          || !spannerOptions.getMetadataDatabase().equals(spannerShard.getDatabaseId())) {
+        throw new IllegalArgumentException(
+            "For Cloud Spanner target, the metadata database and target database must be the same to ensure atomic operations.");
+      }
+    }
+  }
+
+  @Override
+  public SourceSchema getInformationSchema(List<Shard> shards) throws Exception {
+    SpannerShard spannerShard = (SpannerShard) shards.get(0);
+    SpannerConfig targetSpannerConfig =
+        SpannerConfig.create()
+            .withProjectId(spannerShard.getProjectId())
+            .withInstanceId(spannerShard.getInstanceId())
+            .withDatabaseId(spannerShard.getDatabaseId());
+    return new SpannerInformationSchemaScanner(targetSpannerConfig).scan();
+  }
+
+  @Override
+  public boolean isMultiSharded() {
+    return false;
+  }
+
+  @Override
+  public boolean shouldUpdateReadValuesToSpannerRecord() {
+    return true;
+  }
+
+  @Override
+  public org.apache.beam.sdk.values.TupleTag<String> classifyException(Exception exception) {
+    return null;
   }
 }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSourceConnector.java
@@ -72,12 +72,6 @@ public class SpannerSourceConnector implements ISourceConnector {
   @Override
   public void initConnectionHelper(List<Shard> shards, int maxConnections) {
     // SpannerConnectionHelper does not need complex initialization in the same way as JDBC,
-    // but we can pass the shards to it if needed.
-    // Actually, SpannerConnectionHelper.init is currently a no-op or simple.
-    // Let's check what SpannerSourceConnector did before:
-    // It didn't do much in init, but let's check if it needs to call init.
-    // In our previous unit tests, we mocked connectionHelper.init.
-    // Let's just call init with a default request.
     if (!connectionHelper.isConnectionPoolInitialized()) {
       connectionHelper.init(
           new com.google.cloud.teleport.v2.spanner.migrations.connection.ConnectionHelperRequest(
@@ -139,7 +133,7 @@ public class SpannerSourceConnector implements ISourceConnector {
   }
 
   @Override
-  public org.apache.beam.sdk.values.TupleTag<String> classifyException(Exception exception) {
+  public org.apache.beam.sdk.values.TupleTag<String> classifyException(Throwable cause) {
     return null;
   }
 }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSourceConnector.java
@@ -56,7 +56,8 @@ public class SpannerSourceConnector implements ISourceConnector {
   public String getConnectionUrl(Shard shard) {
     if (!(shard instanceof SpannerShard)) {
       throw new IllegalArgumentException(
-          "Expected SpannerShard but got: " + (shard != null ? shard.getClass().getName() : "null"));
+          "Expected SpannerShard but got: "
+              + (shard != null ? shard.getClass().getName() : "null"));
     }
     SpannerShard spannerShard = (SpannerShard) shard;
     return SpannerConnectionHelper.connectionKey(spannerShard);
@@ -79,7 +80,9 @@ public class SpannerSourceConnector implements ISourceConnector {
     // In our previous unit tests, we mocked connectionHelper.init.
     // Let's just call init with a default request.
     if (!connectionHelper.isConnectionPoolInitialized()) {
-      connectionHelper.init(new com.google.cloud.teleport.v2.spanner.migrations.connection.ConnectionHelperRequest(shards, null, maxConnections, null, null, null));
+      connectionHelper.init(
+          new com.google.cloud.teleport.v2.spanner.migrations.connection.ConnectionHelperRequest(
+              shards, null, maxConnections, null, null, null));
     }
   }
 

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSourceConnector.java
@@ -52,8 +52,7 @@ public class SpannerSourceConnector implements ISourceConnector {
     return connectionHelper;
   }
 
-  @Override
-  public String getConnectionUrl(Shard shard) {
+  String getConnectionUrl(Shard shard) {
     if (!(shard instanceof SpannerShard)) {
       throw new IllegalArgumentException(
           "Expected SpannerShard but got: "
@@ -66,7 +65,7 @@ public class SpannerSourceConnector implements ISourceConnector {
   @Override
   public IDao getDao(Shard shard) {
     return new SpannerTargetDao(
-        getConnectionUrl(shard),
+        SpannerConnectionHelper.connectionKey((SpannerShard) shard),
         (IConnectionHelper<com.google.cloud.spanner.DatabaseClient>) getConnectionHelper());
   }
 
@@ -87,7 +86,7 @@ public class SpannerSourceConnector implements ISourceConnector {
   }
 
   @Override
-  public List<Shard> parseShardList(String shardFilePath) throws Exception {
+  public List<Shard> parseShardConfig(String shardFilePath) throws Exception {
     SpannerShardFileReader spannerShardFileReader = new SpannerShardFileReader();
     return spannerShardFileReader.getSpannerShards(shardFilePath);
   }
@@ -130,7 +129,7 @@ public class SpannerSourceConnector implements ISourceConnector {
   }
 
   @Override
-  public boolean isMultiSharded() {
+  public boolean supportsSharding() {
     return false;
   }
 

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSourceConnector.java
@@ -108,6 +108,7 @@ public class SpannerSourceConnector implements ISourceConnector {
         throw new IllegalArgumentException(
             "For Cloud Spanner target, the metadata database and target database must be the same to ensure atomic operations.");
       }
+      //TODO check for read only as well ?
     }
   }
 

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSourceConnector.java
@@ -108,7 +108,7 @@ public class SpannerSourceConnector implements ISourceConnector {
         throw new IllegalArgumentException(
             "For Cloud Spanner target, the metadata database and target database must be the same to ensure atomic operations.");
       }
-      //TODO check for read only as well ?
+      // TODO check for read only as well ?
     }
   }
 

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/AssignShardIdFn.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/AssignShardIdFn.java
@@ -336,7 +336,8 @@ public class AssignShardIdFn
               staleInstant.getEpochSecond(), staleInstant.getNano());
       ModType modType = record.getModType();
 
-      boolean updateReadValuesToSpannerRecord = sourceConnector.shouldUpdateReadValuesToSpannerRecord();
+      boolean updateReadValuesToSpannerRecord =
+          sourceConnector.shouldUpdateReadValuesToSpannerRecord();
 
       List<String> columns =
           ddl.table(tableName).columns().stream()

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/AssignShardIdFn.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/AssignShardIdFn.java
@@ -44,6 +44,8 @@ import com.google.cloud.teleport.v2.spanner.utils.ShardIdResponse;
 import com.google.cloud.teleport.v2.templates.changestream.DataChangeRecordTypeConvertor;
 import com.google.cloud.teleport.v2.templates.changestream.TrimmedShardedDataChangeRecord;
 import com.google.cloud.teleport.v2.templates.constants.Constants;
+import com.google.cloud.teleport.v2.templates.dbutils.processor.ISourceConnector;
+import com.google.cloud.teleport.v2.templates.dbutils.processor.SourceProcessorFactory;
 import com.google.cloud.teleport.v2.templates.utils.SchemaMapperUtils;
 import com.google.cloud.teleport.v2.templates.utils.ShardingLogicImplFetcher;
 import com.google.cloud.teleport.v2.templates.utils.SpannerToSourceDbExceptionClassifier;
@@ -122,6 +124,7 @@ public class AssignShardIdFn
   private final String columnOverrides;
 
   private transient Schema schema;
+  private transient ISourceConnector sourceConnector;
   private transient SchemaFileOverridesParser schemaFileOverridesParser;
 
   public AssignShardIdFn(
@@ -155,6 +158,11 @@ public class AssignShardIdFn
     this.schemaOverridesFilePath = schemaOverridesFilePath;
     this.tableOverrides = tableOverrides;
     this.columnOverrides = columnOverrides;
+    try {
+      this.sourceConnector = SourceProcessorFactory.getSource(sourceType);
+    } catch (com.google.cloud.teleport.v2.templates.exceptions.UnsupportedSourceException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   // setSpannerAccessor is added to be used by unit tests
@@ -209,6 +217,11 @@ public class AssignShardIdFn
     }
     if (schemaOverridesFilePath != null && !schemaOverridesFilePath.isEmpty()) {
       schemaFileOverridesParser = new SchemaFileOverridesParser(schemaOverridesFilePath);
+    }
+    try {
+      sourceConnector = SourceProcessorFactory.getSource(sourceType);
+    } catch (Exception e) {
+      throw new RuntimeException("Error getting source connector", e);
     }
   }
 
@@ -287,7 +300,7 @@ public class AssignShardIdFn
       c.output(KV.of(finalKey, record));
     } catch (Exception e) {
       LOG.error("Error fetching shard Id column: {}", e);
-      TupleTag<String> errorTag = SpannerToSourceDbExceptionClassifier.classify(e);
+      TupleTag<String> errorTag = SpannerToSourceDbExceptionClassifier.classify(e, sourceConnector);
       if (Constants.PERMANENT_ERROR_TAG.equals(errorTag)) {
         record.setShard(Constants.SEVERE_ERROR_SHARD_ID);
       } else {
@@ -323,8 +336,7 @@ public class AssignShardIdFn
               staleInstant.getEpochSecond(), staleInstant.getNano());
       ModType modType = record.getModType();
 
-      // TODO find a way to not make a special case from Cassandra.
-      boolean updateReadValuesToSpannerRecord = (sourceType != Constants.SOURCE_CASSANDRA);
+      boolean updateReadValuesToSpannerRecord = sourceConnector.shouldUpdateReadValuesToSpannerRecord();
 
       List<String> columns =
           ddl.table(tableName).columns().stream()

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFn.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFn.java
@@ -41,6 +41,7 @@ import com.google.cloud.teleport.v2.templates.constants.Constants;
 import com.google.cloud.teleport.v2.templates.dbutils.dao.source.IDao;
 import com.google.cloud.teleport.v2.templates.dbutils.dao.source.TransactionalCheck;
 import com.google.cloud.teleport.v2.templates.dbutils.dao.source.TransactionalCheckException;
+import com.google.cloud.teleport.v2.templates.dbutils.processor.ISourceConnector;
 import com.google.cloud.teleport.v2.templates.dbutils.processor.InputRecordProcessor;
 import com.google.cloud.teleport.v2.templates.dbutils.processor.SourceProcessor;
 import com.google.cloud.teleport.v2.templates.dbutils.processor.SourceProcessorFactory;
@@ -104,6 +105,7 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
   private final int maxThreadPerDataflowWorker;
   private final String source;
   private transient SourceProcessor sourceProcessor;
+  private transient ISourceConnector sourceConnector;
   private final CustomTransformation customTransformation;
   private transient ISpannerMigrationTransformer spannerToSourceTransformer;
 
@@ -150,6 +152,11 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
     this.schemaOverridesFilePath = schemaOverridesFilePath;
     this.tableOverrides = tableOverrides;
     this.columnOverrides = columnOverrides;
+    try {
+      this.sourceConnector = SourceProcessorFactory.getSource(source);
+    } catch (com.google.cloud.teleport.v2.templates.exceptions.UnsupportedSourceException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   // for unit testing purposes
@@ -190,6 +197,7 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
     mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
     sourceProcessor =
         SourceProcessorFactory.createSourceProcessor(source, shards, maxThreadPerDataflowWorker);
+    sourceConnector = SourceProcessorFactory.getSource(source);
     spannerDao = new SpannerDao(spannerConfig);
     spannerToSourceTransformer =
         CustomTransformationImplFetcher.getCustomTransformationLogicImpl(customTransformation);
@@ -383,7 +391,7 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
         if (cause != null) {
           message += ", Caused by: " + cause.getMessage();
         }
-        TupleTag<String> errorTag = SpannerToSourceDbExceptionClassifier.classify(ex);
+        TupleTag<String> errorTag = SpannerToSourceDbExceptionClassifier.classify(ex, sourceConnector);
         outputWithTag(c, errorTag, message, spannerRec);
         UNSUCCESSFUL_WRITE_LATENCY_MS.update(timer.elapsed(TimeUnit.MILLISECONDS));
       }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFn.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFn.java
@@ -391,7 +391,8 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
         if (cause != null) {
           message += ", Caused by: " + cause.getMessage();
         }
-        TupleTag<String> errorTag = SpannerToSourceDbExceptionClassifier.classify(ex, sourceConnector);
+        TupleTag<String> errorTag =
+            SpannerToSourceDbExceptionClassifier.classify(ex, sourceConnector);
         outputWithTag(c, errorTag, message, spannerRec);
         UNSUCCESSFUL_WRITE_LATENCY_MS.update(timer.elapsed(TimeUnit.MILLISECONDS));
       }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifier.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifier.java
@@ -54,16 +54,19 @@ public class SpannerToSourceDbExceptionClassifier {
     return Constants.RETRYABLE_ERROR_TAG;
   }
 
-  private static TupleTag<String> classifySpannerException(SpannerException exception, ISourceConnector connector) {
+  private static TupleTag<String> classifySpannerException(
+      SpannerException exception, ISourceConnector connector) {
     // child exceptions are wrapped inside SpannerException.
     Throwable cause = exception.getCause();
+    if (cause == null) {
+      return Constants.RETRYABLE_ERROR_TAG;
+    }
 
     if (cause instanceof InvalidTransformationException
         || cause instanceof ChangeEventConvertorException
         || cause instanceof InvalidDMLGenerationException) {
       return Constants.PERMANENT_ERROR_TAG;
-    } else if (cause instanceof SQLSyntaxErrorException
-        || cause instanceof SQLDataException) {
+    } else if (cause instanceof SQLSyntaxErrorException || cause instanceof SQLDataException) {
       return Constants.PERMANENT_ERROR_TAG;
     }
 

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifier.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifier.java
@@ -58,9 +58,6 @@ public class SpannerToSourceDbExceptionClassifier {
       SpannerException exception, ISourceConnector connector) {
     // child exceptions are wrapped inside SpannerException.
     Throwable cause = exception.getCause();
-    if (cause == null) {
-      return Constants.RETRYABLE_ERROR_TAG;
-    }
 
     if (cause instanceof InvalidTransformationException
         || cause instanceof ChangeEventConvertorException

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifier.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifier.java
@@ -22,6 +22,8 @@ import com.google.cloud.teleport.v2.spanner.migrations.exceptions.ChangeEventCon
 import com.google.cloud.teleport.v2.templates.constants.Constants;
 import com.google.cloud.teleport.v2.templates.dbutils.processor.ISourceConnector;
 import com.google.cloud.teleport.v2.templates.exceptions.InvalidDMLGenerationException;
+import java.sql.SQLDataException;
+import java.sql.SQLSyntaxErrorException;
 import java.util.Set;
 import org.apache.beam.sdk.values.TupleTag;
 
@@ -41,14 +43,8 @@ public class SpannerToSourceDbExceptionClassifier {
           ErrorCode.INTERNAL);
 
   public static TupleTag<String> classify(Exception exception, ISourceConnector connector) {
-    if (connector != null) {
-      TupleTag<String> dialectTag = connector.classifyException(exception);
-      if (dialectTag != null) {
-        return dialectTag;
-      }
-    }
     if (exception instanceof SpannerException e) {
-      return classifySpannerException(e);
+      return classifySpannerException(e, connector);
     } else if (exception instanceof ChangeEventConvertorException
         || exception instanceof IllegalArgumentException
         || exception instanceof InvalidDMLGenerationException
@@ -58,7 +54,7 @@ public class SpannerToSourceDbExceptionClassifier {
     return Constants.RETRYABLE_ERROR_TAG;
   }
 
-  private static TupleTag<String> classifySpannerException(SpannerException exception) {
+  private static TupleTag<String> classifySpannerException(SpannerException exception, ISourceConnector connector) {
     // child exceptions are wrapped inside SpannerException.
     Throwable cause = exception.getCause();
 
@@ -66,6 +62,16 @@ public class SpannerToSourceDbExceptionClassifier {
         || cause instanceof ChangeEventConvertorException
         || cause instanceof InvalidDMLGenerationException) {
       return Constants.PERMANENT_ERROR_TAG;
+    } else if (cause instanceof SQLSyntaxErrorException
+        || cause instanceof SQLDataException) {
+      return Constants.PERMANENT_ERROR_TAG;
+    }
+
+    if (connector != null) {
+      TupleTag<String> dialectTag = connector.classifyException(cause);
+      if (dialectTag != null) {
+        return dialectTag;
+      }
     }
 
     if (permanentSpannerErrorCodes.contains(exception.getErrorCode())) {

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifier.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifier.java
@@ -15,16 +15,13 @@
  */
 package com.google.cloud.teleport.v2.templates.utils;
 
-import com.datastax.oss.driver.api.core.type.codec.CodecNotFoundException;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.teleport.v2.spanner.exceptions.InvalidTransformationException;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.ChangeEventConvertorException;
 import com.google.cloud.teleport.v2.templates.constants.Constants;
+import com.google.cloud.teleport.v2.templates.dbutils.processor.ISourceConnector;
 import com.google.cloud.teleport.v2.templates.exceptions.InvalidDMLGenerationException;
-import java.sql.SQLDataException;
-import java.sql.SQLNonTransientConnectionException;
-import java.sql.SQLSyntaxErrorException;
 import java.util.Set;
 import org.apache.beam.sdk.values.TupleTag;
 
@@ -43,7 +40,13 @@ public class SpannerToSourceDbExceptionClassifier {
           ErrorCode.UNIMPLEMENTED,
           ErrorCode.INTERNAL);
 
-  public static TupleTag<String> classify(Exception exception) {
+  public static TupleTag<String> classify(Exception exception, ISourceConnector connector) {
+    if (connector != null) {
+      TupleTag<String> dialectTag = connector.classifyException(exception);
+      if (dialectTag != null) {
+        return dialectTag;
+      }
+    }
     if (exception instanceof SpannerException e) {
       return classifySpannerException(e);
     } else if (exception instanceof ChangeEventConvertorException
@@ -56,26 +59,12 @@ public class SpannerToSourceDbExceptionClassifier {
   }
 
   private static TupleTag<String> classifySpannerException(SpannerException exception) {
-    // Since we have wrapped the logic inside Spanner transaction, the exceptions
-    // would also be
-    // wrapped inside a SpannerException.
-    // We need to get and inspect the cause while handling the exception.
+    // child exceptions are wrapped inside SpannerException.
     Throwable cause = exception.getCause();
 
     if (cause instanceof InvalidTransformationException
         || cause instanceof ChangeEventConvertorException
         || cause instanceof InvalidDMLGenerationException) {
-      return Constants.PERMANENT_ERROR_TAG;
-    } else if (cause instanceof CodecNotFoundException
-        || cause instanceof SQLSyntaxErrorException
-        || cause instanceof SQLDataException) {
-      return Constants.PERMANENT_ERROR_TAG;
-    } else if (cause instanceof SQLNonTransientConnectionException e
-        && e.getErrorCode() != 1053
-        && e.getErrorCode() != 1159
-        && e.getErrorCode() != 1161) {
-      // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
-      // error codes 1053,1161 and 1159 can be retried
       return Constants.PERMANENT_ERROR_TAG;
     }
 

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDbTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDbTest.java
@@ -15,37 +15,11 @@
  */
 package com.google.cloud.teleport.v2.templates;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
-
-import com.datastax.oss.driver.api.core.CqlSession;
-import com.datastax.oss.driver.api.core.config.TypedDriverOption;
 import com.google.cloud.spanner.Options.RpcPriority;
 import com.google.cloud.teleport.v2.cdc.dlq.DeadLetterQueueManager;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
-import com.google.cloud.teleport.v2.spanner.migrations.shard.CassandraShard;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
-import com.google.cloud.teleport.v2.spanner.migrations.shard.SpannerShard;
-import com.google.cloud.teleport.v2.spanner.migrations.utils.JarFileReader;
-import com.google.cloud.teleport.v2.spanner.sourceddl.CassandraInformationSchemaScanner;
-import com.google.cloud.teleport.v2.spanner.sourceddl.PostgreSQLInformationSchemaScanner;
-import com.google.cloud.teleport.v2.spanner.sourceddl.SourceDatabaseType;
-import com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema;
 import com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options;
-import com.google.cloud.teleport.v2.templates.constants.Constants;
-import com.google.common.collect.ImmutableMap;
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.Statement;
 import java.util.Collections;
 import java.util.List;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineDebugOptions;
@@ -62,12 +36,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockedConstruction;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -76,12 +46,10 @@ public class SpannerToSourceDbTest {
   @Rule public final transient TestPipeline pipeline = TestPipeline.create();
 
   private Options options;
-  @Mock private SourceSchema mockSourceSchema;
   @Mock private PCollectionView<Ddl> mockDdlView;
   @Mock private PCollectionView<Ddl> mockShadowTableDdlView;
   @Mock private SpannerConfig mockSpannerConfig;
   @Mock private SpannerConfig mockSpannerMetadataConfig;
-  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
   @BeforeClass
   public static void setupFileSystem() {
@@ -149,76 +117,6 @@ public class SpannerToSourceDbTest {
   }
 
   @Test
-  public void testValidateMySQLNotReadOnly_NotReadOnly() throws Exception {
-    try (MockedStatic<SpannerToSourceDb> mocked =
-        Mockito.mockStatic(SpannerToSourceDb.class, Mockito.CALLS_REAL_METHODS)) {
-      Connection mockConnection = mock(Connection.class);
-      mocked
-          .when(() -> SpannerToSourceDb.createJdbcConnection(any(), any(), any()))
-          .thenReturn(mockConnection);
-
-      Statement mockStatement = mock(Statement.class);
-      when(mockConnection.createStatement()).thenReturn(mockStatement);
-      ResultSet mockResultSet = mock(ResultSet.class);
-      when(mockStatement.executeQuery("SELECT @@read_only")).thenReturn(mockResultSet);
-      when(mockResultSet.next()).thenReturn(true);
-      when(mockResultSet.getInt(1)).thenReturn(0); // 0 means NOT read-only
-
-      Shard shard = new Shard();
-      shard.setLogicalShardId("shard1");
-      List<Shard> shards = List.of(shard);
-      SpannerToSourceDb.validateMySQLNotReadOnly(shards);
-
-      // Verify that it didn't throw exception
-      mocked.verify(() -> SpannerToSourceDb.createJdbcConnection(any(), any(), any()));
-    }
-  }
-
-  @Test(expected = RuntimeException.class)
-  public void testValidateMySQLNotReadOnly_ReadOnly() throws Exception {
-    try (MockedStatic<SpannerToSourceDb> mocked =
-        Mockito.mockStatic(SpannerToSourceDb.class, Mockito.CALLS_REAL_METHODS)) {
-      Connection mockConnection = mock(Connection.class);
-      mocked
-          .when(() -> SpannerToSourceDb.createJdbcConnection(any(), any(), any()))
-          .thenReturn(mockConnection);
-
-      Statement mockStatement = mock(Statement.class);
-      when(mockConnection.createStatement()).thenReturn(mockStatement);
-      ResultSet mockResultSet = mock(ResultSet.class);
-      when(mockStatement.executeQuery("SELECT @@read_only")).thenReturn(mockResultSet);
-      when(mockResultSet.next()).thenReturn(true);
-      when(mockResultSet.getInt(1)).thenReturn(1); // 1 means read-only
-
-      Shard shard = new Shard();
-      shard.setLogicalShardId("shard1");
-      List<Shard> shards = List.of(shard);
-      SpannerToSourceDb.validateMySQLNotReadOnly(shards);
-    }
-  }
-
-  @Test
-  public void testFetchSourceSchema_MySQL() throws Exception {
-    try (MockedStatic<SpannerToSourceDb> mocked =
-        Mockito.mockStatic(SpannerToSourceDb.class, Mockito.CALLS_REAL_METHODS)) {
-      SourceSchema dummySchema =
-          SourceSchema.builder(SourceDatabaseType.MYSQL)
-              .databaseName("testdb")
-              .tables(ImmutableMap.of())
-              .build();
-
-      mocked.when(() -> SpannerToSourceDb.getSourceSchema(any(), any())).thenReturn(dummySchema);
-
-      Options options = mock(Options.class);
-      List<Shard> shards = List.of(new Shard());
-
-      SourceSchema result = SpannerToSourceDb.fetchSourceSchema(options, shards);
-
-      Assert.assertSame(dummySchema, result);
-    }
-  }
-
-  @Test
   public void testCalculateConnectionPoolSizePerWorker_Success() {
     int result = SpannerToSourceDb.calculateConnectionPoolSizePerWorker(10L, 2);
     Assert.assertEquals(5, result);
@@ -227,189 +125,5 @@ public class SpannerToSourceDbTest {
   @Test(expected = IllegalArgumentException.class)
   public void testCalculateConnectionPoolSizePerWorker_Failure() {
     SpannerToSourceDb.calculateConnectionPoolSizePerWorker(2L, 10);
-  }
-
-  @Test
-  public void testValidateMySQLNotReadOnly_NoVariable() throws Exception {
-    Shard shard = new Shard();
-    Connection mockConn = mock(Connection.class);
-    Statement mockStmt = mock(Statement.class);
-    ResultSet mockRs = mock(ResultSet.class);
-
-    when(mockConn.createStatement()).thenReturn(mockStmt);
-
-    try (MockedStatic<SpannerToSourceDb> mockedStatic =
-        Mockito.mockStatic(SpannerToSourceDb.class, Mockito.CALLS_REAL_METHODS)) {
-      mockedStatic
-          .when(() -> SpannerToSourceDb.createJdbcConnection(any(), any(), any()))
-          .thenReturn(mockConn);
-
-      SpannerToSourceDb.validateMySQLNotReadOnly(List.of(shard));
-      // Should not throw exception!
-    }
-  }
-
-  @Test
-  public void testGetSourceSchema_PostgreSQL() throws Exception {
-    Options options = mock(Options.class);
-    when(options.getSourceType()).thenReturn(Constants.SOURCE_POSTGRESQL);
-    List<Shard> shards = List.of(new Shard());
-
-    SourceSchema dummySchema =
-        SourceSchema.builder(SourceDatabaseType.POSTGRESQL)
-            .databaseName("db")
-            .tables(ImmutableMap.of())
-            .build();
-
-    try (MockedConstruction<PostgreSQLInformationSchemaScanner> mocked =
-        Mockito.mockConstruction(
-            PostgreSQLInformationSchemaScanner.class,
-            (mock, context) -> {
-              when(mock.scan()).thenReturn(dummySchema);
-            })) {
-
-      try (MockedStatic<SpannerToSourceDb> mockedStatic =
-          Mockito.mockStatic(SpannerToSourceDb.class, Mockito.CALLS_REAL_METHODS)) {
-        mockedStatic
-            .when(() -> SpannerToSourceDb.createJdbcConnection(any(), any(), any()))
-            .thenReturn(mock(Connection.class));
-
-        SourceSchema result = SpannerToSourceDb.getSourceSchema(options, shards);
-        Assert.assertSame(dummySchema, result);
-      }
-    }
-  }
-
-  @Test
-  public void testGetSourceSchema_Cassandra() throws Exception {
-    Options options = mock(Options.class);
-    when(options.getSourceType()).thenReturn("cassandra");
-    CassandraShard mockShard = mock(CassandraShard.class);
-    when(mockShard.getKeySpaceName()).thenReturn("keyspace");
-    List<Shard> shards = List.of(mockShard);
-
-    SourceSchema dummySchema =
-        SourceSchema.builder(SourceDatabaseType.CASSANDRA)
-            .databaseName("db")
-            .tables(ImmutableMap.of())
-            .build();
-
-    try (MockedConstruction<CassandraInformationSchemaScanner> mocked =
-        Mockito.mockConstruction(
-            CassandraInformationSchemaScanner.class,
-            (mock, context) -> {
-              when(mock.scan()).thenReturn(dummySchema);
-            })) {
-
-      try (MockedStatic<SpannerToSourceDb> mockedStatic =
-          Mockito.mockStatic(SpannerToSourceDb.class, Mockito.CALLS_REAL_METHODS)) {
-        mockedStatic
-            .when(() -> SpannerToSourceDb.createCqlSession(any()))
-            .thenReturn(mock(CqlSession.class));
-
-        SourceSchema result = SpannerToSourceDb.getSourceSchema(options, shards);
-        Assert.assertSame(dummySchema, result);
-      }
-    }
-  }
-
-  @Test
-  public void testGetShardList_unsupportedSourceType() {
-    RuntimeException exception =
-        assertThrows(
-            RuntimeException.class,
-            () -> SpannerToSourceDb.getShardList("unsupported_db", "dummy/path.json"));
-    assertNotNull(exception.getCause());
-    assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
-  }
-
-  @Test
-  public void testGetShardList_fileNotFound() {
-    RuntimeException exception =
-        assertThrows(
-            RuntimeException.class,
-            () -> SpannerToSourceDb.getShardList("mysql", "non-existent-file.json"));
-    assertNotNull(exception.getCause());
-    assertEquals(RuntimeException.class, exception.getCause().getClass());
-    assertEquals(
-        "Failed to read configuration input file at non-existent-file.json. Make sure it is ASCII or UTF-8 encoded and contains a well-formed HOCON/JSON string.",
-        exception.getCause().getMessage());
-  }
-
-  @Test
-  public void testGetShardList_jdbc_validJsonWrapped() throws IOException {
-    File tempFile = tempFolder.newFile("jdbc-config-wrapped.json");
-    String wrappedJson =
-        "{\n"
-            + "  \"shardConfigs\": [\n"
-            + "    {\n"
-            + "      \"logicalShardId\": \"shard1\",\n"
-            + "      \"host\": \"localhost\",\n"
-            + "      \"port\": \"3306\",\n"
-            + "      \"user\": \"test-user\",\n"
-            + "      \"password\": \"secret-pass\",\n"
-            + "      \"dbName\": \"testdb\"\n"
-            + "    }\n"
-            + "  ]\n"
-            + "}";
-    Files.writeString(tempFile.toPath(), wrappedJson);
-
-    List<Shard> shards = SpannerToSourceDb.getShardList("mysql", tempFile.getAbsolutePath());
-    assertNotNull(shards);
-    assertEquals(1, shards.size());
-    Shard shard = shards.get(0);
-    assertEquals("shard1", shard.getLogicalShardId());
-    assertEquals("localhost", shard.getHost());
-    assertEquals("3306", shard.getPort());
-    assertEquals("test-user", shard.getUserName());
-    assertEquals("secret-pass", shard.getPassword());
-    assertEquals("testdb", shard.getDbName());
-  }
-
-  @Test
-  public void testSpannerColocationValidation() {
-    options.setSourceType(Constants.SOURCE_SPANNER);
-    options.setSpannerProjectId("p1");
-    options.setMetadataInstance("i1");
-    options.setMetadataDatabase("d1");
-
-    // Shard that matches (colocated)
-    SpannerShard matchedShard = new SpannerShard("p1", "i1", "d1");
-
-    // This should NOT throw
-    SpannerToSourceDb.validateSpannerColocation(options, matchedShard);
-
-    // Shard that doesn't match
-    SpannerShard mismatchedShard = new SpannerShard("p2", "i1", "d1");
-
-    Assert.assertThrows(
-        IllegalArgumentException.class,
-        () -> SpannerToSourceDb.validateSpannerColocation(options, mismatchedShard));
-  }
-
-  @Test
-  public void testGetShardList_cassandra_validConf() throws IOException {
-    try (MockedStatic<JarFileReader> mockFileReader = mockStatic(JarFileReader.class)) {
-      String testGcsPath = "gs://smt-test-bucket/cassandraConfig.conf";
-      URL testUrl = com.google.common.io.Resources.getResource("test-cassandra-config.conf");
-      mockFileReader
-          .when(() -> JarFileReader.saveFilesLocally(testGcsPath))
-          .thenReturn(new URL[] {testUrl});
-
-      List<Shard> shards = SpannerToSourceDb.getShardList("cassandra", testGcsPath);
-      assertNotNull(shards);
-      assertEquals(1, shards.size());
-      Shard shard = shards.get(0);
-      assertEquals("127.0.0.1", shard.getHost());
-      assertEquals("9042", shard.getPort());
-
-      // Assert specific CassandraShard properties
-      CassandraShard cassandraShard = (CassandraShard) shard;
-      assertEquals("cassandra", cassandraShard.getUsername());
-      assertEquals("my_keyspace", cassandraShard.getKeySpaceName());
-      assertEquals(
-          "cassandra",
-          cassandraShard.getOptionsMap().get(TypedDriverOption.AUTH_PROVIDER_PASSWORD));
-    }
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/processor/SourceProcessorFactoryTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/dbutils/processor/SourceProcessorFactoryTest.java
@@ -22,11 +22,11 @@ import com.google.cloud.teleport.v2.spanner.migrations.connection.JdbcConnection
 import com.google.cloud.teleport.v2.spanner.migrations.shard.CassandraShard;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
 import com.google.cloud.teleport.v2.templates.constants.Constants;
-import com.google.cloud.teleport.v2.templates.dbutils.connection.CassandraConnectionHelper;
-import com.google.cloud.teleport.v2.templates.dbutils.dao.source.CassandraDao;
 import com.google.cloud.teleport.v2.templates.dbutils.dao.source.JdbcDao;
 import com.google.cloud.teleport.v2.templates.exceptions.UnsupportedSourceException;
+import com.google.cloud.teleport.v2.templates.source.cassandra.CassandraConnectionHelper;
 import com.google.cloud.teleport.v2.templates.source.cassandra.CassandraDMLGenerator;
+import com.google.cloud.teleport.v2.templates.source.cassandra.CassandraDao;
 import com.google.cloud.teleport.v2.templates.source.cassandra.CassandraSourceConnector;
 import com.google.cloud.teleport.v2.templates.source.mysql.MySQLDMLGenerator;
 import com.google.cloud.teleport.v2.templates.source.mysql.MySQLSourceConnector;

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraConnectionHelperTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraConnectionHelperTest.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.teleport.v2.templates.dbutils.connection;
+package com.google.cloud.teleport.v2.templates.source.cassandra;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraDaoTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraDaoTest.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.teleport.v2.templates.dbutils.dao.source;
+package com.google.cloud.teleport.v2.templates.source.cassandra;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
@@ -30,7 +30,6 @@ import com.google.cloud.teleport.v2.spanner.migrations.connection.IConnectionHel
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.ConnectionException;
 import com.google.cloud.teleport.v2.templates.models.PreparedStatementGeneratedResponse;
 import com.google.cloud.teleport.v2.templates.models.PreparedStatementValueObject;
-import com.google.cloud.teleport.v2.templates.source.cassandra.CassandraTypeHandler;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Before;

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnectorTest.java
@@ -188,7 +188,7 @@ public class CassandraSourceConnectorTest {
                       .saveFilesLocally(testGcsPath))
           .thenReturn(new java.net.URL[] {testUrl});
 
-      List<Shard> shards = connector.parseShardList(testGcsPath);
+      List<Shard> shards = connector.parseShardConfig(testGcsPath);
       assertNotNull(shards);
       assertEquals(1, shards.size());
       Shard shard = shards.get(0);

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnectorTest.java
@@ -74,7 +74,7 @@ public class CassandraSourceConnectorTest {
     when(mockCassandraShard.getKeySpaceName()).thenReturn("mykeyspace");
 
     String url = connector.getConnectionUrl(mockCassandraShard);
-    assertEquals("localhost:9042", url);
+    assertEquals("localhost:9042/cassandra/mykeyspace", url);
   }
 
   @Test
@@ -105,7 +105,7 @@ public class CassandraSourceConnectorTest {
     ConnectionHelperRequest request = requestCaptor.getValue();
     assertEquals(shards, request.getShards());
     assertEquals(maxConnections, request.getMaxConnections());
-    assertEquals(null, request.getDriver());
+    assertEquals("com.datastax.oss.driver.api.core.CqlSession", request.getDriver());
     assertEquals(null, request.getConnectionInitQuery());
     assertEquals(null, request.getJdbcUrlPrefix());
   }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnectorTest.java
@@ -19,7 +19,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -27,7 +30,6 @@ import com.google.cloud.teleport.v2.spanner.migrations.connection.ConnectionHelp
 import com.google.cloud.teleport.v2.spanner.migrations.connection.IConnectionHelper;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.CassandraShard;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
-import com.google.cloud.teleport.v2.templates.dbutils.dao.source.CassandraDao;
 import com.google.cloud.teleport.v2.templates.dbutils.dao.source.IDao;
 import com.google.cloud.teleport.v2.templates.dbutils.dml.IDMLGenerator;
 import java.util.Collections;
@@ -72,7 +74,7 @@ public class CassandraSourceConnectorTest {
     when(mockCassandraShard.getKeySpaceName()).thenReturn("mykeyspace");
 
     String url = connector.getConnectionUrl(mockCassandraShard);
-    assertEquals("localhost:9042/cassandra/mykeyspace", url);
+    assertEquals("localhost:9042", url);
   }
 
   @Test
@@ -103,7 +105,7 @@ public class CassandraSourceConnectorTest {
     ConnectionHelperRequest request = requestCaptor.getValue();
     assertEquals(shards, request.getShards());
     assertEquals(maxConnections, request.getMaxConnections());
-    assertEquals("com.datastax.oss.driver.api.core.CqlSession", request.getDriver());
+    assertEquals(null, request.getDriver());
     assertEquals(null, request.getConnectionInitQuery());
     assertEquals(null, request.getJdbcUrlPrefix());
   }
@@ -118,5 +120,74 @@ public class CassandraSourceConnectorTest {
     connector.initConnectionHelper(shards, maxConnections);
 
     verify(mockConnectionHelper, never()).init(any());
+  }
+
+  @Test
+  public void testClassifyException_Permanent() {
+    com.datastax.oss.driver.api.core.type.codec.CodecNotFoundException mockException =
+        org.mockito.Mockito.mock(com.datastax.oss.driver.api.core.type.codec.CodecNotFoundException.class);
+    Exception codecEx = new Exception("wrapper", mockException);
+    assertEquals(
+        com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
+        connector.classifyException(codecEx));
+  }
+
+  @Test
+  public void testClassifyException_Fallback() {
+    Exception genericEx = new Exception("wrapper", new RuntimeException("generic error"));
+    org.junit.Assert.assertNull(connector.classifyException(genericEx));
+  }
+
+  @Test
+  public void testGetInformationSchema() throws Exception {
+    com.datastax.oss.driver.api.core.CqlSession mockSession = mock(com.datastax.oss.driver.api.core.CqlSession.class);
+    when(mockCassandraShard.getKeySpaceName()).thenReturn("keyspace");
+
+    CassandraSourceConnector spyConnector = spy(connector);
+    doReturn(mockSession).when(spyConnector).createCqlSession(any());
+
+    com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema dummySchema =
+        com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema.builder(com.google.cloud.teleport.v2.spanner.sourceddl.SourceDatabaseType.CASSANDRA)
+            .databaseName("keyspace")
+            .tables(com.google.common.collect.ImmutableMap.of())
+            .build();
+
+    try (org.mockito.MockedConstruction<com.google.cloud.teleport.v2.spanner.sourceddl.CassandraInformationSchemaScanner> mocked =
+        org.mockito.Mockito.mockConstruction(
+            com.google.cloud.teleport.v2.spanner.sourceddl.CassandraInformationSchemaScanner.class,
+            (mock, context) -> {
+              when(mock.scan()).thenReturn(dummySchema);
+            })) {
+
+      com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema result =
+          spyConnector.getInformationSchema(List.of(mockCassandraShard));
+      assertEquals(dummySchema, result);
+    }
+  }
+
+  @Test
+  public void testParseShardList_validConf() throws Exception {
+    try (org.mockito.MockedStatic<com.google.cloud.teleport.v2.spanner.migrations.utils.JarFileReader> mockFileReader =
+        org.mockito.Mockito.mockStatic(com.google.cloud.teleport.v2.spanner.migrations.utils.JarFileReader.class)) {
+      String testGcsPath = "gs://smt-test-bucket/cassandraConfig.conf";
+      java.net.URL testUrl = com.google.common.io.Resources.getResource("test-cassandra-config.conf");
+      mockFileReader
+          .when(() -> com.google.cloud.teleport.v2.spanner.migrations.utils.JarFileReader.saveFilesLocally(testGcsPath))
+          .thenReturn(new java.net.URL[] {testUrl});
+
+      List<Shard> shards = connector.parseShardList(testGcsPath);
+      assertNotNull(shards);
+      assertEquals(1, shards.size());
+      Shard shard = shards.get(0);
+      assertEquals("127.0.0.1", shard.getHost());
+      assertEquals("9042", shard.getPort());
+
+      CassandraShard cassandraShard = (CassandraShard) shard;
+      assertEquals("cassandra", cassandraShard.getUsername());
+      assertEquals("my_keyspace", cassandraShard.getKeySpaceName());
+      assertEquals(
+          "cassandra",
+          cassandraShard.getOptionsMap().get(com.datastax.oss.driver.api.core.config.TypedDriverOption.AUTH_PROVIDER_PASSWORD));
+    }
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnectorTest.java
@@ -127,15 +127,14 @@ public class CassandraSourceConnectorTest {
     com.datastax.oss.driver.api.core.type.codec.CodecNotFoundException mockException =
         org.mockito.Mockito.mock(
             com.datastax.oss.driver.api.core.type.codec.CodecNotFoundException.class);
-    Exception codecEx = new Exception("wrapper", mockException);
     assertEquals(
         com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
-        connector.classifyException(codecEx));
+        connector.classifyException(mockException));
   }
 
   @Test
   public void testClassifyException_Fallback() {
-    Exception genericEx = new Exception("wrapper", new RuntimeException("generic error"));
+    Throwable genericEx = new RuntimeException("generic error");
     org.junit.Assert.assertNull(connector.classifyException(genericEx));
   }
 

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceConnectorTest.java
@@ -125,7 +125,8 @@ public class CassandraSourceConnectorTest {
   @Test
   public void testClassifyException_Permanent() {
     com.datastax.oss.driver.api.core.type.codec.CodecNotFoundException mockException =
-        org.mockito.Mockito.mock(com.datastax.oss.driver.api.core.type.codec.CodecNotFoundException.class);
+        org.mockito.Mockito.mock(
+            com.datastax.oss.driver.api.core.type.codec.CodecNotFoundException.class);
     Exception codecEx = new Exception("wrapper", mockException);
     assertEquals(
         com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
@@ -140,24 +141,29 @@ public class CassandraSourceConnectorTest {
 
   @Test
   public void testGetInformationSchema() throws Exception {
-    com.datastax.oss.driver.api.core.CqlSession mockSession = mock(com.datastax.oss.driver.api.core.CqlSession.class);
+    com.datastax.oss.driver.api.core.CqlSession mockSession =
+        mock(com.datastax.oss.driver.api.core.CqlSession.class);
     when(mockCassandraShard.getKeySpaceName()).thenReturn("keyspace");
 
     CassandraSourceConnector spyConnector = spy(connector);
     doReturn(mockSession).when(spyConnector).createCqlSession(any());
 
     com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema dummySchema =
-        com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema.builder(com.google.cloud.teleport.v2.spanner.sourceddl.SourceDatabaseType.CASSANDRA)
+        com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema.builder(
+                com.google.cloud.teleport.v2.spanner.sourceddl.SourceDatabaseType.CASSANDRA)
             .databaseName("keyspace")
             .tables(com.google.common.collect.ImmutableMap.of())
             .build();
 
-    try (org.mockito.MockedConstruction<com.google.cloud.teleport.v2.spanner.sourceddl.CassandraInformationSchemaScanner> mocked =
-        org.mockito.Mockito.mockConstruction(
-            com.google.cloud.teleport.v2.spanner.sourceddl.CassandraInformationSchemaScanner.class,
-            (mock, context) -> {
-              when(mock.scan()).thenReturn(dummySchema);
-            })) {
+    try (org.mockito.MockedConstruction<
+            com.google.cloud.teleport.v2.spanner.sourceddl.CassandraInformationSchemaScanner>
+        mocked =
+            org.mockito.Mockito.mockConstruction(
+                com.google.cloud.teleport.v2.spanner.sourceddl.CassandraInformationSchemaScanner
+                    .class,
+                (mock, context) -> {
+                  when(mock.scan()).thenReturn(dummySchema);
+                })) {
 
       com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema result =
           spyConnector.getInformationSchema(List.of(mockCassandraShard));
@@ -167,12 +173,19 @@ public class CassandraSourceConnectorTest {
 
   @Test
   public void testParseShardList_validConf() throws Exception {
-    try (org.mockito.MockedStatic<com.google.cloud.teleport.v2.spanner.migrations.utils.JarFileReader> mockFileReader =
-        org.mockito.Mockito.mockStatic(com.google.cloud.teleport.v2.spanner.migrations.utils.JarFileReader.class)) {
+    try (org.mockito.MockedStatic<
+            com.google.cloud.teleport.v2.spanner.migrations.utils.JarFileReader>
+        mockFileReader =
+            org.mockito.Mockito.mockStatic(
+                com.google.cloud.teleport.v2.spanner.migrations.utils.JarFileReader.class)) {
       String testGcsPath = "gs://smt-test-bucket/cassandraConfig.conf";
-      java.net.URL testUrl = com.google.common.io.Resources.getResource("test-cassandra-config.conf");
+      java.net.URL testUrl =
+          com.google.common.io.Resources.getResource("test-cassandra-config.conf");
       mockFileReader
-          .when(() -> com.google.cloud.teleport.v2.spanner.migrations.utils.JarFileReader.saveFilesLocally(testGcsPath))
+          .when(
+              () ->
+                  com.google.cloud.teleport.v2.spanner.migrations.utils.JarFileReader
+                      .saveFilesLocally(testGcsPath))
           .thenReturn(new java.net.URL[] {testUrl});
 
       List<Shard> shards = connector.parseShardList(testGcsPath);
@@ -187,7 +200,11 @@ public class CassandraSourceConnectorTest {
       assertEquals("my_keyspace", cassandraShard.getKeySpaceName());
       assertEquals(
           "cassandra",
-          cassandraShard.getOptionsMap().get(com.datastax.oss.driver.api.core.config.TypedDriverOption.AUTH_PROVIDER_PASSWORD));
+          cassandraShard
+              .getOptionsMap()
+              .get(
+                  com.datastax.oss.driver.api.core.config.TypedDriverOption
+                      .AUTH_PROVIDER_PASSWORD));
     }
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceSchemaReaderTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/cassandra/CassandraSourceSchemaReaderTest.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.google.cloud.teleport.v2.templates.utils;
+package com.google.cloud.teleport.v2.templates.source.cassandra;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.any;

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnectorTest.java
@@ -136,8 +136,7 @@ public class MySQLSourceConnectorTest {
         com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
         connector.classifyException(dataEx));
 
-    Throwable connEx =
-        new java.sql.SQLNonTransientConnectionException("conn error", "state", 9999);
+    Throwable connEx = new java.sql.SQLNonTransientConnectionException("conn error", "state", 9999);
     assertEquals(
         com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
         connector.classifyException(connEx));

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnectorTest.java
@@ -126,21 +126,18 @@ public class MySQLSourceConnectorTest {
 
   @Test
   public void testClassifyException_Permanent() {
-    Exception syntaxEx =
-        new Exception("wrapper", new java.sql.SQLSyntaxErrorException("syntax error"));
+    Throwable syntaxEx = new java.sql.SQLSyntaxErrorException("syntax error");
     assertEquals(
         com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
         connector.classifyException(syntaxEx));
 
-    Exception dataEx = new Exception("wrapper", new java.sql.SQLDataException("data error"));
+    Throwable dataEx = new java.sql.SQLDataException("data error");
     assertEquals(
         com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
         connector.classifyException(dataEx));
 
-    Exception connEx =
-        new Exception(
-            "wrapper",
-            new java.sql.SQLNonTransientConnectionException("conn error", "state", 9999));
+    Throwable connEx =
+        new java.sql.SQLNonTransientConnectionException("conn error", "state", 9999);
     assertEquals(
         com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
         connector.classifyException(connEx));
@@ -150,17 +147,15 @@ public class MySQLSourceConnectorTest {
   public void testClassifyException_Retryable() {
     int[] retryableSqlCodes = {1053, 1159, 1161};
     for (int code : retryableSqlCodes) {
-      Exception connEx =
-          new Exception(
-              "wrapper",
-              new java.sql.SQLNonTransientConnectionException("conn error", "state", code));
+      Throwable connEx =
+          new java.sql.SQLNonTransientConnectionException("conn error", "state", code);
       org.junit.Assert.assertNull(connector.classifyException(connEx));
     }
   }
 
   @Test
   public void testClassifyException_Fallback() {
-    Exception genericEx = new Exception("wrapper", new RuntimeException("generic error"));
+    Throwable genericEx = new RuntimeException("generic error");
     org.junit.Assert.assertNull(connector.classifyException(genericEx));
   }
 

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnectorTest.java
@@ -126,7 +126,8 @@ public class MySQLSourceConnectorTest {
 
   @Test
   public void testClassifyException_Permanent() {
-    Exception syntaxEx = new Exception("wrapper", new java.sql.SQLSyntaxErrorException("syntax error"));
+    Exception syntaxEx =
+        new Exception("wrapper", new java.sql.SQLSyntaxErrorException("syntax error"));
     assertEquals(
         com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
         connector.classifyException(syntaxEx));
@@ -136,7 +137,10 @@ public class MySQLSourceConnectorTest {
         com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
         connector.classifyException(dataEx));
 
-    Exception connEx = new Exception("wrapper", new java.sql.SQLNonTransientConnectionException("conn error", "state", 9999));
+    Exception connEx =
+        new Exception(
+            "wrapper",
+            new java.sql.SQLNonTransientConnectionException("conn error", "state", 9999));
     assertEquals(
         com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
         connector.classifyException(connEx));
@@ -146,7 +150,10 @@ public class MySQLSourceConnectorTest {
   public void testClassifyException_Retryable() {
     int[] retryableSqlCodes = {1053, 1159, 1161};
     for (int code : retryableSqlCodes) {
-      Exception connEx = new Exception("wrapper", new java.sql.SQLNonTransientConnectionException("conn error", "state", code));
+      Exception connEx =
+          new Exception(
+              "wrapper",
+              new java.sql.SQLNonTransientConnectionException("conn error", "state", code));
       org.junit.Assert.assertNull(connector.classifyException(connEx));
     }
   }
@@ -199,7 +206,8 @@ public class MySQLSourceConnectorTest {
 
     java.sql.Statement mockStatement = mock(java.sql.Statement.class);
     when(mockConnection.createStatement()).thenReturn(mockStatement);
-    when(mockStatement.executeQuery("SELECT @@read_only")).thenThrow(new java.sql.SQLException("unknown variable"));
+    when(mockStatement.executeQuery("SELECT @@read_only"))
+        .thenThrow(new java.sql.SQLException("unknown variable"));
 
     List<Shard> shards = List.of(mockShard);
     spyConnector.validate(shards, null);
@@ -213,17 +221,20 @@ public class MySQLSourceConnectorTest {
     doReturn(mockConnection).when(spyConnector).createConnection(mockShard);
 
     com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema dummySchema =
-        com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema.builder(com.google.cloud.teleport.v2.spanner.sourceddl.SourceDatabaseType.MYSQL)
+        com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema.builder(
+                com.google.cloud.teleport.v2.spanner.sourceddl.SourceDatabaseType.MYSQL)
             .databaseName("mydb")
             .tables(com.google.common.collect.ImmutableMap.of())
             .build();
 
-    try (org.mockito.MockedConstruction<com.google.cloud.teleport.v2.spanner.sourceddl.MySqlInformationSchemaScanner> mocked =
-        org.mockito.Mockito.mockConstruction(
-            com.google.cloud.teleport.v2.spanner.sourceddl.MySqlInformationSchemaScanner.class,
-            (mock, context) -> {
-              when(mock.scan()).thenReturn(dummySchema);
-            })) {
+    try (org.mockito.MockedConstruction<
+            com.google.cloud.teleport.v2.spanner.sourceddl.MySqlInformationSchemaScanner>
+        mocked =
+            org.mockito.Mockito.mockConstruction(
+                com.google.cloud.teleport.v2.spanner.sourceddl.MySqlInformationSchemaScanner.class,
+                (mock, context) -> {
+                  when(mock.scan()).thenReturn(dummySchema);
+                })) {
 
       com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema result =
           spyConnector.getInformationSchema(List.of(mockShard));

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnectorTest.java
@@ -260,7 +260,7 @@ public class MySQLSourceConnectorTest {
             + "}";
     java.nio.file.Files.writeString(tempFile.toPath(), wrappedJson);
 
-    List<Shard> shards = connector.parseShardList(tempFile.getAbsolutePath());
+    List<Shard> shards = connector.parseShardConfig(tempFile.getAbsolutePath());
     assertNotNull(shards);
     assertEquals(1, shards.size());
     Shard shard = shards.get(0);

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLSourceConnectorTest.java
@@ -19,7 +19,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -40,6 +43,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MySQLSourceConnectorTest {
+
+  @org.junit.Rule
+  public org.junit.rules.TemporaryFolder tempFolder = new org.junit.rules.TemporaryFolder();
 
   @Mock private IConnectionHelper mockConnectionHelper;
   @Mock private Shard mockShard;
@@ -116,5 +122,142 @@ public class MySQLSourceConnectorTest {
     connector.initConnectionHelper(shards, maxConnections);
 
     verify(mockConnectionHelper, never()).init(any());
+  }
+
+  @Test
+  public void testClassifyException_Permanent() {
+    Exception syntaxEx = new Exception("wrapper", new java.sql.SQLSyntaxErrorException("syntax error"));
+    assertEquals(
+        com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
+        connector.classifyException(syntaxEx));
+
+    Exception dataEx = new Exception("wrapper", new java.sql.SQLDataException("data error"));
+    assertEquals(
+        com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
+        connector.classifyException(dataEx));
+
+    Exception connEx = new Exception("wrapper", new java.sql.SQLNonTransientConnectionException("conn error", "state", 9999));
+    assertEquals(
+        com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
+        connector.classifyException(connEx));
+  }
+
+  @Test
+  public void testClassifyException_Retryable() {
+    int[] retryableSqlCodes = {1053, 1159, 1161};
+    for (int code : retryableSqlCodes) {
+      Exception connEx = new Exception("wrapper", new java.sql.SQLNonTransientConnectionException("conn error", "state", code));
+      org.junit.Assert.assertNull(connector.classifyException(connEx));
+    }
+  }
+
+  @Test
+  public void testClassifyException_Fallback() {
+    Exception genericEx = new Exception("wrapper", new RuntimeException("generic error"));
+    org.junit.Assert.assertNull(connector.classifyException(genericEx));
+  }
+
+  @Test
+  public void testValidate_NotReadOnly() throws Exception {
+    java.sql.Connection mockConnection = mock(java.sql.Connection.class);
+    MySQLSourceConnector spyConnector = spy(connector);
+    doReturn(mockConnection).when(spyConnector).createConnection(mockShard);
+
+    java.sql.Statement mockStatement = mock(java.sql.Statement.class);
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+    java.sql.ResultSet mockResultSet = mock(java.sql.ResultSet.class);
+    when(mockStatement.executeQuery("SELECT @@read_only")).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getInt(1)).thenReturn(0);
+
+    List<Shard> shards = List.of(mockShard);
+    spyConnector.validate(shards, null);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testValidate_ReadOnly() throws Exception {
+    java.sql.Connection mockConnection = mock(java.sql.Connection.class);
+    MySQLSourceConnector spyConnector = spy(connector);
+    doReturn(mockConnection).when(spyConnector).createConnection(mockShard);
+
+    java.sql.Statement mockStatement = mock(java.sql.Statement.class);
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+    java.sql.ResultSet mockResultSet = mock(java.sql.ResultSet.class);
+    when(mockStatement.executeQuery("SELECT @@read_only")).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockResultSet.getInt(1)).thenReturn(1);
+
+    List<Shard> shards = List.of(mockShard);
+    spyConnector.validate(shards, null);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testValidate_NoVariable() throws Exception {
+    java.sql.Connection mockConnection = mock(java.sql.Connection.class);
+    MySQLSourceConnector spyConnector = spy(connector);
+    doReturn(mockConnection).when(spyConnector).createConnection(mockShard);
+
+    java.sql.Statement mockStatement = mock(java.sql.Statement.class);
+    when(mockConnection.createStatement()).thenReturn(mockStatement);
+    when(mockStatement.executeQuery("SELECT @@read_only")).thenThrow(new java.sql.SQLException("unknown variable"));
+
+    List<Shard> shards = List.of(mockShard);
+    spyConnector.validate(shards, null);
+  }
+
+  @Test
+  public void testGetInformationSchema() throws Exception {
+    java.sql.Connection mockConnection = mock(java.sql.Connection.class);
+    when(mockShard.getDbName()).thenReturn("mydb");
+    MySQLSourceConnector spyConnector = spy(connector);
+    doReturn(mockConnection).when(spyConnector).createConnection(mockShard);
+
+    com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema dummySchema =
+        com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema.builder(com.google.cloud.teleport.v2.spanner.sourceddl.SourceDatabaseType.MYSQL)
+            .databaseName("mydb")
+            .tables(com.google.common.collect.ImmutableMap.of())
+            .build();
+
+    try (org.mockito.MockedConstruction<com.google.cloud.teleport.v2.spanner.sourceddl.MySqlInformationSchemaScanner> mocked =
+        org.mockito.Mockito.mockConstruction(
+            com.google.cloud.teleport.v2.spanner.sourceddl.MySqlInformationSchemaScanner.class,
+            (mock, context) -> {
+              when(mock.scan()).thenReturn(dummySchema);
+            })) {
+
+      com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema result =
+          spyConnector.getInformationSchema(List.of(mockShard));
+      assertEquals(dummySchema, result);
+    }
+  }
+
+  @Test
+  public void testParseShardList_validJsonWrapped() throws Exception {
+    java.io.File tempFile = tempFolder.newFile("jdbc-config-wrapped.json");
+    String wrappedJson =
+        "{\n"
+            + "  \"shardConfigs\": [\n"
+            + "    {\n"
+            + "      \"logicalShardId\": \"shard1\",\n"
+            + "      \"host\": \"localhost\",\n"
+            + "      \"port\": \"3306\",\n"
+            + "      \"user\": \"test-user\",\n"
+            + "      \"password\": \"secret-pass\",\n"
+            + "      \"dbName\": \"testdb\"\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}";
+    java.nio.file.Files.writeString(tempFile.toPath(), wrappedJson);
+
+    List<Shard> shards = connector.parseShardList(tempFile.getAbsolutePath());
+    assertNotNull(shards);
+    assertEquals(1, shards.size());
+    Shard shard = shards.get(0);
+    assertEquals("shard1", shard.getLogicalShardId());
+    assertEquals("localhost", shard.getHost());
+    assertEquals("3306", shard.getPort());
+    assertEquals("test-user", shard.getUserName());
+    assertEquals("secret-pass", shard.getPassword());
+    assertEquals("testdb", shard.getDbName());
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnectorTest.java
@@ -200,7 +200,7 @@ public class PostgreSQLSourceConnectorTest {
             + "}";
     java.nio.file.Files.writeString(tempFile.toPath(), wrappedJson);
 
-    List<Shard> shards = connector.parseShardList(tempFile.getAbsolutePath());
+    List<Shard> shards = connector.parseShardConfig(tempFile.getAbsolutePath());
     assertNotNull(shards);
     assertEquals(1, shards.size());
     Shard shard = shards.get(0);

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnectorTest.java
@@ -125,28 +125,17 @@ public class PostgreSQLSourceConnectorTest {
   }
 
   @Test
-  public void testClassifyException_Permanent() {
-    Exception syntaxEx =
-        new Exception("wrapper", new java.sql.SQLSyntaxErrorException("syntax error"));
-    assertEquals(
-        com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
-        connector.classifyException(syntaxEx));
+  public void testClassifyException() {
+    Throwable syntaxEx = new java.sql.SQLSyntaxErrorException("syntax error");
+    org.junit.Assert.assertNull(connector.classifyException(syntaxEx));
 
-    Exception dataEx = new Exception("wrapper", new java.sql.SQLDataException("data error"));
-    assertEquals(
-        com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
-        connector.classifyException(dataEx));
+    Throwable dataEx = new java.sql.SQLDataException("data error");
+    org.junit.Assert.assertNull(connector.classifyException(dataEx));
 
-    Exception connEx =
-        new Exception("wrapper", new java.sql.SQLNonTransientConnectionException("conn error"));
-    assertEquals(
-        com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
-        connector.classifyException(connEx));
-  }
+    Throwable connEx = new java.sql.SQLNonTransientConnectionException("conn error");
+    org.junit.Assert.assertNull(connector.classifyException(connEx));
 
-  @Test
-  public void testClassifyException_Fallback() {
-    Exception genericEx = new Exception("wrapper", new RuntimeException("generic error"));
+    Throwable genericEx = new RuntimeException("generic error");
     org.junit.Assert.assertNull(connector.classifyException(genericEx));
   }
 

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnectorTest.java
@@ -126,7 +126,8 @@ public class PostgreSQLSourceConnectorTest {
 
   @Test
   public void testClassifyException_Permanent() {
-    Exception syntaxEx = new Exception("wrapper", new java.sql.SQLSyntaxErrorException("syntax error"));
+    Exception syntaxEx =
+        new Exception("wrapper", new java.sql.SQLSyntaxErrorException("syntax error"));
     assertEquals(
         com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
         connector.classifyException(syntaxEx));
@@ -136,7 +137,8 @@ public class PostgreSQLSourceConnectorTest {
         com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
         connector.classifyException(dataEx));
 
-    Exception connEx = new Exception("wrapper", new java.sql.SQLNonTransientConnectionException("conn error"));
+    Exception connEx =
+        new Exception("wrapper", new java.sql.SQLNonTransientConnectionException("conn error"));
     assertEquals(
         com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
         connector.classifyException(connEx));
@@ -157,17 +159,21 @@ public class PostgreSQLSourceConnectorTest {
     doReturn(mockConnection).when(spyConnector).createConnection(mockShard);
 
     com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema dummySchema =
-        com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema.builder(com.google.cloud.teleport.v2.spanner.sourceddl.SourceDatabaseType.POSTGRESQL)
+        com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema.builder(
+                com.google.cloud.teleport.v2.spanner.sourceddl.SourceDatabaseType.POSTGRESQL)
             .databaseName("mydb")
             .tables(com.google.common.collect.ImmutableMap.of())
             .build();
 
-    try (org.mockito.MockedConstruction<com.google.cloud.teleport.v2.spanner.sourceddl.PostgreSQLInformationSchemaScanner> mocked =
-        org.mockito.Mockito.mockConstruction(
-            com.google.cloud.teleport.v2.spanner.sourceddl.PostgreSQLInformationSchemaScanner.class,
-            (mock, context) -> {
-              when(mock.scan()).thenReturn(dummySchema);
-            })) {
+    try (org.mockito.MockedConstruction<
+            com.google.cloud.teleport.v2.spanner.sourceddl.PostgreSQLInformationSchemaScanner>
+        mocked =
+            org.mockito.Mockito.mockConstruction(
+                com.google.cloud.teleport.v2.spanner.sourceddl.PostgreSQLInformationSchemaScanner
+                    .class,
+                (mock, context) -> {
+                  when(mock.scan()).thenReturn(dummySchema);
+                })) {
 
       com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema result =
           spyConnector.getInformationSchema(List.of(mockShard));

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLSourceConnectorTest.java
@@ -19,7 +19,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -40,6 +43,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PostgreSQLSourceConnectorTest {
+
+  @org.junit.Rule
+  public org.junit.rules.TemporaryFolder tempFolder = new org.junit.rules.TemporaryFolder();
 
   @Mock private IConnectionHelper mockConnectionHelper;
   @Mock private Shard mockShard;
@@ -116,5 +122,88 @@ public class PostgreSQLSourceConnectorTest {
     connector.initConnectionHelper(shards, maxConnections);
 
     verify(mockConnectionHelper, never()).init(any());
+  }
+
+  @Test
+  public void testClassifyException_Permanent() {
+    Exception syntaxEx = new Exception("wrapper", new java.sql.SQLSyntaxErrorException("syntax error"));
+    assertEquals(
+        com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
+        connector.classifyException(syntaxEx));
+
+    Exception dataEx = new Exception("wrapper", new java.sql.SQLDataException("data error"));
+    assertEquals(
+        com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
+        connector.classifyException(dataEx));
+
+    Exception connEx = new Exception("wrapper", new java.sql.SQLNonTransientConnectionException("conn error"));
+    assertEquals(
+        com.google.cloud.teleport.v2.templates.constants.Constants.PERMANENT_ERROR_TAG,
+        connector.classifyException(connEx));
+  }
+
+  @Test
+  public void testClassifyException_Fallback() {
+    Exception genericEx = new Exception("wrapper", new RuntimeException("generic error"));
+    org.junit.Assert.assertNull(connector.classifyException(genericEx));
+  }
+
+  @Test
+  public void testGetInformationSchema() throws Exception {
+    java.sql.Connection mockConnection = mock(java.sql.Connection.class);
+    when(mockShard.getDbName()).thenReturn("mydb");
+    when(mockShard.getNamespace()).thenReturn("public");
+    PostgreSQLSourceConnector spyConnector = spy(connector);
+    doReturn(mockConnection).when(spyConnector).createConnection(mockShard);
+
+    com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema dummySchema =
+        com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema.builder(com.google.cloud.teleport.v2.spanner.sourceddl.SourceDatabaseType.POSTGRESQL)
+            .databaseName("mydb")
+            .tables(com.google.common.collect.ImmutableMap.of())
+            .build();
+
+    try (org.mockito.MockedConstruction<com.google.cloud.teleport.v2.spanner.sourceddl.PostgreSQLInformationSchemaScanner> mocked =
+        org.mockito.Mockito.mockConstruction(
+            com.google.cloud.teleport.v2.spanner.sourceddl.PostgreSQLInformationSchemaScanner.class,
+            (mock, context) -> {
+              when(mock.scan()).thenReturn(dummySchema);
+            })) {
+
+      com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema result =
+          spyConnector.getInformationSchema(List.of(mockShard));
+      assertEquals(dummySchema, result);
+    }
+  }
+
+  @Test
+  public void testParseShardList_validJsonWrapped() throws Exception {
+    java.io.File tempFile = tempFolder.newFile("jdbc-config-wrapped.json");
+    String wrappedJson =
+        "{\n"
+            + "  \"shardConfigs\": [\n"
+            + "    {\n"
+            + "      \"logicalShardId\": \"shard1\",\n"
+            + "      \"host\": \"localhost\",\n"
+            + "      \"port\": \"5432\",\n"
+            + "      \"user\": \"test-user\",\n"
+            + "      \"password\": \"secret-pass\",\n"
+            + "      \"dbName\": \"testdb\",\n"
+            + "      \"namespace\": \"public\"\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}";
+    java.nio.file.Files.writeString(tempFile.toPath(), wrappedJson);
+
+    List<Shard> shards = connector.parseShardList(tempFile.getAbsolutePath());
+    assertNotNull(shards);
+    assertEquals(1, shards.size());
+    Shard shard = shards.get(0);
+    assertEquals("shard1", shard.getLogicalShardId());
+    assertEquals("localhost", shard.getHost());
+    assertEquals("5432", shard.getPort());
+    assertEquals("test-user", shard.getUserName());
+    assertEquals("secret-pass", shard.getPassword());
+    assertEquals("testdb", shard.getDbName());
+    assertEquals("public", shard.getNamespace());
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSourceConnectorTest.java
@@ -67,21 +67,6 @@ public class SpannerSourceConnectorTest {
   }
 
   @Test
-  public void testGetConnectionUrl() {
-    when(mockSpannerShard.getProjectId()).thenReturn("my-project");
-    when(mockSpannerShard.getInstanceId()).thenReturn("my-instance");
-    when(mockSpannerShard.getDatabaseId()).thenReturn("my-database");
-
-    String url = connector.getConnectionUrl(mockSpannerShard);
-    assertEquals("my-project/my-instance/my-database", url);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetConnectionUrl_invalidShardType() {
-    connector.getConnectionUrl(mockGenericShard);
-  }
-
-  @Test
   public void testGetDao() {
     when(mockSpannerShard.getProjectId()).thenReturn("my-project");
     when(mockSpannerShard.getInstanceId()).thenReturn("my-instance");

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSourceConnectorTest.java
@@ -127,9 +127,13 @@ public class SpannerSourceConnectorTest {
 
   @Test
   public void testValidate_Colocation_Success() throws Exception {
-    org.apache.beam.sdk.options.PipelineOptions mockPipelineOptions = mock(org.apache.beam.sdk.options.PipelineOptions.class);
-    com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options mockOptions = mock(com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options.class);
-    when(mockPipelineOptions.as(com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options.class)).thenReturn(mockOptions);
+    org.apache.beam.sdk.options.PipelineOptions mockPipelineOptions =
+        mock(org.apache.beam.sdk.options.PipelineOptions.class);
+    com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options mockOptions =
+        mock(com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options.class);
+    when(mockPipelineOptions.as(
+            com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options.class))
+        .thenReturn(mockOptions);
 
     when(mockOptions.getSpannerProjectId()).thenReturn("p1");
     when(mockOptions.getMetadataInstance()).thenReturn("i1");
@@ -144,9 +148,13 @@ public class SpannerSourceConnectorTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testValidate_Colocation_Failure() throws Exception {
-    org.apache.beam.sdk.options.PipelineOptions mockPipelineOptions = mock(org.apache.beam.sdk.options.PipelineOptions.class);
-    com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options mockOptions = mock(com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options.class);
-    when(mockPipelineOptions.as(com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options.class)).thenReturn(mockOptions);
+    org.apache.beam.sdk.options.PipelineOptions mockPipelineOptions =
+        mock(org.apache.beam.sdk.options.PipelineOptions.class);
+    com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options mockOptions =
+        mock(com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options.class);
+    when(mockPipelineOptions.as(
+            com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options.class))
+        .thenReturn(mockOptions);
 
     when(mockOptions.getSpannerProjectId()).thenReturn("p1");
     when(mockOptions.getMetadataInstance()).thenReturn("i1");

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSourceConnectorTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -122,5 +123,39 @@ public class SpannerSourceConnectorTest {
     connector.initConnectionHelper(shards, maxConnections);
 
     verify(mockConnectionHelper, never()).init(any());
+  }
+
+  @Test
+  public void testValidate_Colocation_Success() throws Exception {
+    org.apache.beam.sdk.options.PipelineOptions mockPipelineOptions = mock(org.apache.beam.sdk.options.PipelineOptions.class);
+    com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options mockOptions = mock(com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options.class);
+    when(mockPipelineOptions.as(com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options.class)).thenReturn(mockOptions);
+
+    when(mockOptions.getSpannerProjectId()).thenReturn("p1");
+    when(mockOptions.getMetadataInstance()).thenReturn("i1");
+    when(mockOptions.getMetadataDatabase()).thenReturn("d1");
+
+    when(mockSpannerShard.getProjectId()).thenReturn("p1");
+    when(mockSpannerShard.getInstanceId()).thenReturn("i1");
+    when(mockSpannerShard.getDatabaseId()).thenReturn("d1");
+
+    connector.validate(List.of(mockSpannerShard), mockPipelineOptions);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidate_Colocation_Failure() throws Exception {
+    org.apache.beam.sdk.options.PipelineOptions mockPipelineOptions = mock(org.apache.beam.sdk.options.PipelineOptions.class);
+    com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options mockOptions = mock(com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options.class);
+    when(mockPipelineOptions.as(com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options.class)).thenReturn(mockOptions);
+
+    when(mockOptions.getSpannerProjectId()).thenReturn("p1");
+    when(mockOptions.getMetadataInstance()).thenReturn("i1");
+    when(mockOptions.getMetadataDatabase()).thenReturn("d1");
+
+    when(mockSpannerShard.getProjectId()).thenReturn("p2");
+    when(mockSpannerShard.getInstanceId()).thenReturn("i1");
+    when(mockSpannerShard.getDatabaseId()).thenReturn("d1");
+
+    connector.validate(List.of(mockSpannerShard), mockPipelineOptions);
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifierTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifierTest.java
@@ -144,7 +144,8 @@ public class SpannerToSourceDbExceptionClassifierTest {
     TupleTag<String> tag2 = SpannerToSourceDbExceptionClassifier.classify(ex, mockConnector);
     assertEquals(Constants.RETRYABLE_ERROR_TAG, tag2);
 
-    // 3. Connector returns null (fallback to general, which should be retryable for generic RuntimeException)
+    // 3. Connector returns null (fallback to general, which should be retryable for generic
+    // RuntimeException)
     when(mockConnector.classifyException(ex)).thenReturn(null);
     TupleTag<String> tag3 = SpannerToSourceDbExceptionClassifier.classify(ex, mockConnector);
     assertEquals(Constants.RETRYABLE_ERROR_TAG, tag3);

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifierTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifierTest.java
@@ -16,18 +16,17 @@
 package com.google.cloud.teleport.v2.templates.utils;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import com.datastax.oss.driver.api.core.type.codec.CodecNotFoundException;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.cloud.teleport.v2.spanner.exceptions.InvalidTransformationException;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.ChangeEventConvertorException;
 import com.google.cloud.teleport.v2.templates.constants.Constants;
+import com.google.cloud.teleport.v2.templates.dbutils.processor.ISourceConnector;
 import com.google.cloud.teleport.v2.templates.exceptions.InvalidDMLGenerationException;
-import java.sql.SQLDataException;
-import java.sql.SQLNonTransientConnectionException;
-import java.sql.SQLSyntaxErrorException;
 import org.apache.beam.sdk.values.TupleTag;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,7 +52,7 @@ public class SpannerToSourceDbExceptionClassifierTest {
 
     for (ErrorCode code : permanentCodes) {
       SpannerException ex = SpannerExceptionFactory.newSpannerException(code, "test");
-      TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex);
+      TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex, null);
       assertEquals("Expected PERMANENT for " + code, Constants.PERMANENT_ERROR_TAG, tag);
     }
   }
@@ -71,7 +70,7 @@ public class SpannerToSourceDbExceptionClassifierTest {
 
     for (ErrorCode code : retryableCodes) {
       SpannerException ex = SpannerExceptionFactory.newSpannerException(code, "test");
-      TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex);
+      TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex, null);
       assertEquals("Expected RETRYABLE for " + code, Constants.RETRYABLE_ERROR_TAG, tag);
     }
   }
@@ -79,7 +78,7 @@ public class SpannerToSourceDbExceptionClassifierTest {
   @Test
   public void testClassifyChangeEventConvertorException() {
     Exception ex = new ChangeEventConvertorException("test");
-    TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex);
+    TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex, null);
     assertEquals(Constants.PERMANENT_ERROR_TAG, tag);
   }
 
@@ -88,7 +87,7 @@ public class SpannerToSourceDbExceptionClassifierTest {
     SpannerException ex =
         SpannerExceptionFactory.newSpannerException(
             ErrorCode.UNKNOWN, "test", new InvalidTransformationException("test"));
-    TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex);
+    TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex, null);
     assertEquals(Constants.PERMANENT_ERROR_TAG, tag);
   }
 
@@ -97,80 +96,28 @@ public class SpannerToSourceDbExceptionClassifierTest {
     SpannerException ex =
         SpannerExceptionFactory.newSpannerException(
             ErrorCode.UNKNOWN, "test", new ChangeEventConvertorException("test"));
-    TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex);
+    TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex, null);
     assertEquals(Constants.PERMANENT_ERROR_TAG, tag);
-  }
-
-  @Test
-  public void testClassifyWrappedCodecNotFoundException() {
-    CodecNotFoundException mockException = org.mockito.Mockito.mock(CodecNotFoundException.class);
-    SpannerException ex =
-        SpannerExceptionFactory.newSpannerException(ErrorCode.UNKNOWN, "test", mockException);
-    TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex);
-    assertEquals(Constants.PERMANENT_ERROR_TAG, tag);
-  }
-
-  @Test
-  public void testClassifyWrappedSQLSyntaxErrorException() {
-    SpannerException ex =
-        SpannerExceptionFactory.newSpannerException(
-            ErrorCode.UNKNOWN, "test", new SQLSyntaxErrorException("test"));
-    TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex);
-    assertEquals(Constants.PERMANENT_ERROR_TAG, tag);
-  }
-
-  @Test
-  public void testClassifyWrappedSQLDataException() {
-    SpannerException ex =
-        SpannerExceptionFactory.newSpannerException(
-            ErrorCode.UNKNOWN, "test", new SQLDataException("test"));
-    TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex);
-    assertEquals(Constants.PERMANENT_ERROR_TAG, tag);
-  }
-
-  @Test
-  public void testClassifyWrappedSQLNonTransientConnectionExceptionPermanent() {
-    SpannerException ex =
-        SpannerExceptionFactory.newSpannerException(
-            ErrorCode.UNKNOWN,
-            "test",
-            new SQLNonTransientConnectionException("test", "state", 9999));
-    TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex);
-    assertEquals(Constants.PERMANENT_ERROR_TAG, tag);
-  }
-
-  @Test
-  public void testClassifyWrappedSQLNonTransientConnectionExceptionRetryable() {
-    int[] retryableSqlCodes = {1053, 1159, 1161};
-    for (int code : retryableSqlCodes) {
-      SpannerException ex =
-          SpannerExceptionFactory.newSpannerException(
-              ErrorCode.UNKNOWN,
-              "test",
-              new SQLNonTransientConnectionException("test", "state", code));
-      TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex);
-      assertEquals("Expected RETRYABLE for SQL code " + code, Constants.RETRYABLE_ERROR_TAG, tag);
-    }
   }
 
   @Test
   public void testClassifyIllegalArgumentException() {
     Exception ex = new IllegalArgumentException("test");
-    TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex);
+    TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex, null);
     assertEquals(Constants.PERMANENT_ERROR_TAG, tag);
   }
 
   @Test
   public void testClassifyNullPointerException() {
     Exception ex = new NullPointerException("test");
-    TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex);
+    TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex, null);
     assertEquals(Constants.PERMANENT_ERROR_TAG, tag);
   }
 
   @Test
   public void testClassifyGenericException() {
     Exception ex = new RuntimeException("test");
-    TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex);
+    TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(ex, null);
     assertEquals(Constants.RETRYABLE_ERROR_TAG, tag);
   }
 
@@ -178,7 +125,28 @@ public class SpannerToSourceDbExceptionClassifierTest {
   public void testClassifyInvalidDMLGenerationException() {
     InvalidDMLGenerationException exception =
         new InvalidDMLGenerationException("Unknown column present in source table");
-    TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(exception);
+    TupleTag<String> tag = SpannerToSourceDbExceptionClassifier.classify(exception, null);
     assertEquals(Constants.PERMANENT_ERROR_TAG, tag);
+  }
+
+  @Test
+  public void testClassifyDelegatesToConnector() {
+    Exception ex = new RuntimeException("dialect exception");
+    ISourceConnector mockConnector = mock(ISourceConnector.class);
+
+    // 1. Connector returns permanent
+    when(mockConnector.classifyException(ex)).thenReturn(Constants.PERMANENT_ERROR_TAG);
+    TupleTag<String> tag1 = SpannerToSourceDbExceptionClassifier.classify(ex, mockConnector);
+    assertEquals(Constants.PERMANENT_ERROR_TAG, tag1);
+
+    // 2. Connector returns retryable
+    when(mockConnector.classifyException(ex)).thenReturn(Constants.RETRYABLE_ERROR_TAG);
+    TupleTag<String> tag2 = SpannerToSourceDbExceptionClassifier.classify(ex, mockConnector);
+    assertEquals(Constants.RETRYABLE_ERROR_TAG, tag2);
+
+    // 3. Connector returns null (fallback to general, which should be retryable for generic RuntimeException)
+    when(mockConnector.classifyException(ex)).thenReturn(null);
+    TupleTag<String> tag3 = SpannerToSourceDbExceptionClassifier.classify(ex, mockConnector);
+    assertEquals(Constants.RETRYABLE_ERROR_TAG, tag3);
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifierTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifierTest.java
@@ -131,23 +131,24 @@ public class SpannerToSourceDbExceptionClassifierTest {
 
   @Test
   public void testClassifyDelegatesToConnector() {
-    Exception ex = new RuntimeException("dialect exception");
+    Throwable dialectEx = new RuntimeException("dialect exception");
+    SpannerException spannerEx = SpannerExceptionFactory.newSpannerException(ErrorCode.UNKNOWN, dialectEx);
     ISourceConnector mockConnector = mock(ISourceConnector.class);
 
     // 1. Connector returns permanent
-    when(mockConnector.classifyException(ex)).thenReturn(Constants.PERMANENT_ERROR_TAG);
-    TupleTag<String> tag1 = SpannerToSourceDbExceptionClassifier.classify(ex, mockConnector);
+    when(mockConnector.classifyException(dialectEx)).thenReturn(Constants.PERMANENT_ERROR_TAG);
+    TupleTag<String> tag1 = SpannerToSourceDbExceptionClassifier.classify(spannerEx, mockConnector);
     assertEquals(Constants.PERMANENT_ERROR_TAG, tag1);
 
     // 2. Connector returns retryable
-    when(mockConnector.classifyException(ex)).thenReturn(Constants.RETRYABLE_ERROR_TAG);
-    TupleTag<String> tag2 = SpannerToSourceDbExceptionClassifier.classify(ex, mockConnector);
+    when(mockConnector.classifyException(dialectEx)).thenReturn(Constants.RETRYABLE_ERROR_TAG);
+    TupleTag<String> tag2 = SpannerToSourceDbExceptionClassifier.classify(spannerEx, mockConnector);
     assertEquals(Constants.RETRYABLE_ERROR_TAG, tag2);
 
     // 3. Connector returns null (fallback to general, which should be retryable for generic
-    // RuntimeException)
-    when(mockConnector.classifyException(ex)).thenReturn(null);
-    TupleTag<String> tag3 = SpannerToSourceDbExceptionClassifier.classify(ex, mockConnector);
+    // RuntimeException, and generic SpannerException with UNKNOWN error code is retryable)
+    when(mockConnector.classifyException(dialectEx)).thenReturn(null);
+    TupleTag<String> tag3 = SpannerToSourceDbExceptionClassifier.classify(spannerEx, mockConnector);
     assertEquals(Constants.RETRYABLE_ERROR_TAG, tag3);
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifierTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/utils/SpannerToSourceDbExceptionClassifierTest.java
@@ -132,7 +132,7 @@ public class SpannerToSourceDbExceptionClassifierTest {
   @Test
   public void testClassifyDelegatesToConnector() {
     Throwable dialectEx = new RuntimeException("dialect exception");
-    SpannerException spannerEx = SpannerExceptionFactory.newSpannerException(ErrorCode.UNKNOWN, dialectEx);
+    SpannerException spannerEx = SpannerExceptionFactory.newSpannerException(dialectEx);
     ISourceConnector mockConnector = mock(ISourceConnector.class);
 
     // 1. Connector returns permanent


### PR DESCRIPTION
PR1 was - https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/3930
PR2 for reverse replication separation.

This PR completely removed references to sources in the reverse replication pipeline outside of the sources folder. This PR is mainly refactoring. In interest of keeping the PR size manageable, test coverage and TODOs will be addressed in subsequent PRs. 