### PR TITLE
Anomaly detection template improvements

### DIFF
--- a/python/src/main/python/bigquery-anomaly-detection/src/bqmonitor/cdc.py
+++ b/python/src/main/python/bigquery-anomaly-detection/src/bqmonitor/cdc.py
@@ -311,6 +311,14 @@ def _table_key(table_ref: 'bigquery.TableReference') -> str:
   return f'{table_ref.projectId}.{table_ref.datasetId}.{table_ref.tableId}'
 
 
+def _quote_identifier(name: str) -> str:
+  """Backtick-quote a column name for use in generated SQL.
+  """
+  if '`' in name:
+    raise ValueError(f'Invalid column name (contains backtick): {name!r}')
+  return f'`{name}`'
+
+
 def build_changes_query(
     table: str,
     start: Timestamp,
@@ -346,12 +354,13 @@ def build_changes_query(
   # destination tables with their original names. Rename them so they can
   # be persisted to the temp table for Storage Read API reading.
   pseudo = (
-      f"_CHANGE_TYPE AS {change_type_column}, "
-      f"_CHANGE_TIMESTAMP AS {change_timestamp_column}")
+      f"_CHANGE_TYPE AS {_quote_identifier(change_type_column)}, "
+      f"_CHANGE_TIMESTAMP AS {_quote_identifier(change_timestamp_column)}")
   if columns is None:
     select = f"SELECT * EXCEPT(_CHANGE_TYPE, _CHANGE_TIMESTAMP), {pseudo}"
   else:
-    select = f"SELECT {', '.join(columns)}, {pseudo}"
+    quoted = ', '.join(_quote_identifier(c) for c in columns)
+    select = f"SELECT {quoted}, {pseudo}"
   from_clause = (
       f"FROM {change_function}"
       f"(TABLE `{table}`, "
@@ -563,6 +572,7 @@ class _PollChangeHistoryFn(beam.DoFn, beam.transforms.core.RestrictionProvider):
 
     if not restriction_tracker.try_claim(current_index):
       return
+
     restriction_tracker.defer_remainder(Timestamp.of(now) + self._poll_interval)
 
     yield from self._emit_query_ranges(start_ts, end_ts, watermark_estimator)
@@ -1111,7 +1121,6 @@ class _CleanupTempTablesFn(beam.DoFn):
   """
   STREAMS_READ = beam.transforms.userstate.CombiningValueStateSpec(
       'streams_read', sum)
-
   def setup(self) -> None:
     _LOGGER.info('[Cleanup] setup: creating BigQueryWrapper')
     self._bq_wrapper = bigquery_tools.BigQueryWrapper()

--- a/python/src/main/python/bigquery-anomaly-detection/src/bqmonitor/cdc.py
+++ b/python/src/main/python/bigquery-anomaly-detection/src/bqmonitor/cdc.py
@@ -360,7 +360,7 @@ def build_changes_query(
     select = f"SELECT * EXCEPT(_CHANGE_TYPE, _CHANGE_TIMESTAMP), {pseudo}"
   else:
     quoted = ', '.join(_quote_identifier(c) for c in columns)
-    select = f"SELECT {quoted}, {pseudo}"
+    select = f"SELECT {quoted}, {pseudo}" if quoted else f"SELECT {pseudo}"
   from_clause = (
       f"FROM {change_function}"
       f"(TABLE `{table}`, "

--- a/python/src/main/python/bigquery-anomaly-detection/src/bqmonitor/metric.py
+++ b/python/src/main/python/bigquery-anomaly-detection/src/bqmonitor/metric.py
@@ -79,6 +79,7 @@ Example usage::
 """
 
 import dataclasses
+import logging
 import random
 from enum import Enum
 from typing import Any
@@ -86,11 +87,14 @@ from typing import Optional
 from typing import Tuple
 
 import apache_beam as beam
+from apache_beam.metrics import Metrics
 from apache_beam.transforms import combiners
 from apache_beam.transforms import window as beam_window
 
 from bqmonitor.safe_eval import Expr
 from apache_beam.ml.anomaly.specifiable import specifiable
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class WindowType(Enum):
@@ -546,8 +550,47 @@ class _DerivedFieldsFn:
     return row
 
 
+class _DropNullMeasures(beam.DoFn):
+  """Drops rows where any aggregated measure field is None (BigQuery NULL).
+
+  The combiners cannot fold None, ``None + 0`` / ``None < inf`` raise
+  TypeError, which in streaming Dataflow causes the bundle to be retried
+  indefinitely. Skipping NULLs also matches BigQuery aggregate-function
+  semantics (SUM/MIN/MAX/MEAN/COUNT(col) all ignore NULLs).
+
+  A row is dropped whole: when a spec mixes measures over different
+  fields, a NULL in any non-COUNT measure field removes the row from
+  every measure, including COUNTs. Dropped rows are counted in the
+  ``bqmonitor.metric/rows_dropped_null_measure`` counter.
+  """
+
+  _DROPPED_COUNTER = Metrics.counter(
+      'bqmonitor.metric', 'rows_dropped_null_measure')
+
+  def __init__(self, fields):
+    self._fields = fields
+
+  def process(self, row):
+    for field in self._fields:
+      if row.get(field) is None:
+        self._DROPPED_COUNTER.inc()
+        return
+    yield row
+
+
 class _ApplyMetricExpr(beam.DoFn):
-  """DoFn that evaluates a post-aggregation expression on combined results."""
+  """DoFn that evaluates a post-aggregation expression on combined results.
+
+  Arithmetic errors from the expression (e.g. ZeroDivisionError when a
+  ratio's denominator aggregates to zero) drop that window's metric with
+  a counter instead of crashing — a raising bundle would retry forever
+  in streaming and stall the pipeline. The detector simply sees no data
+  point for the affected window.
+  """
+
+  _EXPR_ERROR_COUNTER = Metrics.counter(
+      'bqmonitor.metric', 'metric_expr_errors')
+
   def __init__(self, measure_combiner, is_keyed):
     self._measure_combiner = measure_combiner
     self._is_keyed = is_keyed
@@ -559,7 +602,15 @@ class _ApplyMetricExpr(beam.DoFn):
       agg_dict = element
 
     if self._measure_combiner is not None:
-      value = float(self._measure_combiner(agg_dict))
+      try:
+        value = float(self._measure_combiner(agg_dict))
+      except (ArithmeticError, ValueError, TypeError) as e:
+        self._EXPR_ERROR_COUNTER.inc()
+        _LOGGER.warning(
+            "Metric expression '%s' failed for window [%s, %s): %s. "
+            "Dropping this window's metric.",
+            self._measure_combiner, window.start, window.end, e)
+        return
     else:
       value = float(next(iter(agg_dict.values())))
 
@@ -605,6 +656,15 @@ class ComputeMetric(beam.PTransform):
     if spec.derived_fields:
       pcoll = pcoll | 'DerivedFields' >> beam.Map(
           _DerivedFieldsFn(spec.derived_fields))
+
+    # Step 1b: Drop rows with NULL measure fields (after derived fields,
+    # so derived measure names are covered). COUNT measures don't read
+    # their field, so they impose no non-NULL requirement.
+    null_checked_fields = sorted(
+        {m.field for m in agg.measures if m.agg != AggOp.COUNT})
+    if null_checked_fields:
+      pcoll = pcoll | 'DropNullMeasures' >> beam.ParDo(
+          _DropNullMeasures(null_checked_fields))
 
     # Step 2: Apply windowing
     if agg.window.type == WindowType.FIXED:

--- a/python/src/main/python/bigquery-anomaly-detection/src/bqmonitor/pipeline.py
+++ b/python/src/main/python/bigquery-anomaly-detection/src/bqmonitor/pipeline.py
@@ -73,6 +73,8 @@ from apache_beam.ml.anomaly.detectors import zscore  # noqa: F401
 from apache_beam.ml.anomaly.detectors import iqr  # noqa: F401
 from apache_beam.ml.anomaly.detectors import robust_zscore  # noqa: F401
 
+from bqmonitor.cdc import _quote_identifier
+
 _LOGGER = logging.getLogger(__name__)
 
 _SUPPORTED_DETECTORS = ('ZScore', 'IQR', 'RobustZScore', 'RelativeChange')
@@ -1087,7 +1089,9 @@ def _check_bq_source_table(project, dataset, table_name, options,
 
   # Dry-run a CDC query selecting the metric's required columns.
   # This validates CDC function access and column existence in one step.
-  select_clause = ', '.join(required_columns) if required_columns else '1'
+  select_clause = (
+      ', '.join(_quote_identifier(c) for c in required_columns)
+      if required_columns else '1')
   try:
     sql = (
         f"SELECT {select_clause} FROM {options.change_function}"

--- a/python/src/main/python/bigquery-anomaly-detection/src/bqmonitor/pipeline.py
+++ b/python/src/main/python/bigquery-anomaly-detection/src/bqmonitor/pipeline.py
@@ -37,6 +37,8 @@ import time
 from dataclasses import dataclass
 from typing import Any
 from typing import Optional
+from typing import Tuple
+from typing import Union
 
 import google.auth
 from google.auth.transport.requests import AuthorizedSession
@@ -378,13 +380,27 @@ _SINK_SCHEMA = {
 }
 
 
-def _anomaly_id(value):
+def _anomaly_id(keyed_value):
   """Stable hashable identity per anomaly. Used as AsyncWrapper's id_fn
-  for dedup across runner replays — must survive a serialize/deserialize
-  round-trip, hence (window_micros, model_id) rather than object identity."""
+  for dedup across runner replays, must survive a serialize/deserialize
+  round-trip, hence (key, window_micros, model_id) rather than object
+  identity.
+
+  ``keyed_value`` is the ``(key, AnomalyResult)`` pair that
+  ``_nest_key_for_webhook_id`` copies into the element value. The key
+  MUST be part of the identity: AsyncWrapper tracks in-flight work in a
+  worker-global map indexed by this id alone (its id_fn never sees the
+  element's key), so without it two group-by keys anomalous in the same
+  window with the same detector alias each other,  one alert is silently
+  dropped and the other posted twice. Unkeyed pipelines carry the
+  ``_UNKEYED_SENTINEL`` key, where same-id elements really are replays
+  of the same anomaly.
+  """
+  key, value = keyed_value
   example = value.example
   prediction = value.predictions[0]
   return (
+      key,
       example.window_start.micros,
       example.window_end.micros,
       prediction.model_id or '',
@@ -400,6 +416,34 @@ def _key_anomaly_for_async(element):
     key, value = element
     return (str(key), value)
   return (_UNKEYED_SENTINEL, element)
+
+
+def _nest_key_for_webhook_id(
+    element: Tuple[str, AnomalyResult]
+) -> Tuple[str, Tuple[str, AnomalyResult]]:
+  """Copies the key into the value: ``(key, v)`` -> ``(key, (key, v))``.
+
+  AsyncWrapper computes its dedup id as ``id_fn(element[1])``, from the
+  value only, so the key must ride inside the value for ``_anomaly_id``
+  to include it. See ``_anomaly_id`` for why omitting the key drops or
+  double-posts same-window anomalies on keyed pipelines."""
+  key, value = element
+  return (key, (key, value))
+
+
+def _unnest_key_for_webhook_id(
+    element: Union[Tuple[str, Tuple[str, AnomalyResult]],
+                   Tuple[str, AnomalyResult],
+                   AnomalyResult]
+) -> Tuple[Optional[str], AnomalyResult]:
+  """Inverse of ``_nest_key_for_webhook_id``: returns ``(key, result)``
+  with sentinel keys mapped to None. Also accepts un-nested elements,
+  a bare ``AnomalyResult`` is a dataclass, never a 2-tuple, so the two
+  shapes are unambiguous."""
+  key, result = _unpack_result(element)
+  if _is_keyed_pair(result):
+    key, result = _unpack_result(result)
+  return key, result
 
 
 def _is_outlier(element):
@@ -492,7 +536,7 @@ class _PostAnomalyToWebhook(beam.DoFn):
     self._session = AuthorizedSession(creds)
 
   def process(self, element):
-    key, result = _unpack_result(element)
+    key, result = _unnest_key_for_webhook_id(element)
     fields = _build_anomaly_fields(key, result)
     anomaly_message = _compute_anomaly_message(
         fields, self._message_format, self._message_metadata)
@@ -1340,6 +1384,7 @@ def build_pipeline(pipeline, options, metric_spec, detector):
     )
     _ = (
         alert_anomalies
+        | 'NestKeyForWebhookId' >> beam.Map(_nest_key_for_webhook_id)
         | 'PostAnomaliesToWebhook' >> beam.ParDo(async_webhook_dofn))
 
   if options.sink_table:

--- a/python/src/main/python/bigquery-anomaly-detection/src/bqmonitor/timestamp_buffer.py
+++ b/python/src/main/python/bigquery-anomaly-detection/src/bqmonitor/timestamp_buffer.py
@@ -50,6 +50,7 @@ from typing import Optional
 
 import apache_beam as beam
 from apache_beam.coders import FastPrimitivesCoder
+from apache_beam.metrics import Metrics
 from apache_beam.transforms.timeutil import TimeDomain
 from apache_beam.transforms.userstate import BagStateSpec
 from apache_beam.transforms.userstate import OrderedListStateSpec
@@ -166,6 +167,9 @@ class TimestampBufferDoFn(beam.DoFn, abc.ABC):
 
   TB_STATE = ReadModifyWriteStateSpec('tb_state', FastPrimitivesCoder())
 
+  _LATE_DROPPED_COUNTER = Metrics.counter(
+      'bqmonitor.timestamp_buffer', 'late_elements_dropped')
+
   def __init__(self, context_size, batch_interval_sec=5):
     self._context_size = context_size
     self._batch_interval_sec = batch_interval_sec
@@ -210,21 +214,24 @@ class TimestampBufferDoFn(beam.DoFn, abc.ABC):
 
   def _do_process(self, element, buffer_state, tb_state_handle,
                   min_wm_timer, element_timestamp, **extra_state):
-    """Buffer element, track min/max, set MIN_WM if needed."""
-    _, value = self.extract_kv(element)
-    self._buffer_add(buffer_state, element_timestamp, value)
+    """Buffer element, track min/max, set MIN_WM if needed.
 
+    Late elements (timestamp <= safe_watermark) are rejected.
+    """
     state = tb_state_handle.read() or BufferState()
 
-    state.update_min_max(element_timestamp)
-
     if element_timestamp <= state.safe_watermark:
+      self._LATE_DROPPED_COUNTER.inc()
       _LOGGER.info(
           '[process] dropping late element at %s '
           '(safe_watermark=%s already advanced past it)',
           _fmt(element_timestamp), _fmt(state.safe_watermark))
-      tb_state_handle.write(state)
       return []
+
+    _, value = self.extract_kv(element)
+    self._buffer_add(buffer_state, element_timestamp, value)
+
+    state.update_min_max(element_timestamp)
 
     if state.min_event_time > state.safe_watermark:
       min_wm_timer.set(state.min_event_time)

--- a/python/src/test/java/com/google/cloud/teleport/templates/python/BigQueryAnomalyDetectionIT.java
+++ b/python/src/test/java/com/google/cloud/teleport/templates/python/BigQueryAnomalyDetectionIT.java
@@ -110,6 +110,11 @@ public final class BigQueryAnomalyDetectionIT extends TemplateTestBase {
   }
 
   @Test
+  public void testDetectsAnomalyWithNullMeasureValues() throws IOException, InterruptedException {
+    testNullMeasureValuesImpl();
+  }
+
+  @Test
   public void testGroupedRatioMetric() throws IOException, InterruptedException {
     testGroupedRatioMetricImpl("sharded");
   }
@@ -255,6 +260,161 @@ public final class BigQueryAnomalyDetectionIT extends TemplateTestBase {
 
     // --- Verify BQ sink table ---
     verifySinkTable(SINK_TABLE_NAME, WINDOW_SIZE_SEC, null /* no keys expected */);
+  }
+
+  /**
+   * Tests that NULL measure values are skipped instead of stalling the pipeline.
+   *
+   * <p>Every batch (baseline and anomaly) contains rows whose "amount" column is NULL. The
+   * combiners cannot fold None (regression: a single NULL raised TypeError inside the Combine and
+   * wedged the streaming bundle in a permanent retry loop, so no anomaly was ever published and
+   * this test would time out waiting on Pub/Sub). With NULL rows dropped before aggregation, the
+   * MEAN is computed over the non-NULL rows only and the anomaly spike is still detected.
+   */
+  private void testNullMeasureValuesImpl() throws IOException, InterruptedException {
+    // --- Arrange ---
+
+    String tableName = "null_measure_test";
+    String sinkTableName = "null_measure_results";
+
+    Schema schema =
+        Schema.of(
+            Field.of("id", StandardSQLTypeName.INT64),
+            Field.of("amount", StandardSQLTypeName.FLOAT64));
+    bigQueryResourceManager.createDataset(REGION);
+    bigQueryResourceManager.createTable(tableName, schema);
+
+    TopicName outputTopic = pubsubResourceManager.createTopic("null-anomaly-output");
+    SubscriptionName outputSubscription =
+        pubsubResourceManager.createSubscription(outputTopic, "null-anomaly-output-sub");
+
+    // 1-second fixed windows, MEAN of amount, RobustZScore detector — same
+    // shape as testSimpleSumMetric, so the only variable is the NULLs.
+    String metricSpec =
+        "{\"aggregation\":{\"window\":{\"type\":\"fixed\","
+            + "\"size_seconds\":"
+            + WINDOW_SIZE_SEC
+            + "},\"measures\":[{\"field\":\"amount\","
+            + "\"agg\":\"MEAN\",\"alias\":\"avg_amount\"}]}}";
+    String detectorSpec = "{\"type\":\"RobustZScore\"}";
+
+    String tableRef =
+        String.format(
+            "%s:%s.%s",
+            bigQueryResourceManager.getProjectId(),
+            bigQueryResourceManager.getDatasetId(),
+            tableName);
+
+    String sinkTableRef =
+        String.format(
+            "%s:%s.%s",
+            bigQueryResourceManager.getProjectId(),
+            bigQueryResourceManager.getDatasetId(),
+            sinkTableName);
+
+    // --- Act ---
+
+    LaunchConfig.Builder options =
+        LaunchConfig.builder(testName, specPath)
+            .addParameter("table", tableRef)
+            .addParameter("metric_spec", metricSpec)
+            .addParameter("detector_spec", detectorSpec)
+            .addParameter("topic", outputTopic.toString())
+            .addParameter("poll_interval_sec", "15")
+            .addParameter("start_offset_sec", "300")
+            .addParameter("duration_sec", "600")
+            .addParameter("log_all_results", "true")
+            .addParameter("sink_table", sinkTableRef);
+
+    LaunchInfo info = launchTemplate(options);
+    assertThatPipeline(info).isRunning();
+
+    // Baseline: 360 batches x 100 rows, one per second. Every 5th row has a
+    // NULL amount (the column is simply omitted from the insert), so every
+    // 1-second window the pipeline aggregates contains NULLs.
+    LOG.info(
+        "Inserting {} batches of {} rows every {}ms (amount={}, every 5th row NULL)",
+        BASELINE_BATCHES,
+        ROWS_PER_BATCH,
+        BATCH_INTERVAL_MS,
+        NORMAL_AMOUNT);
+    Random rng = new Random(42);
+    int rowId = 0;
+    for (int batch = 0; batch < BASELINE_BATCHES; batch++) {
+      List<RowToInsert> rows = new ArrayList<>();
+      for (int i = 0; i < ROWS_PER_BATCH; i++) {
+        if (i % 5 == 0) {
+          // NULL amount: omitting the nullable column inserts NULL.
+          rows.add(RowToInsert.of(ImmutableMap.of("id", ++rowId)));
+        } else {
+          // Tiny variance (stdev ~0.5) so MAD/stdev > 0 for the detector.
+          double amount = NORMAL_AMOUNT + rng.nextGaussian() * 0.5;
+          rows.add(RowToInsert.of(ImmutableMap.of("id", ++rowId, "amount", amount)));
+        }
+      }
+      bigQueryResourceManager.write(tableName, rows);
+      if (batch < BASELINE_BATCHES - 1) {
+        TimeUnit.MILLISECONDS.sleep(BATCH_INTERVAL_MS);
+      }
+      if ((batch + 1) % 60 == 0) {
+        LOG.info("Inserted batch {}/{} ({} rows so far)", batch + 1, BASELINE_BATCHES, rowId);
+      }
+    }
+    LOG.info("Inserted {} baseline rows total", rowId);
+
+    // Pause to ensure the anomaly lands in a clean window, not mixed with baseline.
+    TimeUnit.SECONDS.sleep(2);
+
+    // Anomalous spike, also containing NULLs: MEAN of the non-NULL rows ≈ 10000.
+    LOG.info(
+        "Inserting anomalous batch ({} rows, amount={}, every 5th row NULL)",
+        ROWS_PER_BATCH,
+        ANOMALY_AMOUNT);
+    List<RowToInsert> anomalyRows = new ArrayList<>();
+    for (int i = 0; i < ROWS_PER_BATCH; i++) {
+      if (i % 5 == 0) {
+        anomalyRows.add(RowToInsert.of(ImmutableMap.of("id", ++rowId)));
+      } else {
+        anomalyRows.add(RowToInsert.of(ImmutableMap.of("id", ++rowId, "amount", ANOMALY_AMOUNT)));
+      }
+    }
+    bigQueryResourceManager.write(tableName, anomalyRows);
+    LOG.info("Inserted {} anomalous rows", anomalyRows.size());
+
+    // --- Assert ---
+
+    // Without NULL handling the pipeline stalls on the first NULL row and this
+    // check times out: no anomaly message can ever be published.
+    PubsubMessagesCheck pubsubCheck =
+        PubsubMessagesCheck.builder(pubsubResourceManager, outputSubscription)
+            .setMinMessages(1)
+            .build();
+
+    Result result = pipelineOperator().waitForConditionAndCancel(createConfig(info), pubsubCheck);
+    assertThatResult(result).meetsConditions();
+
+    List<ReceivedMessage> messages = pubsubCheck.getReceivedMessageList();
+    assertThat(messages).isNotEmpty();
+
+    String messageData = messages.get(0).getMessage().getData().toStringUtf8();
+    LOG.info("Received anomaly message: {}", messageData);
+    JSONObject payload = new JSONObject(messageData);
+
+    assertThat(payload.getString("event_description")).contains("Anomaly detected");
+    assertThat(payload.getString("agent_id")).isEqualTo("RobustZScore");
+
+    // --- Verify BQ sink table ---
+    verifySinkTable(sinkTableName, WINDOW_SIZE_SEC, null /* no keys expected */);
+
+    // Every baseline window contained NULL rows, so a healthy number of scored
+    // (non-outlier) sink rows proves NULL-bearing windows were aggregated
+    // rather than crashing or being dropped wholesale.
+    TableResult tableResult = bigQueryResourceManager.readTable(sinkTableName);
+    List<Map<String, Object>> sinkRows = BigQueryAsserts.tableResultToRecords(tableResult);
+    long baselineWindows =
+        sinkRows.stream().filter(r -> ((Number) r.get("label")).intValue() != 1).count();
+    assertThat(baselineWindows).isGreaterThan(10);
+    LOG.info("NULL-handling verification passed: {} baseline windows scored", baselineWindows);
   }
 
   /**

--- a/python/src/test/python/bigquery-anomaly-detection/metric_test.py
+++ b/python/src/test/python/bigquery-anomaly-detection/metric_test.py
@@ -252,6 +252,158 @@ class MetricSpecToDictTest(unittest.TestCase):
     self.assertNotIn('name', d)
 
 
+class NullMeasureHandlingTest(unittest.TestCase):
+  """Rows with NULL (None) measure fields must be dropped, not crash.
+
+  BigQuery NULLs arrive as None in the row dicts. The combiners cannot
+  fold None (``None + 0`` raises TypeError), which in streaming wedges
+  the bundle in a permanent retry loop. ComputeMetric drops such rows
+  before aggregation, matching BigQuery aggregate-function semantics.
+  """
+
+  _STREAMING_OPTIONS = beam.options.pipeline_options.PipelineOptions(
+      ['--streaming'])
+
+  def _spec(self, agg, group_by=None, measures=None, combiner=None):
+    return MetricSpec(
+        aggregation=AggregationSpec(
+            window=WindowSpec(type=WindowType.FIXED, size_seconds=60),
+            group_by=group_by or [],
+            measures=measures or [
+                MeasureSpec(field='amount', agg=agg, alias='m')]),
+        measure_combiner=combiner)
+
+  def _run(self, spec, rows, expected, keyed=False,
+           fanout_strategy=FanoutStrategy.NONE):
+    with TestPipeline(options=self._STREAMING_OPTIONS) as p:
+      timestamped = (
+          p
+          | beam.Create(rows)
+          | beam.Map(lambda r: beam_window.TimestampedValue(r, 10)))
+      result = timestamped | ComputeMetric(
+          spec, fanout_strategy=fanout_strategy)
+      if keyed:
+        values = result | beam.MapTuple(lambda k, row: (k, row.value))
+      else:
+        values = result | beam.Map(lambda row: row.value)
+      assert_that(values, equal_to(expected))
+
+  def test_sum_drops_null_rows(self):
+    rows = [{'amount': 10.0}, {'amount': None}, {'amount': 30.0}]
+    self._run(self._spec(AggOp.SUM), rows, [40.0])
+
+  def test_min_drops_null_rows(self):
+    rows = [{'amount': None}, {'amount': 5.0}, {'amount': 7.0}]
+    self._run(self._spec(AggOp.MIN), rows, [5.0])
+
+  def test_mean_drops_null_rows(self):
+    rows = [{'amount': 10.0}, {'amount': None}, {'amount': 20.0}]
+    self._run(self._spec(AggOp.MEAN), rows, [15.0])
+
+  def test_missing_field_treated_as_null(self):
+    rows = [{'amount': 10.0}, {'other': 1.0}]
+    self._run(self._spec(AggOp.SUM), rows, [10.0])
+
+  def test_count_only_spec_keeps_null_rows(self):
+    """COUNT never reads its field, so NULL rows still count."""
+    rows = [{'amount': None}, {'amount': 1.0}, {'amount': None}]
+    self._run(self._spec(AggOp.COUNT), rows, [3.0])
+
+  def test_multi_measure_drops_row_from_all_measures(self):
+    """A NULL measure field drops the whole row, COUNT included, so
+    ratio combiners stay consistent (SUM and COUNT see the same rows)."""
+    spec = self._spec(
+        None,
+        measures=[
+            MeasureSpec(field='amount', agg=AggOp.SUM, alias='total'),
+            MeasureSpec(field='amount', agg=AggOp.COUNT, alias='cnt'),
+        ],
+        combiner=Expr('total / cnt'))
+    rows = [{'amount': 10.0}, {'amount': None}, {'amount': 30.0}]
+    self._run(spec, rows, [20.0])
+
+  def test_keyed_null_rows_dropped_per_row(self):
+    spec = self._spec(AggOp.SUM, group_by=['k'])
+    rows = [
+        {'k': 'a', 'amount': 1.0},
+        {'k': 'a', 'amount': None},
+        {'k': 'b', 'amount': 5.0},
+    ]
+    self._run(spec, rows, [(('a',), 1.0), (('b',), 5.0)], keyed=True)
+
+  def test_sharded_strategy_also_guarded(self):
+    rows = [{'amount': 10.0}, {'amount': None}]
+    self._run(self._spec(AggOp.SUM), rows, [10.0],
+              fanout_strategy=FanoutStrategy.SHARDED)
+
+  def test_null_derived_measure_dropped(self):
+    """Rows whose measure fields are NULL are dropped after the
+    DerivedFields step, so derived expressions still see every row."""
+    spec = MetricSpec(
+        aggregation=AggregationSpec(
+            window=WindowSpec(type=WindowType.FIXED, size_seconds=60),
+            measures=[
+                MeasureSpec(field='amount', agg=AggOp.SUM, alias='total')]),
+        derived_fields=[
+            DerivedField(name='ignored',
+                         expression=Expr("1 if status == 'ok' else 0"))])
+    rows = [
+        {'status': 'ok', 'amount': 2.0},
+        {'status': None, 'amount': None},
+    ]
+    self._run(spec, rows, [2.0])
+
+
+class MetricExprErrorHandlingTest(unittest.TestCase):
+  """Arithmetic errors in measure_combiner drop the window, not the job.
+
+  A ZeroDivisionError raised while evaluating the combiner (e.g. a
+  ratio whose SUM denominator is zero for a window) previously escaped
+  _ApplyMetricExpr; in streaming that wedges the bundle in a permanent
+  retry loop. The affected window is now dropped (with a counter) and
+  healthy windows keep flowing.
+  """
+
+  _STREAMING_OPTIONS = beam.options.pipeline_options.PipelineOptions(
+      ['--streaming'])
+
+  def _ratio_spec(self):
+    return MetricSpec(
+        aggregation=AggregationSpec(
+            window=WindowSpec(type=WindowType.FIXED, size_seconds=60),
+            measures=[
+                MeasureSpec(field='num', agg=AggOp.SUM, alias='n'),
+                MeasureSpec(field='den', agg=AggOp.SUM, alias='d'),
+            ]),
+        measure_combiner=Expr('n / d'))
+
+  def _run(self, rows, expected):
+    with TestPipeline(options=self._STREAMING_OPTIONS) as p:
+      result = (
+          p
+          | beam.Create(rows)
+          | ComputeMetric(
+              self._ratio_spec(), fanout_strategy=FanoutStrategy.NONE))
+      values = result | beam.Map(lambda row: row.value)
+      assert_that(values, equal_to(expected))
+
+  def test_zero_denominator_window_dropped_healthy_window_kept(self):
+    rows = [
+        # Window [0, 60): denominator sums to 0 -> window dropped.
+        beam_window.TimestampedValue({'num': 5.0, 'den': 0.0}, 10),
+        # Window [60, 120): healthy -> emitted.
+        beam_window.TimestampedValue({'num': 8.0, 'den': 2.0}, 70),
+    ]
+    self._run(rows, [4.0])
+
+  def test_all_windows_bad_yields_empty_output(self):
+    rows = [
+        beam_window.TimestampedValue({'num': 5.0, 'den': 0.0}, 10),
+        beam_window.TimestampedValue({'num': 3.0, 'den': 0.0}, 70),
+    ]
+    self._run(rows, [])
+
+
 class MapperSidePrecombineDoFnTest(unittest.TestCase):
   """Unit tests for _MapperSidePrecombine DoFn."""
 

--- a/python/src/test/python/bigquery-anomaly-detection/pipeline_test.py
+++ b/python/src/test/python/bigquery-anomaly-detection/pipeline_test.py
@@ -41,7 +41,9 @@ from bqmonitor.pipeline import _FormatAnomalyAsJson
 from bqmonitor.pipeline import _FormatResultForBQ
 from bqmonitor.pipeline import _is_outlier
 from bqmonitor.pipeline import _key_anomaly_for_async
+from bqmonitor.pipeline import _nest_key_for_webhook_id
 from bqmonitor.pipeline import _parse_detector_spec
+from bqmonitor.pipeline import _unnest_key_for_webhook_id
 from bqmonitor.pipeline import _parse_table_ref
 from bqmonitor.pipeline import _parse_webhook_spec
 from bqmonitor.pipeline import _PostAnomalyToWebhook
@@ -1059,6 +1061,34 @@ class PostAnomalyToWebhookTest(unittest.TestCase):
     self.assertEqual(
         dofn._session.calls[0]['json']['q'], 'k=campaign_search')
 
+  def test_nested_keyed_element_substitutes_key(self):
+    """Production shape: (key, (key, result)) from _nest_key_for_webhook_id
+    so AsyncWrapper's id_fn can include the key. The DoFn must unwrap the
+    inner pair and still substitute {key} correctly."""
+    dofn = self._make_dofn({'q': 'k={key}'})
+    result = self._make_result(label=1)
+    dofn.process(('campaign_search', ('campaign_search', result)))
+    self.assertEqual(
+        dofn._session.calls[0]['json']['q'], 'k=campaign_search')
+
+  def test_nested_unkeyed_sentinel_renders_empty_key(self):
+    """Unkeyed pipelines carry the sentinel key through the nesting; it
+    must still render {key} as empty, exactly like a bare element."""
+    dofn = self._make_dofn({'q': 'k=[{key}]'})
+    result = self._make_result(label=1)
+    dofn.process((_UNKEYED_SENTINEL, (_UNKEYED_SENTINEL, result)))
+    self.assertEqual(dofn._session.calls[0]['json']['q'], 'k=[]')
+
+  def test_nested_unkeyed_default_anomaly_message(self):
+    """The nested unkeyed shape must produce the same {anomaly_message}
+    as a bare element."""
+    dofn = self._make_dofn({'q': '{anomaly_message}'})
+    result = self._make_result(label=1, value=12.0)
+    dofn.process((_UNKEYED_SENTINEL, (_UNKEYED_SENTINEL, result)))
+    body_q = dofn._session.calls[0]['json']['q']
+    self.assertIn('Anomaly detected', body_q)
+    self.assertIn('value=12.0', body_q)
+
   def test_headers_substituted(self):
     dofn = self._make_dofn(
         {'q': 'x'},
@@ -1235,7 +1265,15 @@ class PostAnomalyToWebhookTest(unittest.TestCase):
 
 
 class AnomalyIdTest(unittest.TestCase):
-  """Tests for _anomaly_id used by AsyncWrapper for per-element dedup."""
+  """Tests for _anomaly_id used by AsyncWrapper for per-element dedup.
+
+  _anomaly_id receives the ``(key, AnomalyResult)`` pair that
+  ``_nest_key_for_webhook_id`` copies into the element value. The key
+  must participate in the identity: AsyncWrapper tracks in-flight work
+  in a worker-global map indexed by this id alone, so without the key
+  two group-by keys anomalous in the same window with the same detector
+  would collide — one alert silently dropped, the other posted twice.
+  """
 
   def _result(self, ws=1000, we=1001, model_id='ZScore', value=42.0):
     row = beam.Row(
@@ -1243,24 +1281,67 @@ class AnomalyIdTest(unittest.TestCase):
     pred = AnomalyPrediction(model_id=model_id, score=1.0, label=1)
     return AnomalyResult(example=row, predictions=[pred])
 
-  def test_stable_for_same_anomaly(self):
-    a = self._result()
-    b = self._result()
+  def test_keyed_stable_for_same_anomaly(self):
+    a = ("('search',)", self._result())
+    b = ("('search',)", self._result())
     self.assertEqual(_anomaly_id(a), _anomaly_id(b))
+
+  def test_unkeyed_stable_for_same_anomaly(self):
+    a = (_UNKEYED_SENTINEL, self._result())
+    b = (_UNKEYED_SENTINEL, self._result())
+    self.assertEqual(_anomaly_id(a), _anomaly_id(b))
+
+  def test_differs_by_key(self):
+    """Regression for the AsyncWrapper cross-key collision: two group-by
+    keys anomalous in the SAME window with the SAME detector must get
+    distinct ids, otherwise AsyncWrapper's worker-global in-flight map
+    aliases them (one webhook post dropped, the other duplicated)."""
+    self.assertNotEqual(
+        _anomaly_id(("('search',)", self._result())),
+        _anomaly_id(("('display',)", self._result())))
+
+  def test_keyed_differs_from_unkeyed(self):
+    self.assertNotEqual(
+        _anomaly_id(("('search',)", self._result())),
+        _anomaly_id((_UNKEYED_SENTINEL, self._result())))
 
   def test_differs_by_window(self):
     self.assertNotEqual(
-        _anomaly_id(self._result(ws=1000)),
-        _anomaly_id(self._result(ws=2000)))
+        _anomaly_id(('k1', self._result(ws=1000))),
+        _anomaly_id(('k1', self._result(ws=2000))))
 
   def test_differs_by_model_id(self):
     self.assertNotEqual(
-        _anomaly_id(self._result(model_id='ZScore')),
-        _anomaly_id(self._result(model_id='IQR')))
+        _anomaly_id(('k1', self._result(model_id='ZScore'))),
+        _anomaly_id(('k1', self._result(model_id='IQR'))))
 
   def test_hashable(self):
     # AsyncWrapper stores ids as dict keys, so they must be hashable.
-    hash(_anomaly_id(self._result()))
+    hash(_anomaly_id(("('search',)", self._result())))
+    hash(_anomaly_id((_UNKEYED_SENTINEL, self._result())))
+
+
+class NestKeyForWebhookIdTest(unittest.TestCase):
+  """Tests for _nest_key_for_webhook_id, which copies the element key
+  into the value so AsyncWrapper's id_fn (which only ever sees the
+  value) can include it in the dedup identity."""
+
+  def test_keyed(self):
+    out = _nest_key_for_webhook_id(("('search',)", 'val'))
+    self.assertEqual(out, ("('search',)", ("('search',)", 'val')))
+
+  def test_unkeyed_sentinel(self):
+    out = _nest_key_for_webhook_id((_UNKEYED_SENTINEL, 'val'))
+    self.assertEqual(out, (_UNKEYED_SENTINEL, (_UNKEYED_SENTINEL, 'val')))
+
+  def test_unnest_round_trips_keyed(self):
+    nested = _nest_key_for_webhook_id(("('search',)", 'val'))
+    self.assertEqual(
+        _unnest_key_for_webhook_id(nested), ("('search',)", 'val'))
+
+  def test_unnest_round_trips_unkeyed_to_none(self):
+    nested = _nest_key_for_webhook_id((_UNKEYED_SENTINEL, 'val'))
+    self.assertEqual(_unnest_key_for_webhook_id(nested), (None, 'val'))
 
 
 class KeyAnomalyForAsyncTest(unittest.TestCase):
@@ -1392,7 +1473,11 @@ class AsyncWebhookWiringTest(unittest.TestCase):
 
   def test_outlier_posts_via_async_wrapper(self):
     async_dofn, _, stub = self._build({'q': 'value={value}'})
-    msg = ('k1', self._make_result(label=1, value=99.0))
+    # Production shape: NestKeyForWebhookId copies the key into the value
+    # so _anomaly_id (AsyncWrapper's id_fn, which only sees the value)
+    # can include it.
+    result_obj = self._make_result(label=1, value=99.0)
+    msg = ('k1', ('k1', result_obj))
     state = _FakeBagState([])
     timer = _FakeTimer(0)
 

--- a/python/src/test/python/bigquery-anomaly-detection/pipeline_test.py
+++ b/python/src/test/python/bigquery-anomaly-detection/pipeline_test.py
@@ -1473,7 +1473,7 @@ class AsyncWebhookWiringTest(unittest.TestCase):
 
   def test_outlier_posts_via_async_wrapper(self):
     async_dofn, _, stub = self._build({'q': 'value={value}'})
-    # Production shape: NestKeyForWebhookId copies the key into the value
+    # NestKeyForWebhookId copies the key into the value
     # so _anomaly_id (AsyncWrapper's id_fn, which only sees the value)
     # can include it.
     result_obj = self._make_result(label=1, value=99.0)

--- a/python/src/test/python/bigquery-anomaly-detection/timestamp_buffer_test.py
+++ b/python/src/test/python/bigquery-anomaly-detection/timestamp_buffer_test.py
@@ -642,6 +642,45 @@ class TimestampBufferTest(unittest.TestCase):
               ("k", (5, 50)),
           ]))
 
+  def test_fresh_elements_after_late_element_still_processed(self):
+    """Regression: a late element must not wedge the key.
+
+    Previously _do_process buffered the late element and let it regress
+    min_event_time below safe_watermark BEFORE the late check ran. Every
+    subsequent fresh element then failed the
+    ``min_event_time > safe_watermark`` guard, so MIN_WM was never armed
+    again and the key stopped emitting forever. The fresh element at t=8
+    here never appeared in the output under the old code.
+    """
+    test_stream = (
+        TestStream()
+        # Cycle 1: t=1, t=2 processed normally (safe_watermark >= 2).
+        .add_elements([10], event_timestamp=1)
+        .add_elements([20], event_timestamp=2)
+        .advance_watermark_to(5)
+        .advance_processing_time(10)
+        # Late element behind safe_watermark: must be dropped WITHOUT
+        # poisoning min_event_time.
+        .add_elements([999], event_timestamp=1)
+        # Fresh element: must still start a new cycle and be emitted.
+        .add_elements([80], event_timestamp=8)
+        .advance_watermark_to(9)
+        .advance_processing_time(10))
+    _finalize_test_stream(test_stream)
+    with TestPipeline(options=self.options) as p:
+      result = (
+          p
+          | test_stream
+          | beam.WithKeys("k")
+          | beam.ParDo(self.collect_dofn()))
+      assert_that(
+          result,
+          equal_to([
+              ("k", (1, 10)),
+              ("k", (2, 20)),
+              ("k", (8, 80)),
+          ]))
+
 
 
   def test_elements_arrive_during_batch_wait(self):


### PR DESCRIPTION
- Drop rows with null measure values to avoid TypeErrors during aggregation
- Handle arithmetic errors during metric evaluation to prevent pipeline stalls
- Nest keys to prevent webhook ID collisions in AsyncWrapper, 
- Reject late elements early in TimestampBufferDoFn to prevent key wedging (this shouldnt technically be possible due to how event timestamp works for bq cdc source.