### PR TITLE
Add Datastream to Spanner IT for PostgreSQL partitioned tables

### DIFF
--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerITBase.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToSpannerITBase.java
@@ -48,6 +48,7 @@ import org.apache.beam.it.gcp.datastream.OracleSource;
 import org.apache.beam.it.gcp.datastream.PostgresqlSource;
 import org.apache.beam.it.gcp.pubsub.PubsubResourceManager;
 import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
+import org.apache.beam.it.gcp.spanner.conditions.SpannerRowsCheck;
 import org.apache.beam.it.gcp.spanner.matchers.SpannerAsserts;
 import org.apache.beam.it.gcp.storage.GcsResourceManager;
 import org.apache.beam.it.jdbc.JDBCResourceManager;
@@ -594,5 +595,23 @@ public abstract class DataStreamToSpannerITBase extends TemplateTestBase {
         }
       }
     }
+  }
+
+  protected ConditionCheck buildBaseConditionCheck(
+      SpannerResourceManager resourceManager, Map<String, List<Map<String, Object>>> expectedData) {
+
+    ConditionCheck combinedCondition = null;
+    for (Map.Entry<String, List<Map<String, Object>>> entry : expectedData.entrySet()) {
+      String tableName = entry.getKey();
+      int numRows = entry.getValue().size();
+      ConditionCheck c =
+          SpannerRowsCheck.builder(resourceManager, tableName).setMinRows(numRows).build();
+      if (combinedCondition == null) {
+        combinedCondition = c;
+      } else {
+        combinedCondition = combinedCondition.and(c);
+      }
+    }
+    return combinedCondition;
   }
 }

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDatastreamToSpannerPartitionedIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDatastreamToSpannerPartitionedIT.java
@@ -140,13 +140,16 @@ public class PostgreSQLDatastreamToSpannerPartitionedIT extends DataStreamToSpan
   public static void cleanUp() throws IOException {
     LOG.info("Cleaning up resources...");
     for (PostgreSQLDatastreamToSpannerPartitionedIT instance : testInstances) {
-      instance.tearDownBase();
+      try {
+        instance.tearDownBase();
+      } catch (Exception e) {
+        LOG.error("Failed to tear down base for instance: {}", instance, e);
+      }
     }
 
     // It is important to clean up Datastream before trying to drop the replication slot.
-    ResourceManagerUtils.cleanResources(datastreamResourceManager);
-
     ResourceManagerUtils.cleanResources(
+        datastreamResourceManager,
         postgresResourceManager,
         spannerResourceManager,
         pgDialectSpannerResourceManager,

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDatastreamToSpannerPartitionedIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDatastreamToSpannerPartitionedIT.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates;
+
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
+
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.it.common.PipelineLauncher;
+import org.apache.beam.it.common.PipelineOperator;
+import org.apache.beam.it.common.utils.ResourceManagerUtils;
+import org.apache.beam.it.conditions.ConditionCheck;
+import org.apache.beam.it.gcp.cloudsql.CloudPostgresResourceManager;
+import org.apache.beam.it.gcp.datastream.DatastreamResourceManager;
+import org.apache.beam.it.gcp.datastream.PostgresqlSource;
+import org.apache.beam.it.gcp.pubsub.PubsubResourceManager;
+import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
+import org.apache.beam.it.gcp.spanner.conditions.SpannerRowsCheck;
+import org.apache.beam.it.gcp.spanner.matchers.SpannerAsserts;
+import org.apache.beam.it.gcp.storage.GcsResourceManager;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An integration test for {@link DataStreamToSpanner} Flex template which tests migration of
+ * PostgreSQL partitioned tables (List, Range, Hash).
+ */
+@Category({TemplateIntegrationTest.class, SkipDirectRunnerTest.class})
+@TemplateIntegrationTest(DataStreamToSpanner.class)
+@RunWith(JUnit4.class)
+public class PostgreSQLDatastreamToSpannerPartitionedIT extends DataStreamToSpannerITBase {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(PostgreSQLDatastreamToSpannerPartitionedIT.class);
+
+  private static final String POSTGRESQL_DDL_RESOURCE =
+      "PostgreSQLPartitionedIT/postgresql-schema.sql";
+  private static final String SPANNER_DDL_RESOURCE = "PostgreSQLPartitionedIT/spanner-schema.sql";
+  private static final String PG_DIALECT_SPANNER_DDL_RESOURCE =
+      "PostgreSQLPartitionedIT/pg-dialect-spanner-schema.sql";
+
+  private static CloudPostgresResourceManager.ReplicationInfo replicationInfo;
+  private static CloudPostgresResourceManager.ReplicationInfo pgDialectReplicationInfo;
+
+  private static boolean initialized = false;
+  private static CloudPostgresResourceManager postgresResourceManager;
+  private static SpannerResourceManager spannerResourceManager;
+  private static SpannerResourceManager pgDialectSpannerResourceManager;
+  private static GcsResourceManager gcsResourceManager;
+  private static PubsubResourceManager pubsubResourceManager;
+  private static DatastreamResourceManager datastreamResourceManager;
+
+  private static HashSet<PostgreSQLDatastreamToSpannerPartitionedIT> testInstances =
+      new HashSet<>();
+
+  @Before
+  public void setUp() throws IOException {
+    skipBaseCleanup = true;
+    synchronized (PostgreSQLDatastreamToSpannerPartitionedIT.class) {
+      testInstances.add(this);
+      if (!initialized) {
+        LOG.info("Setting up PostgreSQL resource manager...");
+        postgresResourceManager = CloudPostgresResourceManager.builder(testName).build();
+        LOG.info(
+            "PostgreSQL resource manager created with URI: {}", postgresResourceManager.getUri());
+        LOG.info("Setting up Spanner resource manager...");
+        spannerResourceManager = setUpSpannerResourceManager();
+        LOG.info(
+            "Spanner resource manager created with instance ID: {}",
+            spannerResourceManager.getInstanceId());
+        LOG.info("Setting up PG dialect Spanner resource manager...");
+        pgDialectSpannerResourceManager = setUpPGDialectSpannerResourceManager();
+        LOG.info(
+            "PG dialect Spanner resource manager created with instance ID: {}",
+            pgDialectSpannerResourceManager.getInstanceId());
+        LOG.info("Setting up GCS resource manager...");
+        gcsResourceManager = setUpSpannerITGcsResourceManager();
+        LOG.info("GCS resource manager created with bucket: {}", gcsResourceManager.getBucket());
+        LOG.info("Setting up Pub/Sub resource manager...");
+        pubsubResourceManager = setUpPubSubResourceManager();
+        LOG.info("Pub/Sub resource manager created.");
+        LOG.info("Setting up Datastream resource manager...");
+        datastreamResourceManager =
+            DatastreamResourceManager.builder(testName, PROJECT, REGION)
+                .setCredentialsProvider(credentialsProvider)
+                .setPrivateConnectivity("datastream-connect-2")
+                .build();
+        LOG.info("Datastream resource manager created");
+
+        LOG.info("Executing PostgreSQL DDL script...");
+        executeSqlScript(postgresResourceManager, POSTGRESQL_DDL_RESOURCE);
+
+        replicationInfo = postgresResourceManager.createLogicalReplication();
+        pgDialectReplicationInfo = postgresResourceManager.createLogicalReplication();
+
+        // Alter publications to publish via partition root so Datastream sees the parent table
+        postgresResourceManager.runSQLUpdate(
+            "ALTER PUBLICATION "
+                + replicationInfo.getPublicationName()
+                + " SET (publish_via_partition_root = true);");
+        postgresResourceManager.runSQLUpdate(
+            "ALTER PUBLICATION "
+                + pgDialectReplicationInfo.getPublicationName()
+                + " SET (publish_via_partition_root = true);");
+
+        initialized = true;
+      }
+    }
+  }
+
+  @AfterClass
+  public static void cleanUp() throws IOException {
+    LOG.info("Cleaning up resources...");
+    for (PostgreSQLDatastreamToSpannerPartitionedIT instance : testInstances) {
+      instance.tearDownBase();
+    }
+
+    // It is important to clean up Datastream before trying to drop the replication slot.
+    ResourceManagerUtils.cleanResources(datastreamResourceManager);
+
+    ResourceManagerUtils.cleanResources(
+        postgresResourceManager,
+        spannerResourceManager,
+        pgDialectSpannerResourceManager,
+        gcsResourceManager,
+        pubsubResourceManager);
+  }
+
+  @Test
+  public void testPostgreSqlPartitioned() throws Exception {
+    LOG.info("Creating Spanner DDL...");
+    createSpannerDDL(spannerResourceManager, SPANNER_DDL_RESOURCE);
+
+    PostgresqlSource postgresqlSource =
+        PostgresqlSource.builder(
+                postgresResourceManager.getHost(),
+                postgresResourceManager.getUsername(),
+                postgresResourceManager.getPassword(),
+                postgresResourceManager.getPort(),
+                postgresResourceManager.getDatabaseName(),
+                replicationInfo.getReplicationSlotName(),
+                replicationInfo.getPublicationName())
+            .setAllowedTables(Map.of("public", getAllowedTables()))
+            .build();
+
+    LOG.info("Launching Dataflow job...");
+    PipelineLauncher.LaunchInfo jobInfo =
+        launchDataflowJob(
+            "postgresql-partitioned",
+            null,
+            null,
+            "postgresql-datastream-to-spanner-partitioned",
+            spannerResourceManager,
+            pubsubResourceManager,
+            new HashMap<>(),
+            null,
+            null,
+            gcsResourceManager,
+            datastreamResourceManager,
+            null,
+            postgresqlSource);
+    assertThatPipeline(jobInfo).isRunning();
+
+    Map<String, List<Map<String, Object>>> expectedData = getExpectedData();
+
+    ConditionCheck condition = buildConditionCheck(spannerResourceManager, expectedData);
+    LOG.info("Waiting for pipeline to process data...");
+    PipelineOperator.Result result =
+        pipelineOperator()
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(20)), condition);
+    assertThatResult(result).meetsConditions();
+
+    validateResult(spannerResourceManager, expectedData);
+  }
+
+  @Test
+  public void testPostgreSqlPartitionedPGDialect() throws Exception {
+    LOG.info("Creating PG Dialect Spanner DDL...");
+    createSpannerDDL(pgDialectSpannerResourceManager, PG_DIALECT_SPANNER_DDL_RESOURCE);
+
+    PostgresqlSource postgresqlSource =
+        PostgresqlSource.builder(
+                postgresResourceManager.getHost(),
+                postgresResourceManager.getUsername(),
+                postgresResourceManager.getPassword(),
+                postgresResourceManager.getPort(),
+                postgresResourceManager.getDatabaseName(),
+                pgDialectReplicationInfo.getReplicationSlotName(),
+                pgDialectReplicationInfo.getPublicationName())
+            .setAllowedTables(Map.of("public", getAllowedTables()))
+            .build();
+
+    LOG.info("Launching Dataflow job...");
+    PipelineLauncher.LaunchInfo jobInfo =
+        launchDataflowJob(
+            "postgresql-partitioned-pg-dialect",
+            null,
+            null,
+            "postgresql-datastream-to-spanner-partitioned-pg-dialect",
+            pgDialectSpannerResourceManager,
+            pubsubResourceManager,
+            new HashMap<>(),
+            null,
+            null,
+            gcsResourceManager,
+            datastreamResourceManager,
+            null,
+            postgresqlSource);
+    assertThatPipeline(jobInfo).isRunning();
+
+    Map<String, List<Map<String, Object>>> expectedData = getExpectedData();
+
+    ConditionCheck condition = buildConditionCheck(pgDialectSpannerResourceManager, expectedData);
+    LOG.info("Waiting for pipeline to process data...");
+    PipelineOperator.Result result =
+        pipelineOperator()
+            .waitForCondition(createConfig(jobInfo, Duration.ofMinutes(20)), condition);
+    assertThatResult(result).meetsConditions();
+
+    validateResult(pgDialectSpannerResourceManager, expectedData);
+  }
+
+  private void validateResult(
+      SpannerResourceManager resourceManager, Map<String, List<Map<String, Object>>> expectedData) {
+    for (Map.Entry<String, List<Map<String, Object>>> entry : expectedData.entrySet()) {
+      String tableName = entry.getKey();
+      LOG.info("Asserting table: {}", tableName);
+
+      // Read all columns from the table to assert
+      List<Struct> rows;
+      if (tableName.equals("employees_list")) {
+        rows = resourceManager.readTableRecords(tableName, "id", "name", "department");
+      } else if (tableName.equals("measurements_range")) {
+        rows = resourceManager.readTableRecords(tableName, "id", "city_id", "logdate", "peaktemp");
+      } else {
+        rows = resourceManager.readTableRecords(tableName, "order_id", "customer_id", "amount");
+      }
+
+      for (Struct row : rows) {
+        LOG.info("Found row: {}", row.toString());
+      }
+      SpannerAsserts.assertThatStructs(rows)
+          .hasRecordsUnorderedCaseInsensitiveColumns(entry.getValue());
+    }
+  }
+
+  private List<String> getAllowedTables() {
+    return List.of("measurements_range", "employees_list", "orders_hash");
+  }
+
+  private ConditionCheck buildConditionCheck(
+      SpannerResourceManager resourceManager, Map<String, List<Map<String, Object>>> expectedData) {
+
+    ConditionCheck combinedCondition = null;
+    for (Map.Entry<String, List<Map<String, Object>>> entry : expectedData.entrySet()) {
+      String tableName = entry.getKey();
+      int numRows = entry.getValue().size();
+      ConditionCheck c =
+          SpannerRowsCheck.builder(resourceManager, tableName).setMinRows(numRows).build();
+      if (combinedCondition == null) {
+        combinedCondition = c;
+      } else {
+        combinedCondition = combinedCondition.and(c);
+      }
+    }
+    return combinedCondition;
+  }
+
+  private Map<String, List<Map<String, Object>>> getExpectedData() {
+    HashMap<String, List<Map<String, Object>>> result = new HashMap<>();
+
+    // 1. Range Partitioning
+    List<Map<String, Object>> measurementsRangeRows = new ArrayList<>();
+    Map<String, Object> measurementRow1 = new HashMap<>();
+    measurementRow1.put("id", 1L);
+    measurementRow1.put("city_id", 1L);
+    measurementRow1.put("logdate", com.google.cloud.Date.parseDate("2006-02-15"));
+    measurementRow1.put("peaktemp", 33L);
+    measurementsRangeRows.add(measurementRow1);
+
+    Map<String, Object> measurementRow2 = new HashMap<>();
+    measurementRow2.put("id", 2L);
+    measurementRow2.put("city_id", 2L);
+    measurementRow2.put("logdate", com.google.cloud.Date.parseDate("2006-03-15"));
+    measurementRow2.put("peaktemp", 35L);
+    measurementsRangeRows.add(measurementRow2);
+
+    Map<String, Object> measurementRow3 = new HashMap<>();
+    measurementRow3.put("id", 3L);
+    measurementRow3.put("city_id", 3L);
+    measurementRow3.put("logdate", com.google.cloud.Date.parseDate("2006-05-10"));
+    measurementRow3.put("peaktemp", 40L);
+    measurementsRangeRows.add(measurementRow3);
+
+    Map<String, Object> measurementRow4 = new HashMap<>();
+    measurementRow4.put("id", 4L);
+    measurementRow4.put("city_id", 4L);
+    measurementRow4.put("logdate", com.google.cloud.Date.parseDate("2006-02-20"));
+    measurementRow4.put("peaktemp", 30L);
+    measurementsRangeRows.add(measurementRow4);
+    result.put("measurements_range", measurementsRangeRows);
+
+    // 2. List Partitioning
+    List<Map<String, Object>> employeesListRows = new ArrayList<>();
+    Map<String, Object> empRow1 = new HashMap<>();
+    empRow1.put("id", 1L);
+    empRow1.put("name", "Alice");
+    empRow1.put("department", "Engineering");
+    employeesListRows.add(empRow1);
+
+    Map<String, Object> empRow2 = new HashMap<>();
+    empRow2.put("id", 2L);
+    empRow2.put("name", "Bob");
+    empRow2.put("department", "Sales");
+    employeesListRows.add(empRow2);
+
+    Map<String, Object> empRow3 = new HashMap<>();
+    empRow3.put("id", 3L);
+    empRow3.put("name", "Charlie");
+    empRow3.put("department", "Marketing");
+    employeesListRows.add(empRow3);
+    result.put("employees_list", employeesListRows);
+
+    // 3. Hash Partitioning
+    List<Map<String, Object>> ordersHashRows = new ArrayList<>();
+    Map<String, Object> orderRow1 = new HashMap<>();
+    orderRow1.put("order_id", 1L);
+    orderRow1.put("customer_id", 101L);
+    orderRow1.put("amount", 500L);
+    ordersHashRows.add(orderRow1);
+
+    Map<String, Object> orderRow2 = new HashMap<>();
+    orderRow2.put("order_id", 2L);
+    orderRow2.put("customer_id", 102L);
+    orderRow2.put("amount", 600L);
+    ordersHashRows.add(orderRow2);
+
+    Map<String, Object> orderRow3 = new HashMap<>();
+    orderRow3.put("order_id", 3L);
+    orderRow3.put("customer_id", 103L);
+    orderRow3.put("amount", 700L);
+    ordersHashRows.add(orderRow3);
+    result.put("orders_hash", ordersHashRows);
+
+    return result;
+  }
+}

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDatastreamToSpannerPartitionedIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDatastreamToSpannerPartitionedIT.java
@@ -37,7 +37,6 @@ import org.apache.beam.it.gcp.datastream.DatastreamResourceManager;
 import org.apache.beam.it.gcp.datastream.PostgresqlSource;
 import org.apache.beam.it.gcp.pubsub.PubsubResourceManager;
 import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
