### PR TITLE
[Data Validations] Add shard_id column to MismatchedRecords table

### DIFF
--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/BigQuerySchemas.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/BigQuerySchemas.java
@@ -55,7 +55,11 @@ public final class BigQuerySchemas {
                   new TableFieldSchema()
                       .setName(MismatchedRecord.HASH_COLUMN_NAME)
                       .setType("STRING")
-                      .setMode("REQUIRED")));
+                      .setMode("REQUIRED"),
+                  new TableFieldSchema()
+                      .setName(MismatchedRecord.SHARD_ID_COLUMN_NAME)
+                      .setType("STRING")
+                      .setMode("NULLABLE")));
 
   public static final TableSchema TABLE_VALIDATION_STATS_SCHEMA =
       new TableSchema()

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/ComparisonRecord.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/ComparisonRecord.java
@@ -34,6 +34,9 @@ public abstract class ComparisonRecord {
   @Nullable
   public abstract String getSchemaName();
 
+  @Nullable
+  public abstract String getShardId();
+
   public static Builder builder() {
     return new AutoValue_ComparisonRecord.Builder();
   }
@@ -48,6 +51,8 @@ public abstract class ComparisonRecord {
     public abstract Builder setHash(String hash);
 
     public abstract Builder setSchemaName(String schemaName);
+
+    public abstract Builder setShardId(String shardId);
 
     public abstract ComparisonRecord build();
   }

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/MismatchedRecord.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/dto/MismatchedRecord.java
@@ -31,6 +31,7 @@ public abstract class MismatchedRecord {
   public static final String RECORD_KEY_COLUMN_NAME = "record_key";
   public static final String SOURCE_COLUMN_NAME = "source";
   public static final String HASH_COLUMN_NAME = "hash";
+  public static final String SHARD_ID_COLUMN_NAME = "shard_id";
 
   public abstract String getRunId();
 
@@ -46,6 +47,9 @@ public abstract class MismatchedRecord {
   public abstract String getSource();
 
   public abstract String getHash();
+
+  @Nullable
+  public abstract String getShardId();
 
   public static Builder builder() {
     return new AutoValue_MismatchedRecord.Builder();
@@ -66,6 +70,8 @@ public abstract class MismatchedRecord {
     public abstract Builder setSource(String source);
 
     public abstract Builder setHash(String hash);
+
+    public abstract Builder setShardId(String shardId);
 
     public abstract MismatchedRecord build();
   }

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapper.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapper.java
@@ -62,8 +62,11 @@ public class ComparisonRecordMapper implements Serializable {
   public ComparisonRecord mapFrom(GenericRecord avroRecord) {
     try {
       String tableName = avroRecord.get("tableName").toString();
+      Object shardIdObj = avroRecord.get("shardId");
       String shardId =
-          avroRecord.get("shardId") != null ? avroRecord.get("shardId").toString() : "";
+          (shardIdObj != null && !shardIdObj.toString().trim().isEmpty())
+              ? shardIdObj.toString()
+              : null;
       GenericRecord payload = (GenericRecord) avroRecord.get("payload");
       GenericRecordTypeConvertor convertor =
           new GenericRecordTypeConvertor(schemaMapper, "", shardId, transformer);

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapper.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapper.java
@@ -81,7 +81,7 @@ public class ComparisonRecordMapper implements Serializable {
       }
       List<String> pkNames =
           table.primaryKeys().stream().map(IndexColumn::name).collect(Collectors.toList());
-      return buildRecord(spannerTableName, new TreeMap<>(values), pkNames);
+      return buildRecord(spannerTableName, new TreeMap<>(values), pkNames, shardId);
     } catch (Exception e) {
       throw new RuntimeException(
           "Error mapping GenericRecord to ComparisonRecord: " + e.getMessage(), e);
@@ -103,7 +103,7 @@ public class ComparisonRecordMapper implements Serializable {
     List<String> pkNames =
         table.primaryKeys().stream().map(IndexColumn::name).collect(Collectors.toList());
 
-    return buildRecord(tableName, values, pkNames);
+    return buildRecord(tableName, values, pkNames, null);
   }
 
   /**
@@ -128,7 +128,7 @@ public class ComparisonRecordMapper implements Serializable {
    * on.
    */
   private ComparisonRecord buildRecord(
-      String tableName, TreeMap<String, Value> data, List<String> pkNames) {
+      String tableName, TreeMap<String, Value> data, List<String> pkNames, String shardId) {
 
     // 1. Use the record data to compute the hash
     Hasher hasher = Hashing.murmur3_128().newHasher();
@@ -167,6 +167,7 @@ public class ComparisonRecordMapper implements Serializable {
         .setHash(hash)
         .setPrimaryKeyColumns(primaryKeyColumns)
         .setSchemaName(schemaName)
+        .setShardId(shardId)
         .build();
   }
 

--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/transforms/ReportResultsTransform.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/transforms/ReportResultsTransform.java
@@ -104,7 +104,8 @@ public class ReportResultsTransform extends PTransform<PCollectionTuple, PDone> 
                         .set(MismatchedRecord.MISMATCH_TYPE_COLUMN_NAME, r.getMismatchType())
                         .set(MismatchedRecord.RECORD_KEY_COLUMN_NAME, r.getRecordKey())
                         .set(MismatchedRecord.SOURCE_COLUMN_NAME, r.getSource())
-                        .set(MismatchedRecord.HASH_COLUMN_NAME, r.getHash()))
+                        .set(MismatchedRecord.HASH_COLUMN_NAME, r.getHash())
+                        .set(MismatchedRecord.SHARD_ID_COLUMN_NAME, r.getShardId()))
             .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
             .withWriteDisposition(WriteDisposition.WRITE_APPEND)
             .withMethod(BigQueryIO.Write.Method.FILE_LOADS));
@@ -227,6 +228,7 @@ public class ReportResultsTransform extends PTransform<PCollectionTuple, PDone> 
                             .setRecordKey(formatRecordKey(r.getPrimaryKeyColumns()))
                             .setSource(GCS_SOURCE)
                             .setHash(r.getHash())
+                            .setShardId(r.getShardId())
                             .build()));
 
     PCollection<MismatchedRecord> sourceMismatchedRecords =
@@ -243,6 +245,7 @@ public class ReportResultsTransform extends PTransform<PCollectionTuple, PDone> 
                             .setRecordKey(formatRecordKey(r.getPrimaryKeyColumns()))
                             .setSource(SPANNER_DESTINATION)
                             .setHash(r.getHash())
+                            .setShardId(r.getShardId())
                             .build()));
 
     return PCollectionList.of(spannerMismatchedRecords)

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperBasicTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperBasicTest.java
@@ -90,6 +90,7 @@ public class ComparisonRecordMapperBasicTest {
     assertEquals(1, record.getPrimaryKeyColumns().size());
     assertEquals("id", record.getPrimaryKeyColumns().get(0).getColName());
     assertEquals("1", record.getPrimaryKeyColumns().get(0).getColValue());
+    org.junit.Assert.assertNull(record.getShardId());
   }
 
   @Test
@@ -150,6 +151,7 @@ public class ComparisonRecordMapperBasicTest {
     assertNotNull(record);
     assertEquals(cleanTableName, record.getTableName());
     assertEquals("public", record.getSchemaName());
+    assertEquals("shard1", record.getShardId());
     assertNotNull(record.getHash());
   }
 

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperBasicTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/mapper/ComparisonRecordMapperBasicTest.java
@@ -17,6 +17,7 @@ package com.google.cloud.teleport.v2.mapper;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -90,7 +91,7 @@ public class ComparisonRecordMapperBasicTest {
     assertEquals(1, record.getPrimaryKeyColumns().size());
     assertEquals("id", record.getPrimaryKeyColumns().get(0).getColName());
     assertEquals("1", record.getPrimaryKeyColumns().get(0).getColValue());
-    org.junit.Assert.assertNull(record.getShardId());
+    assertNull(record.getShardId());
   }
 
   @Test

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/transforms/ReportResultsTransformTest.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/transforms/ReportResultsTransformTest.java
@@ -77,6 +77,7 @@ public class ReportResultsTransformTest implements Serializable {
         ComparisonRecord.builder()
             .setTableName("Table1")
             .setHash("hash1")
+            .setShardId("shard1")
             .setPrimaryKeyColumns(
                 Arrays.asList(Column.builder().setColName("id").setColValue("1").build()))
             .build();
@@ -105,6 +106,7 @@ public class ReportResultsTransformTest implements Serializable {
             .setRecordKey("[id:1]")
             .setSource(ReportResultsTransform.GCS_SOURCE)
             .setHash("hash1")
+            .setShardId("shard1")
             .build();
 
     MismatchedRecord expectedSourceMiss =


### PR DESCRIPTION
b/529209067

### Issue
We don’t expose shard_id in BigQuery tables unless ShardIdColumn is a spanner PK (then record_key will have it).

### Impact
- This is a visibility issue for a sharded migration as the user has no good way to trace back rows to their original source shards.
- There might also be a scenario where multiple rows with the same "equivalent" spanner pk values or source pk values fail and it will be impossible to trace the shards that failed and the ones that didn't
- Without a distinct shard_id column, user cant distinguish between random, distributed row drops versus a complete failure of a single shard. Exposing it allows users to aggregate mismatches by shard_id in BigQuery and instantly identify if a specific source database node went down or if its CDC stream disconnected.

### Fix
- Add nullable shard_id column to MismatchedRecords schema
- For a sharded migration, the rows coming from GCS Avro that are reported (MISSING_IN_DESTINATION rows) will populate the logical shard_id in the newly added shard_id column. For all rows coming from Spanner, this value will ALWAYS be null
- For a non-sharded migration, all rows will have a null value in shard_id column.


### Design Decisions:
1. shard_id column was not added to TableValidationStats table
Reason: Source records (read from Avro) contain explicit `shardId` metadata, but destination records (read directly from Spanner) do not. Grouping stats by `shard_id` would cause rows missing in Spanner to correctly group under their source shard (e.g., `shard-A`), but rows missing in the source database to pile up under an empty/unknown shard ID bucket.

2. Always assign `null` to spanner rows even if ShardId column exists with 
Reason: The point of adding `shard_id` column is to improve source traceability. Adding metadata of sharding information to spanner originating rows for the selective cases where a ShardIdColumn exists will be more confusing than helpful.

3. Create a separate shard_id column instead of embedding it inside the `source_record_key` column (column to be added in follow up PR)
Reason:  
- Having shard_id as its own dedicated string column makes it trivially easy to filter, group, and partition in BigQuery.
- `source_record_key` is supposed to represent the primary key of source, and shouldn't have added metadata in it if its avoidable

### Testing
Built modified code into gs://ea-functional-tests/templates-pp28jm/flex/GCS_Spanner_Data_Validator
1. Sharded test: 
- MISSING_IN_DESTINATION rows correctly populated shard_id details
- MISSING_IN_SOURCE rows had null shard_id

2. Non-sharded test (regression test):
- All rows had NULL value in shard_id

Also added unit tests.