### PR TITLE
feat(sourcedb-to-spanner): Implement Neo4j batch data extraction pipeline. #4029

### DIFF
--- a/v2/sourcedb-to-spanner/pom.xml
+++ b/v2/sourcedb-to-spanner/pom.xml
@@ -95,6 +95,10 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.beam</groupId>
+            <artifactId>beam-sdks-java-io-neo4j</artifactId>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/SourceDbToSpannerOptions.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/SourceDbToSpannerOptions.java
@@ -25,6 +25,7 @@ public interface SourceDbToSpannerOptions extends CommonTemplateOptions {
   String ASTRA_DB_SOURCE_DIALECT = "ASTRA_DB";
   String MYSQL_SOURCE_DIALECT = "MYSQL";
   String PG_SOURCE_DIALECT = "POSTGRESQL";
+  String NEO4J_SOURCE_DIALECT = "NEO4J";
 
   @TemplateParameter.Enum(
       order = 1,
@@ -33,10 +34,11 @@ public interface SourceDbToSpannerOptions extends CommonTemplateOptions {
         @TemplateParameter.TemplateEnumOption(ASTRA_DB_SOURCE_DIALECT),
         @TemplateParameter.TemplateEnumOption(CASSANDRA_SOURCE_DIALECT),
         @TemplateParameter.TemplateEnumOption(MYSQL_SOURCE_DIALECT),
-        @TemplateParameter.TemplateEnumOption(PG_SOURCE_DIALECT)
+        @TemplateParameter.TemplateEnumOption(PG_SOURCE_DIALECT),
+        @TemplateParameter.TemplateEnumOption(NEO4J_SOURCE_DIALECT)
       },
       description = "Dialect of the source database",
-      helpText = "Possible values are `CASSANDRA`, `MYSQL` and `POSTGRESQL`.")
+      helpText = "Possible values are `CASSANDRA`, `MYSQL`, `POSTGRESQL` and `NEO4J`.")
   @Default.String("MYSQL")
   String getSourceDbDialect();
 
@@ -440,4 +442,41 @@ public interface SourceDbToSpannerOptions extends CommonTemplateOptions {
   String getGcsOutputDirectory();
 
   void setGcsOutputDirectory(String value);
+
+  @TemplateParameter.Text(
+      order = 35,
+      optional = true,
+      description = "Neo4j Bolt URI",
+      helpText = "Connection URI for the source Neo4j database (e.g. bolt://10.128.0.15:7687)")
+  String getNeo4jUri();
+
+  void setNeo4jUri(String value);
+
+  @TemplateParameter.Text(
+      order = 36,
+      optional = true,
+      description = "Neo4j User Name",
+      helpText = "Database user name to authenticate against Neo4j")
+  String getNeo4jUser();
+
+  void setNeo4jUser(String value);
+
+  @TemplateParameter.Password(
+      order = 37,
+      optional = true,
+      description = "Neo4j Password",
+      helpText = "Database password to authenticate against Neo4j")
+  String getNeo4jPassword();
+
+  void setNeo4jPassword(String value);
+
+  @TemplateParameter.Integer(
+      order = 38,
+      optional = true,
+      description = "Neo4j read partition chunk size",
+      helpText = "Size of ID ranges queried in parallel (default: 100000)")
+  @Default.Integer(100000)
+  Integer getNeo4jReadChunkSize();
+
+  void setNeo4jReadChunkSize(Integer value);
 }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/reader/io/schema/SourceSchemaReference.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/reader/io/schema/SourceSchemaReference.java
@@ -18,6 +18,7 @@ package com.google.cloud.teleport.v2.reader.io.schema;
 import com.google.auto.value.AutoOneOf;
 import com.google.cloud.teleport.v2.reader.io.jdbc.JdbcSchemaReference;
 import com.google.cloud.teleport.v2.source.cassandra.reader.io.cassandra.schema.CassandraSchemaReference;
+import com.google.cloud.teleport.v2.source.neo4j.schema.Neo4jSchemaReference;
 import java.io.Serializable;
 
 /**
@@ -38,7 +39,8 @@ public abstract class SourceSchemaReference implements Serializable {
 
   public enum Kind {
     JDBC,
-    CASSANDRA
+    CASSANDRA,
+    NEO4J
   };
 
   public abstract Kind getKind();
@@ -47,6 +49,8 @@ public abstract class SourceSchemaReference implements Serializable {
 
   public abstract CassandraSchemaReference cassandra();
 
+  public abstract Neo4jSchemaReference neo4j();
+
   public static SourceSchemaReference ofJdbc(JdbcSchemaReference jdbcSchemaReference) {
     return AutoOneOf_SourceSchemaReference.jdbc(jdbcSchemaReference);
   }
@@ -54,6 +58,10 @@ public abstract class SourceSchemaReference implements Serializable {
   public static SourceSchemaReference ofCassandra(
       CassandraSchemaReference cassandraSchemaReference) {
     return AutoOneOf_SourceSchemaReference.cassandra(cassandraSchemaReference);
+  }
+
+  public static SourceSchemaReference ofNeo4j(Neo4jSchemaReference neo4jSchemaReference) {
+    return AutoOneOf_SourceSchemaReference.neo4j(neo4jSchemaReference);
   }
 
   /**
@@ -67,6 +75,8 @@ public abstract class SourceSchemaReference implements Serializable {
         return this.jdbc().getName();
       case CASSANDRA:
         return this.cassandra().getName();
+      case NEO4J:
+        return this.neo4j().getName();
       default:
         throw new IllegalStateException("name not implemented for kind " + this.getKind());
     }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/SourceConnectorFactory.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/SourceConnectorFactory.java
@@ -20,6 +20,7 @@ import com.google.cloud.teleport.v2.reader.io.jdbc.iowrapper.config.SQLDialect;
 import com.google.cloud.teleport.v2.source.cassandra.CassandraSrcToSpSourceConnector;
 import com.google.cloud.teleport.v2.source.jdbc.AbstractJdbcSrcToSpSourceConnector;
 import com.google.cloud.teleport.v2.source.mysql.MySqlSrcToSpSourceConnector;
+import com.google.cloud.teleport.v2.source.neo4j.Neo4jSrcToSpSourceConnector;
 import com.google.cloud.teleport.v2.source.postgres.PostgresSrcToSpSourceConnector;
 import com.google.cloud.teleport.v2.spanner.migrations.constants.Constants;
 
@@ -43,6 +44,8 @@ public class SourceConnectorFactory {
       return new MySqlSrcToSpSourceConnector();
     } else if (SourceDbToSpannerOptions.PG_SOURCE_DIALECT.equals(dialect)) {
       return new PostgresSrcToSpSourceConnector();
+    } else if (SourceDbToSpannerOptions.NEO4J_SOURCE_DIALECT.equals(dialect)) {
+      return new Neo4jSrcToSpSourceConnector();
     }
     /* Implementation detail, not having a default leads to failure in compile time checks enforced here */
     throw new IllegalArgumentException("Unsupported source database dialect: " + dialect);