-import org.apache.beam.it.gcp.spanner.conditions.SpannerRowsCheck;
 import org.apache.beam.it.gcp.spanner.matchers.SpannerAsserts;
 import org.apache.beam.it.gcp.storage.GcsResourceManager;
 import org.junit.AfterClass;
@@ -121,7 +120,13 @@ public class PostgreSQLDatastreamToSpannerPartitionedIT extends DataStreamToSpan
         replicationInfo = postgresResourceManager.createLogicalReplication();
         pgDialectReplicationInfo = postgresResourceManager.createLogicalReplication();
 
-        // Alter publications to publish via partition root so Datastream sees the parent table
+        // Alter publications to set publish_via_partition_root = true.
+        // This is critical because without it, PostgreSQL streams CDC events using the names
+        // of the underlying child partitions (e.g., measurements_range_y2006m02).
+        // Dataflow would drop these events because our Spanner schema only defines the unified
+        // parent table.
+        // Setting this flag masks the child partitions, making Datastream capture all events
+        // as if they occurred directly on the parent partitioned table.
         postgresResourceManager.runSQLUpdate(
             "ALTER PUBLICATION "
                 + replicationInfo.getPublicationName()
@@ -194,7 +199,7 @@ public class PostgreSQLDatastreamToSpannerPartitionedIT extends DataStreamToSpan
 
     Map<String, List<Map<String, Object>>> expectedData = getExpectedData();
 
-    ConditionCheck condition = buildConditionCheck(spannerResourceManager, expectedData);
+    ConditionCheck condition = buildBaseConditionCheck(spannerResourceManager, expectedData);
     LOG.info("Waiting for pipeline to process data...");
     PipelineOperator.Result result =
         pipelineOperator()
@@ -241,7 +246,8 @@ public class PostgreSQLDatastreamToSpannerPartitionedIT extends DataStreamToSpan
 
     Map<String, List<Map<String, Object>>> expectedData = getExpectedData();
 
-    ConditionCheck condition = buildConditionCheck(pgDialectSpannerResourceManager, expectedData);
+    ConditionCheck condition =
+        buildBaseConditionCheck(pgDialectSpannerResourceManager, expectedData);
     LOG.info("Waiting for pipeline to process data...");
     PipelineOperator.Result result =
         pipelineOperator()
@@ -277,24 +283,6 @@ public class PostgreSQLDatastreamToSpannerPartitionedIT extends DataStreamToSpan
 
   private List<String> getAllowedTables() {
     return List.of("measurements_range", "employees_list", "orders_hash");
-  }
-
-  private ConditionCheck buildConditionCheck(
-      SpannerResourceManager resourceManager, Map<String, List<Map<String, Object>>> expectedData) {
-
-    ConditionCheck combinedCondition = null;
-    for (Map.Entry<String, List<Map<String, Object>>> entry : expectedData.entrySet()) {
-      String tableName = entry.getKey();
-      int numRows = entry.getValue().size();
-      ConditionCheck c =
-          SpannerRowsCheck.builder(resourceManager, tableName).setMinRows(numRows).build();
-      if (combinedCondition == null) {
-        combinedCondition = c;
-      } else {
-        combinedCondition = combinedCondition.and(c);
-      }
-    }
-    return combinedCondition;
   }
 
   private Map<String, List<Map<String, Object>>> getExpectedData() {
@@ -350,6 +338,12 @@ public class PostgreSQLDatastreamToSpannerPartitionedIT extends DataStreamToSpan
     empRow3.put("name", "Charlie");
     empRow3.put("department", "Marketing");
     employeesListRows.add(empRow3);
+
+    Map<String, Object> empRow4 = new HashMap<>();
+    empRow4.put("id", 4L);
+    empRow4.put("name", "Dave");
+    empRow4.put("department", "Engineering");
+    employeesListRows.add(empRow4);
     result.put("employees_list", employeesListRows);
 
     // 3. Hash Partitioning
@@ -371,6 +365,12 @@ public class PostgreSQLDatastreamToSpannerPartitionedIT extends DataStreamToSpan
     orderRow3.put("customer_id", 103L);
     orderRow3.put("amount", 700L);
     ordersHashRows.add(orderRow3);
+
+    Map<String, Object> orderRow4 = new HashMap<>();
+    orderRow4.put("order_id", 4L);
+    orderRow4.put("customer_id", 104L);
+    orderRow4.put("amount", 800L);
+    ordersHashRows.add(orderRow4);
     result.put("orders_hash", ordersHashRows);
 
     return result;

--- a/v2/datastream-to-spanner/src/test/resources/PostgreSQLPartitionedIT/pg-dialect-spanner-schema.sql
+++ b/v2/datastream-to-spanner/src/test/resources/PostgreSQLPartitionedIT/pg-dialect-spanner-schema.sql
@@ -1,0 +1,21 @@
+CREATE TABLE measurements_range (
+    id BIGINT,
+    city_id BIGINT,
+    logdate DATE,
+    peaktemp BIGINT,
+    PRIMARY KEY (id, logdate)
+);
+
+CREATE TABLE employees_list (
+    id BIGINT,
+    name VARCHAR(50),
+    department VARCHAR(50),
+    PRIMARY KEY (id, department)
+);
+
+CREATE TABLE orders_hash (
+    order_id BIGINT,
+    customer_id BIGINT,
+    amount BIGINT,
+    PRIMARY KEY (order_id, customer_id)
+);

--- a/v2/datastream-to-spanner/src/test/resources/PostgreSQLPartitionedIT/postgresql-schema.sql
+++ b/v2/datastream-to-spanner/src/test/resources/PostgreSQLPartitionedIT/postgresql-schema.sql
@@ -1,0 +1,50 @@
+CREATE TABLE measurements_range (
+    id INT,
+    city_id INT NOT NULL,
+    logdate DATE NOT NULL,
+    peaktemp INT,
+    PRIMARY KEY (id, logdate)
+) PARTITION BY RANGE (logdate);
+
+CREATE TABLE measurements_range_y2006m02 PARTITION OF measurements_range
+    FOR VALUES FROM ('2006-02-01') TO ('2006-03-01');
+
+CREATE TABLE measurements_range_y2006m03 PARTITION OF measurements_range
+    FOR VALUES FROM ('2006-03-01') TO ('2006-04-01');
+
+CREATE TABLE measurements_range_default PARTITION OF measurements_range DEFAULT;
+
+INSERT INTO measurements_range (id, city_id, logdate, peaktemp) VALUES (1, 1, '2006-02-15', 33);
+INSERT INTO measurements_range (id, city_id, logdate, peaktemp) VALUES (2, 2, '2006-03-15', 35);
+INSERT INTO measurements_range (id, city_id, logdate, peaktemp) VALUES (3, 3, '2006-05-10', 40);
+INSERT INTO measurements_range_y2006m02 (id, city_id, logdate, peaktemp) VALUES (4, 4, '2006-02-20', 30);
+
+CREATE TABLE employees_list (
+    id INT,
+    name VARCHAR(50),
+    department VARCHAR(50),
+    PRIMARY KEY (id, department)
+) PARTITION BY LIST (department);
+
+CREATE TABLE employees_list_engineering PARTITION OF employees_list FOR VALUES IN ('Engineering');
+CREATE TABLE employees_list_sales PARTITION OF employees_list FOR VALUES IN ('Sales');
+CREATE TABLE employees_list_default PARTITION OF employees_list DEFAULT;
+
+INSERT INTO employees_list (id, name, department) VALUES (1, 'Alice', 'Engineering');
+INSERT INTO employees_list (id, name, department) VALUES (2, 'Bob', 'Sales');
+INSERT INTO employees_list (id, name, department) VALUES (3, 'Charlie', 'Marketing');
+
+CREATE TABLE orders_hash (
+    order_id INT,
+    customer_id INT,
+    amount INT,
+    PRIMARY KEY (order_id, customer_id)
+) PARTITION BY HASH (customer_id);
+
+CREATE TABLE orders_hash_p0 PARTITION OF orders_hash FOR VALUES WITH (MODULUS 3, REMAINDER 0);
+CREATE TABLE orders_hash_p1 PARTITION OF orders_hash FOR VALUES WITH (MODULUS 3, REMAINDER 1);
+CREATE TABLE orders_hash_p2 PARTITION OF orders_hash FOR VALUES WITH (MODULUS 3, REMAINDER 2);
+
+INSERT INTO orders_hash (order_id, customer_id, amount) VALUES (1, 101, 500);
+INSERT INTO orders_hash (order_id, customer_id, amount) VALUES (2, 102, 600);
+INSERT INTO orders_hash (order_id, customer_id, amount) VALUES (3, 103, 700);

--- a/v2/datastream-to-spanner/src/test/resources/PostgreSQLPartitionedIT/postgresql-schema.sql
+++ b/v2/datastream-to-spanner/src/test/resources/PostgreSQLPartitionedIT/postgresql-schema.sql
@@ -14,10 +14,10 @@ CREATE TABLE measurements_range_y2006m03 PARTITION OF measurements_range
 
 CREATE TABLE measurements_range_default PARTITION OF measurements_range DEFAULT;
 
-INSERT INTO measurements_range (id, city_id, logdate, peaktemp) VALUES (1, 1, '2006-02-15', 33);
-INSERT INTO measurements_range (id, city_id, logdate, peaktemp) VALUES (2, 2, '2006-03-15', 35);
-INSERT INTO measurements_range (id, city_id, logdate, peaktemp) VALUES (3, 3, '2006-05-10', 40);
-INSERT INTO measurements_range_y2006m02 (id, city_id, logdate, peaktemp) VALUES (4, 4, '2006-02-20', 30);
+INSERT INTO measurements_range_y2006m02 (id, city_id, logdate, peaktemp) VALUES (1, 1, '2006-02-15', 33);
+INSERT INTO measurements_range_y2006m03 (id, city_id, logdate, peaktemp) VALUES (2, 2, '2006-03-15', 35);
+INSERT INTO measurements_range_default (id, city_id, logdate, peaktemp) VALUES (3, 3, '2006-05-10', 40);
+INSERT INTO measurements_range (id, city_id, logdate, peaktemp) VALUES (4, 4, '2006-02-20', 30);
 
 CREATE TABLE employees_list (
     id INT,
@@ -30,9 +30,10 @@ CREATE TABLE employees_list_engineering PARTITION OF employees_list FOR VALUES I
 CREATE TABLE employees_list_sales PARTITION OF employees_list FOR VALUES IN ('Sales');
 CREATE TABLE employees_list_default PARTITION OF employees_list DEFAULT;
 
-INSERT INTO employees_list (id, name, department) VALUES (1, 'Alice', 'Engineering');
-INSERT INTO employees_list (id, name, department) VALUES (2, 'Bob', 'Sales');
-INSERT INTO employees_list (id, name, department) VALUES (3, 'Charlie', 'Marketing');
+INSERT INTO employees_list_engineering (id, name, department) VALUES (1, 'Alice', 'Engineering');
+INSERT INTO employees_list_sales (id, name, department) VALUES (2, 'Bob', 'Sales');
+INSERT INTO employees_list_default (id, name, department) VALUES (3, 'Charlie', 'Marketing');
+INSERT INTO employees_list (id, name, department) VALUES (4, 'Dave', 'Engineering');
 
 CREATE TABLE orders_hash (
     order_id INT,
@@ -48,3 +49,4 @@ CREATE TABLE orders_hash_p2 PARTITION OF orders_hash FOR VALUES WITH (MODULUS 3,
 INSERT INTO orders_hash (order_id, customer_id, amount) VALUES (1, 101, 500);
 INSERT INTO orders_hash (order_id, customer_id, amount) VALUES (2, 102, 600);
 INSERT INTO orders_hash (order_id, customer_id, amount) VALUES (3, 103, 700);
+INSERT INTO orders_hash (order_id, customer_id, amount) VALUES (4, 104, 800);

--- a/v2/datastream-to-spanner/src/test/resources/PostgreSQLPartitionedIT/spanner-schema.sql
+++ b/v2/datastream-to-spanner/src/test/resources/PostgreSQLPartitionedIT/spanner-schema.sql
@@ -1,0 +1,18 @@
+CREATE TABLE measurements_range (
+    id INT64,
+    city_id INT64,
+    logdate DATE,
+    peaktemp INT64,
+) PRIMARY KEY (id, logdate);
+
+CREATE TABLE employees_list (
+    id INT64,
+    name STRING(50),
+    department STRING(50),
+) PRIMARY KEY (id, department);
+
+CREATE TABLE orders_hash (
+    order_id INT64,
+    customer_id INT64,
+    amount INT64,
+) PRIMARY KEY (order_id, customer_id);

--- a/v2/datastream-to-spanner/src/test/resources/PostgreSQLPartitionedIT/spanner-schema.sql
+++ b/v2/datastream-to-spanner/src/test/resources/PostgreSQLPartitionedIT/spanner-schema.sql
@@ -2,17 +2,17 @@ CREATE TABLE measurements_range (
     id INT64,
     city_id INT64,
     logdate DATE,
-    peaktemp INT64,
+    peaktemp INT64
 ) PRIMARY KEY (id, logdate);
 
 CREATE TABLE employees_list (
     id INT64,
     name STRING(50),
-    department STRING(50),
+    department STRING(50)
 ) PRIMARY KEY (id, department);
 
 CREATE TABLE orders_hash (
     order_id INT64,
     customer_id INT64,
-    amount INT64,
+    amount INT64
 ) PRIMARY KEY (order_id, customer_id);


### PR DESCRIPTION
Added a new integration test (PostgreSQLDatastreamToSpannerPartitionedIT) for the Datastream to Spanner template to validate the migration of PostgreSQL partitioned tables.
- It tests Range, List, and Hash partitioning strategies to ensure that Datastream and Dataflow successfully map and route data from physical child partitions into a single unified parent table in Spanner (for both GoogleSQL and PostrgreSQL dialect). 
- It dynamically sets publish_via_partition_root = true on the publication so that Datastream receives events under the parent table name.