### PR TITLE
Add source migration testing skills

### DIFF
--- a/v2/datastream-to-spanner/.agents/skills/add-integ-tests-datastream-to-spanner/SKILL.md
+++ b/v2/datastream-to-spanner/.agents/skills/add-integ-tests-datastream-to-spanner/SKILL.md
@@ -9,15 +9,20 @@ This is a specific runner skill that acts as a wrapper around the global `meta-t
 
 ## Required Prompt Inputs
 1. **Target Source Database Name**
-2. **Reference Mapping Matrix File Path**
-3. **Environment Config Path**
+2. **Reference Datatype Mapping Matrix File Path**
+3. **Testing Environment Setup Path**
+
+> [!IMPORTANT]
+> **Initialization Check**: If ANY of the required prompt inputs are missing from the user's prompt, or if the environment config file does not exist, you **MUST HALT EXECUTION IMMEDIATELY**. Ask the user to provide the missing inputs before proceeding.
+> 
+> **Source Support Validation**: Before proceeding to execution, you must verify if the template actually supports migrating from the provided `Target Source Database Name`. Inspect the template's source code (e.g., `DatastreamToSpanner.java` or `DatastreamToSpannerSourceConnectorRegistry.java`) to confirm this database dialect is implemented. If it is not supported, you **MUST HALT EXECUTION IMMEDIATELY** and inform the user.
 
 ## Execution Instructions
 You must immediately load and execute the `v2/spanner-common/.agents/skills/meta-test-orchestrator/SKILL.md` skill, passing it the following statically mapped parameters:
 
 1. **Target Source Database Name:** Extract from the user prompt.
-2. **Reference Mapping Matrix File Path:** Extract from the user prompt.
-3. **Environment Config:** Extract from the user prompt and assert its presence.
+2. **Reference Datatype Mapping Matrix File Path:** Extract from the user prompt.
+3. **Testing Environment Setup Path:** Extract from the user prompt and assert its presence.
 4. **Manifest File Path:** `v2/datastream-to-spanner/src/test/manifest.yaml`.
 5. **Target Template Path:** `v2/datastream-to-spanner`
 6. **Phase 1 Smoke Scenarios:** `live-it`
@@ -27,6 +32,6 @@ Yield execution completely to the `meta-test-orchestrator`. Instruct the Orchest
 
 ## Example User Prompt
 ```text
-Please run the add-integ-tests-datastream-to-spanner skill for the oracle database. 
-Use the reference matrix located at v2/datastream-to-spanner/src/test/resources/oracle/oracle_datatype_mapping_matrix.csv load the execution properties from testing_execution.env.
+Please run the add-integ-tests-datastream-to-spanner skill for the MySQL database. 
+Use the reference matrix located at v2/datastream-to-spanner/src/test/resources/mysql/mysql_datatype_mapping_matrix.csv load the execution properties from testing_execution.env.
 ```

--- a/v2/datastream-to-spanner/.agents/skills/add-integ-tests-datastream-to-spanner/SKILL.md
+++ b/v2/datastream-to-spanner/.agents/skills/add-integ-tests-datastream-to-spanner/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: add-integ-tests-datastream-to-spanner
+description: >-
+  Specific runner skill that delegates to the Template-Agnostic Meta-Test Orchestrator for the datastream-to-spanner (CDC) template.
+---
+# Datastream-to-Spanner Testing Orchestrator 
+
+This is a specific runner skill that acts as a wrapper around the global `meta-test-orchestrator` skill.
+
+## Required Prompt Inputs
+1. **Target Source Database Name**
+2. **Reference Mapping Matrix File Path**
+3. **Environment Config Path**
+
+## Execution Instructions
+You must immediately load and execute the `v2/spanner-common/.agents/skills/meta-test-orchestrator/SKILL.md` skill, passing it the following statically mapped parameters:
+
+1. **Target Source Database Name:** Extract from the user prompt.
+2. **Reference Mapping Matrix File Path:** Extract from the user prompt.
+3. **Environment Config:** Extract from the user prompt and assert its presence.
+4. **Manifest File Path:** `v2/datastream-to-spanner/src/test/manifest.yaml`.
+5. **Target Template Path:** `v2/datastream-to-spanner`
+6. **Phase 1 Smoke Scenarios:** `live-it`
+7. **Phase 2 Baseline Datatype Scenarios:** `live-datatypes`
+
+Yield execution completely to the `meta-test-orchestrator`. Instruct the Orchestrator to begin Phase 1 using these parameters.
+
+## Example User Prompt
+```text
+Please run the add-integ-tests-datastream-to-spanner skill for the oracle database. 
+Use the reference matrix located at v2/datastream-to-spanner/src/test/resources/oracle/oracle_datatype_mapping_matrix.csv load the execution properties from testing_execution.env.
+```

--- a/v2/datastream-to-spanner/.agents/skills/add-integ-tests-datastream-to-spanner/SKILL.md
+++ b/v2/datastream-to-spanner/.agents/skills/add-integ-tests-datastream-to-spanner/SKILL.md
@@ -25,10 +25,10 @@ You must immediately load and execute the `v2/spanner-common/.agents/skills/meta
 3. **Testing Environment Setup Path:** Extract from the user prompt and assert its presence.
 4. **Manifest File Path:** `v2/datastream-to-spanner/src/test/manifest.yaml`.
 5. **Target Template Path:** `v2/datastream-to-spanner`
-6. **Phase 1 Smoke Scenarios:** `live-it`
-7. **Phase 2 Baseline Datatype Scenarios:** `live-datatypes`
+6. **Smoke Test Scenarios:** `live-it`
+7. **Datatype Test Scenarios:** `live-datatypes`
 
-Yield execution completely to the `meta-test-orchestrator`. Instruct the Orchestrator to begin Phase 1 using these parameters.
+Yield execution completely to the `meta-test-orchestrator`. Instruct the Orchestrator to begin using these parameters.
 
 ## Example User Prompt
 ```text

--- a/v2/datastream-to-spanner/src/test/manifest.yaml
+++ b/v2/datastream-to-spanner/src/test/manifest.yaml
@@ -1,0 +1,176 @@
+scenarios:
+  # ==================================================================
+  # Live CDC Replication (v2/datastream-to-spanner)
+  # ==================================================================
+  - id: live-it
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerIT
+    description: "Main functional integration test for standard datastream-to-spanner live streaming CDC migrations."
+
+  - id: live-events
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerEventsIT
+    description: "Validates event processing, filtering, and delivery semantics under streaming CDC replication."
+
+  - id: live-dlq-all
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerMySQLRetryAllDLQIT
+    description: "Validates standard MySQL live replication DLQ retry operations under message parsing or constraint failures."
+
+  - id: live-dlq-single
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerMySQLRetryDLQIT
+    description: "Validates DLQ processing and single-message retry delivery for non-sharded MySQL live replication pipelines."
+
+  - id: live-sharded-dlq-all
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerShardedMySQLRetryAllDLQIT
+    description: "Validates DLQ retry and dead-letter queue recovery behavior for sharded MySQL live replication databases."
+
+  - id: live-sharded-dlq-single
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerShardedMySQLRetryDLQIT
+    description: "Validates DLQ processing and single-message retry delivery for sharded MySQL live replication pipelines."
+
+  - id: live-widerow-maxcolumns
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerWideRowForMaxColumnsPerTablesIT
+    description: "Validates live replication stability when tables contain the maximum column widths supported by the database engine."
+
+  - id: live-widerow-maxrowsize
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerWideRowForMax9MibTablePerDatabaseIT
+    description: "Tests throughput and streaming limits when migrating single wide rows containing payloads near the maximum size limits (approx 9MB)."
+
+  - id: live-widerow-maxname
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerWideRowForMaxTableNameWithMaxColumnNameIT
+    description: "Validates handling of extremely long table and column identifiers under target-native limits."
+
+  - id: live-widerow-max16key
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerWideRowForMax16KeyTablePerDatabaseIT
+    description: "Validates live streaming replication handling table structures containing a maximum of 16-column primary keys."
+
+  - id: live-datatypes
+    type: datatypes
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLDatastreamToSpannerDataTypesAndExpressionIT
+    description: "Validates streaming replication of standard MySQL data types and expression mappings into Spanner."
+
+  - id: live-tableindex-limits
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLDatastreamToSpannerTableAndIndexLimitsIT
+    description: "Validates live replication table and index propagation limits under heavy schema load."
+
+  - id: live-reservedkeywords
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DatastreamToSpannerReservedKeywordsMySqlIT
+    description: "Validates CDC live replication when dealing with database reserved keywords as column or table names."
+
+  - id: live-fileoverrides
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerFileOverridesIT
+    description: "CDC migration test verifying custom file override configuration properties."
+
+  - id: live-timezone
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerTimezoneIT
+    description: "Verifies timezone conversions and uniformization under real-time streaming CDC ingestion."
+
+  - id: live-session
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerSessionIT
+    description: "Validates custom session mappings under datastream-to-spanner CDC replication."
+
+  - id: live-singledf-sharded
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DatastreamToSpannerSingleDFShardedMigrationIT
+    description: "Validates sharded migration using a single Dataflow pipeline."
+
+  - id: live-ddl
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerDDLIT
+    description: "Asserts DDL synchronization and schema modification propagation from MySQL to Spanner."
+
+  - id: live-stringoverrides
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerStringOverridesIT
+    description: "Verifies string overrides and modifications during CDC streaming."
+
+  - id: live-mixed
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerMixedIT
+    description: "Validates mixed DDL and data migrations under heavy parallel CDC load."
+
+  - id: live-shadow-fileoverrides
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.SeparateShadowTableDatabaseFileOverridesIT
+    description: "Validates CDC migration using separate shadow table databases with file overrides."
+
+  - id: live-shadow-session
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.SeparateShadowTableDatabaseSessionIT
+    description: "Validates shadow table isolation with custom session mapping."
+
+  - id: live-shadow-pkfocused
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.SeparateShadowTableDatabasePKFocusedIT
+    description: "Validates shadow table database mappings focused specifically on primary keys."
+
+  - id: live-shadow-ddl
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.SeparateShadowTableDatabaseDDLIT
+    description: "Validates shadow table database schema DDL creations and syncs."
+
+  - id: live-shadow-events
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.SeparateShadowTableDatabaseEventsIT
+    description: "Validates event stream replication inside separate shadow table databases."
+
+  - id: live-shadow-mixed
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.SeparateShadowTableDatabaseMixedIT
+    description: "Validates mixed DDL operations inside isolated shadow database setups."
+
+  - id: live-shadow-stringoverrides
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.SeparateShadowTableDatabaseStringOverridesIT
+    description: "Verifies string type override modifications inside isolated shadow database environments."
+
+  - id: live-shadow-singledf-sharded
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.SeparateShadowTableDatabaseSingleDFShardedMigrationIT
+    description: "Validates shadow database isolation in a single Dataflow pipeline."
+
+  - id: live-shadow-sharded-with-shardid
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.SeparateShadowTableDatabaseShardedMigrationWithMigrationShardIdColumnIT
+    description: "Sharded migration targeting isolated shadow databases using a migration shard ID column."
+
+  - id: live-shadow-sharded-without-shardid
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.SeparateShadowTableDatabaseShardedMigrationWithoutMigrationShardIdColumnIT
+    description: "Sharded migration targeting isolated shadow databases without a migration shard ID column."
+
+  - id: live-sharded-with-shardid
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerShardedMigrationWithMigrationShardIdColumnIT
+    description: "Validates sharded live CDC migration where the source table explicitly includes a migration shard ID column."
+
+  - id: live-sharded-without-shardid
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerShardedMigrationWithoutMigrationShardIdColumnIT
+    description: "Validates sharded live CDC migration where the pipeline dynamically routes shards without a dedicated shard ID column."
+
+  - id: live-tableindex-limits-pg
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLDatastreamToPGDialectSpannerTableAndIndexLimitsIT
+    spanner_dialect: POSTGRESQL
+    description: "Validates live replication table and index propagation limits targeting a PostgreSQL-dialect Spanner database."
+
+  - id: live-widerow-maxtablename
+    template: v2/datastream-to-spanner
+    context: com.google.cloud.teleport.v2.templates.DataStreamToSpannerWideRowForMaxTableNameIT
+    description: "Validates live streaming replication when table names hit the maximum allowed length."
+

--- a/v2/sourcedb-to-spanner/.agents/skills/add-integ-tests-sourcedb-to-spanner/SKILL.md
+++ b/v2/sourcedb-to-spanner/.agents/skills/add-integ-tests-sourcedb-to-spanner/SKILL.md
@@ -23,10 +23,10 @@ You must immediately load and execute the `v2/spanner-common/.agents/skills/meta
 3. **Testing Environment Setup Path:** Extract from the user prompt and assert its presence.
 4. **Manifest File Path:** `v2/sourcedb-to-spanner/src/test/manifest.yaml`.
 5. **Target Template Path:** `v2/sourcedb-to-spanner`
-6. **Phase 1 Smoke Scenarios:** `bulk-simple`
-7. **Phase 2 Baseline Datatype Scenarios:** `bulk-datatypes`, `bulk-datatypes-pg`
+6. **Smoke Test Scenarios:** `bulk-simple`
+7. **Datatype Test Scenarios:** `bulk-datatypes`, `bulk-datatypes-pg`
 
-Yield execution completely to the `meta-test-orchestrator`. Instruct the Orchestrator to begin Phase 1 using these parameters.
+Yield execution completely to the `meta-test-orchestrator`. Instruct the Orchestrator to begin using these parameters.
 
 ## Example User Prompt
 ```text

--- a/v2/sourcedb-to-spanner/.agents/skills/add-integ-tests-sourcedb-to-spanner/SKILL.md
+++ b/v2/sourcedb-to-spanner/.agents/skills/add-integ-tests-sourcedb-to-spanner/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: add-integ-tests-sourcedb-to-spanner
+description: >-
+  Specific runner skill that delegates to the Template-Agnostic Meta-Test Orchestrator for the sourcedb-to-spanner (Bulk) template.
+---
+# SourceDB-to-Spanner Testing Orchestrator 
+
+This is a specific runner skill that acts as a wrapper around the global `meta-test-orchestrator` skill.
+
+## Required Prompt Inputs
+1. **Target Source Database Name**
+2. **Reference Mapping Matrix File Path**
+3. **Environment Config Path** (e.g. `testing_execution.env`)
+
+## Execution Instructions
+You must immediately load and execute the `v2/spanner-common/.agents/skills/meta-test-orchestrator/SKILL.md` skill, passing it the following statically mapped parameters:
+
+1. **Target Source Database Name:** Extract from the user prompt.
+2. **Reference Mapping Matrix File Path:** Extract from the user prompt.
+3. **Environment Config:** Extract from the user prompt and assert its presence.
+4. **Manifest File Path:** `v2/sourcedb-to-spanner/src/test/manifest.yaml`.
+5. **Target Template Path:** `v2/sourcedb-to-spanner`
+6. **Phase 1 Smoke Scenarios:** `bulk-simple`
+7. **Phase 2 Baseline Datatype Scenarios:** `bulk-datatypes`, `bulk-datatypes-pg`
+
+Yield execution completely to the `meta-test-orchestrator`. Instruct the Orchestrator to begin Phase 1 using these parameters.
+
+## Example User Prompt
+```text
+Please run the add-integ-tests-sourcedb-to-spanner skill for the oracle database. 
+Use the reference matrix located at v2/sourcedb-to-spanner/src/test/resources/oracle/oracle_datatype_mapping_matrix.csv load the execution properties from testing_execution.env.
+```

--- a/v2/sourcedb-to-spanner/.agents/skills/add-integ-tests-sourcedb-to-spanner/SKILL.md
+++ b/v2/sourcedb-to-spanner/.agents/skills/add-integ-tests-sourcedb-to-spanner/SKILL.md
@@ -9,15 +9,18 @@ This is a specific runner skill that acts as a wrapper around the global `meta-t
 
 ## Required Prompt Inputs
 1. **Target Source Database Name**
