### PR TITLE
[Data Validation] Add GCSSpannerDVSchemaTransformationsIT

### DIFF
--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/BulkMigrationAndValidationE2EIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/BulkMigrationAndValidationE2EIT.java
@@ -230,14 +230,13 @@ public class BulkMigrationAndValidationE2EIT extends EndToEndTestingITBase {
                 /* matchedRowCount= */ 3L,
                 /* mismatchRowCount= */ 0L)));
 
+    // Note: In case of a data mismatch, getting two separate rows (one MISSING_IN_SOURCE
+    // and one MISSING_IN_DESTINATION) is the expected behavior.
     GCSSpannerDVTestAsserts.assertMismatchedRecords(
         bigQueryResourceManager,
         Arrays.asList(
             new MismatchedRecordDto(
                 null, null, "Users", "[user_id:2, event_id:E2]", "MISSING_IN_DESTINATION"),
-            // Note: gcs-spanner-dv currently lacks a MISMATCHED_VALUE category.
-            // Differing row values (like User 4's age) are emitted as two discrepancies:
-            // one MISSING_IN_SOURCE and one MISSING_IN_DESTINATION.
             new MismatchedRecordDto(
                 null, null, "Users", "[user_id:4, event_id:E4]", "MISSING_IN_DESTINATION"),
             new MismatchedRecordDto(

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVCoreMatchingIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVCoreMatchingIT.java
@@ -244,14 +244,13 @@ public class GCSSpannerDVCoreMatchingIT extends GCSSpannerDVITBase {
                 /* matchedRowCount= */ 3L,
                 /* mismatchRowCount= */ 0L)));
 
+    // Note: In case of a data mismatch, getting two separate rows (one MISSING_IN_SOURCE
+    // and one MISSING_IN_DESTINATION) is the expected behavior.
     GCSSpannerDVTestAsserts.assertMismatchedRecords(
         bigQueryResourceManager,
         Arrays.asList(
             new MismatchedRecordDto(
                 null, null, "Users", "[user_id:2, event_id:E2]", "MISSING_IN_DESTINATION"),
-            // Note: gcs-spanner-dv currently lacks a MISMATCHED_VALUE category.
-            // Differing row values (like User 4's age) are emitted as two discrepancies:
-            // one MISSING_IN_SOURCE and one MISSING_IN_DESTINATION.
             new MismatchedRecordDto(
                 null, null, "Users", "[user_id:4, event_id:E4]", "MISSING_IN_DESTINATION"),
             new MismatchedRecordDto(

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVCustomTransformationIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVCustomTransformationIT.java
@@ -58,7 +58,7 @@ public class GCSSpannerDVCustomTransformationIT extends GCSSpannerDVITBase {
     createSpannerDDL(spannerResourceManager, SPANNER_DDL_RESOURCE);
 
     // Create and upload jar for custom transformations
-    createAndUploadCustomShardJarToGcs("custom");
+    uploadCustomShardJarToGcs("custom");
   }
 
   /**

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVITBase.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVITBase.java
@@ -200,8 +200,7 @@ public abstract class GCSSpannerDVITBase extends TemplateTestBase {
     return jobInfo;
   }
 
-  public void uploadCustomShardJarToGcs(String gcsPathPrefix)
-      throws IOException {
+  public void uploadCustomShardJarToGcs(String gcsPathPrefix) throws IOException {
     gcsClient.uploadArtifact(
         gcsPathPrefix + "/customTransformation.jar",
         "../spanner-custom-shard/target/spanner-custom-shard-1.0-SNAPSHOT.jar");

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVITBase.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVITBase.java
@@ -33,7 +33,6 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
 import org.apache.beam.it.common.PipelineLauncher.LaunchInfo;
-import org.apache.beam.it.common.utils.IORedirectUtil;
 import org.apache.beam.it.common.utils.PipelineUtils;
 import org.apache.beam.it.gcp.TemplateTestBase;
 import org.apache.beam.it.gcp.bigquery.BigQueryResourceManager;
@@ -201,20 +200,8 @@ public abstract class GCSSpannerDVITBase extends TemplateTestBase {
     return jobInfo;
   }
 
-  public void createAndUploadCustomShardJarToGcs(String gcsPathPrefix)
-      throws IOException, InterruptedException {
-    ProcessBuilder processBuilder =
-        new ProcessBuilder("mvn", "clean", "package", "-DskipTests")
-            .directory(new File("../spanner-custom-shard"));
-
-    Process exec = processBuilder.start();
-
-    IORedirectUtil.redirectLinesLog(exec.getInputStream(), LOG);
-    IORedirectUtil.redirectLinesLog(exec.getErrorStream(), LOG);
-
-    if (exec.waitFor() != 0) {
-      throw new RuntimeException("Error staging template, check Maven logs.");
-    }
+  public void uploadCustomShardJarToGcs(String gcsPathPrefix)
+      throws IOException {
     gcsClient.uploadArtifact(
         gcsPathPrefix + "/customTransformation.jar",
         "../spanner-custom-shard/target/spanner-custom-shard-1.0-SNAPSHOT.jar");

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVPrimaryKeyIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVPrimaryKeyIT.java
@@ -101,7 +101,7 @@ public class GCSSpannerDVPrimaryKeyIT extends GCSSpannerDVITBase {
                 .build()));
 
     // 3. Build Transformation and Launch Job
-    createAndUploadCustomShardJarToGcs("input");
+    uploadCustomShardJarToGcs("input");
 
     CustomTransformation customTransformation =
         CustomTransformation.builder(

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedColumnsIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedColumnsIT.java
@@ -239,6 +239,8 @@ public class GCSSpannerDVRenamedColumnsIT extends GCSSpannerDVITBase {
                 /* matchedRowCount= */ 0L,
                 /* mismatchRowCount= */ 2L)));
 
+    // Note: In case of a data mismatch, getting two separate rows (one MISSING_IN_SOURCE
+    // and one MISSING_IN_DESTINATION) is the expected behavior.
     GCSSpannerDVTestAsserts.assertMismatchedRecords(
         bigQueryResourceManager,
         Arrays.asList(

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedTableIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVRenamedTableIT.java
@@ -248,6 +248,8 @@ public class GCSSpannerDVRenamedTableIT extends GCSSpannerDVITBase {
                 /* matchedRowCount= */ 0L,
                 /* mismatchRowCount= */ 1L)));
 
+    // Note: In case of a data mismatch, getting two separate rows (one MISSING_IN_SOURCE
+    // and one MISSING_IN_DESTINATION) is the expected behavior.
     GCSSpannerDVTestAsserts.assertMismatchedRecords(
         bigQueryResourceManager,
         Arrays.asList(

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVSchemaTransformationsIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVSchemaTransformationsIT.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates;
+
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.teleport.metadata.DirectRunnerTest;
+import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import com.google.cloud.teleport.v2.spanner.migrations.transformation.CustomTransformation;
+import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.MismatchedRecordDto;
+import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.TableValidationStatsDto;
+import com.google.cloud.teleport.v2.templates.GCSSpannerDVTestAsserts.ValidationSummaryDto;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
+import org.apache.beam.it.common.PipelineLauncher.LaunchInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Integration tests covering edge cases where Source and Spanner schemas have differences. Tests:
+ *
+ * <p>1. Data type differences (that don't require custom transformation)
+ *
+ * <p>2. Dropped columns in Spanner
+ *
+ * <p>3. Newly added columns in Spanner (populated via a custom transformation).
+ */
+@Category(TemplateIntegrationTest.class)
+@RunWith(JUnit4.class)
+@TemplateIntegrationTest(GCSSpannerDV.class)
+public class GCSSpannerDVSchemaTransformationsIT extends GCSSpannerDVITBase {
+
+  private static final String SPANNER_DDL_RESOURCE =
+      "GCSSpannerDVSchemaTransformationsIT/spanner-schema.sql";
+
+  @Before
+  public void setUp() throws IOException {
+    spannerResourceManager = setUpSpannerResourceManager();
+    bigQueryResourceManager = setUpBigQueryResourceManager();
+    bigQueryResourceManager.createDataset(REGION);
+    createSpannerDDL(spannerResourceManager, SPANNER_DDL_RESOURCE);
+  }
+
+  /**
+   * Tests data type change (STRING to INT64) of a non-PK column that doesn't require explicit
+   * handling via custom transformations and are automatically handled by the pipeline.
+   */
+  @Test
+  @Category({TemplateIntegrationTest.class, DirectRunnerTest.class})
+  public void testDataTypeDifference() throws Exception {
+    GCSSpannerDVAvroSetupHelper.TableDef tableDef =
+        GCSSpannerDVAvroSetupHelper.TableDef.ACCOUNT_ROLES;
+
+    List<GenericRecord> sourceRecords =
+        Arrays.asList(
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(tableDef, null)
+                .set("role_id", 1)
+                .set("role_name", "1234")
+                .build(), // Match scenario
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(tableDef, null)
+                .set("role_id", 2)
+                .set("role_name", "5678")
+                .build() // Mismatch scenario
+            );
+
+    String gcsInputDirectory = getGcsPath("input");
+    uploadAvroFileToGcs("input/account_roles.avro", tableDef.schema, sourceRecords);
+
+    spannerResourceManager.write(
+        Arrays.asList(
+            Mutation.newInsertOrUpdateBuilder("AccountRoles")
+                .set("role_id")
+                .to(1L)
+                .set("role_name")
+                .to(1234L) // role_name as INT
+                .build(),
+            Mutation.newInsertOrUpdateBuilder("AccountRoles")
+                .set("role_id")
+                .to(2L)
+                .set("role_name")
+                .to(9999L) // Mismatch
+                .build()));
+
+    // Wait for exact staleness
+    Thread.sleep(20000);
+
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
+    LaunchInfo jobInfo =
+        launchDataflowJob(
+            options,
+            testName,
+            PROJECT,
+            spannerResourceManager,
+            bigQueryResourceManager.getDatasetId(),
+            gcsInputDirectory,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    pipelineOperator().waitUntilDone(createConfig(jobInfo));
+
+    System.out.println("DEBUG MismatchedRecords:");
+    bigQueryResourceManager
+        .readTable("MismatchedRecords")
+        .iterateAll()
+        .forEach(r -> System.out.println(r.toString()));
+
+    GCSSpannerDVTestAsserts.assertValidationSummary(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new ValidationSummaryDto(
+                /* status= */ "MISMATCH",
+                /* totalTablesValidated= */ 1L,
+                /* totalRowsMatched= */ 1L,
+                /* totalRowsMismatched= */ 2L,
+                /* tablesWithMismatches= */ "AccountRoles")));
+
+    GCSSpannerDVTestAsserts.assertTableValidationStats(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "AccountRoles",
+                /* status= */ "MISMATCH",
+                /* sourceRowCount= */ 2L,
+                /* destinationRowCount= */ 2L,
+                /* matchedRowCount= */ 1L,
+                /* mismatchRowCount= */ 2L)));
+
+    // Verify role_name column mismatch (Source: 5678, Spanner: 9999)
+    // Note: gcs-spanner-dv currently lacks a MISMATCHED_VALUE category. Differing row values are
+    // emitted as two discrepancies: one MISSING_IN_SOURCE and one MISSING_IN_DESTINATION.
+    GCSSpannerDVTestAsserts.assertMismatchedRecords(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new MismatchedRecordDto(
+                /* shardId= */ null,
+                /* schemaName= */ null,
+                /* tableName= */ "AccountRoles",
+                /* recordKey= */ "[role_id:2]",
+                /* mismatchType= */ "MISSING_IN_DESTINATION"),
+            new MismatchedRecordDto(
+                /* shardId= */ null,
+                /* schemaName= */ null,
+                /* tableName= */ "AccountRoles",
+                /* recordKey= */ "[role_id:2]",
+                /* mismatchType= */ "MISSING_IN_SOURCE")));
+  }
+
+  /** Tests pipeline resilience when columns present in the source are dropped in Spanner. */
+  @Test
+  @Category({TemplateIntegrationTest.class, DirectRunnerTest.class})
+  public void testDroppedColumnInSpanner() throws Exception {
+    GCSSpannerDVAvroSetupHelper.TableDef tableDef = GCSSpannerDVAvroSetupHelper.TableDef.USERS;
+
+    Instant t1 = Instant.parse("2024-01-01T10:00:00Z");
+
+    List<GenericRecord> sourceRecords =
+        Arrays.asList(
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(tableDef, null)
+                .set("user_id", 1L)
+                .set("event_id", "E1")
+                .set("full_name", "Alice")
+                .set("age", 30) // Age is dropped in Spanner
+                .set("created_at", t1)
+                .build(), // Match scenario on remaining columns
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(tableDef, null)
+                .set("user_id", 2L)
+                .set("event_id", "E2")
+                .set("full_name", "Bob")
+                .set("age", 35)
+                .set("created_at", t1)
+                .build() // Mismatch scenario on full_name
+            );
+
+    String gcsInputDirectory = getGcsPath("input");
+    uploadAvroFileToGcs("input/users.avro", tableDef.schema, sourceRecords);
+
+    spannerResourceManager.write(
+        Arrays.asList(
+            Mutation.newInsertOrUpdateBuilder("Users")
+                .set("user_id")
+                .to(1L)
+                .set("event_id")
+                .to("E1")
+                .set("full_name")
+                .to("Alice")
+                .set("created_at")
+                .to(Timestamp.parseTimestamp(t1.toString()))
+                .build(),
+            Mutation.newInsertOrUpdateBuilder("Users")
+                .set("user_id")
+                .to(2L)
+                .set("event_id")
+                .to("E2")
+                .set("full_name")
+                .to("Bobby") // Mismatch in full_name
+                .set("created_at")
+                .to(Timestamp.parseTimestamp(t1.toString()))
+                .build()));
+
+    // Wait for exact staleness
+    Thread.sleep(20000);
+
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
+    LaunchInfo jobInfo =
+        launchDataflowJob(
+            options,
+            testName,
+            PROJECT,
+            spannerResourceManager,
+            bigQueryResourceManager.getDatasetId(),
+            gcsInputDirectory,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    pipelineOperator().waitUntilDone(createConfig(jobInfo));
+
+    GCSSpannerDVTestAsserts.assertValidationSummary(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new ValidationSummaryDto(
+                /* status= */ "MISMATCH",
+                /* totalTablesValidated= */ 1L,
+                /* totalRowsMatched= */ 1L,
+                /* totalRowsMismatched= */ 2L,
+                /* tablesWithMismatches= */ "Users")));
+
+    GCSSpannerDVTestAsserts.assertTableValidationStats(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "Users",
+                /* status= */ "MISMATCH",
+                /* sourceRowCount= */ 2L,
+                /* destinationRowCount= */ 2L,
+                /* matchedRowCount= */ 1L,
+                /* mismatchRowCount= */ 2L)));
+
+    // Verify full_name column mismatch (Source: Bob, Spanner: Bobby)
+    GCSSpannerDVTestAsserts.assertMismatchedRecords(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new MismatchedRecordDto(
+                /* shardId= */ null,
+                /* schemaName= */ null,
+                /* tableName= */ "Users",
+                /* recordKey= */ "[user_id:2, event_id:E2]",
+                /* mismatchType= */ "MISSING_IN_DESTINATION"),
+            new MismatchedRecordDto(
+                /* shardId= */ null,
+                /* schemaName= */ null,
+                /* tableName= */ "Users",
+                /* recordKey= */ "[user_id:2, event_id:E2]",
+                /* mismatchType= */ "MISSING_IN_SOURCE")));
+  }
+
+  /**
+   * Tests pipeline validation when new columns are added in Spanner and populated via custom
+   * transform.
+   */
+  @Test
+  @Category({TemplateIntegrationTest.class, SkipDirectRunnerTest.class})
+  public void testAddedColumnInSpanner() throws Exception {
+    GCSSpannerDVAvroSetupHelper.TableDef tableDef =
+        new GCSSpannerDVAvroSetupHelper.TableDef(
+            GCSSpannerDVAvroSetupHelper.TableDef.USERS.schema,
+            "Users_AddedColumn",
+            Arrays.asList("user_id", "event_id"));
+
+    Instant t1 = Instant.parse("2024-01-01T10:00:00Z");
+
+    List<GenericRecord> sourceRecords =
+        Arrays.asList(
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(tableDef, null)
+                .set("user_id", 1L)
+                .set("event_id", "E1")
+                .set("full_name", "Alice")
+                .set("age", 30)
+                .set("created_at", t1)
+                .build(), // Match scenario (Custom transform adds status ACTIVE)
+            new GCSSpannerDVAvroSetupHelper.RecordBuilder(tableDef, null)
+                .set("user_id", 2L)
+                .set("event_id", "E2")
+                .set("full_name", "Bob")
+                .set("age", 35)
+                .set("created_at", t1)
+                .build() // Mismatch scenario (Spanner has status INACTIVE)
+            );
+
+    String gcsInputDirectory = getGcsPath("input");
+    uploadAvroFileToGcs("input/users_added_column.avro", tableDef.schema, sourceRecords);
+
+    spannerResourceManager.write(
+        Arrays.asList(
+            Mutation.newInsertOrUpdateBuilder("Users_AddedColumn")
+                .set("user_id")
+                .to(1L)
+                .set("event_id")
+                .to("E1")
+                .set("full_name")
+                .to("Alice")
+                .set("age")
+                .to(30L)
+                .set("status")
+                .to("ACTIVE") // Match scenario
+                .set("created_at")
+                .to(Timestamp.parseTimestamp(t1.toString()))
+                .build(),
+            Mutation.newInsertOrUpdateBuilder("Users_AddedColumn")
+                .set("user_id")
+                .to(2L)
+                .set("event_id")
+                .to("E2")
+                .set("full_name")
+                .to("Bob")
+                .set("age")
+                .to(35L)
+                .set("status")
+                .to("INACTIVE") // Mismatch scenario
+                .set("created_at")
+                .to(Timestamp.parseTimestamp(t1.toString()))
+                .build()));
+
+    // DataflowRunner does not need Thread.sleep(20000)
+
+    createAndUploadCustomShardJarToGcs("custom");
+    CustomTransformation customTransformation =
+        CustomTransformation.builder(
+                "custom/customTransformation.jar", "com.custom.CustomTransformationForDVIT")
+            .build();
+
+    LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
+    LaunchInfo jobInfo =
+        launchDataflowJob(
+            options,
+            testName,
+            PROJECT,
+            spannerResourceManager,
+            bigQueryResourceManager.getDatasetId(),
+            gcsInputDirectory,
+            null,
+            null,
+            null,
+            null,
+            customTransformation,
+            null);
+
+    pipelineOperator().waitUntilDone(createConfig(jobInfo));
+
+    GCSSpannerDVTestAsserts.assertValidationSummary(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new ValidationSummaryDto(
+                /* status= */ "MISMATCH",
+                /* totalTablesValidated= */ 1L,
+                /* totalRowsMatched= */ 1L,
+                /* totalRowsMismatched= */ 2L,
+                /* tablesWithMismatches= */ "Users_AddedColumn")));
+
+    GCSSpannerDVTestAsserts.assertTableValidationStats(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new TableValidationStatsDto(
+                /* schemaName= */ null,
+                /* tableName= */ "Users_AddedColumn",
+                /* status= */ "MISMATCH",
+                /* sourceRowCount= */ 2L,
+                /* destinationRowCount= */ 2L,
+                /* matchedRowCount= */ 1L,
+                /* mismatchRowCount= */ 2L)));
+
+    // Verify status column mismatch (Source+Transform: ACTIVE, Spanner: INACTIVE)
+    GCSSpannerDVTestAsserts.assertMismatchedRecords(
+        bigQueryResourceManager,
+        Arrays.asList(
+            new MismatchedRecordDto(
+                /* shardId= */ null,
+                /* schemaName= */ null,
+                /* tableName= */ "Users_AddedColumn",
+                /* recordKey= */ "[user_id:2, event_id:E2]",
+                /* mismatchType= */ "MISSING_IN_DESTINATION"),
+            new MismatchedRecordDto(
+                /* shardId= */ null,
+                /* schemaName= */ null,
+                /* tableName= */ "Users_AddedColumn",
+                /* recordKey= */ "[user_id:2, event_id:E2]",
+                /* mismatchType= */ "MISSING_IN_SOURCE")));
+  }
+}

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVSchemaTransformationsIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVSchemaTransformationsIT.java
@@ -344,7 +344,7 @@ public class GCSSpannerDVSchemaTransformationsIT extends GCSSpannerDVITBase {
 
     // DataflowRunner does not need Thread.sleep(20000)
 
-    createAndUploadCustomShardJarToGcs("custom");
+    uploadCustomShardJarToGcs("custom");
     CustomTransformation customTransformation =
         CustomTransformation.builder(
                 "custom/customTransformation.jar", "com.custom.CustomTransformationForDVIT")

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVSchemaTransformationsIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVSchemaTransformationsIT.java
@@ -39,12 +39,8 @@ import org.junit.runners.JUnit4;
 
 /**
  * Integration tests covering edge cases where Source and Spanner schemas have differences. Tests:
- *
- * <p>1. Data type differences (that don't require custom transformation)
- *
- * <p>2. Dropped columns in Spanner
- *
- * <p>3. Newly added columns in Spanner (populated via a custom transformation).
+ * 1. Data type differences (that don't require custom transformation) 2. Dropped columns in Spanner
+ * 3. Newly added columns in Spanner (populated via a custom transformation).
  */
 @Category(TemplateIntegrationTest.class)
 @RunWith(JUnit4.class)
@@ -122,12 +118,6 @@ public class GCSSpannerDVSchemaTransformationsIT extends GCSSpannerDVITBase {
             null);
 
     pipelineOperator().waitUntilDone(createConfig(jobInfo));
-
-    System.out.println("DEBUG MismatchedRecords:");
-    bigQueryResourceManager
-        .readTable("MismatchedRecords")
-        .iterateAll()
-        .forEach(r -> System.out.println(r.toString()));
 
     GCSSpannerDVTestAsserts.assertValidationSummary(
         bigQueryResourceManager,

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVSchemaTransformationsIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVSchemaTransformationsIT.java
@@ -38,9 +38,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /**
- * Integration tests covering edge cases where Source and Spanner schemas have differences. Tests:
- * 1. Data type differences (that don't require custom transformation) 2. Dropped columns in Spanner
- * 3. Newly added columns in Spanner (populated via a custom transformation).
+ * Integration tests covering edge cases where Source and Spanner schemas have differences. 1. Data
+ * type differences (that don't require custom transformation) 2. Dropped columns in Spanner 3.
+ * Newly added columns in Spanner (populated via a custom transformation).
  */
 @Category(TemplateIntegrationTest.class)
 @RunWith(JUnit4.class)
@@ -98,7 +98,7 @@ public class GCSSpannerDVSchemaTransformationsIT extends GCSSpannerDVITBase {
                 .to(9999L) // Mismatch
                 .build()));
 
-    // Wait for exact staleness
+    // Wait for Spanner's 20-second exact staleness read bound in SpannerReaderTransform
     Thread.sleep(20000);
 
     LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
@@ -212,7 +212,7 @@ public class GCSSpannerDVSchemaTransformationsIT extends GCSSpannerDVITBase {
                 .to(Timestamp.parseTimestamp(t1.toString()))
                 .build()));
 
