### PR TITLE
Increase timeout in SpannerToMySqlCustomTransformationLT

### DIFF
--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToMySqlCustomTransformationLT.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToMySqlCustomTransformationLT.java
@@ -123,7 +123,7 @@ public class SpannerToMySqlCustomTransformationLT extends SpannerToSourceDbLTBas
 
     PipelineOperator.Result result =
         pipelineOperator.waitForCondition(
-            createConfig(jobInfo, Duration.ofMinutes(12), Duration.ofSeconds(30)), check);
+            createConfig(jobInfo, Duration.ofMinutes(20), Duration.ofSeconds(30)), check);
 
     // Assert Conditions
     assertThatResult(result).meetsConditions();


### PR DESCRIPTION
b/529892449

Issue in SpannerToMySqlCustomTransformationLT

```
13:27:35.238 [main] INFO o.a.b.it.conditions.ConditionCheck - [✗] Condition 'JDBC database check if table Person has between 300000 and 300000 rows' not met! Expected 300000 rows but has only 299229
13:27:35.507 [main] INFO o.a.beam.it.common.PipelineOperator - Job 2026-06-30_05_57_04-8944752917686181882 is in state JOB_STATE_RUNNING
13:28:05.508 [main] INFO o.a.b.it.conditions.ConditionCheck - [?] Checking for condition 'JDBC database check if table Person has between 300000 and 300000 rows'...
13:28:07.481 [main] INFO o.a.b.it.conditions.ConditionCheck - [✗] Condition 'JDBC database check if table Person has between 300000 and 300000 rows' not met! Expected 300000 rows but has only 299494
13:28:07.788 [main] INFO o.a.beam.it.common.PipelineOperator - Job 2026-06-30_05_57_04-8944752917686181882 is in state JOB_STATE_RUNNING
13:28:37.788 [main] INFO o.a.b.it.conditions.ConditionCheck - [?] Checking for condition 'JDBC database check if table Person has between 300000 and 300000 rows'...
13:28:39.410 [main] INFO o.a.b.it.conditions.ConditionCheck - [✗] Condition 'JDBC database check if table Person has between 300000 and 300000 rows' not met! Expected 300000 rows but has only 299755
13:28:39.718 [main] INFO o.a.beam.it.common.PipelineOperator - Job 2026-06-30_05_57_04-8944752917686181882 is in state JOB_STATE_RUNNING
13:29:09.718 [main] WARN o.a.beam.it.common.PipelineOperator - Neither the condition or job completion were fulfilled on time.
```

[Dataflow Job](https://pantheon.corp.google.com/dataflow/jobs/us-central1/2026-06-30_05_57_04-8944752917686181882;logsSeverity=ERROR;graphView=0?project=cloud-teleport-testing&pageState=(%22dfTime%22:(%22l%22:%22dfJobMaxTime%22))&e=PangolinKitchenLaunch::PangolinKitchenEnabled&mods=logs_tg_staging)

Clearly, the reverse replication job was making steady progress on the count of rows and was very close to 300k (reached 299755) but timed out prematurely