### PR TITLE
pin commons-configuration2 to less vulnerable version 2.15

### DIFF
--- a/it/pom.xml
+++ b/it/pom.xml
@@ -84,6 +84,11 @@
       <artifactId>failsafe</artifactId>
       <version>${failsafe.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-configuration2</artifactId>
+      <version>${commons-configuration2.version}</version>
+    </dependency>
 
     <!-- Testing -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <commons-compress.version>1.28.0</commons-compress.version>
     <commons-io.version>2.21.0</commons-io.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>
-    <commons-configuration2.version>2.15.0</commons-configuration2.version>
+    <commons-configuration2.version>2.15.1</commons-configuration2.version>
     <commons-text.version>1.10.0</commons-text.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <derby.version>10.14.2.0</derby.version>

--- a/pom.xml
+++ b/pom.xml
@@ -169,11 +169,6 @@
         <version>${commons-io.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-configuration2</artifactId>
-        <version>${commons-configuration2.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro</artifactId>
         <version>${avro.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <commons-compress.version>1.28.0</commons-compress.version>
     <commons-io.version>2.21.0</commons-io.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>
-    <commons-configuration2.version>2.13.0</commons-configuration2.version>
+    <commons-configuration2.version>2.15.0</commons-configuration2.version>
     <commons-text.version>1.10.0</commons-text.version>
     <conscrypt.version>2.5.2</conscrypt.version>
     <derby.version>10.14.2.0</derby.version>
@@ -167,6 +167,11 @@
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>${commons-io.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-configuration2</artifactId>
+        <version>${commons-configuration2.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.avro</groupId>

--- a/v2/common/pom.xml
+++ b/v2/common/pom.xml
@@ -107,6 +107,11 @@
             <version>${commons-text.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+            <version>${commons-configuration2.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-bigquery</artifactId>
         </dependency>


### PR DESCRIPTION
Verified with:
`mvn dependency:tree -Dincludes=org.apache.commons:commons-configuration2 -pl v2/bigquery-to-bigtable,v2/bigquery-to-parquet,v2/googlecloud-and-mongodb`

[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- dependency:3.10.0:tree (default-cli) @ bigquery-to-bigtable ---
[INFO] com.google.cloud.teleport.v2:bigquery-to-bigtable:jar:1.0-SNAPSHOT
[INFO] \- com.google.cloud.teleport:it-google-cloud-platform:jar:1.0-SNAPSHOT:test
[INFO]    \- org.apache.hadoop:hadoop-common:jar:3.4.3:compile
[INFO]       \- org.apache.commons:commons-configuration2:jar:2.15.0:compile
[INFO] 
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- dependency:3.10.0:tree (default-cli) @ bigquery-to-parquet ---
[INFO] com.google.cloud.teleport.v2:bigquery-to-parquet:jar:1.0-SNAPSHOT
[INFO] \- com.google.cloud.teleport:it-google-cloud-platform:jar:1.0-SNAPSHOT:test
[INFO]    \- org.apache.hadoop:hadoop-common:jar:3.4.3:compile
[INFO]       \- org.apache.commons:commons-configuration2:jar:2.15.0:compile
[INFO] 
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- dependency:3.10.0:tree (default-cli) @ googlecloud-and-mongodb ---
[INFO] com.google.cloud.teleport.v2:googlecloud-and-mongodb:jar:1.0-SNAPSHOT
[INFO] \- com.google.cloud.teleport:it-google-cloud-platform:jar:1.0-SNAPSHOT:test
[INFO]    \- org.apache.hadoop:hadoop-common:jar:3.4.3:compile
[INFO]       \- org.apache.commons:commons-configuration2:jar:2.15.0:compile