### PR TITLE
fix initial zizmor issues on release workflow w/o touching write permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       - name: Create release branch
         run: git checkout -b $RELEASE_BRANCH_NAME $BRANCH_COMMIT
         env:
@@ -158,6 +159,7 @@ jobs:
           ref: ${{ steps.variables.outputs.releaseBranchName }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       - name: Setup Environment
         id: setup-env
         uses: ./.github/actions/setup-env
@@ -200,6 +202,7 @@ jobs:
           ref: ${{ steps.variables.outputs.releaseBranchName }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       - name: Setup Environment
         id: setup-env
         uses: ./.github/actions/setup-env
@@ -242,6 +245,7 @@ jobs:
           ref: ${{ steps.variables.outputs.releaseBranchName }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       - name: Setup Environment
         id: setup-env
         uses: ./.github/actions/setup-env
@@ -284,6 +288,7 @@ jobs:
           ref: ${{ steps.variables.outputs.releaseBranchName }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       - name: Push tags
         run: |
           git push -u origin --tags


### PR DESCRIPTION
1. zizmor --fix=all --gh-token=$(gh auth token) .github/workflows/
2. fix release workflow initial findings after the previous rollback - https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/3960