### PR TITLE
fix(datastream-mongodb-to-firestore): handle null-data UPDATE events and improve transient retry classification

### DIFF
--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/DatastreamConstants.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/DatastreamConstants.java
@@ -36,6 +36,7 @@ public class DatastreamConstants {
 
   // Event types
   public static final String DELETE_EVENT = "DELETE";
+  public static final String UPDATE_EVENT = "UPDATE";
   public static final String EMPTY_EVENT = "";
 
   // Default shadow collection prefix

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContext.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/templates/datastream/MongoDbChangeEventContext.java
@@ -57,6 +57,7 @@ public class MongoDbChangeEventContext implements Serializable {
   private final Document shadowDocument;
   private final String jsonStringData;
   private final boolean isDeleteEvent;
+  private final boolean isUpdateEvent;
   private final Document timestampDoc;
   private boolean isDlqReconsumed;
   private int retryCount;
@@ -69,10 +70,20 @@ public class MongoDbChangeEventContext implements Serializable {
     return DatastreamConstants.EMPTY_EVENT;
   }
 
+  public String getChangeType() {
+    return getChangeType(this.changeEvent);
+  }
+
   /** Determines if the event is a delete event based on metadata. */
   private boolean isDeleteEvent(JsonNode changeEvent) {
     String changeType = getChangeType(changeEvent);
     return DatastreamConstants.DELETE_EVENT.equalsIgnoreCase(changeType);
+  }
+
+  /** Determines if the event is an update event based on metadata. */
+  private boolean isUpdateEvent(JsonNode changeEvent) {
+    String changeType = getChangeType(changeEvent);
+    return DatastreamConstants.UPDATE_EVENT.equalsIgnoreCase(changeType);
   }
 
   /** Determines if the event is from dlq. */
@@ -168,6 +179,7 @@ public class MongoDbChangeEventContext implements Serializable {
 
     // Determine event types
     this.isDeleteEvent = isDeleteEvent(changeEvent);
+    this.isUpdateEvent = isUpdateEvent(changeEvent);
 
     this.jsonStringData = dataAsJsonString();
     this.shadowDocument = generateShadowDocument();
@@ -226,6 +238,10 @@ public class MongoDbChangeEventContext implements Serializable {
 
   public boolean isDeleteEvent() {
     return isDeleteEvent;
+  }
+
+  public boolean isUpdateEvent() {
+    return isUpdateEvent;
   }
 
   public Document getShadowDocument() {

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
@@ -354,34 +354,12 @@ public class ProcessChangeEventFn
         if (mongoException.getErrorLabels().contains("TransientTransactionError")) {
           return true;
         }
-        // Extract the server error code across different MongoDB exception wrappers:
-        // - MongoWriteException: getError().getCode()
-        // - MongoCommandException: getErrorCode()
-        // - Standard MongoException: getCode()
-        int errorCode =
-            t instanceof MongoWriteException writeEx
-                ? writeEx.getError().getCode()
-                : t instanceof com.mongodb.MongoCommandException cmdEx
-                    ? cmdEx.getErrorCode()
-                    : mongoException.getCode();
+        int errorCode = getErrorCode(t, mongoException);
+        boolean isUnknownTxn = isUnknownTransactionError(errorCode, mongoException.getMessage());
 
-        // Check for unknown/expired transaction errors:
-        // - Standard MongoDB code 251 (NoSuchTransaction)
-        // - Firestore compatibility code 2 (BadValue) with messages mentioning a missing/unknown
-        //   transaction (case-insensitive to be resilient against server rephrasing).
-        String msg = mongoException.getMessage();
-        boolean isUnknownTxn =
-            errorCode == 251
-                || (errorCode == 2
-                    && msg != null
-                    && msg.toLowerCase().contains("transaction")
-                    && (msg.toLowerCase().contains("unknown")
-                        || msg.toLowerCase().contains("not found")
-                        || msg.toLowerCase().contains("expired")
-                        || msg.toLowerCase().contains("no such")));
-
-        // Error 112 (WriteConflict/Aborted), Error 91 (ShutdownInProgress), and unknown transaction
-        // errors are transient server aborts that succeed when retried with exponential backoff.
+        // Error 112 (WriteConflict/Aborted), Error 91 (ShutdownInProgress), and unknown
+        // transaction errors are transient server aborts that succeed when retried with
+        // exponential backoff.
         if (errorCode == 112 || errorCode == 91 || isUnknownTxn) {
           return true;
         }
@@ -389,5 +367,41 @@ public class ProcessChangeEventFn
       t = t.getCause();
     }
     return false;
+  }
+
+  // Extract the server error code across different MongoDB exception wrappers:
+  // - MongoWriteException: getError().getCode()
+  // - MongoCommandException: getErrorCode()
+  // - Standard MongoException: getCode()
+  private static int getErrorCode(Throwable t, MongoException mongoException) {
+    if (t instanceof MongoWriteException writeEx && writeEx.getError() != null) {
+      return writeEx.getError().getCode();
+    }
+    if (t instanceof com.mongodb.MongoCommandException cmdEx) {
+      return cmdEx.getErrorCode();
+    }
+    return mongoException.getCode();
+  }
+
+  // Check for unknown/expired transaction errors:
+  private static boolean isUnknownTransactionError(int errorCode, String msg) {
+    // Standard MongoDB code 251 (NoSuchTransaction)
+    if (errorCode == 251) {
+      return true;
+    }
+    if (errorCode != 2 || msg == null) {
+      return false;
+    }
+    // Firestore compatibility code 2 (BadValue) with messages mentioning a
+    // missing/unknown
+    // transaction (case-insensitive to be resilient against server rephrasing).
+    String lowerMsg = msg.toLowerCase();
+    if (!lowerMsg.contains("transaction")) {
+      return false;
+    }
+    return lowerMsg.contains("unknown")
+        || lowerMsg.contains("not found")
+        || lowerMsg.contains("expired")
+        || lowerMsg.contains("no such");
   }
 }

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
@@ -161,10 +161,7 @@ public class ProcessChangeEventFn
               }
             } else {
               dataCollection.replaceOne(
-                  session,
-                  lookupById,
-                  docToWrite,
-                  new ReplaceOptions().upsert(true));
+                  session, lookupById, docToWrite, new ReplaceOptions().upsert(true));
               shadowCollection.replaceOne(
                   session,
                   lookupById,
@@ -204,24 +201,18 @@ public class ProcessChangeEventFn
           }
         }
 
