### PR TITLE
test(spanner-to-sourcedb): Add Spanner-to-Spanner integration tests

### DIFF
--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerIT.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerIT.java
@@ -230,8 +230,8 @@ public class SpannerToSpannerIT extends SpannerToSourceDbITBase {
     spannerResourceManager.write(mutations);
 
     // Assert INSERT
-    assertReplication(TABLE_WITH_VIRTUAL_GEN_COL, 2, "id", 2L);
-    assertReplication(TABLE_WITH_STORED_GEN_COL, 2, "id", 2L);
+    assertReplication(TABLE_WITH_VIRTUAL_GEN_COL, 2, List.of("id"), "id", 2L);
+    assertReplication(TABLE_WITH_STORED_GEN_COL, 2, List.of("id"), "id", 2L);
 
     // UPDATE
     mutations = new ArrayList<>();
@@ -252,8 +252,8 @@ public class SpannerToSpannerIT extends SpannerToSourceDbITBase {
     spannerResourceManager.write(mutations);
 
     // Assert UPDATE (wait for propagation)
-    assertReplication(TABLE_WITH_VIRTUAL_GEN_COL, 2, "column1", 4L);
-    assertReplication(TABLE_WITH_STORED_GEN_COL, 2, "column1", 3L);
+    assertReplication(TABLE_WITH_VIRTUAL_GEN_COL, 2, List.of("id", "column1"), "column1", 4L);
+    assertReplication(TABLE_WITH_STORED_GEN_COL, 2, List.of("id", "column1"), "column1", 3L);
 
     // DELETE
     Mutation m1 =
@@ -273,8 +273,8 @@ public class SpannerToSpannerIT extends SpannerToSourceDbITBase {
     spannerResourceManager.write(Arrays.asList(m1, m2, m3, m4));
 
     // Assert DELETE
-    assertReplication(TABLE_WITH_VIRTUAL_GEN_COL, 0, null, null);
-    assertReplication(TABLE_WITH_STORED_GEN_COL, 0, null, null);
+    assertReplication(TABLE_WITH_VIRTUAL_GEN_COL, 0, List.of("id"), null, null);
+    assertReplication(TABLE_WITH_STORED_GEN_COL, 0, List.of("id"), null, null);
   }
 
   @Test
@@ -300,7 +300,7 @@ public class SpannerToSpannerIT extends SpannerToSourceDbITBase {
     spannerResourceManager.write(mutations);
 
     // Assert INSERT
-    assertReplication(TABLE_WITH_IDENTITY_COL, 2, "column1", "id2");
+    assertReplication(TABLE_WITH_IDENTITY_COL, 2, List.of("id", "column1"), "column1", "id2");
   }
 
   @Test
@@ -315,18 +315,20 @@ public class SpannerToSpannerIT extends SpannerToSourceDbITBase {
     spannerResourceManager.write(mutationBuilder.build());
 
     // Assert INSERT
-    assertReplication(BOUNDARY_CHECK_TABLE, 1, "id", 1L);
+    assertReplication(BOUNDARY_CHECK_TABLE, 1, List.of("id"), "id", 1L);
   }
 
   private void assertReplication(
-      String table, int expectedRowCount, String checkCol, Object expectedColValue)
+      String table,
+      int expectedRowCount,
+      List<String> columns,
+      String checkCol,
+      Object expectedColValue)
       throws InterruptedException {
     boolean conditionsMet = false;
     long start = System.currentTimeMillis();
     while (System.currentTimeMillis() - start < TEST_TIMEOUT.toMillis()) {
-      List<Struct> rows =
-          spannerDestinationResourceManager.readTableRecords(
-              table, checkCol == null ? List.of("id") : List.of("id", checkCol));
+      List<Struct> rows = spannerDestinationResourceManager.readTableRecords(table, columns);
 
       if (rows.size() == expectedRowCount) {
         if (expectedRowCount == 0) {

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerIT.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerIT.java
@@ -68,8 +68,8 @@ public class SpannerToSpannerIT extends SpannerToSourceDbITBase {
   private static final HashSet<SpannerToSpannerIT> testInstances = new HashSet<>();
   private static PipelineLauncher.LaunchInfo jobInfo;
 
-  public static SpannerResourceManager spannerResourceManager; // Source Spanner
-  public static SpannerResourceManager spannerDestinationResourceManager; // Destination Spanner
+  private static SpannerResourceManager spannerResourceManager; // Source Spanner
+  private static SpannerResourceManager spannerDestinationResourceManager; // Destination Spanner
   private static SpannerResourceManager spannerMetadataResourceManager;
   private static GcsResourceManager gcsResourceManager;
   private static PubsubResourceManager pubsubResourceManager;

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerIT.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerIT.java
@@ -22,6 +22,7 @@ import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
 import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import com.google.cloud.teleport.v2.templates.constants.Constants;
 import com.google.pubsub.v1.SubscriptionName;
 import java.io.IOException;
 import java.time.Duration;
@@ -134,7 +135,7 @@ public class SpannerToSpannerIT extends SpannerToSourceDbITBase {
                 null,
                 null,
                 null,
-                "spanner", // sourceType = "spanner"
+                Constants.SOURCE_SPANNER,
                 jobParameters);
       }
     }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerIT.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerIT.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.templates;
 
 import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
 
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Struct;
@@ -31,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import org.apache.beam.it.common.PipelineLauncher;
+import org.apache.beam.it.common.PipelineOperator;
 import org.apache.beam.it.common.utils.ResourceManagerUtils;
 import org.apache.beam.it.gcp.pubsub.PubsubResourceManager;
 import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
@@ -166,31 +168,28 @@ public class SpannerToSpannerIT extends SpannerToSourceDbITBase {
     spannerResourceManager.write(m);
     LOG.info("Successfully wrote row to source Spanner Users table");
 
-    boolean isReplicated = false;
-    long start = System.currentTimeMillis();
-    while (System.currentTimeMillis() - start < TEST_TIMEOUT.toMillis()) {
-      List<Struct> rows =
-          spannerDestinationResourceManager.readTableRecords(
-              TABLE, List.of("id", "full_name", "from"));
-      for (Struct row : rows) {
-        if (!row.isNull("id")
-            && row.getLong("id") == 101
-            && !row.isNull("full_name")
-            && "Alice".equals(row.getString("full_name"))) {
-          LOG.info("Row successfully found in destination Spanner: id=101, full_name=Alice");
-          isReplicated = true;
-          break;
-        }
-      }
-      if (isReplicated) {
-        break;
-      }
-      LOG.info("Waiting for row replication...");
-      Thread.sleep(10000); // Wait 10 seconds before polling again
-    }
+    PipelineOperator.Result result =
+        pipelineOperator()
+            .waitForCondition(
+                createConfig(jobInfo, TEST_TIMEOUT),
+                () -> {
+                  List<Struct> rows =
+                      spannerDestinationResourceManager.readTableRecords(
+                          TABLE, List.of("id", "full_name", "from"));
+                  for (Struct row : rows) {
+                    if (!row.isNull("id")
+                        && row.getLong("id") == 101
+                        && !row.isNull("full_name")
+                        && "Alice".equals(row.getString("full_name"))) {
+                      LOG.info(
+                          "Row successfully found in destination Spanner: id=101, full_name=Alice");
+                      return true;
+                    }
+                  }
+                  return false;
+                });
 
-    org.junit.Assert.assertTrue(
-        "Row was not replicated to destination Spanner within timeout", isReplicated);
+    assertThatResult(result).meetsConditions();
   }
 
   @Test
@@ -323,73 +322,59 @@ public class SpannerToSpannerIT extends SpannerToSourceDbITBase {
       int expectedRowCount,
       List<String> columns,
       String checkCol,
-      Object expectedColValue)
-      throws InterruptedException {
-    boolean conditionsMet = false;
-    long start = System.currentTimeMillis();
-    while (System.currentTimeMillis() - start < TEST_TIMEOUT.toMillis()) {
-      List<Struct> rows = spannerDestinationResourceManager.readTableRecords(table, columns);
+      Object expectedColValue) {
+    PipelineOperator.Result result =
+        pipelineOperator()
+            .waitForCondition(
+                createConfig(jobInfo, TEST_TIMEOUT),
+                () -> {
+                  List<Struct> rows =
+                      spannerDestinationResourceManager.readTableRecords(table, columns);
 
-      if (rows.size() == expectedRowCount) {
-        if (expectedRowCount == 0) {
-          conditionsMet = true;
-          break;
-        }
-        boolean valueFound = checkCol == null;
-        if (checkCol != null) {
-          for (Struct row : rows) {
-            if (row.isNull(checkCol)) {
-              continue;
-            }
-            if (expectedColValue instanceof Long
-                && row.getLong(checkCol) == ((Long) expectedColValue).longValue()) {
-              valueFound = true;
-              break;
-            } else if (expectedColValue instanceof String
-                && expectedColValue.equals(row.getString(checkCol))) {
-              valueFound = true;
-              break;
-            } else if (expectedColValue instanceof Boolean
-                && row.getBoolean(checkCol) == ((Boolean) expectedColValue).booleanValue()) {
-              valueFound = true;
-              break;
-            } else if (expectedColValue instanceof Double
-                && row.getDouble(checkCol) == ((Double) expectedColValue).doubleValue()) {
-              valueFound = true;
-              break;
-            } else if (expectedColValue instanceof Float
-                && row.getFloat(checkCol) == ((Float) expectedColValue).floatValue()) {
-              valueFound = true;
-              break;
-            } else if (expectedColValue instanceof java.math.BigDecimal
-                && expectedColValue.equals(row.getBigDecimal(checkCol))) {
-              valueFound = true;
-              break;
-            } else if (expectedColValue instanceof com.google.cloud.ByteArray
-                && expectedColValue.equals(row.getBytes(checkCol))) {
-              valueFound = true;
-              break;
-            } else if (expectedColValue instanceof com.google.cloud.Timestamp
-                && expectedColValue.equals(row.getTimestamp(checkCol))) {
-              valueFound = true;
-              break;
-            } else if (expectedColValue instanceof com.google.cloud.Date
-                && expectedColValue.equals(row.getDate(checkCol))) {
-              valueFound = true;
-              break;
-            }
-          }
-        }
-        if (valueFound) {
-          conditionsMet = true;
-          break;
-        }
-      }
-
-      LOG.info("Waiting for replication to {}", table);
-      Thread.sleep(10000);
-    }
-    org.junit.Assert.assertTrue(
-        "Replication assertions not met for table " + table + " within timeout", conditionsMet);
+                  if (rows.size() == expectedRowCount) {
+                    if (expectedRowCount == 0) {
+                      return true;
+                    }
+                    if (checkCol == null) {
+                      return true;
+                    }
+                    for (Struct row : rows) {
+                      if (row.isNull(checkCol)) {
+                        continue;
+                      }
+                      if (expectedColValue instanceof Long
+                          && row.getLong(checkCol) == ((Long) expectedColValue).longValue()) {
+                        return true;
+                      } else if (expectedColValue instanceof String
+                          && expectedColValue.equals(row.getString(checkCol))) {
+                        return true;
+                      } else if (expectedColValue instanceof Boolean
+                          && row.getBoolean(checkCol)
+                              == ((Boolean) expectedColValue).booleanValue()) {
+                        return true;
+                      } else if (expectedColValue instanceof Double
+                          && row.getDouble(checkCol) == ((Double) expectedColValue).doubleValue()) {
+                        return true;
+                      } else if (expectedColValue instanceof Float
+                          && row.getFloat(checkCol) == ((Float) expectedColValue).floatValue()) {
+                        return true;
+                      } else if (expectedColValue instanceof java.math.BigDecimal
+                          && expectedColValue.equals(row.getBigDecimal(checkCol))) {
+                        return true;
+                      } else if (expectedColValue instanceof com.google.cloud.ByteArray
+                          && expectedColValue.equals(row.getBytes(checkCol))) {
+                        return true;
+                      } else if (expectedColValue instanceof com.google.cloud.Timestamp
+                          && expectedColValue.equals(row.getTimestamp(checkCol))) {
+                        return true;
+                      } else if (expectedColValue instanceof com.google.cloud.Date
+                          && expectedColValue.equals(row.getDate(checkCol))) {
+                        return true;
+                      }
+                    }
+                  }
+                  return false;
+                });
+    assertThatResult(result).meetsConditions();
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerIT.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerIT.java
@@ -1,0 +1,365 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates;
+
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
+
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import com.google.pubsub.v1.SubscriptionName;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.it.common.PipelineLauncher;
+import org.apache.beam.it.common.utils.ResourceManagerUtils;
+import org.apache.beam.it.gcp.pubsub.PubsubResourceManager;
+import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
+import org.apache.beam.it.gcp.storage.GcsResourceManager;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration test for {@link SpannerToSourceDb} Flex template replicating from Spanner to Spanner.
+ */
+@Category({TemplateIntegrationTest.class, SkipDirectRunnerTest.class})
+@TemplateIntegrationTest(SpannerToSourceDb.class)
+@RunWith(JUnit4.class)
+public class SpannerToSpannerIT extends SpannerToSourceDbITBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SpannerToSpannerIT.class);
+
+  private static final Duration TEST_TIMEOUT = Duration.ofMinutes(15);
+
+  private static final String SPANNER_DDL_RESOURCE = "SpannerToSourceDbIT/spanner-schema.sql";
+
+  private static final String TABLE = "Users";
+  private static final String TABLE_WITH_VIRTUAL_GEN_COL = "TableWithVirtualGeneratedColumn";
+  private static final String TABLE_WITH_STORED_GEN_COL = "TableWithStoredGeneratedColumn";
+  private static final String TABLE_WITH_IDENTITY_COL = "TableWithIdentityColumn";
+  private static final String BOUNDARY_CHECK_TABLE =
+      "testtable_03TpCoVF16ED0KLxM3v808cH3bTGQ0uK_FEXuZHbttvYZPAeGeqiO";
+
+  private static final HashSet<SpannerToSpannerIT> testInstances = new HashSet<>();
+  private static PipelineLauncher.LaunchInfo jobInfo;
+
+  public static SpannerResourceManager spannerResourceManager; // Source Spanner
+  public static SpannerResourceManager spannerDestinationResourceManager; // Destination Spanner
+  private static SpannerResourceManager spannerMetadataResourceManager;
+  private static GcsResourceManager gcsResourceManager;
+  private static PubsubResourceManager pubsubResourceManager;
+  private SubscriptionName subscriptionName;
+
+  @Before
+  public void setUp() throws IOException {
+    skipBaseCleanup = true;
+    synchronized (SpannerToSpannerIT.class) {
+      testInstances.add(this);
+      if (jobInfo == null) {
+        spannerResourceManager = createSpannerDatabase(SPANNER_DDL_RESOURCE);
+
+        spannerDestinationResourceManager =
+            SpannerResourceManager.builder("rr-dest-" + testName, PROJECT, REGION)
+                .maybeUseStaticInstance()
+                .build();
+        createSpannerDDL(spannerDestinationResourceManager, SPANNER_DDL_RESOURCE);
+
+        spannerMetadataResourceManager = spannerDestinationResourceManager;
+
+        gcsResourceManager = setUpSpannerITGcsResourceManager();
+
+        String spannerShardConfig =
+            "["
+                + "  {"
+                + "    \"projectId\": \""
+                + PROJECT
+                + "\","
+                + "    \"instanceId\": \""
+                + spannerDestinationResourceManager.getInstanceId()
+                + "\","
+                + "    \"databaseId\": \""
+                + spannerDestinationResourceManager.getDatabaseId()
+                + "\""
+                + "  }"
+                + "]";
+        gcsResourceManager.createArtifact("input/spanner-shard.json", spannerShardConfig);
+
+        pubsubResourceManager = setUpPubSubResourceManager();
+        subscriptionName =
+            createPubsubResources(
+                getClass().getSimpleName(),
+                pubsubResourceManager,
+                getGcsPath("dlq", gcsResourceManager)
+                    .replace("gs://" + gcsResourceManager.getBucket(), ""),
+                gcsResourceManager);
+
+        Map<String, String> jobParameters = new HashMap<>();
+        jobParameters.put(
+            "sourceShardsFilePath", getGcsPath("input/spanner-shard.json", gcsResourceManager));
+
+        jobInfo =
+            launchDataflowJob(
+                gcsResourceManager,
+                spannerResourceManager,
+                spannerMetadataResourceManager,
+                subscriptionName.toString(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                "spanner", // sourceType = "spanner"
+                jobParameters);
+      }
+    }
+  }
+
+  @AfterClass
+  public static void cleanUp() throws IOException {
+    for (SpannerToSpannerIT instance : testInstances) {
+      instance.tearDownBase();
+    }
+    ResourceManagerUtils.cleanResources(
+        spannerResourceManager,
+        spannerDestinationResourceManager,
+        gcsResourceManager,
+        pubsubResourceManager);
+  }
+
+  @Test
+  public void spannerToSpannerBasicReplication() throws InterruptedException {
+    assertThatPipeline(jobInfo).isRunning();
+
+    Mutation m =
+        Mutation.newInsertOrUpdateBuilder(TABLE)
+            .set("id")
+            .to(101)
+            .set("full_name")
+            .to("Alice")
+            .set("from")
+            .to("London")
+            .build();
+    spannerResourceManager.write(m);
+    LOG.info("Successfully wrote row to source Spanner Users table");
+
+    boolean isReplicated = false;
+    long start = System.currentTimeMillis();
+    while (System.currentTimeMillis() - start < TEST_TIMEOUT.toMillis()) {
+      try {
+        java.util.List<Struct> rows =
+            spannerDestinationResourceManager.readTableRecords(
+                TABLE, java.util.List.of("id", "full_name", "from"));
+        for (Struct row : rows) {
+          if (row.getLong("id") == 101 && "Alice".equals(row.getString("full_name"))) {
+            LOG.info("Row successfully found in destination Spanner: id=101, full_name=Alice");
+            isReplicated = true;
+            break;
+          }
+        }
+        if (isReplicated) {
+          break;
+        }
+      } catch (Exception e) {
+        LOG.info("Waiting for row replication... (Details: {})", e.getMessage());
+      }
+      Thread.sleep(10000); // Wait 10 seconds before polling again
+    }
+
+    org.junit.Assert.assertTrue(
+        "Row was not replicated to destination Spanner within timeout", isReplicated);
+  }
+
+  @Test
+  public void spannerToSpannerWithGeneratedColumns() throws InterruptedException {
+    assertThatPipeline(jobInfo).isRunning();
+
+    // INSERT
+    List<Mutation> mutations = new ArrayList<>();
+    mutations.add(
+        Mutation.newInsertBuilder(TABLE_WITH_STORED_GEN_COL)
+            .set("id")
+            .to(1)
+            .set("column1")
+            .to(1)
+            .build());
+    mutations.add(
+        Mutation.newInsertBuilder(TABLE_WITH_STORED_GEN_COL)
+            .set("id")
+            .to(2)
+            .set("column1")
+            .to(2)
+            .build());
+    mutations.add(
+        Mutation.newInsertBuilder(TABLE_WITH_VIRTUAL_GEN_COL)
+            .set("id")
+            .to(1)
+            .set("column1")
+            .to(1)
+            .build());
+    mutations.add(
+        Mutation.newInsertBuilder(TABLE_WITH_VIRTUAL_GEN_COL)
+            .set("id")
+            .to(2)
+            .set("column1")
+            .to(2)
+            .build());
+    spannerResourceManager.write(mutations);
+
+    // Assert INSERT
+    assertReplication(TABLE_WITH_VIRTUAL_GEN_COL, 2, "id", 2L);
+    assertReplication(TABLE_WITH_STORED_GEN_COL, 2, "id", 2L);
+
+    // UPDATE
+    mutations = new ArrayList<>();
+    mutations.add(
+        Mutation.newUpdateBuilder(TABLE_WITH_STORED_GEN_COL)
+            .set("id")
+            .to(1)
+            .set("column1")
+            .to(3)
+            .build());
+    mutations.add(
+        Mutation.newUpdateBuilder(TABLE_WITH_VIRTUAL_GEN_COL)
+            .set("id")
+            .to(1)
+            .set("column1")
+            .to(4)
+            .build());
+    spannerResourceManager.write(mutations);
+
+    // Assert UPDATE (wait for propagation)
+    assertReplication(TABLE_WITH_VIRTUAL_GEN_COL, 2, "column1", 4L);
+    assertReplication(TABLE_WITH_STORED_GEN_COL, 2, "column1", 3L);
+
+    // DELETE
+    Mutation m1 =
+        Mutation.delete(
+            TABLE_WITH_VIRTUAL_GEN_COL,
+            com.google.cloud.spanner.Key.newBuilder().append(1).build());
+    Mutation m2 =
+        Mutation.delete(
+            TABLE_WITH_VIRTUAL_GEN_COL,
+            com.google.cloud.spanner.Key.newBuilder().append(2).build());
+    Mutation m3 =
+        Mutation.delete(
+            TABLE_WITH_STORED_GEN_COL, com.google.cloud.spanner.Key.newBuilder().append(1).build());
+    Mutation m4 =
+        Mutation.delete(
+            TABLE_WITH_STORED_GEN_COL, com.google.cloud.spanner.Key.newBuilder().append(2).build());
+    spannerResourceManager.write(Arrays.asList(m1, m2, m3, m4));
+
+    // Assert DELETE
+    assertReplication(TABLE_WITH_VIRTUAL_GEN_COL, 0, null, null);
+    assertReplication(TABLE_WITH_STORED_GEN_COL, 0, null, null);
+  }
+
+  @Test
+  public void spannerToSpannerWithIdentityColumns() throws InterruptedException {
+    assertThatPipeline(jobInfo).isRunning();
+
+    // INSERT
+    List<Mutation> mutations = new ArrayList<>();
+    mutations.add(
+        Mutation.newInsertBuilder(TABLE_WITH_IDENTITY_COL)
+            .set("id")
+            .to(1)
+            .set("column1")
+            .to("id1")
+            .build());
+    mutations.add(
+        Mutation.newInsertBuilder(TABLE_WITH_IDENTITY_COL)
+            .set("id")
+            .to(2)
+            .set("column1")
+            .to("id2")
+            .build());
+    spannerResourceManager.write(mutations);
+
+    // Assert INSERT
+    assertReplication(TABLE_WITH_IDENTITY_COL, 2, "column1", "id2");
+  }
+
+  @Test
+  public void spannerToSpannerMaxColAndTableNameTest() throws InterruptedException {
+    assertThatPipeline(jobInfo).isRunning();
+
+    Mutation.WriteBuilder mutationBuilder =
+        Mutation.newInsertOrUpdateBuilder(BOUNDARY_CHECK_TABLE).set("id").to(1);
+    mutationBuilder
+        .set("col_qcbF69RmXTRe3B_03TpCoVF16ED0KLxM3v808cH3bTGQ0uK_FEXuZHbttvY")
+        .to("SampleTestValue");
+    spannerResourceManager.write(mutationBuilder.build());
+
+    // Assert INSERT
+    assertReplication(BOUNDARY_CHECK_TABLE, 1, "id", 1L);
+  }
+
+  private void assertReplication(
+      String table, int expectedRowCount, String checkCol, Object expectedColValue)
+      throws InterruptedException {
+    boolean conditionsMet = false;
+    long start = System.currentTimeMillis();
+    while (System.currentTimeMillis() - start < TEST_TIMEOUT.toMillis()) {
+      try {
+        List<Struct> rows =
+            spannerDestinationResourceManager.readTableRecords(
+                table, checkCol == null ? List.of("id") : List.of("id", checkCol));
+
+        if (rows.size() == expectedRowCount) {
+          if (expectedRowCount == 0) {
+            conditionsMet = true;
+            break;
+          }
+          boolean valueFound = checkCol == null;
+          if (checkCol != null) {
+            for (Struct row : rows) {
+              if (expectedColValue instanceof Long
+                  && row.getLong(checkCol) == ((Long) expectedColValue).longValue()) {
+                valueFound = true;
+                break;
+              } else if (expectedColValue instanceof String
+                  && expectedColValue.equals(row.getString(checkCol))) {
+                valueFound = true;
+                break;
+              }
+            }
+          }
+          if (valueFound) {
+            conditionsMet = true;
+            break;
+          }
+        }
+      } catch (Exception e) {
+        LOG.info("Waiting for replication to {}", table);
+      }
+      Thread.sleep(10000);
+    }
+    org.junit.Assert.assertTrue(
+        "Replication assertions not met for table " + table + " within timeout", conditionsMet);
+  }
+}

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerIT.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerIT.java
@@ -54,7 +54,7 @@ public class SpannerToSpannerIT extends SpannerToSourceDbITBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(SpannerToSpannerIT.class);
 
-  private static final Duration TEST_TIMEOUT = Duration.ofMinutes(15);
+  private static final Duration TEST_TIMEOUT = Duration.ofMinutes(2);
 
   private static final String SPANNER_DDL_RESOURCE = "SpannerToSourceDbIT/spanner-schema.sql";
 

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerIT.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerIT.java
@@ -73,7 +73,6 @@ public class SpannerToSpannerIT extends SpannerToSourceDbITBase {
   private static SpannerResourceManager spannerMetadataResourceManager;
   private static GcsResourceManager gcsResourceManager;
   private static PubsubResourceManager pubsubResourceManager;
-  private SubscriptionName subscriptionName;
 
   @Before
   public void setUp() throws IOException {
@@ -110,7 +109,7 @@ public class SpannerToSpannerIT extends SpannerToSourceDbITBase {
         gcsResourceManager.createArtifact("input/spanner-shard.json", spannerShardConfig);
 
         pubsubResourceManager = setUpPubSubResourceManager();
-        subscriptionName =
+        SubscriptionName subscriptionName =
             createPubsubResources(
                 getClass().getSimpleName(),
                 pubsubResourceManager,
@@ -171,11 +170,14 @@ public class SpannerToSpannerIT extends SpannerToSourceDbITBase {
     long start = System.currentTimeMillis();
     while (System.currentTimeMillis() - start < TEST_TIMEOUT.toMillis()) {
       try {
-        java.util.List<Struct> rows =
+        List<Struct> rows =
             spannerDestinationResourceManager.readTableRecords(
-                TABLE, java.util.List.of("id", "full_name", "from"));
+                TABLE, List.of("id", "full_name", "from"));
         for (Struct row : rows) {
-          if (row.getLong("id") == 101 && "Alice".equals(row.getString("full_name"))) {
+          if (!row.isNull("id")
+              && row.getLong("id") == 101
+              && !row.isNull("full_name")
+              && "Alice".equals(row.getString("full_name"))) {
             LOG.info("Row successfully found in destination Spanner: id=101, full_name=Alice");
             isReplicated = true;
             break;
@@ -338,6 +340,9 @@ public class SpannerToSpannerIT extends SpannerToSourceDbITBase {
           boolean valueFound = checkCol == null;
           if (checkCol != null) {
             for (Struct row : rows) {
+              if (row.isNull(checkCol)) {
+                continue;
+              }
               if (expectedColValue instanceof Long
                   && row.getLong(checkCol) == ((Long) expectedColValue).longValue()) {
                 valueFound = true;

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerIT.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerIT.java
@@ -351,6 +351,34 @@ public class SpannerToSpannerIT extends SpannerToSourceDbITBase {
                   && expectedColValue.equals(row.getString(checkCol))) {
                 valueFound = true;
                 break;
+              } else if (expectedColValue instanceof Boolean
+                  && row.getBoolean(checkCol) == ((Boolean) expectedColValue).booleanValue()) {
+                valueFound = true;
+                break;
+              } else if (expectedColValue instanceof Double
+                  && row.getDouble(checkCol) == ((Double) expectedColValue).doubleValue()) {
+                valueFound = true;
+                break;
+              } else if (expectedColValue instanceof Float
+                  && row.getFloat(checkCol) == ((Float) expectedColValue).floatValue()) {
+                valueFound = true;
+                break;
+              } else if (expectedColValue instanceof java.math.BigDecimal
+                  && expectedColValue.equals(row.getBigDecimal(checkCol))) {
+                valueFound = true;
+                break;
+              } else if (expectedColValue instanceof com.google.cloud.ByteArray
+                  && expectedColValue.equals(row.getBytes(checkCol))) {
+                valueFound = true;
+                break;
+              } else if (expectedColValue instanceof com.google.cloud.Timestamp
+                  && expectedColValue.equals(row.getTimestamp(checkCol))) {
+                valueFound = true;
+                break;
+              } else if (expectedColValue instanceof com.google.cloud.Date
+                  && expectedColValue.equals(row.getDate(checkCol))) {
+                valueFound = true;
+                break;
               }
             }
           }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerIT.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerIT.java
@@ -169,26 +169,23 @@ public class SpannerToSpannerIT extends SpannerToSourceDbITBase {
     boolean isReplicated = false;
     long start = System.currentTimeMillis();
     while (System.currentTimeMillis() - start < TEST_TIMEOUT.toMillis()) {
-      try {
-        List<Struct> rows =
-            spannerDestinationResourceManager.readTableRecords(
-                TABLE, List.of("id", "full_name", "from"));
-        for (Struct row : rows) {
-          if (!row.isNull("id")
-              && row.getLong("id") == 101
-              && !row.isNull("full_name")
-              && "Alice".equals(row.getString("full_name"))) {
-            LOG.info("Row successfully found in destination Spanner: id=101, full_name=Alice");
-            isReplicated = true;
-            break;
-          }
-        }
-        if (isReplicated) {
+      List<Struct> rows =
+          spannerDestinationResourceManager.readTableRecords(
+              TABLE, List.of("id", "full_name", "from"));
+      for (Struct row : rows) {
+        if (!row.isNull("id")
+            && row.getLong("id") == 101
+            && !row.isNull("full_name")
+            && "Alice".equals(row.getString("full_name"))) {
+          LOG.info("Row successfully found in destination Spanner: id=101, full_name=Alice");
+          isReplicated = true;
           break;
         }
-      } catch (Exception e) {
-        LOG.info("Waiting for row replication... (Details: {})", e.getMessage());
       }
+      if (isReplicated) {
+        break;
+      }
+      LOG.info("Waiting for row replication...");
       Thread.sleep(10000); // Wait 10 seconds before polling again
     }
 
@@ -327,69 +324,67 @@ public class SpannerToSpannerIT extends SpannerToSourceDbITBase {
     boolean conditionsMet = false;
     long start = System.currentTimeMillis();
     while (System.currentTimeMillis() - start < TEST_TIMEOUT.toMillis()) {
-      try {
-        List<Struct> rows =
-            spannerDestinationResourceManager.readTableRecords(
-                table, checkCol == null ? List.of("id") : List.of("id", checkCol));
+      List<Struct> rows =
+          spannerDestinationResourceManager.readTableRecords(
+              table, checkCol == null ? List.of("id") : List.of("id", checkCol));
 
-        if (rows.size() == expectedRowCount) {
-          if (expectedRowCount == 0) {
-            conditionsMet = true;
-            break;
-          }
-          boolean valueFound = checkCol == null;
-          if (checkCol != null) {
-            for (Struct row : rows) {
-              if (row.isNull(checkCol)) {
-                continue;
-              }
-              if (expectedColValue instanceof Long
-                  && row.getLong(checkCol) == ((Long) expectedColValue).longValue()) {
-                valueFound = true;
-                break;
-              } else if (expectedColValue instanceof String
-                  && expectedColValue.equals(row.getString(checkCol))) {
-                valueFound = true;
-                break;
-              } else if (expectedColValue instanceof Boolean
-                  && row.getBoolean(checkCol) == ((Boolean) expectedColValue).booleanValue()) {
-                valueFound = true;
-                break;
-              } else if (expectedColValue instanceof Double
-                  && row.getDouble(checkCol) == ((Double) expectedColValue).doubleValue()) {
-                valueFound = true;
-                break;
-              } else if (expectedColValue instanceof Float
-                  && row.getFloat(checkCol) == ((Float) expectedColValue).floatValue()) {
-                valueFound = true;
-                break;
-              } else if (expectedColValue instanceof java.math.BigDecimal
-                  && expectedColValue.equals(row.getBigDecimal(checkCol))) {
-                valueFound = true;
-                break;
-              } else if (expectedColValue instanceof com.google.cloud.ByteArray
-                  && expectedColValue.equals(row.getBytes(checkCol))) {
-                valueFound = true;
-                break;
-              } else if (expectedColValue instanceof com.google.cloud.Timestamp
-                  && expectedColValue.equals(row.getTimestamp(checkCol))) {
-                valueFound = true;
-                break;
-              } else if (expectedColValue instanceof com.google.cloud.Date
-                  && expectedColValue.equals(row.getDate(checkCol))) {
-                valueFound = true;
-                break;
-              }
+      if (rows.size() == expectedRowCount) {
+        if (expectedRowCount == 0) {
+          conditionsMet = true;
+          break;
+        }
+        boolean valueFound = checkCol == null;
+        if (checkCol != null) {
+          for (Struct row : rows) {
+            if (row.isNull(checkCol)) {
+              continue;
+            }
+            if (expectedColValue instanceof Long
+                && row.getLong(checkCol) == ((Long) expectedColValue).longValue()) {
+              valueFound = true;
+              break;
+            } else if (expectedColValue instanceof String
+                && expectedColValue.equals(row.getString(checkCol))) {
+              valueFound = true;
+              break;
+            } else if (expectedColValue instanceof Boolean
+                && row.getBoolean(checkCol) == ((Boolean) expectedColValue).booleanValue()) {
+              valueFound = true;
+              break;
+            } else if (expectedColValue instanceof Double
+                && row.getDouble(checkCol) == ((Double) expectedColValue).doubleValue()) {
+              valueFound = true;
+              break;
+            } else if (expectedColValue instanceof Float
+                && row.getFloat(checkCol) == ((Float) expectedColValue).floatValue()) {
+              valueFound = true;
+              break;
+            } else if (expectedColValue instanceof java.math.BigDecimal
+                && expectedColValue.equals(row.getBigDecimal(checkCol))) {
+              valueFound = true;
+              break;
+            } else if (expectedColValue instanceof com.google.cloud.ByteArray
+                && expectedColValue.equals(row.getBytes(checkCol))) {
+              valueFound = true;
+              break;
+            } else if (expectedColValue instanceof com.google.cloud.Timestamp
+                && expectedColValue.equals(row.getTimestamp(checkCol))) {
+              valueFound = true;
+              break;
+            } else if (expectedColValue instanceof com.google.cloud.Date
+                && expectedColValue.equals(row.getDate(checkCol))) {
+              valueFound = true;
+              break;
             }
           }
-          if (valueFound) {
-            conditionsMet = true;
-            break;
-          }
         }
-      } catch (Exception e) {
-        LOG.info("Waiting for replication to {}", table);
+        if (valueFound) {
+          conditionsMet = true;
+          break;
+        }
       }
+
+      LOG.info("Waiting for replication to {}", table);
       Thread.sleep(10000);
     }
     org.junit.Assert.assertTrue(


### PR DESCRIPTION
This PR adds end-to-end integration tests for the Spanner-to-Spanner reverse replication pipeline.

Since Spanner-to-Spanner replication uses the `SpannerToSourceDb` template with `--sourceType=spanner`, this introduces a new `SpannerToSpannerIT` tests to ensure data integrity across various Spanner schema features.

The tests dynamically provision real source and destination Spanner databases and is mirroring MySQL test scenarios covering the following replication scenarios:
* Basic `INSERT` replication.
* Operations (`INSERT`, `UPDATE`, `DELETE`) on tables with Virtual and Stored Generated Columns.
* Replication into Identity columns.
* Boundary checks for maximum length table and column names.