### PR TITLE
Switch Lakehouse from v1beta to v1

### DIFF
--- a/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/IcebergToAlloyDBYamlIT.java
+++ b/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/IcebergToAlloyDBYamlIT.java
@@ -164,7 +164,7 @@ public class IcebergToAlloyDBYamlIT extends TemplateTestBase {
   private Map<String, String> getCatalogProperties() {
     return Map.of(
         "type", "rest",
-        "uri", "https://biglake.googleapis.com/iceberg/v1beta/restcatalog",
+        "uri", "https://biglake.googleapis.com/iceberg/v1/restcatalog",
         "warehouse", "gs://" + warehouseGcsResourceManager.getBucket(),
         "header.x-goog-user-project", PROJECT,
         "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager");

--- a/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/IcebergToMySQLYamlIT.java
+++ b/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/IcebergToMySQLYamlIT.java
@@ -175,7 +175,7 @@ public class IcebergToMySQLYamlIT extends TemplateTestBase {
   private Map<String, String> getCatalogProperties() {
     return Map.of(
         "type", "rest",
-        "uri", "https://biglake.googleapis.com/iceberg/v1beta/restcatalog",
+        "uri", "https://biglake.googleapis.com/iceberg/v1/restcatalog",
         "warehouse", "gs://" + warehouseGcsResourceManager.getBucket(),
         "header.x-goog-user-project", PROJECT,
         "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager");

--- a/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/IcebergToPostgreSQLYamlIT.java
+++ b/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/IcebergToPostgreSQLYamlIT.java
@@ -204,7 +204,7 @@ public class IcebergToPostgreSQLYamlIT extends TemplateTestBase {
   private Map<String, String> getCatalogProperties() {
     return Map.of(
         "type", "rest",
-        "uri", "https://biglake.googleapis.com/iceberg/v1beta/restcatalog",
+        "uri", "https://biglake.googleapis.com/iceberg/v1/restcatalog",
         "warehouse", "gs://" + warehouseGcsResourceManager.getBucket(),
         "header.x-goog-user-project", PROJECT,
         "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager");

--- a/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/IcebergToSQLServerYamlIT.java
+++ b/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/IcebergToSQLServerYamlIT.java
@@ -215,7 +215,7 @@ public class IcebergToSQLServerYamlIT extends TemplateTestBase {
   private Map<String, String> getCatalogProperties() {
     return Map.of(
         "type", "rest",
-        "uri", "https://biglake.googleapis.com/iceberg/v1beta/restcatalog",
+        "uri", "https://biglake.googleapis.com/iceberg/v1/restcatalog",
         "warehouse", "gs://" + warehouseGcsResourceManager.getBucket(),
         "header.x-goog-user-project", PROJECT,
         "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager");

--- a/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/KafkaToIcebergYamlIT.java
+++ b/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/KafkaToIcebergYamlIT.java
@@ -185,7 +185,7 @@ public class KafkaToIcebergYamlIT extends TemplateTestBase {
         "type",
         "rest",
         "uri",
-        "https://biglake.googleapis.com/iceberg/v1beta/restcatalog",
+        "https://biglake.googleapis.com/iceberg/v1/restcatalog",
         "warehouse",
         "gs://" + warehouseGcsResourceManager.getBucket(),
         "header.x-goog-user-project",

--- a/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/MySQLToIcebergYamlIT.java
+++ b/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/MySQLToIcebergYamlIT.java
@@ -156,7 +156,7 @@ public class MySQLToIcebergYamlIT extends TemplateTestBase {
   private Map<String, String> getCatalogProperties() {
     return Map.of(
         "type", "rest",
-        "uri", "https://biglake.googleapis.com/iceberg/v1beta/restcatalog",
+        "uri", "https://biglake.googleapis.com/iceberg/v1/restcatalog",
         "warehouse", "gs://" + warehouseGcsResourceManager.getBucket(),
         "header.x-goog-user-project", PROJECT,
         "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager");

--- a/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/PostgreSQLToIcebergYamlIT.java
+++ b/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/PostgreSQLToIcebergYamlIT.java
@@ -156,7 +156,7 @@ public class PostgreSQLToIcebergYamlIT extends TemplateTestBase {
   private Map<String, String> getCatalogProperties() {
     return Map.of(
         "type", "rest",
-        "uri", "https://biglake.googleapis.com/iceberg/v1beta/restcatalog",
+        "uri", "https://biglake.googleapis.com/iceberg/v1/restcatalog",
         "warehouse", "gs://" + warehouseGcsResourceManager.getBucket(),
         "header.x-goog-user-project", PROJECT,
         "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager");

--- a/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/PubsubToIcebergYamlIT.java
+++ b/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/PubsubToIcebergYamlIT.java
@@ -146,7 +146,7 @@ public class PubsubToIcebergYamlIT extends TemplateTestBase {
   private Map<String, String> getCatalogProperties() {
     return Map.of(
         "type", "rest",
-        "uri", "https://biglake.googleapis.com/iceberg/v1beta/restcatalog",
+        "uri", "https://biglake.googleapis.com/iceberg/v1/restcatalog",
         "warehouse", "gs://" + gcsClient.getBucket(),
         "header.x-goog-user-project", PROJECT,
         "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager");

--- a/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/SQLServerToIcebergYamlIT.java
+++ b/yaml/src/test/java/com/google/cloud/teleport/templates/yaml/SQLServerToIcebergYamlIT.java
@@ -180,7 +180,7 @@ public class SQLServerToIcebergYamlIT extends TemplateTestBase {
   private Map<String, String> getCatalogProperties() {
     return Map.of(
         "type", "rest",
-        "uri", "https://biglake.googleapis.com/iceberg/v1beta/restcatalog",
+        "uri", "https://biglake.googleapis.com/iceberg/v1/restcatalog",
         "warehouse", "gs://" + warehouseGcsResourceManager.getBucket(),
         "header.x-goog-user-project", PROJECT,
         "rest.auth.type", "org.apache.iceberg.gcp.auth.GoogleAuthManager");


### PR DESCRIPTION
Lakehouse's Iceberg REST Catalog went GA last November (https://cloud.google.com/blog/products/data-analytics/biglake-metastore-now-supports-iceberg-rest-catalog), so we should be using the v1 api instead of v1beta.