-        // Check if the error is permanent (e.g. code 2 for InvalidArgument when exceeding nesting
-        // limit)
-        boolean isPermanent = false;
-        if (e instanceof MongoWriteException writeException) {
-          if (writeException.getError().getCode() == INVALID_ARGUMENT) {
-            isPermanent = true;
-          }
-        }
-
-        // Check if the error is transient and safe to retry
-        boolean isTransient = isTransientTransactionError(e);
-
-        // If it's a permanent error or not transient, fail fast and route to severe DLQ
-        if (isPermanent || !isTransient) {
+        // Check if the error is transient and safe to retry.
+        // Non-transient errors (including permanent schema/argument errors such as code 2
+        // INVALID_ARGUMENT when exceeding nesting limits, but excluding transient errors like
+        // "Transaction number ... is unknown") fail fast and are routed to the severe DLQ.
+        if (!isTransientTransactionError(e)) {
           LOG.error(
-              "Permanent or non-retryable error for document ID: {}: {}",
+              "Permanent or non-retryable error on attempt {} (not retried in-memory) for document"
+                  + " ID: {}: {}",
+              retryCount + 1,
               element.getDocumentId(),
-              e.getMessage());
+              e.getMessage(),
+              e);
           FailsafeElement<MongoDbChangeEventContext, MongoDbChangeEventContext> failedElement =
               FailsafeElement.of(element, element);
           failedElement.setErrorMessage(e.getMessage());
@@ -280,7 +271,9 @@ public class ProcessChangeEventFn
           retryCount++;
         } else {
           LOG.error(
-              "Transaction failed after {} attempts for document ID: {}: {}",
+              "Transient transaction error exceeded maxRetries ({}) after {} attempts for document"
+                  + " ID: {}: {}",
+              maxRetries,
               retryCount + 1,
               element.getDocumentId(),
               e.getMessage(),
@@ -291,7 +284,10 @@ public class ProcessChangeEventFn
           failedElement.setStacktrace(Throwables.getStackTraceAsString(e));
           out.get(failedWriteTag).output(failedElement);
           retriableFailedWrites.inc();
-          LOG.info("Failed element of id {} sent to DLQ", element.getDocumentId());
+          LOG.info(
+              "Failed element of id {} sent to retry DLQ after {} attempts",
+              element.getDocumentId(),
+              retryCount + 1);
           break; // Exit the retry loop on non-transient error or max retries
         }
       } finally {
@@ -300,11 +296,12 @@ public class ProcessChangeEventFn
         }
       }
     }