-2. **Reference Mapping Matrix File Path**
-3. **Environment Config Path** (e.g. `testing_execution.env`)
+2. **Reference Datatype Mapping Matrix File Path**
+3. **Testing Environment Setup Path** (e.g. `testing_execution.env`)
+
+> [!IMPORTANT]
+> **Initialization Check**: If ANY of the required prompt inputs are missing from the user's prompt, or if the environment config file does not exist, you **MUST HALT EXECUTION IMMEDIATELY**. Ask the user to provide the missing inputs before proceeding.
 
 ## Execution Instructions
 You must immediately load and execute the `v2/spanner-common/.agents/skills/meta-test-orchestrator/SKILL.md` skill, passing it the following statically mapped parameters:
 
 1. **Target Source Database Name:** Extract from the user prompt.
-2. **Reference Mapping Matrix File Path:** Extract from the user prompt.
-3. **Environment Config:** Extract from the user prompt and assert its presence.
+2. **Reference Datatype Mapping Matrix File Path:** Extract from the user prompt.
+3. **Testing Environment Setup Path:** Extract from the user prompt and assert its presence.
 4. **Manifest File Path:** `v2/sourcedb-to-spanner/src/test/manifest.yaml`.
 5. **Target Template Path:** `v2/sourcedb-to-spanner`
 6. **Phase 1 Smoke Scenarios:** `bulk-simple`
@@ -27,6 +30,6 @@ Yield execution completely to the `meta-test-orchestrator`. Instruct the Orchest
 
 ## Example User Prompt
 ```text
-Please run the add-integ-tests-sourcedb-to-spanner skill for the oracle database. 
-Use the reference matrix located at v2/sourcedb-to-spanner/src/test/resources/oracle/oracle_datatype_mapping_matrix.csv load the execution properties from testing_execution.env.
+Please run the add-integ-tests-sourcedb-to-spanner skill for the MySQL database. 
+Use the reference matrix located at v2/sourcedb-to-spanner/src/test/resources/mysql/mysql_datatype_mapping_matrix.csv load the execution properties from testing_execution.env.
 ```

--- a/v2/sourcedb-to-spanner/src/test/manifest.yaml
+++ b/v2/sourcedb-to-spanner/src/test/manifest.yaml
@@ -1,0 +1,127 @@
+scenarios:
+  # ==================================================================
+  # Bulk Migration (v2/sourcedb-to-spanner)
+  # ==================================================================
+  - id: bulk-datatypes
+    type: datatypes
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLDataTypesIT
+    description: "Porting reference MySQL DataTypes validation suite to verify target database dialect type mappings (e.g. integers, decimals, date/time types, blobs, and text)."
+
+  - id: bulk-datatypes-pg
+    type: datatypes
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLDataTypesPGDialectIT
+    spanner_dialect: POSTGRESQL
+    description: "Validates MySQL data type mappings specifically targeting a PostgreSQL-dialect Spanner database."
+
+  - id: bulk-timezone
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.SourceDbToSpannerTimezoneIT
+    description: "Verifies MySQL bulk migration timezone offsets, conversion constraints, and validation logic."
+
+  - id: bulk-simple
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLSourceDbToSpannerSimpleIT
+    description: "Validates basic bulk database migrations using single-shard configuration."
+
+  - id: bulk-session-mapper-transform
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLSessionSchemaMapperWithTransformationIT
+    description: "Validates schema mapper executing custom column transformation logic using session file configurations."
+
+  - id: bulk-widerow-maxcolumnsize
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLSourceDBToSpannerWideRowMaxColumnAndTableSizeIT
+    description: "Validates wide rows with large column counts and table sizes under database constraints."
+
+  - id: bulk-session-mapper-tablefilter
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLSessionSchemaMapperWithTableFilterIT
+    description: "Validates session schema mapper filtering specified tables out of the migration stream."
+
+  - id: bulk-identity-schema-mapper
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLIdentitySchemaMapperIT
+    description: "Validates custom identity schema mapper direct projections (zero changes)."
+
+  - id: bulk-reserved-keywords
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLReservedKeywordsIT
+    description: "Validates behavior when dealing with database reserved keywords as column, table, or constraint names."
+
+  - id: bulk-singleshard
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLSingleShardIT
+    description: "Validates single shard data replication from MySQL to Spanner."
+
+  - id: bulk-string-overrides-mapper
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLStringOverridesSchemaMapperIT
+    description: "Validates custom string type override column mappings."
+
+  - id: bulk-widerow-maxrowsize
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLSourceDBToSpannerWideRowMaxRowSizeIT
+    description: "Validates wide rows testing the maximum row size limits in the database."
+
+  - id: bulk-widerow-maxsizetablekey
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLSourceDbToSpannerWideRowMaxSizeTableKeyIT
+    description: "Validates wide rows testing large size limits on primary key columns."
+
+  - id: bulk-ddl
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLDDLIT
+    description: "Verifies direct DDL schema translation logic."
+
+  - id: bulk-widerow-maxcolumns-pertable
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLToSpannerWiderowForMaxColumnsPerTableIT
+    description: "Validates wide rows containing large column counts per table."
+
+  - id: bulk-session-mapper
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLSessionSchemaMapperIT
+    description: "Validates session schema mapper mapping database tables using session file configurations."
+
+  - id: bulk-widerow-maxcolumns-tablekey
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLSourceDbToSpannerWideRowMaxColumnsTableKeyIT
+    description: "Validates wide rows with large column counts in primary keys."
+
+  - id: bulk-identity-mapper-transform
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLIdentitySchemaMapperWithTransformationIT
+    description: "Validates identity mapper combined with custom column transformations."
+
+  - id: bulk-fileoverrides-mapper
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLFileOverridesSchemaMapperIT
+    description: "Validates schema mapper custom file override configuration properties."
+
+  - id: bulk-foreignkey-dependency
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLForeignKeyDependencyIT
+    description: "Validates relation mappings, foreign key constraints, and relational integrity dependency checks."
+
+  - id: bulk-widerow-maxsizestring
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLSourceDBToSpannerWideRowMaxSizeStringIT
+    description: "Validates wide rows containing large string columns up to database constraints."
+
+  - id: bulk-customtransformation
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLCustomTransformationsNonShardedIT
+    description: "Validates applying custom column value transformations to data during bulk migration."
+
+  - id: bulk-namespace
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.NamespaceIT
+    description: "Verifies handling of custom database schema namespaces, prefixes, and catalog qualifiers during bulk migration."
+
+  - id: bulk-widerow-interleavedepth
+    template: v2/sourcedb-to-spanner
+    context: com.google.cloud.teleport.v2.templates.MySQLSourceDBToSpannerWideRowInterleaveDepthIT
+    description: "Validates wide rows across deep parent-child interleaved table hierarchies in Spanner."
+