-    // Wait for exact staleness
+    // Wait for Spanner's 20-second exact staleness read bound in SpannerReaderTransform
     Thread.sleep(20000);
 
     LaunchConfig.Builder options = LaunchConfig.builder(testName, specPath);
@@ -256,6 +256,8 @@ public class GCSSpannerDVSchemaTransformationsIT extends GCSSpannerDVITBase {
                 /* mismatchRowCount= */ 2L)));
 
     // Verify full_name column mismatch (Source: Bob, Spanner: Bobby)
+    // Note: In case of a data mismatch, getting two separate rows (one MISSING_IN_SOURCE
+    // and one MISSING_IN_DESTINATION) is the expected behavior.
     GCSSpannerDVTestAsserts.assertMismatchedRecords(
         bigQueryResourceManager,
         Arrays.asList(
@@ -389,6 +391,8 @@ public class GCSSpannerDVSchemaTransformationsIT extends GCSSpannerDVITBase {
                 /* mismatchRowCount= */ 2L)));
 
     // Verify status column mismatch (Source+Transform: ACTIVE, Spanner: INACTIVE)
+    // Note: In case of a data mismatch, getting two separate rows (one MISSING_IN_SOURCE
+    // and one MISSING_IN_DESTINATION) is the expected behavior.
     GCSSpannerDVTestAsserts.assertMismatchedRecords(
         bigQueryResourceManager,
         Arrays.asList(

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVSchemaTransformationsIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/GCSSpannerDVSchemaTransformationsIT.java
@@ -141,9 +141,8 @@ public class GCSSpannerDVSchemaTransformationsIT extends GCSSpannerDVITBase {
                 /* matchedRowCount= */ 1L,
                 /* mismatchRowCount= */ 2L)));
 
