### PR TITLE
Directrunner fix for live/reverse template

### DIFF
--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToSpanner.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToSpanner.java
@@ -863,18 +863,22 @@ public class DataStreamToSpanner {
     TextIO.Write filterEventsWrite;
     if (options.getRunner() != null && options.getRunner().getSimpleName().equals("DirectRunner")) {
       // DirectRunner does not support dynamic sharding for unbounded PCollections
-      filterEventsWrite = TextIO.write().to(filterEventsDirectory).withSuffix(".json").withWindowedWrites().withNumShards(20);
+      filterEventsWrite =
+          TextIO.write()
+              .to(filterEventsDirectory)
+              .withSuffix(".json")
+              .withWindowedWrites()
+              .withNumShards(20);
     } else {
       // Cloud Dataflow natively supports dynamic sharding
-      filterEventsWrite = TextIO.write().to(filterEventsDirectory).withSuffix(".json").withWindowedWrites();
+      filterEventsWrite =
+          TextIO.write().to(filterEventsDirectory).withSuffix(".json").withWindowedWrites();
     }
 
     transformedRecords
         .get(DatastreamToSpannerConstants.FILTERED_EVENT_TAG)
         .apply(Window.into(FixedWindows.of(org.joda.time.Duration.standardMinutes(1))))
-        .apply(
-            "Write Filtered Events To GCS",
-            filterEventsWrite);
+        .apply("Write Filtered Events To GCS", filterEventsWrite);
 
     spannerConfig =
         SpannerServiceFactoryImpl.createSpannerService(

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToSpanner.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToSpanner.java
@@ -860,10 +860,15 @@ public class DataStreamToSpanner {
             ? tempLocation + "filteredEvents/"
             : options.getFilteredEventsDirectory();
     LOG.info("Filtered events directory: {}", filterEventsDirectory);
-    TextIO.Write filterEventsWrite = TextIO.write().to(filterEventsDirectory).withSuffix(".json").withWindowedWrites();
+    TextIO.Write filterEventsWrite;
     if (options.getRunner() != null && options.getRunner().getSimpleName().equals("DirectRunner")) {
-      filterEventsWrite = filterEventsWrite.withNumShards(20);
+      // DirectRunner does not support dynamic sharding for unbounded PCollections
+      filterEventsWrite = TextIO.write().to(filterEventsDirectory).withSuffix(".json").withWindowedWrites().withNumShards(20);
+    } else {
+      // Cloud Dataflow natively supports dynamic sharding
+      filterEventsWrite = TextIO.write().to(filterEventsDirectory).withSuffix(".json").withWindowedWrites();
     }
+
     transformedRecords
         .get(DatastreamToSpannerConstants.FILTERED_EVENT_TAG)
         .apply(Window.into(FixedWindows.of(org.joda.time.Duration.standardMinutes(1))))

--- a/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToSpanner.java
+++ b/v2/datastream-to-spanner/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToSpanner.java
@@ -860,12 +860,16 @@ public class DataStreamToSpanner {
             ? tempLocation + "filteredEvents/"
             : options.getFilteredEventsDirectory();
     LOG.info("Filtered events directory: {}", filterEventsDirectory);
+    TextIO.Write filterEventsWrite = TextIO.write().to(filterEventsDirectory).withSuffix(".json").withWindowedWrites();
+    if (options.getRunner() != null && options.getRunner().getSimpleName().equals("DirectRunner")) {
+      filterEventsWrite = filterEventsWrite.withNumShards(20);
+    }
     transformedRecords
         .get(DatastreamToSpannerConstants.FILTERED_EVENT_TAG)
         .apply(Window.into(FixedWindows.of(org.joda.time.Duration.standardMinutes(1))))
         .apply(
             "Write Filtered Events To GCS",
-            TextIO.write().to(filterEventsDirectory).withSuffix(".json").withWindowedWrites());
+            filterEventsWrite);
 
     spannerConfig =
         SpannerServiceFactoryImpl.createSpannerService(

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToMySqlDataTypesPGDialectIT.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToMySqlDataTypesPGDialectIT.java
@@ -22,6 +22,7 @@ import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
 
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
@@ -125,7 +126,8 @@ public class SpannerToMySqlDataTypesPGDialectIT extends SpannerToSourceDbITBase 
             null,
             null,
             MYSQL_SOURCE_TYPE,
-            jobParameters);
+            jobParameters,
+            Dialect.POSTGRESQL);
   }
 
   @After

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDbITBase.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDbITBase.java
@@ -234,12 +234,11 @@ public abstract class SpannerToSourceDbITBase extends TemplateTestBase {
     gcsResourceManager.createArtifact("input/cassandra-config.conf", cassandraConfigContents);
   }
 
-  protected String getSpannerServerTime(SpannerResourceManager spannerResourceManager) {
-    return spannerResourceManager
-        .runQuery("SELECT CURRENT_TIMESTAMP()")
-        .get(0)
-        .getTimestamp(0)
-        .toString();
+  protected String getSpannerServerTime(
+      SpannerResourceManager spannerResourceManager, Dialect dialect) {
+    String query =
+        dialect == Dialect.POSTGRESQL ? "SELECT CURRENT_TIMESTAMP" : "SELECT CURRENT_TIMESTAMP()";
+    return spannerResourceManager.runQuery(query).get(0).getTimestamp(0).toString();
   }
 
   public PipelineLauncher.LaunchInfo launchDataflowJob(
@@ -254,6 +253,35 @@ public abstract class SpannerToSourceDbITBase extends TemplateTestBase {
       CustomTransformation customTransformation,
       String sourceType,
       Map<String, String> jobParameters)
+      throws IOException {
+    return launchDataflowJob(
+        gcsResourceManager,
+        spannerResourceManager,
+        spannerMetadataResourceManager,
+        subscriptionName,
+        identifierSuffix,
+        shardingCustomJarPath,
+        shardingCustomClassName,
+        sourceDbTimezoneOffset,
+        customTransformation,
+        sourceType,
+        jobParameters,
+        Dialect.GOOGLE_STANDARD_SQL);
+  }
+
+  public PipelineLauncher.LaunchInfo launchDataflowJob(
+      GcsResourceManager gcsResourceManager,
+      SpannerResourceManager spannerResourceManager,
+      SpannerResourceManager spannerMetadataResourceManager,
+      String subscriptionName,
+      String identifierSuffix,
+      String shardingCustomJarPath,
+      String shardingCustomClassName,
+      String sourceDbTimezoneOffset,
+      CustomTransformation customTransformation,
+      String sourceType,
+      Map<String, String> jobParameters,
+      Dialect dialect)
       throws IOException {
 
     Map<String, String> params =
@@ -284,7 +312,7 @@ public abstract class SpannerToSourceDbITBase extends TemplateTestBase {
             put("workerMachineType", "n2-standard-4");
             // Query Spanner server time to bypass local clock skew and set as startTimestamp
             // to ensure the DirectRunner catches all test mutations during initialization.
-            put("startTimestamp", getSpannerServerTime(spannerResourceManager));
+            put("startTimestamp", getSpannerServerTime(spannerResourceManager, dialect));
           }
         };
 

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDbITBase.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDbITBase.java
@@ -18,6 +18,7 @@ package com.google.cloud.teleport.v2.templates;
 import static com.google.cloud.teleport.v2.spanner.migrations.constants.Constants.MYSQL_SOURCE_TYPE;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
 
+import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
 import com.google.cloud.teleport.v2.spanner.migrations.source.config.JdbcShardConfig;
@@ -274,6 +275,7 @@ public abstract class SpannerToSourceDbITBase extends TemplateTestBase {
             put("numWorkers", "1");
             put("sourceType", sourceType);
             put("workerMachineType", "n2-standard-4");
+            put("startTimestamp", Timestamp.now().toString());
           }
         };
 

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDbITBase.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDbITBase.java
@@ -275,7 +275,12 @@ public abstract class SpannerToSourceDbITBase extends TemplateTestBase {
             put("numWorkers", "1");
             put("sourceType", sourceType);
             put("workerMachineType", "n2-standard-4");
-            put("startTimestamp", Timestamp.now().toString());
+            // Set startTimestamp 5 minutes in the past to account for any clock skew between
+            // the local machine/CI runner and Spanner's server time.
+            put(
+                "startTimestamp",
+                Timestamp.ofTimeMicroseconds((System.currentTimeMillis() - 300000) * 1000)
+                    .toString());
           }
         };
 

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDbITBase.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDbITBase.java
@@ -18,7 +18,6 @@ package com.google.cloud.teleport.v2.templates;
 import static com.google.cloud.teleport.v2.spanner.migrations.constants.Constants.MYSQL_SOURCE_TYPE;
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
 
-import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
 import com.google.cloud.teleport.v2.spanner.migrations.source.config.JdbcShardConfig;
@@ -235,6 +234,14 @@ public abstract class SpannerToSourceDbITBase extends TemplateTestBase {
     gcsResourceManager.createArtifact("input/cassandra-config.conf", cassandraConfigContents);
   }
 
+  protected String getSpannerServerTime(SpannerResourceManager spannerResourceManager) {
+    return spannerResourceManager
+        .runQuery("SELECT CURRENT_TIMESTAMP()")
+        .get(0)
+        .getTimestamp(0)
+        .toString();
+  }
+
   public PipelineLauncher.LaunchInfo launchDataflowJob(
       GcsResourceManager gcsResourceManager,
       SpannerResourceManager spannerResourceManager,
@@ -275,12 +282,9 @@ public abstract class SpannerToSourceDbITBase extends TemplateTestBase {
             put("numWorkers", "1");
             put("sourceType", sourceType);
             put("workerMachineType", "n2-standard-4");
-            // Set startTimestamp 5 minutes in the past to account for any clock skew between
-            // the local machine/CI runner and Spanner's server time.
-            put(
-                "startTimestamp",
-                Timestamp.ofTimeMicroseconds((System.currentTimeMillis() - 300000) * 1000)
-                    .toString());
+            // Query Spanner server time to bypass local clock skew and set as startTimestamp
+            // to ensure the DirectRunner catches all test mutations during initialization.
+            put("startTimestamp", getSpannerServerTime(spannerResourceManager));
           }
         };
 


### PR DESCRIPTION
### Issue

Fix Live/Reverse replication integration tests on DirectRunner

Currently, the Bulk template integration tests (ITs) execute successfully using the DirectRunner, but the Live and Reverse replication ITs fail or time out. This PR resolves these runner-specific issues.

By enabling all template ITs to run on the DirectRunner, this change allows for full local test execution. This significantly reduces the overhead of deploying to the Dataflow runner during test development and decreases local test execution times.

### Fix

#### 1. Fix TextIO Sharding for Local Testing
                                                                                                                                                                          
  • **Issue:** Writing unbounded data (like dead-letter queues) to files via  TextIO  defaults to runner-determined dynamic sharding.                                         
  • **Why Dataflow Passes:** The fully-managed Dataflow runner inherently supports and dynamically orchestrates unbounded file sharding.                                      
  • **Why DirectRunner Fails:** The  DirectRunner  does not support dynamic sharding for unbounded  PCollections  and immediately throws an  IllegalArgumentException .       
  • **Fix Applied:** Added  .withNumShards(20)  to explicitly define a fixed shard count for direct runner, bypassing dynamic sharding and allowing local  DirectRunner  execution to succeed. 
                                                                                                                                                                          
#### 2. Fix Spanner Change Stream Race Condition
                                                                                                                                                                          
  • **Issue:** Integration tests inject seed data into Spanner, which the pipeline must read via a Change Stream.                                                             
  • **Why Dataflow Passes:** The IT framework uses the Cloud API to actively block test execution until the Dataflow job is  RUNNING  and workers are provisioned, ensuring the Change Stream reader is listening before data is inserted.                                                                                                          
  • **Why DirectRunner Fails:** The IT framework spawns the  DirectRunner  asynchronously in a background Java thread and instantly reports  RUNNING . This causes the test to fire Spanner mutations while the pipeline is still initializing locally, resulting in dropped events.                                                                
  • **Fix Applied:** Injected a  startTimestamp  into the pipeline options set slightly before the test fires its mutations. This forces the Spanner reader to look backward in time, ensuring no events are missed regardless of local initialization delays.   