### PR TITLE
Import Export test fix

### DIFF
--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
@@ -73,7 +73,7 @@ import org.junit.experimental.categories.Category;
 @Category({TemplateIntegrationTest.class, SpannerStagingTest.class})
 public class InformationSchemaScannerIT extends SpannerTemplateITBase {
 
-  public static final String INSTANCE_PARTITION_ID = "mr-partition";
+  public static final String INSTANCE_PARTITION_ID = "default";
 
   public static SpannerResourceManager sharedSpannerResourceManager;
   public static SpannerResourceManager sharedPgSpannerResourceManager;
@@ -188,11 +188,10 @@ public class InformationSchemaScannerIT extends SpannerTemplateITBase {
 
     SpannerResourceManager.Builder builder =
         SpannerResourceManager.builder(
-                testName + "-" + UUID.randomUUID().toString().substring(0, 8),
-                projectId,
-                "nam6",
-                dialect)
-            .setInstancePartition(INSTANCE_PARTITION_ID, "nam3");
+            testName + "-" + UUID.randomUUID().toString().substring(0, 8),
+            projectId,
+            "nam3",
+            dialect);
     if (protoDescriptors != null) {
       builder.setProtoDescriptors(protoDescriptors);
     }


### PR DESCRIPTION
b/531449982

Reason for using default partition instead of creating a new one:
- When a spanner instance is created, Spanner implicitly provisions a built-in partition named `"default"` that shares the instance's region configuration.
-  Spanner strictly prohibits creating a *new* custom instance partition that shares the exact same region as another partition - so we can't use the spanner instance region due to the default partition that was created
- Therefore, to successfully create a custom partition, the base instance must be created in one configuration (e.g., `nam3`), and the custom partition must be created in a *different* configuration (e.g., `nam6`).
- But across our three environments (Prod, Pre-Prod, and Cloud-devel), there isn't a universally shared set of *two distinct* multi-region configurations. 
- So we will utilize the default partition instead of provisioning a secondary partition.