### PR TITLE
Enable Apache Iceberg REST Metrics Reporting for Lakehouse

### DIFF
--- a/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/IcebergToAlloyDBYamlIT.java
+++ b/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/IcebergToAlloyDBYamlIT.java
@@ -167,7 +167,6 @@ public class IcebergToAlloyDBYamlIT extends TemplateTestBase {
         "uri", "https://biglake.googleapis.com/iceberg/v1beta/restcatalog",
         "warehouse", "gs://" + warehouseGcsResourceManager.getBucket(),
         "header.x-goog-user-project", PROJECT,
-        "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager",
-        "rest-metrics-reporting-enabled", "false");
+        "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager");
   }
 }

--- a/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/IcebergToMySQLYamlIT.java
+++ b/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/IcebergToMySQLYamlIT.java
@@ -178,7 +178,6 @@ public class IcebergToMySQLYamlIT extends TemplateTestBase {
         "uri", "https://biglake.googleapis.com/iceberg/v1beta/restcatalog",
         "warehouse", "gs://" + warehouseGcsResourceManager.getBucket(),
         "header.x-goog-user-project", PROJECT,
-        "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager",
-        "rest-metrics-reporting-enabled", "false");
+        "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager");
   }
 }

--- a/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/IcebergToPostgreSQLYamlIT.java
+++ b/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/IcebergToPostgreSQLYamlIT.java
@@ -207,7 +207,6 @@ public class IcebergToPostgreSQLYamlIT extends TemplateTestBase {
         "uri", "https://biglake.googleapis.com/iceberg/v1beta/restcatalog",
         "warehouse", "gs://" + warehouseGcsResourceManager.getBucket(),
         "header.x-goog-user-project", PROJECT,
-        "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager",
-        "rest-metrics-reporting-enabled", "false");
+        "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager");
   }
 }

--- a/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/IcebergToSQLServerYamlIT.java
+++ b/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/IcebergToSQLServerYamlIT.java
@@ -218,7 +218,6 @@ public class IcebergToSQLServerYamlIT extends TemplateTestBase {
         "uri", "https://biglake.googleapis.com/iceberg/v1beta/restcatalog",
         "warehouse", "gs://" + warehouseGcsResourceManager.getBucket(),
         "header.x-goog-user-project", PROJECT,
-        "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager",
-        "rest-metrics-reporting-enabled", "false");
+        "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager");
   }
 }

--- a/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/KafkaToIcebergYamlIT.java
+++ b/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/KafkaToIcebergYamlIT.java
@@ -191,8 +191,6 @@ public class KafkaToIcebergYamlIT extends TemplateTestBase {
         "header.x-goog-user-project",
         PROJECT,
         "rest.auth.type",
-        "org.apache.iceberg.gcp.auth.GoogleAuthManager",
-        "rest-metrics-reporting-enabled",
-        "false");
+        "org.apache.iceberg.gcp.auth.GoogleAuthManager");
   }
 }

--- a/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/MySQLToIcebergYamlIT.java
+++ b/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/MySQLToIcebergYamlIT.java
@@ -159,7 +159,6 @@ public class MySQLToIcebergYamlIT extends TemplateTestBase {
         "uri", "https://biglake.googleapis.com/iceberg/v1beta/restcatalog",
         "warehouse", "gs://" + warehouseGcsResourceManager.getBucket(),
         "header.x-goog-user-project", PROJECT,
-        "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager",
-        "rest-metrics-reporting-enabled", "false");
+        "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager");
   }
 }

--- a/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/PostgreSQLToIcebergYamlIT.java
+++ b/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/PostgreSQLToIcebergYamlIT.java
@@ -159,7 +159,6 @@ public class PostgreSQLToIcebergYamlIT extends TemplateTestBase {
         "uri", "https://biglake.googleapis.com/iceberg/v1beta/restcatalog",
         "warehouse", "gs://" + warehouseGcsResourceManager.getBucket(),
         "header.x-goog-user-project", PROJECT,
-        "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager",
-        "rest-metrics-reporting-enabled", "false");
+        "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager");
   }
 }

--- a/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/PubsubToIcebergYamlIT.java
+++ b/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/PubsubToIcebergYamlIT.java
@@ -149,7 +149,6 @@ public class PubsubToIcebergYamlIT extends TemplateTestBase {
         "uri", "https://biglake.googleapis.com/iceberg/v1beta/restcatalog",
         "warehouse", "gs://" + gcsClient.getBucket(),
         "header.x-goog-user-project", PROJECT,
-        "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager",
-        "rest-metrics-reporting-enabled", "false");
+        "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager");
   }
 }

--- a/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/SQLServerToIcebergYamlIT.java
+++ b/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/SQLServerToIcebergYamlIT.java
@@ -183,7 +183,6 @@ public class SQLServerToIcebergYamlIT extends TemplateTestBase {
         "uri", "https://biglake.googleapis.com/iceberg/v1beta/restcatalog",
         "warehouse", "gs://" + warehouseGcsResourceManager.getBucket(),
         "header.x-goog-user-project", PROJECT,
-        "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager",
-        "rest-metrics-reporting-enabled", "false");
+        "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager");
   }
 }


### PR DESCRIPTION
According to https://docs.cloud.google.com/lakehouse/docs/release-notes#May_07_2026, we no longer need to override `rest-metrics-reporting-enabled` to `false`.