@@ -66,6 +69,8 @@ public class SourceConnectorFactory {
         return new PostgresSrcToSpSourceConnector();
       case Constants.CASSANDRA_SOURCE_TYPE:
         return new CassandraSrcToSpSourceConnector();
+      case Constants.NEO4J_SOURCE_TYPE:
+        return new Neo4jSrcToSpSourceConnector();
       default:
         throw new IllegalArgumentException("Unsupported source type: " + sourceType);
     }

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/Neo4jSrcToSpSourceConnector.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/Neo4jSrcToSpSourceConnector.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.neo4j;
+
+import com.google.cloud.teleport.v2.options.SourceDbToSpannerOptions;
+import com.google.cloud.teleport.v2.source.ISrcToSpSourceConnector;
+import com.google.cloud.teleport.v2.source.neo4j.iowrapper.Neo4jIoWrapperFactory;
+import com.google.cloud.teleport.v2.spanner.migrations.constants.Constants;
+import com.google.cloud.teleport.v2.templates.DbConfigContainerDefaultImpl;
+import com.google.cloud.teleport.v2.templates.PipelineController;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
+
+/** Neo4j implementation of {@link ISrcToSpSourceConnector}. */
+public class Neo4jSrcToSpSourceConnector implements ISrcToSpSourceConnector {
+
+  @Override
+  public String getSourceType() {
+    return Constants.NEO4J_SOURCE_TYPE;
+  }
+
+  @Override
+  public PipelineResult executeMigration(
+      SourceDbToSpannerOptions options, Pipeline pipeline, SpannerConfig spannerConfig) {
+    return PipelineController.executeMigrationForDbConfigContainer(
+        options,
+        pipeline,
+        spannerConfig,
+        new DbConfigContainerDefaultImpl(Neo4jIoWrapperFactory.fromPipelineOptions(options)));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jIoWrapper.java
@@ -51,8 +51,7 @@ public final class Neo4jIoWrapper implements IoWrapper, Serializable {
         SourceSchemaReference.ofNeo4j(
             Neo4jSchemaReference.builder().setDatabaseName("neo4j").build());
 
-    SourceSchema.Builder schemaBuilder =
-        SourceSchema.builder().setSchemaReference(schemaReference);
+    SourceSchema.Builder schemaBuilder = SourceSchema.builder().setSchemaReference(schemaReference);
 
     UnifiedTypeMapper typeMapper = new UnifiedTypeMapper(Neo4jMappingsProvider.getMapping());
 
@@ -61,9 +60,12 @@ public final class Neo4jIoWrapper implements IoWrapper, Serializable {
         SourceTableSchema.builder(typeMapper)
             .setTableName("GraphNode")
             .setPrimaryKeyColumns(ImmutableList.of("id"))
-            .addSourceColumnNameToSourceColumnType("id", new SourceColumnType("STRING", new Long[0], null))
-            .addSourceColumnNameToSourceColumnType("label", new SourceColumnType("STRING", new Long[0], null))
-            .addSourceColumnNameToSourceColumnType("properties", new SourceColumnType("JSON", new Long[0], null))
+            .addSourceColumnNameToSourceColumnType(
+                "id", new SourceColumnType("STRING", new Long[0], null))
+            .addSourceColumnNameToSourceColumnType(
+                "label", new SourceColumnType("STRING", new Long[0], null))
+            .addSourceColumnNameToSourceColumnType(
+                "properties", new SourceColumnType("JSON", new Long[0], null))
             .build();
     schemaBuilder.addTableSchema(nodeTableSchema);
 
@@ -72,11 +74,16 @@ public final class Neo4jIoWrapper implements IoWrapper, Serializable {
         SourceTableSchema.builder(typeMapper)
             .setTableName("GraphEdge")
             .setPrimaryKeyColumns(ImmutableList.of("id", "dest_id", "edge_id"))
-            .addSourceColumnNameToSourceColumnType("id", new SourceColumnType("STRING", new Long[0], null))
-            .addSourceColumnNameToSourceColumnType("dest_id", new SourceColumnType("STRING", new Long[0], null))
-            .addSourceColumnNameToSourceColumnType("edge_id", new SourceColumnType("STRING", new Long[0], null))
-            .addSourceColumnNameToSourceColumnType("label", new SourceColumnType("STRING", new Long[0], null))
-            .addSourceColumnNameToSourceColumnType("properties", new SourceColumnType("JSON", new Long[0], null))
+            .addSourceColumnNameToSourceColumnType(
+                "id", new SourceColumnType("STRING", new Long[0], null))
+            .addSourceColumnNameToSourceColumnType(
+                "dest_id", new SourceColumnType("STRING", new Long[0], null))
+            .addSourceColumnNameToSourceColumnType(
+                "edge_id", new SourceColumnType("STRING", new Long[0], null))
+            .addSourceColumnNameToSourceColumnType(
+                "label", new SourceColumnType("STRING", new Long[0], null))
+            .addSourceColumnNameToSourceColumnType(
+                "properties", new SourceColumnType("JSON", new Long[0], null))
             .build();
     schemaBuilder.addTableSchema(edgeTableSchema);
 

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jIoWrapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jIoWrapper.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.neo4j.iowrapper;
+
+import com.google.cloud.teleport.v2.reader.io.IoWrapper;
+import com.google.cloud.teleport.v2.reader.io.row.SourceRow;
+import com.google.cloud.teleport.v2.reader.io.schema.SourceSchema;
+import com.google.cloud.teleport.v2.reader.io.schema.SourceSchemaReference;
+import com.google.cloud.teleport.v2.reader.io.schema.SourceTableReference;
+import com.google.cloud.teleport.v2.reader.io.schema.SourceTableSchema;
+import com.google.cloud.teleport.v2.reader.io.schema.typemapping.UnifiedTypeMapper;
+import com.google.cloud.teleport.v2.source.neo4j.schema.Neo4jSchemaReference;
+import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.io.Serializable;
+import java.util.List;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+
+/** IO Wrapper for Neo4j source mapping database tables. */
+public final class Neo4jIoWrapper implements IoWrapper, Serializable {
+
+  private final SourceSchema sourceSchema;
+  private final ImmutableMap<
+          ImmutableList<SourceTableReference>, PTransform<PBegin, PCollection<SourceRow>>>
+      tableReaders;
+
+  public Neo4jIoWrapper(
+      String neo4jUri,
+      String neo4jUser,
+      String neo4jPassword,
+      int readChunkSize,
+      List<String> sourceTables) {
+
+    SourceSchemaReference schemaReference =
+        SourceSchemaReference.ofNeo4j(
+            Neo4jSchemaReference.builder().setDatabaseName("neo4j").build());
+
+    SourceSchema.Builder schemaBuilder =
+        SourceSchema.builder().setSchemaReference(schemaReference);
+
+    UnifiedTypeMapper typeMapper = new UnifiedTypeMapper(Neo4jMappingsProvider.getMapping());
+
+    // 1. Construct Virtual Node Table Schema
+    SourceTableSchema nodeTableSchema =
+        SourceTableSchema.builder(typeMapper)
+            .setTableName("GraphNode")
+            .setPrimaryKeyColumns(ImmutableList.of("id"))
+            .addSourceColumnNameToSourceColumnType("id", new SourceColumnType("STRING", new Long[0], null))
+            .addSourceColumnNameToSourceColumnType("label", new SourceColumnType("STRING", new Long[0], null))
+            .addSourceColumnNameToSourceColumnType("properties", new SourceColumnType("JSON", new Long[0], null))
+            .build();
+    schemaBuilder.addTableSchema(nodeTableSchema);
+
+    // 2. Construct Virtual Edge Table Schema
+    SourceTableSchema edgeTableSchema =
+        SourceTableSchema.builder(typeMapper)
+            .setTableName("GraphEdge")
+            .setPrimaryKeyColumns(ImmutableList.of("id", "dest_id", "edge_id"))
+            .addSourceColumnNameToSourceColumnType("id", new SourceColumnType("STRING", new Long[0], null))
+            .addSourceColumnNameToSourceColumnType("dest_id", new SourceColumnType("STRING", new Long[0], null))
+            .addSourceColumnNameToSourceColumnType("edge_id", new SourceColumnType("STRING", new Long[0], null))
+            .addSourceColumnNameToSourceColumnType("label", new SourceColumnType("STRING", new Long[0], null))
+            .addSourceColumnNameToSourceColumnType("properties", new SourceColumnType("JSON", new Long[0], null))
+            .build();
+    schemaBuilder.addTableSchema(edgeTableSchema);
+
+    this.sourceSchema = schemaBuilder.build();
+
+    // Construct table reader transforms
+    ImmutableMap.Builder<
+            ImmutableList<SourceTableReference>, PTransform<PBegin, PCollection<SourceRow>>>
+        readersBuilder = ImmutableMap.builder();
+
+    SourceTableReference nodeRef =
+        SourceTableReference.builder()
+            .setSourceSchemaReference(schemaReference)
+            .setSourceTableSchemaUUID(nodeTableSchema.tableSchemaUUID())
+            .setSourceTableName("GraphNode")
+            .build();
+    readersBuilder.put(
+        ImmutableList.of(nodeRef),
+        new Neo4jTableReader(neo4jUri, neo4jUser, neo4jPassword, readChunkSize, nodeTableSchema));
+
+    SourceTableReference edgeRef =
+        SourceTableReference.builder()
+            .setSourceSchemaReference(schemaReference)
+            .setSourceTableSchemaUUID(edgeTableSchema.tableSchemaUUID())
+            .setSourceTableName("GraphEdge")
+            .build();
+    readersBuilder.put(
+        ImmutableList.of(edgeRef),
+        new Neo4jTableReader(neo4jUri, neo4jUser, neo4jPassword, readChunkSize, edgeTableSchema));
+
+    this.tableReaders = readersBuilder.build();
+  }
+
+  @Override
+  public ImmutableMap<
+          ImmutableList<SourceTableReference>, PTransform<PBegin, PCollection<SourceRow>>>
+      getTableReaders() {
+    return this.tableReaders;
+  }
+
+  @Override
+  public ImmutableList<SourceSchema> discoverTableSchema() {
+    return ImmutableList.of(this.sourceSchema);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jIoWrapperFactory.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jIoWrapperFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.neo4j.iowrapper;
+
+import com.google.cloud.teleport.v2.options.SourceDbToSpannerOptions;
+import com.google.cloud.teleport.v2.reader.IoWrapperFactory;
+import com.google.cloud.teleport.v2.reader.io.IoWrapper;
+import com.google.common.base.Preconditions;
+import java.io.Serializable;
+import java.util.List;
+import org.apache.beam.sdk.transforms.Wait.OnSignal;
+
+/** Factory to construct {@link Neo4jIoWrapper}. */
+public class Neo4jIoWrapperFactory implements IoWrapperFactory, Serializable {
+
+  private final String neo4jUri;
+  private final String neo4jUser;
+  private final String neo4jPassword;
+  private final int readChunkSize;
+
+  public Neo4jIoWrapperFactory(
+      String neo4jUri, String neo4jUser, String neo4jPassword, int readChunkSize) {
+    this.neo4jUri = neo4jUri;
+    this.neo4jUser = neo4jUser;
+    this.neo4jPassword = neo4jPassword;
+    this.readChunkSize = readChunkSize;
+  }
+
+  public static Neo4jIoWrapperFactory fromPipelineOptions(SourceDbToSpannerOptions options) {
+    Preconditions.checkArgument(
+        options.getSourceDbDialect().equals(SourceDbToSpannerOptions.NEO4J_SOURCE_DIALECT),
+        "Unexpected Dialect " + options.getSourceDbDialect() + " for Neo4j Source");
+    Preconditions.checkNotNull(options.getNeo4jUri(), "Neo4j URI must be specified");
+    Preconditions.checkNotNull(options.getNeo4jUser(), "Neo4j Username must be specified");
+    Preconditions.checkNotNull(options.getNeo4jPassword(), "Neo4j Password must be specified");
+
+    return new Neo4jIoWrapperFactory(
+        options.getNeo4jUri(),
+        options.getNeo4jUser(),
+        options.getNeo4jPassword(),
+        options.getNeo4jReadChunkSize());
+  }
+
+  @Override
+  public IoWrapper getIOWrapper(List<String> sourceTables, OnSignal<?> waitOnSignal) {
+    return new Neo4jIoWrapper(neo4jUri, neo4jUser, neo4jPassword, readChunkSize, sourceTables);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jMappingsProvider.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jMappingsProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.neo4j.iowrapper;
+
+import com.google.cloud.teleport.v2.reader.io.schema.typemapping.UnifiedTypeMapping;
+import com.google.cloud.teleport.v2.reader.io.schema.typemapping.provider.unified.UnifiedMappingProvider;
+import com.google.common.collect.ImmutableMap;
+
+/** Mapping provider for Neo4j basic virtual types (STRING, JSON). */
+public class Neo4jMappingsProvider {
+
+  public static ImmutableMap<String, UnifiedTypeMapping> getMapping() {
+    return ImmutableMap.<String, UnifiedTypeMapping>builder()
+        .put("STRING", UnifiedMappingProvider.getMapping(UnifiedMappingProvider.Type.STRING))
+        .put("JSON", UnifiedMappingProvider.getMapping(UnifiedMappingProvider.Type.JSON))
+        .build();
+  }
+
+  private Neo4jMappingsProvider() {}
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jPartitionTask.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jPartitionTask.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.neo4j.iowrapper;
+
+import java.io.Serializable;
+
+/** Describes a bounded node/edge ID query partition task. */
+public class Neo4jPartitionTask implements Serializable {
+  private final String elementType; // "node" or "edge"
+  private final long startId;
+  private final long endId;
+
+  public Neo4jPartitionTask(String elementType, long startId, long endId) {
+    this.elementType = elementType;
+    this.startId = startId;
+    this.endId = endId;
+  }
+
+  public String getElementType() {
+    return elementType;
+  }
+
+  public long getStartId() {
+    return startId;
+  }
+
+  public long getEndId() {
+    return endId;
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jTableReader.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jTableReader.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.neo4j.iowrapper;
+
+import com.google.cloud.teleport.v2.reader.io.row.SourceRow;
+import com.google.cloud.teleport.v2.reader.io.schema.SourceSchemaReference;
+import com.google.cloud.teleport.v2.reader.io.schema.SourceTableSchema;
+import com.google.cloud.teleport.v2.source.neo4j.rowmapper.Neo4jRowMapper;
+import com.google.cloud.teleport.v2.source.neo4j.schema.Neo4jSchemaReference;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Custom Beam PTransform to partition and query Neo4j node/edge tables. */
+public class Neo4jTableReader extends PTransform<PBegin, PCollection<SourceRow>> {
+  private static final Logger LOG = LoggerFactory.getLogger(Neo4jTableReader.class);
+
+  private final String uri;
+  private final String user;
+  private final String password;
+  private final int chunkSize;
+  private final SourceTableSchema sourceTableSchema;
+
+  public Neo4jTableReader(
+      String uri,
+      String user,
+      String password,
+      int chunkSize,
+      SourceTableSchema sourceTableSchema) {
+    this.uri = uri;
+    this.user = user;
+    this.password = password;
+    this.chunkSize = chunkSize;
+    this.sourceTableSchema = sourceTableSchema;
+  }
+
+  private long fetchMaxId(String query) {
+    try (Driver driver = GraphDatabase.driver(uri, AuthTokens.basic(user, password));
+        Session session = driver.session()) {
+      Result result = session.run(query);
+      if (result.hasNext()) {
+        Record record = result.next();
+        Value val = record.get(0);
+        if (!val.isNull()) {
+          return val.asLong();
+        }
+      }
+    } catch (Exception e) {
+      LOG.warn("Error querying max ID from Neo4j (defaulting to 0):", e);
+    }
+    return 0L;
+  }
+
+  @Override
+  public PCollection<SourceRow> expand(PBegin input) {
+    String tableName = sourceTableSchema.tableName();
+    String elementType = "GraphNode".equals(tableName) ? "node" : "edge";
+    String maxQuery = "node".equals(elementType)
+        ? "MATCH (n) RETURN max(id(n))"
+        : "MATCH ()-[r]->() RETURN max(id(r))";
+
+    long maxId = fetchMaxId(maxQuery);
+    LOG.info("Neo4j database returned max {} ID: {}", elementType, maxId);
+
+    List<Neo4jPartitionTask> partitionTasks = new ArrayList<>();
+    for (long i = 0; i <= maxId; i += chunkSize) {
+      partitionTasks.add(new Neo4jPartitionTask(elementType, i, i + chunkSize));
+    }
+    if (partitionTasks.isEmpty()) {
+      partitionTasks.add(new Neo4jPartitionTask(elementType, 0, 0));
+    }
+
+    return input
+        .apply("CreatePartitions_" + tableName, Create.of(partitionTasks))
+        .apply(
+            "ReadFromNeo4j_" + tableName,
+            ParDo.of(new ReadFromNeo4jFn(uri, user, password, sourceTableSchema)));
+  }
+
+  /** DoFn that runs on workers to query ranges of Neo4j IDs. */
+  private static class ReadFromNeo4jFn extends DoFn<Neo4jPartitionTask, SourceRow> {
+    private final String uri;
+    private final String user;
+    private final String password;
+    private final SourceTableSchema sourceTableSchema;
+    private transient Driver driver;
+    private transient Neo4jRowMapper rowMapper;
+
+    public ReadFromNeo4jFn(
+        String uri, String user, String password, SourceTableSchema sourceTableSchema) {
+      this.uri = uri;
+      this.user = user;
+      this.password = password;
+      this.sourceTableSchema = sourceTableSchema;
+    }
+
+    @Setup
+    public void setup() {
+      this.driver = GraphDatabase.driver(uri, AuthTokens.basic(user, password));
+      // Construct schema reference referencing the virtual database
+      SourceSchemaReference schemaReference =
+          SourceSchemaReference.ofNeo4j(
+              Neo4jSchemaReference.builder().setDatabaseName("neo4j").build());
+      this.rowMapper = new Neo4jRowMapper(schemaReference, sourceTableSchema);
+    }
+
+    @Teardown
+    public void teardown() {
+      if (this.driver != null) {
+        this.driver.close();
+      }
+    }
+
+    @ProcessElement
+    public void processElement(@Element Neo4jPartitionTask task, OutputReceiver<SourceRow> out)
+        throws Exception {
+      try (Session session = driver.session()) {
+        if ("node".equals(task.getElementType())) {
+          extractNodes(session, task, out);
+        } else {
+          extractEdges(session, task, out);
+        }
+      }
+    }
+
+    private void extractNodes(
+        Session session, Neo4jPartitionTask task, OutputReceiver<SourceRow> out) throws Exception {
+      String cypher =
+          "MATCH (n) WHERE id(n) >= $startId AND id(n) < $endId "
+              + "RETURN id(n) AS id, labels(n) AS labels, properties(n) AS properties";
+
+      Map<String, Object> parameters = new HashMap<>();
+      parameters.put("startId", task.getStartId());
+      parameters.put("endId", task.getEndId());
+
+      Result result = session.run(cypher, parameters);
+      while (result.hasNext()) {
+        Record record = result.next();
+        out.output(rowMapper.map(record));
+      }
+    }
+
+    private void extractEdges(
+        Session session, Neo4jPartitionTask task, OutputReceiver<SourceRow> out) throws Exception {
+      String cypher =
+          "MATCH (src)-[r]->(dest) WHERE id(r) >= $startId AND id(r) < $endId "
+              + "RETURN id(src) AS src_id, id(dest) AS dest_id, id(r) AS edge_id, type(r) AS label, properties(r) AS properties";
+
+      Map<String, Object> parameters = new HashMap<>();
+      parameters.put("startId", task.getStartId());
+      parameters.put("endId", task.getEndId());
+
+      Result result = session.run(cypher, parameters);
+      while (result.hasNext()) {
+        Record record = result.next();
+        out.output(rowMapper.map(record));
+      }
+    }
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jTableReader.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jTableReader.java
@@ -84,9 +84,10 @@ public class Neo4jTableReader extends PTransform<PBegin, PCollection<SourceRow>>
   public PCollection<SourceRow> expand(PBegin input) {
     String tableName = sourceTableSchema.tableName();
     String elementType = "GraphNode".equals(tableName) ? "node" : "edge";
-    String maxQuery = "node".equals(elementType)
-        ? "MATCH (n) RETURN max(id(n))"
-        : "MATCH ()-[r]->() RETURN max(id(r))";
+    String maxQuery =
+        "node".equals(elementType)
+            ? "MATCH (n) RETURN max(id(n))"
+            : "MATCH ()-[r]->() RETURN max(id(r))";
 
     long maxId = fetchMaxId(maxQuery);
     LOG.info("Neo4j database returned max {} ID: {}", elementType, maxId);

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/** Neo4j IOWrapper classes for source database reader pipelines. */
+package com.google.cloud.teleport.v2.source.neo4j.iowrapper;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/** Neo4j source connector classes. */
+package com.google.cloud.teleport.v2.source.neo4j;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/rowmapper/Neo4jRowMapper.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/rowmapper/Neo4jRowMapper.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.neo4j.rowmapper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.cloud.teleport.v2.reader.io.row.SourceRow;
+import com.google.cloud.teleport.v2.reader.io.schema.SourceSchemaReference;
+import com.google.cloud.teleport.v2.reader.io.schema.SourceTableSchema;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Value;
+
+/** Custom row mapper to translate Neo4j Records into Avro-based SourceRows. */
+public class Neo4jRowMapper implements Serializable {
+
+  private final SourceSchemaReference sourceSchemaReference;
+  private final SourceTableSchema sourceTableSchema;
+  private final ObjectMapper objectMapper;
+
+  public Neo4jRowMapper(
+      SourceSchemaReference sourceSchemaReference, SourceTableSchema sourceTableSchema) {
+    this.sourceSchemaReference = sourceSchemaReference;
+    this.sourceTableSchema = sourceTableSchema;
+    this.objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+  }
+
+  private long getCurrentTimeMicros() {
+    Instant now = Instant.now();
+    return TimeUnit.NANOSECONDS.toMicros(
+        TimeUnit.SECONDS.toNanos(now.getEpochSecond()) + now.getNano());
+  }
+
+  public SourceRow map(Record record) throws Exception {
+    long time = getCurrentTimeMicros();
+    SourceRow.Builder sourceRowBuilder =
+        SourceRow.builder(sourceSchemaReference, sourceTableSchema, null, time);
+
+    String tableName = sourceTableSchema.tableName();
+    if ("GraphNode".equals(tableName)) {
+      sourceRowBuilder.setField("id", String.valueOf(record.get("id").asLong()));
+
+      List<String> labels = record.get("labels").asList(Value::asString);
+      String label = labels.isEmpty() ? "graphnode" : labels.get(0).toLowerCase();
+      sourceRowBuilder.setField("label", label);
+
+      Map<String, Object> props = record.get("properties").asMap();
+      sourceRowBuilder.setField("properties", toLowercaseJson(props));
+
+    } else if ("GraphEdge".equals(tableName)) {
+      sourceRowBuilder.setField("id", String.valueOf(record.get("src_id").asLong()));
+      sourceRowBuilder.setField("dest_id", String.valueOf(record.get("dest_id").asLong()));
+      sourceRowBuilder.setField("edge_id", String.valueOf(record.get("edge_id").asLong()));
+
+      String label = record.get("label").asString().toLowerCase();
+      sourceRowBuilder.setField("label", label);
+
+      Map<String, Object> props = record.get("properties").asMap();
+      sourceRowBuilder.setField("properties", toLowercaseJson(props));
+    } else {
+      throw new IllegalArgumentException("Unknown virtual Neo4j table: " + tableName);
+    }
+
+    return sourceRowBuilder.build();
+  }
+
+  private String toLowercaseJson(Map<String, Object> map) throws Exception {
+    Map<String, Object> lowercaseMap = new HashMap<>();
+    for (Map.Entry<String, Object> entry : map.entrySet()) {
+      lowercaseMap.put(entry.getKey().toLowerCase(), entry.getValue());
+    }
+    return objectMapper.writeValueAsString(lowercaseMap);
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/rowmapper/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/rowmapper/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/** Row mapping classes to translate Neo4j records into generic source rows. */
+package com.google.cloud.teleport.v2.source.neo4j.rowmapper;

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/schema/Neo4jSchemaReference.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/schema/Neo4jSchemaReference.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.neo4j.schema;
+
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+import javax.annotation.Nullable;
+
+/** Neo4j database schema reference descriptor. */
+@AutoValue
+public abstract class Neo4jSchemaReference implements Serializable {
+
+  public abstract @Nullable String databaseName();
+
+  public static Builder builder() {
+    return new AutoValue_Neo4jSchemaReference.Builder();
+  }
+
+  public String getName() {
+    return "Database." + databaseName();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setDatabaseName(@Nullable String value);
+
+    public abstract Neo4jSchemaReference build();
+  }
+}

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/schema/package-info.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/neo4j/schema/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/** Neo4j database schema reference metadata classes. */
+package com.google.cloud.teleport.v2.source.neo4j.schema;

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jIoWrapperFactoryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jIoWrapperFactoryTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.neo4j.iowrapper;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.teleport.v2.options.SourceDbToSpannerOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.junit.Test;
+
+/** Unit tests for {@link Neo4jIoWrapperFactory}. */
+public class Neo4jIoWrapperFactoryTest {
+
+  @Test
+  public void testFromPipelineOptions() {
+    SourceDbToSpannerOptions options = PipelineOptionsFactory.as(SourceDbToSpannerOptions.class);
+    options.setSourceDbDialect(SourceDbToSpannerOptions.NEO4J_SOURCE_DIALECT);
+    options.setNeo4jUri("bolt://localhost:7687");
+    options.setNeo4jUser("neo4j");
+    options.setNeo4jPassword("password");
+    options.setNeo4jReadChunkSize(100);
+
+    Neo4jIoWrapperFactory factory = Neo4jIoWrapperFactory.fromPipelineOptions(options);
+    assertNotNull(factory);
+  }
+
+  @Test
+  public void testFromPipelineOptions_invalidDialect() {
+    SourceDbToSpannerOptions options = PipelineOptionsFactory.as(SourceDbToSpannerOptions.class);
+    options.setSourceDbDialect(SourceDbToSpannerOptions.MYSQL_SOURCE_DIALECT);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> Neo4jIoWrapperFactory.fromPipelineOptions(options));
+  }
+
+  @Test
+  public void testFromPipelineOptions_missingUri() {
+    SourceDbToSpannerOptions options = PipelineOptionsFactory.as(SourceDbToSpannerOptions.class);
+    options.setSourceDbDialect(SourceDbToSpannerOptions.NEO4J_SOURCE_DIALECT);
+    options.setNeo4jUser("neo4j");
+    options.setNeo4jPassword("password");
+
+    assertThrows(
+        NullPointerException.class,
+        () -> Neo4jIoWrapperFactory.fromPipelineOptions(options));
+  }
+}

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jIoWrapperFactoryTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jIoWrapperFactoryTest.java
@@ -44,8 +44,7 @@ public class Neo4jIoWrapperFactoryTest {
     options.setSourceDbDialect(SourceDbToSpannerOptions.MYSQL_SOURCE_DIALECT);
 
     assertThrows(
-        IllegalArgumentException.class,
-        () -> Neo4jIoWrapperFactory.fromPipelineOptions(options));
+        IllegalArgumentException.class, () -> Neo4jIoWrapperFactory.fromPipelineOptions(options));
   }
 
   @Test
@@ -56,7 +55,6 @@ public class Neo4jIoWrapperFactoryTest {
     options.setNeo4jPassword("password");
 
     assertThrows(
-        NullPointerException.class,
-        () -> Neo4jIoWrapperFactory.fromPipelineOptions(options));
+        NullPointerException.class, () -> Neo4jIoWrapperFactory.fromPipelineOptions(options));
   }
 }

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jIoWrapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jIoWrapperTest.java
@@ -34,8 +34,7 @@ public class Neo4jIoWrapperTest {
   @Test
   public void testDiscoverTableSchema() {
     Neo4jIoWrapper ioWrapper =
-        new Neo4jIoWrapper(
-            "bolt://localhost:7687", "neo4j", "password", 1000, ImmutableList.of());
+        new Neo4jIoWrapper("bolt://localhost:7687", "neo4j", "password", 1000, ImmutableList.of());
 
     List<SourceSchema> schemas = ioWrapper.discoverTableSchema();
     assertEquals(1, schemas.size());
@@ -65,7 +64,8 @@ public class Neo4jIoWrapperTest {
     assertTrue(nodeSchema.sourceColumnNameToSourceColumnType().containsKey("properties"));
     assertEquals("STRING", nodeSchema.sourceColumnNameToSourceColumnType().get("id").getName());
     assertEquals("STRING", nodeSchema.sourceColumnNameToSourceColumnType().get("label").getName());
-    assertEquals("JSON", nodeSchema.sourceColumnNameToSourceColumnType().get("properties").getName());
+    assertEquals(
+        "JSON", nodeSchema.sourceColumnNameToSourceColumnType().get("properties").getName());
 
     // Verify GraphEdge columns
     SourceTableSchema edgeSchema =
@@ -81,17 +81,19 @@ public class Neo4jIoWrapperTest {
     assertTrue(edgeSchema.sourceColumnNameToSourceColumnType().containsKey("label"));
     assertTrue(edgeSchema.sourceColumnNameToSourceColumnType().containsKey("properties"));
     assertEquals("STRING", edgeSchema.sourceColumnNameToSourceColumnType().get("id").getName());
-    assertEquals("STRING", edgeSchema.sourceColumnNameToSourceColumnType().get("dest_id").getName());
-    assertEquals("STRING", edgeSchema.sourceColumnNameToSourceColumnType().get("edge_id").getName());
+    assertEquals(
+        "STRING", edgeSchema.sourceColumnNameToSourceColumnType().get("dest_id").getName());
+    assertEquals(
+        "STRING", edgeSchema.sourceColumnNameToSourceColumnType().get("edge_id").getName());
     assertEquals("STRING", edgeSchema.sourceColumnNameToSourceColumnType().get("label").getName());
-    assertEquals("JSON", edgeSchema.sourceColumnNameToSourceColumnType().get("properties").getName());
+    assertEquals(
+        "JSON", edgeSchema.sourceColumnNameToSourceColumnType().get("properties").getName());
   }
 
   @Test
   public void testGetTableReaders() {
     Neo4jIoWrapper ioWrapper =
-        new Neo4jIoWrapper(
-            "bolt://localhost:7687", "neo4j", "password", 1000, ImmutableList.of());
+        new Neo4jIoWrapper("bolt://localhost:7687", "neo4j", "password", 1000, ImmutableList.of());
 
     var readers = ioWrapper.getTableReaders();
     assertEquals(2, readers.size());

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jIoWrapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/neo4j/iowrapper/Neo4jIoWrapperTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.source.neo4j.iowrapper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.teleport.v2.reader.io.schema.SourceSchema;
+import com.google.cloud.teleport.v2.reader.io.schema.SourceTableReference;
+import com.google.cloud.teleport.v2.reader.io.schema.SourceTableSchema;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+/** Unit tests for {@link Neo4jIoWrapper}. */
+public class Neo4jIoWrapperTest {
+
+  @Test
+  public void testDiscoverTableSchema() {
+    Neo4jIoWrapper ioWrapper =
+        new Neo4jIoWrapper(
+            "bolt://localhost:7687", "neo4j", "password", 1000, ImmutableList.of());
+
+    List<SourceSchema> schemas = ioWrapper.discoverTableSchema();
+    assertEquals(1, schemas.size());
+
+    SourceSchema sourceSchema = schemas.get(0);
+    assertNotNull(sourceSchema);
+    assertEquals("Database.neo4j", sourceSchema.schemaReference().getName());
+
+    List<SourceTableSchema> tableSchemas = sourceSchema.tableSchemas();
+    assertEquals(2, tableSchemas.size());
+
+    Set<String> tableNames =
+        tableSchemas.stream().map(SourceTableSchema::tableName).collect(Collectors.toSet());
+    assertTrue(tableNames.contains("GraphNode"));
+    assertTrue(tableNames.contains("GraphEdge"));
+
+    // Verify GraphNode columns
+    SourceTableSchema nodeSchema =
+        tableSchemas.stream()
+            .filter(s -> "GraphNode".equals(s.tableName()))
+            .findFirst()
+            .orElse(null);
+    assertNotNull(nodeSchema);
+    assertEquals(ImmutableList.of("id"), nodeSchema.primaryKeyColumns());
+    assertTrue(nodeSchema.sourceColumnNameToSourceColumnType().containsKey("id"));
+    assertTrue(nodeSchema.sourceColumnNameToSourceColumnType().containsKey("label"));
+    assertTrue(nodeSchema.sourceColumnNameToSourceColumnType().containsKey("properties"));
+    assertEquals("STRING", nodeSchema.sourceColumnNameToSourceColumnType().get("id").getName());
+    assertEquals("STRING", nodeSchema.sourceColumnNameToSourceColumnType().get("label").getName());
+    assertEquals("JSON", nodeSchema.sourceColumnNameToSourceColumnType().get("properties").getName());
+
+    // Verify GraphEdge columns
+    SourceTableSchema edgeSchema =
+        tableSchemas.stream()
+            .filter(s -> "GraphEdge".equals(s.tableName()))
+            .findFirst()
+            .orElse(null);
+    assertNotNull(edgeSchema);
+    assertEquals(ImmutableList.of("id", "dest_id", "edge_id"), edgeSchema.primaryKeyColumns());
+    assertTrue(edgeSchema.sourceColumnNameToSourceColumnType().containsKey("id"));
+    assertTrue(edgeSchema.sourceColumnNameToSourceColumnType().containsKey("dest_id"));
+    assertTrue(edgeSchema.sourceColumnNameToSourceColumnType().containsKey("edge_id"));
+    assertTrue(edgeSchema.sourceColumnNameToSourceColumnType().containsKey("label"));
+    assertTrue(edgeSchema.sourceColumnNameToSourceColumnType().containsKey("properties"));
+    assertEquals("STRING", edgeSchema.sourceColumnNameToSourceColumnType().get("id").getName());
+    assertEquals("STRING", edgeSchema.sourceColumnNameToSourceColumnType().get("dest_id").getName());
+    assertEquals("STRING", edgeSchema.sourceColumnNameToSourceColumnType().get("edge_id").getName());
+    assertEquals("STRING", edgeSchema.sourceColumnNameToSourceColumnType().get("label").getName());
+    assertEquals("JSON", edgeSchema.sourceColumnNameToSourceColumnType().get("properties").getName());
+  }
+
+  @Test
+  public void testGetTableReaders() {
+    Neo4jIoWrapper ioWrapper =
+        new Neo4jIoWrapper(
+            "bolt://localhost:7687", "neo4j", "password", 1000, ImmutableList.of());
+
+    var readers = ioWrapper.getTableReaders();
+    assertEquals(2, readers.size());
+
+    Set<String> readerTables =
+        readers.keySet().stream()
+            .flatMap(List::stream)
+            .map(SourceTableReference::sourceTableName)
+            .collect(Collectors.toSet());
+    assertTrue(readerTables.contains("GraphNode"));
+    assertTrue(readerTables.contains("GraphEdge"));
+  }
+}

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/constants/Constants.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/constants/Constants.java
@@ -30,6 +30,9 @@ public class Constants {
   /* The value for Postgres databases in the source type key */
   public static final String POSTGRES_SOURCE_TYPE = "postgresql";
 
+  /* The value for Neo4j databases in the source type key */
+  public static final String NEO4J_SOURCE_TYPE = "neo4j";
+
   /* The value for Spanner databases in the source type key */
   public static final String SPANNER_SOURCE_TYPE = "spanner";
 


### PR DESCRIPTION
Closes #4029

- Register NEO4J as a supported source database dialect.
- Add pipeline options for --neo4jUri, --neo4jUser, --neo4jPassword, and --neo4jReadChunkSize.
- Add beam-sdks-java-io-neo4j dependency to sourcedb-to-spanner pom.xml.
- Implement Neo4jSrcToSpSourceConnector and route dialect options to Neo4j.
- Implement virtual schema discovery (Neo4jIoWrapper) mapping elements into GraphNode and GraphEdge virtual tables.
- Implement Neo4jTableReader to partition ID ranges and run parallel Cypher query extractions on worker pools.
- Implement Neo4jRowMapper, registering Jackson JavaTimeModule to support serializing date/time attributes.
- Create unit tests for Neo4jIoWrapper and Neo4jIoWrapperFactory.