-    if (lastException != null && retryCount > maxRetries) {
-      LOG.error(
-          "Transaction failed after max retries ({}) for document ID: {}: {}",
-          maxRetries,
+    if (lastException != null && retryCount >= maxRetries) {
+      LOG.warn(
+          "Transaction for document ID: {} exceeded maxRetries ({}) and has been routed to the"
+              + " Automatic Retry DLQ (/retry/) for background reconsumption. Last exception: {}",
           element.getDocumentId(),
+          maxRetries,
           lastException.getMessage(),
           lastException);
     }
@@ -351,7 +348,46 @@ public class ProcessChangeEventFn
   }
 
   public static boolean isTransientTransactionError(Exception e) {
-    return e instanceof MongoException
-        && ((MongoException) e).getErrorLabels().contains("TransientTransactionError");
+    Throwable t = e;
+    while (t != null) {
+      if (t instanceof MongoException mongoException) {
+        if (mongoException.getErrorLabels().contains("TransientTransactionError")) {
+          return true;
+        }
+        // Extract the server error code across different MongoDB exception wrappers:
+        // - MongoWriteException: getError().getCode()
+        // - MongoCommandException: getErrorCode()
+        // - Standard MongoException: getCode()
+        int errorCode =
+            t instanceof MongoWriteException writeEx
+                ? writeEx.getError().getCode()
+                : t instanceof com.mongodb.MongoCommandException cmdEx
+                    ? cmdEx.getErrorCode()
+                    : mongoException.getCode();
+
+        // Check for unknown/expired transaction errors:
+        // - Standard MongoDB code 251 (NoSuchTransaction)
+        // - Firestore compatibility code 2 (BadValue) with messages mentioning a missing/unknown
+        //   transaction (case-insensitive to be resilient against server rephrasing).
+        String msg = mongoException.getMessage();
+        boolean isUnknownTxn =
+            errorCode == 251
+                || (errorCode == 2
+                    && msg != null
+                    && msg.toLowerCase().contains("transaction")
+                    && (msg.toLowerCase().contains("unknown")
+                        || msg.toLowerCase().contains("not found")
+                        || msg.toLowerCase().contains("expired")
+                        || msg.toLowerCase().contains("no such")));
+
+        // Error 112 (WriteConflict/Aborted), Error 91 (ShutdownInProgress), and unknown transaction
+        // errors are transient server aborts that succeed when retried with exponential backoff.
+        if (errorCode == 112 || errorCode == 91 || isUnknownTxn) {
+          return true;
+        }
+      }
+      t = t.getCause();
+    }
+    return false;
   }
 }

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFn.java
@@ -79,6 +79,8 @@ public class ProcessChangeEventFn
       Metrics.counter(ProcessChangeEventFn.class, "inMemoryRetries");
   private final Counter outOfOrderSkips =
       Metrics.counter(ProcessChangeEventFn.class, "outOfOrderSkips");
+  private final Counter nullDataUpdateSkips =
+      Metrics.counter(ProcessChangeEventFn.class, "nullDataUpdateSkips");
 
   public ProcessChangeEventFn(String connectionString, String databaseName) {
     this.connectionString = connectionString;
@@ -124,6 +126,7 @@ public class ProcessChangeEventFn
         Document shadowDoc = shadowCollection.find(session, lookupById).first();
 
         if (isEventNewerThanShadowDoc(element, shadowDoc)) {
+          boolean writeSucceeded = false;
           if (element.isDeleteEvent()) {
             // This is a delete event - delete the document from data collection
             dataCollection.deleteOne(session, lookupById);
@@ -133,20 +136,49 @@ public class ProcessChangeEventFn
                 lookupById,
                 element.getShadowDocument(),
                 new ReplaceOptions().upsert(true));
+            writeSucceeded = true;
           } else {
             // Regular insert or update.
-            dataCollection.replaceOne(
-                session,
-                lookupById,
-                Utils.jsonToDocument(element.getDataAsJsonString(), element.getDocumentId()),
-                new ReplaceOptions().upsert(true));
-            shadowCollection.replaceOne(
-                session,
-                lookupById,
-                element.getShadowDocument(),
-                new ReplaceOptions().upsert(true));
+            Document docToWrite =
+                Utils.jsonToDocument(element.getDataAsJsonString(), element.getDocumentId());
+            if (docToWrite == null) {
+              if (element.isUpdateEvent()) {
+                LOG.info(
+                    "Skipping update event for document ID: {} because 'data' field is null"
+                        + " (document may have been deleted immediately after update in MongoDB).",
+                    element.getDocumentId());
+                nullDataUpdateSkips.inc();
+                Metrics.counter(
+                        ProcessChangeEventFn.class,
+                        "nullDataUpdateSkips_" + element.getChangeType())
+                    .inc();
+              } else {
+                throw new IllegalArgumentException(
+                    "Event payload has missing or null 'data' field for non-UPDATE event (type: "
+                        + element.getChangeType()
+                        + "), document ID: "
+                        + element.getDocumentId());
+              }
+            } else {
+              dataCollection.replaceOne(
+                  session,
+                  lookupById,
+                  docToWrite,
+                  new ReplaceOptions().upsert(true));
+              shadowCollection.replaceOne(
+                  session,
+                  lookupById,
+                  element.getShadowDocument(),
+                  new ReplaceOptions().upsert(true));
+              writeSucceeded = true;
+            }
           }
-          successfulWrites.inc();
+          if (writeSucceeded) {
+            successfulWrites.inc();
+            Metrics.counter(
+                    ProcessChangeEventFn.class, "successfulWrites_" + element.getChangeType())
+                .inc();
+          }
         } else {
           // Existing document has a later timestamp, skip this event
           outOfOrderSkips.inc();

--- a/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/Utils.java
+++ b/v2/datastream-mongodb-to-firestore/src/main/java/com/google/cloud/teleport/v2/transforms/Utils.java
@@ -60,6 +60,9 @@ public final class Utils {
           "Document parsing for {} failed due to {}, try casting.", jsonString, ex.getMessage());
       rawDoc = (Document) Document.parse(jsonString).get(DATA_COL);
     }
