### PR TITLE
[Data Validation] Add GCSSpannerDvRenamedColumnsIT and GCSSpannerDvRenamedTableIT

### DIFF
--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedColumnsIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedColumnsIT.java
@@ -39,9 +39,8 @@ import org.slf4j.LoggerFactory;
  * Integration test for GCSSpannerDV pipeline covering column renaming scenarios.
  *
  * <p>This test validates that the pipeline correctly maps source columns to Spanner columns when
- * they have been renamed during the migration, given the proper configuration files (Overrides or
- * Session files). It also validates that mismatches are correctly identified if the configuration
- * file is omitted.
+ * they have been renamed during the migration, for both: overrides file and session file flow. It
+ * also validates that mismatches are correctly identified if the configuration file is omitted.
  */
 @Category(TemplateIntegrationTest.class)
 @RunWith(JUnit4.class)
@@ -53,8 +52,7 @@ public class GCSSpannerDVRenamedColumnsIT extends GCSSpannerDVITBase {
       "GCSSpannerDVRenamedColumnsIT/spanner-schema.sql";
   private static final String OVERRIDES_FILE_RESOURCE =
       "GCSSpannerDVRenamedColumnsIT/schema_overrides.json";
-  private static final String SESSION_FILE_RESOURCE =
-      "GCSSpannerDVRenamedColumnsIT/session.json";
+  private static final String SESSION_FILE_RESOURCE = "GCSSpannerDVRenamedColumnsIT/session.json";
 
   @Before
   public void setUp() throws IOException {
@@ -236,7 +234,7 @@ public class GCSSpannerDVRenamedColumnsIT extends GCSSpannerDVITBase {
                 /* status= */ "MISMATCH",
                 /* totalTablesValidated= */ 1L,
                 /* totalRowsMatched= */ 0L,
-                /* totalRowsMismatched= */ 2L, 
+                /* totalRowsMismatched= */ 2L,
                 /* tablesWithMismatches= */ "Users")));
 
     GCSSpannerDVTestAsserts.assertTableValidationStats(

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedColumnsIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedColumnsIT.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates;
+
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.MismatchedRecordDto;
+import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.TableValidationStatsDto;
+import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.ValidationSummaryDto;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
+import org.apache.beam.it.common.PipelineLauncher.LaunchInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration test for GCSSpannerDV pipeline covering column renaming scenarios.
+ *
+ * <p>This test validates that the pipeline correctly maps source columns to Spanner columns when
+ * they have been renamed during the migration, given the proper configuration files (Overrides or
+ * Session files). It also validates that mismatches are correctly identified if the configuration
+ * file is omitted.
+ */
+@Category(TemplateIntegrationTest.class)
+@RunWith(JUnit4.class)
+@TemplateIntegrationTest(GCSSpannerDV.class)
+public class GCSSpannerDVRenamedColumnsIT extends GCSSpannerDVITBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GCSSpannerDVRenamedColumnsIT.class);
+  private static final String SPANNER_DDL_RESOURCE =
+      "GCSSpannerDVRenamedColumnsIT/spanner-schema.sql";
+  private static final String OVERRIDES_FILE_RESOURCE =
+      "GCSSpannerDVRenamedColumnsIT/schema_overrides.json";
+  private static final String SESSION_FILE_RESOURCE =
+      "GCSSpannerDVRenamedColumnsIT/session.json";
+
+  @Before
+  public void setUp() throws IOException {
+    LOG.info("Setting up Spanner and BigQuery resources");
+    spannerResourceManager = setUpSpannerResourceManager();
+    bigQueryResourceManager = setUpBigQueryResourceManager();
+    bigQueryResourceManager.createDataset(REGION);
+    LOG.info("BigQuery dataset created");
+    createSpannerDDL(spannerResourceManager, SPANNER_DDL_RESOURCE);
+    LOG.info("Spanner instance created");
+  }
+
+  private void generateAndUploadData(String gcsSubDir) throws IOException {
+    LOG.info("Generating and Uploading Avro Records to GCS under {}", gcsSubDir);
+    Instant t1 = Instant.parse("2024-01-01T10:00:00Z");
+
+    List<GenericRecord> usersRecords =
+        Arrays.asList(
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(
+                    GCSSpannerDVAvroSetupHelper.TableDef.USERS, null)
+                .set("user_id", 1L)
+                .set("event_id", "E1")
+                .set("full_name", "Alice")
+                .set("age", 30)
+                .set("created_at", t1)
+                .build());
+
+    uploadAvroFileToGcs(
+        gcsSubDir + "/users.avro", GCSSpannerDVAvroSetupHelper.TableDef.USERS.schema, usersRecords);
+
+    LOG.info("Injecting Spanner records with renamed column 'name'");
+    spannerResourceManager.write(
+        Arrays.asList(
+            Mutation.newInsertOrUpdateBuilder("Users")
+                .set("user_id")
+                .to(1L)
+                .set("event_id")
+                .to("E1")
+                .set("name") // Renamed column
+                .to("Alice")
+                .set("age")
+                .to(30L)
+                .set("created_at")
+                .to(com.google.cloud.Timestamp.parseTimestamp(t1.toString()))
+                .build()));
+  }
+
+  @Test
+  public void testWithSchemaOverridesFile() throws Exception {
+    String gcsInputDirectory = getGcsPath("input_overrides");
+    generateAndUploadData("input_overrides");
+
+    // Wait for Spanner's exact staleness read bound in SpannerReaderTransform
+    Thread.sleep(20000);
+
+    LOG.info("Launching Dataflow validation job with Schema Overrides");
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
+    LaunchInfo jobInfo =
+        launchDataflowJob(
+            options,
+            testName,
+            PROJECT,
+            spannerResourceManager,
+            bigQueryResourceManager.getDatasetId(),
+            gcsInputDirectory,
+            null, // sessionFilePath
+            OVERRIDES_FILE_RESOURCE,
+            null,
+            null,
+            null,
+            null);
+
+    pipelineOperator().waitUntilDone(createConfig(jobInfo));
+
+    GCSSpannerDVTestAsserts.assertValidationSummary(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new ValidationSummaryDto(
+                /* status= */ "MATCH",
+                /* totalTablesValidated= */ 1L,
+                /* totalRowsMatched= */ 1L,
+                /* totalRowsMismatched= */ 0L,
+                /* tablesWithMismatches= */ "")));
+
+    GCSSpannerDVTestAsserts.assertTableValidationStats(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "Users",
+                /* status= */ "MATCH",
+                /* sourceRowCount= */ 1L,
+                /* destinationRowCount= */ 1L,
+                /* matchedRowCount= */ 1L,
+                /* mismatchRowCount= */ 0L)));
+  }
+
+  @Test
+  public void testWithSessionFile() throws Exception {
+    String gcsInputDirectory = getGcsPath("input_session");
+    generateAndUploadData("input_session");
+
+    // Wait for Spanner's exact staleness read bound in SpannerReaderTransform
+    Thread.sleep(20000);
+
+    LOG.info("Launching Dataflow validation job with Session File");
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
+    LaunchInfo jobInfo =
+        launchDataflowJob(
+            options,
+            testName,
+            PROJECT,
+            spannerResourceManager,
+            bigQueryResourceManager.getDatasetId(),
+            gcsInputDirectory,
+            SESSION_FILE_RESOURCE,
+            null, // schemaOverridesFilePath
+            null,
+            null,
+            null,
+            null);
+
+    pipelineOperator().waitUntilDone(createConfig(jobInfo));
+
+    GCSSpannerDVTestAsserts.assertValidationSummary(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new ValidationSummaryDto(
+                /* status= */ "MATCH",
+                /* totalTablesValidated= */ 1L,
+                /* totalRowsMatched= */ 1L,
+                /* totalRowsMismatched= */ 0L,
+                /* tablesWithMismatches= */ "")));
+
+    GCSSpannerDVTestAsserts.assertTableValidationStats(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "Users",
+                /* status= */ "MATCH",
+                /* sourceRowCount= */ 1L,
+                /* destinationRowCount= */ 1L,
+                /* matchedRowCount= */ 1L,
+                /* mismatchRowCount= */ 0L)));
+  }
+
+  @Test
+  public void testWithoutSchemaMappingFile() throws Exception {
+    String gcsInputDirectory = getGcsPath("input_nomapping");
+    generateAndUploadData("input_nomapping");
+
+    // Wait for Spanner's exact staleness read bound in SpannerReaderTransform
+    Thread.sleep(20000);
+
+    LOG.info("Launching Dataflow validation job with No Mapping");
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
+    LaunchInfo jobInfo =
+        launchDataflowJob(
+            options,
+            testName,
+            PROJECT,
+            spannerResourceManager,
+            bigQueryResourceManager.getDatasetId(),
+            gcsInputDirectory,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    pipelineOperator().waitUntilDone(createConfig(jobInfo));
+
+    GCSSpannerDVTestAsserts.assertValidationSummary(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new ValidationSummaryDto(
+                /* status= */ "MISMATCH",
+                /* totalTablesValidated= */ 1L,
+                /* totalRowsMatched= */ 0L,
+                /* totalRowsMismatched= */ 2L, 
+                /* tablesWithMismatches= */ "Users")));
+
+    GCSSpannerDVTestAsserts.assertTableValidationStats(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "Users",
+                /* status= */ "MISMATCH",
+                /* sourceRowCount= */ 1L,
+                /* destinationRowCount= */ 1L,
+                /* matchedRowCount= */ 0L,
+                /* mismatchRowCount= */ 2L)));
+
+    GCSSpannerDVTestAsserts.assertMismatchedRecords(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new MismatchedRecordDto(
+                null, null, "Users", "[user_id:1, event_id:E1]", "MISSING_IN_DESTINATION"),
+            new MismatchedRecordDto(
+                null, null, "Users", "[user_id:1, event_id:E1]", "MISSING_IN_SOURCE")));
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedColumnsIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedColumnsIT.java
@@ -32,8 +32,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Integration test for GCSSpannerDV pipeline covering column renaming scenarios.
@@ -47,7 +45,6 @@ import org.slf4j.LoggerFactory;
 @TemplateIntegrationTest(GCSSpannerDV.class)
 public class GCSSpannerDVRenamedColumnsIT extends GCSSpannerDVITBase {
 
-  private static final Logger LOG = LoggerFactory.getLogger(GCSSpannerDVRenamedColumnsIT.class);
   private static final String SPANNER_DDL_RESOURCE =
       "GCSSpannerDVRenamedColumnsIT/spanner-schema.sql";
   private static final String OVERRIDES_FILE_RESOURCE =
@@ -56,17 +53,13 @@ public class GCSSpannerDVRenamedColumnsIT extends GCSSpannerDVITBase {
 
   @Before
   public void setUp() throws IOException {
-    LOG.info("Setting up Spanner and BigQuery resources");
     spannerResourceManager = setUpSpannerResourceManager();
     bigQueryResourceManager = setUpBigQueryResourceManager();
     bigQueryResourceManager.createDataset(REGION);
-    LOG.info("BigQuery dataset created");
     createSpannerDDL(spannerResourceManager, SPANNER_DDL_RESOURCE);
-    LOG.info("Spanner instance created");
   }
 
   private void generateAndUploadData(String gcsSubDir) throws IOException {
-    LOG.info("Generating and Uploading Avro Records to GCS under {}", gcsSubDir);
     Instant t1 = Instant.parse("2024-01-01T10:00:00Z");
 
     List<GenericRecord> usersRecords =
@@ -83,7 +76,6 @@ public class GCSSpannerDVRenamedColumnsIT extends GCSSpannerDVITBase {
     uploadAvroFileToGcs(
         gcsSubDir + "/users.avro", GCSSpannerDVAvroSetupHelper.TableDef.USERS.schema, usersRecords);
 
-    LOG.info("Injecting Spanner records with renamed column 'name'");
     spannerResourceManager.write(
         Arrays.asList(
             Mutation.newInsertOrUpdateBuilder("Users")
@@ -108,7 +100,6 @@ public class GCSSpannerDVRenamedColumnsIT extends GCSSpannerDVITBase {
     // Wait for Spanner's exact staleness read bound in SpannerReaderTransform
     Thread.sleep(20000);
 
-    LOG.info("Launching Dataflow validation job with Schema Overrides");
     LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
     LaunchInfo jobInfo =
         launchDataflowJob(
@@ -158,7 +149,6 @@ public class GCSSpannerDVRenamedColumnsIT extends GCSSpannerDVITBase {
     // Wait for Spanner's exact staleness read bound in SpannerReaderTransform
     Thread.sleep(20000);
 
-    LOG.info("Launching Dataflow validation job with Session File");
     LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
     LaunchInfo jobInfo =
         launchDataflowJob(
@@ -208,7 +198,6 @@ public class GCSSpannerDVRenamedColumnsIT extends GCSSpannerDVITBase {
     // Wait for Spanner's exact staleness read bound in SpannerReaderTransform
     Thread.sleep(20000);
 
-    LOG.info("Launching Dataflow validation job with No Mapping");
     LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
     LaunchInfo jobInfo =
         launchDataflowJob(

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedTableIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedTableIT.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates;
+
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.MismatchedRecordDto;
+import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.TableValidationStatsDto;
+import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.ValidationSummaryDto;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
+import org.apache.beam.it.common.PipelineLauncher.LaunchInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration test for GCSSpannerDV pipeline covering table renaming scenarios.
+ *
+ * <p>This test validates that the pipeline correctly maps source tables to Spanner tables when
+ * they have been renamed during the migration, given the proper configuration files (Overrides or
+ * Session files). It also validates that mismatches are correctly identified if the configuration
+ * file is omitted.
+ */
+@Category(TemplateIntegrationTest.class)
+@RunWith(JUnit4.class)
+@TemplateIntegrationTest(GCSSpannerDV.class)
+public class GCSSpannerDVRenamedTableIT extends GCSSpannerDVITBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GCSSpannerDVRenamedTableIT.class);
+  private static final String SPANNER_DDL_RESOURCE =
+      "GCSSpannerDVRenamedTableIT/spanner-schema.sql";
+  private static final String OVERRIDES_FILE_RESOURCE =
+      "GCSSpannerDVRenamedTableIT/schema_overrides.json";
+  private static final String SESSION_FILE_RESOURCE =
+      "GCSSpannerDVRenamedTableIT/session.json";
+
+  @Before
+  public void setUp() throws IOException {
+    LOG.info("Setting up Spanner and BigQuery resources");
+    spannerResourceManager = setUpSpannerResourceManager();
+    bigQueryResourceManager = setUpBigQueryResourceManager();
+    bigQueryResourceManager.createDataset(REGION);
+    LOG.info("BigQuery dataset created");
+    createSpannerDDL(spannerResourceManager, SPANNER_DDL_RESOURCE);
+    LOG.info("Spanner instance created");
+  }
+
+  private void generateAndUploadData(String gcsSubDir) throws IOException {
+    LOG.info("Generating and Uploading Avro Records to GCS under {}", gcsSubDir);
+    Instant t1 = Instant.parse("2024-01-01T10:00:00Z");
+
+    List<GenericRecord> usersRecords =
+        Arrays.asList(
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(
+                    GCSSpannerDVAvroSetupHelper.TableDef.USERS, null)
+                .set("user_id", 1L)
+                .set("event_id", "E1")
+                .set("full_name", "Alice")
+                .set("age", 30)
+                .set("created_at", t1)
+                .build());
+
+    uploadAvroFileToGcs(
+        gcsSubDir + "/users.avro", GCSSpannerDVAvroSetupHelper.TableDef.USERS.schema, usersRecords);
+
+    LOG.info("Injecting Spanner records into renamed table 'Members'");
+    spannerResourceManager.write(
+        Arrays.asList(
+            Mutation.newInsertOrUpdateBuilder("Members")
+                .set("user_id")
+                .to(1L)
+                .set("event_id")
+                .to("E1")
+                .set("full_name")
+                .to("Alice")
+                .set("age")
+                .to(30L)
+                .set("created_at")
+                .to(com.google.cloud.Timestamp.parseTimestamp(t1.toString()))
+                .build()));
+  }
+
+  @Test
+  public void testWithSchemaOverridesFile() throws Exception {
+    String gcsInputDirectory = getGcsPath("input_overrides");
+    generateAndUploadData("input_overrides");
+
+    // Wait for Spanner's exact staleness read bound in SpannerReaderTransform
+    Thread.sleep(20000);
+
+    LOG.info("Launching Dataflow validation job with Schema Overrides");
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
+    LaunchInfo jobInfo =
+        launchDataflowJob(
+            options,
+            testName,
+            PROJECT,
+            spannerResourceManager,
+            bigQueryResourceManager.getDatasetId(),
+            gcsInputDirectory,
+            null, // sessionFilePath
+            OVERRIDES_FILE_RESOURCE,
+            null,
+            null,
+            null,
+            null);
+
+    pipelineOperator().waitUntilDone(createConfig(jobInfo));
+
+    GCSSpannerDVTestAsserts.assertValidationSummary(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new ValidationSummaryDto(
+                /* status= */ "MATCH",
+                /* totalTablesValidated= */ 1L,
+                /* totalRowsMatched= */ 1L,
+                /* totalRowsMismatched= */ 0L,
+                /* tablesWithMismatches= */ "")));
+
+    GCSSpannerDVTestAsserts.assertTableValidationStats(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "Members",
+                /* status= */ "MATCH",
+                /* sourceRowCount= */ 1L,
+                /* destinationRowCount= */ 1L,
+                /* matchedRowCount= */ 1L,
+                /* mismatchRowCount= */ 0L)));
+  }
+
+  @Test
+  public void testWithSessionFile() throws Exception {
+    String gcsInputDirectory = getGcsPath("input_session");
+    generateAndUploadData("input_session");
+
+    // Wait for Spanner's exact staleness read bound in SpannerReaderTransform
+    Thread.sleep(20000);
+
+    LOG.info("Launching Dataflow validation job with Session File");
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
+    LaunchInfo jobInfo =
+        launchDataflowJob(
+            options,
+            testName,
+            PROJECT,
+            spannerResourceManager,
+            bigQueryResourceManager.getDatasetId(),
+            gcsInputDirectory,
+            SESSION_FILE_RESOURCE,
+            null, // schemaOverridesFilePath
+            null,
+            null,
+            null,
+            null);
+
+    pipelineOperator().waitUntilDone(createConfig(jobInfo));
+
+    GCSSpannerDVTestAsserts.assertValidationSummary(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new ValidationSummaryDto(
+                /* status= */ "MATCH",
+                /* totalTablesValidated= */ 1L,
+                /* totalRowsMatched= */ 1L,
+                /* totalRowsMismatched= */ 0L,
+                /* tablesWithMismatches= */ "")));
+
+    GCSSpannerDVTestAsserts.assertTableValidationStats(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "Members",
+                /* status= */ "MATCH",
+                /* sourceRowCount= */ 1L,
+                /* destinationRowCount= */ 1L,
+                /* matchedRowCount= */ 1L,
+                /* mismatchRowCount= */ 0L)));
+  }
+
+  @Test
+  @org.junit.Ignore("Bug in template: pipeline crashes if source table is missing from Spanner DDL")
+  public void testWithoutSchemaMappingFile() throws Exception {
+    String gcsInputDirectory = getGcsPath("input_nomapping");
+    generateAndUploadData("input_nomapping");
+
+    // Wait for Spanner's exact staleness read bound in SpannerReaderTransform
+    Thread.sleep(20000);
+
+    LOG.info("Launching Dataflow validation job with No Mapping");
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
+    LaunchInfo jobInfo =
+        launchDataflowJob(
+            options,
+            testName,
+            PROJECT,
+            spannerResourceManager,
+            bigQueryResourceManager.getDatasetId(),
+            gcsInputDirectory,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    pipelineOperator().waitUntilDone(createConfig(jobInfo));
+
+    GCSSpannerDVTestAsserts.assertValidationSummary(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new ValidationSummaryDto(
+                /* status= */ "MISMATCH",
+                /* totalTablesValidated= */ 2L,
+                /* totalRowsMatched= */ 0L,
+                /* totalRowsMismatched= */ 2L,
+                /* tablesWithMismatches= */ "Members,Users")));
+
+    GCSSpannerDVTestAsserts.assertTableValidationStats(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "Users",
+                /* status= */ "MISMATCH",
+                /* sourceRowCount= */ 1L,
+                /* destinationRowCount= */ 0L,
+                /* matchedRowCount= */ 0L,
+                /* mismatchRowCount= */ 1L),
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "Members",
+                /* status= */ "MISMATCH",
+                /* sourceRowCount= */ 0L,
+                /* destinationRowCount= */ 1L,
+                /* matchedRowCount= */ 0L,
+                /* mismatchRowCount= */ 1L)));
+
+    GCSSpannerDVTestAsserts.assertMismatchedRecords(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new MismatchedRecordDto(
+                null, null, "Users", "[user_id:1, event_id:E1]", "MISSING_IN_DESTINATION"),
+            new MismatchedRecordDto(
+                null, null, "Members", "[user_id:1, event_id:E1]", "MISSING_IN_SOURCE")));
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedTableIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedTableIT.java
@@ -32,8 +32,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Integration test for GCSSpannerDV pipeline covering table renaming scenarios.
@@ -47,7 +45,6 @@ import org.slf4j.LoggerFactory;
 @TemplateIntegrationTest(GCSSpannerDV.class)
 public class GCSSpannerDVRenamedTableIT extends GCSSpannerDVITBase {
 
-  private static final Logger LOG = LoggerFactory.getLogger(GCSSpannerDVRenamedTableIT.class);
   private static final String SPANNER_DDL_RESOURCE =
       "GCSSpannerDVRenamedTableIT/spanner-schema.sql";
   private static final String OVERRIDES_FILE_RESOURCE =
@@ -56,17 +53,13 @@ public class GCSSpannerDVRenamedTableIT extends GCSSpannerDVITBase {
 
   @Before
   public void setUp() throws IOException {
-    LOG.info("Setting up Spanner and BigQuery resources");
     spannerResourceManager = setUpSpannerResourceManager();
     bigQueryResourceManager = setUpBigQueryResourceManager();
     bigQueryResourceManager.createDataset(REGION);
-    LOG.info("BigQuery dataset created");
     createSpannerDDL(spannerResourceManager, SPANNER_DDL_RESOURCE);
-    LOG.info("Spanner instance created");
   }
 
   private void generateAndUploadData(String gcsSubDir) throws IOException {
-    LOG.info("Generating and Uploading Avro Records to GCS under {}", gcsSubDir);
     Instant t1 = Instant.parse("2024-01-01T10:00:00Z");
 
     List<GenericRecord> usersRecords =
@@ -83,7 +76,6 @@ public class GCSSpannerDVRenamedTableIT extends GCSSpannerDVITBase {
     uploadAvroFileToGcs(
         gcsSubDir + "/users.avro", GCSSpannerDVAvroSetupHelper.TableDef.USERS.schema, usersRecords);
 
-    LOG.info("Injecting Spanner records into renamed table 'Members'");
     spannerResourceManager.write(
         Arrays.asList(
             Mutation.newInsertOrUpdateBuilder("Members")
@@ -108,7 +100,6 @@ public class GCSSpannerDVRenamedTableIT extends GCSSpannerDVITBase {
     // Wait for Spanner's exact staleness read bound in SpannerReaderTransform
     Thread.sleep(20000);
 
-    LOG.info("Launching Dataflow validation job with Schema Overrides");
     LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
     LaunchInfo jobInfo =
         launchDataflowJob(
@@ -158,7 +149,6 @@ public class GCSSpannerDVRenamedTableIT extends GCSSpannerDVITBase {
     // Wait for Spanner's exact staleness read bound in SpannerReaderTransform
     Thread.sleep(20000);
 
-    LOG.info("Launching Dataflow validation job with Session File");
     LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
     LaunchInfo jobInfo =
         launchDataflowJob(
@@ -209,7 +199,6 @@ public class GCSSpannerDVRenamedTableIT extends GCSSpannerDVITBase {
     // Wait for Spanner's exact staleness read bound in SpannerReaderTransform
     Thread.sleep(20000);
 
-    LOG.info("Launching Dataflow validation job with No Mapping");
     LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
     LaunchInfo jobInfo =
         launchDataflowJob(

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedTableIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedTableIT.java
@@ -38,10 +38,9 @@ import org.slf4j.LoggerFactory;
 /**
  * Integration test for GCSSpannerDV pipeline covering table renaming scenarios.
  *
- * <p>This test validates that the pipeline correctly maps source tables to Spanner tables when
- * they have been renamed during the migration, given the proper configuration files (Overrides or
- * Session files). It also validates that mismatches are correctly identified if the configuration
- * file is omitted.
+ * <p>This test validates that the pipeline correctly maps source tables to Spanner tables when they
+ * have been renamed during the migration, for both: overrides file and session file flow. It also
+ * validates that mismatches are correctly identified if the configuration file is omitted.
  */
 @Category(TemplateIntegrationTest.class)
 @RunWith(JUnit4.class)
@@ -53,8 +52,7 @@ public class GCSSpannerDVRenamedTableIT extends GCSSpannerDVITBase {
       "GCSSpannerDVRenamedTableIT/spanner-schema.sql";
   private static final String OVERRIDES_FILE_RESOURCE =
       "GCSSpannerDVRenamedTableIT/schema_overrides.json";
-  private static final String SESSION_FILE_RESOURCE =
-      "GCSSpannerDVRenamedTableIT/session.json";
+  private static final String SESSION_FILE_RESOURCE = "GCSSpannerDVRenamedTableIT/session.json";
 
   @Before
   public void setUp() throws IOException {

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVRenamedColumnsIT/schema_overrides.json
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVRenamedColumnsIT/schema_overrides.json
@@ -1,0 +1,7 @@
+{
+  "renamedColumns": {
+    "Users": {
+      "full_name": "name"
+    }
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVRenamedColumnsIT/session.json
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVRenamedColumnsIT/session.json
@@ -1,0 +1,485 @@
+{
+  "SessionName": "GCSSpannerDVRenamedColumnsIT_Session",
+  "SpSchema": {
+    "t18": {
+      "Name": "Users",
+      "ColIds": [
+        "c12",
+        "c13",
+        "c14",
+        "c15",
+        "c16"
+      ],
+      "ShardIdColumn": "",
+      "ColDefs": {
+        "c12": {
+          "Name": "user_id",
+          "T": {
+            "Name": "INT64",
+            "Len": 0,
+            "IsArray": false
+          },
+          "NotNull": true,
+          "Comment": "From: user_id bigint(19)",
+          "Id": "c12",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        },
+        "c13": {
+          "Name": "event_id",
+          "T": {
+            "Name": "STRING",
+            "Len": 255,
+            "IsArray": false
+          },
+          "NotNull": true,
+          "Comment": "From: event_id varchar(255)",
+          "Id": "c13",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        },
+        "c14": {
+          "Name": "name",
+          "T": {
+            "Name": "STRING",
+            "Len": 255,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: full_name varchar(255)",
+          "Id": "c14",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        },
+        "c15": {
+          "Name": "age",
+          "T": {
+            "Name": "INT64",
+            "Len": 0,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: age int(10)",
+          "Id": "c15",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        },
+        "c16": {
+          "Name": "created_at",
+          "T": {
+            "Name": "TIMESTAMP",
+            "Len": 0,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: created_at timestamp",
+          "Id": "c16",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        }
+      },
+      "PrimaryKeys": [
+        {
+          "ColId": "c12",
+          "Desc": false,
+          "Order": 1
+        },
+        {
+          "ColId": "c13",
+          "Desc": false,
+          "Order": 2
+        }
+      ],
+      "ForeignKeys": null,
+      "Indexes": null,
+      "ParentTable": {
+        "Id": "",
+        "OnDelete": "",
+        "InterleaveType": ""
+      },
+      "CheckConstraints": null,
+      "Comment": "Spanner schema for source table Users",
+      "Id": "t18"
+    }
+  },
+  "SrcSchema": {
+    "t18": {
+      "Name": "Users",
+      "Schema": "plugin-test1",
+      "ColIds": [
+        "c12",
+        "c13",
+        "c14",
+        "c15",
+        "c16"
+      ],
+      "ColDefs": {
+        "c12": {
+          "Name": "user_id",
+          "Type": {
+            "Name": "bigint",
+            "Mods": [
+              19
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": true,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c12",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          }
+        },
+        "c13": {
+          "Name": "event_id",
+          "Type": {
+            "Name": "varchar",
+            "Mods": [
+              255
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": true,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c13",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          }
+        },
+        "c14": {
+          "Name": "full_name",
+          "Type": {
+            "Name": "varchar",
+            "Mods": [
+              255
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c14",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          }
+        },
+        "c15": {
+          "Name": "age",
+          "Type": {
+            "Name": "int",
+            "Mods": [
+              10
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c15",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          }
+        },
+        "c16": {
+          "Name": "created_at",
+          "Type": {
+            "Name": "timestamp",
+            "Mods": null,
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c16",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          }
+        }
+      },
+      "PrimaryKeys": [
+        {
+          "ColId": "c12",
+          "Desc": false,
+          "Order": 1
+        },
+        {
+          "ColId": "c13",
+          "Desc": false,
+          "Order": 2
+        }
+      ],
+      "ForeignKeys": null,
+      "CheckConstraints": null,
+      "Indexes": null,
+      "Id": "t18"
+    }
+  },
+  "SyntheticPKeys": {},
+  "ToSpanner": {
+    "Users": {
+      "Name": "Users",
+      "Cols": {
+        "age": "age",
+        "created_at": "created_at",
+        "event_id": "event_id",
+        "full_name": "name",
+        "user_id": "user_id"
+      }
+    }
+  },
+  "DatabaseType": "mysql",
+  "DatabaseName": "plugin-test1",
+  "Dialect": "google_standard_sql"
+}

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVRenamedColumnsIT/spanner-schema.sql
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVRenamedColumnsIT/spanner-schema.sql
@@ -3,5 +3,5 @@ CREATE TABLE Users (
     event_id STRING(MAX) NOT NULL,
     name STRING(MAX),
     age INT64,
-    created_at TIMESTAMP,
+    created_at TIMESTAMP
 ) PRIMARY KEY (user_id, event_id);

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVRenamedColumnsIT/spanner-schema.sql
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVRenamedColumnsIT/spanner-schema.sql
@@ -1,0 +1,7 @@
+CREATE TABLE Users (
+    user_id INT64 NOT NULL,
+    event_id STRING(MAX) NOT NULL,
+    name STRING(MAX),
+    age INT64,
+    created_at TIMESTAMP,
+) PRIMARY KEY (user_id, event_id);

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVRenamedTableIT/schema_overrides.json
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVRenamedTableIT/schema_overrides.json
@@ -1,0 +1,5 @@
+{
+  "renamedTables": {
+    "Users": "Members"
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVRenamedTableIT/session.json
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVRenamedTableIT/session.json
@@ -1,0 +1,522 @@
+{
+  "SessionName": "NewSession",
+  "EditorName": "",
+  "DatabaseType": "mysql",
+  "DatabaseName": "plugin-test1",
+  "Dialect": "google_standard_sql",
+  "Notes": null,
+  "Tags": null,
+  "SpSchema": {
+    "t18": {
+      "Name": "Members",
+      "ColIds": [
+        "c12",
+        "c13",
+        "c14",
+        "c15",
+        "c16"
+      ],
+      "ShardIdColumn": "",
+      "ColDefs": {
+        "c12": {
+          "Name": "user_id",
+          "T": {
+            "Name": "INT64",
+            "Len": 0,
+            "IsArray": false
+          },
+          "NotNull": true,
+          "Comment": "From: user_id bigint(19)",
+          "Id": "c12",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        },
+        "c13": {
+          "Name": "event_id",
+          "T": {
+            "Name": "STRING",
+            "Len": 255,
+            "IsArray": false
+          },
+          "NotNull": true,
+          "Comment": "From: event_id varchar(255)",
+          "Id": "c13",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        },
+        "c14": {
+          "Name": "full_name",
+          "T": {
+            "Name": "STRING",
+            "Len": 255,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: full_name varchar(255)",
+          "Id": "c14",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        },
+        "c15": {
+          "Name": "age",
+          "T": {
+            "Name": "INT64",
+            "Len": 0,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: age int(10)",
+          "Id": "c15",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        },
+        "c16": {
+          "Name": "created_at",
+          "T": {
+            "Name": "TIMESTAMP",
+            "Len": 0,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: created_at timestamp",
+          "Id": "c16",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        }
+      },
+      "PrimaryKeys": [
+        {
+          "ColId": "c12",
+          "Desc": false,
+          "Order": 1
+        },
+        {
+          "ColId": "c13",
+          "Desc": false,
+          "Order": 2
+        }
+      ],
+      "ForeignKeys": null,
+      "Indexes": null,
+      "ParentTable": {
+        "Id": "",
+        "OnDelete": "",
+        "InterleaveType": ""
+      },
+      "CheckConstraints": null,
+      "Comment": "Spanner schema for source table Users",
+      "Id": "t18"
+    }
+  },
+  "SyntheticPKeys": {},
+  "SrcSchema": {
+    "t18": {
+      "Name": "Users",
+      "Schema": "plugin-test1",
+      "ColIds": [
+        "c12",
+        "c13",
+        "c14",
+        "c15",
+        "c16"
+      ],
+      "ColDefs": {
+        "c12": {
+          "Name": "user_id",
+          "Type": {
+            "Name": "bigint",
+            "Mods": [
+              19
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": true,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c12",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          }
+        },
+        "c13": {
+          "Name": "event_id",
+          "Type": {
+            "Name": "varchar",
+            "Mods": [
+              255
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": true,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c13",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          }
+        },
+        "c14": {
+          "Name": "full_name",
+          "Type": {
+            "Name": "varchar",
+            "Mods": [
+              255
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c14",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          }
+        },
+        "c15": {
+          "Name": "age",
+          "Type": {
+            "Name": "int",
+            "Mods": [
+              10
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c15",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          }
+        },
+        "c16": {
+          "Name": "created_at",
+          "Type": {
+            "Name": "timestamp",
+            "Mods": null,
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c16",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          }
+        }
+      },
+      "PrimaryKeys": [
+        {
+          "ColId": "c12",
+          "Desc": false,
+          "Order": 1
+        },
+        {
+          "ColId": "c13",
+          "Desc": false,
+          "Order": 2
+        }
+      ],
+      "ForeignKeys": null,
+      "CheckConstraints": null,
+      "Indexes": null,
+      "Id": "t18"
+    }
+  },
+  "SchemaIssues": {
+    "t18": {
+      "ColumnLevelIssues": {
+        "c15": [
+          14
+        ]
+      },
+      "TableLevelIssues": null
+    }
+  },
+  "InvalidCheckExp": null,
+  "ToSpanner": {
+    "Users": {
+      "Name": "Members",
+      "Cols": {
+        "age": "age",
+        "created_at": "created_at",
+        "event_id": "event_id",
+        "full_name": "full_name",
+        "user_id": "user_id"
+      }
+    }
+  },
+  "Location": {},
+  "TimezoneOffset": "+00:00",
+  "SpDialect": "google_standard_sql",
+  "UniquePKey": {},
+  "Rules": [],
+  "IsSharded": false,
+  "SpRegion": "",
+  "ResourceValidation": false,
+  "UI": false,
+  "SpSequences": {},
+  "SrcSequences": {},
+  "SpProjectId": "span-cloud-ck-testing-external",
+  "SpInstanceId": "ea-functional-tests",
+  "Source": "mysql",
+  "DatabaseOptions": {
+    "DbName": "",
+    "DefaultTimezone": ""
+  },
+  "DefaultIdentityOptions": {
+    "SkipRangeMin": "",
+    "SkipRangeMax": "",
+    "StartCounterWith": ""
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVRenamedTableIT/spanner-schema.sql
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVRenamedTableIT/spanner-schema.sql
@@ -1,0 +1,7 @@
+CREATE TABLE Members (
+    user_id INT64 NOT NULL,
+    event_id STRING(MAX) NOT NULL,
+    full_name STRING(MAX),
+    age INT64,
+    created_at TIMESTAMP,
+) PRIMARY KEY (user_id, event_id);

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVRenamedTableIT/spanner-schema.sql
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVRenamedTableIT/spanner-schema.sql
@@ -3,5 +3,5 @@ CREATE TABLE Members (
     event_id STRING(MAX) NOT NULL,
     full_name STRING(MAX),
     age INT64,
-    created_at TIMESTAMP,
+    created_at TIMESTAMP
 ) PRIMARY KEY (user_id, event_id);


### PR DESCRIPTION
**Call out:**
`testWithoutSchemaMappingFile` testcase in `GCSSpannerDvRenamedTableIT` currently has the `@Ignore` tag due to the bug where if source table is not found in Spanner DDL, the validation pipeline crashes.