-    // Verify role_name column mismatch (Source: 5678, Spanner: 9999)
-    // Note: gcs-spanner-dv currently lacks a MISMATCHED_VALUE category. Differing row values are
-    // emitted as two discrepancies: one MISSING_IN_SOURCE and one MISSING_IN_DESTINATION.
+    // Note: In case of a data mismatch, getting two separate rows (one MISSING_IN_SOURCE
+    // and one MISSING_IN_DESTINATION) is the expected behavior.
     GCSSpannerDVTestAsserts.assertMismatchedRecords(
         bigQueryResourceManager,
         Arrays.asList(

--- a/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/ShardedBulkMigrationAndValidationE2EIT.java
+++ b/v2/gcs-spanner-dv/src/test/java/com/google/cloud/teleport/v2/templates/ShardedBulkMigrationAndValidationE2EIT.java
@@ -299,9 +299,9 @@ public class ShardedBulkMigrationAndValidationE2EIT extends EndToEndTestingITBas
                 USERS_TABLE,
                 "[migration_shard_id:logical_shard1, user_id:2, event_id:E2]",
                 MISSING_IN_DESTINATION),
-            // Note: gcs-spanner-dv currently lacks a MISMATCHED_VALUE category.
-            // Differing row values (like User 4's age) are emitted as two discrepancies:
-            // one MISSING_IN_SOURCE and one MISSING_IN_DESTINATION.
+
+            // Note: In case of a data mismatch, getting two separate rows (one MISSING_IN_SOURCE
+            // and one MISSING_IN_DESTINATION) is the expected behavior.
             new MismatchedRecordDto(
                 LOGICAL_SHARD_2,
                 null,

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVSchemaTransformationsIT/spanner-schema.sql
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVSchemaTransformationsIT/spanner-schema.sql
@@ -1,0 +1,23 @@
+-- Test Case 1: Data type change (INT -> STRING) and size limit (STRING(10))
+CREATE TABLE AccountRoles (
+    role_id INT64,
+    role_name INT64
+) PRIMARY KEY(role_id);
+
+-- Test Case 2: Column 'age' dropped in Spanner
+CREATE TABLE Users (
+    user_id INT64,
+    event_id STRING(MAX),
+    full_name STRING(MAX),
+    created_at TIMESTAMP
+) PRIMARY KEY(user_id, event_id);
+
+-- Test Case 3: Column 'status' added in Spanner
+CREATE TABLE Users_AddedColumn (
+    user_id INT64,
+    event_id STRING(MAX),
+    full_name STRING(MAX),
+    age INT64,
+    created_at TIMESTAMP,
+    status STRING(MAX)
+) PRIMARY KEY(user_id, event_id);

--- a/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVSchemaTransformationsIT/spanner-schema.sql
+++ b/v2/gcs-spanner-dv/src/test/resources/GCSSpannerDVSchemaTransformationsIT/spanner-schema.sql
@@ -1,4 +1,4 @@
--- Test Case 1: Data type change (INT -> STRING) and size limit (STRING(10))
+-- Test Case 1: Data type change (STRING -> INT64) automatically handled by the pipeline
 CREATE TABLE AccountRoles (
     role_id INT64,
     role_name INT64

--- a/v2/spanner-custom-shard/src/main/java/com/custom/CustomTransformationForDVIT.java
+++ b/v2/spanner-custom-shard/src/main/java/com/custom/CustomTransformationForDVIT.java
@@ -81,6 +81,11 @@ public class CustomTransformationForDVIT implements ISpannerMigrationTransformer
 
       return new MigrationTransformationResponse(responseRow, false);
     }
+
+    if ("Users_AddedColumn".equals(request.getTableName())) {
+      responseRow.put("status", "ACTIVE");
+      return new MigrationTransformationResponse(responseRow, false);
+    }
     return new MigrationTransformationResponse(null, false);
   }
 


### PR DESCRIPTION
1. Source data type differs from the Spanner schema but can be handled automatically without requiring custom transformation
2. Columns present in the source are dropped in Spanner
3. New columns are added in Spanner

The third one uses a transformation, and as seen in [this](https://github.com/GoogleCloudPlatform/DataflowTemplates/pull/4062) PR, this needs to be run on **DataflowRunner** to avoid resource leaks. The rest of the test methods are functional and so have been configured to run on **DirectRunner**

Also fixes this issue: b/541972060
The other ITs using custom transformations were relying on the mvn build during IT execution. The mvn command i had introduced in the test was rebuilding the JAR and so any parallelly executing IT that relied on the JAR would fail due to it being deleted during this process