--- a/v2/spanner-common/.agents/skills/add-source-datatype-integ-test/SKILL.md
+++ b/v2/spanner-common/.agents/skills/add-source-datatype-integ-test/SKILL.md
@@ -1,0 +1,352 @@
+---
+name: add-source-datatype-integ-test
+description: >
+  Skill for adding data type integ tests for new source by provided datatype_mapping_matrix.
+---
+
+# New Source DataTypes Integration Test Generation Skill
+
+This skill instructs an AI Coding Agent to design and synthesize an exhaustive, dialect-wide integration test suite for Dataflow Templates for a new database source dialect from first principles, without being biased by a reference database test.
+
+---
+
+## 1. Goal
+Given a Scenario ID, parse its configuration from `manifest.yaml`, gather structural class/helper context from a reference test (without copying its columns/assertions), research and compile a comprehensive list of all native datatypes supported by the target database dialect (including recommended and alternative Spanner mappings), generate native source SQL schemas containing CREATE and INSERT statements with type-specific formats, write a complete Java integration test from scratch with dynamic assertions, compile-verify, and self-heal.
+
+## 1.1 Initialization Check
+Before you begin parsing or executing any core steps, you MUST verify the following inputs and dependencies exist:
+1. **Scenario ID** 
+2. **Path to the `manifest.yaml`**
+3. **Target Database Name**
+4. **Path to the `.csv` Reference Mapping file**
+5. **Environment Configuration**: You MUST proactively check the workspace root directory for a `.env` file named `testing_execution.env`.
+
+If ANY of the prompt inputs are missing, or if the `testing_execution.env` file does not exist in the root directory, you **MUST HALT EXECUTION IMMEDIATELY**. Do not attempt to guess, hallucinate paths, or proceed without the environment variables. Output a direct question asking for the missing inputs or complaining about the missing file.
+
+---
+
+## 1.2 Prerequisites: Execution Configuration
+The agent must look for a `testing_execution.env` file in the workspace root with the following schema:
+```env
+REMOTE_WORKSPACE_PATH=
+REMOTE_EXEC_TEMPLATE=
+REMOTE_SYNC_TEMPLATE=
+TEST_PROJECT=
+TEST_REGION=
+TEST_SPANNER_INSTANCE=
+TEST_STAGE_BUCKET=
+TEST_ARTIFACT_BUCKET=
+TEST_HOST_IP=
+TEST_PRIVATE_CONNECTIVITY=
+TEST_DB_USER=
+TEST_DB_PASSWORD=
+```
+
+---
+
+## 1.3 Directory Segregation Rule
+To prevent cluttering the root templates package, you MUST place all generated files into a strictly nested directory structure matching the lowercased name of the target database.
+- **Java Class Path:** `src/test/java/com/google/cloud/teleport/v2/templates/{target_db_name_lowercase}/{TestClassName}.java`
+- **Java Package:** `package com.google.cloud.teleport.v2.templates.{target_db_name_lowercase};`
+- **SQL Resources Path:** `src/test/resources/{target_db_name_lowercase}/{TestClassName}/`
+
+---
+
+## 1.4 Global Constraint: Production Code Priority Rule
+
+> [!CRITICAL]
+> **Production Code Priority Rule (Source Over Test)**:
+> This is a global constraint that applies to all phases of this skill (context discovery, type mapping, code generation, compilation, execution, and debugging).
+> If an integration test fails during compilation or execution, you MUST first assume that the bug lies in the **production template source code** (e.g., dialect adapters, DML generators, schema mappers, or exception classifiers) rather than the test harness or DDL.
+> *   **Systematic Investigation**: You must thoroughly analyze the template's core Java engine to identify if it is failing to support the target database's dialect behavior correctly.
+> *   **No Test Hacking**: You are strictly forbidden from "hacking", disabling, or loosening a test assertion or DDL constraint to bypass a failure, unless the production template is proven to be behaving 100% correctly and the mismatch is purely due to database-specific padding/formatting differences.
+> *   **Documentation**: Every change to the production template must be documented in your final report with a root-cause explanation, and any test adaptation must be explicitly justified in the code with JavaDocs.
+
+---
+
+## 2. Step 1: Input Parsing & Scenario Scouting
+1. The user MUST provide the path to the `manifest.yaml` scenario registry file in their prompt. Open that file.
+2. Locate the scenario matching the input `Scenario ID`.
+3. Extract:
+   - `context`: Fully qualified name of the reference test class (e.g., `com.google.cloud.teleport.v2.templates.<ReferenceSourceDialect>DataTypesIT`).
+   - `template`: Path to the template module (e.g., `v2/<template_path>`).
+   - `spanner_dialect`: Target Spanner database dialect (`GOOGLE_STANDARD_SQL` or `POSTGRESQL`). If not explicitly defined, default to `GOOGLE_STANDARD_SQL`.
+   - Check if a baseline data type mapping file has been supplied in the prompt/context (e.g., `mapping.json` or `mapping.yaml`).
+4. Determine the **Migration Direction**:
+   - Inspect the `template` path and the `context` class inheritance chain (scouted in Step 2):
+     - If the reference class extends a forward migration base class (e.g., `<SourceDbToSpannerITBaseClass>`) or the `template` path contains a forward template name (e.g., `sourcedb-to-spanner` or `datastream-to-spanner`): **Forward Migration** (Source Database -> Spanner).
+     - If the reference class extends a reverse migration base class (e.g., `<SpannerToSourceDbITBaseClass>`) or the `template` path contains a reverse template name (e.g., `spanner-to-sourcedb`): **Reverse Migration** (Spanner -> Target Database).
+
+---
+
+## 3. Step 2: Context Scouting (Structural Analysis Only)
+To build a compilable integration test, you must analyze the structural patterns of the template test suite.
+
+> [!IMPORTANT]
+> **Strict Scouting Constraint**:
+> Open the reference class, its parent classes, and configuration base classes *strictly* to discover:
+> - The class inheritance chain (e.g., extends `<BaseITClass>`).
+> - Setup helper APIs (e.g., `setUp<SourceDialect>ResourceManager()`, `setUpSpannerResourceManager()`).
+> - The pipeline launching structure (e.g., `launchDataflowJob(...)`, `pipelineOperator()`).
+>
+> You **MUST NOT** copy the list of tables, columns, data types, test values, or assertions defined in the reference class. The new test suite must be built independently from first principles.
+
+1. **Locate Reference Class File**:
+   - Perform a glob/grep search to find the file matching the context class name on disk.
+2. **Scan Inheritance Chain**:
+   - Open the reference class file and inspect its `extends <SuperClass>` signature.
+   - Recursively search for and open all parent/base classes up the inheritance chain to read all available setup and helper APIs.
+
+---
+
+## 4. Step 3: Ingesting the Ground Truth Mapping
+Instead of researching the database dialect from scratch, this skill assumes a complete, human-approved data type mapping matrix has been provided in CSV format (the "Ground Truth"). Your task is to ingest this mapping and use it to strictly drive all subsequent schema and code generation.
+
+> [!IMPORTANT]
+> **Mandatory Input Rule**:
+> You MUST receive the exact path to the initial mapping `.csv` file from the user or Orchestrator in your prompt.
+> You MUST NOT perform independent web research, nor should you invent types that are not listed in this CSV file. Treat this file as the absolute, exhaustive dictionary of what must be tested.
+
+1. **Ingest the Mapping File**:
+   - Read the provided mapping `.csv` file. 
+   - Parse the matrix into memory.
+2. **Identify Dialect Validations**:
+   - Check the `spanner_dialect` determined in Step 1 (`GOOGLE_STANDARD_SQL` vs `POSTGRESQL`). 
+   - Fetch the mapping strictly from the corresponding Spanner Dialect column in the CSV (e.g., `Spanner GoogleSQL Default Datatype` vs `Spanner PostgreSQL Default Datatype`).
+3. **Identify Validation Targets**:
+   - Extract every row that is intended for Default or Alternative mapping (Scenarios A and B).
+   - **Primary Keys (Scenario C):** You MUST explicitly read the matrix column defining PK support (e.g., `Is the datatype supported as a PK in the source?`). If supported, you MUST apply the specific mapped type provided in the `If Column is a PK` column for that dialect, as some types must be shortened or converted to binary for PK compatibility.
+   - Extract every row marked as Unsupported or Complex (Scenario D).
+4. **No User Approval Required**:
+   - Because this mapping file was vetted in a prior phase, do **NOT** ask the user for approval. Proceed immediately to Step 4.
+
+---
+
+## 5. Step 4: DDL Schema Synthesis (Tested Scenarios)
+
+For every discovered datatype **and every identified type alias**, you must generate schemas covering the following scenarios:
+- **Scenario A: Default Type Migration**: Regular column using recommended/default Spanner mapping.
+  - *Naming Pattern*: Table Name: `{type_or_alias}_table`, Target Column: `{type_or_alias}_col`.
+- **Scenario B: Alternative Type Migration**: Regular column using an alternative Spanner mapping.
+  - *Naming Pattern*: Table Name: `{type_or_alias}_to_{clean_target_type}_table`, Target Column: `{type_or_alias}_to_{clean_target_type}_col`.
+- **Scenario C: Primary Key Mapping**: Testing the data type or alias as part of the primary key constraint.
+  - *Naming Pattern*: Table Name: `{type_or_alias}_pk_table`, Target Column: `{type_or_alias}_pk_col` as the primary key.
+  - *Feasibility & Column Override*: You MUST only generate Scenario C if the matrix explicitly marks `Is the datatype supported as a PK in the source?` as `Yes`. Check the `If Column is a PK` column for the target dialect, as you might need to use a different Spanner type (e.g., `BYTES` or restricted `STRING`) when the key is indexed.
+  - **SMT Range Splitter Constraint**: You MUST exclude all floating-point and decimal/numeric types (e.g. `FLOAT`, `DOUBLE`, `REAL`, `NUMERIC`, `DECIMAL` with fractional scales) from Scenario C (`is_pk_feasible = False`). During range queries, SMT's range splitter casts partition boundaries to `Long` integers, truncating the fractional bounds and causing extreme boundary float rows to be silently dropped during migration.
+- **Scenario D: Unsupported/Complex Types**: Tables containing unsupported spatial, collection, or complex types to verify graceful migration and row-count consistency without pipeline failures.
+- **Scenario E: Array/Collection Types**: Tables explicitly testing arrays, lists, or collections of all supported scalar base types.
+
+> [!IMPORTANT]
+> [!IMPORTANT]
+> **Case Preservation & Identifier Quoting**:
+> To ensure generated tests and schemas run successfully, you must align and preserve the exact character casing of all table names, column names, keys, and constraints between the target source database and the target Spanner database.
+> 1. **Check Case Preservation Requirement**:
+>    - First check if the reference schema, target Spanner schema, or target test uses any uppercase or mixed-case identifiers.
+>    - Check if the target database folds unquoted identifiers to a different case by default (e.g., some database folds unquoted names to lowercase, or another database folds to uppercase).
+>    - If the target database folds unquoted identifiers, AND there are mixed-case/uppercase names, case preservation is **REQUIRED**.
+>    - If all identifiers are already completely lowercase, case preservation is **NOT required** (and you should NOT wrap them in redundant quotes).
+> 2. **Apply Quoting if Case Preservation is Required**:
+>    - Wrap all identifiers (table names, column names, keys, etc.) in dialect-appropriate quotes in the generated DDL statements.
+>    - **Do Not Alter Original Intent**: You MUST NOT alter the original casing of the reference schema identifiers (e.g., converting mixed-case names to all-caps or all-lowercase) just to trivially bypass the database's folding rules. You MUST apply quotes to preserve the original intended mixed-casing exactly as it was provided in the reference.
+> 3. **Casing Parity Between Target Source and Spanner**:
+>    - In some cases (such as data type ITs), target schema table names might differ from the reference test schema.
+>    - However, whatever names are used for the target source schema, their exact character case **MUST be identical** in the target Spanner database schema DDL.
+
+### 5.1 FORWARD MIGRATION SCHEMA GUIDELINES
+If the migration direction is **Forward**:
+1. **Target Source Schema DDL (`{target_source_dialect}-schema.sql`)**:
+   - Generate `CREATE TABLE` statements for Scenarios A, B, C, D, and E.
+   - **Multi-Row Insertion Mandate (CRITICAL):**
+     1. **CSV Edge Cases First**: For EVERY table (Scenarios A, B, and E), you MUST first extract the literal array of values from the `Edge Cases for Smoke Test` column in the CSV mapping for this datatype. Generate an `INSERT` statement for every single parsed value.
+     2. **Supplement with Core Boundaries**: After inserting the CSV edge cases, you MUST forcefully supplement the table with your own generated values for the following explicit boundary scenarios:
+        - **Typical/Normal Value.**
+        - **Absolute Maximum Boundary Value** (e.g., Max Integer, Max Precision Decimal, max string length).
+        - **Absolute Minimum Boundary Value / Empty** (e.g., Min Integer, empty string, empty array).
+        - **NULL Value** (test null handling for the column).
+        - **Special/Edge Cases** (e.g., Emojis, Leap Year dates, multi-byte Unicode).
+     - *Type-Specific Formatting*: Ensure these `INSERT` statements use any special formats required by the source type (e.g., hex strings/literals for binary, escaped strings, date/time string formats, array literals, JSON strings).
+
+2. **Target Spanner Schema DDL (`{target_source_dialect}-{spanner_dialect}-spanner-schema.sql`)**:
+   - Translate target source tables to target Spanner DDL statements matching Scenarios A, B, C, D, and E structures.
+   - Do NOT include any `INSERT` or population statements in the Spanner schema DDL.
+   - For Spanner `GOOGLE_STANDARD_SQL` dialect, do NOT use double quotes (`"`) or single quotes (`'`) to quote identifiers. Only use backticks (`` ` ``) if escaping is required. Use double quotes if targeting `POSTGRESQL` Spanner dialect.
+
+### 5.2 REVERSE MIGRATION SCHEMA GUIDELINES
+If the migration direction is **Reverse**:
+1. **Target Spanner Schema DDL (`{target_source_dialect}-{spanner_dialect}-spanner-schema.sql`)**:
+   - Synthesize Spanner `CREATE TABLE` DDL statements matching Scenarios A, B, C, D, and E structures.
+   - Do NOT include any `INSERT` or population statements in this file. (Data population will be handled in Java using Spanner mutations).
+   - For Spanner `GOOGLE_STANDARD_SQL` dialect, do NOT use double quotes (`"`) or single quotes (`'`) to quote identifiers. Only use backticks (`` ` ``) if escaping is required. Use double quotes if targeting `POSTGRESQL` Spanner dialect.
+2. **Target Source Schema DDL (`{target_source_dialect}-schema.sql`)**:
+   - Generate native target database `CREATE TABLE` statements for Scenarios A, B, C, D, and E.
+   - Do NOT write any `INSERT INTO` statements in this file.
+
+### 5.3 Schema Completeness Self-Audit
+Before proceeding to Step 5, the agent MUST perform a completeness self-audit:
+1.  **Cross-Reference Table Mappings**: Compare the generated `{target_source_dialect}-schema.sql` tables against the approved Logical Type Mapping Table from Step 3.
+2.  **Verify Scenario Coverage**: Ensure that for *every* data type and type alias listed in the mapping table, dedicated test tables are defined for:
+    *   **Scenario A** (Default recommended Spanner mapping)
+    *   **Scenario B** (Alternative Spanner mappings)
+    *   **Scenario C** (Primary Key mapping - if indexable and feasible)
+    *   **Scenario E** (Array/Collection mapping - if array types exist)
+3.  **Verify Scenario D (Unsupported Types)**: Ensure that *every* type identified as unsupported or complex in the mapping table (e.g. geometric, spatial, system/internal types) is represented in a Scenario D table to verify that the pipeline migrates them gracefully (maintaining row count consistency) without failure.
+4.  **Enforce Resolution**: If any type, alias, or unsupported type is missing from the synthesized DDL schemas, you must generate the missing tables and insert statements before proceeding.
+
+---
+
+## 6. Step 5: Infrastructure Lifecycle & Resource Manager Setup
+
+### 6.1 Source Database ResourceManager lookup and check
+To provision infrastructure resources for integration tests, you MUST inherit the `ResourceManager` architectural pattern used by the `reference_test_class`. If the reference test delegates setup to a method in a base class (e.g., an `ITBase.java` class), you MUST declare a matching method for your target database in that same base class if it doesn't already exist.
+
+1. **Inherit Reference Pattern**: Inspect the `ResourceManager` imported by the reference test's setup method. 
+   - If the reference test logic uses a simple testcontainers-based Resource Manager from the Apache Beam IT SDK (`org.apache.beam.it`), you MUST find and use the equivalent simple testcontainers Resource Manager from the Beam IT SDK for your target source.
+   - If the reference test instead imports a custom cloud-based Resource Manager from the local `it/` codebase, you MUST search the local `it/` codebase for the equivalent cloud Resource Manager for your target source.
+2. **Base Class Injection**: Once you determine the correct `ResourceManager` class using the pattern above, inject the corresponding setup method directly into the Integration Test Base Class, and be sure to update any of its helper methods (such as dialect or driver locators) to support it.
+3. **Synthesize Missing Custom ResourceManager**: If neither the local codebase nor the Apache Beam IT SDK has support for the target source, you MUST synthesize a new custom `ResourceManager` class from scratch:
+   - For JDBC sources: Use `AbstractJDBCResourceManager.java` or an existing dialect's `ResourceManager` from the `it/` folder as a blueprint, extending `AbstractJDBCResourceManager`. Write the class to the appropriate test utility directory.
+   - For non-JDBC/NoSQL/messaging sources: Use an existing robust implementation like `SpannerResourceManager.java` from the `it/` folder as your architectural blueprint for establishing connection URIs, teardown lifecycles, and test containers.
+
+---
+
+## 7. Step 6: Java Test Class Synthesis
+Write the concrete Java integration test class from scratch under the target package/directory:
+
+### Coding Constraints
+1. **Header**: Start the file with the exact header comment: `/* GENERATED BY: Test Automation Skill */`.
+2. **No Inline SQL/DDL**: Load SQL schemas strictly by referencing the resource path constant.
+3. **Dynamic Source Resource Manager Setup**:
+   - Inspect the discovered base class files to locate the correct target `ResourceManager` class and its setup method.
+   - Call the corresponding setup method defined on the base class (e.g., `setUp<SourceDialect>ResourceManager()` for the target source dialect).
+4. **Dynamic Spanner Resource Manager Setup**:
+   - Inspect the discovered base/parent class files to locate the correct method to initialize the Spanner ResourceManager matching the target `spanner_dialect` (e.g. search for `setUpPGDialectSpannerResourceManager` if Spanner dialect is `POSTGRESQL`, or `setUpSpannerResourceManager` if `GOOGLE_STANDARD_SQL`).
+5. **Case Preservation in Java SQL Queries**:
+   - If the target source database folds unquoted identifiers by default, and the reference test/schema uses uppercase or mixed-case identifiers, you MUST wrap table and column names in dialect-appropriate quotes within the generated Java test class SQL queries.
+6. **Proprietary Database Drivers (`jdbcDriverJars`)**:
+   - Some databases are natively bundled in the flex template container by default while proprietary ones are often excluded via test scopes. If your target source database relies on a proprietary JDBC driver that is excluded from the main template deployment, the test will crash on Cloud Dataflow unless you explicitly pass the `--jdbcDriverJars` parameter. 
+   - You MUST ensure your generated Java test class retrieves the dynamically staged driver GCS URL from the base IT class environment (e.g. checking the parent class for a GCS driver path method matching your dialect) and maps it into the `launchTemplate(...)` parameters block.
+7. **Unified Launch Method (`launchDataflowJob`)**:
+   - Always run the template using the base helper method:
+     `jobInfo = launchDataflowJob(getClass().getSimpleName(), ...);`
+   - Do NOT construct manual inline runner option maps or direct pipeline executions in the test class. The `TemplateTestBase` framework automatically routes execution to local `DirectRunner` or Cloud `Dataflow` depending on build system parameters.
+
+---
+
+## 8. Step 7: Maven POM Dependency Injection
+1. Open the `pom.xml` file for the target template module (e.g., `<template_path>/pom.xml`).
+2. Identify the required dependencies for communicating with the target database/source.
+3. If the identified dependency is not already declared in the `pom.xml`, add it inside the `<dependencies>` section with `<scope>test</scope>`.
+
+---
+
+## 9. Step 8: Compilation, Execution, and Runtime Cleanup
+
+Load the variables from `testing_execution.env`. You MUST route all synchronization and execution through the provided template strings to support the vendor's specific environment.
+
+### 9.1 Workspace Synchronization
+1. Sync the local workspace to the execution environment (Note: If the vendor configured local execution, this may just be a harmless `echo` command):
+   - Read `REMOTE_SYNC_TEMPLATE`. Replace `<LOCAL_PATH>` with `./` and `<REMOTE_PATH>` with the value of `REMOTE_WORKSPACE_PATH`.
+   - Execute the resulting command in your terminal.
+2. **Pre-build local dependencies**: If the test dynamically loads jars from other modules (e.g., `spanner-custom-shard` target directory) which are excluded from sync, build those modules on the target environment:
+   - Read `REMOTE_EXEC_TEMPLATE`. Replace `<COMMAND>` with `cd ${REMOTE_WORKSPACE_PATH} && mvn package -pl v2/spanner-custom-shard -am -DskipTests`.
+   - Execute the rendered command.
+
+### 9.2 Compilation Verification
+Verify compilation:
+1. Replace `<COMMAND>` in `REMOTE_EXEC_TEMPLATE` with `cd ${REMOTE_WORKSPACE_PATH} && mvn test-compile -pl <template_path> -am -Dcheckstyle.skip=true`.
+2. Execute it.
+If compilation fails:
+- Extract the compiler error block matching your target test class name.
+- Analyze the compiler logs, fix the Java code locally, re-sync (Step 8.1), and compile-verify again until it succeeds.
+
+### 9.3 DirectRunner Testing Loop (DirectRunner-First Strategy)
+To minimize development turnaround time, always attempt to execute your tests using local pipeline first:
+1. Run the test by appending `-DdirectRunnerTest` to your maven execution command.
+   - Replace `<COMMAND>` in `REMOTE_EXEC_TEMPLATE` with the following command (substitute the `<variables>` appropriately):
+   `cd ${REMOTE_WORKSPACE_PATH} && rm -f live_logs && mvn verify -f pom.xml -U -PtemplatesIntegrationTests,splunkDeps -pl <template_path> -am -Dtest=<TestClassName> -e -DdirectRunnerTest -Dmdep.analyze.skip -Dcheckstyle.skip -Dspotless.check.skip=true -Djib.skip -DskipShade -DartifactBucket="${TEST_ARTIFACT_BUCKET}" -DstageBucket="${TEST_STAGE_BUCKET}" -Dproject="${TEST_PROJECT}" -Dregion=${TEST_REGION} -DspannerInstanceId="${TEST_SPANNER_INSTANCE}" -Dsurefire.useFile=false -DitParallelismType=none -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -DhostIp=${TEST_HOST_IP} -DprivateConnectivity=${TEST_PRIVATE_CONNECTIVITY} -DcloudProxyHost=${TEST_HOST_IP} -DcloudProxyPassword="${TEST_DB_PASSWORD}" -DcloudProxyUsername="${TEST_DB_USER}" > live_logs 2>&1`
+   - Run the rendered template command in the background (append `&`).
+2. The testing framework will bypass cloud staging and run the template inside the local JVM in-process.
+3. **Thread Cancellation Fix**: Ensure `DirectRunnerClient.java` is patched to cancel running jobs using `thread.interrupt()` instead of the deprecated `thread.stop()`, preventing test hangs during resource cleanup.
+
+### 9.4 Functional Test Execution (Cloud Dataflow)
+1. Run the test without the `-DdirectRunnerTest` property. 
+   - Replace `<COMMAND>` in `REMOTE_EXEC_TEMPLATE` with the same Maven command from 8.3, but omitting `-DdirectRunnerTest`.
+   - Run the rendered template command in the background (append `&`).
+2. Monitor execution progress by tailing the logs (e.g., `tail -n 100 live_logs`).
+
+### 9.5 Resource Teardown & Cleanup Verification
+1. **Do Not Ignore Cleanup Failures**: If the test execution hangs or fails during the teardown phase (e.g., failure to drop databases or replication slots), the test must be considered **FAILED**. Do not manually terminate and call it a pass.
+2. **Investigate Cleanup Order**: A common cause of cleanup failure is incorrect resource manager shutdown order. Ensure that consumer resources (e.g., Datastream streams, Dataflow jobs) are fully stopped and deleted *before* attempting to clean up source resources (e.g., database instances, replication slots).
+3. **Leaked Resource Check**: Always verify that all provisioned resources (Spanner databases, Cloud SQL databases, replication slots, GCS files) are deleted after the run. If leakages are detected, update the test teardown logic to handle them.
+
+### 9.6 Investigation & Debugging of Test Failures
+If the integration test fails (assertion failure, runtime exception, or timeout):
+1. **Analyze Test Logs**: Inspect the test output or surefire reports (`live_logs` if running remotely) to identify the failing assertion or exception stack trace.
+2. **Inspect Dataflow Job Status**: Retrieve the Dataflow job ID from the logs and check its status and error messages:
+   ```bash
+   gcloud dataflow jobs list --project=${TEST_PROJECT} --region=${TEST_REGION}
+   gcloud logging read "resource.type=\"dataflow_step\" AND resource.labels.job_id=\"<YOUR_JOB_ID>\" AND severity>=WARNING" --project=${TEST_PROJECT} --limit=100
+   ```
+3. **Identify the Root Cause**: Determine if the failure is due to:
+   - Schema mismatch (casing, type conversion).
+   - Network connectivity issues.
+   - Permission issues on GCP resources.
+   - Logical bug in the template code.
+4. **Apply Fixes & Re-test**: Apply fixes to the test code or template code, re-sync changes, and re-run.
+
+### 9.7 Artifact Archiving
+1. Upon a completely successful test run (compilation, execution, and zero DLQ errors), you MUST create a dedicated artifact folder relative to the workspace root: `src/test/resources/<target_db_name_lowercase>/reports/datatype_testing/<Scenario_ID>_<Timestamp>/`.
+2. Copy the following artifacts into this folder:
+   - The successful `live_logs` output.
+   - The provided initial mapping file.
+---
+
+## 10. Step 9: Post-Validation Migration Report
+1. You MUST generate a markdown report file named `test_automation_migration_report.md` at the exact path relative to the workspace root: `<template_path>/src/test/resources/<target_db_name_lowercase>/reports/datatype_testing/<Scenario_ID>_<Timestamp>/test_automation_migration_report.md`. Placed anywhere else, the user will not see it.
+2. The report MUST rigidly follow this structure:
+   
+   **1. Test Suite Details:**
+   - Scenario ID, Target Source Dialect, and Target Spanner Dialect.
+   - Summarize what the test suite is validating (e.g., "Validating 42 Postgres types and 3 alternative mappings using DirectRunner").
+
+   **2. Execution Result & Final Command:**
+   - Final Status (SUCCESS/FAILURE).
+   - The exact Maven command used for the final successful execution.
+
+   **3. Source Code Bugs & Fixes:**
+   - Detail any bugs discovered in the *production template code* (not the test code).
+   - Show the exact code changes applied to fix the production code.
+
+   **4. Self-Healing & Retry History:**
+   - A chronological list of all failed attempts during compilation or execution.
+   - Format: `Retry # | Issue/Exception Encountered | Fix Applied`.
+
+   **5. Exhaustive Type Testing Matrix:**
+   - A single comprehensive table detailing every tested type.
+   - Columns: `Type Category`, `Source Type`, `Spanner Type`, `Edge Cases Tested` (List the specific boundary/null/special values tested), `Pass/Fail`.
+
+   **6. Coverage vs. Initial Baseline:**
+   - A single comprehensive table (Single type per table) to compare the final tested types against the initial user-provided baseline mapping.
+   - Explicitly list which new types or alternative overrides were discovered by the agent's independent research.
+   - **Must include a comprehensive Baseline Mapping Table** with the following columns: 
+     - `Source Type`
+     - `Target Spanner Type` (include alternative mapping overrides)
+     - `Covered?` (Yes/No/Skipped)
+     - `Table Name` (table name which test this type)
+     - `Verification` (Pass/Fail)
+     - `Values Tested` (list of exact values tested and what was value verified on spanner)
+     - `Notes` (Any specific notes to be added, like reason for skip, reason for failure, etc)
+---
+
+## 11. Strict Code Editing Constraints
+CRITICAL RULE: Do NOT write secondary Python or Bash scripts to execute find-and-replace string manipulations on the template `.java` or `pom.xml` source code. You must use your native AI file-editing tools explicitly to modify code block-by-block.
+
+---
+
+## 12. Human Escalation & Clarification Guidelines
+As an autonomous agent executing this skill, you must stop and ask the user for confirmation or input in the following scenarios:
+1. **Unresolved Compilation Errors**: If after **3 self-healing attempts** the test class still fails to compile, stop, present the compiler error block and your current code, and ask the user for guidance.
+2. **Missing ResourceManager blue-prints**: If you determine that a new ResourceManager needs to be synthesized from scratch and you cannot find any suitable blueprint reference, ask the user to specify/confirm the ResourceManager setup structure.
+3. **Data Type Ambiguity**: If mapping a data type from the source schema results in multiple potential target database/Spanner dialect mappings with different behaviors, ask the user to confirm the preferred mapping choice.
+
+

--- a/v2/spanner-common/.agents/skills/add-source-datatype-integ-test/SKILL.md
+++ b/v2/spanner-common/.agents/skills/add-source-datatype-integ-test/SKILL.md
@@ -11,15 +11,15 @@ This skill instructs an AI Coding Agent to design and synthesize an exhaustive, 
 ---
 
 ## 1. Goal
-Given a Scenario ID, parse its configuration from `manifest.yaml`, gather structural class/helper context from a reference test (without copying its columns/assertions), research and compile a comprehensive list of all native datatypes supported by the target database dialect (including recommended and alternative Spanner mappings), generate native source SQL schemas containing CREATE and INSERT statements with type-specific formats, write a complete Java integration test from scratch with dynamic assertions, compile-verify, and self-heal.
+Given a Scenario ID, parse its configuration from `manifest.yaml`, gather structural class/helper context from a reference test (without copying its columns/assertions), read provided datatype mapping matrix and compile a comprehensive list of all native datatypes supported by the target database dialect (including recommended and alternative Spanner mappings), generate native source SQL schemas containing CREATE and INSERT statements with type-specific formats, write a complete Java integration test from scratch with dynamic assertions, compile-verify, and self-heal.
 
 ## 1.1 Initialization Check
 Before you begin parsing or executing any core steps, you MUST verify the following inputs and dependencies exist:
-1. **Scenario ID** 
-2. **Path to the `manifest.yaml`**
-3. **Target Database Name**
-4. **Path to the `.csv` Reference Mapping file**
-5. **Environment Configuration**: You MUST proactively check the workspace root directory for a `.env` file named `testing_execution.env`.
+1. **Scenario ID**
+2. **Manifest File Path**
+3. **Target Source Database Name**
+4. **Reference Datatype Mapping Matrix File Path**
+5. **Testing Environment Setup Path**: You MUST proactively check the workspace root directory for a `.env` file named `testing_execution.env`.
 
 If ANY of the prompt inputs are missing, or if the `testing_execution.env` file does not exist in the root directory, you **MUST HALT EXECUTION IMMEDIATELY**. Do not attempt to guess, hallucinate paths, or proceed without the environment variables. Output a direct question asking for the missing inputs or complaining about the missing file.
 
@@ -136,7 +136,6 @@ For every discovered datatype **and every identified type alias**, you must gene
 - **Scenario D: Unsupported/Complex Types**: Tables containing unsupported spatial, collection, or complex types to verify graceful migration and row-count consistency without pipeline failures.
 - **Scenario E: Array/Collection Types**: Tables explicitly testing arrays, lists, or collections of all supported scalar base types.
 
-> [!IMPORTANT]
 > [!IMPORTANT]
 > **Case Preservation & Identifier Quoting**:
 > To ensure generated tests and schemas run successfully, you must align and preserve the exact character casing of all table names, column names, keys, and constraints between the target source database and the target Spanner database.

--- a/v2/spanner-common/.agents/skills/add-source-datatype-integ-test/SKILL.md
+++ b/v2/spanner-common/.agents/skills/add-source-datatype-integ-test/SKILL.md
@@ -20,8 +20,13 @@ Before you begin parsing or executing any core steps, you MUST verify the follow
 3. **Target Source Database Name**
 4. **Reference Datatype Mapping Matrix File Path**
 5. **Testing Environment Setup Path**: You MUST proactively check the workspace root directory for a `.env` file named `testing_execution.env`.
+6. **Mapping Matrix Schema Validation**: 
+   You must dynamically validate the `.csv` mapping file against the canonical schema.
+   1. Use the `read_url_content` tool to fetch the canonical reference: `https://raw.githubusercontent.com/GoogleCloudPlatform/spanner-migration-tool/master/.agents/skills/source_research_helper/sampleOutput/mysql_datatype_mapping_matrix.csv`
+   2. Parse the headers (first line) of both the fetched sample and the local file at `Reference Datatype Mapping Matrix File Path`.
+   3. Verify that *every* column header present in the fetched sample is also present in the local provided matrix (a subset match; the local matrix may contain extra columns).
 
-If ANY of the prompt inputs are missing, or if the `testing_execution.env` file does not exist in the root directory, you **MUST HALT EXECUTION IMMEDIATELY**. Do not attempt to guess, hallucinate paths, or proceed without the environment variables. Output a direct question asking for the missing inputs or complaining about the missing file.
+If ANY of the prompt inputs are missing, or if the `testing_execution.env` file does not exist, or if the provided mapping matrix is missing any canonical headers, you **MUST HALT EXECUTION IMMEDIATELY**. Do not attempt to guess, hallucinate paths, or proceed. Output a direct question asking for the missing inputs, missing file, or reporting the explicitly missing columns.
 
 ---
 
@@ -110,13 +115,14 @@ Instead of researching the database dialect from scratch, this skill assumes a c
 1. **Ingest the Mapping File**:
    - Read the provided mapping `.csv` file. 
    - Parse the matrix into memory.
+   - Use the `"Source Database Type / Alias"` column to identify the native source database type.
 2. **Identify Dialect Validations**:
    - Check the `spanner_dialect` determined in Step 1 (`GOOGLE_STANDARD_SQL` vs `POSTGRESQL`). 
-   - Fetch the mapping strictly from the corresponding Spanner Dialect column in the CSV (e.g., `Spanner GoogleSQL Default Datatype` vs `Spanner PostgreSQL Default Datatype`).
+   - Fetch the mapping strictly from the corresponding Spanner Dialect column in the CSV (e.g., `"Spanner GoogleSQL Default Datatype"`, `"Spanner GoogleSQL Alternative Datatypes"`, `"Spanner PostgreSQL Default Datatype"`, `"Spanner PostgreSQL Alternative Datatypes"`).
 3. **Identify Validation Targets**:
    - Extract every row that is intended for Default or Alternative mapping (Scenarios A and B).
-   - **Primary Keys (Scenario C):** You MUST explicitly read the matrix column defining PK support (e.g., `Is the datatype supported as a PK in the source?`). If supported, you MUST apply the specific mapped type provided in the `If Column is a PK` column for that dialect, as some types must be shortened or converted to binary for PK compatibility.
-   - Extract every row marked as Unsupported or Complex (Scenario D).
+   - **Primary Keys (Scenario C):** You MUST explicitly read the `"Is Source Datatype Supported as PK?"` column in the matrix. If supported (`Yes` or similar), you MUST apply the specific mapped type provided in the `"Spanner GoogleSQL Default Datatype If Column is PK"` or `"Spanner PostgreSQL Default Datatype If Column is PK"` column depending on the target dialect.
+   - **Unsupported/Complex Types (Scenario D):** Extract every row marked as Unsupported or Complex. To identify rows for Scenario D, filter for any rows where `"Datastream Support Status"` is marked as unsupported (or equivalent phrasing like 'No' or 'Unsupported').
 4. **No User Approval Required**:
    - Because this mapping file was vetted in a prior phase, do **NOT** ask the user for approval. Proceed immediately to Step 4.
 

--- a/v2/spanner-common/.agents/skills/add-source-functional-integ-test/SKILL.md
+++ b/v2/spanner-common/.agents/skills/add-source-functional-integ-test/SKILL.md
@@ -20,8 +20,13 @@ Before you begin parsing or executing any core steps, you MUST verify the follow
 3. **Target Source Database Name**
 4. **Reference Datatype Mapping Matrix File Path**
 5. **Testing Environment Setup Path**: You MUST proactively check the workspace root directory for a `.env` file named `testing_execution.env`.
+6. **Mapping Matrix Schema Validation**: 
+   You must dynamically validate the `.csv` mapping file against the canonical schema.
+   1. Use the `read_url_content` tool to fetch the canonical reference: `https://raw.githubusercontent.com/GoogleCloudPlatform/spanner-migration-tool/master/.agents/skills/source_research_helper/sampleOutput/mysql_datatype_mapping_matrix.csv`
+   2. Parse the headers (first line) of both the fetched sample and the local file at `Reference Datatype Mapping Matrix File Path`.
+   3. Verify that *every* column header present in the fetched sample is also present in the local provided matrix (a subset match; the local matrix may contain extra columns).
 
-If ANY of the prompt inputs are missing, or if the `testing_execution.env` file does not exist in the root directory, you **MUST HALT EXECUTION IMMEDIATELY**. Do not attempt to guess, hallucinate paths, or proceed without the environment variables. Output a direct question asking the user to provide the missing inputs or create the file.
+If ANY of the prompt inputs are missing, or if the `testing_execution.env` file does not exist, or if the provided mapping matrix is missing any canonical headers, you **MUST HALT EXECUTION IMMEDIATELY**. Do not attempt to guess, hallucinate paths, or proceed. Output a direct question asking for the missing inputs, missing file, or reporting the explicitly missing columns.
 
 ---
 

--- a/v2/spanner-common/.agents/skills/add-source-functional-integ-test/SKILL.md
+++ b/v2/spanner-common/.agents/skills/add-source-functional-integ-test/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: add-source-functional-integ-test
+description: >
+  Skill for adding functional integ test for new source by taking reference from existing MySQL integ tests.
+---
+
+# New Source Functional Integration Test Generation Skill
+
+This skill instructs an AI Coding Agent to generate and verify integration tests for a new database source scenario (e.g. migrating from a reference source to a target source) for Dataflow Templates.
+
+---
+
+## 1. Goal
+Given a Scenario ID, read its configuration from `manifest.yaml`, locate all reference resources and code, discover logical data type mappings, translate schemas/DDLs and the concrete Java test class, verify via compilation, and self-heal any compilation failures.
+
+## 1.1 Initialization Check
+Before you begin parsing or executing any core steps, you MUST verify the following inputs and dependencies exist:
+1. **Scenario ID** (Must be in your prompt)
+2. **Path to the `manifest.yaml`** (Must be in your prompt)
+3. **Target Database Name** (Must be in your prompt)
+4. **Path to the `.csv` Reference Mapping file** (Must be in your prompt)
+5. **Environment Configuration**: You MUST proactively check the workspace root directory for a `.env` file named `testing_execution.env`.
+
+If ANY of the prompt inputs are missing, or if the `testing_execution.env` file does not exist in the root directory, you **MUST HALT EXECUTION IMMEDIATELY**. Do not attempt to guess, hallucinate paths, or proceed without the environment variables. Output a direct question asking the user to provide the missing inputs or create the file.
+
+---
+
+## 1.2 Prerequisites: Execution Configuration
+The agent must look for a `testing_execution.env` file in the workspace root with the following schema:
+```env
+REMOTE_WORKSPACE_PATH=
+REMOTE_EXEC_TEMPLATE=
+REMOTE_SYNC_TEMPLATE=
+TEST_PROJECT=
+TEST_REGION=
+TEST_SPANNER_INSTANCE=
+TEST_STAGE_BUCKET=
+TEST_ARTIFACT_BUCKET=
+TEST_HOST_IP=
+TEST_PRIVATE_CONNECTIVITY=
+TEST_DB_USER=
+TEST_DB_PASSWORD=
+```
+
+---
+
+## 1.3 Directory Segregation Rule
+To prevent cluttering the root templates package, you MUST place all generated files into a strictly nested directory structure matching the lowercased name of the target database.
+- **Java Class Path:** `src/test/java/com/google/cloud/teleport/v2/templates/{target_db_name_lowercase}/{TestClassName}.java`
+- **Java Package:** `package com.google.cloud.teleport.v2.templates.{target_db_name_lowercase};`
+- **SQL Resources Path:** `src/test/resources/{target_db_name_lowercase}/{TestClassName}/`
+
+---
+
+## 1.4 Global Constraint: Production Code Priority Rule
+
+> [!CRITICAL]
+> **Production Code Priority Rule (Source Over Test)**:
+> This is a global constraint that applies to all phases of this skill (context discovery, type mapping, code generation, compilation, execution, and debugging).
+> If an integration test fails during compilation or execution, you MUST first assume that the bug lies in the **production template source code** (e.g., dialect adapters, DML generators, schema mappers, or exception classifiers) rather than the test harness or DDL.
+> *   **Systematic Investigation**: You must thoroughly analyze the template's core Java engine to identify if it is failing to support the target database's dialect behavior correctly.
+> *   **No Test Hacking**: You are strictly forbidden from "hacking", disabling, or loosening a test assertion or DDL constraint to bypass a failure, unless the production template is proven to be behaving 100% correctly and the mismatch is purely due to database-specific padding/formatting differences.
+> *   **Documentation**: Every change to the production template must be documented in your final report with a root-cause explanation, and any test adaptation must be explicitly justified in the code with JavaDocs.
+
+---
+
+## 2. Step 1: Input Parsing & Scenario Scouting
+1. The user MUST provide the path to the `manifest.yaml` scenario registry file in their prompt. Open that file.
+2. Locate the scenario matching the input `Scenario ID`.
+3. Extract:
+   - `context`: Fully qualified name of the reference test class (e.g. `com.google.cloud.teleport.v2.templates.MySQLDataTypesIT`).
+   - `template`: Path to the template module (e.g. `v2/sourcedb-to-spanner`).
+   - `spanner_dialect`: Target Spanner database dialect (`GOOGLE_STANDARD_SQL` or `POSTGRESQL`). If not explicitly defined in the manifest for the scenario, default to `GOOGLE_STANDARD_SQL`.
+   - `type` (optional): Set to `datatypes` for exhaustive type-mapping integration tests.
+   - `type_mappings` (optional): A pre-defined list of mappings. Each mapping specifies:
+     - `source_type`: The data type in the reference source database (e.g., `VARCHAR(21000)`).
+     - `spanner_type`: The desired Spanner data type (e.g., `STRING(MAX)`).
+
+---
+
+## 3. Step 2: Context Discovery (Scouting)
+To avoid hallucinating helper methods or base configurations, you must gather all relevant context:
+
+> [!IMPORTANT]
+> **Strict Context Constraint**: Anchor all context discovery strictly starting from the reference class file extracted in Step 1. Do NOT search for or inspect other unrelated integration tests (e.g., other PostgreSQL or MySQL tests) in the codebase unless they are direct ancestors or referenced resources of the reference class. Inspecting unrelated test files can lead to hallucinating mismatched setup methods, parent classes, or helper signatures.
+
+1. **Locate Reference Class File**:
+   - Perform a glob/grep search to find the file matching the context class name on disk.
+2. **Scan Inheritance Chain**:
+   - Open the reference class file and inspect its `extends <SuperClass>` signature.
+   - Recursively search for and open all parent/base classes up the inheritance chain to read all available setup and helper APIs.
+3. **Scan Referenced Resource Files**:
+   - In the reference class file and parent classes, look for string constants pointing to *any* resource files (e.g., SQL schemas, Avro files, JSON mappings, CSVs).
+   - Locate and read all of these referenced resource files from the repository.
+
+---
+
+## 4. Step 3: Logical Type Mapping Discovery
+Because you are generating functional tests (e.g., sharding, foreign keys) and not exhaustively generating boundary data, you MUST translate the DDL schemas using the exact data types defined in the provided CSV Ground Truth mapping.
+
+1. **Ingest the CSV Mapping File**:
+   - Read the `.csv` file provided in your prompt.
+   - Parse the matrix to understand how default types are mapped for the target Spanner Dialect (`GOOGLE_STANDARD_SQL` vs `POSTGRESQL`).
+2. **Translate Types**:
+   - As you scan the reference DDL schema from Step 2, identify the column data types.
+   - Use the ingested CSV matrix as a strict dictionary to translate those column types into the Target Source Type and the matching Target Spanner Type.
+3. **No User Approval Required**:
+   - Because this mapping file was vetted in a prior phase (or curated by the user), it is the absolute source of truth.
+   - Do **NOT** construct a markdown mapping table to ask the user for approval. 
+   - Proceed immediately to Step 4 (DDL Schema Translation).
+
+---
+
+## 5. Step 4: DDL Schema Translation
+Identify whether case sensitivity is required to match Spanner schemas, and perform quoting adjustments:
+
+> [!IMPORTANT]
+> **Case Preservation & Identifier Quoting**:
+> To ensure generated tests and schemas run successfully, you must align and preserve the exact character casing of all table names, column names, keys, and constraints between the target source database and the target Spanner database.
+> 1. **Check Case Preservation Requirement**:
+>    - First check if the reference schema, target Spanner schema, or target test uses any uppercase or mixed-case identifiers.
+>    - Check if the target database folds unquoted identifiers to a different case by default (e.g., some database folds unquoted names to lowercase, or another database folds to uppercase).
+>    - If the target database folds unquoted identifiers, AND there are mixed-case/uppercase names, case preservation is **REQUIRED**.
+>    - If all identifiers are already completely lowercase, case preservation is **NOT required** (and you should NOT wrap them in redundant quotes).
+> 2. **Apply Quoting if Case Preservation is Required**:
+>    - Wrap all identifiers (table names, column names, keys, etc.) in dialect-appropriate quotes in the generated DDL statements.
+>    - **Do Not Alter Original Intent**: You MUST NOT alter the original casing of the reference schema identifiers (e.g., converting mixed-case names to all-caps or all-lowercase) just to trivially bypass the database's folding rules. You MUST apply quotes to preserve the original intended mixed-casing exactly as it was provided in the reference.
+> 3. **Casing Parity Between Target Source and Spanner**:
+>    - In some cases (such as data type ITs), target schema table names might differ from the reference test schema.
+>    - However, whatever names are used for the target source schema, their exact character case **MUST be identical** in the target Spanner database schema DDL.
+
+### 5.1 Target Source Schema DDL
+1. Translate the reference source DDL schema file(s) into native SQL statements compatible with the target source database dialect.
+2. The column data types in the generated SQL schema MUST use the standard equivalent target source types identified in the logical type mapping table.
+3. Apply the **Case Preservation & Identifier Quoting** check and rule to prevent the target database from folding identifier cases.
+4. Save the generated DDL file to the target template resources directory using the pattern: `{target_source_dialect}-schema.sql`.
+
+### 5.2 Target Spanner Schema DDL
+1. Translate the reference Spanner DDL SQL file to the target Spanner database dialect (`GOOGLE_STANDARD_SQL` or `POSTGRESQL`).
+2. Align column names, table structures, and primary keys with the target source schema, ensuring the exact character case of all table and column names matches the target source schema exactly. Apply the **Case Preservation & Identifier Quoting** rule if targeting Spanner PostgreSQL dialect.
+   - **Important**: For Spanner `GOOGLE_STANDARD_SQL` dialect, do NOT use double quotes (`"`) or single quotes (`'`) to quote identifiers (tables, columns, etc.) as they are not supported. Only use backticks (`` ` ``) if escaping is required; otherwise, leave identifiers unquoted.
+3. Save the translated Spanner DDL SQL file to the target template resources directory using the pattern: `{target_source_dialect}-{spanner_dialect}-spanner-schema.sql`.
+
+---
+
+## 6. Step 5: Infrastructure Lifecycle & Resource Manager Setup
+
+### 6.1 Source Database ResourceManager lookup and check
+To provision infrastructure resources for integration tests, you MUST inherit the `ResourceManager` architectural pattern used by the `reference_test_class`. If the reference test delegates setup to a method in a base class (e.g., an `ITBase.java` class), you MUST declare a matching method for your target database in that same base class if it doesn't already exist.
+
+1. **Inherit Reference Pattern**: Inspect the `ResourceManager` imported by the reference test's setup method. 
+   - If the reference test logic uses a simple testcontainers-based Resource Manager from the Apache Beam IT SDK (`org.apache.beam.it`), you MUST find and use the equivalent simple testcontainers Resource Manager from the Beam IT SDK for your target source.
+   - If the reference test instead imports a custom cloud-based Resource Manager from the local `it/` codebase, you MUST search the local `it/` codebase for the equivalent cloud Resource Manager for your target source.
+2. **Base Class Injection**: Once you determine the correct `ResourceManager` class using the pattern above, inject the corresponding setup method directly into the Integration Test Base Class, and be sure to update any of its helper methods (such as dialect or driver locators) to support it.
+3. **Synthesize Missing Custom ResourceManager**: If neither the local codebase nor the Apache Beam IT SDK has support for the target source, you MUST synthesize a new custom `ResourceManager` class from scratch:
+   - For JDBC sources: Use `AbstractJDBCResourceManager.java` or an existing dialect's `ResourceManager` from the `it/` folder as a blueprint, extending `AbstractJDBCResourceManager`. Write the class to the appropriate test utility directory.
+   - For non-JDBC/NoSQL/messaging sources: Use an existing robust implementation like `SpannerResourceManager.java` from the `it/` folder as your architectural blueprint for establishing connection URIs, teardown lifecycles, and test containers.
+
+---
+
+## 7. Step 6: Java Test Class Translation
+Translate the reference Java class to the target dialect class under the target package/directory:
+
+### Name Mapping Rules
+- Target class name: Replace the reference source dialect name in the class name with the target source dialect name (e.g. `<SourceDialect>DataTypesIT` -> `<TargetDialect>DataTypesIT`).
+
+### Strict Coding Constraints
+1. **Header**: Start the file with the exact header comment: `/* GENERATED BY: Test Automation Skill */`.
+2. **No Inline SQL/DDL**: Load SQL schemas strictly by referencing the resource path constant.
+3. **Dynamic Source Resource Manager Setup**:
+   - Inspect the discovered base class files to locate the correct target `ResourceManager` class and its setup method.
+   - Call the corresponding setup method defined on the base class (e.g., `setUp<TargetDialect>ResourceManager()` for the target dialect).
+4. **Dynamic Spanner Resource Manager Setup**:
+   - Inspect the discovered base/parent class files to locate the correct method to initialize the Spanner ResourceManager matching the target `spanner_dialect` (e.g. search for `setUpPGDialectSpannerResourceManager` if Spanner dialect is `POSTGRESQL`, or `setUpSpannerResourceManager` if `GOOGLE_STANDARD_SQL`).
+5. **Case Preservation in Java SQL Queries**:
+   - If the target source database folds unquoted identifiers by default, and the reference test/schema uses uppercase or mixed-case identifiers, you MUST wrap these table and column names in dialect-appropriate quotes within the generated Java test class SQL queries, inserts, or validations.
+6. **Proprietary Database Drivers (`jdbcDriverJars`)**:
+   - Some databases are natively bundled in the flex template container by default while proprietary ones are often excluded via test scopes. If your target source database relies on a proprietary JDBC driver that is excluded from the main template deployment, the test will crash on Cloud Dataflow unless you explicitly pass the `--jdbcDriverJars` parameter. 
+   - You MUST ensure your generated Java test class retrieves the dynamically staged driver GCS URL from the base IT class environment (e.g. checking the parent class for a GCS driver path method matching your dialect) and maps it into the `launchTemplate(...)` parameters block.
+7. **Replication/CDC Setup**:
+   - If the template processes CDC updates, ensure the source database resource manager initializes logical replication or binlogs, and pass the resulting replication configuration (e.g., slot names, publication names, or GTID/binlog positions) to the source connector configuration.
+
+---
+
+## 8. Step 7: Maven POM Dependency Injection
+1. Open the `pom.xml` file for the target template module (e.g., `<template_path>/pom.xml`).
+2. Identify the required dependencies for communicating with the target database/source. These can include:
+   - For JDBC sources: The JDBC driver dependency (e.g., `<jdbc_driver_artifact_id>` for `<TargetSourceDBDialect>`).
+   - For non-JDBC/NoSQL/messaging/etc. sources: The target database's official Java client library SDK dependency (e.g., Cassandra or MongoDB driver) or the Apache Beam IO connector library dependency (e.g., `beam-sdks-java-io-cassandra`).
+3. If the identified dependency is not already declared in the `pom.xml`, add it inside the `<dependencies>` section with `<scope>test</scope>`.
+
+---
+
+## 9. Step 8: Compilation, Execution, and Runtime Cleanup
+
+Load the variables from `testing_execution.env`. You MUST route all synchronization and execution through the provided template strings to support the vendor's specific environment.
+
+### 9.1 Workspace Synchronization
+1. Sync the local workspace to the execution environment (Note: If the vendor configured local execution, this may just be a harmless `echo` command):
+   - Read `REMOTE_SYNC_TEMPLATE`. Replace `<LOCAL_PATH>` with `./` and `<REMOTE_PATH>` with the value of `REMOTE_WORKSPACE_PATH`.
+   - Execute the resulting command in your terminal.
+2. **Pre-build local dependencies**: If the test dynamically loads jars from other modules (e.g., `spanner-custom-shard` target directory) which are excluded from sync, build those modules on the target environment:
+   - Read `REMOTE_EXEC_TEMPLATE`. Replace `<COMMAND>` with `cd ${REMOTE_WORKSPACE_PATH} && mvn package -pl v2/spanner-custom-shard -am -DskipTests`.
+   - Execute the rendered command.
+
+### 9.2 Compilation Verification
+Verify compilation:
+1. Replace `<COMMAND>` in `REMOTE_EXEC_TEMPLATE` with `cd ${REMOTE_WORKSPACE_PATH} && mvn test-compile -pl <template_path> -am -Dcheckstyle.skip=true`.
+2. Execute it.
+If compilation fails:
+- Extract the compiler error block matching your target test class name.
+- Analyze the compiler logs, fix the Java code locally, re-sync (Step 8.1), and compile-verify again until it succeeds.
+
+### 9.3 DirectRunner Testing Loop (DirectRunner-First Strategy)
+To minimize development turnaround time, always attempt to execute your tests using local pipeline first:
+1. Run the test by appending `-DdirectRunnerTest` to your maven execution command.
+   - Replace `<COMMAND>` in `REMOTE_EXEC_TEMPLATE` with the following command (substitute the `<variables>` appropriately):
+   `cd ${REMOTE_WORKSPACE_PATH} && rm -f live_logs && mvn verify -f pom.xml -U -PtemplatesIntegrationTests,splunkDeps -pl <template_path> -am -Dtest=<TestClassName> -e -DdirectRunnerTest -Dmdep.analyze.skip -Dcheckstyle.skip -Dspotless.check.skip=true -Djib.skip -DskipShade -DartifactBucket="${TEST_ARTIFACT_BUCKET}" -DstageBucket="${TEST_STAGE_BUCKET}" -Dproject="${TEST_PROJECT}" -Dregion=${TEST_REGION} -DspannerInstanceId="${TEST_SPANNER_INSTANCE}" -Dsurefire.useFile=false -DitParallelismType=none -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -DhostIp=${TEST_HOST_IP} -DprivateConnectivity=${TEST_PRIVATE_CONNECTIVITY} -DcloudProxyHost=${TEST_HOST_IP} -DcloudProxyPassword="${TEST_DB_PASSWORD}" -DcloudProxyUsername="${TEST_DB_USER}" > live_logs 2>&1`
+   - Run the rendered template command in the background (append `&`).
+2. The testing framework will bypass cloud staging and run the template inside the local JVM in-process.
+3. **Thread Cancellation Fix**: Ensure `DirectRunnerClient.java` is patched to cancel running jobs using `thread.interrupt()` instead of the deprecated `thread.stop()`, preventing test hangs during resource cleanup.
+
+### 9.4 Functional Test Execution (Cloud Dataflow)
+1. Run the test without the `-DdirectRunnerTest` property. 
+   - Replace `<COMMAND>` in `REMOTE_EXEC_TEMPLATE` with the same Maven command from 8.3, but omitting `-DdirectRunnerTest`.
+   - Run the rendered template command in the background (append `&`).
+2. Monitor execution progress by tailing the logs (e.g., `tail -n 100 live_logs`).
+
+### 9.5 Resource Teardown & Cleanup Verification
+1. **Do Not Ignore Cleanup Failures**: If the test execution hangs or fails during the teardown phase (e.g., failure to drop databases or replication slots), the test must be considered **FAILED**. Do not manually terminate and call it a pass.
+2. **Investigate Cleanup Order**: A common cause of cleanup failure is incorrect resource manager shutdown order. Ensure that consumer resources (e.g., Datastream streams, Dataflow jobs) are fully stopped and deleted *before* attempting to clean up source resources (e.g., database instances, replication slots).
+3. **Leaked Resource Check**: Always verify that all provisioned resources (Spanner databases, Cloud SQL databases, replication slots, GCS files) are deleted after the run. If leakages are detected, update the test teardown logic to handle them.
+
+### 9.6 Investigation & Debugging of Test Failures
+If the integration test fails (assertion failure, runtime exception, or timeout):
+1. **Analyze Test Logs**: Inspect the test output or surefire reports (`live_logs` if running remotely) to identify the failing assertion or exception stack trace.
+2. **Inspect Dataflow Job Status**: Retrieve the Dataflow job ID from the logs and check its status and error messages:
+   ```bash
+   gcloud dataflow jobs list --project=${TEST_PROJECT} --region=${TEST_REGION}
+   gcloud logging read "resource.type=\"dataflow_step\" AND resource.labels.job_id=\"<YOUR_JOB_ID>\" AND severity>=WARNING" --project=${TEST_PROJECT} --limit=100
+   ```
+3. **Identify the Root Cause**: Determine if the failure is due to:
+   - Schema mismatch (casing, type conversion).
+   - Network connectivity issues.
+   - Permission issues on GCP resources.
+   - Logical bug in the template code.
+4. **Apply Fixes & Re-test**: Apply fixes to the test code or template code, re-sync changes, and re-run.
+
+### 9.7 Artifact Archiving
+1. Upon a completely successful test run (compilation, execution, and zero DLQ errors), you MUST create a dedicated artifact folder relative to the workspace root: `src/test/resources/<target_db_name_lowercase>/reports/functional_testing/<Scenario_ID>_<Timestamp>/`.
+2. Copy the following artifacts into this folder:
+   - The successful `live_logs` output.
+
+---
+
+## 10. Step 9: Post-Validation Migration Report
+1. You MUST generate a markdown report file named `test_automation_migration_report.md` at the exact path relative to the workspace root: `<template_path>/src/test/resources/<target_db_name_lowercase>/reports/functional_testing/<Scenario_ID>_<Timestamp>/test_automation_migration_report.md`. Placed anywhere else, the user will not see it.
+2. The report must contain:
+   
+   **1. Test Suite Details:**
+   - Scenario ID, Target Source Dialect, and Target Spanner Dialect.
+   - Summarize what the test suite is validating/testing with what varification has been done.
+
+   **2. Execution Result & Final Command:**
+   - Final Status (SUCCESS/FAILURE).
+   - The exact Maven command used for the final successful execution.
+
+   **3. Source Code Bugs & Fixes:**
+   - Detail any bugs discovered in the *production template code* (not the test code).
+   - Show the exact code changes applied to fix the production code.
+
+   **4. Self-Healing & Retry History:**
+   - A chronological list of all failed attempts during compilation or execution.
+   - Format: `Retry # | Issue/Exception Encountered | Fix Applied`.
+
+   **5. Exhaustive Type Testing Matrix:**
+   - A single comprehensive table (Single-Row-Per-Table) detailing every tested type.
+   - Columns: `Type Category`, `Source Type`, `Spanner Type`, `Edge Cases Tested`, `Pass/Fail`.
+
+---
+
+## 11. Strict Code Editing Constraints
+CRITICAL RULE: Do NOT write secondary Python or Bash scripts to execute find-and-replace string manipulations on the template `.java` or `pom.xml` source code. You must use your native AI file-editing tools explicitly to modify code block-by-block.
+
+---
+
+## 12. Human Escalation & Clarification Guidelines
+As an autonomous agent executing this skill, you must stop and ask the user for confirmation or input in the following scenarios:
+1. **Unresolved Compilation Errors**: If after **3 self-healing attempts** the test class still fails to compile, stop, present the compiler error block and your current code, and ask the user for guidance.
+2. **Missing ResourceManager blue-prints**: If you determine that a new ResourceManager needs to be synthesized from scratch (i.e. no existing ResourceManager exists in the templates module for the target dialect) and you cannot find any suitable blueprint reference, ask the user to specify/confirm the ResourceManager setup structure.
+3. **Data Type Ambiguity**: If mapping a data type from the source schema results in multiple potential target database/Spanner dialect mappings with different behaviors, ask the user to confirm the preferred mapping choice.

--- a/v2/spanner-common/.agents/skills/add-source-functional-integ-test/SKILL.md
+++ b/v2/spanner-common/.agents/skills/add-source-functional-integ-test/SKILL.md
@@ -15,11 +15,11 @@ Given a Scenario ID, read its configuration from `manifest.yaml`, locate all ref
 
 ## 1.1 Initialization Check
 Before you begin parsing or executing any core steps, you MUST verify the following inputs and dependencies exist:
-1. **Scenario ID** (Must be in your prompt)
-2. **Path to the `manifest.yaml`** (Must be in your prompt)
-3. **Target Database Name** (Must be in your prompt)
-4. **Path to the `.csv` Reference Mapping file** (Must be in your prompt)
-5. **Environment Configuration**: You MUST proactively check the workspace root directory for a `.env` file named `testing_execution.env`.
+1. **Scenario ID**
+2. **Manifest File Path**
+3. **Target Source Database Name**
+4. **Reference Datatype Mapping Matrix File Path**
+5. **Testing Environment Setup Path**: You MUST proactively check the workspace root directory for a `.env` file named `testing_execution.env`.
 
 If ANY of the prompt inputs are missing, or if the `testing_execution.env` file does not exist in the root directory, you **MUST HALT EXECUTION IMMEDIATELY**. Do not attempt to guess, hallucinate paths, or proceed without the environment variables. Output a direct question asking the user to provide the missing inputs or create the file.
 

--- a/v2/spanner-common/.agents/skills/meta-test-orchestrator/SKILL.md
+++ b/v2/spanner-common/.agents/skills/meta-test-orchestrator/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: meta-test-orchestrator
+description: >-
+  Template-agnostic Orchestrator Skill for generating and executing exhaustive testing suites for any migration template. It will generate the functional and datatype related test for the source.
+---
+# Template-Agnostic Orchestrator Meta-Skill
+
+This skill instructs an AI Agent to act as the "Project Manager" for onboarding a new database source into ANY given Dataflow testing template. It automates the generation and execution of the template's entire testing suite by spawning specialized subagents.
+
+---
+
+## 1. Goal
+Orchestrate a fully automated, 3-Phase pipeline to build, test, and verify every single scenario defined in the template's `src/test/manifest.yaml`. 
+
+You MUST execute all spawned subagents **sequentially**. Do NOT run subagents concurrently, to prevent Maven staging conflicts.
+
+---
+
+## 2. Global Constraint: Orchestrator Heartbeats
+
+> [!CRITICAL]
+> **Resilience & Subagent Monitoring Rule**:
+> Because the full execution pipeline can take hours, backend server maintenance restarts might occasionally drop background polling scripts, leaving your subagents stranded in a "waiting" state while tests actually finish in the cloud.
+> - As the Orchestrator, you MUST maintain a proactive heartbeat. 
+> - You MUST set a recurring `schedule` tool timer (e.g. `CronExpression: "*/2 * * * *"`, `IsDaemon: false`) dedicated to babysitting.
+> - Whenever the heartbeat timer fires, explicitly use `manage_subagents list` to check statuses. If you notice a subagent stuck in `waiting_for_message` for an extended period, you must manually run `ssh ... tail` against the remote logs to check the pipeline's true status, and then explicitly use `send_message` to blast the subagent awake with the logs so it resumes working.
+
+---
+
+## 3. Initialization Requirements
+When a user begins a session with this Meta-Skill, ensure you have the following inputs before starting:
+1. **Target Source Database Name:**
+2. **Reference Mapping Matrix File Path:**
+3. **Environment Config:** Confirm that `testing_execution.env` is populated in the workspace root.
+4. **Target Template Path:**
+5. **Phase 1 Smoke Scenarios:** (comma-separated list of scenario IDs)
+6. **Phase 2 Baseline Datatype Scenarios:** (comma-separated list of scenario IDs)
+7. **Manifest File Path:**
+
+---
+
+## 4. Orchestration Rules
+
+1. **Sequential Threading:** You may only have **one** active subagent running at any time.
+2. **Template Onboarding Report:** You MUST maintain a live markdown artifact called `template_onboarding_report.md`.
+   - **Progress Tracker:** Maintain a high-level counter (e.g., `5 / 20 scenarios completed`).
+   - **Consolidated Bug Log:** Aggregate all source-code bugs discovered by subagents and the fixes applied to the `<Target_Template_Path>` source code.
+   - **Challenges:** Summarize any roadblocks or unsupported features (e.g., missing Spanner APIs).
+3. **Error Escalation:** If a subagent exhausts its self-healing retries and fails, report back to the user with a summary of the roadblock before halting the pipeline.
+4. **Artifact Relocation & Syncing:** Subagents frequently save their final migration reports (e.g., `test_automation_migration_report.md` and `live_logs.txt`) into their isolated 'brain' execution sandboxes. As the parent Orchestrator, upon validating a subagent's success, you MUST natively copy their generated reports out of their system-isolated directories and move them directly into the correct workspace root directory using the following exact structure:
+   - For Datatype tests: `src/test/resources/<target_db_name_lowercase>/reports/datatype_testing/<Scenario_ID>_<Timestamp>/`
+   - For Functional tests: `src/test/resources/<target_db_name_lowercase>/reports/functional_testing/<Scenario_ID>_<Timestamp>/`
+5. **Continuous Meta-Report Syncing:** You MUST copy the overarching meta-skill report (`template_onboarding_report.md`) and orchestration execution logs to a persistent directory in the workspace at `src/test/resources/<target_db_name_lowercase>/reports/meta-reports/` right from the beginning, and you must constantly update/overwrite this workspace file as tests run and statuses change iteratively!
+
+
+---
+
+## 5. The 3-Phase Execution Pipeline
+
+You must guide the workflow through these phases sequentially, waiting for one subagent to complete successfully before advancing or spinning up the next.
+
+### Phase 1: Infrastructure Smoke Tests
+**Goal:** Prove the infrastructure and `testing_execution.env` works before adding complex data types.
+**Action:** Spawn a subagent using **Prompt Template A** targeting only the scenarios provided in the **Phase 1 Smoke Scenarios** input list (e.g., `bulk-simple`).
+
+### Phase 2: Complete Datatypes Validation
+**Goal:** Validate all datatypes for the template (including alternate dialects like PostgreSQL Spanner deployments) using the provided reference mapping file.
+**Action:** Spawn subagents sequentially using **Prompt Template B** for the explicit scenarios provided in the **Phase 2 Baseline Datatype Scenarios** input list.
+
+Once those are complete, aggressively scan the provided **Manifest File Path** for any **additional** scenarios tagged with `type: datatypes` (that you haven't executed yet) and spawn subagents for them one at a time. Wait for each subagent to complete before spawning the next.
+
+### Phase 3: Functional Scenarios Scale-Out
+**Goal:** Translate the remaining complex features (e.g., sharding, foreign keys, limits).
+**Action:** Scan the provided **Manifest File Path** for all remaining functional scenarios (not covered in Phases 1-2).
+- Spawn subagents for each scenario **one at a time** using **Prompt Template A**.
+- **Crucial Rule:** As soon as one subagent completes successfully, instantly capture its logs and reports, update your tracker, and proactively move linearly to spawn the next subagent scenario. Do absolutely NOT halt the pipeline or wait for user input/confirmation between scenarios!
+
+### Final Validation
+**Goal:** Run a complete verification regression suite across all generated tests to guarantee zero regressions.
+**Action:** 
+1. To construct the final regression test command, read `v2/spanner-common/.agents/skills/add-source-functional-integ-test/SKILL.md` to learn how to natively assemble the `mvn verify` parameter list from the environment configs. 
+2. Once assembled, swap the target class name parameter for the overarching wildcard corresponding to the dialect (e.g., `-Dtest=Oracle*IT`).
+3. Maintain the `-DdirectRunnerTest` flag to run the regression safely and rapidly. Execute this on the remote test VM.
+4. If the regression suite fails on any specific test, you must re-invoke a subagent dedicated to that specific failing test scenario, passing it the failure logs and instructing it to self-heal the source code and verify its individual test again.
+5. Capture the final outcome of the regression run in your meta-report and securely copy the final executed regression logs to the workspace.
+
+---
+
+## 6. Subagent Prompt Templates
+
+### Prompt Template A (Functional Worker)
+Use this prompt when invoking subagents for Phases 1 and 4.
+**Skill to load:** `v2/spanner-common/.agents/skills/add-source-functional-integ-test/SKILL.md`
+```text
+Please load and execute the `v2/spanner-common/.agents/skills/add-source-functional-integ-test/SKILL.md` skill to generate a functional integration test.
+
+Inputs:
+1. Scenario ID: [INSERT_SCENARIO_ID]
+2. Manifest Path: [INSERT_MANIFEST_FILE_PATH]
+3. Reference Mapping File: [INSERT_MAPPING_FILE_PATH]
+4. Target Database: [INSERT_DB_NAME]
+
+CRITICAL CONSTRAINTS:
+- Treat the provided Reference Mapping File as your absolute source of truth to derive baseline mapping schemas. You MUST strictly use this matrix to generate testing mappings. Do NOT perform independent type research.
+- Load execution strategy from `testing_execution.env`.
+- Follow the Production Code Priority Rule: if tests fail, investigate the target template source code before assuming the test is wrong.
+- Use the `-DdirectRunnerTest` flag for iterative testing. Once the DirectRunner loop passes, you MUST perform a final execution directly against Cloud Dataflow (omitting the flag) and ensure that run completely succeeds before generating your final report.
+- Upon completing your artifact report, ensure `RequestFeedback: false` is set so your status naturally changes back to idle. Do NOT pause waiting for conversational human feedback.
+
+```
+
+### Prompt Template B (Datatype Worker)
+Use this prompt when invoking subagents for Phases 2 and 3.
+**Skill to load:** `v2/spanner-common/.agents/skills/add-source-datatype-integ-test/SKILL.md`
+```text
+Please load and execute the `v2/spanner-common/.agents/skills/add-source-datatype-integ-test/SKILL.md` skill to generate a datatype integration test.
+
+Inputs:
+1. Scenario ID: [INSERT_SCENARIO_ID]
+2. Manifest Path: [INSERT_MANIFEST_FILE_PATH]
+3. Reference Mapping File: [INSERT_MAPPING_FILE_PATH]
+4. Target Database: [INSERT_DB_NAME]
+
+CRITICAL CONSTRAINTS:
+- Treat the provided Reference Mapping File as your absolute source of truth to derive baseline mapping schemas. You MUST strictly use this matrix to generate testing mappings. Do NOT perform independent type research.
+- Load execution strategy from `testing_execution.env`.
+- Use the `-DdirectRunnerTest` flag for iterative testing.Once the DirectRunner loop passes, you MUST perform a final execution directly against Cloud Dataflow (omitting the flag) and ensure that run completely succeeds before generating your final report.
+- Upon completing your artifact report, ensure `RequestFeedback: false` is set so your status naturally changes back to idle. Do NOT pause waiting for conversational human feedback.
+
+```

--- a/v2/spanner-common/.agents/skills/meta-test-orchestrator/SKILL.md
+++ b/v2/spanner-common/.agents/skills/meta-test-orchestrator/SKILL.md
@@ -31,11 +31,13 @@ You MUST execute all spawned subagents **sequentially**. Do NOT run subagents co
 When a user begins a session with this Meta-Skill, ensure you have the following inputs before starting:
 1. **Target Source Database Name:**
 2. **Reference Mapping Matrix File Path:**
-3. **Environment Config:** Confirm that `testing_execution.env` is populated in the workspace root.
+3. **Testing Environment Setup Path:** Confirm that `testing_execution.env` is populated in the workspace root.
 4. **Target Template Path:**
 5. **Phase 1 Smoke Scenarios:** (comma-separated list of scenario IDs)
 6. **Phase 2 Baseline Datatype Scenarios:** (comma-separated list of scenario IDs)
 7. **Manifest File Path:**
+
+If ANY of the prompt inputs are missing, or if the `testing_execution.env` file does not exist in the root directory, you **MUST HALT EXECUTION IMMEDIATELY**. Do not attempt to guess, hallucinate paths, or proceed. Output a direct question asking the user to provide the missing inputs or create the missing environment file.
 
 ---
 
@@ -47,7 +49,7 @@ When a user begins a session with this Meta-Skill, ensure you have the following
    - **Consolidated Bug Log:** Aggregate all source-code bugs discovered by subagents and the fixes applied to the `<Target_Template_Path>` source code.
    - **Challenges:** Summarize any roadblocks or unsupported features (e.g., missing Spanner APIs).
 3. **Error Escalation:** If a subagent exhausts its self-healing retries and fails, report back to the user with a summary of the roadblock before halting the pipeline.
-4. **Artifact Relocation & Syncing:** Subagents frequently save their final migration reports (e.g., `test_automation_migration_report.md` and `live_logs.txt`) into their isolated 'brain' execution sandboxes. As the parent Orchestrator, upon validating a subagent's success, you MUST natively copy their generated reports out of their system-isolated directories and move them directly into the correct workspace root directory using the following exact structure:
+4. **Artifact Relocation & Syncing:** Subagents frequently save their final migration reports (e.g., `test_automation_migration_report.md` and `live_logs`) into their isolated 'brain' execution sandboxes. As the parent Orchestrator, upon validating a subagent's success, you MUST natively copy their generated reports out of their system-isolated directories and move them directly into the correct workspace root directory using the following exact structure:
    - For Datatype tests: `src/test/resources/<target_db_name_lowercase>/reports/datatype_testing/<Scenario_ID>_<Timestamp>/`
    - For Functional tests: `src/test/resources/<target_db_name_lowercase>/reports/functional_testing/<Scenario_ID>_<Timestamp>/`
 5. **Continuous Meta-Report Syncing:** You MUST copy the overarching meta-skill report (`template_onboarding_report.md`) and orchestration execution logs to a persistent directory in the workspace at `src/test/resources/<target_db_name_lowercase>/reports/meta-reports/` right from the beginning, and you must constantly update/overwrite this workspace file as tests run and statuses change iteratively!
@@ -96,9 +98,10 @@ Please load and execute the `v2/spanner-common/.agents/skills/add-source-functio
 
 Inputs:
 1. Scenario ID: [INSERT_SCENARIO_ID]
-2. Manifest Path: [INSERT_MANIFEST_FILE_PATH]
-3. Reference Mapping File: [INSERT_MAPPING_FILE_PATH]
-4. Target Database: [INSERT_DB_NAME]
+2. Manifest File Path: [INSERT_MANIFEST_FILE_PATH]
+3. Target Source Database Name: [INSERT_DB_NAME]
+4. Reference Datatype Mapping Matrix File Path: [INSERT_MAPPING_FILE_PATH]
+5. Testing Environment Setup Path: [INSERT_ENV_PATH]
 
 CRITICAL CONSTRAINTS:
 - Treat the provided Reference Mapping File as your absolute source of truth to derive baseline mapping schemas. You MUST strictly use this matrix to generate testing mappings. Do NOT perform independent type research.
@@ -117,9 +120,10 @@ Please load and execute the `v2/spanner-common/.agents/skills/add-source-datatyp
 
 Inputs:
 1. Scenario ID: [INSERT_SCENARIO_ID]
-2. Manifest Path: [INSERT_MANIFEST_FILE_PATH]
-3. Reference Mapping File: [INSERT_MAPPING_FILE_PATH]
-4. Target Database: [INSERT_DB_NAME]
+2. Manifest File Path: [INSERT_MANIFEST_FILE_PATH]
+3. Target Source Database Name: [INSERT_DB_NAME]
+4. Reference Datatype Mapping Matrix File Path: [INSERT_MAPPING_FILE_PATH]
+5. Testing Environment Setup Path: [INSERT_ENV_PATH]
 
 CRITICAL CONSTRAINTS:
 - Treat the provided Reference Mapping File as your absolute source of truth to derive baseline mapping schemas. You MUST strictly use this matrix to generate testing mappings. Do NOT perform independent type research.

--- a/v2/spanner-common/.agents/skills/meta-test-orchestrator/SKILL.md
+++ b/v2/spanner-common/.agents/skills/meta-test-orchestrator/SKILL.md
@@ -37,7 +37,14 @@ When a user begins a session with this Meta-Skill, ensure you have the following
 6. **Phase 2 Baseline Datatype Scenarios:** (comma-separated list of scenario IDs)
 7. **Manifest File Path:**
 
-If ANY of the prompt inputs are missing, or if the `testing_execution.env` file does not exist in the root directory, you **MUST HALT EXECUTION IMMEDIATELY**. Do not attempt to guess, hallucinate paths, or proceed. Output a direct question asking the user to provide the missing inputs or create the missing environment file.
+> [!IMPORTANT]
+> **Mapping Matrix Schema Validation**: 
+> You must dynamically validate the user's provided `.csv` mapping file against the canonical schema before proceeding with any orchestration or code generation. 
+> 1. Use the `read_url_content` tool to fetch the raw canonical reference from: `https://raw.githubusercontent.com/GoogleCloudPlatform/spanner-migration-tool/master/.agents/skills/source_research_helper/sampleOutput/mysql_datatype_mapping_matrix.csv`
+> 2. Parse the headers (first line) of both the fetched sample matrix and the local file at `Reference Datatype Mapping Matrix File Path`.
+> 3. Verify that *every* column header present in the fetched sample is also present in the local provided matrix (a subset match; the local matrix may contain extra custom columns, which is fine).
+
+If ANY of the prompt inputs are missing, or if the `testing_execution.env` file does not exist in the root directory, or if the provided matrix is missing canonical headers, you **MUST HALT EXECUTION IMMEDIATELY**. Do not attempt to guess, hallucinate paths, or proceed. Output a direct question asking the user to provide the missing inputs, create the missing environment file, or fix the explicitly missing columns.
 
 ---
 

--- a/v2/spanner-common/.agents/skills/meta-test-orchestrator/SKILL.md
+++ b/v2/spanner-common/.agents/skills/meta-test-orchestrator/SKILL.md
@@ -10,7 +10,7 @@ This skill instructs an AI Agent to act as the "Project Manager" for onboarding 
 ---
 
 ## 1. Goal
-Orchestrate a fully automated, 3-Phase pipeline to build, test, and verify every single scenario defined in the template's `src/test/manifest.yaml`. 
+Orchestrate a fully automated, pipeline to build, test, and verify every single scenario defined in the template's `src/test/manifest.yaml`. 
 
 You MUST execute all spawned subagents **sequentially**. Do NOT run subagents concurrently, to prevent Maven staging conflicts.
 
@@ -33,8 +33,8 @@ When a user begins a session with this Meta-Skill, ensure you have the following
 2. **Reference Mapping Matrix File Path:**
 3. **Testing Environment Setup Path:** Confirm that `testing_execution.env` is populated in the workspace root.
 4. **Target Template Path:**
-5. **Phase 1 Smoke Scenarios:** (comma-separated list of scenario IDs)
-6. **Phase 2 Baseline Datatype Scenarios:** (comma-separated list of scenario IDs)
+5. **Smoke Test Scenarios:** (comma-separated list of scenario IDs)
+6. **Datatype Test Scenarios:** (comma-separated list of scenario IDs)
 7. **Manifest File Path:**
 
 > [!IMPORTANT]
@@ -64,23 +64,23 @@ If ANY of the prompt inputs are missing, or if the `testing_execution.env` file 
 
 ---
 
-## 5. The 3-Phase Execution Pipeline
+## 5. The Execution Pipeline
 
-You must guide the workflow through these phases sequentially, waiting for one subagent to complete successfully before advancing or spinning up the next.
+You must guide the workflow through these steps sequentially, waiting for one subagent to complete successfully before advancing or spinning up the next.
 
-### Phase 1: Infrastructure Smoke Tests
+### Infrastructure Smoke Tests
 **Goal:** Prove the infrastructure and `testing_execution.env` works before adding complex data types.
-**Action:** Spawn a subagent using **Prompt Template A** targeting only the scenarios provided in the **Phase 1 Smoke Scenarios** input list (e.g., `bulk-simple`).
+**Action:** Spawn a subagent using **Prompt Template A** targeting only the scenarios provided in the **Smoke Test Scenarios** input list (e.g., `bulk-simple`).
 
-### Phase 2: Complete Datatypes Validation
+### Complete Datatypes Validation
 **Goal:** Validate all datatypes for the template (including alternate dialects like PostgreSQL Spanner deployments) using the provided reference mapping file.
-**Action:** Spawn subagents sequentially using **Prompt Template B** for the explicit scenarios provided in the **Phase 2 Baseline Datatype Scenarios** input list.
+**Action:** Spawn subagents sequentially using **Prompt Template B** for the explicit scenarios provided in the **Datatype Test Scenarios** input list.
 
 Once those are complete, aggressively scan the provided **Manifest File Path** for any **additional** scenarios tagged with `type: datatypes` (that you haven't executed yet) and spawn subagents for them one at a time. Wait for each subagent to complete before spawning the next.
 
-### Phase 3: Functional Scenarios Scale-Out
+### Functional Scenarios Scale-Out
 **Goal:** Translate the remaining complex features (e.g., sharding, foreign keys, limits).
-**Action:** Scan the provided **Manifest File Path** for all remaining functional scenarios (not covered in Phases 1-2).
+**Action:** Scan the provided **Manifest File Path** for all remaining functional scenarios (not covered in the previous steps).
 - Spawn subagents for each scenario **one at a time** using **Prompt Template A**.
 - **Crucial Rule:** As soon as one subagent completes successfully, instantly capture its logs and reports, update your tracker, and proactively move linearly to spawn the next subagent scenario. Do absolutely NOT halt the pipeline or wait for user input/confirmation between scenarios!
 
@@ -98,7 +98,7 @@ Once those are complete, aggressively scan the provided **Manifest File Path** f
 ## 6. Subagent Prompt Templates
 
 ### Prompt Template A (Functional Worker)
-Use this prompt when invoking subagents for Phases 1 and 4.
+Use this prompt when invoking subagents for Smoke Tests and Functional Scenarios.
 **Skill to load:** `v2/spanner-common/.agents/skills/add-source-functional-integ-test/SKILL.md`
 ```text
 Please load and execute the `v2/spanner-common/.agents/skills/add-source-functional-integ-test/SKILL.md` skill to generate a functional integration test.
@@ -120,7 +120,7 @@ CRITICAL CONSTRAINTS:
 ```
 
 ### Prompt Template B (Datatype Worker)
-Use this prompt when invoking subagents for Phases 2 and 3.
+Use this prompt when invoking subagents for Datatypes Validation.
 **Skill to load:** `v2/spanner-common/.agents/skills/add-source-datatype-integ-test/SKILL.md`
 ```text
 Please load and execute the `v2/spanner-common/.agents/skills/add-source-datatype-integ-test/SKILL.md` skill to generate a datatype integration test.

--- a/v2/spanner-common/src/test/resources/testing_execution.env.template
+++ b/v2/spanner-common/src/test/resources/testing_execution.env.template
@@ -1,0 +1,44 @@
+
+# ==============================================================================
+# testing_execution.env
+# Configuration for integration testing execution.
+# ==============================================================================
+
+# ----------------------------------------------------
+# 1. Execution Path & Command Templates
+# ----------------------------------------------------
+# Define how the AI should connect to the execution environment.
+
+# --- OPTION A: LOCAL EXECUTION ---
+# Uncomment these 3 lines and remove option B if you want the tests to run directly on your current machine.
+# REMOTE_WORKSPACE_PATH="."
+# REMOTE_EXEC_TEMPLATE="bash -c '<COMMAND>'"
+# REMOTE_SYNC_TEMPLATE="echo 'Local execution - skipping sync'"
+
+# --- OPTION B: REMOTE EXECUTION (SSH Multiplexing) ---
+# Uncomment these 3 lines and remove option A if you want the tests to run on dedicated remote VM.
+# REMOTE_WORKSPACE_PATH="<workspace_path_on_remote>"
+# REMOTE_EXEC_TEMPLATE="<how_to_execute_command_on_vm>" 
+# REMOTE_SYNC_TEMPLATE="<how_to_sync_local_and_remote_workspace>"
+
+# e.g. 
+# REMOTE_WORKSPACE_PATH="/home/myuser/test_workspace"
+# REMOTE_EXEC_TEMPLATE="ssh -o ControlPath=~/.ssh/mux_socket myuser@192.168.1.50 -- '<COMMAND>'"
+# REMOTE_SYNC_TEMPLATE="rsync -avz -e 'ssh -o ControlPath=~/.ssh/mux_socket' --exclude='.git/' --exclude='.ssh_mux/' --exclude='**/target/' <LOCAL_PATH> myuser@192.168.1.50:<REMOTE_PATH>"
+
+# ----------------------------------------------------
+# 2. GCP & Test Infrastructure Parameters
+# ----------------------------------------------------
+TEST_PROJECT="<gcp_project_to_use>"
+TEST_REGION="<region>"
+TEST_SPANNER_INSTANCE="<spanner_instance_to_use>"
+TEST_STAGE_BUCKET="<gcs_bucket_path_to_stage_template>"
+TEST_ARTIFACT_BUCKET="<gcs_bucket_path_to_store_artifact>"
+
+# ----------------------------------------------------
+# 3. Target Source Database Details
+# ----------------------------------------------------
+TEST_HOST_IP="<host_ip>"
+TEST_PRIVATE_CONNECTIVITY="<private_connectivity_config>"
+TEST_DB_USER="<username>"
+TEST_DB_PASSWORD="<password>"

--- a/v2/spanner-to-sourcedb/.agents/skills/add-integ-tests-spanner-to-sourcedb/SKILL.md
+++ b/v2/spanner-to-sourcedb/.agents/skills/add-integ-tests-spanner-to-sourcedb/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: add-integ-tests-spanner-to-sourcedb
+description: >-
+  Specific runner skill that delegates to the Template-Agnostic Meta-Test Orchestrator for the spanner-to-sourcedb (Reverse Migration) template.
+---
+# Spanner-to-SourceDB Testing Orchestrator 
+
+This is a specific runner skill that acts as a wrapper around the global `meta-test-orchestrator` skill.
+
+## Required Prompt Inputs
+1. **Target Source Database Name**
+2. **Reference Mapping Matrix File Path**
+3. **Environment Config Path** (e.g. `testing_execution.env`)
+
+## Execution Instructions
+You must immediately load and execute the `v2/spanner-common/.agents/skills/meta-test-orchestrator/SKILL.md` skill, passing it the following statically mapped parameters:
+
+1. **Target Source Database Name:** Extract from the user prompt.
+2. **Reference Mapping Matrix File Path:** Extract from the user prompt.
+3. **Environment Config:** Extract from the user prompt and assert its presence.
+4. **Manifest File Path:** `v2/spanner-to-sourcedb/src/test/manifest.yaml`.
+5. **Target Template Path:** `v2/spanner-to-sourcedb`
+6. **Phase 1 Smoke Scenarios:** `reverse-it`
+7. **Phase 2 Baseline Datatype Scenarios:** `reverse-datatypes`, `reverse-datatypes-pg`
+
+Yield execution completely to the `meta-test-orchestrator`. Instruct the Orchestrator to begin Phase 1 using these parameters.
+
+## Example User Prompt
+```text
+Please run the add-integ-tests-spanner-to-sourcedb skill for the oracle database. 
+Use the reference matrix located at v2/spanner-to-sourcedb/src/test/resources/oracle/oracle_datatype_mapping_matrix.csv load the execution properties from testing_execution.env.
+```

--- a/v2/spanner-to-sourcedb/.agents/skills/add-integ-tests-spanner-to-sourcedb/SKILL.md
+++ b/v2/spanner-to-sourcedb/.agents/skills/add-integ-tests-spanner-to-sourcedb/SKILL.md
@@ -9,15 +9,18 @@ This is a specific runner skill that acts as a wrapper around the global `meta-t
 
 ## Required Prompt Inputs
 1. **Target Source Database Name**
-2. **Reference Mapping Matrix File Path**
-3. **Environment Config Path** (e.g. `testing_execution.env`)
+2. **Reference Datatype Mapping Matrix File Path**
+3. **Testing Environment Setup Path** (e.g. `testing_execution.env`)
+
+> [!IMPORTANT]
+> **Initialization Check**: If ANY of the required prompt inputs are missing from the user's prompt, or if the environment config file does not exist, you **MUST HALT EXECUTION IMMEDIATELY**. Ask the user to provide the missing inputs before proceeding.
 
 ## Execution Instructions
 You must immediately load and execute the `v2/spanner-common/.agents/skills/meta-test-orchestrator/SKILL.md` skill, passing it the following statically mapped parameters:
 
 1. **Target Source Database Name:** Extract from the user prompt.
-2. **Reference Mapping Matrix File Path:** Extract from the user prompt.
-3. **Environment Config:** Extract from the user prompt and assert its presence.
+2. **Reference Datatype Mapping Matrix File Path:** Extract from the user prompt.
+3. **Testing Environment Setup Path:** Extract from the user prompt and assert its presence.
 4. **Manifest File Path:** `v2/spanner-to-sourcedb/src/test/manifest.yaml`.
 5. **Target Template Path:** `v2/spanner-to-sourcedb`
 6. **Phase 1 Smoke Scenarios:** `reverse-it`
@@ -27,6 +30,6 @@ Yield execution completely to the `meta-test-orchestrator`. Instruct the Orchest
 
 ## Example User Prompt
 ```text
-Please run the add-integ-tests-spanner-to-sourcedb skill for the oracle database. 
-Use the reference matrix located at v2/spanner-to-sourcedb/src/test/resources/oracle/oracle_datatype_mapping_matrix.csv load the execution properties from testing_execution.env.
+Please run the add-integ-tests-spanner-to-sourcedb skill for the MySQL database. 
+Use the reference matrix located at v2/spanner-to-sourcedb/src/test/resources/mysql/mysql_datatype_mapping_matrix.csv load the execution properties from testing_execution.env.
 ```

--- a/v2/spanner-to-sourcedb/.agents/skills/add-integ-tests-spanner-to-sourcedb/SKILL.md
+++ b/v2/spanner-to-sourcedb/.agents/skills/add-integ-tests-spanner-to-sourcedb/SKILL.md
@@ -23,10 +23,10 @@ You must immediately load and execute the `v2/spanner-common/.agents/skills/meta
 3. **Testing Environment Setup Path:** Extract from the user prompt and assert its presence.
 4. **Manifest File Path:** `v2/spanner-to-sourcedb/src/test/manifest.yaml`.
 5. **Target Template Path:** `v2/spanner-to-sourcedb`
-6. **Phase 1 Smoke Scenarios:** `reverse-it`
-7. **Phase 2 Baseline Datatype Scenarios:** `reverse-datatypes`, `reverse-datatypes-pg`
+6. **Smoke Test Scenarios:** `reverse-it`
+7. **Datatype Test Scenarios:** `reverse-datatypes`, `reverse-datatypes-pg`
 
-Yield execution completely to the `meta-test-orchestrator`. Instruct the Orchestrator to begin Phase 1 using these parameters.
+Yield execution completely to the `meta-test-orchestrator`. Instruct the Orchestrator to begin using these parameters.
 
 ## Example User Prompt
 ```text

--- a/v2/spanner-to-sourcedb/src/test/manifest.yaml
+++ b/v2/spanner-to-sourcedb/src/test/manifest.yaml
@@ -1,0 +1,102 @@
+scenarios:
+  # ==================================================================
+  # Reverse Replication (v2/spanner-to-sourcedb)
+  # ==================================================================
+  - id: reverse-it
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToSourceDbIT
+    description: "Main functional integration test for reverse replication from Spanner to target MySQL databases."
+
+  - id: reverse-datatypes
+    type: datatypes
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToMySqlDataTypesIT
+    description: "Validates reverse data type mappings, conversion formats, and value checks from Spanner to MySQL."
+
+  - id: reverse-reservedkeywords
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToMySqlReservedKeywordsIT
+    description: "Evaluates reverse replication updates targeting tables and columns named after MySQL reserved keywords."
+
+  - id: reverse-timezone
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToSourceDbTimezoneIT
+    description: "Validates timezone offset conversions and date-time column updates during reverse replication."
+
+  - id: reverse-dlq-all
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToSourceDBMySQLRetryAllDLQIT
+    description: "Verifies DLQ routing and reprocessing metrics when reverse replication writes to MySQL encounter failures."
+
+  - id: reverse-sharded-dlq
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToSourceDBShardedMySQLRetryDLQIT
+    description: "Verifies DLQ reprocessing and retry delivery patterns under sharded MySQL configuration."
+
+  - id: reverse-widerow-10mb
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToMySqlSourceDbWideRow10MbIT
+    description: "Asserts reverse replication throughput and synchronization speed under heavy 10MB payloads."
+
+  - id: reverse-widerow-maxcolumns
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToMySqlSourceDbWideRowMaxColumnsIT
+    description: "Validates reverse replication stability when writing rows containing the maximum supported column counts in MySQL."
+
+  - id: reverse-datatypes-pg
+    type: datatypes
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToMySqlDataTypesPGDialectIT
+    spanner_dialect: POSTGRESQL
+    description: "Validates reverse data type mappings targeting a PostgreSQL-dialect Spanner database."
+
+  - id: reverse-without-session
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToMySqlWithoutSessionIT
+    description: "Validates reverse replication flow without specifying custom mapping session files."
+
+  - id: reverse-customsharding
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToSourceDbCustomShardIT
+    description: "Validates custom sharding configurations in spanner-to-sourcedb reverse replication."
+
+  - id: reverse-customtransformation
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToSourceDbCustomTransformationIT
+    description: "Validates custom transformations during reverse replication."
+
+  - id: reverse-fileoverrides
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToSourceDbFileOverridesSchemaMapperIT
+    description: "Verifies reverse replication mapping overrides configured via custom files."
+
+  - id: reverse-stringoverrides
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToSourceDbStringOverridesSchemaMapperIT
+    description: "Verifies string column type overrides mapping configurations."
+
+  - id: reverse-interleaved-multishard
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToSourceDbInterleaveMultiShardIT
+    description: "Validates reverse replication child tables interleaved under multi-sharded configurations."
+
+  - id: reverse-datatypes-generic
+    type: datatypes
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToSourceDbDatatypeIT
+    description: "Validates generic reverse data type mappings and value checks from Spanner to target database."
+
+  - id: reverse-widerow-basic
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToSourceDbWideRowBasicIT
+    description: "Validates baseline wide-row reverse replication without extreme payload or column boundary constraints."
+
+  - id: reverse-dlq-single
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToSourceDBMySQLRetryDLQIT
+    description: "Verifies single-message Dead Letter Queue (DLQ) retry routing for non-sharded reverse replication pipelines."
+
+  - id: reverse-sharded-dlq-all
+    template: v2/spanner-to-sourcedb
+    context: com.google.cloud.teleport.v2.templates.SpannerToSourceDBShardedMySQLRetryAllDLQIT
+    description: "Verifies retry-all DLQ recovery and redelivery behavior under sharded reverse replication configuration."


### PR DESCRIPTION
Add skills and manifest files for integration test generation

This PR introduces new skills and manifest files to implement integration tests for any source across all three templates. 

### Skills 
* **Functional integration test skill:** Uses a provided reference test case from another source to build the equivalent test for a given source.
* **Data type integration test skill:** Creates integration tests for various data type mappings from the source to Spanner. It synthesizes tests from a provided data type mapping matrix.
* **Meta-orchestrator skill:** Orchestrates the complete test suite generation for a template based on a manifest file.
* **Template-specific skills:** Provide the required inputs and delegate work to the meta-orchestrator skill to generate the test suite for a given template and source.

### Manifest files
* Added manifest files that capture various scenarios and reference test case files from other sources across all three templates.
