### PR TITLE
Fix bug where Spanner STORING arrays were incorrectly parsed as VECTOR index keys

### DIFF
--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScanner.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScanner.java
@@ -602,13 +602,10 @@ public class InformationSchemaScanner {
         boolean isStoring = resultSet.isNull(7);
         if (isStoring) {
           indexColumnsBuilder.storing();
-        } else if (spannerType != null
-            && (spannerType.equals(tokenlistType)
-                || spannerType.startsWith("ARRAY")
-                || spannerType.contains("vector length"))) {
-          // Tokenlist columns do not have ordering.
+        } else if (ordering == null) {
+          // Unordered keys (like Vector ARRAYs and Search TOKENLISTs) have no column ordering
           indexColumnsBuilder.none();
-        } else if (ordering != null) {
+        } else {
           ordering = ordering.toUpperCase();
           if (ordering.startsWith("ASC")) {
             indexColumnsBuilder.asc();

--- a/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScanner.java
+++ b/v1/src/main/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScanner.java
@@ -599,15 +599,16 @@ public class InformationSchemaScanner {
         }
         IndexColumn.IndexColumnsBuilder<Index.Builder> indexColumnsBuilder =
             indexBuilder.columns().create().name(columnName);
-        // Tokenlist columns do not have ordering.
-        if (spannerType != null
+        boolean isStoring = resultSet.isNull(7);
+        if (isStoring) {
+          indexColumnsBuilder.storing();
+        } else if (spannerType != null
             && (spannerType.equals(tokenlistType)
                 || spannerType.startsWith("ARRAY")
                 || spannerType.contains("vector length"))) {
+          // Tokenlist columns do not have ordering.
           indexColumnsBuilder.none();
-        } else if (ordering == null) {
-          indexColumnsBuilder.storing();
-        } else {
+        } else if (ordering != null) {
           ordering = ordering.toUpperCase();
           if (ordering.startsWith("ASC")) {
             indexColumnsBuilder.asc();
@@ -633,7 +634,7 @@ public class InformationSchemaScanner {
       case GOOGLE_STANDARD_SQL:
         return Statement.of(
             "SELECT t.table_schema, t.table_name, t.column_name, t.column_ordering, t.index_name,"
-                + " t.index_type, t.spanner_type "
+                + " t.index_type, t.spanner_type, t.ordinal_position "
                 + "FROM information_schema.index_columns AS t "
                 + " WHERE t.table_schema NOT IN"
                 + " ('INFORMATION_SCHEMA', 'SPANNER_SYS')"
@@ -641,7 +642,7 @@ public class InformationSchemaScanner {
       case POSTGRESQL:
         return Statement.of(
             "SELECT t.table_schema, t.table_name, t.column_name, t.column_ordering, t.index_name,"
-                + " t.index_type, t.spanner_type "
+                + " t.index_type, t.spanner_type, t.ordinal_position "
                 + "FROM information_schema.index_columns AS t "
                 + "WHERE t.table_schema NOT IN "
                 + "('information_schema', 'spanner_sys', 'pg_catalog') "

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
@@ -1915,25 +1915,25 @@ public class InformationSchemaScannerIT extends SpannerTemplateITBase {
         });
   }
 
-  private SharedTestCase arrayStoringIndexBug() {
+  private SharedTestCase testStoringArrayColumn() {
     List<String> statements =
         Arrays.asList(
-            "CREATE TABLE `t_arrayStoringIndexBug_VectorTable` ("
+            "CREATE TABLE `t_testStoringArrayColumn_VectorTable` ("
                 + " `Id` INT64 NOT NULL,"
                 + " `MyEmbedding` ARRAY<FLOAT64>"
                 + ") PRIMARY KEY (`Id` ASC)",
-            "CREATE INDEX `i_arrayStoringIndexBug_VectorIndex` ON `t_arrayStoringIndexBug_VectorTable`(`Id` ASC) STORING (`MyEmbedding`)");
+            "CREATE INDEX `i_testStoringArrayColumn_VectorIndex` ON `t_testStoringArrayColumn_VectorTable`(`Id` ASC) STORING (`MyEmbedding`)");
 
     return new SharedTestCase(
         statements,
         ddl -> {
-          Table table = ddl.table("t_arrayStoringIndexBug_VectorTable");
+          Table table = ddl.table("t_testStoringArrayColumn_VectorTable");
           assertThat(table, notNullValue());
           assertThat(table.indexes().size(), is(1));
           assertThat(
               table.indexes().get(0),
               equalTo(
-                  "CREATE INDEX `i_arrayStoringIndexBug_VectorIndex` ON `t_arrayStoringIndexBug_VectorTable`(`Id` ASC) STORING (`MyEmbedding`)"));
+                  "CREATE INDEX `i_testStoringArrayColumn_VectorIndex` ON `t_testStoringArrayColumn_VectorTable`(`Id` ASC) STORING (`MyEmbedding`)"));
         });
   }
 
@@ -1967,7 +1967,7 @@ public class InformationSchemaScannerIT extends SpannerTemplateITBase {
             propertyGraphOnViewMixedOrder(),
             propertyGraphOnViewTablesFirst(),
             propertyGraphOnViewWithNamedSchema(),
-            arrayStoringIndexBug());
+            testStoringArrayColumn());
 
     List<String> allStatements = new ArrayList<>();
     for (SharedTestCase testCase : testCases) {

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerIT.java
@@ -1915,6 +1915,28 @@ public class InformationSchemaScannerIT extends SpannerTemplateITBase {
         });
   }
 
+  private SharedTestCase arrayStoringIndexBug() {
+    List<String> statements =
+        Arrays.asList(
+            "CREATE TABLE `t_arrayStoringIndexBug_VectorTable` ("
+                + " `Id` INT64 NOT NULL,"
+                + " `MyEmbedding` ARRAY<FLOAT64>"
+                + ") PRIMARY KEY (`Id` ASC)",
+            "CREATE INDEX `i_arrayStoringIndexBug_VectorIndex` ON `t_arrayStoringIndexBug_VectorTable`(`Id` ASC) STORING (`MyEmbedding`)");
+
+    return new SharedTestCase(
+        statements,
+        ddl -> {
+          Table table = ddl.table("t_arrayStoringIndexBug_VectorTable");
+          assertThat(table, notNullValue());
+          assertThat(table.indexes().size(), is(1));
+          assertThat(
+              table.indexes().get(0),
+              equalTo(
+                  "CREATE INDEX `i_arrayStoringIndexBug_VectorIndex` ON `t_arrayStoringIndexBug_VectorTable`(`Id` ASC) STORING (`MyEmbedding`)"));
+        });
+  }
+
   @Test
   public void sharedInformationSchemaScannerTestGsql() throws Exception {
     List<SharedTestCase> testCases =
@@ -1944,7 +1966,8 @@ public class InformationSchemaScannerIT extends SpannerTemplateITBase {
             propertyGraphOnViewSimple(),
             propertyGraphOnViewMixedOrder(),
             propertyGraphOnViewTablesFirst(),
-            propertyGraphOnViewWithNamedSchema());
+            propertyGraphOnViewWithNamedSchema(),
+            arrayStoringIndexBug());
 
     List<String> allStatements = new ArrayList<>();
     for (SharedTestCase testCase : testCases) {

--- a/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerTest.java
+++ b/v1/src/test/java/com/google/cloud/teleport/spanner/ddl/InformationSchemaScannerTest.java
@@ -185,7 +185,7 @@ public class InformationSchemaScannerTest {
         googleSQLInfoScanner.listIndexColumnsSQL().getSql(),
         equalToCompressingWhiteSpace(
             "SELECT t.table_schema, t.table_name, t.column_name, t.column_ordering, t.index_name, "
-                + "t.index_type, t.spanner_type "
+                + "t.index_type, t.spanner_type, t.ordinal_position "
                 + "FROM information_schema.index_columns AS t "
                 + " WHERE t.table_schema NOT IN"
                 + " ('INFORMATION_SCHEMA', 'SPANNER_SYS')"
@@ -195,7 +195,7 @@ public class InformationSchemaScannerTest {
         postgresSQLInfoScanner.listIndexColumnsSQL().getSql(),
         equalToCompressingWhiteSpace(
             "SELECT t.table_schema, t.table_name, t.column_name, t.column_ordering, t.index_name, "
-                + "t.index_type, t.spanner_type "
+                + "t.index_type, t.spanner_type, t.ordinal_position "
                 + "FROM information_schema.index_columns AS t "
                 + "WHERE t.table_schema NOT IN "
                 + "('information_schema', 'spanner_sys', 'pg_catalog') "


### PR DESCRIPTION
**Bug**
Previous code assumed any `ARRAY` column with a `NULL` sort order was a Vector search key. This broke standard indexes that used arrays in their `STORING` clause. Instead of treating the array as stored payload data, the export template parsed it as an index key and generated corrupted DDL.

```sql
CREATE INDEX MyIndex ON MyTable(StandardKey) STORING (MyStoredArray)
```

❌ **Bad DDL generated before this fix:**
```sql
-- The array was wrongly forced into the key list
CREATE INDEX MyIndex ON MyTable(StandardKey, MyStoredArray)
```
✅ Correct DDL generated after this fix:

```sql
CREATE INDEX MyIndex ON MyTable(StandardKey) STORING (MyStoredArray)
```