### PR TITLE
build: update to latest import-spec version

### DIFF
--- a/v2/googlecloud-to-neo4j/pom.xml
+++ b/v2/googlecloud-to-neo4j/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.neo4j.importer</groupId>
       <artifactId>import-spec</artifactId>
-      <version>1.0.0-rc17</version>
+      <version>1.0.0-rc21</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.teleport.v2</groupId>

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/InputValidator.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/InputValidator.java
@@ -18,7 +18,7 @@ package com.google.cloud.teleport.v2.neo4j.model;
 import com.google.cloud.secretmanager.v1.SecretVersionName;
 import com.google.cloud.teleport.v2.neo4j.model.Json.ParsingResult;
 import com.google.cloud.teleport.v2.neo4j.options.Neo4jFlexTemplateOptions;
-import com.networknt.schema.Schema;
+import com.networknt.schema.JsonSchema;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -55,8 +55,8 @@ public class InputValidator {
   }
 
   public static ParsingResult validateNeo4jConnection(String json) {
-    Schema connectionSchema =
-        Json.SCHEMA_REGISTRY.getSchema(
+    JsonSchema connectionSchema =
+        Json.SCHEMA_FACTORY.getSchema(
             InputValidator.class.getResourceAsStream("/schemas/connection.v1.0.json"));
     return Json.parseAndValidate(json, connectionSchema);
   }

--- a/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/Json.java
+++ b/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/model/Json.java
@@ -19,14 +19,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.networknt.schema.Error;
-import com.networknt.schema.InputFormat;
-import com.networknt.schema.Schema;
-import com.networknt.schema.SchemaRegistry;
-import com.networknt.schema.SchemaRegistryConfig;
-import com.networknt.schema.SpecificationVersion;
-import com.networknt.schema.path.NodePath;
-import com.networknt.schema.path.PathType;
+import com.networknt.schema.CustomErrorMessageType;
+import com.networknt.schema.JsonNodePath;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.PathType;
+import com.networknt.schema.SpecVersion.VersionFlag;
+import com.networknt.schema.ValidationMessage;
 import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.List;
@@ -35,18 +34,14 @@ import java.util.stream.Collectors;
 
 public class Json {
 
-  public static final SchemaRegistry SCHEMA_REGISTRY =
-      SchemaRegistry.withDefaultDialect(
-          SpecificationVersion.DRAFT_2020_12,
-          builder ->
-              builder.schemaRegistryConfig(
-                  SchemaRegistryConfig.builder().pathType(PathType.LEGACY).build()));
+  public static final JsonSchemaFactory SCHEMA_FACTORY =
+      JsonSchemaFactory.getInstance(VersionFlag.V202012);
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
-  public static ParsingResult parseAndValidate(String json, Schema schema) {
+  public static ParsingResult parseAndValidate(String json, JsonSchema schema) {
     ParsingResult result = Json.parseNode(json);
-    return result.flatMap(node -> ParsingResult.of(node, schema.validate(json, InputFormat.JSON)));
+    return result.flatMap(node -> ParsingResult.of(node, schema.validate(node)));
   }
 
   public static <T> T map(ParsingResult result, Class<T> type) {
@@ -57,12 +52,15 @@ public class Json {
     try {
       return ParsingResult.success(MAPPER.readTree(json));
     } catch (JsonProcessingException e) {
+      var messageType = CustomErrorMessageType.of("dataflow.invalidJSON");
+      var parentPath = new JsonNodePath(PathType.DEFAULT);
       return ParsingResult.failure(
           List.of(
-              Error.builder()
-                  .keyword("invalidJson")
-                  .instanceLocation(new NodePath(PathType.LEGACY))
-                  .format(new MessageFormat("The provided string is not valid JSON: {0}"))
+              ValidationMessage.builder()
+                  .type("invalidJson")
+                  .code(messageType.getErrorCode())
+                  .instanceLocation(parentPath)
+                  .format(new MessageFormat("The provided string is not valid JSON: {1}"))
                   .arguments(json)
                   .build()));
     }
@@ -70,14 +68,14 @@ public class Json {
 
   public static class ParsingResult {
     private final JsonNode node;
-    private final Collection<Error> errors;
+    private final Collection<ValidationMessage> errors;
 
-    private ParsingResult(JsonNode node, Collection<Error> errors) {
+    private ParsingResult(JsonNode node, Collection<ValidationMessage> errors) {
       this.node = node;
       this.errors = errors;
     }
 
-    public static ParsingResult of(JsonNode node, Collection<Error> messages) {
+    public static ParsingResult of(JsonNode node, Collection<ValidationMessage> messages) {
       if (!messages.isEmpty()) {
         return failure(messages);
       }
@@ -88,7 +86,7 @@ public class Json {
       return new ParsingResult(node, List.of());
     }
 
-    public static ParsingResult failure(Collection<Error> errors) {
+    public static ParsingResult failure(Collection<ValidationMessage> errors) {
       return new ParsingResult(null, errors);
     }
 
@@ -110,7 +108,7 @@ public class Json {
     }
 
     @VisibleForTesting
-    Collection<Error> getErrors() {
+    Collection<ValidationMessage> getErrors() {
       return errors;
     }
 
@@ -119,7 +117,7 @@ public class Json {
       return node;
     }
 
-    private static String formatValidationError(String prefix, Error error) {
+    private static String formatValidationError(String prefix, ValidationMessage error) {
       return String.format("%s: %s", prefix, error.getMessage());
     }
   }

--- a/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/model/InputValidatorTest.java
+++ b/v2/googlecloud-to-neo4j/src/test/java/com/google/cloud/teleport/v2/neo4j/model/InputValidatorTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.cloud.teleport.v2.neo4j.model.Json.ParsingResult;
 import com.google.cloud.teleport.v2.neo4j.options.Neo4jFlexTemplateOptions;
-import com.networknt.schema.Error;
+import com.networknt.schema.ValidationMessage;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.Test;
@@ -122,9 +122,9 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors).hasSize(1);
-    assertThat(errors.get(0)).startsWith("$: The provided string is not valid JSON: invalidjson");
+    assertThat(errors.get(0)).startsWith("The provided string is not valid JSON: invalidjson");
   }
 
   @Test
@@ -135,7 +135,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors).containsExactly("$: array found, object expected");
   }
 
@@ -147,7 +147,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors).containsExactly("$: required property 'server_url' not found");
   }
 
@@ -159,7 +159,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors)
         .contains("$.server_url: does not match the regex pattern ^(neo4j|bolt)(\\+s(sc)?)?://");
   }
@@ -173,7 +173,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors)
         .containsExactly(
             "$.server_url: does not match the regex pattern ^(neo4j|bolt)(\\+s(sc)?)?://");
@@ -188,7 +188,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors).containsExactly("$.database: must be at least 1 characters long");
   }
 
@@ -201,7 +201,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors)
         .containsExactly(
             "$.auth_type: does not have a value in the enumeration [\"basic\", \"none\", \"kerberos\", \"bearer\", \"custom\"]");