+    if (rawDoc == null) {
+      return null;
+    }
     rawDoc.put(MongoDbChangeEventContext.DOC_ID_COL, documentId);
     return rawDoc;
   }

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
@@ -17,6 +17,8 @@ package com.google.cloud.teleport.v2.transforms;
 
 import static com.mongodb.client.model.Filters.eq;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -497,8 +499,7 @@ public class ProcessChangeEventFnTest {
 
     processFn.processElement(mockContext, mockReceiver);
 
-    verify(mockDataCollection, never())
-        .replaceOne(any(), any(), any(), any(ReplaceOptions.class));
+    verify(mockDataCollection, never()).replaceOne(any(), any(), any(), any(ReplaceOptions.class));
     verify(mockShadowCollection, never())
         .replaceOne(any(), any(), any(), any(ReplaceOptions.class));
     verify(mockSession).commitTransaction();
@@ -533,11 +534,107 @@ public class ProcessChangeEventFnTest {
 
     processFn.processElement(mockContext, mockReceiver);
 
-    verify(mockDataCollection, never())
-        .replaceOne(any(), any(), any(), any(ReplaceOptions.class));
+    verify(mockDataCollection, never()).replaceOne(any(), any(), any(), any(ReplaceOptions.class));
     verify(mockShadowCollection, never())
         .replaceOne(any(), any(), any(), any(ReplaceOptions.class));
     verify(mockReceiver).get(ProcessChangeEventFn.severeFailedWriteTag);
     verify(mockSevereFailureReceiver, times(1)).output(any());
+  }
+
+  @Test
+  public void testIsTransientTransactionError_code112WithoutLabel() {
+    org.bson.BsonDocument response = new org.bson.BsonDocument("code", new org.bson.BsonInt32(112));
+    com.mongodb.MongoCommandException commandException =
+        new com.mongodb.MongoCommandException(
+            response, new com.mongodb.ServerAddress("localhost", 27017));
+    assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));
+  }
+
+  @Test
+  public void testIsTransientTransactionError_writeExceptionCode112WithoutLabel() {
+    WriteError writeError = new WriteError(112, "Write conflict", new org.bson.BsonDocument());
+    MongoWriteException writeException =
+        new MongoWriteException(writeError, new com.mongodb.ServerAddress("localhost", 27017));
+    assertTrue(ProcessChangeEventFn.isTransientTransactionError(writeException));
+  }
+
+  @Test
+  public void testIsTransientTransactionError_nonTransientError() {
+    org.bson.BsonDocument response = new org.bson.BsonDocument("code", new org.bson.BsonInt32(123));
+    com.mongodb.MongoCommandException commandException =
+        new com.mongodb.MongoCommandException(
+            response, new com.mongodb.ServerAddress("localhost", 27017));
+    assertFalse(ProcessChangeEventFn.isTransientTransactionError(commandException));
+  }
+
+  @Test
+  public void testIsTransientTransactionError_unknownTransactionNumber() {
+    org.bson.BsonDocument response =
+        new org.bson.BsonDocument("code", new org.bson.BsonInt32(2))
+            .append("errmsg", new org.bson.BsonString("Transaction number 488769 is unknown."));
+    com.mongodb.MongoCommandException commandException =
+        new com.mongodb.MongoCommandException(
+            response, new com.mongodb.ServerAddress("localhost", 27017));
+    assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));
+  }
+
+  @Test
+  public void testIsTransientTransactionError_code251NoSuchTransaction() {
+    org.bson.BsonDocument response =
+        new org.bson.BsonDocument("code", new org.bson.BsonInt32(251))
+            .append(
+                "errmsg",
+                new org.bson.BsonString("Given transaction number 488769 does not exist"));
+    com.mongodb.MongoCommandException commandException =
+        new com.mongodb.MongoCommandException(
+            response, new com.mongodb.ServerAddress("localhost", 27017));
+    assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));
+  }
+
+  @Test
+  public void testIsTransientTransactionError_rephrasedUnknownTransaction() {
+    org.bson.BsonDocument response =
+        new org.bson.BsonDocument("code", new org.bson.BsonInt32(2))
+            .append("errmsg", new org.bson.BsonString("Transaction 488769 not found on server"));
+    com.mongodb.MongoCommandException commandException =
+        new com.mongodb.MongoCommandException(
+            response, new com.mongodb.ServerAddress("localhost", 27017));
+    assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));
+  }
+
+  @Test
+  public void testIsTransientTransactionError_commandExceptionCode112WithoutLabel() {
+    org.bson.BsonDocument response =
+        new org.bson.BsonDocument("code", new org.bson.BsonInt32(112))
+            .append("errmsg", new org.bson.BsonString("Too much contention on these documents."));
+    com.mongodb.MongoCommandException commandException =
+        new com.mongodb.MongoCommandException(
+            response, new com.mongodb.ServerAddress("localhost", 27017));
+    assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));
+  }
+
+  @Test
+  public void testIsTransientTransactionError_commandExceptionCode91ShutdownInProgress() {
+    org.bson.BsonDocument response =
+        new org.bson.BsonDocument("code", new org.bson.BsonInt32(91))
+            .append(
+                "errmsg",
+                new org.bson.BsonString(
+                    "The service is temporarily unavailable. Please retry with exponential"
+                        + " backoff."));
+    com.mongodb.MongoCommandException commandException =
+        new com.mongodb.MongoCommandException(
+            response, new com.mongodb.ServerAddress("localhost", 27017));
+    assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));
+  }
+
+  @Test
+  public void testIsTransientTransactionError_wrappedInRuntimeException() {
+    org.bson.BsonDocument response = new org.bson.BsonDocument("code", new org.bson.BsonInt32(112));
+    com.mongodb.MongoCommandException commandException =
+        new com.mongodb.MongoCommandException(
+            response, new com.mongodb.ServerAddress("localhost", 27017));
+    RuntimeException wrappedException = new RuntimeException("Wrapped error", commandException);
+    assertTrue(ProcessChangeEventFn.isTransientTransactionError(wrappedException));
   }
 }

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
@@ -369,8 +369,7 @@ public class ProcessChangeEventFnTest {
     WriteError writeError =
         new WriteError(
             2, "At most 20 nested array/entity values are supported.", new BsonDocument());
-    MongoWriteException permanentError =
-        new MongoWriteException(writeError, new ServerAddress());
+    MongoWriteException permanentError = new MongoWriteException(writeError, new ServerAddress());
 
     when(mockShadowCollection.find(mockSession, LOOKUP_BY_DOC_ID)).thenThrow(permanentError);
 
@@ -582,9 +581,7 @@ public class ProcessChangeEventFnTest {
   public void testIsTransientTransactionError_code251NoSuchTransaction() {
     BsonDocument response =
         new BsonDocument("code", new BsonInt32(251))
-            .append(
-                "errmsg",
-                new BsonString("Given transaction number 488769 does not exist"));
+            .append("errmsg", new BsonString("Given transaction number 488769 does not exist"));
     MongoCommandException commandException =
         new MongoCommandException(response, new ServerAddress("localhost", 27017));
     assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
@@ -486,4 +486,58 @@ public class ProcessChangeEventFnTest {
     verify(mockSevereFailureReceiver, times(1)).output(any());
     verify(mockSession, never()).commitTransaction();
   }
+
+  @Test
+  public void testProcessElement_updateEventWithNullDataSkips() {
+    when(mockFindIterable.first()).thenReturn(null);
+    when(mockElement.getDataAsJsonString()).thenReturn(new Document("data", null).toJson());
+    when(mockElement.isDeleteEvent()).thenReturn(false);
+    when(mockElement.isUpdateEvent()).thenReturn(true);
+    when(mockElement.getChangeType()).thenReturn("UPDATE");
+
+    processFn.processElement(mockContext, mockReceiver);
+
+    verify(mockDataCollection, never())
+        .replaceOne(any(), any(), any(), any(ReplaceOptions.class));
+    verify(mockShadowCollection, never())
+        .replaceOne(any(), any(), any(), any(ReplaceOptions.class));
+    verify(mockSession).commitTransaction();
+    verify(mockSession, never()).abortTransaction();
+    verify(mockReceiver).get(ProcessChangeEventFn.successfulWriteTag);
+    verify(mockSuccessReceiver, times(1)).output(mockElement);
+
+    MetricsContainerImpl container =
+        (MetricsContainerImpl) MetricsEnvironment.getCurrentContainer();
+    assertEquals(
+        1L,
+        (long)
+            container
+                .getCounter(MetricName.named(ProcessChangeEventFn.class, "nullDataUpdateSkips"))
+                .getCumulative());
+    assertEquals(
+        1L,
+        (long)
+            container
+                .getCounter(
+                    MetricName.named(ProcessChangeEventFn.class, "nullDataUpdateSkips_UPDATE"))
+                .getCumulative());
+  }
+
+  @Test
+  public void testProcessElement_insertEventWithNullDataRoutesToSevereDlq() {
+    when(mockFindIterable.first()).thenReturn(null);
+    when(mockElement.getDataAsJsonString()).thenReturn(new Document("data", null).toJson());
+    when(mockElement.isDeleteEvent()).thenReturn(false);
+    when(mockElement.isUpdateEvent()).thenReturn(false);
+    when(mockElement.getChangeType()).thenReturn("INSERT");
+
+    processFn.processElement(mockContext, mockReceiver);
+
+    verify(mockDataCollection, never())
+        .replaceOne(any(), any(), any(), any(ReplaceOptions.class));
+    verify(mockShadowCollection, never())
+        .replaceOne(any(), any(), any(), any(ReplaceOptions.class));
+    verify(mockReceiver).get(ProcessChangeEventFn.severeFailedWriteTag);
+    verify(mockSevereFailureReceiver, times(1)).output(any());
+  }
 }

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
@@ -458,8 +458,7 @@ public class ProcessChangeEventFnTest {
   public void testProcessElementTransientCommandError_retry() {
     BsonDocument response = new BsonDocument("code", new BsonInt32(123));
     MongoCommandException commandException =
-        new MongoCommandException(
-            response, new ServerAddress("localhost", 27017));
+        new MongoCommandException(response, new ServerAddress("localhost", 27017));
     commandException.addLabel("TransientTransactionError");
 
     when(mockShadowCollection.find(mockSession, LOOKUP_BY_DOC_ID))
@@ -481,8 +480,7 @@ public class ProcessChangeEventFnTest {
   public void testProcessElementSevereCommandError() {
     BsonDocument response = new BsonDocument("code", new BsonInt32(123));
     MongoCommandException commandException =
-        new MongoCommandException(
-            response, new ServerAddress("localhost", 27017));
+        new MongoCommandException(response, new ServerAddress("localhost", 27017));
 
     when(mockShadowCollection.find(mockSession, LOOKUP_BY_DOC_ID)).thenThrow(commandException);
 
@@ -550,8 +548,7 @@ public class ProcessChangeEventFnTest {
   public void testIsTransientTransactionError_code112WithoutLabel() {
     BsonDocument response = new BsonDocument("code", new BsonInt32(112));
     MongoCommandException commandException =
-        new MongoCommandException(
-            response, new ServerAddress("localhost", 27017));
+        new MongoCommandException(response, new ServerAddress("localhost", 27017));
     assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));
   }
 
@@ -567,8 +564,7 @@ public class ProcessChangeEventFnTest {
   public void testIsTransientTransactionError_nonTransientError() {
     BsonDocument response = new BsonDocument("code", new BsonInt32(123));
     MongoCommandException commandException =
-        new MongoCommandException(
-            response, new ServerAddress("localhost", 27017));
+        new MongoCommandException(response, new ServerAddress("localhost", 27017));
     assertFalse(ProcessChangeEventFn.isTransientTransactionError(commandException));
   }
 
@@ -578,8 +574,7 @@ public class ProcessChangeEventFnTest {
         new BsonDocument("code", new BsonInt32(2))
             .append("errmsg", new BsonString("Transaction number 488769 is unknown."));
     MongoCommandException commandException =
-        new MongoCommandException(
-            response, new ServerAddress("localhost", 27017));
+        new MongoCommandException(response, new ServerAddress("localhost", 27017));
     assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));
   }
 
@@ -591,8 +586,7 @@ public class ProcessChangeEventFnTest {
                 "errmsg",
                 new BsonString("Given transaction number 488769 does not exist"));
     MongoCommandException commandException =
-        new MongoCommandException(
-            response, new ServerAddress("localhost", 27017));
+        new MongoCommandException(response, new ServerAddress("localhost", 27017));
     assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));
   }
 
@@ -602,8 +596,7 @@ public class ProcessChangeEventFnTest {
         new BsonDocument("code", new BsonInt32(2))
             .append("errmsg", new BsonString("Transaction 488769 not found on server"));
     MongoCommandException commandException =
-        new MongoCommandException(
-            response, new ServerAddress("localhost", 27017));
+        new MongoCommandException(response, new ServerAddress("localhost", 27017));
     assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));
   }
 
