### PR TITLE
[Data Validation] Add Sharded Setup IT

### DIFF
--- a/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/fn/ValidationSummaryCombineFn.java
+++ b/v2/gcs-spanner-dv/src/main/java/com/google/cloud/teleport/v2/fn/ValidationSummaryCombineFn.java
@@ -105,7 +105,10 @@ public class ValidationSummaryCombineFn
         .setDestinationDatabase(destinationDatabase)
         .setStatus(status)
         .setTotalTablesValidated(accumulator.totalTables)
-        .setTablesWithMismatches(String.join(",", accumulator.tablesWithMismatches))
+        .setTablesWithMismatches(
+            accumulator.tablesWithMismatches.stream()
+                .sorted()
+                .collect(java.util.stream.Collectors.joining(",")))
         .setTotalRowsMatched(accumulator.totalMatched)
         .setTotalRowsMismatched(accumulator.totalMismatched)
         .setStartTimestamp(startTimestamp)

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVSchemaIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVSchemaIT.java
@@ -69,6 +69,9 @@ public class GCSSpannerDVSchemaIT extends GCSSpannerDVITBase {
         GCSSpannerDVAvroSetupHelper.TableDef.ACCOUNT_ROLES.schema,
         Collections.emptyList());
 
+    // Wait for the 15-second Spanner staleness bound so that tables created in setUp are visible
+    Thread.sleep(20000);
+
     // Launch Pipeline
     LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
     LaunchInfo jobInfo =

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVSchemaIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVSchemaIT.java
@@ -69,7 +69,8 @@ public class GCSSpannerDVSchemaIT extends GCSSpannerDVITBase {
         GCSSpannerDVAvroSetupHelper.TableDef.ACCOUNT_ROLES.schema,
         Collections.emptyList());
 
