### PR TITLE
docs(sourcedb-to-spanner): update PostgreSQL limitations and supported types

### DIFF
--- a/v2/sourcedb-to-spanner/README.md
+++ b/v2/sourcedb-to-spanner/README.md
@@ -14,7 +14,7 @@ Currently, this template works for tables of any size on the follow sources
 
 Tables without primary keys or primary keys not mentioned above are not supported.
 
-For detailed information regarding PostgreSQL-specific features and limitations, please refer to the [PostgreSQL Specific Limitations](#postgresql-specific-limitations) section.
+For detailed information regarding PostgreSQL-specific features and limitations, please refer to the [PostgreSQL Supported Features and Limitations](#postgresql-supported-features-and-limitations) section.
 
 ## Getting Started
 
@@ -151,7 +151,7 @@ However, because the continuous reader watches the `retry/` directory indefinite
     * For tables with string primary key, all shards have the same weights for a given collation (the collection weight detection
       is queried on available shards for efficient parallel discovery).
 
-#### PostgreSQL Specific Limitations
+#### PostgreSQL Supported Features and Limitations
 * **Table Inheritance:** When migrating databases utilizing table inheritance, the pipeline queries parent tables using the `ONLY` keyword. This ensures data is not duplicated from child tables into the parent table in Spanner. Instead, child tables are discovered and migrated as their own separate, independent tables in Spanner.
 * **Declarative Partitioning:** Fully supported. When migrating partitioned tables, provision only the parent table in your target Spanner schema. The pipeline will automatically read records from all underlying source partitions and seamlessly consolidate them into the single parent table in Spanner. **Do not provision the individual child partitions in Spanner, as doing so will cause the pipeline to migrate them separately and result in data duplication.**
 * **Custom Namespaces:** Full end-to-end support for custom namespaces (schemas other than `public`) is currently out of scope. Providing a custom namespace will cause the pipeline initialization to fail-fast.

--- a/v2/sourcedb-to-spanner/README.md
+++ b/v2/sourcedb-to-spanner/README.md
@@ -8,10 +8,13 @@ Currently, this template works for tables of any size on the follow sources
   including unsigned) and Binary/VarBinary primary keys.
 * MySQL 5.7+ - Integer like (up to BigInteger including unsigned) and
   Binary/VarBinary primary keys.
-* PostgreSQL 13+ - String (upto 3 byte characters) and Integer like (up to
-  BigInteger including unsigned) primary keys.
+* PostgreSQL 13+ - String (`VARCHAR` and `TEXT` only, upto 3 byte characters; `CHAR` is not supported), Integer like (up to
+  BigInteger including unsigned), Float, Double, Numeric/Decimal, Date, Time,
+  Timetz, Timestamp, Timestamptz, Bit, and UUID primary keys.
 
 Tables without primary keys or primary keys not mentioned above are not supported.
+
+For detailed information regarding PostgreSQL-specific features and limitations, please refer to the [PostgreSQL Specific Limitations](#postgresql-specific-limitations) section.
 
 ## Getting Started
 
@@ -147,3 +150,57 @@ However, because the continuous reader watches the `retry/` directory indefinite
     * All shards have same dialect (mixed dialect migration will cause pipeline failure during initialization)
     * For tables with string primary key, all shards have the same weights for a given collation (the collection weight detection
       is queried on available shards for efficient parallel discovery).
+
+#### PostgreSQL Specific Limitations
+* **Table Inheritance:** When migrating databases utilizing table inheritance, the pipeline queries parent tables using the `ONLY` keyword. This ensures data is not duplicated from child tables into the parent table in Spanner. Instead, child tables are discovered and migrated as their own separate, independent tables in Spanner.
+* **Declarative Partitioning:** Fully supported. When migrating partitioned tables, provision only the parent table in your target Spanner schema. The pipeline will automatically read records from all underlying source partitions and seamlessly consolidate them into the single parent table in Spanner. **Do not provision the individual child partitions in Spanner, as doing so will cause the pipeline to migrate them separately and result in data duplication.**
+* **Custom Namespaces:** Full end-to-end support for custom namespaces (schemas other than `public`) is currently out of scope. Providing a custom namespace will cause the pipeline initialization to fail-fast.
+* **Supported Data Types:**
+  * **`SMALLINT` / `SMALLSERIAL`:**
+    * *Spanner GoogleSQL:* `INT64`, `NUMERIC`, `FLOAT32`, `FLOAT64`, `STRING`
+    * *Spanner PostgreSQL:* `BIGINT`, `NUMERIC`, `REAL`, `DOUBLE PRECISION`, `VARCHAR` / `TEXT`
+  * **`INTEGER` / `SERIAL` / `OID`:**
+    * *Spanner GoogleSQL:* `INT64`, `NUMERIC`, `FLOAT64`, `STRING`
+    * *Spanner PostgreSQL:* `BIGINT`, `NUMERIC`, `DOUBLE PRECISION`, `VARCHAR` / `TEXT`
+  * **`BIGINT` / `BIGSERIAL`:**
+    * *Spanner GoogleSQL:* `INT64`, `NUMERIC`, `STRING`
+    * *Spanner PostgreSQL:* `BIGINT`, `NUMERIC`, `VARCHAR` / `TEXT`
+  * **`REAL` (`FLOAT4`):**
+    * *Spanner GoogleSQL:* `FLOAT32`, `FLOAT64`, `STRING`
+    * *Spanner PostgreSQL:* `REAL`, `DOUBLE PRECISION`, `VARCHAR` / `TEXT`
+  * **`DOUBLE PRECISION` (`FLOAT8`):**
+    * *Spanner GoogleSQL:* `FLOAT64`, `STRING`
+    * *Spanner PostgreSQL:* `DOUBLE PRECISION`, `VARCHAR` / `TEXT`
+  * **`DECIMAL` / `NUMERIC`:**
+    * *Spanner GoogleSQL:* `STRING`
+    * *Spanner PostgreSQL:* `VARCHAR` / `TEXT`
+  * **`MONEY`:**
+    * *Spanner GoogleSQL:* `NUMERIC`, `STRING`
+    * *Spanner PostgreSQL:* `NUMERIC`, `VARCHAR` / `TEXT`
+  * **`CHAR`, `VARCHAR`, `TEXT`:**
+    * *Spanner GoogleSQL:* `STRING`
+    * *Spanner PostgreSQL:* `VARCHAR` / `TEXT`
+  * **`DATE`:**
+    * *Spanner GoogleSQL:* `DATE`, `STRING`
+    * *Spanner PostgreSQL:* `DATE`, `VARCHAR` / `TEXT`
+  * **`TIMESTAMP` , `TIMESTAMPTZ`:**
+    * *Spanner GoogleSQL:* `TIMESTAMP`, `STRING`
+    * *Spanner PostgreSQL:* `TIMESTAMPTZ`, `VARCHAR` / `TEXT`
+  * **`TIME`, `TIMETZ`, `INTERVAL`:**
+    * *Spanner GoogleSQL:* `STRING`
+    * *Spanner PostgreSQL:* `VARCHAR` / `TEXT`
+  * **`BOOL` / `BOOLEAN`:**
+    * *Spanner GoogleSQL:* `BOOL`, `STRING`
+    * *Spanner PostgreSQL:* `BOOLEAN`, `VARCHAR` / `TEXT`
+  * **`BYTEA`, `BIT`, `VARBIT`:**
+    * *Spanner GoogleSQL:* `BYTES`
+    * *Spanner PostgreSQL:* `BYTEA`
+  * **`UUID`:**
+    * *Spanner GoogleSQL:* `UUID`, `BYTES`, `STRING`
+    * *Spanner PostgreSQL:* `UUID`, `BYTEA`, `VARCHAR` / `TEXT`
+  * **`CIDR`, `INET`:**
+    * *Spanner GoogleSQL:* `STRING`
+    * *Spanner PostgreSQL:* `VARCHAR` / `TEXT`
+  * **`JSON` / `JSONB`:**
+    * *Spanner GoogleSQL:* `JSON`, `STRING`
+    * *Spanner PostgreSQL:* `JSONB`, `VARCHAR` / `TEXT`

--- a/v2/sourcedb-to-spanner/README.md
+++ b/v2/sourcedb-to-spanner/README.md
@@ -154,7 +154,7 @@ However, because the continuous reader watches the `retry/` directory indefinite
 #### PostgreSQL Supported Features and Limitations
 * **Table Inheritance:** When migrating databases utilizing table inheritance, the pipeline queries parent tables using the `ONLY` keyword. This ensures data is not duplicated from child tables into the parent table in Spanner. Instead, child tables are discovered and migrated as their own separate, independent tables in Spanner.
 * **Declarative Partitioning:** Fully supported. When migrating partitioned tables, provision only the parent table in your target Spanner schema. The pipeline will automatically read records from all underlying source partitions and seamlessly consolidate them into the single parent table in Spanner. **Do not provision the individual child partitions in Spanner, as doing so will cause the pipeline to migrate them separately and result in data duplication.**
-* **Custom Namespaces:** Full end-to-end support for custom namespaces (schemas other than `public`) is currently out of scope. Providing a custom namespace will cause the pipeline initialization to fail-fast.
+* **Custom Namespaces:** Custom namespaces (schemas other than the default schema i.e. `public`) are not supported.
 * **Supported Data Types:**
   * **`SMALLINT` / `SMALLSERIAL`:**
     * *Spanner GoogleSQL:* `INT64`, `NUMERIC`, `FLOAT32`, `FLOAT64`, `STRING`

--- a/v2/sourcedb-to-spanner/README.md
+++ b/v2/sourcedb-to-spanner/README.md
@@ -196,8 +196,8 @@ However, because the continuous reader watches the `retry/` directory indefinite
     * *Spanner GoogleSQL:* `BYTES`
     * *Spanner PostgreSQL:* `BYTEA`
   * **`UUID`:**
-    * *Spanner GoogleSQL:* `UUID`, `BYTES`, `STRING`
-    * *Spanner PostgreSQL:* `UUID`, `BYTEA`, `VARCHAR` / `TEXT`
+    * *Spanner GoogleSQL:* `UUID`, `STRING`
+    * *Spanner PostgreSQL:* `UUID`, `VARCHAR` / `TEXT`
   * **`CIDR`, `INET`:**
     * *Spanner GoogleSQL:* `STRING`
     * *Spanner PostgreSQL:* `VARCHAR` / `TEXT`

--- a/v2/sourcedb-to-spanner/README_Sourcedb_to_Spanner_Flex.md
+++ b/v2/sourcedb-to-spanner/README_Sourcedb_to_Spanner_Flex.md
@@ -42,7 +42,7 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 * **transformationJarPath**: Custom jar location in Cloud Storage that contains the custom transformation logic for processing records. Defaults to empty.
 * **transformationClassName**: Fully qualified class name having the custom transformation logic. It is a mandatory field in case transformationJarPath is specified. Defaults to empty.
 * **transformationCustomParameters**: String containing any custom parameters to be passed to the custom transformation class. Defaults to empty.
-* **namespace**: Namespace to exported. For PostgreSQL, if no namespace is provided, 'public' will be used. Note: Custom non-public namespaces are currently unsupported for PostgreSQL and will cause the job to fail immediately. Defaults to empty.
+* **namespace**: Namespace to be exported. For PostgreSQL, if no namespace is provided, 'public' will be used. Note: Custom non-public namespaces are currently unsupported for PostgreSQL and will cause the job to fail immediately. Defaults to empty.
 * **insertOnlyModeForSpannerMutations**: By default the pipeline uses Upserts to write rows to spanner. Which means existing rows would get overwritten. If InsertOnly mode is enabled, inserts would be used instead of upserts and existing rows won't be overwritten.
 * **batchSizeForSpannerMutations**: BatchSize in bytes for Spanner Mutations. if set less than 0, default of Apache Beam's SpannerIO is used, which is 1MB. Set this to 0 or 10, to disable batching mutations.
 * **spannerPriority**: The request priority for Cloud Spanner calls. The value must be one of: [`HIGH`,`MEDIUM`,`LOW`]. Defaults to `HIGH`.

--- a/v2/sourcedb-to-spanner/README_Sourcedb_to_Spanner_Flex.md
+++ b/v2/sourcedb-to-spanner/README_Sourcedb_to_Spanner_Flex.md
@@ -42,7 +42,7 @@ on [Metadata Annotations](https://github.com/GoogleCloudPlatform/DataflowTemplat
 * **transformationJarPath**: Custom jar location in Cloud Storage that contains the custom transformation logic for processing records. Defaults to empty.
 * **transformationClassName**: Fully qualified class name having the custom transformation logic. It is a mandatory field in case transformationJarPath is specified. Defaults to empty.
 * **transformationCustomParameters**: String containing any custom parameters to be passed to the custom transformation class. Defaults to empty.
-* **namespace**: Namespace to exported. For PostgreSQL, if no namespace is provided, 'public' will be used. Defaults to empty.
+* **namespace**: Namespace to exported. For PostgreSQL, if no namespace is provided, 'public' will be used. Note: Custom non-public namespaces are currently unsupported for PostgreSQL and will cause the job to fail immediately. Defaults to empty.
 * **insertOnlyModeForSpannerMutations**: By default the pipeline uses Upserts to write rows to spanner. Which means existing rows would get overwritten. If InsertOnly mode is enabled, inserts would be used instead of upserts and existing rows won't be overwritten.
 * **batchSizeForSpannerMutations**: BatchSize in bytes for Spanner Mutations. if set less than 0, default of Apache Beam's SpannerIO is used, which is 1MB. Set this to 0 or 10, to disable batching mutations.
 * **spannerPriority**: The request priority for Cloud Spanner calls. The value must be one of: [`HIGH`,`MEDIUM`,`LOW`]. Defaults to `HIGH`.

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/SourceDbToSpannerOptions.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/SourceDbToSpannerOptions.java
@@ -257,7 +257,7 @@ public interface SourceDbToSpannerOptions extends CommonTemplateOptions {
       optional = true,
       description = "Namespace",
       helpText =
-          "Namespace to exported. For PostgreSQL, if no namespace is provided, 'public' will be used. Note: Custom non-public namespaces are currently unsupported for PostgreSQL and will cause the job to fail immediately.")
+          "Namespace to be exported. For PostgreSQL, if no namespace is provided, 'public' will be used. Note: Custom non-public namespaces are currently unsupported for PostgreSQL and will cause the job to fail immediately.")
   @Default.String("")
   String getNamespace();
 

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/SourceDbToSpannerOptions.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/options/SourceDbToSpannerOptions.java
@@ -257,7 +257,7 @@ public interface SourceDbToSpannerOptions extends CommonTemplateOptions {
       optional = true,
       description = "Namespace",
       helpText =
-          "Namespace to exported. For PostgreSQL, if no namespace is provided, 'public' will be used")
+          "Namespace to exported. For PostgreSQL, if no namespace is provided, 'public' will be used. Note: Custom non-public namespaces are currently unsupported for PostgreSQL and will cause the job to fail immediately.")
   @Default.String("")
   String getNamespace();
 


### PR DESCRIPTION
Updated the sourcedb-to-spanner documentation to explicitly define PostgreSQL-specific behaviors, limitations, and type mapping parity. 

Changes:
- Type Mappings: Added a detailed matrix mapping all supported PostgreSQL source types to both GoogleSQL and PostgreSQL Spanner targets.
- Updated docs state custom schemas (non-public) fail-fast and the wide range of primary key supported.
- Inheritance: Clarified pipeline uses ONLY to prevent child-table data duplication.
- Partitioning: Instructed users to provision only the parent table in Spanner.