@@ -613,8 +606,7 @@ public class ProcessChangeEventFnTest {
         new BsonDocument("code", new BsonInt32(112))
             .append("errmsg", new BsonString("Too much contention on these documents."));
     MongoCommandException commandException =
-        new MongoCommandException(
-            response, new ServerAddress("localhost", 27017));
+        new MongoCommandException(response, new ServerAddress("localhost", 27017));
     assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));
   }
 
@@ -628,8 +620,7 @@ public class ProcessChangeEventFnTest {
                     "The service is temporarily unavailable. Please retry with exponential"
                         + " backoff."));
     MongoCommandException commandException =
-        new MongoCommandException(
-            response, new ServerAddress("localhost", 27017));
+        new MongoCommandException(response, new ServerAddress("localhost", 27017));
     assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));
   }
 
@@ -637,8 +628,7 @@ public class ProcessChangeEventFnTest {
   public void testIsTransientTransactionError_wrappedInRuntimeException() {
     BsonDocument response = new BsonDocument("code", new BsonInt32(112));
     MongoCommandException commandException =
-        new MongoCommandException(
-            response, new ServerAddress("localhost", 27017));
+        new MongoCommandException(response, new ServerAddress("localhost", 27017));
     RuntimeException wrappedException = new RuntimeException("Wrapped error", commandException);
     assertTrue(ProcessChangeEventFn.isTransientTransactionError(wrappedException));
   }

--- a/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
+++ b/v2/datastream-mongodb-to-firestore/src/test/java/com/google/cloud/teleport/v2/transforms/ProcessChangeEventFnTest.java
@@ -28,8 +28,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.teleport.v2.templates.datastream.MongoDbChangeEventContext;
+import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
 import com.mongodb.MongoWriteException;
+import com.mongodb.ServerAddress;
 import com.mongodb.WriteError;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.FindIterable;
@@ -45,6 +47,9 @@ import org.apache.beam.sdk.metrics.MetricsEnvironment;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFn.MultiOutputReceiver;
 import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.junit.Before;
@@ -363,9 +368,9 @@ public class ProcessChangeEventFnTest {
   public void testProcessElementPermanentError_Code2() {
     WriteError writeError =
         new WriteError(
-            2, "At most 20 nested array/entity values are supported.", new org.bson.BsonDocument());
+            2, "At most 20 nested array/entity values are supported.", new BsonDocument());
     MongoWriteException permanentError =
-        new MongoWriteException(writeError, new com.mongodb.ServerAddress());
+        new MongoWriteException(writeError, new ServerAddress());
 
     when(mockShadowCollection.find(mockSession, LOOKUP_BY_DOC_ID)).thenThrow(permanentError);
 
@@ -429,9 +434,9 @@ public class ProcessChangeEventFnTest {
 
   @Test
   public void testProcessElementTransientWriteError_retry() {
-    WriteError writeError = new WriteError(11000, "Duplicate key", new org.bson.BsonDocument());
+    WriteError writeError = new WriteError(11000, "Duplicate key", new BsonDocument());
     MongoWriteException writeException =
-        new MongoWriteException(writeError, new com.mongodb.ServerAddress("localhost", 27017));
+        new MongoWriteException(writeError, new ServerAddress("localhost", 27017));
     writeException.addLabel("TransientTransactionError");
 
     when(mockShadowCollection.find(mockSession, LOOKUP_BY_DOC_ID))
@@ -451,10 +456,10 @@ public class ProcessChangeEventFnTest {
 
   @Test
   public void testProcessElementTransientCommandError_retry() {
-    org.bson.BsonDocument response = new org.bson.BsonDocument("code", new org.bson.BsonInt32(123));
-    com.mongodb.MongoCommandException commandException =
-        new com.mongodb.MongoCommandException(
-            response, new com.mongodb.ServerAddress("localhost", 27017));
+    BsonDocument response = new BsonDocument("code", new BsonInt32(123));
+    MongoCommandException commandException =
+        new MongoCommandException(
+            response, new ServerAddress("localhost", 27017));
     commandException.addLabel("TransientTransactionError");
 
     when(mockShadowCollection.find(mockSession, LOOKUP_BY_DOC_ID))
@@ -474,10 +479,10 @@ public class ProcessChangeEventFnTest {
 
   @Test
   public void testProcessElementSevereCommandError() {
-    org.bson.BsonDocument response = new org.bson.BsonDocument("code", new org.bson.BsonInt32(123));
-    com.mongodb.MongoCommandException commandException =
-        new com.mongodb.MongoCommandException(
-            response, new com.mongodb.ServerAddress("localhost", 27017));
+    BsonDocument response = new BsonDocument("code", new BsonInt32(123));
+    MongoCommandException commandException =
+        new MongoCommandException(
+            response, new ServerAddress("localhost", 27017));
 
     when(mockShadowCollection.find(mockSession, LOOKUP_BY_DOC_ID)).thenThrow(commandException);
 
@@ -543,97 +548,97 @@ public class ProcessChangeEventFnTest {
 
   @Test
   public void testIsTransientTransactionError_code112WithoutLabel() {
-    org.bson.BsonDocument response = new org.bson.BsonDocument("code", new org.bson.BsonInt32(112));
-    com.mongodb.MongoCommandException commandException =
-        new com.mongodb.MongoCommandException(
-            response, new com.mongodb.ServerAddress("localhost", 27017));
+    BsonDocument response = new BsonDocument("code", new BsonInt32(112));
+    MongoCommandException commandException =
+        new MongoCommandException(
+            response, new ServerAddress("localhost", 27017));
     assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));
   }
 
   @Test
   public void testIsTransientTransactionError_writeExceptionCode112WithoutLabel() {
-    WriteError writeError = new WriteError(112, "Write conflict", new org.bson.BsonDocument());
+    WriteError writeError = new WriteError(112, "Write conflict", new BsonDocument());
     MongoWriteException writeException =
-        new MongoWriteException(writeError, new com.mongodb.ServerAddress("localhost", 27017));
+        new MongoWriteException(writeError, new ServerAddress("localhost", 27017));
     assertTrue(ProcessChangeEventFn.isTransientTransactionError(writeException));
   }
 
   @Test
   public void testIsTransientTransactionError_nonTransientError() {
-    org.bson.BsonDocument response = new org.bson.BsonDocument("code", new org.bson.BsonInt32(123));
-    com.mongodb.MongoCommandException commandException =
-        new com.mongodb.MongoCommandException(
-            response, new com.mongodb.ServerAddress("localhost", 27017));
+    BsonDocument response = new BsonDocument("code", new BsonInt32(123));
+    MongoCommandException commandException =
+        new MongoCommandException(
+            response, new ServerAddress("localhost", 27017));
     assertFalse(ProcessChangeEventFn.isTransientTransactionError(commandException));
   }
 
   @Test
   public void testIsTransientTransactionError_unknownTransactionNumber() {
-    org.bson.BsonDocument response =
-        new org.bson.BsonDocument("code", new org.bson.BsonInt32(2))
-            .append("errmsg", new org.bson.BsonString("Transaction number 488769 is unknown."));
-    com.mongodb.MongoCommandException commandException =
-        new com.mongodb.MongoCommandException(
-            response, new com.mongodb.ServerAddress("localhost", 27017));
+    BsonDocument response =
+        new BsonDocument("code", new BsonInt32(2))
+            .append("errmsg", new BsonString("Transaction number 488769 is unknown."));
+    MongoCommandException commandException =
+        new MongoCommandException(
+            response, new ServerAddress("localhost", 27017));
     assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));
   }
 
   @Test
   public void testIsTransientTransactionError_code251NoSuchTransaction() {
-    org.bson.BsonDocument response =
-        new org.bson.BsonDocument("code", new org.bson.BsonInt32(251))
+    BsonDocument response =
+        new BsonDocument("code", new BsonInt32(251))
             .append(
                 "errmsg",
-                new org.bson.BsonString("Given transaction number 488769 does not exist"));
-    com.mongodb.MongoCommandException commandException =
-        new com.mongodb.MongoCommandException(
-            response, new com.mongodb.ServerAddress("localhost", 27017));
+                new BsonString("Given transaction number 488769 does not exist"));
+    MongoCommandException commandException =
+        new MongoCommandException(
+            response, new ServerAddress("localhost", 27017));
     assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));
   }
 
   @Test
   public void testIsTransientTransactionError_rephrasedUnknownTransaction() {
-    org.bson.BsonDocument response =
-        new org.bson.BsonDocument("code", new org.bson.BsonInt32(2))
-            .append("errmsg", new org.bson.BsonString("Transaction 488769 not found on server"));
-    com.mongodb.MongoCommandException commandException =
-        new com.mongodb.MongoCommandException(
-            response, new com.mongodb.ServerAddress("localhost", 27017));
+    BsonDocument response =
+        new BsonDocument("code", new BsonInt32(2))
+            .append("errmsg", new BsonString("Transaction 488769 not found on server"));
+    MongoCommandException commandException =
+        new MongoCommandException(
+            response, new ServerAddress("localhost", 27017));
     assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));
   }
 
   @Test
   public void testIsTransientTransactionError_commandExceptionCode112WithoutLabel() {
-    org.bson.BsonDocument response =
-        new org.bson.BsonDocument("code", new org.bson.BsonInt32(112))
-            .append("errmsg", new org.bson.BsonString("Too much contention on these documents."));
-    com.mongodb.MongoCommandException commandException =
-        new com.mongodb.MongoCommandException(
-            response, new com.mongodb.ServerAddress("localhost", 27017));
+    BsonDocument response =
+        new BsonDocument("code", new BsonInt32(112))
+            .append("errmsg", new BsonString("Too much contention on these documents."));
+    MongoCommandException commandException =
+        new MongoCommandException(
+            response, new ServerAddress("localhost", 27017));
     assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));
   }
 
   @Test
   public void testIsTransientTransactionError_commandExceptionCode91ShutdownInProgress() {
-    org.bson.BsonDocument response =
-        new org.bson.BsonDocument("code", new org.bson.BsonInt32(91))
+    BsonDocument response =
+        new BsonDocument("code", new BsonInt32(91))
             .append(
                 "errmsg",
-                new org.bson.BsonString(
+                new BsonString(
                     "The service is temporarily unavailable. Please retry with exponential"
                         + " backoff."));
-    com.mongodb.MongoCommandException commandException =
-        new com.mongodb.MongoCommandException(
-            response, new com.mongodb.ServerAddress("localhost", 27017));
+    MongoCommandException commandException =
+        new MongoCommandException(
+            response, new ServerAddress("localhost", 27017));
     assertTrue(ProcessChangeEventFn.isTransientTransactionError(commandException));
   }
 
   @Test
   public void testIsTransientTransactionError_wrappedInRuntimeException() {
-    org.bson.BsonDocument response = new org.bson.BsonDocument("code", new org.bson.BsonInt32(112));
-    com.mongodb.MongoCommandException commandException =
-        new com.mongodb.MongoCommandException(
-            response, new com.mongodb.ServerAddress("localhost", 27017));
+    BsonDocument response = new BsonDocument("code", new BsonInt32(112));
+    MongoCommandException commandException =
+        new MongoCommandException(
+            response, new ServerAddress("localhost", 27017));
     RuntimeException wrappedException = new RuntimeException("Wrapped error", commandException);
     assertTrue(ProcessChangeEventFn.isTransientTransactionError(wrappedException));
   }


### PR DESCRIPTION
### Summary
Improves CDC null-payload handling and transaction retry classification.
### Key Changes
* **Null-Data Event Handling For Updates**:
  * Skips `UPDATE` events with null `data` (e.g. document deleted immediately after update) at `INFO` level and increments `nullDataUpdateSkips`.
  * Routes non-UPDATE events with null `data` directly to the Severe DLQ (`/severe/`) as permanent errors.
  * Added null-check in `Utils.jsonToDocument()` to prevent `NullPointerException`.
* **Transient Error Classification & Logging**:
  * Refactored `isTransientTransactionError` across all Mongo exception wrappers (`MongoWriteException`, `MongoCommandException`, `MongoException`).
  * Recognizes transient transaction errors on standard code `251` and compatibility code `2` (`"transaction"` + `"unknown"`/`"not found"`/`"expired"`/`"no such"`), alongside codes `112` and `91`.
  * Includes attempt counts (`retryCount + 1`) in retry logs and clarifies when records exceed `maxRetries` and route to the Automatic Retry DLQ (`/retry/`).
