### PR TITLE
[Data Validation] Add Custom Transformation ITs

### DIFF
--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVCustomTransformationIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVCustomTransformationIT.java
@@ -1,6 +1,22 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.teleport.v2.templates;
 
 import com.google.cloud.ByteArray;
+import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.teleport.metadata.DirectRunnerTest;
 import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
@@ -19,45 +35,48 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Integration tests verifying the custom transformation logic of the GCSSpannerDV pipeline.
  *
- * <p>Ensures the pipeline can apply custom user transformations for dropping rows,
- * explicitly type casting columns, handling complex avro datatypes, and adding dynamically computed columns.
+ * <p>Ensures the pipeline can apply custom user transformations for dropping rows, explicitly type
+ * casting columns, handling complex avro datatypes, and adding dynamically computed columns.
  */
 @Category({TemplateIntegrationTest.class, DirectRunnerTest.class})
 @RunWith(JUnit4.class)
 @TemplateIntegrationTest(GCSSpannerDV.class)
 public class GCSSpannerDVCustomTransformationIT extends GCSSpannerDVITBase {
 
-  private static final Logger LOG =
-      LoggerFactory.getLogger(GCSSpannerDVCustomTransformationIT.class);
   private static final String SPANNER_DDL_RESOURCE =
       "GCSSpannerDVCustomTransformationIT/spanner-schema.sql";
 
   @Before
   public void setUp() throws IOException, InterruptedException {
-    LOG.info("Setting up Spanner and BigQuery resources");
     spannerResourceManager = setUpSpannerResourceManager();
     bigQueryResourceManager = setUpBigQueryResourceManager();
     bigQueryResourceManager.createDataset(REGION);
-    LOG.info("BigQuery dataset created");
     createSpannerDDL(spannerResourceManager, SPANNER_DDL_RESOURCE);
-    LOG.info("Spanner instance created");
 
     // Create and upload jar for custom transformations
     createAndUploadJarToGcs("custom");
   }
 
+  /**
+   * Tests custom transformation scenarios:
+   *
+   * <ol>
+   *   <li>Basic non-PK data transformation (inherently tested by points 2 and 3).
+   *   <li>Explicit type handling (String full_name -> BYTES).
+   *   <li>Complex Avro datatype transformation (modifying TIMESTAMP created_at by +1 hour).
+   *   <li>Row filtering via isEventFiltered() (dropping Users record where age = 99).
+   *   <li>Passing transformationCustomParameters ("InWonderland" parameter appended to full_name).
+   *   <li>Sharded topology (preserving migration_shard_id column without explicit transformations).
+   * </ol>
+   */
   @Test
   public void testCustomTransformations() throws Exception {
-    LOG.info("Generating and Uploading Avro Records to GCS");
 
     Instant t1 = Instant.parse("2024-01-01T10:00:00Z");
-    Instant t2 = Instant.parse("2024-01-02T10:00:00Z");
 
     // 1 matched record, 1 record to be filtered out (age = 99)
     List<GenericRecord> usersRecords =
@@ -76,7 +95,7 @@ public class GCSSpannerDVCustomTransformationIT extends GCSSpannerDVITBase {
                 .set("event_id", "E2")
                 .set("full_name", "Bob")
                 .set("age", 99) // Will be filtered out
-                .set("created_at", t2)
+                .set("created_at", t1)
                 .build()); // Dropped record
 
     String gcsInputDirectory = getGcsPath("input");
@@ -84,8 +103,6 @@ public class GCSSpannerDVCustomTransformationIT extends GCSSpannerDVITBase {
         "input/users.avro", GCSSpannerDVAvroSetupHelper.TableDef.USERS.schema, usersRecords);
 
     // 2. Inject Spanner Records (Destination)
-    LOG.info("Injecting Spanner records");
-
     spannerResourceManager.write(
         Arrays.asList(
             Mutation.newInsertOrUpdateBuilder("Users")
@@ -98,7 +115,9 @@ public class GCSSpannerDVCustomTransformationIT extends GCSSpannerDVITBase {
                 .set("age")
                 .to(30L)
                 .set("created_at")
-                .to("Time_1704106800000000") // "2024-01-01T10:00:00Z" + 1 hour in microseconds
+                .to(
+                    Timestamp.parseTimestamp(
+                        "2024-01-01T11:00:00Z")) // "2024-01-01T10:00:00Z" + 1 hour
                 .set("migration_shard_id")
                 .to("shard1")
                 .build())); // Dropped record (user_id=2) is NOT written to Spanner.
@@ -107,11 +126,11 @@ public class GCSSpannerDVCustomTransformationIT extends GCSSpannerDVITBase {
     Thread.sleep(20000);
 
     // 3. Launch Pipeline
-    LOG.info("Launching Dataflow validation job");
     LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
-    
+
     CustomTransformation customTransformation =
-        CustomTransformation.builder("custom/customTransformation.jar", "com.custom.CustomTransformationForDVIT")
+        CustomTransformation.builder(
+                "custom/customTransformation.jar", "com.custom.CustomTransformationForDVIT")
             .setCustomParameters("InWonderland")
             .build();
 
@@ -155,7 +174,9 @@ public class GCSSpannerDVCustomTransformationIT extends GCSSpannerDVITBase {
                 /* matchedRowCount= */ 1L,
                 /* mismatchRowCount= */ 0L)));
 
-    GCSSpannerDVTestAsserts.assertMismatchedRecords(
-        bigQueryResourceManager, Arrays.asList());
+    GCSSpannerDVTestAsserts.assertMismatchedRecords(bigQueryResourceManager, Arrays.asList());
   }
+
+  // TODO: @aasthabharill Add test for scenario where Exception is thrown by Custom transformation
+  // once bug is fixed. (Currently, it crashes the validation pipeline)
 }

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVCustomTransformationIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVCustomTransformationIT.java
@@ -1,0 +1,161 @@
+package com.google.cloud.teleport.v2.templates;
+
+import com.google.cloud.ByteArray;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.teleport.metadata.DirectRunnerTest;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import com.google.cloud.teleport.v2.spanner.migrations.transformation.CustomTransformation;
+import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.TableValidationStatsDto;
+import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.ValidationSummaryDto;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
+import org.apache.beam.it.common.PipelineLauncher.LaunchInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration tests verifying the custom transformation logic of the GCSSpannerDV pipeline.
+ *
+ * <p>Ensures the pipeline can apply custom user transformations for dropping rows,
+ * explicitly type casting columns, handling complex avro datatypes, and adding dynamically computed columns.
+ */
+@Category({TemplateIntegrationTest.class, DirectRunnerTest.class})
+@RunWith(JUnit4.class)
+@TemplateIntegrationTest(GCSSpannerDV.class)
+public class GCSSpannerDVCustomTransformationIT extends GCSSpannerDVITBase {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(GCSSpannerDVCustomTransformationIT.class);
+  private static final String SPANNER_DDL_RESOURCE =
+      "GCSSpannerDVCustomTransformationIT/spanner-schema.sql";
+
+  @Before
+  public void setUp() throws IOException, InterruptedException {
+    LOG.info("Setting up Spanner and BigQuery resources");
+    spannerResourceManager = setUpSpannerResourceManager();
+    bigQueryResourceManager = setUpBigQueryResourceManager();
+    bigQueryResourceManager.createDataset(REGION);
+    LOG.info("BigQuery dataset created");
+    createSpannerDDL(spannerResourceManager, SPANNER_DDL_RESOURCE);
+    LOG.info("Spanner instance created");
+
+    // Create and upload jar for custom transformations
+    createAndUploadJarToGcs("custom");
+  }
+
+  @Test
+  public void testCustomTransformations() throws Exception {
+    LOG.info("Generating and Uploading Avro Records to GCS");
+
+    Instant t1 = Instant.parse("2024-01-01T10:00:00Z");
+    Instant t2 = Instant.parse("2024-01-02T10:00:00Z");
+
+    // 1 matched record, 1 record to be filtered out (age = 99)
+    List<GenericRecord> usersRecords =
+        Arrays.asList(
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(
+                    GCSSpannerDVAvroSetupHelper.TableDef.USERS, "shard1")
+                .set("user_id", 1L)
+                .set("event_id", "E1")
+                .set("full_name", "Alice")
+                .set("age", 30)
+                .set("created_at", t1)
+                .build(), // Matched record
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(
+                    GCSSpannerDVAvroSetupHelper.TableDef.USERS, "shard1")
+                .set("user_id", 2L)
+                .set("event_id", "E2")
+                .set("full_name", "Bob")
+                .set("age", 99) // Will be filtered out
+                .set("created_at", t2)
+                .build()); // Dropped record
+
+    String gcsInputDirectory = getGcsPath("input");
+    uploadAvroFileToGcs(
+        "input/users.avro", GCSSpannerDVAvroSetupHelper.TableDef.USERS.schema, usersRecords);
+
+    // 2. Inject Spanner Records (Destination)
+    LOG.info("Injecting Spanner records");
+
+    spannerResourceManager.write(
+        Arrays.asList(
+            Mutation.newInsertOrUpdateBuilder("Users")
+                .set("user_id")
+                .to(1L)
+                .set("event_id")
+                .to("E1")
+                .set("full_name")
+                .to(ByteArray.copyFrom("AliceInWonderland"))
+                .set("age")
+                .to(30L)
+                .set("created_at")
+                .to("Time_1704106800000000") // "2024-01-01T10:00:00Z" + 1 hour in microseconds
+                .set("migration_shard_id")
+                .to("shard1")
+                .build())); // Dropped record (user_id=2) is NOT written to Spanner.
+
+    // Wait for Spanner's 20-second exact staleness read bound in SpannerReaderTransform
+    Thread.sleep(20000);
+
+    // 3. Launch Pipeline
+    LOG.info("Launching Dataflow validation job");
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
+    
+    CustomTransformation customTransformation =
+        CustomTransformation.builder("custom/customTransformation.jar", "com.custom.CustomTransformationForDVIT")
+            .setCustomParameters("InWonderland")
+            .build();
+
+    LaunchInfo jobInfo =
+        launchDataflowJob(
+            options,
+            testName,
+            PROJECT,
+            spannerResourceManager,
+            bigQueryResourceManager.getDatasetId(),
+            gcsInputDirectory,
+            "GCSSpannerDVCustomTransformationIT/session.json",
+            null,
+            null,
+            null,
+            customTransformation,
+            null);
+
+    pipelineOperator().waitUntilDone(createConfig(jobInfo));
+
+    // 4. Assert BigQuery Validation Results
+    GCSSpannerDVTestAsserts.assertValidationSummary(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new ValidationSummaryDto(
+                /* status= */ "MATCH",
+                /* totalTablesValidated= */ 1L,
+                /* totalRowsMatched= */ 1L,
+                /* totalRowsMismatched= */ 0L,
+                /* tablesWithMismatches= */ "")));
+
+    GCSSpannerDVTestAsserts.assertTableValidationStats(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "Users",
+                /* status= */ "MATCH",
+                /* sourceRowCount= */ 1L, // Record 2 is filtered out
+                /* destinationRowCount= */ 1L,
+                /* matchedRowCount= */ 1L,
+                /* mismatchRowCount= */ 0L)));
+
+    GCSSpannerDVTestAsserts.assertMismatchedRecords(
+        bigQueryResourceManager, Arrays.asList());
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVCustomTransformationIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVCustomTransformationIT.java
@@ -18,7 +18,7 @@ package com.google.cloud.teleport.v2.templates;
 import com.google.cloud.ByteArray;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Mutation;
