### PR TITLE
Run Validation ITs using DirectRunner

### DIFF
--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
@@ -197,13 +197,26 @@ public abstract class TemplateTestBase {
     }
 
     try {
-      Method testMethod = getClass().getMethod(testName);
-      annotation = testMethod.getAnnotation(TemplateIntegrationTest.class);
-      Category methodCategory = testMethod.getAnnotation(Category.class);
-      if (methodCategory != null) {
-        Collections.addAll(categories, methodCategory.value());
+      Method testMethod = null;
+      try {
+        testMethod = getClass().getMethod(testName);
+      } catch (NoSuchMethodException e) {
+        for (Method method : getClass().getMethods()) {
+          if (testName.startsWith(method.getName())) {
+            if (testMethod == null || method.getName().length() > testMethod.getName().length()) {
+              testMethod = method;
+            }
+          }
+        }
       }
-    } catch (NoSuchMethodException e) {
+      if (testMethod != null) {
+        annotation = testMethod.getAnnotation(TemplateIntegrationTest.class);
+        Category methodCategory = testMethod.getAnnotation(Category.class);
+        if (methodCategory != null) {
+          Collections.addAll(categories, methodCategory.value());
+        }
+      }
+    } catch (Exception e) {
       // ignore error
     }
 

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
@@ -106,11 +106,13 @@ public abstract class TemplateTestBase {
   public static final String ADDITIONAL_EXPERIMENTS_ENVIRONMENT = "additionalExperiments";
 
   public String testName;
+  protected Description testDescription;
 
   @Rule
   public TestRule watcher =
       new TestWatcher() {
         protected void starting(Description description) {
+          testDescription = description;
           testName = description.getMethodName();
           // In case of parameterization the testName can contain subscript like testName[paramName]
           // Converting testName from testName[paramName] to testNameParamName since it is used to
@@ -196,28 +198,12 @@ public abstract class TemplateTestBase {
       Collections.addAll(categories, classCategory.value());
     }
 
-    try {
-      Method testMethod = null;
-      try {
-        testMethod = getClass().getMethod(testName);
-      } catch (NoSuchMethodException e) {
-        for (Method method : getClass().getMethods()) {
-          if (testName.startsWith(method.getName())) {
-            if (testMethod == null || method.getName().length() > testMethod.getName().length()) {
-              testMethod = method;
-            }
-          }
-        }
+    if (testDescription != null) {
+      annotation = testDescription.getAnnotation(TemplateIntegrationTest.class);
+      Category methodCategory = testDescription.getAnnotation(Category.class);
+      if (methodCategory != null) {
+        Collections.addAll(categories, methodCategory.value());
       }
-      if (testMethod != null) {
-        annotation = testMethod.getAnnotation(TemplateIntegrationTest.class);
-        Category methodCategory = testMethod.getAnnotation(Category.class);
-        if (methodCategory != null) {
-          Collections.addAll(categories, methodCategory.value());
-        }
-      }
-    } catch (Exception e) {
-      // ignore error
     }
 
     if (categories.contains(DirectRunnerTest.class)) {

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/TemplateTestBase.java
@@ -48,12 +48,13 @@ import java.nio.channels.ReadableByteChannel;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import org.apache.beam.it.common.PipelineLauncher;
@@ -187,18 +188,32 @@ public abstract class TemplateTestBase {
     MultiTemplateIntegrationTest multiAnnotation =
         getClass().getAnnotation(MultiTemplateIntegrationTest.class);
     usingDirectRunner = System.getProperty("directRunnerTest") != null;
+
+    Set<Class<?>> categories = new HashSet<>();
+
+    Category classCategory = getClass().getAnnotation(Category.class);
+    if (classCategory != null) {
+      Collections.addAll(categories, classCategory.value());
+    }
+
     try {
       Method testMethod = getClass().getMethod(testName);
       annotation = testMethod.getAnnotation(TemplateIntegrationTest.class);
-      Category category = testMethod.getAnnotation(Category.class);
-      if (category != null) {
-        usingDirectRunner =
-            Arrays.asList(category.value()).contains(DirectRunnerTest.class) || usingDirectRunner;
-        skipRunnerV2 = Arrays.asList(category.value()).contains(SkipRunnerV2Test.class);
+      Category methodCategory = testMethod.getAnnotation(Category.class);
+      if (methodCategory != null) {
+        Collections.addAll(categories, methodCategory.value());
       }
     } catch (NoSuchMethodException e) {
       // ignore error
     }
+
+    if (categories.contains(DirectRunnerTest.class)) {
+      usingDirectRunner = true;
+    }
+    if (categories.contains(SkipRunnerV2Test.class)) {
+      skipRunnerV2 = true;
+    }
+
     if (annotation == null) {
       annotation = getClass().getAnnotation(TemplateIntegrationTest.class);
     }

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVCoreMatchingIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVCoreMatchingIT.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.templates;
 
 import com.google.cloud.spanner.Mutation;
+import com.google.cloud.teleport.metadata.DirectRunnerTest;
 import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
 import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.MismatchedRecordDto;
 import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.TableValidationStatsDto;
@@ -63,6 +64,7 @@ public class GCSSpannerDVCoreMatchingIT extends GCSSpannerDVITBase {
    * BigQuery tables.
    */
   @Test
+  @Category(DirectRunnerTest.class)
   public void validationTestWithMatchingAndMismatchedRecords() throws Exception {
 
     // 1. Generate and Upload Avro Records (Source)

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVCoreMatchingIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVCoreMatchingIT.java
@@ -41,7 +41,7 @@ import org.junit.runners.JUnit4;
  * (Spanner) across multiple tables, and correctly report on matches, missing rows, and data
  * discrepancies.
  */
-@Category(TemplateIntegrationTest.class)
+@Category({TemplateIntegrationTest.class, DirectRunnerTest.class})
 @RunWith(JUnit4.class)
 @TemplateIntegrationTest(GCSSpannerDV.class)
 public class GCSSpannerDVCoreMatchingIT extends GCSSpannerDVITBase {
@@ -64,7 +64,6 @@ public class GCSSpannerDVCoreMatchingIT extends GCSSpannerDVITBase {
    * BigQuery tables.
    */
   @Test
-  @Category(DirectRunnerTest.class)
   public void validationTestWithMatchingAndMismatchedRecords() throws Exception {
 
     // 1. Generate and Upload Avro Records (Source)

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedColumnsIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedColumnsIT.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.templates;
 
 import com.google.cloud.spanner.Mutation;
+import com.google.cloud.teleport.metadata.DirectRunnerTest;
 import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
 import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.MismatchedRecordDto;
 import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.TableValidationStatsDto;
@@ -40,7 +41,7 @@ import org.junit.runners.JUnit4;
  * they have been renamed during the migration, for both: overrides file and session file flow. It
  * also validates that mismatches are correctly identified if the configuration file is omitted.
  */
-@Category(TemplateIntegrationTest.class)
+@Category({TemplateIntegrationTest.class, DirectRunnerTest.class})
 @RunWith(JUnit4.class)
 @TemplateIntegrationTest(GCSSpannerDV.class)
 public class GCSSpannerDVRenamedColumnsIT extends GCSSpannerDVITBase {

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedTableIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedTableIT.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.templates;
 
 import com.google.cloud.spanner.Mutation;
+import com.google.cloud.teleport.metadata.DirectRunnerTest;
 import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
 import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.MismatchedRecordDto;
 import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.TableValidationStatsDto;
@@ -40,7 +41,7 @@ import org.junit.runners.JUnit4;
  * have been renamed during the migration, for both: overrides file and session file flow. It also
  * validates that mismatches are correctly identified if the configuration file is omitted.
  */
-@Category(TemplateIntegrationTest.class)
+@Category({TemplateIntegrationTest.class, DirectRunnerTest.class})
 @RunWith(JUnit4.class)
 @TemplateIntegrationTest(GCSSpannerDV.class)
 public class GCSSpannerDVRenamedTableIT extends GCSSpannerDVITBase {

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVSchemaIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVSchemaIT.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.templates;
 
 import com.google.cloud.spanner.Mutation;
+import com.google.cloud.teleport.metadata.DirectRunnerTest;
 import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
 import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.TableValidationStatsDto;
 import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.ValidationSummaryDto;
@@ -40,7 +41,7 @@ import org.junit.runners.JUnit4;
  * <li>Empty tables (both source and destination have 0 rows).
  * <li>Reserved SQL Keywords (tables and columns that share names with SQL keywords).
  */
-@Category(TemplateIntegrationTest.class)
+@Category({TemplateIntegrationTest.class, DirectRunnerTest.class})
 @RunWith(JUnit4.class)
 @TemplateIntegrationTest(GCSSpannerDV.class)
 public class GCSSpannerDVSchemaIT extends GCSSpannerDVITBase {


### PR DESCRIPTION
b/539158138

The tests to be run with DirectRunner will run as a part of Integration Smoke tests. Dataflow runner tests will run as part of the Integration Test. 

- Resolves a bug where class annotations weren't being correctly read and consumed
- Resolves a bug where test method names aren't correctly read