### PR TITLE
Fix import/export failures

### DIFF
--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
@@ -185,7 +185,6 @@ public class InformationSchemaScannerIT extends SpannerTemplateITBase {
 
   private void setupResourceManager(Dialect dialect, byte[] protoDescriptors) {
     String projectId = TestProperties.project();
-    String region = TestProperties.region();
 
     SpannerResourceManager.Builder builder =
         SpannerResourceManager.builder(
@@ -193,7 +192,7 @@ public class InformationSchemaScannerIT extends SpannerTemplateITBase {
                 projectId,
                 "nam3",
                 dialect)
-            .setInstancePartition(INSTANCE_PARTITION_ID, "nam3");
+            .setInstancePartition(INSTANCE_PARTITION_ID, "nam6");
     if (protoDescriptors != null) {
       builder.setProtoDescriptors(protoDescriptors);
     }

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
@@ -34,8 +34,9 @@ import com.google.cloud.spanner.BatchClient;
 import com.google.cloud.spanner.BatchReadOnlyTransaction;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.TimestampBound;
+import com.google.cloud.teleport.metadata.SpannerStagingTest;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
 import com.google.cloud.teleport.spanner.DdlToAvroSchemaConverter;
-import com.google.cloud.teleport.spanner.IntegrationTest;
 import com.google.cloud.teleport.spanner.common.Type;
 import com.google.cloud.teleport.spanner.tests.TestMessage;
 import com.google.common.collect.HashMultimap;
@@ -53,12 +54,11 @@ import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.beam.it.common.TestProperties;
 import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
+import org.apache.beam.it.gcp.spanner.SpannerTemplateITBase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.TestName;
 
 /**
  * Test coverage for {@link InformationSchemaScanner}. This requires an active GCP project with a
@@ -70,12 +70,10 @@ import org.junit.rules.TestName;
  * comprehensively here is extremely important to complete the loop of testing the Export and Import
  * Pipelines.
  */
-@Category(IntegrationTest.class)
-public class InformationSchemaScannerIT {
+@Category({TemplateIntegrationTest.class, SpannerStagingTest.class})
+public class InformationSchemaScannerIT extends SpannerTemplateITBase {
 
   public static final String INSTANCE_PARTITION_ID = "mr-partition";
-
-  @Rule public final TestName testName = new TestName();
 
   public static SpannerResourceManager sharedSpannerResourceManager;
   public static SpannerResourceManager sharedPgSpannerResourceManager;
@@ -188,11 +186,10 @@ public class InformationSchemaScannerIT {
   private void setupResourceManager(Dialect dialect, byte[] protoDescriptors) {
     String projectId = TestProperties.project();
     String region = TestProperties.region();
-    String spannerHost = System.getProperty("spannerHost");
 
     SpannerResourceManager.Builder builder =
         SpannerResourceManager.builder(
-                testName.getMethodName() + "-" + UUID.randomUUID().toString().substring(0, 8),
+                testName + "-" + UUID.randomUUID().toString().substring(0, 8),
                 projectId,
                 "nam3",
                 dialect)
@@ -755,9 +752,9 @@ public class InformationSchemaScannerIT {
           assertThat(udf2, notNullValue());
           assertThat(ddl.udf("s_simpleUdf.u_simpleUdf_default_values"), sameInstance(udf2));
 
-          Udf udf3 = ddl.udf("s1.remote_udf");
+          Udf udf3 = ddl.udf("s_simpleUdf.u_remote_udf");
           assertThat(udf3, notNullValue());
-          assertThat(ddl.udf("S1.REMOTE_UDF"), sameInstance(udf3));
+          assertThat(ddl.udf("S_SIMPLEUDF.U_REMOTE_UDF"), sameInstance(udf3));
 
           assertThat(udf1.name(), equalTo("s_simpleUdf.u_simpleUdf_foo"));
           assertThat(udf1.type(), equalTo("INT64"));

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
@@ -190,9 +190,9 @@ public class InformationSchemaScannerIT extends SpannerTemplateITBase {
         SpannerResourceManager.builder(
                 testName + "-" + UUID.randomUUID().toString().substring(0, 8),
                 projectId,
-                "nam3",
+                "nam6",
                 dialect)
-            .setInstancePartition(INSTANCE_PARTITION_ID, "nam6");
+            .setInstancePartition(INSTANCE_PARTITION_ID, "nam3");
     if (protoDescriptors != null) {
       builder.setProtoDescriptors(protoDescriptors);
     }

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
@@ -34,9 +34,8 @@ import com.google.cloud.spanner.BatchClient;
 import com.google.cloud.spanner.BatchReadOnlyTransaction;
 import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.TimestampBound;
-import com.google.cloud.teleport.metadata.SpannerStagingTest;
-import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
 import com.google.cloud.teleport.spanner.DdlToAvroSchemaConverter;
+import com.google.cloud.teleport.spanner.IntegrationTest;
 import com.google.cloud.teleport.spanner.common.Type;
 import com.google.cloud.teleport.spanner.tests.TestMessage;
 import com.google.common.collect.HashMultimap;
@@ -54,11 +53,12 @@ import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.beam.it.common.TestProperties;
 import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
-import org.apache.beam.it.gcp.spanner.SpannerTemplateITBase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
 
 /**
  * Test coverage for {@link InformationSchemaScanner}. This requires an active GCP project with a
@@ -70,10 +70,12 @@ import org.junit.experimental.categories.Category;
  * comprehensively here is extremely important to complete the loop of testing the Export and Import
  * Pipelines.
  */
-@Category({TemplateIntegrationTest.class, SpannerStagingTest.class})
-public class InformationSchemaScannerIT extends SpannerTemplateITBase {
+@Category(IntegrationTest.class)
+public class InformationSchemaScannerIT {
 
   public static final String INSTANCE_PARTITION_ID = "mr-partition";
+
+  @Rule public final TestName testName = new TestName();
 
   public static SpannerResourceManager sharedSpannerResourceManager;
   public static SpannerResourceManager sharedPgSpannerResourceManager;
@@ -150,8 +152,7 @@ public class InformationSchemaScannerIT extends SpannerTemplateITBase {
                 region,
                 Dialect.GOOGLE_STANDARD_SQL)
             .maybeUseStaticInstance()
-            .setProtoDescriptors(protoDescriptorBytes.toByteArray())
-            .setInstancePartition(INSTANCE_PARTITION_ID, "nam3");
+            .setProtoDescriptors(protoDescriptorBytes.toByteArray());
     if (spannerHost != null) {
       builder.useCustomHost(spannerHost);
     }
@@ -163,8 +164,7 @@ public class InformationSchemaScannerIT extends SpannerTemplateITBase {
                 projectId,
                 region,
                 Dialect.POSTGRESQL)
-            .maybeUseStaticInstance()
-            .setInstancePartition(INSTANCE_PARTITION_ID, "nam3");
+            .maybeUseStaticInstance();
     if (spannerHost != null) {
       pgBuilder.useCustomHost(spannerHost);
     }
@@ -188,14 +188,14 @@ public class InformationSchemaScannerIT extends SpannerTemplateITBase {
   private void setupResourceManager(Dialect dialect, byte[] protoDescriptors) {
     String projectId = TestProperties.project();
     String region = TestProperties.region();
+    String spannerHost = System.getProperty("spannerHost");
 
     SpannerResourceManager.Builder builder =
         SpannerResourceManager.builder(
-                testName + "-" + UUID.randomUUID().toString().substring(0, 8),
+                testName.getMethodName() + "-" + UUID.randomUUID().toString().substring(0, 8),
                 projectId,
-                region,
+                "nam3",
                 dialect)
-            .maybeUseStaticInstance()
             .setInstancePartition(INSTANCE_PARTITION_ID, "nam3");
     if (protoDescriptors != null) {
       builder.setProtoDescriptors(protoDescriptors);
@@ -755,9 +755,9 @@ public class InformationSchemaScannerIT extends SpannerTemplateITBase {
           assertThat(udf2, notNullValue());
           assertThat(ddl.udf("s_simpleUdf.u_simpleUdf_default_values"), sameInstance(udf2));
 
-          Udf udf3 = ddl.udf("s_simpleUdf.u_remote_udf");
+          Udf udf3 = ddl.udf("s1.remote_udf");
           assertThat(udf3, notNullValue());
-          assertThat(ddl.udf("S_SIMPLEUDF.U_REMOTE_UDF"), sameInstance(udf3));
+          assertThat(ddl.udf("S1.REMOTE_UDF"), sameInstance(udf3));
 
           assertThat(udf1.name(), equalTo("s_simpleUdf.u_simpleUdf_foo"));
           assertThat(udf1.type(), equalTo("INT64"));


### PR DESCRIPTION
b/530658927

The tests seem to be failing on cloud-devel and staging environments, but they pass in Prod

## RCA:

The test suite is failing during the setup phase of `InformationSchemaScannerIT`. Specifically, it is failing with the error:
> `FAILED_PRECONDITION: Cannot create an instance partition in a single region instance.`

This happens because of a [recent change](https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/3915) that added the following line to the `SpannerResourceManager` builders in `setupResourceManager()` and the shared setups:
```java
.setInstancePartition(INSTANCE_PARTITION_ID, "nam3");
```

However, the builder also calls `.maybeUseStaticInstance()`. During the test run, the resource manager finds and reuses the existing static Spanner instance named `teleport` in the test environment (as seen in the logs: `Not creating Spanner instance - reusing static teleport`).

The problem is that the `teleport` instance is a **single-region** instance, and Cloud Spanner does not support creating instance partitions (like the multi-region `nam3` config) on single-region instances.


## Fix
1.  **Fixed the Shared Database Setups:**
Removed `.setInstancePartition(INSTANCE_PARTITION_ID, "nam3")` from `setupSharedResourceManagers()`. This allows all the other tests to safely reuse the static `teleport` single-region instance again, ensuring they run fast without crashing.
2.  **Fixed the Isolated Placement Tests:**
Modified the `setupResourceManager()` method (which is now *only* used by the two placement tests). I removed `.maybeUseStaticInstance()` so it is forced to create a fresh instance. Crucially, I also hardcoded the region to `"nam6"`. This guarantees the framework spins up a temporary multi-region instance specifically capable of supporting instance partitions.



## FAQ
The instance in both prod and cloud-devel environements is a single-region instance - so technically it should be failing on both of the environments. So how does prod have an instance partition? 

The CL that introduced this change(cl/915640674) mentions this in its description:
```
We prevent new geo-partitioning customers creating instance partition under a single-region parent instance.
Specifically, when CreateInstancePartition:
1. if parent instance config is multi-region config -> OK
2. if parent instance config is single-region config, but already has instance partitions -> we consider they are pre-existing legacy geo-partitioning customers, OK.
3. if parent instance config is single-region, and no other additional instance partitions -> we consider they are new geo-partitioning customers, fail the CreateInstancePartition.
```

So the most plausible explanation is that the instance partition was created on the prod instance before the fix was rolled out in May. 


## Test to confirm RCA
#### Prod environment
Tried to create an instance partition on one of the static instances used by the test - and it shows the partition already exists which means its able to support partitions. 
```
aasthabharill@aasthabharill:~$ gcloud spanner instances describe teleport --project=cloud-teleport-testing
config: projects/cloud-teleport-testing/instanceConfigs/regional-us-central1
createTime: '2025-06-11T15:26:59.975539Z'
defaultBackupScheduleType: AUTOMATIC
displayName: teleport
edition: ENTERPRISE_PLUS
instanceType: PROVISIONED
name: projects/cloud-teleport-testing/instances/teleport
nodeCount: 8
processingUnits: 8000
replicaComputeCapacity:
- nodeCount: 8
  replicaSelection:
    location: us-central1
resourceLocation: us-central1
state: READY
updateTime: '2026-06-23T11:58:09.279175Z'

aasthabharill@aasthabharill:~$ gcloud alpha spanner instance-partitions create mr-partition \
    --instance=teleport \
    --config=nam3 \
    --nodes=1 \
    --description="test partition" \
    --project=cloud-teleport-testing
ERROR: (gcloud.alpha.spanner.instance-partitions.create) ALREADY_EXISTS: Instance partition already exists: projects/cloud-teleport-testing/instances/teleport/instancePartitions/mr-partition
```

#### Cloud Devel environment
Tried to create an instance partition on one of the static instances used by the test - and it fails with the same error we saw in the test run stack trace

```
aasthabharill@aasthabharill:~$ gcloud config set api_endpoint_overrides/spanner https://staging-wrenchworks.mtls.sandbox.googleapis.com/
Updated property [api_endpoint_overrides/spanner].

aasthabharill@aasthabharill:~$ gcloud spanner instances describe teleport --project=cloud-teleport-testing
config: projects/cloud-teleport-testing/instanceConfigs/regional-us-central1
createTime: '2022-09-07T05:21:15.959158Z'
displayName: teleport
edition: ENTERPRISE_PLUS
instanceType: PROVISIONED
name: projects/cloud-teleport-testing/instances/teleport
nodeCount: 5
processingUnits: 5000
replicaComputeCapacity:
- nodeCount: 5
  replicaSelection:
    location: us-central1
resourceLocation: us-central1
state: READY
updateTime: '2024-10-26T17:47:48.200048Z'

aasthabharill@aasthabharill:~$ gcloud alpha spanner instance-partitions create mr-partition \
    --instance=teleport \
    --config=nam3 \
    --nodes=1 \
    --description="test partition" \
    --project=cloud-teleport-testing
ERROR: (gcloud.alpha.spanner.instance-partitions.create) FAILED_PRECONDITION: Cannot create an instance partition in a single region instance.
- '@type': type.googleapis.com/google.rpc.DebugInfo
  detail: '[ORIGINAL ERROR] generic::failed_precondition: Cannot create an instance
    partition in a single region instance. [google.rpc.error_details_ext] { message:
    "Cannot create an instance partition in a single region instance." } 485239697
    { 1: "Cannot create an instance partition in a single region instance." 2 { 1:
    9 2: "Cannot create an instance partition in a single region instance." } }'
```