-import com.google.cloud.teleport.metadata.DirectRunnerTest;
+import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
 import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
 import com.google.cloud.teleport.v2.spanner.migrations.transformation.CustomTransformation;
 import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.TableValidationStatsDto;
@@ -42,7 +42,7 @@ import org.junit.runners.JUnit4;
  * <p>Ensures the pipeline can apply custom user transformations for dropping rows, explicitly type
  * casting columns, handling complex avro datatypes, and adding dynamically computed columns.
  */
-@Category({TemplateIntegrationTest.class, DirectRunnerTest.class})
+@Category({TemplateIntegrationTest.class, SkipDirectRunnerTest.class})
 @RunWith(JUnit4.class)
 @TemplateIntegrationTest(GCSSpannerDV.class)
 public class GCSSpannerDVCustomTransformationIT extends GCSSpannerDVITBase {

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVCustomTransformationIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVCustomTransformationIT.java
@@ -58,7 +58,7 @@ public class GCSSpannerDVCustomTransformationIT extends GCSSpannerDVITBase {
     createSpannerDDL(spannerResourceManager, SPANNER_DDL_RESOURCE);
 
     // Create and upload jar for custom transformations
-    createAndUploadJarToGcs("custom");
+    createAndUploadCustomShardJarToGcs("custom");
   }
 
   /**
@@ -134,6 +134,9 @@ public class GCSSpannerDVCustomTransformationIT extends GCSSpannerDVITBase {
             .setCustomParameters("InWonderland")
             .build();
 
+    // Passing the session file is required because we're defining a shardIdColumn
+    // The session file supplies this mapping to the pipeline; the schema overrides flow for this is
+    // currently broken.
     LaunchInfo jobInfo =
         launchDataflowJob(
             options,

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVITBase.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVITBase.java
@@ -203,11 +203,11 @@ public abstract class GCSSpannerDVITBase extends TemplateTestBase {
 
   public void createAndUploadJarToGcs(String gcsPathPrefix)
       throws IOException, InterruptedException {
-    String[] shellCommand = {
-      "/bin/bash", "-c", "cd ../spanner-custom-shard && mvn clean package -DskipTests"
-    };
+    ProcessBuilder processBuilder =
+        new ProcessBuilder("/bin/bash", "-c", "mvn clean package -DskipTests")
+            .directory(new File("../spanner-custom-shard"));
 
-    Process exec = Runtime.getRuntime().exec(shellCommand);
+    Process exec = processBuilder.start();
 
     IORedirectUtil.redirectLinesLog(exec.getInputStream(), LOG);
     IORedirectUtil.redirectLinesLog(exec.getErrorStream(), LOG);

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVITBase.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVITBase.java
@@ -203,7 +203,9 @@ public abstract class GCSSpannerDVITBase extends TemplateTestBase {
 
   public void createAndUploadJarToGcs(String gcsPathPrefix)
       throws IOException, InterruptedException {
-    String[] shellCommand = {"/bin/bash", "-c", "cd ../spanner-custom-shard && mvn clean package -DskipTests"};
+    String[] shellCommand = {
+      "/bin/bash", "-c", "cd ../spanner-custom-shard && mvn clean package -DskipTests"
+    };
 
     Process exec = Runtime.getRuntime().exec(shellCommand);
 

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVITBase.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVITBase.java
@@ -33,6 +33,7 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
 import org.apache.beam.it.common.PipelineLauncher.LaunchInfo;
+import org.apache.beam.it.common.utils.IORedirectUtil;
 import org.apache.beam.it.common.utils.PipelineUtils;
 import org.apache.beam.it.gcp.TemplateTestBase;
 import org.apache.beam.it.gcp.bigquery.BigQueryResourceManager;
@@ -198,6 +199,23 @@ public abstract class GCSSpannerDVITBase extends TemplateTestBase {
     assertThatPipeline(jobInfo).isRunning();
 
     return jobInfo;
+  }
+
+  public void createAndUploadJarToGcs(String gcsPathPrefix)
+      throws IOException, InterruptedException {
+    String[] shellCommand = {"/bin/bash", "-c", "cd ../spanner-custom-shard && mvn clean package -DskipTests"};
+
+    Process exec = Runtime.getRuntime().exec(shellCommand);
+
+    IORedirectUtil.redirectLinesLog(exec.getInputStream(), LOG);
+    IORedirectUtil.redirectLinesLog(exec.getErrorStream(), LOG);
+
+    if (exec.waitFor() != 0) {
+      throw new RuntimeException("Error staging template, check Maven logs.");
+    }
+    gcsClient.uploadArtifact(
+        gcsPathPrefix + "/customTransformation.jar",
+        "../spanner-custom-shard/target/spanner-custom-shard-1.0-SNAPSHOT.jar");
   }
 
   /**

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVITBase.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVITBase.java
@@ -201,10 +201,10 @@ public abstract class GCSSpannerDVITBase extends TemplateTestBase {
     return jobInfo;
   }
 
-  public void createAndUploadJarToGcs(String gcsPathPrefix)
+  public void createAndUploadCustomShardJarToGcs(String gcsPathPrefix)
       throws IOException, InterruptedException {
     ProcessBuilder processBuilder =
-        new ProcessBuilder("/bin/bash", "-c", "mvn clean package -DskipTests")
+        new ProcessBuilder("mvn", "clean", "package", "-DskipTests")
             .directory(new File("../spanner-custom-shard"));
 
     Process exec = processBuilder.start();

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVCustomTransformationIT/session.json
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVCustomTransformationIT/session.json
@@ -1,0 +1,565 @@
+{
+  "SessionName": "NewSession",
+  "EditorName": "",
+  "DatabaseType": "mysql",
+  "DatabaseName": "plugin-test1",
+  "Dialect": "google_standard_sql",
+  "Notes": null,
+  "Tags": null,
+  "SpSchema": {
+    "t18": {
+      "Name": "Users",
+      "ColIds": [
+        "c12",
+        "c13",
+        "c14",
+        "c15",
+        "c16",
+        "c_shard_id"
+      ],
+      "ShardIdColumn": "c_shard_id",
+      "ColDefs": {
+        "c12": {
+          "Name": "user_id",
+          "T": {
+            "Name": "INT64",
+            "Len": 0,
+            "IsArray": false
+          },
+          "NotNull": true,
+          "Comment": "From: user_id bigint(19)",
+          "Id": "c12",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        },
+        "c13": {
+          "Name": "event_id",
+          "T": {
+            "Name": "STRING",
+            "Len": 255,
+            "IsArray": false
+          },
+          "NotNull": true,
+          "Comment": "From: event_id varchar(255)",
+          "Id": "c13",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        },
+        "c14": {
+          "Name": "full_name",
+          "T": {
+            "Name": "STRING",
+            "Len": 255,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: full_name varchar(255)",
+          "Id": "c14",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        },
+        "c15": {
+          "Name": "age",
+          "T": {
+            "Name": "INT64",
+            "Len": 0,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: age int(10)",
+          "Id": "c15",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        },
+        "c16": {
+          "Name": "created_at",
+          "T": {
+            "Name": "TIMESTAMP",
+            "Len": 0,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: created_at timestamp",
+          "Id": "c16",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        },
+        "c_shard_id": {
+          "Name": "migration_shard_id",
+          "T": {
+            "Name": "STRING",
+            "Len": 255,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "Added shard id",
+          "Id": "c_shard_id",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          },
+          "Opts": null
+        }
+      },
+      "PrimaryKeys": [
+        {
+          "ColId": "c_shard_id",
+          "Desc": false,
+          "Order": 1
+        },
+        {
+          "ColId": "c12",
+          "Desc": false,
+          "Order": 2
+        },
+        {
+          "ColId": "c13",
+          "Desc": false,
+          "Order": 3
+        }
+      ],
+      "ForeignKeys": null,
+      "Indexes": null,
+      "ParentTable": {
+        "Id": "",
+        "OnDelete": "",
+        "InterleaveType": ""
+      },
+      "CheckConstraints": null,
+      "Comment": "Spanner schema for source table Users",
+      "Id": "t18"
+    }
+  },
+  "SyntheticPKeys": {},
+  "SrcSchema": {
+    "t18": {
+      "Name": "Users",
+      "Schema": "plugin-test1",
+      "ColIds": [
+        "c12",
+        "c13",
+        "c14",
+        "c15",
+        "c16"
+      ],
+      "ColDefs": {
+        "c12": {
+          "Name": "user_id",
+          "Type": {
+            "Name": "bigint",
+            "Mods": [
+              19
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": true,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c12",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          }
+        },
+        "c13": {
+          "Name": "event_id",
+          "Type": {
+            "Name": "varchar",
+            "Mods": [
+              255
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": true,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c13",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          }
+        },
+        "c14": {
+          "Name": "full_name",
+          "Type": {
+            "Name": "varchar",
+            "Mods": [
+              255
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c14",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          }
+        },
+        "c15": {
+          "Name": "age",
+          "Type": {
+            "Name": "int",
+            "Mods": [
+              10
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c15",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          }
+        },
+        "c16": {
+          "Name": "created_at",
+          "Type": {
+            "Name": "timestamp",
+            "Mods": null,
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Ignored": {
+            "Check": false,
+            "Identity": false,
+            "Default": false,
+            "Exclusion": false,
+            "ForeignKey": false,
+            "AutoIncrement": false
+          },
+          "Id": "c16",
+          "AutoGen": {
+            "Name": "",
+            "GenerationType": "",
+            "IdentityOptions": {
+              "SkipRangeMin": "",
+              "SkipRangeMax": "",
+              "StartCounterWith": ""
+            }
+          },
+          "DefaultValue": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            }
+          },
+          "GeneratedColumn": {
+            "IsPresent": false,
+            "Value": {
+              "ExpressionId": "",
+              "Statement": ""
+            },
+            "Type": ""
+          }
+        }
+      },
+      "PrimaryKeys": [
+        {
+          "ColId": "c12",
+          "Desc": false,
+          "Order": 1
+        },
+        {
+          "ColId": "c13",
+          "Desc": false,
+          "Order": 2
+        }
+      ],
+      "ForeignKeys": null,
+      "CheckConstraints": null,
+      "Indexes": null,
+      "Id": "t18"
+    }
+  },
+  "SchemaIssues": {
+    "t18": {
+      "ColumnLevelIssues": {
+        "c15": [
+          14
+        ]
+      },
+      "TableLevelIssues": null
+    }
+  },
+  "InvalidCheckExp": null,
+  "ToSpanner": {
+    "Users": {
+      "Name": "Users",
+      "Cols": {
+        "age": "age",
+        "created_at": "created_at",
+        "event_id": "event_id",
+        "full_name": "full_name",
+        "user_id": "user_id",
+        "migration_shard_id": "migration_shard_id"
+      }
+    }
+  },
+  "Location": {},
+  "TimezoneOffset": "+00:00",
+  "SpDialect": "google_standard_sql",
+  "UniquePKey": {},
+  "Rules": [],
+  "IsSharded": false,
+  "SpRegion": "",
+  "ResourceValidation": false,
+  "UI": false,
+  "SpSequences": {},
+  "SrcSequences": {},
+  "SpProjectId": "span-cloud-ck-testing-external",
+  "SpInstanceId": "ea-functional-tests",
+  "Source": "mysql",
+  "DatabaseOptions": {
+    "DbName": "",
+    "DefaultTimezone": ""
+  },
+  "DefaultIdentityOptions": {
+    "SkipRangeMin": "",
+    "SkipRangeMax": "",
+    "StartCounterWith": ""
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVCustomTransformationIT/spanner-schema.sql
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVCustomTransformationIT/spanner-schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE Users (
+  user_id INT64 NOT NULL,
+  event_id STRING(MAX),
+  full_name BYTES(MAX),
+  age INT64,
+  created_at STRING(MAX),
+  migration_shard_id STRING(MAX)
+) PRIMARY KEY (migration_shard_id, user_id);

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVCustomTransformationIT/spanner-schema.sql
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVCustomTransformationIT/spanner-schema.sql
@@ -3,6 +3,6 @@ CREATE TABLE Users (
   event_id STRING(MAX),
   full_name BYTES(MAX),
   age INT64,
-  created_at STRING(MAX),
+  created_at TIMESTAMP,
   migration_shard_id STRING(MAX)
 ) PRIMARY KEY (migration_shard_id, user_id);

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVCustomTransformationIT/spanner-schema.sql
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVCustomTransformationIT/spanner-schema.sql
@@ -5,4 +5,4 @@ CREATE TABLE Users (
   age INT64,
   created_at TIMESTAMP,
   migration_shard_id STRING(MAX)
-) PRIMARY KEY (migration_shard_id, user_id);
+) PRIMARY KEY (migration_shard_id, user_id, event_id);

--- a/v2/spanner-custom-shard/src/main/java/com/custom/CustomTransformationForDVIT.java
+++ b/v2/spanner-custom-shard/src/main/java/com/custom/CustomTransformationForDVIT.java
@@ -48,7 +48,7 @@ public class CustomTransformationForDVIT implements ISpannerMigrationTransformer
     Map<String, Object> row = request.getRequestRow();
     Map<String, Object> responseRow = new HashMap<>(row);
 
-    if (request.getTableName().equals("Users")) {
+    if ("Users".equals(request.getTableName())) {
       // Filter out records where age is 99
       if (row.get("age") != null && ((Number) row.get("age")).intValue() == 99) {
         return new MigrationTransformationResponse(new HashMap<>(), true);

--- a/v2/spanner-custom-shard/src/main/java/com/custom/CustomTransformationForDVIT.java
+++ b/v2/spanner-custom-shard/src/main/java/com/custom/CustomTransformationForDVIT.java
@@ -1,0 +1,70 @@
+package com.custom;
+
+import com.google.cloud.teleport.v2.spanner.exceptions.InvalidTransformationException;
+import com.google.cloud.teleport.v2.spanner.utils.ISpannerMigrationTransformer;
+import com.google.cloud.teleport.v2.spanner.utils.MigrationTransformationRequest;
+import com.google.cloud.teleport.v2.spanner.utils.MigrationTransformationResponse;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CustomTransformationForDVIT implements ISpannerMigrationTransformer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CustomTransformationForDVIT.class);
+  private String customParam = "";
+
+  @Override
+  public void init(String parameters) {
+    LOG.info("init called with {}", parameters);
+    if (parameters != null) {
+      this.customParam = parameters;
+    }
+  }
+
+  @Override
+  public MigrationTransformationResponse toSpannerRow(MigrationTransformationRequest request)
+      throws InvalidTransformationException {
+    if (request.getTableName().equals("Users")) {
+      Map<String, Object> row = request.getRequestRow();
+      
+      // Filter out records where age is 99
+      if (row.get("age") != null && ((Number) row.get("age")).intValue() == 99) {
+        return new MigrationTransformationResponse(new HashMap<>(), true);
+      }
+
+      Map<String, Object> responseRow = new HashMap<>(row);
+
+      if (row.get("full_name") != null) {
+        // Convert full_name to a hex string representation
+        String name = row.get("full_name").toString();
+        String val = name + customParam;
+        responseRow.put("full_name", java.util.HexFormat.of().formatHex(val.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+      }
+
+      if (row.get("created_at") != null) {
+        // Parse created_at and add 1 hour as a data transformation
+        java.time.Instant t = java.time.Instant.parse((String) row.get("created_at"));
+        java.time.Instant shifted = t.plus(1, java.time.temporal.ChronoUnit.HOURS);
+        Long micros = (shifted.getEpochSecond() * 1000000L) + (shifted.getNano() / 1000L);
+        responseRow.put("created_at", "Time_" + micros);
+      }
+
+
+      return new MigrationTransformationResponse(responseRow, false);
+    }
+    return new MigrationTransformationResponse(null, false);
+  }
+
+  @Override
+  public MigrationTransformationResponse toSourceRow(MigrationTransformationRequest request)
+      throws InvalidTransformationException {
+    return new MigrationTransformationResponse(null, false);
+  }
+
+  @Override
+  public MigrationTransformationResponse transformFailedSpannerMutation(
+      MigrationTransformationRequest request) throws InvalidTransformationException {
+    return new MigrationTransformationResponse(null, false);
+  }
+}

--- a/v2/spanner-custom-shard/src/main/java/com/custom/CustomTransformationForDVIT.java
+++ b/v2/spanner-custom-shard/src/main/java/com/custom/CustomTransformationForDVIT.java
@@ -1,10 +1,29 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.custom;
 
 import com.google.cloud.teleport.v2.spanner.exceptions.InvalidTransformationException;
 import com.google.cloud.teleport.v2.spanner.utils.ISpannerMigrationTransformer;
 import com.google.cloud.teleport.v2.spanner.utils.MigrationTransformationRequest;
 import com.google.cloud.teleport.v2.spanner.utils.MigrationTransformationResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
+import java.util.HexFormat;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,31 +44,30 @@ public class CustomTransformationForDVIT implements ISpannerMigrationTransformer
   @Override
   public MigrationTransformationResponse toSpannerRow(MigrationTransformationRequest request)
       throws InvalidTransformationException {
+
+    Map<String, Object> row = request.getRequestRow();
+    Map<String, Object> responseRow = new HashMap<>(row);
+
     if (request.getTableName().equals("Users")) {
-      Map<String, Object> row = request.getRequestRow();
-      
       // Filter out records where age is 99
       if (row.get("age") != null && ((Number) row.get("age")).intValue() == 99) {
         return new MigrationTransformationResponse(new HashMap<>(), true);
       }
 
-      Map<String, Object> responseRow = new HashMap<>(row);
-
+      // Convert full_name to a hex string representation
       if (row.get("full_name") != null) {
-        // Convert full_name to a hex string representation
         String name = row.get("full_name").toString();
         String val = name + customParam;
-        responseRow.put("full_name", java.util.HexFormat.of().formatHex(val.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+        responseRow.put(
+            "full_name", HexFormat.of().formatHex(val.getBytes(StandardCharsets.UTF_8)));
       }
 
+      // Parse created_at and add 1 hour as a data transformation
       if (row.get("created_at") != null) {
-        // Parse created_at and add 1 hour as a data transformation
-        java.time.Instant t = java.time.Instant.parse((String) row.get("created_at"));
-        java.time.Instant shifted = t.plus(1, java.time.temporal.ChronoUnit.HOURS);
-        Long micros = (shifted.getEpochSecond() * 1000000L) + (shifted.getNano() / 1000L);
-        responseRow.put("created_at", "Time_" + micros);
+        Instant t = Instant.parse((String) row.get("created_at"));
+        Instant shifted = t.plus(1, ChronoUnit.HOURS);
+        responseRow.put("created_at", shifted);
       }
-
 
       return new MigrationTransformationResponse(responseRow, false);
     }


### PR DESCRIPTION
**Call out:**
Codecov will constantly fail on this PR because of the Custom Transformation file (`CustomTransformationForDVIT`)- but there is no need to add a test file for this so please ignore it.

Using DataflowRunner for now as the Custom transformation gets cached in the DirectRunner and the subsequent tests start failing 

- **The Issue:** `GCSSpannerDVShardedIT` integration tests unexpectedly began failing with `NullPointerException`s in the CI/CD pipeline immediately after `GCSSpannerDVCustomTransformationIT` was introduced.
```
Caused by: java.lang.RuntimeException: Error mapping GenericRecord to ComparisonRecord: Cannot invoke "java.util.Map.entrySet()" because "transformedCols" is null
```
The NullPointerException is a seperate bug that will be fixed in the next PR, but for the test `GCSSpannerDVShardedIT`, it should not even have reached this part of the code as `customTransformer = null`. This points to a resource leak.
-   **The Root Cause (Test Isolation Leak):** `CustomTransformationImplFetcher` utilized a single `static` variable to cache the loaded transformer. Because Maven runs integration tests sequentially in the same JVM, the transformer loaded by `GCSSpannerDVCustomTransformationIT` persisted in memory and was erroneously injected into `GCSSpannerDVShardedIT`, even though the latter had an empty transformation configuration.

