### PR TITLE
Update FirestoreToFirestore documentation to explicitly state Datastore API requirement

### DIFF
--- a/v2/firestore-to-firestore/README_Cloud_Firestore_to_Firestore.md
+++ b/v2/firestore-to-firestore/README_Cloud_Firestore_to_Firestore.md
@@ -7,6 +7,8 @@ writes them to another Firestore database.
 
 It does not support using an Enterprise edition database as the source.
 
+The datastore.googleapis.com API must be enabled to use this template.
+
 Data consistency is guaranteed only at the end of the pipeline when all data has
 been written to the destination database.
 

--- a/v2/firestore-to-firestore/README_Cloud_Firestore_to_Firestore.md
+++ b/v2/firestore-to-firestore/README_Cloud_Firestore_to_Firestore.md
@@ -7,8 +7,6 @@ writes them to another Firestore database.
 
 It does not support using an Enterprise edition database as the source.
 
-The datastore.googleapis.com API must be enabled to use this template.
-
 Data consistency is guaranteed only at the end of the pipeline when all data has
 been written to the destination database.
 

--- a/v2/firestore-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/FirestoreToFirestore.java
+++ b/v2/firestore-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/FirestoreToFirestore.java
@@ -58,6 +58,7 @@ import org.slf4j.LoggerFactory;
           + " <a href=\"https://cloud.google.com/firestore/docs\">Firestore</a> database and writes"
           + " them to another Firestore database. ",
       "It does not support using an Enterprise edition database as the source.",
+      "The datastore.googleapis.com API must be enabled to use this template.",
       "Data consistency is guaranteed only at the end of the pipeline when all data has been"
           + " written to the destination database.\n",
     },


### PR DESCRIPTION
The Datastore API is required to run the FirestoreToFirestore dataflow template because it queries for collection groups under the hood. Update the template's description block and the README file.

BUG=b/532687838