-    // Wait for the 15-second Spanner staleness bound so that tables created in setUp are visible
+    // The pipeline's SpannerReaderTransform performs a 15-second stale read.
+    // We must wait 20s to ensure the tables created in setUp() exist in that past snapshot.
     Thread.sleep(20000);
 
     // Launch Pipeline

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVShardedIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVShardedIT.java
@@ -1,0 +1,452 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates;
+
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.teleport.metadata.DirectRunnerTest;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.TableValidationStatsDto;
+import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.ValidationSummaryDto;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
+import org.apache.beam.it.common.PipelineLauncher.LaunchInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Integration tests verifying the Data Validation logic for sharded environments. This class
+ * validates the pipeline's behavior when aggregating data across multiple source database shards.
+ *
+ * <p>We test the following three scenarios, both with expected MATCH (Users) and MISMATCH
+ * (AccountRoles): 1. Globally unique PKs across shards without a shardIdColumn. 2. Duplicate PKs
+ * across shards without a shardIdColumn. 3. Duplicate PKs across shards using a shardIdColumn to
+ * disambiguate.
+ */
+@Category({TemplateIntegrationTest.class, DirectRunnerTest.class})
+@RunWith(JUnit4.class)
+@TemplateIntegrationTest(GCSSpannerDV.class)
+public class GCSSpannerDVShardedIT extends GCSSpannerDVITBase {
+
+  private static final String SPANNER_DDL_RESOURCE = "GCSSpannerDVShardedIT/spanner-schema.sql";
+  private static final String SPANNER_SHARDED_DDL_RESOURCE =
+      "GCSSpannerDVShardedIT/spanner-schema-shardIdColumn.sql";
+  private static final String SESSION_SHARDED_RESOURCE =
+      "GCSSpannerDVShardedIT/session-sharded.json";
+
+  @Before
+  public void setUp() throws IOException {
+    spannerResourceManager = setUpSpannerResourceManager();
+    bigQueryResourceManager = setUpBigQueryResourceManager();
+    bigQueryResourceManager.createDataset(REGION);
+  }
+
+  /** Simulates globally unique PKs across shards without a shardIdColumn. */
+  @Test
+  public void testUniquePKs() throws Exception {
+    createSpannerDDL(spannerResourceManager, SPANNER_DDL_RESOURCE);
+
+    Instant t1 = Instant.parse("2024-01-01T10:00:00Z");
+    Instant t2 = Instant.parse("2024-01-02T10:00:00Z");
+
+    List<GenericRecord> usersRecords =
+        Arrays.asList(
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(
+                    GCSSpannerDVAvroSetupHelper.TableDef.USERS, "shard1")
+                .set("user_id", 1L)
+                .set("event_id", "E1")
+                .set("full_name", "Alice")
+                .set("age", 30)
+                .set("created_at", t1)
+                .build(),
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(
+                    GCSSpannerDVAvroSetupHelper.TableDef.USERS, "shard2")
+                .set("user_id", 2L)
+                .set("event_id", "E2")
+                .set("full_name", "Bob")
+                .set("age", 31)
+                .set("created_at", t2)
+                .build());
+
+    List<GenericRecord> rolesRecords =
+        Arrays.asList(
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(
+                    GCSSpannerDVAvroSetupHelper.TableDef.ACCOUNT_ROLES, "shard1")
+                .set("role_id", 1)
+                .set("role_name", "ADMIN")
+                .build(),
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(
+                    GCSSpannerDVAvroSetupHelper.TableDef.ACCOUNT_ROLES, "shard2")
+                .set("role_id", 2)
+                .set("role_name", "USER")
+                .build() // This record will be dropped in Spanner to simulate a MISMATCH scenario
+            );
+
+    String gcsInputDirectory = getGcsPath("input");
+    uploadAvroFileToGcs(
+        "input/users.avro", GCSSpannerDVAvroSetupHelper.TableDef.USERS.schema, usersRecords);
+    uploadAvroFileToGcs(
+        "input/roles.avro",
+        GCSSpannerDVAvroSetupHelper.TableDef.ACCOUNT_ROLES.schema,
+        rolesRecords);
+
+    spannerResourceManager.write(
+        Arrays.asList(
+            Mutation.newInsertOrUpdateBuilder("Users")
+                .set("user_id")
+                .to(1L)
+                .set("event_id")
+                .to("E1")
+                .set("full_name")
+                .to("Alice")
+                .set("age")
+                .to(30L)
+                .set("created_at")
+                .to(Timestamp.parseTimestamp(t1.toString()))
+                .build(),
+            Mutation.newInsertOrUpdateBuilder("Users")
+                .set("user_id")
+                .to(2L)
+                .set("event_id")
+                .to("E2")
+                .set("full_name")
+                .to("Bob")
+                .set("age")
+                .to(31L)
+                .set("created_at")
+                .to(Timestamp.parseTimestamp(t2.toString()))
+                .build(),
+            Mutation.newInsertOrUpdateBuilder("AccountRoles")
+                .set("role_id")
+                .to(1L)
+                .set("role_name")
+                .to("ADMIN")
+                .build()));
+
+    Thread.sleep(20000);
+
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
+    LaunchInfo jobInfo =
+        launchDataflowJob(
+            options,
+            testName,
+            PROJECT,
+            spannerResourceManager,
+            bigQueryResourceManager.getDatasetId(),
+            gcsInputDirectory,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    pipelineOperator().waitUntilDone(createConfig(jobInfo));
+
+    GCSSpannerDVTestAsserts.assertValidationSummary(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new ValidationSummaryDto(
+                /* status= */ "MISMATCH",
+                /* totalTablesValidated= */ 2L,
+                /* totalRowsMatched= */ 3L,
+                /* totalRowsMismatched= */ 1L,
+                /* tablesWithMismatches= */ "AccountRoles")));
+    GCSSpannerDVTestAsserts.assertTableValidationStats(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "Users",
+                /* status= */ "MATCH",
+                /* sourceRowCount= */ 2L,
+                /* destinationRowCount= */ 2L,
+                /* matchedRowCount= */ 2L,
+                /* mismatchRowCount= */ 0L),
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "AccountRoles",
+                /* status= */ "MISMATCH",
+                /* sourceRowCount= */ 2L,
+                /* destinationRowCount= */ 1L,
+                /* matchedRowCount= */ 1L,
+                /* mismatchRowCount= */ 1L)));
+  }
+
+  /**
+   * Simulates duplicate PKs across shards without a shardIdColumn to disambiguate. Expectation: For
+   * Users, Spanner stores only 1 row per PK, but data validation matches both source records to
+   * that single row due to identical hashes. For AccountRoles, dropping the single row in Spanner
+   * leads to a MISMATCH for both source records.
+   */
+  @Test
+  public void testDuplicatePKsNoShardIdColumn() throws Exception {
+    createSpannerDDL(spannerResourceManager, SPANNER_DDL_RESOURCE);
+
+    Instant t1 = Instant.parse("2024-01-01T10:00:00Z");
+
+    List<GenericRecord> usersRecords =
+        Arrays.asList(
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(
+                    GCSSpannerDVAvroSetupHelper.TableDef.USERS, "shard1")
+                .set("user_id", 1L)
+                .set("event_id", "E1")
+                .set("full_name", "Alice")
+                .set("age", 30)
+                .set("created_at", t1)
+                .build(),
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(
+                    GCSSpannerDVAvroSetupHelper.TableDef.USERS, "shard2")
+                .set("user_id", 1L)
+                .set("event_id", "E1")
+                .set("full_name", "Alice")
+                .set("age", 30)
+                .set("created_at", t1)
+                .build());
+
+    // These records will be dropped in Spanner to simulate a MISMATCH scenario
+    List<GenericRecord> rolesRecords =
+        Arrays.asList(
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(
+                    GCSSpannerDVAvroSetupHelper.TableDef.ACCOUNT_ROLES, "shard1")
+                .set("role_id", 1)
+                .set("role_name", "ADMIN")
+                .build(),
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(
+                    GCSSpannerDVAvroSetupHelper.TableDef.ACCOUNT_ROLES, "shard2")
+                .set("role_id", 1)
+                .set("role_name", "ADMIN")
+                .build());
+
+    String gcsInputDirectory = getGcsPath("input");
+    uploadAvroFileToGcs(
+        "input/users.avro", GCSSpannerDVAvroSetupHelper.TableDef.USERS.schema, usersRecords);
+    uploadAvroFileToGcs(
+        "input/roles.avro",
+        GCSSpannerDVAvroSetupHelper.TableDef.ACCOUNT_ROLES.schema,
+        rolesRecords);
+
+    spannerResourceManager.write(
+        Arrays.asList(
+            Mutation.newInsertOrUpdateBuilder("Users")
+                .set("user_id")
+                .to(1L)
+                .set("event_id")
+                .to("E1")
+                .set("full_name")
+                .to("Alice")
+                .set("age")
+                .to(30L)
+                .set("created_at")
+                .to(Timestamp.parseTimestamp(t1.toString()))
+                .build()));
+
+    Thread.sleep(20000);
+
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
+    LaunchInfo jobInfo =
+        launchDataflowJob(
+            options,
+            testName,
+            PROJECT,
+            spannerResourceManager,
+            bigQueryResourceManager.getDatasetId(),
+            gcsInputDirectory,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    pipelineOperator().waitUntilDone(createConfig(jobInfo));
+
+    GCSSpannerDVTestAsserts.assertValidationSummary(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new ValidationSummaryDto(
+                /* status= */ "MISMATCH",
+                /* totalTablesValidated= */ 2L,
+                /* totalRowsMatched= */ 2L,
+                /* totalRowsMismatched= */ 2L,
+                /* tablesWithMismatches= */ "AccountRoles")));
+    GCSSpannerDVTestAsserts.assertTableValidationStats(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "Users",
+                /* status= */ "MATCH",
+                /* sourceRowCount= */ 2L,
+                /* destinationRowCount= */ 2L, // TODO: @aasthabharill investigate duplicate row
+                // reporting - as this is misleading
+                /* matchedRowCount= */ 2L,
+                /* mismatchRowCount= */ 0L),
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "AccountRoles",
+                /* status= */ "MISMATCH",
+                /* sourceRowCount= */ 2L,
+                /* destinationRowCount= */ 0L,
+                /* matchedRowCount= */ 0L,
+                /* mismatchRowCount= */ 2L)));
+  }
+
+  /*
+   * Simulates duplicate PKs across shards using a shardIdColumn to disambiguate.
+   */
+  @Test
+  public void testDuplicatePKsWithShardIdColumn() throws Exception {
+    createSpannerDDL(spannerResourceManager, SPANNER_SHARDED_DDL_RESOURCE);
+
+    Instant t1 = Instant.parse("2024-01-01T10:00:00Z");
+
+    List<GenericRecord> usersRecords =
+        Arrays.asList(
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(
+                    GCSSpannerDVAvroSetupHelper.TableDef.USERS, "shard1")
+                .set("user_id", 1L)
+                .set("event_id", "E1")
+                .set("full_name", "Alice")
+                .set("age", 30)
+                .set("created_at", t1)
+                .build(),
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(
+                    GCSSpannerDVAvroSetupHelper.TableDef.USERS, "shard2")
+                .set("user_id", 1L)
+                .set("event_id", "E1")
+                .set("full_name", "Alice")
+                .set("age", 30)
+                .set("created_at", t1)
+                .build());
+
+    List<GenericRecord> rolesRecords =
+        Arrays.asList(
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(
+                    GCSSpannerDVAvroSetupHelper.TableDef.ACCOUNT_ROLES, "shard1")
+                .set("role_id", 1)
+                .set("role_name", "ADMIN")
+                .build(),
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(
+                    GCSSpannerDVAvroSetupHelper.TableDef.ACCOUNT_ROLES, "shard2")
+                .set("role_id", 1)
+                .set("role_name", "ADMIN")
+                .build() // This record will be dropped in Spanner to simulate a MISMATCH scenario
+            );
+
+    String gcsInputDirectory = getGcsPath("input");
+    uploadAvroFileToGcs(
+        "input/users.avro", GCSSpannerDVAvroSetupHelper.TableDef.USERS.schema, usersRecords);
+    uploadAvroFileToGcs(
+        "input/roles.avro",
+        GCSSpannerDVAvroSetupHelper.TableDef.ACCOUNT_ROLES.schema,
+        rolesRecords);
+
+    spannerResourceManager.write(
+        Arrays.asList(
+            Mutation.newInsertOrUpdateBuilder("Users")
+                .set("migration_shard_id")
+                .to("shard1")
+                .set("user_id")
+                .to(1L)
+                .set("event_id")
+                .to("E1")
+                .set("full_name")
+                .to("Alice")
+                .set("age")
+                .to(30L)
+                .set("created_at")
+                .to(Timestamp.parseTimestamp(t1.toString()))
+                .build(),
+            Mutation.newInsertOrUpdateBuilder("Users")
+                .set("migration_shard_id")
+                .to("shard2")
+                .set("user_id")
+                .to(1L)
+                .set("event_id")
+                .to("E1")
+                .set("full_name")
+                .to("Alice")
+                .set("age")
+                .to(30L)
+                .set("created_at")
+                .to(Timestamp.parseTimestamp(t1.toString()))
+                .build(),
+            Mutation.newInsertOrUpdateBuilder("AccountRoles")
+                .set("migration_shard_id")
+                .to("shard1")
+                .set("role_id")
+                .to(1L)
+                .set("role_name")
+                .to("ADMIN")
+                .build()));
+
+    Thread.sleep(20000);
+
+    // It's mandatory to pass the session file for the ShardIdColumn testcase so the pipeline
+    // is aware of it, since the overrides flow is currently broken for this usecase.
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
+    LaunchInfo jobInfo =
+        launchDataflowJob(
+            options,
+            testName,
+            PROJECT,
+            spannerResourceManager,
+            bigQueryResourceManager.getDatasetId(),
+            gcsInputDirectory,
+            SESSION_SHARDED_RESOURCE,
+            null,
+            null,
+            null,
+            null,
+            null);
+    pipelineOperator().waitUntilDone(createConfig(jobInfo));
+
+    GCSSpannerDVTestAsserts.assertValidationSummary(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new ValidationSummaryDto(
+                /* status= */ "MISMATCH",
+                /* totalTablesValidated= */ 2L,
+                /* totalRowsMatched= */ 3L,
+                /* totalRowsMismatched= */ 1L,
+                /* tablesWithMismatches= */ "AccountRoles")));
+    GCSSpannerDVTestAsserts.assertTableValidationStats(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "Users",
+                /* status= */ "MATCH",
+                /* sourceRowCount= */ 2L,
+                /* destinationRowCount= */ 2L,
+                /* matchedRowCount= */ 2L,
+                /* mismatchRowCount= */ 0L),
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "AccountRoles",
+                /* status= */ "MISMATCH",
+                /* sourceRowCount= */ 2L,
+                /* destinationRowCount= */ 1L,
+                /* matchedRowCount= */ 1L,
+                /* mismatchRowCount= */ 1L)));
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVShardedIT/session-sharded.json
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVShardedIT/session-sharded.json
@@ -1,0 +1,374 @@
+{
+  "SessionName": "NewSession",
+  "EditorName": "",
+  "DatabaseType": "mysql",
+  "DatabaseName": "plugin-test1",
+  "Dialect": "google_standard_sql",
+  "Notes": null,
+  "Tags": null,
+  "SpSchema": {
+    "t17": {
+      "Name": "AccountRoles",
+      "ColIds": [
+        "c_migration_shard_id",
+        "c10",
+        "c11"
+      ],
+      "ShardIdColumn": "c_migration_shard_id",
+      "ColDefs": {
+        "c_migration_shard_id": {
+          "Name": "migration_shard_id",
+          "T": {
+            "Name": "STRING",
+            "Len": 50,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Id": "c_migration_shard_id"
+        },
+        "c10": {
+          "Name": "role_id",
+          "T": {
+            "Name": "INT64",
+            "Len": 0,
+            "IsArray": false
+          },
+          "NotNull": true,
+          "Comment": "From: role_id bigint(19)",
+          "Id": "c10"
+        },
+        "c11": {
+          "Name": "role_name",
+          "T": {
+            "Name": "STRING",
+            "Len": 255,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: role_name varchar(255)",
+          "Id": "c11"
+        }
+      },
+      "PrimaryKeys": [
+        {
+          "ColId": "c_migration_shard_id",
+          "Desc": false,
+          "Order": 1
+        },
+        {
+          "ColId": "c10",
+          "Desc": false,
+          "Order": 2
+        }
+      ],
+      "ForeignKeys": null,
+      "Indexes": null,
+      "ParentTable": {
+        "Id": "",
+        "OnDelete": "",
+        "InterleaveType": ""
+      },
+      "CheckConstraints": null,
+      "Comment": "Spanner schema for source table AccountRoles",
+      "Id": "t17"
+    },
+    "t18": {
+      "Name": "Users",
+      "ColIds": [
+        "c_migration_shard_id",
+        "c12",
+        "c13",
+        "c14",
+        "c15",
+        "c16"
+      ],
+      "ShardIdColumn": "c_migration_shard_id",
+      "ColDefs": {
+        "c_migration_shard_id": {
+          "Name": "migration_shard_id",
+          "T": {
+            "Name": "STRING",
+            "Len": 50,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Id": "c_migration_shard_id"
+        },
+        "c12": {
+          "Name": "user_id",
+          "T": {
+            "Name": "INT64",
+            "Len": 0,
+            "IsArray": false
+          },
+          "NotNull": true,
+          "Comment": "From: user_id bigint(19)",
+          "Id": "c12"
+        },
+        "c13": {
+          "Name": "event_id",
+          "T": {
+            "Name": "STRING",
+            "Len": 255,
+            "IsArray": false
+          },
+          "NotNull": true,
+          "Comment": "From: event_id varchar(255)",
+          "Id": "c13"
+        },
+        "c14": {
+          "Name": "full_name",
+          "T": {
+            "Name": "STRING",
+            "Len": 255,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: full_name varchar(255)",
+          "Id": "c14"
+        },
+        "c15": {
+          "Name": "age",
+          "T": {
+            "Name": "INT64",
+            "Len": 0,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: age int(10)",
+          "Id": "c15"
+        },
+        "c16": {
+          "Name": "created_at",
+          "T": {
+            "Name": "TIMESTAMP",
+            "Len": 0,
+            "IsArray": false
+          },
+          "NotNull": false,
+          "Comment": "From: created_at timestamp",
+          "Id": "c16"
+        }
+      },
+      "PrimaryKeys": [
+        {
+          "ColId": "c_migration_shard_id",
+          "Desc": false,
+          "Order": 1
+        },
+        {
+          "ColId": "c12",
+          "Desc": false,
+          "Order": 2
+        },
+        {
+          "ColId": "c13",
+          "Desc": false,
+          "Order": 3
+        }
+      ],
+      "ForeignKeys": null,
+      "Indexes": null,
+      "ParentTable": {
+        "Id": "",
+        "OnDelete": "",
+        "InterleaveType": ""
+      },
+      "CheckConstraints": null,
+      "Comment": "Spanner schema for source table Users",
+      "Id": "t18"
+    }
+  },
+  "SyntheticPKeys": {},
+  "SrcSchema": {
+    "t17": {
+      "Name": "AccountRoles",
+      "Schema": "plugin-test1",
+      "ColIds": [
+        "c10",
+        "c11"
+      ],
+      "ColDefs": {
+        "c10": {
+          "Name": "role_id",
+          "Type": {
+            "Name": "bigint",
+            "Mods": [
+              19
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": true,
+          "Id": "c10"
+        },
+        "c11": {
+          "Name": "role_name",
+          "Type": {
+            "Name": "varchar",
+            "Mods": [
+              255
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Id": "c11"
+        }
+      },
+      "PrimaryKeys": [
+        {
+          "ColId": "c10",
+          "Desc": false,
+          "Order": 1
+        }
+      ],
+      "ForeignKeys": null,
+      "CheckConstraints": null,
+      "Indexes": null,
+      "Id": "t17"
+    },
+    "t18": {
+      "Name": "Users",
+      "Schema": "plugin-test1",
+      "ColIds": [
+        "c12",
+        "c13",
+        "c14",
+        "c15",
+        "c16"
+      ],
+      "ColDefs": {
+        "c12": {
+          "Name": "user_id",
+          "Type": {
+            "Name": "bigint",
+            "Mods": [
+              19
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": true,
+          "Id": "c12"
+        },
+        "c13": {
+          "Name": "event_id",
+          "Type": {
+            "Name": "varchar",
+            "Mods": [
+              255
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": true,
+          "Id": "c13"
+        },
+        "c14": {
+          "Name": "full_name",
+          "Type": {
+            "Name": "varchar",
+            "Mods": [
+              255
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Id": "c14"
+        },
+        "c15": {
+          "Name": "age",
+          "Type": {
+            "Name": "int",
+            "Mods": [
+              10
+            ],
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Id": "c15"
+        },
+        "c16": {
+          "Name": "created_at",
+          "Type": {
+            "Name": "timestamp",
+            "Mods": null,
+            "ArrayBounds": null
+          },
+          "NotNull": false,
+          "Id": "c16"
+        }
+      },
+      "PrimaryKeys": [
+        {
+          "ColId": "c12",
+          "Desc": false,
+          "Order": 1
+        },
+        {
+          "ColId": "c13",
+          "Desc": false,
+          "Order": 2
+        }
+      ],
+      "ForeignKeys": null,
+      "CheckConstraints": null,
+      "Indexes": null,
+      "Id": "t18"
+    }
+  },
+  "SchemaIssues": {
+    "t17": {
+      "ColumnLevelIssues": {},
+      "TableLevelIssues": null
+    },
+    "t18": {
+      "ColumnLevelIssues": {
+        "c15": [
+          14
+        ]
+      },
+      "TableLevelIssues": null
+    }
+  },
+  "InvalidCheckExp": null,
+  "ToSpanner": {
+    "AccountRoles": {
+      "Name": "AccountRoles",
+      "Cols": {
+        "role_id": "role_id",
+        "role_name": "role_name"
+      }
+    },
+    "Users": {
+      "Name": "Users",
+      "Cols": {
+        "age": "age",
+        "created_at": "created_at",
+        "event_id": "event_id",
+        "full_name": "full_name",
+        "user_id": "user_id"
+      }
+    }
+  },
+  "Location": {},
+  "TimezoneOffset": "+00:00",
+  "SpDialect": "google_standard_sql",
+  "UniquePKey": {},
+  "Rules": [],
+  "IsSharded": true,
+  "SpRegion": "",
+  "ResourceValidation": false,
+  "UI": false,
+  "SpSequences": {},
+  "SrcSequences": {},
+  "SpProjectId": "span-cloud-ck-testing-external",
+  "SpInstanceId": "ea-functional-tests",
+  "Source": "mysql",
+  "DatabaseOptions": {
+    "DbName": "",
+    "DefaultTimezone": ""
+  },
+  "DefaultIdentityOptions": {
+    "SkipRangeMin": "",
+    "SkipRangeMax": "",
+    "StartCounterWith": ""
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVShardedIT/spanner-schema-shardIdColumn.sql
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVShardedIT/spanner-schema-shardIdColumn.sql
@@ -1,0 +1,14 @@
+CREATE TABLE AccountRoles (
+    migration_shard_id STRING(50),
+    role_id INT64 NOT NULL,
+    role_name STRING(255),
+) PRIMARY KEY (migration_shard_id, role_id);
+
+CREATE TABLE Users (
+    migration_shard_id STRING(50),
+    user_id INT64 NOT NULL,
+    event_id STRING(255) NOT NULL,
+    full_name STRING(255),
+    age INT64,
+    created_at TIMESTAMP,
+) PRIMARY KEY (migration_shard_id, user_id, event_id);

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVShardedIT/spanner-schema-shardIdColumn.sql
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVShardedIT/spanner-schema-shardIdColumn.sql
@@ -1,7 +1,7 @@
 CREATE TABLE AccountRoles (
     migration_shard_id STRING(50),
     role_id INT64 NOT NULL,
-    role_name STRING(255),
+    role_name STRING(255)
 ) PRIMARY KEY (migration_shard_id, role_id);
 
 CREATE TABLE Users (
@@ -10,5 +10,5 @@ CREATE TABLE Users (
     event_id STRING(255) NOT NULL,
     full_name STRING(255),
     age INT64,
-    created_at TIMESTAMP,
+    created_at TIMESTAMP
 ) PRIMARY KEY (migration_shard_id, user_id, event_id);

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVShardedIT/spanner-schema.sql
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVShardedIT/spanner-schema.sql
@@ -1,0 +1,12 @@
+CREATE TABLE AccountRoles (
+role_id INT64 NOT NULL,
+role_name STRING(255),
+) PRIMARY KEY (role_id);
+
+CREATE TABLE Users (
+user_id INT64 NOT NULL,
+event_id STRING(255) NOT NULL,
+full_name STRING(255),
+age INT64,
+created_at TIMESTAMP,
+) PRIMARY KEY (user_id, event_id);

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVShardedIT/spanner-schema.sql
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVShardedIT/spanner-schema.sql
@@ -1,6 +1,6 @@
 CREATE TABLE AccountRoles (
 role_id INT64 NOT NULL,
-role_name STRING(255),
+role_name STRING(255)
 ) PRIMARY KEY (role_id);
 
 CREATE TABLE Users (
@@ -8,5 +8,5 @@ user_id INT64 NOT NULL,
 event_id STRING(255) NOT NULL,
 full_name STRING(255),
 age INT64,
-created_at TIMESTAMP,
+created_at TIMESTAMP
 ) PRIMARY KEY (user_id, event_id);


### PR DESCRIPTION
Call outs:
- Modified `ValidationSummary` table `setTablesWithMismatches` to sort table names before writing as currently it's completely random and non-deterministic. This makes user readability difficult (and also test assertions). Spanner supports a max of 5000 tables, so a one-time sort should not be a problem.
- The second test checks duplicate scenario which is non-ideal IMO so have added a TODO item on me to investigate further but keeping the test in to check current behaviour anyway
- validationTestWithEmptyTables was flaky due to lack of wait time so added 