### PR TITLE
feat(sourcedb-to-spanner): support PostgreSQL inheritance tables via …

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
@@ -651,18 +651,35 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
   }
 
   private String getExtractionTableName(String tableName) {
-    // The Beam JdbcIoWrapper wraps table names in double quotes (e.g. '"my_table"').
-    // We must strip these quotes before checking against the parentTables cache,
-    // which stores unquoted table names populated directly from pg_catalog.
-    String unquotedTableName = tableName;
-    if (unquotedTableName.startsWith("\"") && unquotedTableName.endsWith("\"")) {
-      unquotedTableName =
-          unquotedTableName.substring(1, unquotedTableName.length() - 1).replace("\"\"", "\"");
-    }
+    // Extract the unquoted base table name (ignoring schema qualifiers) to check
+    // against the parentTables cache, which stores raw table names from pg_catalog.
+    String unquotedTableName = extractBaseTableName(tableName);
+
     if (parentTables.contains(unquotedTableName)) {
       return "ONLY " + tableName;
     }
     return tableName;
+  }
+
+  private String extractBaseTableName(String tableName) {
+    int lastDotIndex = -1;
+    boolean inQuotes = false;
+
+    for (int i = 0; i < tableName.length(); i++) {
+      if (tableName.charAt(i) == '"') {
+        inQuotes = !inQuotes;
+      } else if (tableName.charAt(i) == '.' && !inQuotes) {
+        lastDotIndex = i;
+      }
+    }
+
+    String baseName = tableName.substring(lastDotIndex + 1);
+
+    if (baseName.startsWith("\"") && baseName.endsWith("\"")) {
+      baseName = baseName.substring(1, baseName.length() - 1).replace("\"\"", "\"");
+    }
+
+    return baseName;
   }
 
   private static final class ColumnKey implements Serializable {

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
@@ -125,7 +125,7 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
     try (Connection conn = dataSource.getConnection();
         PreparedStatement stmt = conn.prepareStatement(query)) {
 
-      discoverAndCacheParentTables(conn, sourceSchemaReference.namespace());
+      discoverAndCacheParentTables(conn);
 
       stmt.setString(1, sourceSchemaReference.dbName());
       stmt.setString(2, sourceSchemaReference.namespace());
@@ -449,31 +449,28 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
   }
 
   /** Discovers and caches parent tables in an inheritance hierarchy. */
-  private void discoverAndCacheParentTables(Connection conn, String namespace)
+  private void discoverAndCacheParentTables(Connection conn)
       throws SchemaDiscoveryException {
     final String parentTableQuery =
         "SELECT DISTINCT c.relname AS table_name "
             + "FROM pg_catalog.pg_inherits i "
             + "JOIN pg_catalog.pg_class c ON i.inhparent = c.oid "
             + "JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid "
-            + "WHERE n.nspname = ?";
+            + "WHERE n.nspname = 'public' AND c.relkind = 'r'";
 
     try (PreparedStatement parentStmt = conn.prepareStatement(parentTableQuery)) {
-      parentStmt.setString(1, namespace);
       try (ResultSet parentRs = parentStmt.executeQuery()) {
         while (parentRs.next()) {
           parentTables.add(parentRs.getString("table_name"));
         }
         logger.info(
-            "Successfully cached inheritance parent tables for namespace '{}': {}",
-            namespace,
+            "Successfully cached inheritance parent tables for namespace 'public': {}",
             parentTables);
       }
     } catch (SQLException e) {
       logger.error(
-          "Failed to discover inheritance parent tables for namespace={} "
+          "Failed to discover inheritance parent tables for namespace='public' "
               + "(check pg_catalog permissions).",
-          namespace,
           e);
       schemaDiscoveryErrors.inc();
       throw new SchemaDiscoveryException(e);
@@ -662,18 +659,13 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
   }
 
   private String extractBaseTableName(String tableName) {
-    int lastDotIndex = -1;
-    boolean inQuotes = false;
+    String baseName = tableName;
 
-    for (int i = 0; i < tableName.length(); i++) {
-      if (tableName.charAt(i) == '"') {
-        inQuotes = !inQuotes;
-      } else if (tableName.charAt(i) == '.' && !inQuotes) {
-        lastDotIndex = i;
-      }
+    if (baseName.startsWith("public.")) {
+      baseName = baseName.substring("public.".length());
+    } else if (baseName.startsWith("\"public\".")) {
+      baseName = baseName.substring("\"public\".".length());
     }
-
-    String baseName = tableName.substring(lastDotIndex + 1);
 
     if (baseName.startsWith("\"") && baseName.endsWith("\"")) {
       baseName = baseName.substring(1, baseName.length() - 1).replace("\"\"", "\"");

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
@@ -89,6 +89,9 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
   private final PostgreSQLVersion version;
   private final Set<ColumnKey> uuidColumnKeys = ConcurrentHashMap.newKeySet();
 
+  // Stores parent tables so we can append 'ONLY' to their extraction queries and avoid duplicates.
+  private final Set<String> parentTables = ConcurrentHashMap.newKeySet();
+
   public PostgreSQLDialectAdapter(PostgreSQLVersion version) {
     this.version = version;
   }
@@ -121,6 +124,9 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
     ImmutableList.Builder<String> tablesBuilder = ImmutableList.builder();
     try (Connection conn = dataSource.getConnection();
         PreparedStatement stmt = conn.prepareStatement(query)) {
+
+      discoverAndCacheParentTables(conn, sourceSchemaReference.namespace());
+
       stmt.setString(1, sourceSchemaReference.dbName());
       stmt.setString(2, sourceSchemaReference.namespace());
       try (ResultSet rs = stmt.executeQuery()) {
@@ -442,6 +448,38 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
     return tableIndexes;
   }
 
+  /** Discovers and caches parent tables in an inheritance hierarchy. */
+  private void discoverAndCacheParentTables(Connection conn, String namespace)
+      throws SchemaDiscoveryException {
+    final String parentTableQuery =
+        "SELECT DISTINCT c.relname AS table_name "
+            + "FROM pg_catalog.pg_inherits i "
+            + "JOIN pg_catalog.pg_class c ON i.inhparent = c.oid "
+            + "JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid "
+            + "WHERE n.nspname = ?";
+
+    try (PreparedStatement parentStmt = conn.prepareStatement(parentTableQuery)) {
+      parentStmt.setString(1, namespace);
+      try (ResultSet parentRs = parentStmt.executeQuery()) {
+        while (parentRs.next()) {
+          parentTables.add(parentRs.getString("table_name"));
+        }
+        logger.info(
+            "Successfully cached inheritance parent tables for namespace '{}': {}",
+            namespace,
+            parentTables);
+      }
+    } catch (SQLException e) {
+      logger.error(
+          "Failed to discover inheritance parent tables for namespace={} "
+              + "(check pg_catalog permissions).",
+          namespace,
+          e);
+      schemaDiscoveryErrors.inc();
+      throw new SchemaDiscoveryException(e);
+    }
+  }
+
   /**
    * Get query for the prepared statement to read columns within a range.
    *
@@ -451,7 +489,8 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
    */
   @Override
   public String getReadQuery(String tableName, ImmutableList<String> partitionColumns) {
-    return addWhereClause("SELECT * FROM " + tableName, partitionColumns);
+    String extractionTableName = getExtractionTableName(tableName);
+    return addWhereClause("SELECT * FROM " + extractionTableName, partitionColumns);
   }
 
   /**
@@ -469,7 +508,9 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
   @Override
   public String getCountQuery(
       String tableName, ImmutableList<String> partitionColumns, long timeoutMillis) {
-    return addWhereClause(String.format("SELECT COUNT(*) FROM %s", tableName), partitionColumns);
+    String extractionTableName = getExtractionTableName(tableName);
+    return addWhereClause(
+        String.format("SELECT COUNT(*) FROM %s", extractionTableName), partitionColumns);
   }
 
   /**
@@ -485,12 +526,13 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
   @Override
   public String getBoundaryQuery(
       String tableName, ImmutableList<String> partitionColumns, String colName) {
+    String extractionTableName = getExtractionTableName(tableName);
     if (uuidColumnKeys.contains(new ColumnKey(tableName, colName))) {
-      return getUuidBoundaryQuery(tableName, partitionColumns, colName);
+      return getUuidBoundaryQuery(extractionTableName, partitionColumns, colName);
     }
 
     return addWhereClause(
-        String.format("SELECT MIN(%s), MAX(%s) FROM %s", colName, colName, tableName),
+        String.format("SELECT MIN(%s), MAX(%s) FROM %s", colName, colName, extractionTableName),
         partitionColumns);
   }
 
@@ -606,6 +648,21 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
         && (upperTypeName.equals("CHARACTER")
             || upperTypeName.equals("CHAR")
             || upperTypeName.equals("BPCHAR"));
+  }
+
+  private String getExtractionTableName(String tableName) {
+    // The Beam JdbcIoWrapper wraps table names in double quotes (e.g. '"my_table"').
+    // We must strip these quotes before checking against the parentTables cache,
+    // which stores unquoted table names populated directly from pg_catalog.
+    String unquotedTableName = tableName;
+    if (unquotedTableName.startsWith("\"") && unquotedTableName.endsWith("\"")) {
+      unquotedTableName =
+          unquotedTableName.substring(1, unquotedTableName.length() - 1).replace("\"\"", "\"");
+    }
+    if (parentTables.contains(unquotedTableName)) {
+      return "ONLY " + tableName;
+    }
+    return tableName;
   }
 
   private static final class ColumnKey implements Serializable {

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
@@ -449,8 +449,7 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
   }
 
   /** Discovers and caches parent tables in an inheritance hierarchy. */
-  private void discoverAndCacheParentTables(Connection conn)
-      throws SchemaDiscoveryException {
+  private void discoverAndCacheParentTables(Connection conn) throws SchemaDiscoveryException {
     final String parentTableQuery =
         "SELECT DISTINCT c.relname AS table_name "
             + "FROM pg_catalog.pg_inherits i "

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapterTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapterTest.java
@@ -524,6 +524,27 @@ public class PostgreSQLDialectAdapterTest {
             "SELECT MIN(id), MAX(id) FROM ONLY \"my_parent_table\" "
                 + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "
                 + "AND ((? = FALSE) OR (col2 >= ? AND (col2 < ? OR (? = TRUE AND col2 = ?))))");
+
+    // Test that the adapter correctly matches schema-qualified quoted identifiers
+    assertThat(adapter.getBoundaryQuery("\"public\".\"my_parent_table\"", ImmutableList.of(), "id"))
+        .isEqualTo("SELECT MIN(id), MAX(id) FROM ONLY \"public\".\"my_parent_table\"");
+    assertThat(
+            adapter.getBoundaryQuery(
+                "\"public\".\"my_parent_table\"", ImmutableList.of("col1", "col2"), "id"))
+        .isEqualTo(
+            "SELECT MIN(id), MAX(id) FROM ONLY \"public\".\"my_parent_table\" "
+                + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "
+                + "AND ((? = FALSE) OR (col2 >= ? AND (col2 < ? OR (? = TRUE AND col2 = ?))))");
+
+    // Test that the adapter correctly matches schema-qualified unquoted identifiers
+    assertThat(adapter.getBoundaryQuery("public.my_parent_table", ImmutableList.of(), "id"))
+        .isEqualTo("SELECT MIN(id), MAX(id) FROM ONLY public.my_parent_table");
+    assertThat(
+            adapter.getBoundaryQuery("public.my_parent_table", ImmutableList.of("col1", "col2"), "id"))
+        .isEqualTo(
+            "SELECT MIN(id), MAX(id) FROM ONLY public.my_parent_table "
+                + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "
+                + "AND ((? = FALSE) OR (col2 >= ? AND (col2 < ? OR (? = TRUE AND col2 = ?))))");
   }
 
   @Test
@@ -562,6 +583,21 @@ public class PostgreSQLDialectAdapterTest {
                 + " parent_col = ?))))) SELECT (SELECT col_uuid FROM filtered_uuid ORDER BY"
                 + " col_uuid ASC NULLS LAST LIMIT 1), (SELECT col_uuid FROM filtered_uuid ORDER BY"
                 + " col_uuid DESC NULLS LAST LIMIT 1)");
+
+    // Test that the adapter correctly matches quoted identifiers passed from JdbcIoWrapper for UUIDs
+    assertThat(adapter.getBoundaryQuery("\"my_parent_table\"", ImmutableList.of(), "col_uuid"))
+        .isEqualTo(
+            "SELECT (SELECT col_uuid FROM ONLY \"my_parent_table\" ORDER BY col_uuid ASC NULLS LAST"
+                + " LIMIT 1), (SELECT col_uuid FROM ONLY \"my_parent_table\" ORDER BY col_uuid DESC"
+                + " NULLS LAST LIMIT 1)");
+    assertThat(
+            adapter.getBoundaryQuery("\"my_parent_table\"", ImmutableList.of("parent_col"), "col_uuid"))
+        .isEqualTo(
+            "WITH filtered_uuid AS NOT MATERIALIZED (SELECT col_uuid FROM ONLY \"my_parent_table\""
+                + " WHERE ((? = FALSE) OR (parent_col >= ? AND (parent_col < ? OR (? = TRUE AND"
+                + " parent_col = ?))))) SELECT (SELECT col_uuid FROM filtered_uuid ORDER BY"
+                + " col_uuid ASC NULLS LAST LIMIT 1), (SELECT col_uuid FROM filtered_uuid ORDER BY"
+                + " col_uuid DESC NULLS LAST LIMIT 1)");
   }
 
   @Test
@@ -592,6 +628,26 @@ public class PostgreSQLDialectAdapterTest {
     assertThat(adapter.getReadQuery("\"my_parent_table\"", ImmutableList.of("col1", "col2")))
         .isEqualTo(
             "SELECT * FROM ONLY \"my_parent_table\" "
+                + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "
+                + "AND ((? = FALSE) OR (col2 >= ? AND (col2 < ? OR (? = TRUE AND col2 = ?))))");
+
+    // Test that the adapter correctly matches schema-qualified quoted identifiers
+    assertThat(adapter.getReadQuery("\"public\".\"my_parent_table\"", ImmutableList.of()))
+        .isEqualTo("SELECT * FROM ONLY \"public\".\"my_parent_table\"");
+    assertThat(adapter.getReadQuery("\"public\".\"my_parent_table\"", ImmutableList.of("col1", "col2")))
+        .isEqualTo(
+            "SELECT * FROM ONLY \"public\".\"my_parent_table\" "
+                + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "
+                + "AND ((? = FALSE) OR (col2 >= ? AND (col2 < ? OR (? = TRUE AND col2 = ?))))");
+    assertThat(adapter.getReadQuery("public.\"my_parent_table\"", ImmutableList.of()))
+        .isEqualTo("SELECT * FROM ONLY public.\"my_parent_table\"");
+
+    // Test that the adapter correctly matches schema-qualified unquoted identifiers
+    assertThat(adapter.getReadQuery("public.my_parent_table", ImmutableList.of()))
+        .isEqualTo("SELECT * FROM ONLY public.my_parent_table");
+    assertThat(adapter.getReadQuery("public.my_parent_table", ImmutableList.of("col1", "col2")))
+        .isEqualTo(
+            "SELECT * FROM ONLY public.my_parent_table "
                 + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "
                 + "AND ((? = FALSE) OR (col2 >= ? AND (col2 < ? OR (? = TRUE AND col2 = ?))))");
   }
@@ -625,6 +681,28 @@ public class PostgreSQLDialectAdapterTest {
             adapter.getCountQuery("\"my_parent_table\"", ImmutableList.of("col1", "col2"), 1000L))
         .isEqualTo(
             "SELECT COUNT(*) FROM ONLY \"my_parent_table\" "
+                + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "
+                + "AND ((? = FALSE) OR (col2 >= ? AND (col2 < ? OR (? = TRUE AND col2 = ?))))");
+
+    // Test that the adapter correctly matches schema-qualified quoted identifiers
+    assertThat(adapter.getCountQuery("\"public\".\"my_parent_table\"", ImmutableList.of(), 1000L))
+        .isEqualTo("SELECT COUNT(*) FROM ONLY \"public\".\"my_parent_table\"");
+    assertThat(
+            adapter.getCountQuery(
+                "\"public\".\"my_parent_table\"", ImmutableList.of("col1", "col2"), 1000L))
+        .isEqualTo(
+            "SELECT COUNT(*) FROM ONLY \"public\".\"my_parent_table\" "
+                + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "
+                + "AND ((? = FALSE) OR (col2 >= ? AND (col2 < ? OR (? = TRUE AND col2 = ?))))");
+
+    // Test that the adapter correctly matches schema-qualified unquoted identifiers
+    assertThat(adapter.getCountQuery("public.my_parent_table", ImmutableList.of(), 1000L))
+        .isEqualTo("SELECT COUNT(*) FROM ONLY public.my_parent_table");
+    assertThat(
+            adapter.getCountQuery(
+                "public.my_parent_table", ImmutableList.of("col1", "col2"), 1000L))
+        .isEqualTo(
+            "SELECT COUNT(*) FROM ONLY public.my_parent_table "
                 + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "
                 + "AND ((? = FALSE) OR (col2 >= ? AND (col2 < ? OR (? = TRUE AND col2 = ?))))");
   }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapterTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapterTest.java
@@ -18,6 +18,8 @@ package com.google.cloud.teleport.v2.source.postgres.reader.io.jdbc.dialectadapt
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.teleport.v2.reader.io.exception.RetriableSchemaDiscoveryException;
@@ -71,14 +73,28 @@ public class PostgreSQLDialectAdapterTest {
   @Test
   public void testDiscoverTablesReturnsSchemaAndTableNames()
       throws SQLException, RetriableSchemaDiscoveryException {
+    PreparedStatement mockParentPreparedStatement = mock(PreparedStatement.class);
+    ResultSet mockParentResultSet = mock(ResultSet.class);
+
     when(mockDataSource.getConnection()).thenReturn(mockConnection);
+
+    // Default mock for any prepareStatement (used by information_schema query)
     when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+
+    // Specific mock for the pg_inherits query
+    when(mockConnection.prepareStatement(contains("pg_inherits")))
+        .thenReturn(mockParentPreparedStatement);
+
+    when(mockParentPreparedStatement.executeQuery()).thenReturn(mockParentResultSet);
+    when(mockParentResultSet.next()).thenReturn(true, false);
+    when(mockParentResultSet.getString("table_name")).thenReturn("parent_table1");
+
     when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
-    when(mockResultSet.next()).thenReturn(true, true, false);
-    when(mockResultSet.getString("table_name")).thenReturn("table1", "table2");
+    when(mockResultSet.next()).thenReturn(true, true, true, false);
+    when(mockResultSet.getString("table_name")).thenReturn("table1", "table2", "parent_table1");
 
     assertThat(adapter.discoverTables(mockDataSource, sourceSchemaReference))
-        .containsExactly("table1", "table2");
+        .containsExactly("table1", "table2", "parent_table1");
   }
 
   @Test
@@ -108,6 +124,29 @@ public class PostgreSQLDialectAdapterTest {
         () ->
             new PostgreSQLDialectAdapter(PostgreSQLVersion.DEFAULT)
                 .discoverTables(mockDataSource, sourceSchemaReference));
+  }
+
+  @Test
+  public void testDiscoverTablesThrowsExceptionWhenInheritanceQueryFails() throws SQLException {
+    PreparedStatement mockParentPreparedStatement = mock(PreparedStatement.class);
+
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+
+    // Mock pg_inherits query to throw an exception
+    when(mockConnection.prepareStatement(contains("pg_inherits")))
+        .thenReturn(mockParentPreparedStatement);
+    when(mockParentPreparedStatement.executeQuery())
+        .thenThrow(new SQLException("Permission denied"));
+
+    SchemaDiscoveryException exception =
+        assertThrows(
+            SchemaDiscoveryException.class,
+            () ->
+                new PostgreSQLDialectAdapter(PostgreSQLVersion.DEFAULT)
+                    .discoverTables(mockDataSource, sourceSchemaReference));
+
+    assertThat(exception).hasCauseThat().hasMessageThat().contains("Permission denied");
   }
 
   @Test
@@ -466,12 +505,93 @@ public class PostgreSQLDialectAdapterTest {
   }
 
   @Test
+  public void testBoundaryQueryForParentTable() throws Exception {
+    populateParentTableCache("my_parent_table");
+    assertThat(adapter.getBoundaryQuery("my_parent_table", ImmutableList.of(), "id"))
+        .isEqualTo("SELECT MIN(id), MAX(id) FROM ONLY my_parent_table");
+    assertThat(adapter.getBoundaryQuery("my_parent_table", ImmutableList.of("col1", "col2"), "id"))
+        .isEqualTo(
+            "SELECT MIN(id), MAX(id) FROM ONLY my_parent_table "
+                + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "
+                + "AND ((? = FALSE) OR (col2 >= ? AND (col2 < ? OR (? = TRUE AND col2 = ?))))");
+
+    // Test that the adapter correctly matches quoted identifiers passed from JdbcIoWrapper
+    assertThat(adapter.getBoundaryQuery("\"my_parent_table\"", ImmutableList.of(), "id"))
+        .isEqualTo("SELECT MIN(id), MAX(id) FROM ONLY \"my_parent_table\"");
+    assertThat(
+            adapter.getBoundaryQuery("\"my_parent_table\"", ImmutableList.of("col1", "col2"), "id"))
+        .isEqualTo(
+            "SELECT MIN(id), MAX(id) FROM ONLY \"my_parent_table\" "
+                + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "
+                + "AND ((? = FALSE) OR (col2 >= ? AND (col2 < ? OR (? = TRUE AND col2 = ?))))");
+  }
+
+  @Test
+  public void testUuidBoundaryQueryForParentTable() throws Exception {
+    populateParentTableCache("my_parent_table");
+
+    // Populate uuid cache manually via discoverTableIndexes
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true, false);
+    when(mockResultSet.getString("table_name")).thenReturn("my_parent_table");
+    when(mockResultSet.getString("column_name")).thenReturn("col_uuid");
+    when(mockResultSet.getString("index_name")).thenReturn("idx_uuid");
+    when(mockResultSet.getBoolean("is_unique")).thenReturn(true);
+    when(mockResultSet.getBoolean("is_primary")).thenReturn(true);
+    when(mockResultSet.getLong("cardinality")).thenReturn(1L);
+    when(mockResultSet.getLong("ordinal_position")).thenReturn(1L);
+    when(mockResultSet.getString("type_category")).thenReturn("U");
+    when(mockResultSet.getString("type_name")).thenReturn("uuid");
+    when(mockResultSet.getInt("type_length")).thenReturn(0);
+    when(mockResultSet.wasNull()).thenReturn(true);
+
+    adapter.discoverTableIndexes(
+        mockDataSource, sourceSchemaReference, ImmutableList.of("my_parent_table"));
+
+    assertThat(adapter.getBoundaryQuery("my_parent_table", ImmutableList.of(), "col_uuid"))
+        .isEqualTo(
+            "SELECT (SELECT col_uuid FROM ONLY my_parent_table ORDER BY col_uuid ASC NULLS LAST"
+                + " LIMIT 1), (SELECT col_uuid FROM ONLY my_parent_table ORDER BY col_uuid DESC"
+                + " NULLS LAST LIMIT 1)");
+    assertThat(
+            adapter.getBoundaryQuery("my_parent_table", ImmutableList.of("parent_col"), "col_uuid"))
+        .isEqualTo(
+            "WITH filtered_uuid AS NOT MATERIALIZED (SELECT col_uuid FROM ONLY my_parent_table"
+                + " WHERE ((? = FALSE) OR (parent_col >= ? AND (parent_col < ? OR (? = TRUE AND"
+                + " parent_col = ?))))) SELECT (SELECT col_uuid FROM filtered_uuid ORDER BY"
+                + " col_uuid ASC NULLS LAST LIMIT 1), (SELECT col_uuid FROM filtered_uuid ORDER BY"
+                + " col_uuid DESC NULLS LAST LIMIT 1)");
+  }
+
+  @Test
   public void testReadQuery() {
     assertThat(adapter.getReadQuery("my_schema.table1", ImmutableList.of()))
         .isEqualTo("SELECT * FROM my_schema.table1");
     assertThat(adapter.getReadQuery("my_schema.table1", ImmutableList.of("col1", "col2")))
         .isEqualTo(
             "SELECT * FROM my_schema.table1 "
+                + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "
+                + "AND ((? = FALSE) OR (col2 >= ? AND (col2 < ? OR (? = TRUE AND col2 = ?))))");
+  }
+
+  @Test
+  public void testReadQueryForParentTable() throws Exception {
+    populateParentTableCache("my_parent_table");
+    assertThat(adapter.getReadQuery("my_parent_table", ImmutableList.of()))
+        .isEqualTo("SELECT * FROM ONLY my_parent_table");
+    assertThat(adapter.getReadQuery("my_parent_table", ImmutableList.of("col1", "col2")))
+        .isEqualTo(
+            "SELECT * FROM ONLY my_parent_table "
+                + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "
+                + "AND ((? = FALSE) OR (col2 >= ? AND (col2 < ? OR (? = TRUE AND col2 = ?))))");
+
+    // Test that the adapter correctly matches quoted identifiers passed from JdbcIoWrapper
+    assertThat(adapter.getReadQuery("\"my_parent_table\"", ImmutableList.of()))
+        .isEqualTo("SELECT * FROM ONLY \"my_parent_table\"");
+    assertThat(adapter.getReadQuery("\"my_parent_table\"", ImmutableList.of("col1", "col2")))
+        .isEqualTo(
+            "SELECT * FROM ONLY \"my_parent_table\" "
                 + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "
                 + "AND ((? = FALSE) OR (col2 >= ? AND (col2 < ? OR (? = TRUE AND col2 = ?))))");
   }
@@ -485,6 +605,48 @@ public class PostgreSQLDialectAdapterTest {
             "SELECT COUNT(*) FROM my_schema.table1 "
                 + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "
                 + "AND ((? = FALSE) OR (col2 >= ? AND (col2 < ? OR (? = TRUE AND col2 = ?))))");
+  }
+
+  @Test
+  public void testCountQueryForParentTable() throws Exception {
+    populateParentTableCache("my_parent_table");
+    assertThat(adapter.getCountQuery("my_parent_table", ImmutableList.of(), 1000L))
+        .isEqualTo("SELECT COUNT(*) FROM ONLY my_parent_table");
+    assertThat(adapter.getCountQuery("my_parent_table", ImmutableList.of("col1", "col2"), 1000L))
+        .isEqualTo(
+            "SELECT COUNT(*) FROM ONLY my_parent_table "
+                + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "
+                + "AND ((? = FALSE) OR (col2 >= ? AND (col2 < ? OR (? = TRUE AND col2 = ?))))");
+
+    // Test that the adapter correctly matches quoted identifiers passed from JdbcIoWrapper
+    assertThat(adapter.getCountQuery("\"my_parent_table\"", ImmutableList.of(), 1000L))
+        .isEqualTo("SELECT COUNT(*) FROM ONLY \"my_parent_table\"");
+    assertThat(
+            adapter.getCountQuery("\"my_parent_table\"", ImmutableList.of("col1", "col2"), 1000L))
+        .isEqualTo(
+            "SELECT COUNT(*) FROM ONLY \"my_parent_table\" "
+                + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "
+                + "AND ((? = FALSE) OR (col2 >= ? AND (col2 < ? OR (? = TRUE AND col2 = ?))))");
+  }
+
+  private void populateParentTableCache(String parentTableName) throws Exception {
+    PreparedStatement mockParentPreparedStatement = mock(PreparedStatement.class);
+    ResultSet mockParentResultSet = mock(ResultSet.class);
+
+    when(mockDataSource.getConnection()).thenReturn(mockConnection);
+    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+    when(mockConnection.prepareStatement(contains("pg_inherits")))
+        .thenReturn(mockParentPreparedStatement);
+
+    when(mockParentPreparedStatement.executeQuery()).thenReturn(mockParentResultSet);
+    when(mockParentResultSet.next()).thenReturn(true, false);
+    when(mockParentResultSet.getString("table_name")).thenReturn(parentTableName);
+
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true, true, false);
+    when(mockResultSet.getString("table_name")).thenReturn(parentTableName, "normal_table");
+
+    adapter.discoverTables(mockDataSource, sourceSchemaReference);
   }
 
   @Test

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapterTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapterTest.java
@@ -540,7 +540,8 @@ public class PostgreSQLDialectAdapterTest {
     assertThat(adapter.getBoundaryQuery("public.my_parent_table", ImmutableList.of(), "id"))
         .isEqualTo("SELECT MIN(id), MAX(id) FROM ONLY public.my_parent_table");
     assertThat(
-            adapter.getBoundaryQuery("public.my_parent_table", ImmutableList.of("col1", "col2"), "id"))
+            adapter.getBoundaryQuery(
+                "public.my_parent_table", ImmutableList.of("col1", "col2"), "id"))
         .isEqualTo(
             "SELECT MIN(id), MAX(id) FROM ONLY public.my_parent_table "
                 + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "
@@ -584,14 +585,16 @@ public class PostgreSQLDialectAdapterTest {
                 + " col_uuid ASC NULLS LAST LIMIT 1), (SELECT col_uuid FROM filtered_uuid ORDER BY"
                 + " col_uuid DESC NULLS LAST LIMIT 1)");
 
-    // Test that the adapter correctly matches quoted identifiers passed from JdbcIoWrapper for UUIDs
+    // Test that the adapter correctly matches quoted identifiers passed from JdbcIoWrapper for
+    // UUIDs
     assertThat(adapter.getBoundaryQuery("\"my_parent_table\"", ImmutableList.of(), "col_uuid"))
         .isEqualTo(
             "SELECT (SELECT col_uuid FROM ONLY \"my_parent_table\" ORDER BY col_uuid ASC NULLS LAST"
                 + " LIMIT 1), (SELECT col_uuid FROM ONLY \"my_parent_table\" ORDER BY col_uuid DESC"
                 + " NULLS LAST LIMIT 1)");
     assertThat(
-            adapter.getBoundaryQuery("\"my_parent_table\"", ImmutableList.of("parent_col"), "col_uuid"))
+            adapter.getBoundaryQuery(
+                "\"my_parent_table\"", ImmutableList.of("parent_col"), "col_uuid"))
         .isEqualTo(
             "WITH filtered_uuid AS NOT MATERIALIZED (SELECT col_uuid FROM ONLY \"my_parent_table\""
                 + " WHERE ((? = FALSE) OR (parent_col >= ? AND (parent_col < ? OR (? = TRUE AND"
@@ -634,7 +637,9 @@ public class PostgreSQLDialectAdapterTest {
     // Test that the adapter correctly matches schema-qualified quoted identifiers
     assertThat(adapter.getReadQuery("\"public\".\"my_parent_table\"", ImmutableList.of()))
         .isEqualTo("SELECT * FROM ONLY \"public\".\"my_parent_table\"");
-    assertThat(adapter.getReadQuery("\"public\".\"my_parent_table\"", ImmutableList.of("col1", "col2")))
+    assertThat(
+            adapter.getReadQuery(
+                "\"public\".\"my_parent_table\"", ImmutableList.of("col1", "col2")))
         .isEqualTo(
             "SELECT * FROM ONLY \"public\".\"my_parent_table\" "
                 + "WHERE ((? = FALSE) OR (col1 >= ? AND (col1 < ? OR (? = TRUE AND col1 = ?)))) "

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapterTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapterTest.java
@@ -549,61 +549,6 @@ public class PostgreSQLDialectAdapterTest {
   }
 
   @Test
-  public void testUuidBoundaryQueryForParentTable() throws Exception {
-    populateParentTableCache("my_parent_table");
-
-    // Populate uuid cache manually via discoverTableIndexes
-    when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
-    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
-    when(mockResultSet.next()).thenReturn(true, false);
-    when(mockResultSet.getString("table_name")).thenReturn("my_parent_table");
-    when(mockResultSet.getString("column_name")).thenReturn("col_uuid");
-    when(mockResultSet.getString("index_name")).thenReturn("idx_uuid");
-    when(mockResultSet.getBoolean("is_unique")).thenReturn(true);
-    when(mockResultSet.getBoolean("is_primary")).thenReturn(true);
-    when(mockResultSet.getLong("cardinality")).thenReturn(1L);
-    when(mockResultSet.getLong("ordinal_position")).thenReturn(1L);
-    when(mockResultSet.getString("type_category")).thenReturn("U");
-    when(mockResultSet.getString("type_name")).thenReturn("uuid");
-    when(mockResultSet.getInt("type_length")).thenReturn(0);
-    when(mockResultSet.wasNull()).thenReturn(true);
-
-    adapter.discoverTableIndexes(
-        mockDataSource, sourceSchemaReference, ImmutableList.of("my_parent_table"));
-
-    assertThat(adapter.getBoundaryQuery("my_parent_table", ImmutableList.of(), "col_uuid"))
-        .isEqualTo(
-            "SELECT (SELECT col_uuid FROM ONLY my_parent_table ORDER BY col_uuid ASC NULLS LAST"
-                + " LIMIT 1), (SELECT col_uuid FROM ONLY my_parent_table ORDER BY col_uuid DESC"
-                + " NULLS LAST LIMIT 1)");
-    assertThat(
-            adapter.getBoundaryQuery("my_parent_table", ImmutableList.of("parent_col"), "col_uuid"))
-        .isEqualTo(
-            "WITH filtered_uuid AS NOT MATERIALIZED (SELECT col_uuid FROM ONLY my_parent_table"
-                + " WHERE ((? = FALSE) OR (parent_col >= ? AND (parent_col < ? OR (? = TRUE AND"
-                + " parent_col = ?))))) SELECT (SELECT col_uuid FROM filtered_uuid ORDER BY"
-                + " col_uuid ASC NULLS LAST LIMIT 1), (SELECT col_uuid FROM filtered_uuid ORDER BY"
-                + " col_uuid DESC NULLS LAST LIMIT 1)");
-
-    // Test that the adapter correctly matches quoted identifiers passed from JdbcIoWrapper for
-    // UUIDs
-    assertThat(adapter.getBoundaryQuery("\"my_parent_table\"", ImmutableList.of(), "col_uuid"))
-        .isEqualTo(
-            "SELECT (SELECT col_uuid FROM ONLY \"my_parent_table\" ORDER BY col_uuid ASC NULLS LAST"
-                + " LIMIT 1), (SELECT col_uuid FROM ONLY \"my_parent_table\" ORDER BY col_uuid DESC"
-                + " NULLS LAST LIMIT 1)");
-    assertThat(
-            adapter.getBoundaryQuery(
-                "\"my_parent_table\"", ImmutableList.of("parent_col"), "col_uuid"))
-        .isEqualTo(
-            "WITH filtered_uuid AS NOT MATERIALIZED (SELECT col_uuid FROM ONLY \"my_parent_table\""
-                + " WHERE ((? = FALSE) OR (parent_col >= ? AND (parent_col < ? OR (? = TRUE AND"
-                + " parent_col = ?))))) SELECT (SELECT col_uuid FROM filtered_uuid ORDER BY"
-                + " col_uuid ASC NULLS LAST LIMIT 1), (SELECT col_uuid FROM filtered_uuid ORDER BY"
-                + " col_uuid DESC NULLS LAST LIMIT 1)");
-  }
-
-  @Test
   public void testReadQuery() {
     assertThat(adapter.getReadQuery("my_schema.table1", ImmutableList.of()))
         .isEqualTo("SELECT * FROM my_schema.table1");

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLInheritanceTablesIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLInheritanceTablesIT.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates;
+
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
+
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import com.google.common.collect.ImmutableList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.it.common.PipelineLauncher;
+import org.apache.beam.it.common.PipelineOperator;
+import org.apache.beam.it.common.utils.ResourceManagerUtils;
+import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
+import org.apache.beam.it.gcp.spanner.matchers.SpannerAsserts;
+import org.apache.beam.it.jdbc.PostgresResourceManager;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * An integration test for {@link SourceDbToSpanner} Flex template which tests a migration from a
+ * PostgreSQL database containing multi-level table inheritance.
+ */
+@Category({TemplateIntegrationTest.class, SkipDirectRunnerTest.class})
+@TemplateIntegrationTest(SourceDbToSpanner.class)
+@RunWith(JUnit4.class)
+public class PostgreSQLInheritanceTablesIT extends SourceDbToSpannerITBase {
+
+  private static boolean initialized = false;
+  private static PipelineLauncher.LaunchInfo jobInfo;
+
+  public static PostgresResourceManager postgresSQLResourceManager;
+  public static SpannerResourceManager gsqlSpannerResourceManager;
+  public static SpannerResourceManager pgDialectSpannerResourceManager;
+
+  private static final String POSTGRESQL_DDL_RESOURCE = "InheritanceTablesIT/postgresql-schema.sql";
+  private static final String SPANNER_GSQL_DDL_RESOURCE =
+      "InheritanceTablesIT/spanner-gsql-schema.sql";
+  private static final String SPANNER_PG_DDL_RESOURCE = "InheritanceTablesIT/spanner-pg-schema.sql";
+
+  @Before
+  public void setUp() throws Exception {
+    synchronized (PostgreSQLInheritanceTablesIT.class) {
+      if (!initialized) {
+        postgresSQLResourceManager = setUpPostgreSQLResourceManager();
+        gsqlSpannerResourceManager = setUpSpannerResourceManager();
+        pgDialectSpannerResourceManager = setUpPGDialectSpannerResourceManager();
+
+        loadSQLFileResource(postgresSQLResourceManager, POSTGRESQL_DDL_RESOURCE);
+
+        initialized = true;
+      }
+    }
+  }
+
+  @AfterClass
+  public static void cleanUp() {
+    ResourceManagerUtils.cleanResources(
+        postgresSQLResourceManager, gsqlSpannerResourceManager, pgDialectSpannerResourceManager);
+  }
+
+  @Test
+  public void testPostgreSQLInheritanceGoogleSQLDialect() throws Exception {
+    createSpannerDDL(gsqlSpannerResourceManager, SPANNER_GSQL_DDL_RESOURCE);
+    jobInfo =
+        launchDataflowJob(
+            getClass().getSimpleName() + "GSQL",
+            null,
+            null,
+            postgresSQLResourceManager,
+            gsqlSpannerResourceManager,
+            new HashMap<>(),
+            null);
+
+    PipelineOperator.Result result = pipelineOperator().waitUntilDone(createConfig(jobInfo));
+    assertThatResult(result).isLaunchFinished();
+
+    verifyData(gsqlSpannerResourceManager);
+  }
+
+  @Test
+  public void testPostgreSQLInheritancePostgreSQLDialect() throws Exception {
+    createSpannerDDL(pgDialectSpannerResourceManager, SPANNER_PG_DDL_RESOURCE);
+    jobInfo =
+        launchDataflowJob(
+            getClass().getSimpleName() + "PG",
+            null,
+            null,
+            postgresSQLResourceManager,
+            pgDialectSpannerResourceManager,
+            new HashMap<>(),
+            null);
+
+    PipelineOperator.Result result = pipelineOperator().waitUntilDone(createConfig(jobInfo));
+    assertThatResult(result).isLaunchFinished();
+
+    verifyData(pgDialectSpannerResourceManager);
+  }
+
+  private void verifyData(SpannerResourceManager spannerResourceManager) {
+    List<Map<String, Object>> vehiclesPostgreSQL =
+        postgresSQLResourceManager.runSQLQuery("SELECT id, make FROM ONLY vehicles");
+    ImmutableList<Struct> vehiclesSpanner =
+        spannerResourceManager.readTableRecords("vehicles", "id", "make");
+    SpannerAsserts.assertThatStructs(vehiclesSpanner)
+        .hasRecordsUnorderedCaseInsensitiveColumns(vehiclesPostgreSQL);
+
+    List<Map<String, Object>> carsPostgreSQL =
+        postgresSQLResourceManager.runSQLQuery("SELECT id, make, doors FROM ONLY cars");
+    ImmutableList<Struct> carsSpanner =
+        spannerResourceManager.readTableRecords("cars", "id", "make", "doors");
+    SpannerAsserts.assertThatStructs(carsSpanner)
+        .hasRecordsUnorderedCaseInsensitiveColumns(carsPostgreSQL);
+
+    List<Map<String, Object>> sportsCarsPostgreSQL =
+        postgresSQLResourceManager.runSQLQuery(
+            "SELECT id, make, doors, top_speed FROM sports_cars");
+    ImmutableList<Struct> sportsCarsSpanner =
+        spannerResourceManager.readTableRecords("sports_cars", "id", "make", "doors", "top_speed");
+    SpannerAsserts.assertThatStructs(sportsCarsSpanner)
+        .hasRecordsUnorderedCaseInsensitiveColumns(sportsCarsPostgreSQL);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/resources/InheritanceTablesIT/postgresql-schema.sql
+++ b/v2/sourcedb-to-spanner/src/test/resources/InheritanceTablesIT/postgresql-schema.sql
@@ -1,0 +1,18 @@
+CREATE TABLE vehicles (
+    id INT PRIMARY KEY,
+    make VARCHAR(50)
+);
+
+CREATE TABLE cars (
+    doors INT,
+    PRIMARY KEY (id)
+) INHERITS (vehicles);
+
+CREATE TABLE sports_cars (
+    top_speed INT,
+    PRIMARY KEY (id)
+) INHERITS (cars);
+
+INSERT INTO vehicles (id, make) VALUES (1, 'Generic Vehicle');
+INSERT INTO cars (id, make, doors) VALUES (2, 'Honda', 4);
+INSERT INTO sports_cars (id, make, doors, top_speed) VALUES (3, 'Ferrari', 2, 200);

--- a/v2/sourcedb-to-spanner/src/test/resources/InheritanceTablesIT/spanner-gsql-schema.sql
+++ b/v2/sourcedb-to-spanner/src/test/resources/InheritanceTablesIT/spanner-gsql-schema.sql
@@ -1,0 +1,17 @@
+CREATE TABLE vehicles (
+    id INT64,
+    make STRING(MAX)
+) PRIMARY KEY(id);
+
+CREATE TABLE cars (
+    id INT64,
+    make STRING(MAX),
+    doors INT64
+) PRIMARY KEY(id);
+
+CREATE TABLE sports_cars (
+    id INT64,
+    make STRING(MAX),
+    doors INT64,
+    top_speed INT64
+) PRIMARY KEY(id);

--- a/v2/sourcedb-to-spanner/src/test/resources/InheritanceTablesIT/spanner-pg-schema.sql
+++ b/v2/sourcedb-to-spanner/src/test/resources/InheritanceTablesIT/spanner-pg-schema.sql
@@ -1,0 +1,17 @@
+CREATE TABLE vehicles (
+    id bigint PRIMARY KEY,
+    make character varying
+);
+
+CREATE TABLE cars (
+    id bigint PRIMARY KEY,
+    make character varying,
+    doors bigint
+);
+
+CREATE TABLE sports_cars (
+    id bigint PRIMARY KEY,
+    make character varying,
+    doors bigint,
+    top_speed bigint
+);


### PR DESCRIPTION
Adds support for migrating PostgreSQL inheritance tables without duplicating child table records into Spanner.

When a database uses table inheritance, standard extraction queries (e.g., SELECT * FROM parent) return both parent and child rows, causing duplicated exports. This PR updates the PostgreSQLDialectAdapter to detect parent tables and automatically prepend the ONLY keyword to extraction queries (e.g., SELECT * FROM ONLY "parent").
Added tests to ensure 'ONLY' is correctly applied to parent tables in the Inheritance table to read, count, and boundary queries.
Added PostgreSQLInheritanceTablesIT to verify a multi-level inheritance hierarchy migrates to Spanner with exact row counts and no duplication.