@@ -215,7 +215,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors).containsExactly("$: required property 'username' not found");
   }
 
@@ -228,7 +228,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors).containsExactly("$.username: must be at least 1 characters long");
   }
 
@@ -240,7 +240,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors).containsExactly("$: required property 'pwd' not found");
   }
 
@@ -252,7 +252,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors).containsExactly("$.pwd: must be at least 1 characters long");
   }
 
@@ -264,7 +264,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors).containsExactly("$: required property 'ticket' not found");
   }
 
@@ -277,7 +277,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors).containsExactly("$.ticket: must be at least 1 characters long");
   }
 
@@ -290,7 +290,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors).containsExactly("$.token: must be at least 1 characters long");
   }
 
@@ -303,7 +303,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors).containsExactly("$: required property 'principal' not found");
   }
 
@@ -316,7 +316,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors).containsExactly("$.principal: must be at least 1 characters long");
   }
 
@@ -329,7 +329,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors).containsExactly("$: required property 'credentials' not found");
   }
 
@@ -342,7 +342,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors).containsExactly("$.credentials: must be at least 1 characters long");
   }
 
@@ -355,7 +355,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors).containsExactly("$: required property 'scheme' not found");
   }
 
@@ -368,7 +368,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors).containsExactly("$.scheme: must be at least 1 characters long");
   }
 
@@ -381,7 +381,7 @@ public class InputValidatorTest {
 
     assertThat(result.isSuccessful()).isFalse();
     List<String> errors =
-        result.getErrors().stream().map(Error::toString).collect(Collectors.toList());
+        result.getErrors().stream().map(ValidationMessage::toString).collect(Collectors.toList());
     assertThat(errors).containsExactly("$.realm: must be at least 1 characters long");
   }
 


### PR DESCRIPTION
This includes a serializability fix for key mappings.

This also includes a downgrade of the JSON schema library, which silently broke the Java 11 compatibility promise of import-spec (Dataflow works with Java 17+ so it's not an issue here, but it's an issue in other import-spec user projects).
This is basically a partial revert of f22c284695e6324bd6bb0ddea53b55f7b9eb5972