### PR TITLE
[Data Validation] Add Primary Key IT

### DIFF
--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVPrimaryKeyIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVPrimaryKeyIT.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates;
+
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.teleport.metadata.DirectRunnerTest;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import com.google.cloud.teleport.v2.spanner.migrations.transformation.CustomTransformation;
+import com.google.cloud.teleport.v2.templates.GCSSpannerDVAvroSetupHelper.RecordBuilder;
+import com.google.cloud.teleport.v2.templates.GCSSpannerDVAvroSetupHelper.TableDef;
+import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.TableValidationStatsDto;
+import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.ValidationSummaryDto;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
+import org.apache.beam.it.common.PipelineLauncher.LaunchInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Integration tests verifying complex primary key handling in the GCSSpannerDV pipeline.
+ *
+ * <p>This test suite validates the data validation pipeline's ability to accurately match records
+ * between source (Avro files in GCS) and destination (Spanner databases) when complex primary key
+ * scenarios are involved. It covers cases where primary key values are transformed, where primary
+ * key columns differ between the source schema and the destination database, and where complex Avro
+ * datatypes (like timestamp-micros) are used as primary keys.
+ */
+@Category(TemplateIntegrationTest.class)
+@RunWith(JUnit4.class)
+@TemplateIntegrationTest(GCSSpannerDV.class)
+public class GCSSpannerDVPrimaryKeyIT extends GCSSpannerDVITBase {
+
+  private static final String SPANNER_DDL_RESOURCE = "GCSSpannerDVPrimaryKeyIT/spanner-schema.sql";
+
+  @Before
+  public void setUp() throws Exception {
+    spannerResourceManager = setUpSpannerResourceManager();
+    bigQueryResourceManager = setUpBigQueryResourceManager();
+    bigQueryResourceManager.createDataset(REGION);
+    createSpannerDDL(spannerResourceManager, SPANNER_DDL_RESOURCE);
+  }
+
+  /** Transformed primary keys (value change using custom transformation). */
+  @Test
+  public void testTransformedPrimaryKey() throws Exception {
+    // 1. Setup Source Avro Data
+    TableDef transformedTableDef =
+        new TableDef(
+            TableDef.USERS.schema,
+            "Users",
+            Arrays.asList(
+                "user_id", "full_name")); // full_name as PK as this will be transformed by
+    // CustomTransformation
+
+    List<GenericRecord> usersRecords =
+        Arrays.asList(
+            new RecordBuilder(transformedTableDef, null)
+                .set("user_id", 1L)
+                .set("event_id", "E1")
+                .set("full_name", "Alice")
+                .set("age", 30)
+                .set("created_at", Instant.parse("2024-01-01T10:00:00Z"))
+                .build());
+
+    String gcsInputDirectory = getGcsPath("input");
+    uploadAvroFileToGcs("input/users.avro", transformedTableDef.schema, usersRecords);
+
+    // 2. Insert Destination Spanner Data
+    // full_name is changed to hex string by the custom transformation
+    spannerResourceManager.write(
+        Arrays.asList(
+            Mutation.newInsertOrUpdateBuilder("Users")
+                .set("user_id")
+                .to(1L)
+                .set("event_id")
+                .to("E1")
+                .set("full_name")
+                .to("416c696365") // Hex for "Alice"
+                .set("age")
+                .to(30L)
+                .set("created_at")
+                .to(
+                    Timestamp.parseTimestamp(
+                        "2024-01-01T11:00:00Z")) // CustomTransformation adds 1 hour
+                .build()));
+
+    // Wait for Spanner's 20-second exact staleness read bound in SpannerReaderTransform
+    Thread.sleep(20000);
+
+    // 3. Build Transformation and Launch Job
+    createAndUploadCustomShardJarToGcs("input");
+
+    CustomTransformation customTransformation =
+        CustomTransformation.builder(
+                "input/customTransformation.jar", "com.custom.CustomTransformationForDVIT")
+            .build();
+
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
+    LaunchInfo jobInfo =
+        launchDataflowJob(
+            options,
+            testName,
+            PROJECT,
+            spannerResourceManager,
+            bigQueryResourceManager.getDatasetId(),
+            gcsInputDirectory,
+            null,
+            null,
+            null,
+            null,
+            customTransformation,
+            null);
+
+    pipelineOperator().waitUntilDone(createConfig(jobInfo));
+
+    // 4. Validate Results
+    GCSSpannerDVTestAsserts.assertValidationSummary(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new ValidationSummaryDto(
+                /* status= */ "MATCH",
+                /* totalTablesValidated= */ 1L,
+                /* totalRowsMatched= */ 1L,
+                /* totalRowsMismatched= */ 0L,
+                /* tablesWithMismatches= */ "")));
+    GCSSpannerDVTestAsserts.assertTableValidationStats(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "Users",
+                /* status= */ "MATCH",
+                /* sourceRowCount= */ 1L,
+                /* destinationRowCount= */ 1L,
+                /* matchedRowCount= */ 1L,
+                /* mismatchRowCount= */ 0L)));
+  }
+
+  /** Modified primary key columns (where PK columns are different in SQL and Spanner). */
+  @Category({TemplateIntegrationTest.class, DirectRunnerTest.class})
+  @Test
+  public void testModifiedPrimaryKeyColumn() throws Exception {
+    // 1. Setup Source Avro Data
+    // We retain the original TableDef with 'role_id' as the primary key. This intentionally
+    // creates a mismatch with Spanner's DDL where 'role_name' is the primary key.
+    TableDef originalTableDef = TableDef.ACCOUNT_ROLES;
+
+    List<GenericRecord> rolesRecords =
+        Arrays.asList(
+            new RecordBuilder(originalTableDef, null)
+                .set("role_id", 1)
+                .set("role_name", "ADMIN")
+                .build());
+
+    String gcsInputDirectory = getGcsPath("input");
+    uploadAvroFileToGcs("input/roles.avro", originalTableDef.schema, rolesRecords);
+
+    // 2. Insert Destination Spanner Data
+    // Insert data into Spanner where 'role_name' is enforced natively as the primary key.
+    spannerResourceManager.write(
+        Arrays.asList(
+            Mutation.newInsertOrUpdateBuilder("AccountRoles")
+                .set("role_id")
+                .to(1L)
+                .set("role_name")
+                .to("ADMIN")
+                .build()));
+
+    // Wait for Spanner's 20-second exact staleness read bound in SpannerReaderTransform
+    Thread.sleep(20000);
+
+    // 3. Launch Job
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
+    LaunchInfo jobInfo =
+        launchDataflowJob(
+            options,
+            testName,
+            PROJECT,
+            spannerResourceManager,
+            bigQueryResourceManager.getDatasetId(),
+            gcsInputDirectory,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    pipelineOperator().waitUntilDone(createConfig(jobInfo));
+
+    // 4. Validate Results
+    GCSSpannerDVTestAsserts.assertValidationSummary(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new ValidationSummaryDto(
+                /* status= */ "MATCH",
+                /* totalTablesValidated= */ 1L,
+                /* totalRowsMatched= */ 1L,
+                /* totalRowsMismatched= */ 0L,
+                /* tablesWithMismatches= */ "")));
+    GCSSpannerDVTestAsserts.assertTableValidationStats(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "AccountRoles",
+                /* status= */ "MATCH",
+                /* sourceRowCount= */ 1L,
+                /* destinationRowCount= */ 1L,
+                /* matchedRowCount= */ 1L,
+                /* mismatchRowCount= */ 0L)));
+  }
+
+  /** Complex Avro datatype as PK column. */
+  @Category({TemplateIntegrationTest.class, DirectRunnerTest.class})
+  @Test
+  public void testTimestampPrimaryKey() throws Exception {
+    // 1. Setup Source Avro Data
+    // Define a new TableDef pointing to the custom Avro schema where a Timestamp field
+    // ('created_at') is the sole primary key.
+    TableDef timestampTableDef =
+        new TableDef(TableDef.USERS.schema, "Users_TimestampPK", Arrays.asList("created_at"));
+
+    Instant t1 = Instant.parse("2024-01-01T10:00:00Z");
+
+    List<GenericRecord> usersRecords =
+        Arrays.asList(
+            new RecordBuilder(timestampTableDef, null)
+                .set("user_id", 1L)
+                .set("event_id", "E1")
+                .set("full_name", "Alice")
+                .set("age", 30)
+                .set("created_at", t1)
+                .build());
+
+    String gcsInputDirectory = getGcsPath("input");
+    uploadAvroFileToGcs("input/users_timestamp.avro", timestampTableDef.schema, usersRecords);
+
+    // 2. Insert Destination Spanner Data
+    // Write matching data with the timestamp to Spanner.
+    spannerResourceManager.write(
+        Arrays.asList(
+            Mutation.newInsertOrUpdateBuilder("Users_TimestampPK")
+                .set("user_id")
+                .to(1L)
+                .set("event_id")
+                .to("E1")
+                .set("full_name")
+                .to("Alice")
+                .set("age")
+                .to(30L)
+                .set("created_at")
+                .to(Timestamp.parseTimestamp(t1.toString()))
+                .build()));
+    Thread.sleep(20000);
+
+    // 3. Launch Job
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
+    LaunchInfo jobInfo =
+        launchDataflowJob(
+            options,
+            testName,
+            PROJECT,
+            spannerResourceManager,
+            bigQueryResourceManager.getDatasetId(),
+            gcsInputDirectory,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    pipelineOperator().waitUntilDone(createConfig(jobInfo));
+
+    // 4. Validate Results
+    GCSSpannerDVTestAsserts.assertValidationSummary(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new ValidationSummaryDto(
+                /* status= */ "MATCH",
+                /* totalTablesValidated= */ 1L,
+                /* totalRowsMatched= */ 1L,
+                /* totalRowsMismatched= */ 0L,
+                /* tablesWithMismatches= */ "")));
+    GCSSpannerDVTestAsserts.assertTableValidationStats(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "Users_TimestampPK",
+                /* status= */ "MATCH",
+                /* sourceRowCount= */ 1L,
+                /* destinationRowCount= */ 1L,
+                /* matchedRowCount= */ 1L,
+                /* mismatchRowCount= */ 0L)));
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVPrimaryKeyIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVPrimaryKeyIT.java
@@ -62,6 +62,9 @@ public class GCSSpannerDVPrimaryKeyIT extends GCSSpannerDVITBase {
   /** Transformed primary keys (value change using custom transformation). */
   @Test
   public void testTransformedPrimaryKey() throws Exception {
+    // We run this test using DataflowRunner to avoid custom transformation resource leakage that
+    // happens in DirectRunner.
+
     // 1. Setup Source Avro Data
     TableDef transformedTableDef =
         new TableDef(
@@ -164,7 +167,7 @@ public class GCSSpannerDVPrimaryKeyIT extends GCSSpannerDVITBase {
     List<GenericRecord> rolesRecords =
         Arrays.asList(
             new RecordBuilder(originalTableDef, null)
-                .set("role_id", 1L)
+                .set("role_id", 1)
                 .set("role_name", "ADMIN")
                 .build());
 

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVPrimaryKeyIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVPrimaryKeyIT.java
@@ -62,17 +62,14 @@ public class GCSSpannerDVPrimaryKeyIT extends GCSSpannerDVITBase {
   /** Transformed primary keys (value change using custom transformation). */
   @Test
   public void testTransformedPrimaryKey() throws Exception {
-    // We run this test using DataflowRunner to avoid custom transformation resource leakage that
-    // happens in DirectRunner.
-
     // 1. Setup Source Avro Data
     TableDef transformedTableDef =
         new TableDef(
             TableDef.USERS.schema,
-            "Users",
+            "Users_PKTransformed",
             Arrays.asList(
-                "user_id", "full_name")); // full_name as PK as this will be transformed by
-    // CustomTransformation
+                "user_id",
+                "full_name")); // user_id as PK as this will be transformed by CustomTransformation
 
     List<GenericRecord> usersRecords =
         Arrays.asList(
@@ -88,22 +85,19 @@ public class GCSSpannerDVPrimaryKeyIT extends GCSSpannerDVITBase {
     uploadAvroFileToGcs("input/users.avro", transformedTableDef.schema, usersRecords);
 
     // 2. Insert Destination Spanner Data
-    // full_name is changed to hex string by the custom transformation
     spannerResourceManager.write(
         Arrays.asList(
-            Mutation.newInsertOrUpdateBuilder("Users")
+            Mutation.newInsertOrUpdateBuilder("Users_Transformed")
                 .set("user_id")
-                .to(1L)
+                .to(11L) // Transformed
                 .set("event_id")
                 .to("E1")
                 .set("full_name")
-                .to("416c696365") // Hex for "Alice"
+                .to("Alice")
                 .set("age")
                 .to(30L)
                 .set("created_at")
-                .to(
-                    Timestamp.parseTimestamp(
-                        "2024-01-01T11:00:00Z")) // CustomTransformation adds 1 hour
+                .to(Timestamp.parseTimestamp("2024-01-01T10:00:00Z"))
                 .build()));
 
     // 3. Build Transformation and Launch Job
@@ -147,7 +141,7 @@ public class GCSSpannerDVPrimaryKeyIT extends GCSSpannerDVITBase {
         Arrays.asList(
             new TableValidationStatsDto(
                 /* schemaName= */ null,
-                /* tableName= */ "Users",
+                /* tableName= */ "Users_Transformed",
                 /* status= */ "MATCH",
                 /* sourceRowCount= */ 1L,
                 /* destinationRowCount= */ 1L,

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVPrimaryKeyIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVPrimaryKeyIT.java
@@ -87,7 +87,7 @@ public class GCSSpannerDVPrimaryKeyIT extends GCSSpannerDVITBase {
     // 2. Insert Destination Spanner Data
     spannerResourceManager.write(
         Arrays.asList(
-            Mutation.newInsertOrUpdateBuilder("Users_Transformed")
+            Mutation.newInsertOrUpdateBuilder("Users_PKTransformed")
                 .set("user_id")
                 .to(11L) // Transformed
                 .set("event_id")
@@ -141,7 +141,7 @@ public class GCSSpannerDVPrimaryKeyIT extends GCSSpannerDVITBase {
         Arrays.asList(
             new TableValidationStatsDto(
                 /* schemaName= */ null,
-                /* tableName= */ "Users_Transformed",
+                /* tableName= */ "Users_PKTransformed",
                 /* status= */ "MATCH",
                 /* sourceRowCount= */ 1L,
                 /* destinationRowCount= */ 1L,

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVPrimaryKeyIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVPrimaryKeyIT.java
@@ -37,13 +37,12 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /**
- * Integration tests verifying complex primary key handling in the GCSSpannerDV pipeline.
- *
- * <p>This test suite validates the data validation pipeline's ability to accurately match records
- * between source (Avro files in GCS) and destination (Spanner databases) when complex primary key
- * scenarios are involved. It covers cases where primary key values are transformed, where primary
- * key columns differ between the source schema and the destination database, and where complex Avro
- * datatypes (like timestamp-micros) are used as primary keys.
+ * Integration tests verifying complex primary key handling in the GCSSpannerDV pipeline. This test
+ * suite validates the data validation pipeline's ability to accurately match records between source
+ * (Avro files in GCS) and destination (Spanner databases) when complex primary key scenarios are
+ * involved. It covers cases where primary key values are transformed, where primary key columns
+ * differ between the source schema and the destination database, and where complex Avro datatypes
+ * (like timestamp-micros) are used as primary keys.
  */
 @Category(TemplateIntegrationTest.class)
 @RunWith(JUnit4.class)
@@ -103,9 +102,6 @@ public class GCSSpannerDVPrimaryKeyIT extends GCSSpannerDVITBase {
                     Timestamp.parseTimestamp(
                         "2024-01-01T11:00:00Z")) // CustomTransformation adds 1 hour
                 .build()));
-
-    // Wait for Spanner's 20-second exact staleness read bound in SpannerReaderTransform
-    Thread.sleep(20000);
 
     // 3. Build Transformation and Launch Job
     createAndUploadCustomShardJarToGcs("input");
@@ -168,7 +164,7 @@ public class GCSSpannerDVPrimaryKeyIT extends GCSSpannerDVITBase {
     List<GenericRecord> rolesRecords =
         Arrays.asList(
             new RecordBuilder(originalTableDef, null)
-                .set("role_id", 1)
+                .set("role_id", 1L)
                 .set("role_name", "ADMIN")
                 .build());
 

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVPrimaryKeyIT/spanner-schema.sql
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVPrimaryKeyIT/spanner-schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE Users (
+CREATE TABLE Users_PKTransformed (
     user_id INT64,
     event_id STRING(MAX),
     full_name STRING(MAX),

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVPrimaryKeyIT/spanner-schema.sql
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVPrimaryKeyIT/spanner-schema.sql
@@ -1,0 +1,20 @@
+CREATE TABLE Users (
+    user_id INT64,
+    event_id STRING(MAX),
+    full_name STRING(MAX),
+    age INT64,
+    created_at TIMESTAMP
+) PRIMARY KEY (user_id, full_name);
+
+CREATE TABLE AccountRoles (
+    role_id INT64,
+    role_name STRING(MAX)
+) PRIMARY KEY (role_name);
+
+CREATE TABLE Users_TimestampPK (
+    user_id INT64,
+    event_id STRING(MAX),
+    full_name STRING(MAX),
+    age INT64,
+    created_at TIMESTAMP
+) PRIMARY KEY (created_at);

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertor.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertor.java
@@ -261,6 +261,9 @@ public class GenericRecordTypeConvertor {
       return null;
     }
     Map<String, Object> transformedCols = migrationTransformationResponse.getResponseRow();
+    if (transformedCols == null) {
+      return result;
+    }
     for (Map.Entry<String, Object> entry : transformedCols.entrySet()) {
       LOG.debug(
           "Updating record with {} from custom transformations for table {}", entry, srcTableName);

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertorTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/GenericRecordTypeConvertorTest.java
@@ -687,18 +687,22 @@ public class GenericRecordTypeConvertorTest {
     assertThat(genericRecordTypeConvertor.transformChangeEvent(payload, "few_types"))
         .isEqualTo(
             Map.of(
-                "booleanCol", Value.bool(true),
-                "intervalNanoCol", Value.string("P1083Y4M3890DT30H31M12.000000009S"),
+                "booleanCol",
+                Value.bool(true),
+                "intervalNanoCol",
+                Value.string("P1083Y4M3890DT30H31M12.000000009S"),
                 "timeStampCol",
-                    Value.timestamp(Timestamp.parseTimestamp("2020-10-13T14:30:00.056000000Z")),
-                "booleanArrayCol", Value.boolArray(ImmutableList.of(true, false)),
+                Value.timestamp(Timestamp.parseTimestamp("2020-10-13T14:30:00.056000000Z")),
+                "booleanArrayCol",
+                Value.boolArray(ImmutableList.of(true, false)),
                 "intervalNanoArrayCol",
-                    Value.stringArray(
-                        ImmutableList.of(
-                            "P1083Y4M3890DT30H31M12.000000009S",
-                            "P1083Y4M3890DT30H31M12.000000009S",
-                            "P1083Y4M3890DT25H12.000000009S")),
-                "timeStampArrayCol", Value.timestampArray(expectedTimeStampArray)));
+                Value.stringArray(
+                    ImmutableList.of(
+                        "P1083Y4M3890DT30H31M12.000000009S",
+                        "P1083Y4M3890DT30H31M12.000000009S",
+                        "P1083Y4M3890DT25H12.000000009S")),
+                "timeStampArrayCol",
+                Value.timestampArray(expectedTimeStampArray)));
   }
 
   @Test
@@ -1033,16 +1037,24 @@ public class GenericRecordTypeConvertorTest {
         genericRecordTypeConvertor.transformChangeEvent(genericRecord, "all_types");
     Map<String, Value> expected =
         Map.of(
-            "bool_col", Value.bool(true),
-            "int_col", Value.int64(10),
-            "float_col", Value.float64(10.34),
-            "string_col", Value.string("hello"),
-            "numeric_col", Value.numeric(new BigDecimal("12.340000000")),
-            "bytes_col", Value.bytes(ByteArray.copyFrom(new byte[] {10, 20, 30})),
+            "bool_col",
+            Value.bool(true),
+            "int_col",
+            Value.int64(10),
+            "float_col",
+            Value.float64(10.34),
+            "string_col",
+            Value.string("hello"),
+            "numeric_col",
+            Value.numeric(new BigDecimal("12.340000000")),
+            "bytes_col",
+            Value.bytes(ByteArray.copyFrom(new byte[] {10, 20, 30})),
             "timestamp_col",
-                Value.timestamp(Timestamp.parseTimestamp("2020-10-13T14:30:00.056483Z")),
-            "date_col", Value.date(com.google.cloud.Date.parseDate("3993-04-16")),
-            "simple_array_col", Value.stringArray(ImmutableList.of("G", "O", "O", "G")));
+            Value.timestamp(Timestamp.parseTimestamp("2020-10-13T14:30:00.056483Z")),
+            "date_col",
+            Value.date(com.google.cloud.Date.parseDate("3993-04-16")),
+            "simple_array_col",
+            Value.stringArray(ImmutableList.of("G", "O", "O", "G")));
     // Implementation Detail, the transform returns Spanner values, and Value.Null is not equal to
     // java null,
     // So simple transform for expected map to have null values does not work for us.
@@ -1564,6 +1576,55 @@ public class GenericRecordTypeConvertorTest {
         new byte[] {127, -1, -1, -1, -1, -1, -1, -1}; // Signed bytes for 0x7F FF...
 
     assertEquals(Value.bytes(ByteArray.copyFrom(expectedBytes)), actual.get("bytes_col"));
+  }
+
+  @Test
+  public void transformChangeEventTest_NullResponseRowFromCustomTransform()
+      throws InvalidTransformationException {
+    /*
+     * This test verifies that if a Custom Transformation returns a MigrationTransformationResponse
+     * with a null responseRow (meaning no custom transformation is applied to this record),
+     * the pipeline safely falls back to returning the original row instead of throwing a NullPointerException.
+     */
+    GenericRecord genericRecord = new GenericData.Record(getAllSpannerTypesSchema());
+    genericRecord.put("int_col", 123L);
+    genericRecord.put("string_col", "test_string");
+
+    // Define a transformer that returns null for responseRow
+    ISpannerMigrationTransformer nullResponseRowTransformer =
+        new ISpannerMigrationTransformer() {
+          @Override
+          public void init(String customParameters) {}
+
+          @Override
+          public MigrationTransformationResponse toSpannerRow(
+              MigrationTransformationRequest request) {
+            return new MigrationTransformationResponse(null, false);
+          }
+
+          @Override
+          public MigrationTransformationResponse toSourceRow(
+              MigrationTransformationRequest request) {
+            return null;
+          }
+
+          @Override
+          public MigrationTransformationResponse transformFailedSpannerMutation(
+              MigrationTransformationRequest request) throws InvalidTransformationException {
+            return new MigrationTransformationResponse(request.getRequestRow(), false);
+          }
+        };
+
+    GenericRecordTypeConvertor genericRecordTypeConvertor =
+        new GenericRecordTypeConvertor(
+            new IdentityMapper(getIdentityDdl()), "", null, nullResponseRowTransformer);
+
+    Map<String, Value> actual =
+        genericRecordTypeConvertor.transformChangeEvent(genericRecord, "all_types");
+
+    // Expected: The original row is returned untouched
+    assertEquals(Value.int64(123L), actual.get("int_col"));
+    assertEquals(Value.string("test_string"), actual.get("string_col"));
   }
 
   private class TestCustomTransform implements ISpannerMigrationTransformer {

--- a/v2/spanner-custom-shard/pom.xml
+++ b/v2/spanner-custom-shard/pom.xml
@@ -61,6 +61,7 @@
                         <!-- Excluding auto-generated classes. -->
                         <exclude>**/*AutoValue_*</exclude>
                         <exclude>**/CustomTransformationForCassandraAllDataTypesIT.*</exclude>
+                        <exclude>**/CustomTransformationForDVIT.*</exclude>
                     </excludes>
                 </configuration>
                 <executions>

--- a/v2/spanner-custom-shard/src/main/java/com/custom/CustomTransformationForDVIT.java
+++ b/v2/spanner-custom-shard/src/main/java/com/custom/CustomTransformationForDVIT.java
@@ -46,7 +46,7 @@ public class CustomTransformationForDVIT implements ISpannerMigrationTransformer
       throws InvalidTransformationException {
 
     Map<String, Object> row = request.getRequestRow();
-    Map<String, Object> responseRow = new HashMap<>(row);
+    Map<String, Object> responseRow = new HashMap<>();
 
     if ("Users".equals(request.getTableName())) {
       // Filter out records where age is 99
@@ -67,6 +67,16 @@ public class CustomTransformationForDVIT implements ISpannerMigrationTransformer
         Instant t = Instant.parse((String) row.get("created_at"));
         Instant shifted = t.plus(1, ChronoUnit.HOURS);
         responseRow.put("created_at", shifted);
+      }
+
+      return new MigrationTransformationResponse(responseRow, false);
+    }
+
+    if ("Users_PKTransformed".equals(request.getTableName())) {
+      // Transform Primary Key user_id
+      if (row.get("user_id") != null) {
+        long id = ((Number) row.get("user_id")).longValue();
+        responseRow.put("user_id", id + 10);
       }
 
       return new MigrationTransformationResponse(responseRow, false);


### PR DESCRIPTION
**Call out:**
Three test cases:
1. Transformed primary keys (value change using custom transformation)
2. Modified primary key columns (where PK columns are different in SQL and Spanner)
3. Complex Avro datatype as PK column

The first one uses a transformation, and as seen in [this](https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/4062) PR, this needs to be run on **DataflowRunner** to avoid resource leaks. The rest of the test methods are functional and so have been configured to run on **DirectRunner**

