### PR TITLE
Spanner to spanner transactional handling fixes

### DIFF
--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/sourceddl/SourceSchema.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/sourceddl/SourceSchema.java
@@ -33,6 +33,9 @@ public abstract class SourceSchema implements Serializable {
   public abstract ImmutableMap<String, SourceTable> tables();
 
   @Nullable
+  public abstract Object rawDdl();
+
+  @Nullable
   public abstract String version();
 
   public static Builder builder(SourceDatabaseType sourceType) {
@@ -51,6 +54,8 @@ public abstract class SourceSchema implements Serializable {
     public abstract Builder tables(ImmutableMap<String, SourceTable> tables);
 
     public abstract Builder version(String version);
+
+    public abstract Builder rawDdl(@Nullable Object rawDdl);
 
     public abstract SourceSchema build();
   }

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/sourceddl/SpannerInformationSchemaScanner.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/sourceddl/SpannerInformationSchemaScanner.java
@@ -54,8 +54,7 @@ public class SpannerInformationSchemaScanner implements SourceSchemaScanner {
     this.spannerConfig = spannerConfig;
   }
 
-  @Override
-  public SourceSchema scan() {
+  public Ddl scanDdl() {
     SpannerAccessor accessor = SpannerAccessor.getOrCreate(spannerConfig);
     try {
       BatchClient batchClient = accessor.getBatchClient();
@@ -63,13 +62,19 @@ public class SpannerInformationSchemaScanner implements SourceSchemaScanner {
       InformationSchemaScanner scanner = new InformationSchemaScanner(txn);
       Ddl ddl = scanner.scan();
       LOG.info("Scanned Spanner schema for database '{}'", spannerConfig.getDatabaseId().get());
-      return convertDdlToSourceSchema(ddl);
+      return ddl;
     } finally {
       accessor.close();
     }
   }
 
-  SourceSchema convertDdlToSourceSchema(Ddl ddl) {
+  @Override
+  public SourceSchema scan() {
+    Ddl ddl = scanDdl();
+    return convertDdlToSourceSchema(ddl);
+  }
+
+  public SourceSchema convertDdlToSourceSchema(Ddl ddl) {
     Map<String, SourceTable> tables = new HashMap<>();
     for (Table spannerTable : ddl.allTables()) {
       SourceTable sourceTable = convertTable(spannerTable);

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/sourceddl/SpannerInformationSchemaScanner.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/sourceddl/SpannerInformationSchemaScanner.java
@@ -83,6 +83,7 @@ public class SpannerInformationSchemaScanner implements SourceSchemaScanner {
     return SourceSchema.builder(sourceType)
         .databaseName(spannerConfig.getDatabaseId().get())
         .tables(ImmutableMap.copyOf(tables))
+        .rawDdl(ddl)
         .build();
   }
 

--- a/v2/spanner-to-sourcedb/pom.xml
+++ b/v2/spanner-to-sourcedb/pom.xml
@@ -54,6 +54,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.apis</groupId>
+            <artifactId>google-api-services-dataflow</artifactId>
+            <version>v1b3-rev20260503-2.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>${json.version}</version>

--- a/v2/spanner-to-sourcedb/pom.xml
+++ b/v2/spanner-to-sourcedb/pom.xml
@@ -54,11 +54,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.google.apis</groupId>
-            <artifactId>google-api-services-dataflow</artifactId>
-            <version>v1b3-rev20260503-2.0.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>${json.version}</version>

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/dao/source/IDao.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/dao/source/IDao.java
@@ -31,23 +31,4 @@ public interface IDao {
    */
   void write(DMLGeneratorResponse dmlGeneratorResponse, TransactionalCheck transactionalCheck)
       throws Exception;
-
-  /**
-   * Executes a given write dmlGeneratorResponse against the data source under a specific
-   * transaction context. If the transaction context is null, it delegates to {@link #write(Object,
-   * TransactionalCheck)}.
-   *
-   * @param dmlGeneratorResponse Query dmlGeneratorResponse.
-   * @param transactionalCheck Callback function which will be executed and checked before
-   *     committing the transaction.
-   * @param transactionContext The transaction context to execute the write under.
-   * @throws Exception If the write could not be successfully executed.
-   */
-  default void write(
-      DMLGeneratorResponse dmlGeneratorResponse,
-      TransactionalCheck transactionalCheck,
-      Object transactionContext)
-      throws Exception {
-    write(dmlGeneratorResponse, transactionalCheck);
-  }
 }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/processor/SourceProcessorFactory.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/dbutils/processor/SourceProcessorFactory.java
@@ -63,15 +63,15 @@ public class SourceProcessorFactory {
    * @param shards the list of shards for the source
    * @param maxConnections the maximum number of connections
    * @return a configured SourceProcessor instance
-   * @throws Exception if the source type is invalid
+   * @throws UnsupportedSourceException if the source type is invalid
    */
   public static SourceProcessor createSourceProcessor(
       String source, List<Shard> shards, int maxConnections) throws UnsupportedSourceException {
-    ISpToSrcSourceConnector sourceInstance = getSource(source);
+    ISpToSrcSourceConnector sourceConnector = getSource(source);
 
-    IDMLGenerator dmlGenerator = sourceInstance.getDmlGenerator();
-    sourceInstance.initConnectionHelper(shards, maxConnections);
-    Map<String, IDao> sourceDaoMap = createSourceDaoMap(sourceInstance, shards);
+    IDMLGenerator dmlGenerator = sourceConnector.getDmlGenerator();
+    sourceConnector.initConnectionHelper(shards, maxConnections);
+    Map<String, IDao> sourceDaoMap = createSourceDaoMap(sourceConnector, shards);
 
     return SourceProcessor.builder().dmlGenerator(dmlGenerator).sourceDaoMap(sourceDaoMap).build();
   }
@@ -82,10 +82,10 @@ public class SourceProcessorFactory {
   }
 
   private static Map<String, IDao> createSourceDaoMap(
-      ISpToSrcSourceConnector sourceInstance, List<Shard> shards) {
+      ISpToSrcSourceConnector sourceConnector, List<Shard> shards) {
     Map<String, IDao> sourceDaoMap = new HashMap<>();
     for (Shard shard : shards) {
-      sourceDaoMap.put(shard.getLogicalShardId(), sourceInstance.getDao(shard));
+      sourceDaoMap.put(shard.getLogicalShardId(), sourceConnector.getDao(shard));
     }
     return sourceDaoMap;
   }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/models/SpannerMutationResponse.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/models/SpannerMutationResponse.java
@@ -27,10 +27,6 @@ public class SpannerMutationResponse extends DMLGeneratorResponse {
   private final Mutation mutation;
   private final Key primaryKey;
 
-  public SpannerMutationResponse(Mutation mutation) {
-    this(mutation, null);
-  }
-
   public SpannerMutationResponse(Mutation mutation, Key primaryKey) {
     super("");
     this.mutation = mutation;

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/models/SpannerMutationResponse.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/models/SpannerMutationResponse.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.v2.templates.models;
 
+import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation;
 
 /**
@@ -24,14 +25,24 @@ import com.google.cloud.spanner.Mutation;
 public class SpannerMutationResponse extends DMLGeneratorResponse {
 
   private final Mutation mutation;
+  private final Key primaryKey;
 
   public SpannerMutationResponse(Mutation mutation) {
+    this(mutation, null);
+  }
+
+  public SpannerMutationResponse(Mutation mutation, Key primaryKey) {
     super("");
     this.mutation = mutation;
+    this.primaryKey = primaryKey;
   }
 
   public Mutation getMutation() {
     return mutation;
+  }
+
+  public Key getPrimaryKey() {
+    return primaryKey;
   }
 
   @Override

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGenerator.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGenerator.java
@@ -27,10 +27,7 @@ import com.google.cloud.teleport.v2.spanner.ddl.Table;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaMapper;
 import com.google.cloud.teleport.v2.spanner.sourceddl.SourceTable;
 import com.google.cloud.teleport.v2.spanner.type.Type;
-import com.google.cloud.teleport.v2.templates.constants.Constants;
 import com.google.cloud.teleport.v2.templates.dbutils.dml.IDMLGenerator;
-import com.google.cloud.teleport.v2.templates.dbutils.processor.ISpToSrcSourceConnector;
-import com.google.cloud.teleport.v2.templates.dbutils.processor.SourceProcessorFactory;
 import com.google.cloud.teleport.v2.templates.exceptions.InvalidDMLGenerationException;
 import com.google.cloud.teleport.v2.templates.models.DMLGeneratorRequest;
 import com.google.cloud.teleport.v2.templates.models.DMLGeneratorResponse;
@@ -75,7 +72,13 @@ public class SpannerDMLGenerator implements IDMLGenerator {
       throw new InvalidDMLGenerationException("Spanner DDL must not be null.");
     }
     if (targetSpannerSchema == null) {
-      throw new InvalidDMLGenerationException("SourceSchema must not be null.");
+      throw new InvalidDMLGenerationException("target spanner schema could not be fetched.");
+    }
+
+    Ddl targetDdl =
+        (targetSpannerSchema.rawDdl() instanceof Ddl) ? (Ddl) targetSpannerSchema.rawDdl() : null;
+    if (targetDdl == null) {
+      throw new InvalidDMLGenerationException("target spanner ddl could not be fetched.");
     }
 
     Table origSpannerTable = originalSpannerDdl.table(origSpannerTableName);
@@ -109,10 +112,10 @@ public class SpannerDMLGenerator implements IDMLGenerator {
     String modType = request.getModType();
     if ("INSERT".equals(modType) || "UPDATE".equals(modType)) {
       return buildUpsertMutation(
-          origSpannerTable, targetSpannerTable, schemaMapper, request, targetTableName);
+          origSpannerTable, targetSpannerTable, schemaMapper, request, targetTableName, targetDdl);
     } else if ("DELETE".equals(modType)) {
       return buildDeleteMutation(
-          origSpannerTable, targetSpannerTable, schemaMapper, request, targetTableName);
+          origSpannerTable, targetSpannerTable, schemaMapper, request, targetTableName, targetDdl);
     } else {
       throw new InvalidDMLGenerationException(
           "Unsupported modType '" + modType + "' for table " + origSpannerTableName);
@@ -124,7 +127,8 @@ public class SpannerDMLGenerator implements IDMLGenerator {
       SourceTable targetSpannerTable,
       ISchemaMapper schemaMapper,
       DMLGeneratorRequest request,
-      String targetTableName) {
+      String targetTableName,
+      Ddl targetDdl) {
 
     Mutation.WriteBuilder builder = Mutation.newInsertOrUpdateBuilder(targetTableName);
     JSONObject newValuesJson = request.getNewValuesJson();
@@ -178,6 +182,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
     Key primaryKey =
         buildTargetPrimaryKey(
             origSpannerTable,
+            targetDdl,
             targetSpannerTable,
             schemaMapper,
             newValuesJson,
@@ -188,65 +193,55 @@ public class SpannerDMLGenerator implements IDMLGenerator {
 
   private static Key buildTargetPrimaryKey(
       Table origSpannerTable,
+      Ddl targetDdl,
       SourceTable targetSpannerTable,
       ISchemaMapper schemaMapper,
       JSONObject newValuesJson,
       JSONObject keyValuesJson,
       Map<String, Object> customTransformationResponse) {
-    // TODO- rework class to take targetDdl in constructor
-    Ddl targetDdl = null;
-    try {
-      ISpToSrcSourceConnector sourceConnector =
-          SourceProcessorFactory.getSource(Constants.SOURCE_SPANNER);
-      if (sourceConnector instanceof SpannerSpToSrcSourceConnector) {
-        targetDdl = ((SpannerSpToSrcSourceConnector) sourceConnector).getTargetDdl();
-      }
-    } catch (Exception e) {
-      LOG.warn("could not fetch spanner source", e);
-    }
-
     Key.Builder keyBuilder = Key.newBuilder();
     for (String targetColName : targetSpannerTable.primaryKeyColumns()) {
-      Object customVal = null;
-      if (customTransformationResponse != null
-          && customTransformationResponse.containsKey(targetColName)) {
-        customVal = customTransformationResponse.get(targetColName);
-      }
       Column targetCol = null;
       if (targetDdl != null && targetDdl.table(targetSpannerTable.name()) != null) {
         targetCol = targetDdl.table(targetSpannerTable.name()).column(targetColName);
-      }
-      if (targetCol == null) {
-        String origColName = null;
-        try {
-          if (schemaMapper != null) {
-            origColName =
-                schemaMapper.getSpannerColumnName("", targetSpannerTable.name(), targetColName);
-          }
-        } catch (NoSuchElementException ignored) {
-        }
-        if (origColName == null) {
-          origColName = targetColName;
-        }
-        if (origSpannerTable != null && origColName != null) {
-          targetCol = origSpannerTable.column(origColName);
-        }
       }
       if (targetCol == null) {
         throw new InvalidDMLGenerationException(
             "Primary key column '" + targetColName + "' not found in DDL.");
       }
 
-      JSONObject valuesJson = keyValuesJson.has(targetColName) ? keyValuesJson : newValuesJson;
-      if (customVal != null) {
-        appendCustomKeyComponent(keyBuilder, targetCol, customVal);
-      } else if (valuesJson.has(targetColName)) {
-        appendCustomKeyComponent(keyBuilder, targetCol, valuesJson.get(targetColName));
-      } else {
-        LOG.warn("Primary key column '{}' could not be resolved.", targetColName);
-        throw new InvalidDMLGenerationException(
-            "Primary key column '" + targetColName + "' could not be resolved.");
+      String origColName = null;
+      try {
+        if (schemaMapper != null) {
+          origColName =
+              schemaMapper.getSpannerColumnName("", targetSpannerTable.name(), targetColName);
+        }
+      } catch (NoSuchElementException ignored) {
       }
+      if (origColName == null) {
+        origColName = targetColName;
+      }
+
+      Object targetColValue = null;
+      if (customTransformationResponse != null
+          && customTransformationResponse.containsKey(targetColName)) {
+        targetColValue = customTransformationResponse.get(targetColName);
+      } else {
+        // Fetch the value from the changestream record
+        if (keyValuesJson.has(origColName)) {
+          // column was a part of key in the original record.
+          targetColValue = keyValuesJson.get(origColName);
+        } else if (newValuesJson.has(origColName)) {
+          // column was not a part of key in the original record.
+          targetColValue = newValuesJson.get(origColName);
+        } else {
+          // column not resolvable
+          LOG.warn("Primary key column '{}' could not be resolved.", targetColName);
+          throw new InvalidDMLGenerationException(
+              "Primary key column '" + targetColName + "' could not be resolved.");
+        }
+      }
+      appendCustomKeyComponent(keyBuilder, targetCol, targetColValue);
     }
     return keyBuilder.build();
   }
@@ -256,7 +251,8 @@ public class SpannerDMLGenerator implements IDMLGenerator {
       SourceTable targetSpannerTable,
       ISchemaMapper schemaMapper,
       DMLGeneratorRequest request,
-      String targetTableName) {
+      String targetTableName,
+      Ddl targetDdl) {
 
     JSONObject keyValuesJson = request.getKeyValuesJson();
     JSONObject newValuesJson = request.getNewValuesJson();
@@ -264,6 +260,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
     Key primaryKey =
         buildTargetPrimaryKey(
             origSpannerTable,
+            targetDdl,
             targetSpannerTable,
             schemaMapper,
             newValuesJson,
@@ -454,6 +451,10 @@ public class SpannerDMLGenerator implements IDMLGenerator {
    * {@link #setCustomColumnValue} for the DELETE path.
    */
   private static void appendCustomKeyComponent(Key.Builder keyBuilder, Column col, Object value) {
+    if (value == null) {
+      keyBuilder.appendObject(null);
+      return;
+    }
     Type type = col.type();
     switch (type.getCode()) {
       case BOOL:

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGenerator.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGenerator.java
@@ -221,7 +221,10 @@ public class SpannerDMLGenerator implements IDMLGenerator {
         } catch (NoSuchElementException e) {
           throw new InvalidDMLGenerationException(
               "there is no mapped column or custom transformation for table'"
-                  + targetSpannerTable.name() + "' column'" + targetColName + "'");
+                  + targetSpannerTable.name()
+                  + "' column'"
+                  + targetColName
+                  + "'");
         }
         // Fetch the value from the changestream record
         if (keyValuesJson != null && keyValuesJson.has(origColName)) {
@@ -233,7 +236,8 @@ public class SpannerDMLGenerator implements IDMLGenerator {
         } else {
           // column not resolvable
           throw new InvalidDMLGenerationException(
-              "Primary key column '" + targetColName
+              "Primary key column '"
+                  + targetColName
                   + "' could not be resolved because of incorrect schema mapper.");
         }
       }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGenerator.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGenerator.java
@@ -29,9 +29,9 @@ import com.google.cloud.teleport.v2.spanner.sourceddl.SourceTable;
 import com.google.cloud.teleport.v2.spanner.type.Type;
 import com.google.cloud.teleport.v2.templates.constants.Constants;
 import com.google.cloud.teleport.v2.templates.dbutils.dml.IDMLGenerator;
+import com.google.cloud.teleport.v2.templates.dbutils.processor.ISpToSrcSourceConnector;
 import com.google.cloud.teleport.v2.templates.dbutils.processor.SourceProcessorFactory;
 import com.google.cloud.teleport.v2.templates.exceptions.InvalidDMLGenerationException;
-import com.google.cloud.teleport.v2.templates.exceptions.UnsupportedSourceException;
 import com.google.cloud.teleport.v2.templates.models.DMLGeneratorRequest;
 import com.google.cloud.teleport.v2.templates.models.DMLGeneratorResponse;
 import com.google.cloud.teleport.v2.templates.models.SpannerMutationResponse;
@@ -62,10 +62,10 @@ public class SpannerDMLGenerator implements IDMLGenerator {
 
     // Target - The spanner database which this pipeline is writing to
     // Original - The spanner database whose writes are being replicated via changestream
-    String originalSpTableName = request.getSpannerTableName();
+    String origSpannerTableName = request.getSpannerTableName();
     ISchemaMapper schemaMapper = request.getSchemaMapper();
     Ddl originalSpannerDdl = request.getSpannerDdl();
-    com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema targetSpSchema =
+    com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema targetSpannerSchema =
         request.getSourceSchema();
 
     if (schemaMapper == null) {
@@ -74,25 +74,25 @@ public class SpannerDMLGenerator implements IDMLGenerator {
     if (originalSpannerDdl == null) {
       throw new InvalidDMLGenerationException("Spanner DDL must not be null.");
     }
-    if (targetSpSchema == null) {
+    if (targetSpannerSchema == null) {
       throw new InvalidDMLGenerationException("SourceSchema must not be null.");
     }
 
-    Table originalSpannerTable = originalSpannerDdl.table(originalSpTableName);
-    if (originalSpannerTable == null) {
+    Table origSpannerTable = originalSpannerDdl.table(origSpannerTableName);
+    if (origSpannerTable == null) {
       throw new InvalidDMLGenerationException(
-          "Original Spanner table '" + originalSpTableName + "' not found in source DDL.");
+          "Original Spanner table '" + origSpannerTableName + "' not found in source DDL.");
     }
 
     String targetTableName;
     try {
-      targetTableName = schemaMapper.getSourceTableName("", originalSpTableName);
+      targetTableName = schemaMapper.getSourceTableName("", origSpannerTableName);
     } catch (NoSuchElementException e) {
       throw new InvalidDMLGenerationException(
-          "Could not find target table name for source Spanner table: " + originalSpTableName, e);
+          "Could not find target table name for source Spanner table: " + origSpannerTableName, e);
     }
 
-    SourceTable targetSpannerTable = targetSpSchema.table(targetTableName);
+    SourceTable targetSpannerTable = targetSpannerSchema.table(targetTableName);
     if (targetSpannerTable == null) {
       throw new InvalidDMLGenerationException(
           "Target table '" + targetTableName + "' not found in SourceSchema.");
@@ -109,18 +109,18 @@ public class SpannerDMLGenerator implements IDMLGenerator {
     String modType = request.getModType();
     if ("INSERT".equals(modType) || "UPDATE".equals(modType)) {
       return buildUpsertMutation(
-          originalSpannerTable, targetSpannerTable, schemaMapper, request, targetTableName);
+          origSpannerTable, targetSpannerTable, schemaMapper, request, targetTableName);
     } else if ("DELETE".equals(modType)) {
       return buildDeleteMutation(
-          originalSpannerTable, targetSpannerTable, schemaMapper, request, targetTableName);
+          origSpannerTable, targetSpannerTable, schemaMapper, request, targetTableName);
     } else {
       throw new InvalidDMLGenerationException(
-          "Unsupported modType '" + modType + "' for table " + originalSpTableName);
+          "Unsupported modType '" + modType + "' for table " + origSpannerTableName);
     }
   }
 
   private static DMLGeneratorResponse buildUpsertMutation(
-      Table originalSpannerTable,
+      Table origSpannerTable,
       SourceTable targetSpannerTable,
       ISchemaMapper schemaMapper,
       DMLGeneratorRequest request,
@@ -146,7 +146,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
         continue;
       }
 
-      Column origCol = originalSpannerTable.column(originalColName);
+      Column origCol = origSpannerTable.column(originalColName);
       if (origCol == null) {
         // There is no column in the original spanner which maps to the target spanner
         continue;
@@ -177,7 +177,9 @@ public class SpannerDMLGenerator implements IDMLGenerator {
 
     Key primaryKey =
         buildTargetPrimaryKey(
+            origSpannerTable,
             targetSpannerTable,
+            schemaMapper,
             newValuesJson,
             keyValuesJson,
             request.getCustomTransformationResponse());
@@ -185,20 +187,22 @@ public class SpannerDMLGenerator implements IDMLGenerator {
   }
 
   private static Key buildTargetPrimaryKey(
+      Table origSpannerTable,
       SourceTable targetSpannerTable,
+      ISchemaMapper schemaMapper,
       JSONObject newValuesJson,
       JSONObject keyValuesJson,
       Map<String, Object> customTransformationResponse) {
     // TODO- rework class to take targetDdl in constructor
     Ddl targetDdl = null;
     try {
-      targetDdl =
-          ((SpannerSpToSrcSourceConnector)
-                  SourceProcessorFactory.getSource(Constants.SOURCE_SPANNER))
-              .getTargetDdl();
-    } catch (UnsupportedSourceException e) {
-      LOG.warn("could not fetch spanner source");
-      throw new RuntimeException(e);
+      ISpToSrcSourceConnector sourceConnector =
+          SourceProcessorFactory.getSource(Constants.SOURCE_SPANNER);
+      if (sourceConnector instanceof SpannerSpToSrcSourceConnector) {
+        targetDdl = ((SpannerSpToSrcSourceConnector) sourceConnector).getTargetDdl();
+      }
+    } catch (Exception e) {
+      LOG.warn("could not fetch spanner source", e);
     }
 
     Key.Builder keyBuilder = Key.newBuilder();
@@ -208,7 +212,31 @@ public class SpannerDMLGenerator implements IDMLGenerator {
           && customTransformationResponse.containsKey(targetColName)) {
         customVal = customTransformationResponse.get(targetColName);
       }
-      Column targetCol = targetDdl.table(targetSpannerTable.name()).column(targetColName);
+      Column targetCol = null;
+      if (targetDdl != null && targetDdl.table(targetSpannerTable.name()) != null) {
+        targetCol = targetDdl.table(targetSpannerTable.name()).column(targetColName);
+      }
+      if (targetCol == null) {
+        String origColName = null;
+        try {
+          if (schemaMapper != null) {
+            origColName =
+                schemaMapper.getSpannerColumnName("", targetSpannerTable.name(), targetColName);
+          }
+        } catch (NoSuchElementException ignored) {
+        }
+        if (origColName == null) {
+          origColName = targetColName;
+        }
+        if (origSpannerTable != null && origColName != null) {
+          targetCol = origSpannerTable.column(origColName);
+        }
+      }
+      if (targetCol == null) {
+        throw new InvalidDMLGenerationException(
+            "Primary key column '" + targetColName + "' not found in DDL.");
+      }
+
       JSONObject valuesJson = keyValuesJson.has(targetColName) ? keyValuesJson : newValuesJson;
       if (customVal != null) {
         appendCustomKeyComponent(keyBuilder, targetCol, customVal);
@@ -235,7 +263,9 @@ public class SpannerDMLGenerator implements IDMLGenerator {
 
     Key primaryKey =
         buildTargetPrimaryKey(
+            origSpannerTable,
             targetSpannerTable,
+            schemaMapper,
             newValuesJson,
             keyValuesJson,
             request.getCustomTransformationResponse());

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGenerator.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGenerator.java
@@ -170,7 +170,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
           if (valuesJson.isNull(originalColName)) {
             setNullValue(builder, targetColName, origCol.type());
           } else {
-            setColumnValue(builder, targetColName, origCol, valuesJson);
+            setColumnValue(builder, targetCol, origCol, valuesJson);
           }
         }
       }
@@ -219,6 +219,9 @@ public class SpannerDMLGenerator implements IDMLGenerator {
                 schemaMapper.getSpannerColumnName("", targetSpannerTable.name(), targetColName);
           }
         } catch (NoSuchElementException e) {
+          throw new InvalidDMLGenerationException(
+              "there is no mapped column or custom transformation for table'"
+                  + targetSpannerTable.name() + "' column'" + targetColName + "'");
         }
         // Fetch the value from the changestream record
         if (keyValuesJson != null && keyValuesJson.has(origColName)) {
@@ -229,9 +232,9 @@ public class SpannerDMLGenerator implements IDMLGenerator {
           targetColValue = newValuesJson.get(origColName);
         } else {
           // column not resolvable
-          LOG.warn("Primary key column '{}' could not be resolved.", targetColName);
           throw new InvalidDMLGenerationException(
-              "Primary key column '" + targetColName + "' could not be resolved.");
+              "Primary key column '" + targetColName
+                  + "' could not be resolved because of incorrect schema mapper.");
         }
       }
       appendCustomKeyComponent(keyBuilder, targetCol, targetColValue);
@@ -264,19 +267,19 @@ public class SpannerDMLGenerator implements IDMLGenerator {
   }
 
   private static void setColumnValue(
-      Mutation.WriteBuilder builder, String targetColName, Column col, JSONObject valuesJson) {
-    String sourceColName = col.name();
-    Type type = col.type();
+      WriteBuilder builder, Column targetCol, Column origCol, JSONObject valuesJson) {
+    String origColName = origCol.name();
+    Type type = targetCol.type();
 
     if (type.getCode() == Type.Code.ARRAY || type.getCode() == Type.Code.PG_ARRAY) {
       builder
-          .set(targetColName)
-          .to(buildArrayValue(type.getArrayElementType(), valuesJson.getJSONArray(sourceColName)));
+          .set(targetCol.name())
+          .to(buildArrayValue(type.getArrayElementType(), valuesJson.getJSONArray(origColName)));
       return;
     }
 
-    Object value = valuesJson.get(sourceColName);
-    setCustomColumnValue(builder, col, value);
+    Object value = valuesJson.get(origColName);
+    setCustomColumnValue(builder, targetCol, value);
   }
 
   private static void setNullValue(Mutation.WriteBuilder builder, String targetColName, Type type) {

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGenerator.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGenerator.java
@@ -20,6 +20,7 @@ import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Mutation.WriteBuilder;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.teleport.v2.spanner.ddl.Column;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
@@ -133,48 +134,44 @@ public class SpannerDMLGenerator implements IDMLGenerator {
     Mutation.WriteBuilder builder = Mutation.newInsertOrUpdateBuilder(targetTableName);
     JSONObject newValuesJson = request.getNewValuesJson();
     JSONObject keyValuesJson = request.getKeyValuesJson();
+    Table targetSpTable = targetDdl.table(targetTableName);
 
-    for (com.google.cloud.teleport.v2.spanner.sourceddl.SourceColumn targetCol :
-        targetSpannerTable.columns()) {
+    for (Column targetCol : targetSpTable.columns()) {
       if (targetCol.isGenerated()) {
         continue;
       }
 
       String targetColName = targetCol.name();
 
-      String originalColName;
-      try {
-        originalColName =
-            schemaMapper.getSpannerColumnName("", targetSpannerTable.name(), targetColName);
-      } catch (NoSuchElementException e) {
-        continue;
-      }
-
-      Column origCol = origSpannerTable.column(originalColName);
-      if (origCol == null) {
-        // There is no column in the original spanner which maps to the target spanner
-        continue;
-      }
-
       if (request.getCustomTransformationResponse() != null
-          && request.getCustomTransformationResponse().containsKey(originalColName)) {
-        Object customVal = request.getCustomTransformationResponse().get(originalColName);
+          && request.getCustomTransformationResponse().containsKey(targetColName)) {
+        Object customVal = request.getCustomTransformationResponse().get(targetColName);
         if (customVal == null) {
-          setNullValue(builder, targetColName, origCol.type());
+          setNullValue(builder, targetColName, targetCol.type());
         } else {
-          setCustomColumnValue(builder, targetColName, origCol, customVal);
+          setCustomColumnValue(builder, targetCol, customVal);
         }
-      } else if (newValuesJson.has(originalColName)) {
-        if (newValuesJson.isNull(originalColName)) {
-          setNullValue(builder, targetColName, origCol.type());
-        } else {
-          setColumnValue(builder, targetColName, origCol, newValuesJson);
+      } else {
+        String originalColName;
+        try {
+          originalColName =
+              schemaMapper.getSpannerColumnName("", targetSpannerTable.name(), targetColName);
+        } catch (NoSuchElementException e) {
+          continue;
         }
-      } else if (keyValuesJson.has(originalColName)) {
-        if (keyValuesJson.isNull(originalColName)) {
-          setNullValue(builder, targetColName, origCol.type());
-        } else {
-          setColumnValue(builder, targetColName, origCol, keyValuesJson);
+
+        Column origCol = origSpannerTable.column(originalColName);
+        if (origCol == null) {
+          // There is no column in the original spanner which maps to the target spanner
+          continue;
+        }
+        JSONObject valuesJson = keyValuesJson.has(originalColName) ? keyValuesJson : newValuesJson;
+        if (valuesJson.has(originalColName)) {
+          if (valuesJson.isNull(originalColName)) {
+            setNullValue(builder, targetColName, origCol.type());
+          } else {
+            setColumnValue(builder, targetColName, origCol, valuesJson);
+          }
         }
       }
     }
@@ -210,28 +207,24 @@ public class SpannerDMLGenerator implements IDMLGenerator {
             "Primary key column '" + targetColName + "' not found in DDL.");
       }
 
-      String origColName = null;
-      try {
-        if (schemaMapper != null) {
-          origColName =
-              schemaMapper.getSpannerColumnName("", targetSpannerTable.name(), targetColName);
-        }
-      } catch (NoSuchElementException ignored) {
-      }
-      if (origColName == null) {
-        origColName = targetColName;
-      }
-
       Object targetColValue = null;
       if (customTransformationResponse != null
           && customTransformationResponse.containsKey(targetColName)) {
         targetColValue = customTransformationResponse.get(targetColName);
       } else {
+        String origColName = null;
+        try {
+          if (schemaMapper != null) {
+            origColName =
+                schemaMapper.getSpannerColumnName("", targetSpannerTable.name(), targetColName);
+          }
+        } catch (NoSuchElementException e) {
+        }
         // Fetch the value from the changestream record
-        if (keyValuesJson.has(origColName)) {
+        if (keyValuesJson != null && keyValuesJson.has(origColName)) {
           // column was a part of key in the original record.
           targetColValue = keyValuesJson.get(origColName);
-        } else if (newValuesJson.has(origColName)) {
+        } else if (newValuesJson != null && newValuesJson.has(origColName)) {
           // column was not a part of key in the original record.
           targetColValue = newValuesJson.get(origColName);
         } else {
@@ -275,7 +268,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
     String sourceColName = col.name();
     Type type = col.type();
 
-    if (type.getCode() == Type.Code.ARRAY) {
+    if (type.getCode() == Type.Code.ARRAY || type.getCode() == Type.Code.PG_ARRAY) {
       builder
           .set(targetColName)
           .to(buildArrayValue(type.getArrayElementType(), valuesJson.getJSONArray(sourceColName)));
@@ -283,42 +276,61 @@ public class SpannerDMLGenerator implements IDMLGenerator {
     }
 
     Object value = valuesJson.get(sourceColName);
-    setCustomColumnValue(builder, targetColName, col, value);
+    setCustomColumnValue(builder, col, value);
   }
 
   private static void setNullValue(Mutation.WriteBuilder builder, String targetColName, Type type) {
     switch (type.getCode()) {
       case BOOL:
+      case PG_BOOL:
         builder.set(targetColName).to((Boolean) null);
         break;
       case INT64:
+      case PG_INT8:
         builder.set(targetColName).to((Long) null);
         break;
       case FLOAT64:
+      case PG_FLOAT8:
         builder.set(targetColName).to((Double) null);
         break;
       case FLOAT32:
+      case PG_FLOAT4:
         builder.set(targetColName).to((Float) null);
         break;
       case STRING:
+      case PG_TEXT:
+      case PG_VARCHAR:
+      case UUID:
+      case PG_UUID:
         builder.set(targetColName).to((String) null);
         break;
       case JSON:
         builder.set(targetColName).to(Value.json(null));
         break;
+      case PG_JSONB:
+        builder.set(targetColName).to(Value.pgJsonb(null));
+        break;
       case BYTES:
+      case PG_BYTEA:
         builder.set(targetColName).to((ByteArray) null);
         break;
       case DATE:
+      case PG_DATE:
         builder.set(targetColName).to((Date) null);
         break;
       case TIMESTAMP:
+      case PG_TIMESTAMPTZ:
+      case PG_COMMIT_TIMESTAMP:
         builder.set(targetColName).to((Timestamp) null);
         break;
       case NUMERIC:
         builder.set(targetColName).to((BigDecimal) null);
         break;
+      case PG_NUMERIC:
+        builder.set(targetColName).to(Value.pgNumeric(null));
+        break;
       case ARRAY:
+      case PG_ARRAY:
         setNullArrayValue(builder, targetColName, type.getArrayElementType());
         break;
       default:
@@ -330,34 +342,52 @@ public class SpannerDMLGenerator implements IDMLGenerator {
       Mutation.WriteBuilder builder, String targetColName, Type elementType) {
     switch (elementType.getCode()) {
       case BOOL:
+      case PG_BOOL:
         builder.set(targetColName).toBoolArray((Iterable<Boolean>) null);
         break;
       case INT64:
+      case PG_INT8:
         builder.set(targetColName).toInt64Array((Iterable<Long>) null);
         break;
       case FLOAT64:
+      case PG_FLOAT8:
         builder.set(targetColName).toFloat64Array((Iterable<Double>) null);
         break;
       case FLOAT32:
+      case PG_FLOAT4:
         builder.set(targetColName).toFloat32Array((Iterable<Float>) null);
         break;
       case STRING:
+      case PG_TEXT:
+      case PG_VARCHAR:
+      case UUID:
+      case PG_UUID:
         builder.set(targetColName).toStringArray((Iterable<String>) null);
         break;
       case JSON:
         builder.set(targetColName).toJsonArray((Iterable<String>) null);
         break;
+      case PG_JSONB:
+        builder.set(targetColName).toPgJsonbArray((Iterable<String>) null);
+        break;
       case BYTES:
+      case PG_BYTEA:
         builder.set(targetColName).toBytesArray((Iterable<ByteArray>) null);
         break;
       case DATE:
+      case PG_DATE:
         builder.set(targetColName).toDateArray((Iterable<Date>) null);
         break;
       case TIMESTAMP:
+      case PG_TIMESTAMPTZ:
+      case PG_COMMIT_TIMESTAMP:
         builder.set(targetColName).toTimestampArray((Iterable<Timestamp>) null);
         break;
       case NUMERIC:
         builder.set(targetColName).toNumericArray((Iterable<BigDecimal>) null);
+        break;
+      case PG_NUMERIC:
+        builder.set(targetColName).toPgNumericArray((Iterable<String>) null);
         break;
       default:
         builder.set(targetColName).toStringArray((Iterable<String>) null);
@@ -369,11 +399,12 @@ public class SpannerDMLGenerator implements IDMLGenerator {
    * Spanner type. Strings are coerced into the correct primitive when needed; already-typed values
    * (e.g. from Java-based transformers) are bound directly.
    */
-  private static void setCustomColumnValue(
-      Mutation.WriteBuilder builder, String targetColName, Column col, Object value) {
-    Type type = col.type();
+  private static void setCustomColumnValue(WriteBuilder builder, Column targetCol, Object value) {
+    String targetColName = targetCol.name();
+    Type type = targetCol.type();
     switch (type.getCode()) {
       case BOOL:
+      case PG_BOOL:
         if (value instanceof Boolean) {
           builder.set(targetColName).to((Boolean) value);
         } else {
@@ -381,6 +412,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
         }
         break;
       case INT64:
+      case PG_INT8:
         if (value instanceof Number) {
           builder.set(targetColName).to(((Number) value).longValue());
         } else {
@@ -388,6 +420,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
         }
         break;
       case FLOAT64:
+      case PG_FLOAT8:
         if (value instanceof Number) {
           builder.set(targetColName).to(((Number) value).doubleValue());
         } else {
@@ -395,6 +428,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
         }
         break;
       case FLOAT32:
+      case PG_FLOAT4:
         if (value instanceof Number) {
           builder.set(targetColName).to(((Number) value).floatValue());
         } else {
@@ -402,12 +436,20 @@ public class SpannerDMLGenerator implements IDMLGenerator {
         }
         break;
       case STRING:
+      case PG_TEXT:
+      case PG_VARCHAR:
+      case UUID:
+      case PG_UUID:
         builder.set(targetColName).to(value.toString());
         break;
       case JSON:
         builder.set(targetColName).to(Value.json(value.toString()));
         break;
+      case PG_JSONB:
+        builder.set(targetColName).to(Value.pgJsonb(value.toString()));
+        break;
       case BYTES:
+      case PG_BYTEA:
         if (value instanceof byte[]) {
           builder.set(targetColName).to(ByteArray.copyFrom((byte[]) value));
         } else if (value instanceof ByteArray) {
@@ -417,6 +459,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
         }
         break;
       case DATE:
+      case PG_DATE:
         if (value instanceof com.google.cloud.Date) {
           builder.set(targetColName).to((com.google.cloud.Date) value);
         } else {
@@ -424,6 +467,8 @@ public class SpannerDMLGenerator implements IDMLGenerator {
         }
         break;
       case TIMESTAMP:
+      case PG_TIMESTAMPTZ:
+      case PG_COMMIT_TIMESTAMP:
         if (value instanceof com.google.cloud.Timestamp) {
           builder.set(targetColName).to((com.google.cloud.Timestamp) value);
         } else {
@@ -436,6 +481,9 @@ public class SpannerDMLGenerator implements IDMLGenerator {
         } else {
           builder.set(targetColName).to(new BigDecimal(value.toString()));
         }
+        break;
+      case PG_NUMERIC:
+        builder.set(targetColName).to(Value.pgNumeric(value.toString()));
         break;
       default:
         LOG.warn(
@@ -458,6 +506,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
     Type type = col.type();
     switch (type.getCode()) {
       case BOOL:
+      case PG_BOOL:
         if (value instanceof Boolean) {
           keyBuilder.append((Boolean) value);
         } else {
@@ -465,6 +514,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
         }
         break;
       case INT64:
+      case PG_INT8:
         if (value instanceof Number) {
           keyBuilder.append(((Number) value).longValue());
         } else {
@@ -472,6 +522,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
         }
         break;
       case FLOAT64:
+      case PG_FLOAT8:
         if (value instanceof Number) {
           keyBuilder.append(((Number) value).doubleValue());
         } else {
@@ -479,6 +530,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
         }
         break;
       case FLOAT32:
+      case PG_FLOAT4:
         if (value instanceof Number) {
           keyBuilder.append(((Number) value).floatValue());
         } else {
@@ -486,6 +538,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
         }
         break;
       case BYTES:
+      case PG_BYTEA:
         if (value instanceof byte[]) {
           keyBuilder.append(ByteArray.copyFrom((byte[]) value));
         } else if (value instanceof ByteArray) {
@@ -495,6 +548,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
         }
         break;
       case DATE:
+      case PG_DATE:
         if (value instanceof com.google.cloud.Date) {
           keyBuilder.append((com.google.cloud.Date) value);
         } else {
@@ -502,6 +556,8 @@ public class SpannerDMLGenerator implements IDMLGenerator {
         }
         break;
       case TIMESTAMP:
+      case PG_TIMESTAMPTZ:
+      case PG_COMMIT_TIMESTAMP:
         if (value instanceof com.google.cloud.Timestamp) {
           keyBuilder.append((com.google.cloud.Timestamp) value);
         } else {
@@ -509,6 +565,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
         }
         break;
       case NUMERIC:
+      case PG_NUMERIC:
         if (value instanceof BigDecimal) {
           keyBuilder.append((BigDecimal) value);
         } else {
@@ -524,6 +581,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
   private static Value buildArrayValue(Type elementSpannerType, JSONArray jsonArray) {
     switch (elementSpannerType.getCode()) {
       case BOOL:
+      case PG_BOOL:
         {
           List<Boolean> vals = new ArrayList<>();
           for (int i = 0; i < jsonArray.length(); i++) {
@@ -532,6 +590,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
           return Value.boolArray(vals);
         }
       case INT64:
+      case PG_INT8:
         {
           List<Long> vals = new ArrayList<>();
           for (int i = 0; i < jsonArray.length(); i++) {
@@ -540,6 +599,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
           return Value.int64Array(vals);
         }
       case FLOAT64:
+      case PG_FLOAT8:
         {
           List<Double> vals = new ArrayList<>();
           for (int i = 0; i < jsonArray.length(); i++) {
@@ -548,6 +608,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
           return Value.float64Array(vals);
         }
       case FLOAT32:
+      case PG_FLOAT4:
         {
           List<Float> vals = new ArrayList<>();
           for (int i = 0; i < jsonArray.length(); i++) {
@@ -556,6 +617,7 @@ public class SpannerDMLGenerator implements IDMLGenerator {
           return Value.float32Array(vals);
         }
       case DATE:
+      case PG_DATE:
         {
           List<Date> vals = new ArrayList<>();
           for (int i = 0; i < jsonArray.length(); i++) {
@@ -564,6 +626,8 @@ public class SpannerDMLGenerator implements IDMLGenerator {
           return Value.dateArray(vals);
         }
       case TIMESTAMP:
+      case PG_TIMESTAMPTZ:
+      case PG_COMMIT_TIMESTAMP:
         {
           List<Timestamp> vals = new ArrayList<>();
           for (int i = 0; i < jsonArray.length(); i++) {
@@ -579,6 +643,14 @@ public class SpannerDMLGenerator implements IDMLGenerator {
           }
           return Value.numericArray(vals);
         }
+      case PG_NUMERIC:
+        {
+          List<String> vals = new ArrayList<>();
+          for (int i = 0; i < jsonArray.length(); i++) {
+            vals.add(jsonArray.isNull(i) ? null : jsonArray.getString(i));
+          }
+          return Value.pgNumericArray(vals);
+        }
       case JSON:
         {
           List<String> vals = new ArrayList<>();
@@ -587,7 +659,16 @@ public class SpannerDMLGenerator implements IDMLGenerator {
           }
           return Value.jsonArray(vals);
         }
+      case PG_JSONB:
+        {
+          List<String> vals = new ArrayList<>();
+          for (int i = 0; i < jsonArray.length(); i++) {
+            vals.add(jsonArray.isNull(i) ? null : jsonArray.getString(i));
+          }
+          return Value.pgJsonbArray(vals);
+        }
       case BYTES:
+      case PG_BYTEA:
         {
           List<ByteArray> vals = new ArrayList<>();
           for (int i = 0; i < jsonArray.length(); i++) {

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGenerator.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGenerator.java
@@ -169,7 +169,24 @@ public class SpannerDMLGenerator implements IDMLGenerator {
       }
     }
 
-    return new SpannerMutationResponse(builder.build());
+    Key.Builder keyBuilder = Key.newBuilder();
+    for (IndexColumn pkIndexCol : sourceSpannerTable.primaryKeys()) {
+      String sourceColName = pkIndexCol.name();
+      Column sourceCol = sourceSpannerTable.column(sourceColName);
+      Object customVal = null;
+      if (request.getCustomTransformationResponse() != null
+          && request.getCustomTransformationResponse().containsKey(sourceColName)) {
+        customVal = request.getCustomTransformationResponse().get(sourceColName);
+      }
+      JSONObject valuesJson = keyValuesJson.has(sourceColName) ? keyValuesJson : newValuesJson;
+      if (customVal != null) {
+        appendCustomKeyComponent(keyBuilder, sourceCol, customVal);
+      } else if (valuesJson.has(sourceColName)) {
+        appendKeyComponent(keyBuilder, sourceCol, valuesJson, sourceColName);
+      }
+    }
+
+    return new SpannerMutationResponse(builder.build(), keyBuilder.build());
   }
 
   private static DMLGeneratorResponse buildDeleteMutation(
@@ -220,8 +237,9 @@ public class SpannerDMLGenerator implements IDMLGenerator {
       }
     }
 
-    Mutation mutation = Mutation.delete(targetTableName, keyBuilder.build());
-    return new SpannerMutationResponse(mutation);
+    Key primaryKey = keyBuilder.build();
+    Mutation mutation = Mutation.delete(targetTableName, primaryKey);
+    return new SpannerMutationResponse(mutation, primaryKey);
   }
 
   private static void setColumnValue(

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGenerator.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGenerator.java
@@ -23,19 +23,22 @@ import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Value;
 import com.google.cloud.teleport.v2.spanner.ddl.Column;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
-import com.google.cloud.teleport.v2.spanner.ddl.IndexColumn;
 import com.google.cloud.teleport.v2.spanner.ddl.Table;
 import com.google.cloud.teleport.v2.spanner.migrations.schema.ISchemaMapper;
 import com.google.cloud.teleport.v2.spanner.sourceddl.SourceTable;
 import com.google.cloud.teleport.v2.spanner.type.Type;
+import com.google.cloud.teleport.v2.templates.constants.Constants;
 import com.google.cloud.teleport.v2.templates.dbutils.dml.IDMLGenerator;
+import com.google.cloud.teleport.v2.templates.dbutils.processor.SourceProcessorFactory;
 import com.google.cloud.teleport.v2.templates.exceptions.InvalidDMLGenerationException;
+import com.google.cloud.teleport.v2.templates.exceptions.UnsupportedSourceException;
 import com.google.cloud.teleport.v2.templates.models.DMLGeneratorRequest;
 import com.google.cloud.teleport.v2.templates.models.DMLGeneratorResponse;
 import com.google.cloud.teleport.v2.templates.models.SpannerMutationResponse;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -57,37 +60,39 @@ public class SpannerDMLGenerator implements IDMLGenerator {
           "DMLGeneratorRequest is null. Cannot process the request.");
     }
 
-    String sourceTableName = request.getSpannerTableName();
+    // Target - The spanner database which this pipeline is writing to
+    // Original - The spanner database whose writes are being replicated via changestream
+    String originalSpTableName = request.getSpannerTableName();
     ISchemaMapper schemaMapper = request.getSchemaMapper();
-    Ddl spannerDdl = request.getSpannerDdl();
-    com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema sourceSchema =
+    Ddl originalSpannerDdl = request.getSpannerDdl();
+    com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema targetSpSchema =
         request.getSourceSchema();
 
     if (schemaMapper == null) {
       throw new InvalidDMLGenerationException("SchemaMapper must not be null.");
     }
-    if (spannerDdl == null) {
-      throw new InvalidDMLGenerationException("Source Spanner DDL must not be null.");
+    if (originalSpannerDdl == null) {
+      throw new InvalidDMLGenerationException("Spanner DDL must not be null.");
     }
-    if (sourceSchema == null) {
+    if (targetSpSchema == null) {
       throw new InvalidDMLGenerationException("SourceSchema must not be null.");
     }
 
-    Table sourceSpannerTable = spannerDdl.table(sourceTableName);
-    if (sourceSpannerTable == null) {
+    Table originalSpannerTable = originalSpannerDdl.table(originalSpTableName);
+    if (originalSpannerTable == null) {
       throw new InvalidDMLGenerationException(
-          "Source Spanner table '" + sourceTableName + "' not found in source DDL.");
+          "Original Spanner table '" + originalSpTableName + "' not found in source DDL.");
     }
 
     String targetTableName;
     try {
-      targetTableName = schemaMapper.getSourceTableName("", sourceTableName);
+      targetTableName = schemaMapper.getSourceTableName("", originalSpTableName);
     } catch (NoSuchElementException e) {
       throw new InvalidDMLGenerationException(
-          "Could not find target table name for source Spanner table: " + sourceTableName, e);
+          "Could not find target table name for source Spanner table: " + originalSpTableName, e);
     }
 
-    SourceTable targetSpannerTable = sourceSchema.table(targetTableName);
+    SourceTable targetSpannerTable = targetSpSchema.table(targetTableName);
     if (targetSpannerTable == null) {
       throw new InvalidDMLGenerationException(
           "Target table '" + targetTableName + "' not found in SourceSchema.");
@@ -104,18 +109,18 @@ public class SpannerDMLGenerator implements IDMLGenerator {
     String modType = request.getModType();
     if ("INSERT".equals(modType) || "UPDATE".equals(modType)) {
       return buildUpsertMutation(
-          sourceSpannerTable, targetSpannerTable, schemaMapper, request, targetTableName);
+          originalSpannerTable, targetSpannerTable, schemaMapper, request, targetTableName);
     } else if ("DELETE".equals(modType)) {
       return buildDeleteMutation(
-          sourceSpannerTable, targetSpannerTable, schemaMapper, request, targetTableName);
+          originalSpannerTable, targetSpannerTable, schemaMapper, request, targetTableName);
     } else {
       throw new InvalidDMLGenerationException(
-          "Unsupported modType '" + modType + "' for table " + sourceTableName);
+          "Unsupported modType '" + modType + "' for table " + originalSpTableName);
     }
   }
 
   private static DMLGeneratorResponse buildUpsertMutation(
-      Table sourceSpannerTable,
+      Table originalSpannerTable,
       SourceTable targetSpannerTable,
       ISchemaMapper schemaMapper,
       DMLGeneratorRequest request,
@@ -133,64 +138,93 @@ public class SpannerDMLGenerator implements IDMLGenerator {
 
       String targetColName = targetCol.name();
 
-      String sourceColName;
+      String originalColName;
       try {
-        sourceColName =
+        originalColName =
             schemaMapper.getSpannerColumnName("", targetSpannerTable.name(), targetColName);
       } catch (NoSuchElementException e) {
         continue;
       }
 
-      Column sourceCol = sourceSpannerTable.column(sourceColName);
-      if (sourceCol == null) {
+      Column origCol = originalSpannerTable.column(originalColName);
+      if (origCol == null) {
+        // There is no column in the original spanner which maps to the target spanner
         continue;
       }
 
       if (request.getCustomTransformationResponse() != null
-          && request.getCustomTransformationResponse().containsKey(sourceColName)) {
-        Object customVal = request.getCustomTransformationResponse().get(sourceColName);
+          && request.getCustomTransformationResponse().containsKey(originalColName)) {
+        Object customVal = request.getCustomTransformationResponse().get(originalColName);
         if (customVal == null) {
-          setNullValue(builder, targetColName, sourceCol.type());
+          setNullValue(builder, targetColName, origCol.type());
         } else {
-          setCustomColumnValue(builder, targetColName, sourceCol, customVal);
+          setCustomColumnValue(builder, targetColName, origCol, customVal);
         }
-      } else if (newValuesJson.has(sourceColName)) {
-        if (newValuesJson.isNull(sourceColName)) {
-          setNullValue(builder, targetColName, sourceCol.type());
+      } else if (newValuesJson.has(originalColName)) {
+        if (newValuesJson.isNull(originalColName)) {
+          setNullValue(builder, targetColName, origCol.type());
         } else {
-          setColumnValue(builder, targetColName, sourceCol, newValuesJson);
+          setColumnValue(builder, targetColName, origCol, newValuesJson);
         }
-      } else if (keyValuesJson.has(sourceColName)) {
-        if (keyValuesJson.isNull(sourceColName)) {
-          setNullValue(builder, targetColName, sourceCol.type());
+      } else if (keyValuesJson.has(originalColName)) {
+        if (keyValuesJson.isNull(originalColName)) {
+          setNullValue(builder, targetColName, origCol.type());
         } else {
-          setColumnValue(builder, targetColName, sourceCol, keyValuesJson);
+          setColumnValue(builder, targetColName, origCol, keyValuesJson);
         }
       }
+    }
+
+    Key primaryKey =
+        buildTargetPrimaryKey(
+            targetSpannerTable,
+            newValuesJson,
+            keyValuesJson,
+            request.getCustomTransformationResponse());
+    return new SpannerMutationResponse(builder.build(), primaryKey);
+  }
+
+  private static Key buildTargetPrimaryKey(
+      SourceTable targetSpannerTable,
+      JSONObject newValuesJson,
+      JSONObject keyValuesJson,
+      Map<String, Object> customTransformationResponse) {
+    // TODO- rework class to take targetDdl in constructor
+    Ddl targetDdl = null;
+    try {
+      targetDdl =
+          ((SpannerSpToSrcSourceConnector)
+                  SourceProcessorFactory.getSource(Constants.SOURCE_SPANNER))
+              .getTargetDdl();
+    } catch (UnsupportedSourceException e) {
+      LOG.warn("could not fetch spanner source");
+      throw new RuntimeException(e);
     }
 
     Key.Builder keyBuilder = Key.newBuilder();
-    for (IndexColumn pkIndexCol : sourceSpannerTable.primaryKeys()) {
-      String sourceColName = pkIndexCol.name();
-      Column sourceCol = sourceSpannerTable.column(sourceColName);
+    for (String targetColName : targetSpannerTable.primaryKeyColumns()) {
       Object customVal = null;
-      if (request.getCustomTransformationResponse() != null
-          && request.getCustomTransformationResponse().containsKey(sourceColName)) {
-        customVal = request.getCustomTransformationResponse().get(sourceColName);
+      if (customTransformationResponse != null
+          && customTransformationResponse.containsKey(targetColName)) {
+        customVal = customTransformationResponse.get(targetColName);
       }
-      JSONObject valuesJson = keyValuesJson.has(sourceColName) ? keyValuesJson : newValuesJson;
+      Column targetCol = targetDdl.table(targetSpannerTable.name()).column(targetColName);
+      JSONObject valuesJson = keyValuesJson.has(targetColName) ? keyValuesJson : newValuesJson;
       if (customVal != null) {
-        appendCustomKeyComponent(keyBuilder, sourceCol, customVal);
-      } else if (valuesJson.has(sourceColName)) {
-        appendKeyComponent(keyBuilder, sourceCol, valuesJson, sourceColName);
+        appendCustomKeyComponent(keyBuilder, targetCol, customVal);
+      } else if (valuesJson.has(targetColName)) {
+        appendCustomKeyComponent(keyBuilder, targetCol, valuesJson.get(targetColName));
+      } else {
+        LOG.warn("Primary key column '{}' could not be resolved.", targetColName);
+        throw new InvalidDMLGenerationException(
+            "Primary key column '" + targetColName + "' could not be resolved.");
       }
     }
-
-    return new SpannerMutationResponse(builder.build(), keyBuilder.build());
+    return keyBuilder.build();
   }
 
   private static DMLGeneratorResponse buildDeleteMutation(
-      Table sourceSpannerTable,
+      Table origSpannerTable,
       SourceTable targetSpannerTable,
       ISchemaMapper schemaMapper,
       DMLGeneratorRequest request,
@@ -199,45 +233,12 @@ public class SpannerDMLGenerator implements IDMLGenerator {
     JSONObject keyValuesJson = request.getKeyValuesJson();
     JSONObject newValuesJson = request.getNewValuesJson();
 
-    Key.Builder keyBuilder = Key.newBuilder();
-    for (IndexColumn pkIndexCol : sourceSpannerTable.primaryKeys()) {
-      String sourceColName = pkIndexCol.name();
-
-      String targetColName;
-      try {
-        targetColName = schemaMapper.getSourceColumnName("", targetTableName, sourceColName);
-      } catch (NoSuchElementException e) {
-        targetColName = sourceColName;
-      }
-
-      Column sourceCol = sourceSpannerTable.column(sourceColName);
-      if (sourceCol == null) {
-        throw new InvalidDMLGenerationException(
-            "Column '" + sourceColName + "' not found in Spanner DDL for table " + targetTableName);
-      }
-
-      Object customVal = null;
-      if (request.getCustomTransformationResponse() != null
-          && request.getCustomTransformationResponse().containsKey(sourceColName)) {
-        customVal = request.getCustomTransformationResponse().get(sourceColName);
-      }
-
-      JSONObject valuesJson = keyValuesJson.has(sourceColName) ? keyValuesJson : newValuesJson;
-
-      if (!valuesJson.has(sourceColName) && customVal == null) {
-        LOG.warn("Primary key column '{}' not found in change record for DELETE.", sourceColName);
-        throw new InvalidDMLGenerationException(
-            "Primary key column '" + sourceColName + "' not found in change record for DELETE.");
-      }
-
-      if (customVal != null) {
-        appendCustomKeyComponent(keyBuilder, sourceCol, customVal);
-      } else {
-        appendKeyComponent(keyBuilder, sourceCol, valuesJson, sourceColName);
-      }
-    }
-
-    Key primaryKey = keyBuilder.build();
+    Key primaryKey =
+        buildTargetPrimaryKey(
+            targetSpannerTable,
+            newValuesJson,
+            keyValuesJson,
+            request.getCustomTransformationResponse());
     Mutation mutation = Mutation.delete(targetTableName, primaryKey);
     return new SpannerMutationResponse(mutation, primaryKey);
   }
@@ -334,13 +335,6 @@ public class SpannerDMLGenerator implements IDMLGenerator {
       default:
         builder.set(targetColName).toStringArray((Iterable<String>) null);
     }
-  }
-
-  /** Appends a single primary-key component to the Key builder. */
-  private static void appendKeyComponent(
-      Key.Builder keyBuilder, Column col, JSONObject valuesJson, String sourceColName) {
-    Object value = valuesJson.get(sourceColName);
-    appendCustomKeyComponent(keyBuilder, col, value);
   }
 
   /**

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSpToSrcSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSpToSrcSourceConnector.java
@@ -30,6 +30,12 @@ import java.util.List;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
 import org.apache.beam.sdk.options.PipelineOptions;
 
+/**
+ * Implementation of SpToSrcConnector which will read from a Spanner database (called
+ * originalSpanner) and write to a new database (called targetSpanner). The type of objects being
+ * returned maybe tagged as SourceSchema etc as the target being written to is referred to as the
+ * source for all other sources.
+ */
 public class SpannerSpToSrcSourceConnector implements ISpToSrcSourceConnector {
 
   private final IConnectionHelper connectionHelper;
@@ -82,7 +88,8 @@ public class SpannerSpToSrcSourceConnector implements ISpToSrcSourceConnector {
         targetDdl);
   }
 
-  private synchronized Ddl checkAndInitTargetDdl(SpannerShard spannerShard) {
+  private synchronized void checkAndInitTargetDdl(SpannerShard spannerShard) {
+    // TODO - update the flow to set targetDDL in the constructor/init
     if (targetDdl == null) {
       SpannerConfig targetSpannerConfig =
           SpannerConfig.create()
@@ -91,7 +98,6 @@ public class SpannerSpToSrcSourceConnector implements ISpToSrcSourceConnector {
               .withDatabaseId(spannerShard.getDatabaseId());
       targetDdl = new SpannerInformationSchemaScanner(targetSpannerConfig).scanDdl();
     }
-    return targetDdl;
   }
 
   @Override

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSpToSrcSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSpToSrcSourceConnector.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.v2.templates.source.spanner;
 
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.migrations.connection.IConnectionHelper;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.Shard;
 import com.google.cloud.teleport.v2.spanner.migrations.shard.SpannerShard;
@@ -32,6 +33,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 public class SpannerSpToSrcSourceConnector implements ISpToSrcSourceConnector {
 
   private final IConnectionHelper connectionHelper;
+  private Ddl targetDdl;
 
   public SpannerSpToSrcSourceConnector() {
     this.connectionHelper = new SpannerConnectionHelper();
@@ -40,6 +42,14 @@ public class SpannerSpToSrcSourceConnector implements ISpToSrcSourceConnector {
   @VisibleForTesting
   SpannerSpToSrcSourceConnector(IConnectionHelper connectionHelper) {
     this.connectionHelper = connectionHelper;
+  }
+
+  public void setTargetDdl(Ddl targetDdl) {
+    this.targetDdl = targetDdl;
+  }
+
+  public Ddl getTargetDdl() {
+    return targetDdl;
   }
 
   @Override
@@ -64,9 +74,24 @@ public class SpannerSpToSrcSourceConnector implements ISpToSrcSourceConnector {
 
   @Override
   public IDao getDao(Shard shard) {
+    SpannerShard spannerShard = (SpannerShard) shard;
+    checkAndInitTargetDdl(spannerShard);
     return new SpannerTargetDao(
-        SpannerConnectionHelper.connectionKey((SpannerShard) shard),
-        (IConnectionHelper<com.google.cloud.spanner.DatabaseClient>) getConnectionHelper());
+        SpannerConnectionHelper.connectionKey(spannerShard),
+        (IConnectionHelper<com.google.cloud.spanner.DatabaseClient>) getConnectionHelper(),
+        targetDdl);
+  }
+
+  private synchronized Ddl checkAndInitTargetDdl(SpannerShard spannerShard) {
+    if (targetDdl == null) {
+      SpannerConfig targetSpannerConfig =
+          SpannerConfig.create()
+              .withProjectId(spannerShard.getProjectId())
+              .withInstanceId(spannerShard.getInstanceId())
+              .withDatabaseId(spannerShard.getDatabaseId());
+      targetDdl = new SpannerInformationSchemaScanner(targetSpannerConfig).scanDdl();
+    }
+    return targetDdl;
   }
 
   @Override
@@ -104,7 +129,10 @@ public class SpannerSpToSrcSourceConnector implements ISpToSrcSourceConnector {
             .withProjectId(spannerShard.getProjectId())
             .withInstanceId(spannerShard.getInstanceId())
             .withDatabaseId(spannerShard.getDatabaseId());
-    return new SpannerInformationSchemaScanner(targetSpannerConfig).scan();
+    SpannerInformationSchemaScanner scanner =
+        new SpannerInformationSchemaScanner(targetSpannerConfig);
+    targetDdl = scanner.scanDdl();
+    return scanner.convertDdlToSourceSchema(targetDdl);
   }
 
   @Override

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSpToSrcSourceConnector.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSpToSrcSourceConnector.java
@@ -94,22 +94,6 @@ public class SpannerSpToSrcSourceConnector implements ISpToSrcSourceConnector {
       throw new IllegalArgumentException(
           "Expected SpannerShard but got: " + shards.get(0).getClass());
     }
-    SpannerShard spannerShard = (SpannerShard) shards.get(0);
-
-    com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options spannerOptions =
-        options.as(com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options.class);
-    if (spannerOptions != null
-        && spannerOptions.getSpannerProjectId() != null
-        && spannerOptions.getMetadataInstance() != null
-        && spannerOptions.getMetadataDatabase() != null) {
-      if (!spannerOptions.getSpannerProjectId().equals(spannerShard.getProjectId())
-          || !spannerOptions.getMetadataInstance().equals(spannerShard.getInstanceId())
-          || !spannerOptions.getMetadataDatabase().equals(spannerShard.getDatabaseId())) {
-        throw new IllegalArgumentException(
-            "For Cloud Spanner target, the metadata database and target database must be the same to ensure atomic operations.");
-      }
-      // TODO check for read only as well ?
-    }
   }
 
   @Override

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDao.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDao.java
@@ -34,6 +34,7 @@ import com.google.cloud.teleport.v2.templates.dbutils.dao.source.IDao;
 import com.google.cloud.teleport.v2.templates.dbutils.dao.source.TransactionalCheck;
 import com.google.cloud.teleport.v2.templates.models.DMLGeneratorResponse;
 import com.google.cloud.teleport.v2.templates.models.SpannerMutationResponse;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -89,6 +90,7 @@ public class SpannerTargetDao implements IDao {
     // (in the transaction check) and the main transaction are on the same database
     client
         .readWriteTransaction(Options.priority(RpcPriority.HIGH))
+        .allowNestedTransaction()
         .run(
             (TransactionRunner.TransactionCallable<Void>)
                 mainTxn -> {
@@ -106,7 +108,8 @@ public class SpannerTargetDao implements IDao {
                 });
   }
 
-  private void readDataTableRowWithExclusiveLock(
+  @VisibleForTesting
+  void readDataTableRowWithExclusiveLock(
       TransactionContext transactionContext, String tableName, Key primaryKey, Ddl ddl) {
     Table table = ddl.table(tableName);
     if (table == null) {

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDao.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDao.java
@@ -51,11 +51,6 @@ public class SpannerTargetDao implements IDao {
   public void write(
       DMLGeneratorResponse dmlGeneratorResponse, TransactionalCheck transactionalCheck)
       throws Exception {
-    if (transactionalCheck != null) {
-      throw new UnsupportedOperationException(
-          "TransactionalCheck is not supported for the Spanner target DAO.");
-    }
-
     if (!(dmlGeneratorResponse instanceof SpannerMutationResponse)) {
       throw new IllegalArgumentException(
           "Expected SpannerMutationResponse but received: "
@@ -65,6 +60,10 @@ public class SpannerTargetDao implements IDao {
     DatabaseClient client = connectionHelper.getConnection(connectionKey);
     if (client == null) {
       throw new ConnectionException("DatabaseClient is null for connection key: " + connectionKey);
+    }
+
+    if (transactionalCheck != null) {
+      transactionalCheck.check();
     }
 
     Mutation mutation = ((SpannerMutationResponse) dmlGeneratorResponse).getMutation();
@@ -84,8 +83,7 @@ public class SpannerTargetDao implements IDao {
     }
 
     if (transactionalCheck != null) {
-      throw new UnsupportedOperationException(
-          "TransactionalCheck is not supported for the Spanner target DAO.");
+      transactionalCheck.check();
     }
 
     if (!(dmlGeneratorResponse instanceof SpannerMutationResponse)) {

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDao.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDao.java
@@ -85,7 +85,7 @@ public class SpannerTargetDao implements IDao {
     Mutation mutation = spannerMutationResponse.getMutation();
     Key primaryKey = spannerMutationResponse.getPrimaryKey();
 
-    //TODO - optimize this flow to avoid the nested transaction if the shadow transaction
+    // TODO - optimize this flow to avoid the nested transaction if the shadow transaction
     // (in the transaction check) and the main transaction are on the same database
     client
         .readWriteTransaction(Options.priority(RpcPriority.HIGH))
@@ -99,7 +99,8 @@ public class SpannerTargetDao implements IDao {
                   if (transactionalCheck != null) {
                     transactionalCheck.check();
                   }
-                  //TODO- add support for delete where PK has changed - similar to data dml in live flow
+                  // TODO- add support for delete where PK has changed - similar to data dml in live
+                  // flow
                   mainTxn.buffer(ImmutableList.of(mutation));
                   return null;
                 });

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDao.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDao.java
@@ -16,14 +16,27 @@
 package com.google.cloud.teleport.v2.templates.source.spanner;
 
 import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Options;
+import com.google.cloud.spanner.Options.RpcPriority;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.TransactionContext;
+import com.google.cloud.spanner.TransactionRunner;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.IndexColumn;
+import com.google.cloud.teleport.v2.spanner.ddl.Table;
 import com.google.cloud.teleport.v2.spanner.migrations.connection.IConnectionHelper;
 import com.google.cloud.teleport.v2.spanner.migrations.exceptions.ConnectionException;
+import com.google.cloud.teleport.v2.spanner.migrations.spanner.SpannerReadUtils;
 import com.google.cloud.teleport.v2.templates.dbutils.dao.source.IDao;
 import com.google.cloud.teleport.v2.templates.dbutils.dao.source.TransactionalCheck;
 import com.google.cloud.teleport.v2.templates.models.DMLGeneratorResponse;
 import com.google.cloud.teleport.v2.templates.models.SpannerMutationResponse;
 import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,18 +53,25 @@ public class SpannerTargetDao implements IDao {
 
   private final String connectionKey;
   private final IConnectionHelper<DatabaseClient> connectionHelper;
+  private final Ddl targetDdl;
+
+  public SpannerTargetDao(
+      String connectionKey, IConnectionHelper<DatabaseClient> connectionHelper, Ddl targetDdl) {
+    this.connectionKey = connectionKey;
+    this.connectionHelper = connectionHelper;
+    this.targetDdl = targetDdl;
+  }
 
   public SpannerTargetDao(
       String connectionKey, IConnectionHelper<DatabaseClient> connectionHelper) {
-    this.connectionKey = connectionKey;
-    this.connectionHelper = connectionHelper;
+    this(connectionKey, connectionHelper, null);
   }
 
   @Override
   public void write(
       DMLGeneratorResponse dmlGeneratorResponse, TransactionalCheck transactionalCheck)
       throws Exception {
-    if (!(dmlGeneratorResponse instanceof SpannerMutationResponse)) {
+    if (!(dmlGeneratorResponse instanceof SpannerMutationResponse spannerMutationResponse)) {
       throw new IllegalArgumentException(
           "Expected SpannerMutationResponse but received: "
               + dmlGeneratorResponse.getClass().getSimpleName());
@@ -62,38 +82,44 @@ public class SpannerTargetDao implements IDao {
       throw new ConnectionException("DatabaseClient is null for connection key: " + connectionKey);
     }
 
-    if (transactionalCheck != null) {
-      transactionalCheck.check();
-    }
+    Mutation mutation = spannerMutationResponse.getMutation();
+    Key primaryKey = spannerMutationResponse.getPrimaryKey();
 
-    Mutation mutation = ((SpannerMutationResponse) dmlGeneratorResponse).getMutation();
-    client.writeAtLeastOnce(ImmutableList.of(mutation));
-    LOG.debug("Successfully wrote mutation via SpannerTargetDao for key: {}", connectionKey);
+    //TODO - optimize this flow to avoid the nested transaction if the shadow transaction
+    // (in the transaction check) and the main transaction are on the same database
+    client
+        .readWriteTransaction(Options.priority(RpcPriority.HIGH))
+        .run(
+            (TransactionRunner.TransactionCallable<Void>)
+                mainTxn -> {
+                  if (targetDdl != null && primaryKey != null) {
+                    readDataTableRowWithExclusiveLock(
+                        mainTxn, mutation.getTable(), primaryKey, targetDdl);
+                  }
+                  if (transactionalCheck != null) {
+                    transactionalCheck.check();
+                  }
+                  //TODO- add support for delete where PK has changed - similar to data dml in live flow
+                  mainTxn.buffer(ImmutableList.of(mutation));
+                  return null;
+                });
   }
 
-  @Override
-  public void write(
-      DMLGeneratorResponse dmlGeneratorResponse,
-      TransactionalCheck transactionalCheck,
-      Object transactionContext)
-      throws Exception {
-    if (transactionContext == null) {
-      write(dmlGeneratorResponse, transactionalCheck);
+  private void readDataTableRowWithExclusiveLock(
+      TransactionContext transactionContext, String tableName, Key primaryKey, Ddl ddl) {
+    Table table = ddl.table(tableName);
+    if (table == null) {
+      LOG.warn("Table '{}' not found in target DDL; skipping exclusive lock read.", tableName);
       return;
     }
-
-    if (transactionalCheck != null) {
-      transactionalCheck.check();
+    List<String> columnNames =
+        table.primaryKeys().stream().map(IndexColumn::name).collect(Collectors.toList());
+    Statement sql =
+        SpannerReadUtils.generateReadSQLWithExclusiveLock(tableName, columnNames, primaryKey, ddl);
+    ResultSet resultSet = transactionContext.executeQuery(sql);
+    if (!resultSet.next()) {
+      return;
     }
-
-    if (!(dmlGeneratorResponse instanceof SpannerMutationResponse)) {
-      throw new IllegalArgumentException(
-          "Expected SpannerMutationResponse but received: "
-              + dmlGeneratorResponse.getClass().getSimpleName());
-    }
-
-    Mutation mutation = ((SpannerMutationResponse) dmlGeneratorResponse).getMutation();
-    ((com.google.cloud.spanner.TransactionContext) transactionContext).buffer(mutation);
-    LOG.debug("Successfully buffered mutation via SpannerTargetDao for key: {}", connectionKey);
+    resultSet.getCurrentRowAsStruct();
   }
 }

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDao.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDao.java
@@ -21,6 +21,7 @@ import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Options;
 import com.google.cloud.spanner.Options.RpcPriority;
 import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.TransactionContext;
 import com.google.cloud.spanner.TransactionRunner;
@@ -46,7 +47,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Receives a {@link SpannerMutationResponse} from the DML generator and commits the contained
  * {@link Mutation} via a {@link DatabaseClient} obtained from the {@link
- * com.google.cloud.teleport.v2.templates.dbutils.connection.SpannerConnectionHelper}.
+ * com.google.cloud.teleport.v2.templates.source.spanner.SpannerConnectionHelper}.
  */
 public class SpannerTargetDao implements IDao {
 
@@ -99,7 +100,17 @@ public class SpannerTargetDao implements IDao {
                         mainTxn, mutation.getTable(), primaryKey, targetDdl);
                   }
                   if (transactionalCheck != null) {
-                    transactionalCheck.check();
+                    try {
+                      transactionalCheck.check();
+                    } catch (SpannerException e) {
+                      if (e.getErrorCode() == com.google.cloud.spanner.ErrorCode.ABORTED) {
+                        // Wrap the exception to prevent mainTxn from infinitely retrying an aborted
+                        // outer transaction.
+                        throw new IllegalStateException(
+                            "shadow transaction aborted during check", e);
+                      }
+                      throw e;
+                    }
                   }
                   // TODO- add support for delete where PK has changed - similar to data dml in live
                   // flow

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFn.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFn.java
@@ -47,7 +47,6 @@ import com.google.cloud.teleport.v2.templates.dbutils.processor.InputRecordProce
 import com.google.cloud.teleport.v2.templates.dbutils.processor.SourceProcessor;
 import com.google.cloud.teleport.v2.templates.dbutils.processor.SourceProcessorFactory;
 import com.google.cloud.teleport.v2.templates.exceptions.UnsupportedSourceException;
-import com.google.cloud.teleport.v2.templates.models.DMLGeneratorResponse;
 import com.google.cloud.teleport.v2.templates.utils.SchemaMapperUtils;
 import com.google.cloud.teleport.v2.templates.utils.ShadowTableRecord;
 import com.google.cloud.teleport.v2.templates.utils.SpannerToSourceDbExceptionClassifier;
@@ -289,66 +288,41 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
                                               >= Long.parseLong(spannerRec.getRecordSequence())));
 
                           if (!isSourceAhead) {
-                            if (Constants.SOURCE_SPANNER.equals(source)) {
-                              DMLGeneratorResponse response =
-                                  InputRecordProcessor.generateDMLResponse(
-                                      spannerRec,
-                                      schemaMapper,
-                                      ddl,
-                                      sourceSchema,
-                                      shardId,
-                                      sourceDbTimezoneOffset,
-                                      sourceProcessor.getDmlGenerator(),
-                                      spannerToSourceTransformer,
-                                      source);
-                              if (response == null) {
-                                outputWithTag(
-                                    c,
-                                    Constants.FILTERED_TAG,
-                                    Constants.FILTERED_TAG_MESSAGE,
-                                    spannerRec);
-                              } else {
-                                IDao sourceDao = sourceProcessor.getSourceDao(shardId);
-                                sourceDao.write(response, null, shadowTransaction);
-                                isRecordWritten.set(true);
-                              }
-                            } else {
-                              IDao sourceDao = sourceProcessor.getSourceDao(shardId);
-                              TransactionalCheck check =
-                                  () -> {
-                                    ShadowTableRecord newShadowTableRecord =
-                                        spannerDao.readShadowTableRecordWithExclusiveLock(
-                                            shadowTableName,
-                                            primaryKey,
-                                            shadowTableDdl,
-                                            shadowTransaction);
-                                    if (!ShadowTableRecord.isEquals(
-                                        shadowTableRecord, newShadowTableRecord)) {
-                                      throw new TransactionalCheckException(
-                                          "Shadow table sequence changed during transaction");
-                                    }
-                                  };
-                              boolean isEventFiltered =
-                                  InputRecordProcessor.processRecord(
-                                      spannerRec,
-                                      schemaMapper,
-                                      ddl,
-                                      sourceSchema,
-                                      sourceDao,
-                                      shardId,
-                                      sourceDbTimezoneOffset,
-                                      sourceProcessor.getDmlGenerator(),
-                                      spannerToSourceTransformer,
-                                      this.source,
-                                      check);
-                              isRecordWritten.set(!isEventFiltered);
-                              if (isEventFiltered) {
-                                outputWithTag(
-                                    c,
-                                    Constants.FILTERED_TAG,
-                                    Constants.FILTERED_TAG_MESSAGE,
-                                    spannerRec);
-                              }
+                            IDao sourceDao = sourceProcessor.getSourceDao(shardId);
+                            TransactionalCheck check =
+                                () -> {
+                                  ShadowTableRecord newShadowTableRecord =
+                                      spannerDao.readShadowTableRecordWithExclusiveLock(
+                                          shadowTableName,
+                                          primaryKey,
+                                          shadowTableDdl,
+                                          shadowTransaction);
+                                  if (!ShadowTableRecord.isEquals(
+                                      shadowTableRecord, newShadowTableRecord)) {
+                                    throw new TransactionalCheckException(
+                                        "Shadow table sequence changed during transaction");
+                                  }
+                                };
+                            boolean isEventFiltered =
+                                InputRecordProcessor.processRecord(
+                                    spannerRec,
+                                    schemaMapper,
+                                    ddl,
+                                    sourceSchema,
+                                    sourceDao,
+                                    shardId,
+                                    sourceDbTimezoneOffset,
+                                    sourceProcessor.getDmlGenerator(),
+                                    spannerToSourceTransformer,
+                                    this.source,
+                                    check);
+                            isRecordWritten.set(!isEventFiltered);
+                            if (isEventFiltered) {
+                              outputWithTag(
+                                  c,
+                                  Constants.FILTERED_TAG,
+                                  Constants.FILTERED_TAG_MESSAGE,
+                                  spannerRec);
                             }
 
                             spannerDao.updateShadowTable(

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFn.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFn.java
@@ -260,6 +260,7 @@ public class SourceWriterFn extends DoFn<KV<Long, TrimmedShardedDataChangeRecord
             spannerDao
                 .getDatabaseClient()
                 .readWriteTransaction(Options.priority(spannerConfig.getRpcPriority().get()))
+                .allowNestedTransaction()
                 .run(
                     (TransactionRunner.TransactionCallable<Boolean>)
                         shadowTransaction -> {

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerCrossDbIT.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSpannerCrossDbIT.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates;
+
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatPipeline;
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
+
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.teleport.metadata.SkipDirectRunnerTest;
+import com.google.cloud.teleport.metadata.TemplateIntegrationTest;
+import com.google.cloud.teleport.v2.templates.constants.Constants;
+import com.google.pubsub.v1.SubscriptionName;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.it.common.PipelineLauncher;
+import org.apache.beam.it.common.PipelineOperator;
+import org.apache.beam.it.common.utils.ResourceManagerUtils;
+import org.apache.beam.it.gcp.pubsub.PubsubResourceManager;
+import org.apache.beam.it.gcp.spanner.SpannerResourceManager;
+import org.apache.beam.it.gcp.storage.GcsResourceManager;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration test for {@link SpannerToSourceDb} Flex template replicating from Spanner to Spanner
+ * where the metadatadb and target Spanner are on different instances.
+ */
+@Category({TemplateIntegrationTest.class, SkipDirectRunnerTest.class})
+@TemplateIntegrationTest(SpannerToSourceDb.class)
+@RunWith(JUnit4.class)
+public class SpannerToSpannerCrossDbIT extends SpannerToSourceDbITBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SpannerToSpannerCrossDbIT.class);
+
+  private static final Duration TEST_TIMEOUT = Duration.ofMinutes(15);
+
+  private static final String SPANNER_DDL_RESOURCE = "SpannerToSourceDbIT/spanner-schema.sql";
+
+  private static final String TABLE = "Users";
+
+  private static final HashSet<SpannerToSpannerCrossDbIT> testInstances = new HashSet<>();
+  private static PipelineLauncher.LaunchInfo jobInfo;
+
+  private static SpannerResourceManager spannerResourceManager; // Source Spanner
+  private static SpannerResourceManager spannerDestinationResourceManager; // Destination Spanner
+  private static SpannerResourceManager spannerMetadataResourceManager;
+  private static GcsResourceManager gcsResourceManager;
+  private static PubsubResourceManager pubsubResourceManager;
+
+  @Before
+  public void setUp() throws IOException {
+    skipBaseCleanup = true;
+    synchronized (SpannerToSpannerCrossDbIT.class) {
+      testInstances.add(this);
+      if (jobInfo == null) {
+        spannerResourceManager = createSpannerDatabase(SPANNER_DDL_RESOURCE);
+
+        spannerDestinationResourceManager =
+            SpannerResourceManager.builder("rr-dest-" + testName, PROJECT, REGION)
+                .maybeUseStaticInstance()
+                .build();
+        createSpannerDDL(spannerDestinationResourceManager, SPANNER_DDL_RESOURCE);
+
+        spannerMetadataResourceManager = createSpannerMetadataDatabase();
+
+        gcsResourceManager = setUpSpannerITGcsResourceManager();
+
+        String spannerShardConfig =
+            "["
+                + "  {"
+                + "    \"projectId\": \""
+                + PROJECT
+                + "\","
+                + "    \"instanceId\": \""
+                + spannerDestinationResourceManager.getInstanceId()
+                + "\","
+                + "    \"databaseId\": \""
+                + spannerDestinationResourceManager.getDatabaseId()
+                + "\""
+                + "  }"
+                + "]";
+        gcsResourceManager.createArtifact("input/spanner-shard.json", spannerShardConfig);
+
+        pubsubResourceManager = setUpPubSubResourceManager();
+        SubscriptionName subscriptionName =
+            createPubsubResources(
+                getClass().getSimpleName(),
+                pubsubResourceManager,
+                getGcsPath("dlq", gcsResourceManager)
+                    .replace("gs://" + gcsResourceManager.getBucket(), ""),
+                gcsResourceManager);
+
+        Map<String, String> jobParameters = new HashMap<>();
+        jobParameters.put(
+            "sourceShardsFilePath", getGcsPath("input/spanner-shard.json", gcsResourceManager));
+
+        jobInfo =
+            launchDataflowJob(
+                gcsResourceManager,
+                spannerResourceManager,
+                spannerMetadataResourceManager,
+                subscriptionName.toString(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                Constants.SOURCE_SPANNER,
+                jobParameters);
+      }
+    }
+  }
+
+  @AfterClass
+  public static void cleanUp() throws IOException {
+    for (SpannerToSpannerCrossDbIT instance : testInstances) {
+      instance.tearDownBase();
+    }
+    ResourceManagerUtils.cleanResources(
+        spannerResourceManager,
+        spannerDestinationResourceManager,
+        spannerMetadataResourceManager,
+        gcsResourceManager,
+        pubsubResourceManager);
+  }
+
+  @Test
+  public void spannerToSpannerBasicReplication() throws InterruptedException {
+    assertThatPipeline(jobInfo).isRunning();
+
+    Mutation m =
+        Mutation.newInsertOrUpdateBuilder(TABLE)
+            .set("id")
+            .to(101)
+            .set("full_name")
+            .to("Alice")
+            .set("from")
+            .to("London")
+            .build();
+    spannerResourceManager.write(m);
+    LOG.info("Successfully wrote row to source Spanner Users table");
+
+    PipelineOperator.Result result =
+        pipelineOperator()
+            .waitForCondition(
+                createConfig(jobInfo, TEST_TIMEOUT),
+                () -> {
+                  List<Struct> rows =
+                      spannerDestinationResourceManager.readTableRecords(
+                          TABLE, List.of("id", "full_name", "from"));
+                  for (Struct row : rows) {
+                    if (!row.isNull("id")
+                        && row.getLong("id") == 101
+                        && !row.isNull("full_name")
+                        && "Alice".equals(row.getString("full_name"))) {
+                      LOG.info(
+                          "Row successfully found in destination Spanner: id=101, full_name=Alice");
+                      return true;
+                    }
+                  }
+                  return false;
+                });
+
+    assertThatResult(result).meetsConditions();
+  }
+}

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/models/SpannerMutationResponseTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/models/SpannerMutationResponseTest.java
@@ -31,7 +31,7 @@ public final class SpannerMutationResponseTest {
 
   @Test
   public void isEmptyReturnsTrueForNullMutation() {
-    SpannerMutationResponse response = new SpannerMutationResponse(null);
+    SpannerMutationResponse response = new SpannerMutationResponse(null, null);
     assertTrue(response.isEmpty());
     assertNull(response.getMutation());
     assertNull(response.getPrimaryKey());
@@ -46,7 +46,7 @@ public final class SpannerMutationResponseTest {
             .set("Name")
             .to("John")
             .build();
-    SpannerMutationResponse response = new SpannerMutationResponse(mutation);
+    SpannerMutationResponse response = new SpannerMutationResponse(mutation, null);
     assertFalse(response.isEmpty());
     assertEquals(mutation, response.getMutation());
     assertNull(response.getPrimaryKey());

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/models/SpannerMutationResponseTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/models/SpannerMutationResponseTest.java
@@ -15,9 +15,12 @@
  */
 package com.google.cloud.teleport.v2.templates.models;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,6 +33,8 @@ public final class SpannerMutationResponseTest {
   public void isEmptyReturnsTrueForNullMutation() {
     SpannerMutationResponse response = new SpannerMutationResponse(null);
     assertTrue(response.isEmpty());
+    assertNull(response.getMutation());
+    assertNull(response.getPrimaryKey());
   }
 
   @Test
@@ -43,5 +48,32 @@ public final class SpannerMutationResponseTest {
             .build();
     SpannerMutationResponse response = new SpannerMutationResponse(mutation);
     assertFalse(response.isEmpty());
+    assertEquals(mutation, response.getMutation());
+    assertNull(response.getPrimaryKey());
+  }
+
+  @Test
+  public void twoArgumentConstructorStoresMutationAndPrimaryKey() {
+    Mutation mutation =
+        Mutation.newInsertOrUpdateBuilder("Singers")
+            .set("SingerId")
+            .to(12)
+            .set("Name")
+            .to("John")
+            .build();
+    Key key = Key.of(12L);
+    SpannerMutationResponse response = new SpannerMutationResponse(mutation, key);
+    assertFalse(response.isEmpty());
+    assertEquals(mutation, response.getMutation());
+    assertEquals(key, response.getPrimaryKey());
+  }
+
+  @Test
+  public void isEmptyReturnsTrueWhenMutationNullEvenIfKeyProvided() {
+    Key key = Key.of(12L);
+    SpannerMutationResponse response = new SpannerMutationResponse(null, key);
+    assertTrue(response.isEmpty());
+    assertNull(response.getMutation());
+    assertEquals(key, response.getPrimaryKey());
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGeneratorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGeneratorTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.ByteArray;
 import com.google.cloud.Date;
 import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
 import com.google.cloud.teleport.v2.spanner.ddl.IndexColumn;
@@ -3138,5 +3139,178 @@ public final class SpannerDMLGeneratorTest {
     assertEquals("TargetAlbums", mutation.getTable());
     assertEquals(
         com.google.cloud.spanner.Key.of(1L, 2L).toString(), mutResp.getPrimaryKey().toString());
+  }
+
+  @Test
+  public void insertWithCustomTransformationUsingTargetColumnName() throws Exception {
+    Ddl origDdl =
+        Ddl.builder()
+            .createTable("Users")
+            .column("id")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("first_name")
+            .string()
+            .size(50)
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .build();
+
+    Ddl targetDdl =
+        Ddl.builder()
+            .createTable("TargetUsers")
+            .column("id")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("target_first_name")
+            .string()
+            .size(50)
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .build();
+
+    SourceSchema targetSchema =
+        SourceSchema.builder(SRC_TYPE)
+            .databaseName("test-db")
+            .tables(
+                ImmutableMap.of(
+                    "TargetUsers",
+                    SourceTable.builder(SRC_TYPE)
+                        .name("TargetUsers")
+                        .primaryKeyColumns(ImmutableList.of("id"))
+                        .columns(
+                            ImmutableList.of(
+                                SourceColumn.builder(SRC_TYPE)
+                                    .name("id")
+                                    .type("INT64")
+                                    .isPrimaryKey(true)
+                                    .build(),
+                                SourceColumn.builder(SRC_TYPE)
+                                    .name("target_first_name")
+                                    .type("STRING")
+                                    .build()))
+                        .build()))
+            .rawDdl(targetDdl)
+            .build();
+
+    ISchemaMapper mapper = mock(ISchemaMapper.class);
+    when(mapper.getSourceTableName("", "Users")).thenReturn("TargetUsers");
+    when(mapper.getSpannerColumnName("", "TargetUsers", "id")).thenReturn("id");
+    when(mapper.getSpannerColumnName("", "TargetUsers", "target_first_name"))
+        .thenReturn("first_name");
+
+    JSONObject newValues = new JSONObject("{\"first_name\":\"Alice\"}");
+    JSONObject keyValues = new JSONObject("{\"id\":\"10\"}");
+
+    Map<String, Object> customResponse = new HashMap<>();
+    customResponse.put("target_first_name", "Transformed Alice");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "Users", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(origDdl)
+                    .setSourceSchema(targetSchema)
+                    .setCustomTransformationResponse(customResponse)
+                    .build());
+
+    SpannerMutationResponse mutResp = (SpannerMutationResponse) response;
+    Mutation mutation = mutResp.getMutation();
+    assertEquals(Mutation.Op.INSERT_OR_UPDATE, mutation.getOperation());
+    assertEquals("TargetUsers", mutation.getTable());
+    assertEquals("Transformed Alice", mutation.asMap().get("target_first_name").getString());
+    assertEquals(10L, mutResp.getPrimaryKey().getParts().iterator().next());
+  }
+
+  @Test
+  public void insertWithTargetPgDialectTypes() throws Exception {
+    Ddl origDdl =
+        Ddl.builder()
+            .createTable("Users")
+            .column("id")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("name")
+            .string()
+            .size(50)
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .build();
+
+    Ddl targetPgDdl =
+        Ddl.builder(Dialect.POSTGRESQL)
+            .createTable("Users")
+            .column("id")
+            .pgInt8()
+            .notNull()
+            .endColumn()
+            .column("name")
+            .pgVarchar()
+            .size(50)
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .build();
+
+    SourceSchema targetSchema =
+        SourceSchema.builder(SRC_TYPE)
+            .databaseName("test-db")
+            .tables(
+                ImmutableMap.of(
+                    "Users",
+                    SourceTable.builder(SRC_TYPE)
+                        .name("Users")
+                        .primaryKeyColumns(ImmutableList.of("id"))
+                        .columns(
+                            ImmutableList.of(
+                                SourceColumn.builder(SRC_TYPE)
+                                    .name("id")
+                                    .type("PG_INT8")
+                                    .isPrimaryKey(true)
+                                    .build(),
+                                SourceColumn.builder(SRC_TYPE)
+                                    .name("name")
+                                    .type("PG_VARCHAR")
+                                    .build()))
+                        .build()))
+            .rawDdl(targetPgDdl)
+            .build();
+
+    ISchemaMapper mapper = mock(ISchemaMapper.class);
+    when(mapper.getSourceTableName("", "Users")).thenReturn("Users");
+    when(mapper.getSpannerColumnName("", "Users", "id")).thenReturn("id");
+    when(mapper.getSpannerColumnName("", "Users", "name")).thenReturn("name");
+
+    JSONObject newValues = new JSONObject("{\"name\":\"Bob\"}");
+    JSONObject keyValues = new JSONObject("{\"id\":\"20\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "Users", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(origDdl)
+                    .setSourceSchema(targetSchema)
+                    .build());
+
+    SpannerMutationResponse mutResp = (SpannerMutationResponse) response;
+    Mutation mutation = mutResp.getMutation();
+    assertEquals("Bob", mutation.asMap().get("name").getString());
+    assertEquals(20L, mutResp.getPrimaryKey().getParts().iterator().next());
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGeneratorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGeneratorTest.java
@@ -103,10 +103,11 @@ public final class SpannerDMLGeneratorTest {
   /** Creates a schema mapper that maps Singers → Singers with identity column mapping. */
   private static ISchemaMapper buildIdentityMapper() throws Exception {
     ISchemaMapper mapper = mock(ISchemaMapper.class);
-    when(mapper.getSourceTableName("", "Singers")).thenReturn("Singers");
+    when(mapper.getSpannerTableName("", "Singers")).thenReturn("Singers");
     when(mapper.getSpannerColumnName("", "Singers", "SingerId")).thenReturn("SingerId");
     when(mapper.getSpannerColumnName("", "Singers", "FirstName")).thenReturn("FirstName");
     when(mapper.getSpannerColumnName("", "Singers", "LastName")).thenReturn("LastName");
+    when(mapper.getSourceTableName("", "Singers")).thenReturn("Singers");
     when(mapper.getSourceColumnName("", "Singers", "SingerId")).thenReturn("SingerId");
     when(mapper.getSourceColumnName("", "Singers", "FirstName")).thenReturn("FirstName");
     when(mapper.getSourceColumnName("", "Singers", "LastName")).thenReturn("LastName");
@@ -1243,10 +1244,13 @@ public final class SpannerDMLGeneratorTest {
                         .build()))
             .rawDdl(ddl)
             .build();
-    ISchemaMapper mapper = buildIdentityMapper();
+    ISchemaMapper mapper = mock(ISchemaMapper.class);
     when(mapper.getSourceTableName("", "Albums")).thenReturn("Albums");
     when(mapper.getSourceColumnName("", "Albums", "SingerId")).thenReturn("SingerId");
     when(mapper.getSourceColumnName("", "Albums", "AlbumId")).thenReturn("AlbumId");
+    when(mapper.getSpannerTableName("", "Albums")).thenReturn("Albums");
+    when(mapper.getSpannerColumnName("", "Albums", "SingerId")).thenReturn("SingerId");
+    when(mapper.getSpannerColumnName("", "Albums", "AlbumId")).thenReturn("AlbumId");
 
     JSONObject newValues = new JSONObject("{}");
     JSONObject keyValues = new JSONObject("{\"SingerId\":\"1\", \"AlbumId\":\"2\"}");
@@ -1673,7 +1677,7 @@ public final class SpannerDMLGeneratorTest {
     Table.Builder tableBuilder = builder.createTable("Singers");
     tableBuilder.column("SingerId").int64().notNull().endColumn();
     tableBuilder.column("FirstName").string().max().endColumn();
-    tableBuilder.column("GenCol").string().max().endColumn();
+    tableBuilder.column("GenCol").string().max().isGenerated(true).endColumn();
     tableBuilder.primaryKey().asc("SingerId").end();
     tableBuilder.endTable();
     Ddl ddl = builder.build();
@@ -2823,34 +2827,6 @@ public final class SpannerDMLGeneratorTest {
     assertEquals(
         "{\"f1\":\"val\"}",
         ((SpannerMutationResponse) respCustom).getMutation().asMap().get("StructVal").getString());
-  }
-
-  @Test
-  public void
-      schemaMapperThrowsNoSuchElementExceptionInPrimaryKeyResolutionFallsBackToTargetColName()
-          throws Exception {
-    Ddl ddl = buildDdl();
-    SourceSchema schema = buildSourceSchema();
-    ISchemaMapper mapper = buildIdentityMapper();
-    when(mapper.getSpannerColumnName("", "Singers", "SingerId"))
-        .thenThrow(new NoSuchElementException("Column unmapped"));
-
-    JSONObject newValues = new JSONObject("{\"FirstName\":\"John\",\"LastName\":\"Doe\"}");
-    JSONObject keyValues = new JSONObject("{\"SingerId\":\"42\"}");
-
-    DMLGeneratorResponse response =
-        new SpannerDMLGenerator()
-            .getDMLStatement(
-                new DMLGeneratorRequest.Builder("INSERT", "Singers", newValues, keyValues, "+00:00")
-                    .setSchemaMapper(mapper)
-                    .setDdl(ddl)
-                    .setSourceSchema(schema)
-                    .build());
-
-    SpannerMutationResponse mutResp = (SpannerMutationResponse) response;
-    assertNotNull(mutResp.getMutation());
-    assertEquals(
-        com.google.cloud.spanner.Key.of(42L).toString(), mutResp.getPrimaryKey().toString());
   }
 
   @Test

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGeneratorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGeneratorTest.java
@@ -16,6 +16,7 @@
 package com.google.cloud.teleport.v2.templates.source.spanner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -36,6 +37,8 @@ import com.google.cloud.teleport.v2.spanner.sourceddl.SourceDatabaseType;
 import com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema;
 import com.google.cloud.teleport.v2.spanner.sourceddl.SourceTable;
 import com.google.cloud.teleport.v2.spanner.type.Type;
+import com.google.cloud.teleport.v2.templates.constants.Constants;
+import com.google.cloud.teleport.v2.templates.dbutils.processor.SourceProcessorFactory;
 import com.google.cloud.teleport.v2.templates.exceptions.InvalidDMLGenerationException;
 import com.google.cloud.teleport.v2.templates.models.DMLGeneratorRequest;
 import com.google.cloud.teleport.v2.templates.models.DMLGeneratorResponse;
@@ -45,6 +48,7 @@ import com.google.common.collect.ImmutableMap;
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -1560,5 +1564,1290 @@ public final class SpannerDMLGeneratorTest {
                         .setSchemaMapper(buildIdentityMapper())
                         .setDdl(buildDdl())
                         .build()));
+  }
+
+  @Test
+  public void targetTableWithoutPrimaryKeyThrows() throws Exception {
+    Ddl ddl = buildDdl();
+    SourceTable noPkTable =
+        SourceTable.builder(SRC_TYPE)
+            .name("Singers")
+            .columns(
+                ImmutableList.of(
+                    SourceColumn.builder(SRC_TYPE).name("SingerId").type("INT64").build(),
+                    SourceColumn.builder(SRC_TYPE).name("FirstName").type("STRING").build()))
+            .primaryKeyColumns(ImmutableList.of())
+            .build();
+    SourceSchema schema =
+        SourceSchema.builder(SRC_TYPE)
+            .databaseName("test-db")
+            .tables(ImmutableMap.of("Singers", noPkTable))
+            .build();
+    ISchemaMapper mapper = buildIdentityMapper();
+
+    assertThrows(
+        InvalidDMLGenerationException.class,
+        () ->
+            new SpannerDMLGenerator()
+                .getDMLStatement(
+                    new DMLGeneratorRequest.Builder(
+                            "INSERT",
+                            "Singers",
+                            new JSONObject("{\"FirstName\":\"Alice\"}"),
+                            new JSONObject("{\"SingerId\":\"1\"}"),
+                            "+00:00")
+                        .setSchemaMapper(mapper)
+                        .setDdl(ddl)
+                        .setSourceSchema(schema)
+                        .build()));
+  }
+
+  @Test
+  public void targetTableNameLookupThrowsNoSuchElementException() throws Exception {
+    Ddl ddl = buildDdl();
+    SourceSchema schema = buildSourceSchema();
+    ISchemaMapper mapper = mock(ISchemaMapper.class);
+    when(mapper.getSourceTableName("", "Singers"))
+        .thenThrow(new NoSuchElementException("Not found"));
+
+    assertThrows(
+        InvalidDMLGenerationException.class,
+        () ->
+            new SpannerDMLGenerator()
+                .getDMLStatement(
+                    new DMLGeneratorRequest.Builder(
+                            "INSERT",
+                            "Singers",
+                            new JSONObject("{\"FirstName\":\"Alice\"}"),
+                            new JSONObject("{\"SingerId\":\"1\"}"),
+                            "+00:00")
+                        .setSchemaMapper(mapper)
+                        .setDdl(ddl)
+                        .setSourceSchema(schema)
+                        .build()));
+  }
+
+  @Test
+  public void generatedColumnInTargetTableIsSkipped() throws Exception {
+    Ddl.Builder builder = Ddl.builder();
+    Table.Builder tableBuilder = builder.createTable("Singers");
+    tableBuilder.column("SingerId").int64().notNull().endColumn();
+    tableBuilder.column("FirstName").string().max().endColumn();
+    tableBuilder.column("GenCol").string().max().endColumn();
+    tableBuilder.primaryKey().asc("SingerId").end();
+    tableBuilder.endTable();
+    Ddl ddl = builder.build();
+
+    SourceColumn singerIdCol =
+        SourceColumn.builder(SRC_TYPE).name("SingerId").type("INT64").isPrimaryKey(true).build();
+    SourceColumn firstNameCol =
+        SourceColumn.builder(SRC_TYPE).name("FirstName").type("STRING").build();
+    SourceColumn genCol =
+        SourceColumn.builder(SRC_TYPE).name("GenCol").type("STRING").isGenerated(true).build();
+
+    SourceTable table =
+        SourceTable.builder(SRC_TYPE)
+            .name("Singers")
+            .columns(ImmutableList.of(singerIdCol, firstNameCol, genCol))
+            .primaryKeyColumns(ImmutableList.of("SingerId"))
+            .build();
+    SourceSchema schema =
+        SourceSchema.builder(SRC_TYPE)
+            .databaseName("test-db")
+            .tables(ImmutableMap.of("Singers", table))
+            .build();
+
+    ISchemaMapper mapper = buildIdentityMapper();
+    when(mapper.getSpannerColumnName("", "Singers", "GenCol")).thenReturn("GenCol");
+
+    JSONObject newValues = new JSONObject("{\"FirstName\":\"John\",\"GenCol\":\"generated\"}");
+    JSONObject keyValues = new JSONObject("{\"SingerId\":\"1\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "Singers", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+
+    Mutation mutation = ((SpannerMutationResponse) response).getMutation();
+    assertNotNull(mutation);
+    assertEquals("John", mutation.asMap().get("FirstName").getString());
+    assertFalse(mutation.asMap().containsKey("GenCol"));
+  }
+
+  @Test
+  public void columnMappingThrowsNoSuchElementExceptionIsSkipped() throws Exception {
+    Ddl ddl = buildDdl();
+    SourceSchema schema = buildSourceSchema();
+    ISchemaMapper mapper = buildIdentityMapper();
+    when(mapper.getSpannerColumnName("", "Singers", "LastName"))
+        .thenThrow(new NoSuchElementException());
+
+    JSONObject newValues = new JSONObject("{\"FirstName\":\"John\",\"LastName\":\"Doe\"}");
+    JSONObject keyValues = new JSONObject("{\"SingerId\":\"1\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "Singers", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+
+    Mutation mutation = ((SpannerMutationResponse) response).getMutation();
+    assertEquals("John", mutation.asMap().get("FirstName").getString());
+    assertFalse(mutation.asMap().containsKey("LastName"));
+  }
+
+  @Test
+  public void mappedColumnNotInSourceDdlIsSkipped() throws Exception {
+    Ddl ddl = buildDdl(); // Only has SingerId, FirstName, LastName
+    SourceColumn singerIdCol =
+        SourceColumn.builder(SRC_TYPE).name("SingerId").type("INT64").isPrimaryKey(true).build();
+    SourceColumn firstNameCol =
+        SourceColumn.builder(SRC_TYPE).name("FirstName").type("STRING").build();
+    SourceColumn extraCol = SourceColumn.builder(SRC_TYPE).name("ExtraCol").type("STRING").build();
+
+    SourceTable table =
+        SourceTable.builder(SRC_TYPE)
+            .name("Singers")
+            .columns(ImmutableList.of(singerIdCol, firstNameCol, extraCol))
+            .primaryKeyColumns(ImmutableList.of("SingerId"))
+            .build();
+    SourceSchema schema =
+        SourceSchema.builder(SRC_TYPE)
+            .databaseName("test-db")
+            .tables(ImmutableMap.of("Singers", table))
+            .build();
+
+    ISchemaMapper mapper = buildIdentityMapper();
+    when(mapper.getSpannerColumnName("", "Singers", "ExtraCol")).thenReturn("ExtraCol");
+
+    JSONObject newValues = new JSONObject("{\"FirstName\":\"John\",\"ExtraCol\":\"val\"}");
+    JSONObject keyValues = new JSONObject("{\"SingerId\":\"1\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "Singers", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+
+    Mutation mutation = ((SpannerMutationResponse) response).getMutation();
+    assertEquals("John", mutation.asMap().get("FirstName").getString());
+    assertFalse(mutation.asMap().containsKey("ExtraCol"));
+  }
+
+  @Test
+  public void columnValueInKeyValuesJsonInsteadOfNewValuesJson() throws Exception {
+    Ddl ddl = buildDdl();
+    SourceSchema schema = buildSourceSchema();
+    ISchemaMapper mapper = buildIdentityMapper();
+
+    JSONObject newValues = new JSONObject();
+    JSONObject keyValues =
+        new JSONObject("{\"SingerId\":\"1\", \"FirstName\":\"FromKey\", \"LastName\":null}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "Singers", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+
+    Mutation mutation = ((SpannerMutationResponse) response).getMutation();
+    assertEquals("FromKey", mutation.asMap().get("FirstName").getString());
+    assertTrue(mutation.asMap().get("LastName").isNull());
+  }
+
+  @Test
+  public void nullValueForNumericColumnIsTypedNull() throws Exception {
+    Ddl ddl = buildDdlWithSingleNonPkCol("NumVal", Type.numeric());
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("NumVal", "NUMERIC");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    JSONObject newValues = new JSONObject();
+    newValues.put("NumVal", JSONObject.NULL);
+    JSONObject keyValues = new JSONObject("{\"Id\":\"1\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "T", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+
+    com.google.cloud.spanner.Value v =
+        ((SpannerMutationResponse) response).getMutation().asMap().get("NumVal");
+    assertNotNull(v);
+    assertTrue(v.isNull());
+    assertEquals(com.google.cloud.spanner.Type.numeric(), v.getType());
+  }
+
+  @Test
+  public void nullValueForFloat64ColumnIsTypedNull() throws Exception {
+    Ddl ddl = buildDdlWithSingleNonPkCol("FloatVal", Type.float64());
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("FloatVal", "FLOAT64");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    JSONObject newValues = new JSONObject();
+    newValues.put("FloatVal", JSONObject.NULL);
+    JSONObject keyValues = new JSONObject("{\"Id\":\"1\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "T", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+
+    com.google.cloud.spanner.Value v =
+        ((SpannerMutationResponse) response).getMutation().asMap().get("FloatVal");
+    assertNotNull(v);
+    assertTrue(v.isNull());
+    assertEquals(com.google.cloud.spanner.Type.float64(), v.getType());
+  }
+
+  @Test
+  public void nullValueForFloat32ColumnIsTypedNull() throws Exception {
+    Ddl ddl = buildDdlWithSingleNonPkCol("Float32Val", Type.float32());
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("Float32Val", "FLOAT32");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    JSONObject newValues = new JSONObject();
+    newValues.put("Float32Val", JSONObject.NULL);
+    JSONObject keyValues = new JSONObject("{\"Id\":\"1\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "T", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+
+    com.google.cloud.spanner.Value v =
+        ((SpannerMutationResponse) response).getMutation().asMap().get("Float32Val");
+    assertNotNull(v);
+    assertTrue(v.isNull());
+    assertEquals(com.google.cloud.spanner.Type.float32(), v.getType());
+  }
+
+  @Test
+  public void nullValueForBytesColumnIsTypedNull() throws Exception {
+    Ddl ddl = buildDdlWithSingleNonPkCol("BytesVal", Type.bytes());
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("BytesVal", "BYTES");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    JSONObject newValues = new JSONObject();
+    newValues.put("BytesVal", JSONObject.NULL);
+    JSONObject keyValues = new JSONObject("{\"Id\":\"1\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "T", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+
+    com.google.cloud.spanner.Value v =
+        ((SpannerMutationResponse) response).getMutation().asMap().get("BytesVal");
+    assertNotNull(v);
+    assertTrue(v.isNull());
+    assertEquals(com.google.cloud.spanner.Type.bytes(), v.getType());
+  }
+
+  @Test
+  public void nullValueForTimestampColumnIsTypedNull() throws Exception {
+    Ddl ddl = buildDdlWithSingleNonPkCol("TsVal", Type.timestamp());
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("TsVal", "TIMESTAMP");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    JSONObject newValues = new JSONObject();
+    newValues.put("TsVal", JSONObject.NULL);
+    JSONObject keyValues = new JSONObject("{\"Id\":\"1\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "T", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+
+    com.google.cloud.spanner.Value v =
+        ((SpannerMutationResponse) response).getMutation().asMap().get("TsVal");
+    assertNotNull(v);
+    assertTrue(v.isNull());
+    assertEquals(com.google.cloud.spanner.Type.timestamp(), v.getType());
+  }
+
+  @Test
+  public void nullValueForInt64ColumnIsTypedNull() throws Exception {
+    Ddl ddl = buildDdlWithSingleNonPkCol("IntVal", Type.int64());
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("IntVal", "INT64");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    JSONObject newValues = new JSONObject();
+    newValues.put("IntVal", JSONObject.NULL);
+    JSONObject keyValues = new JSONObject("{\"Id\":\"1\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "T", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+
+    com.google.cloud.spanner.Value v =
+        ((SpannerMutationResponse) response).getMutation().asMap().get("IntVal");
+    assertNotNull(v);
+    assertTrue(v.isNull());
+    assertEquals(com.google.cloud.spanner.Type.int64(), v.getType());
+  }
+
+  @Test
+  public void nullArrayOfFloat64IsBoundAsTypedNullArray() throws Exception {
+    Ddl ddl = buildDdlWithSingleNonPkCol("ArrVal", Type.array(Type.float64()));
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("ArrVal", "ARRAY<FLOAT64>");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    JSONObject newValues = new JSONObject();
+    newValues.put("ArrVal", JSONObject.NULL);
+    JSONObject keyValues = new JSONObject("{\"Id\":\"1\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "T", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+
+    com.google.cloud.spanner.Value v =
+        ((SpannerMutationResponse) response).getMutation().asMap().get("ArrVal");
+    assertNotNull(v);
+    assertTrue(v.isNull());
+    assertEquals(
+        com.google.cloud.spanner.Type.array(com.google.cloud.spanner.Type.float64()), v.getType());
+  }
+
+  @Test
+  public void nullArrayOfFloat32IsBoundAsTypedNullArray() throws Exception {
+    Ddl ddl = buildDdlWithSingleNonPkCol("ArrVal", Type.array(Type.float32()));
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("ArrVal", "ARRAY<FLOAT32>");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    JSONObject newValues = new JSONObject();
+    newValues.put("ArrVal", JSONObject.NULL);
+    JSONObject keyValues = new JSONObject("{\"Id\":\"1\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "T", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+
+    com.google.cloud.spanner.Value v =
+        ((SpannerMutationResponse) response).getMutation().asMap().get("ArrVal");
+    assertNotNull(v);
+    assertTrue(v.isNull());
+    assertEquals(
+        com.google.cloud.spanner.Type.array(com.google.cloud.spanner.Type.float32()), v.getType());
+  }
+
+  @Test
+  public void nullArrayOfStringIsBoundAsTypedNullArray() throws Exception {
+    Ddl ddl = buildDdlWithSingleNonPkCol("ArrVal", Type.array(Type.string()));
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("ArrVal", "ARRAY<STRING>");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    JSONObject newValues = new JSONObject();
+    newValues.put("ArrVal", JSONObject.NULL);
+    JSONObject keyValues = new JSONObject("{\"Id\":\"1\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "T", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+
+    com.google.cloud.spanner.Value v =
+        ((SpannerMutationResponse) response).getMutation().asMap().get("ArrVal");
+    assertNotNull(v);
+    assertTrue(v.isNull());
+    assertEquals(
+        com.google.cloud.spanner.Type.array(com.google.cloud.spanner.Type.string()), v.getType());
+  }
+
+  @Test
+  public void nullArrayOfJsonIsBoundAsTypedNullArray() throws Exception {
+    Ddl ddl = buildDdlWithSingleNonPkCol("ArrVal", Type.array(Type.json()));
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("ArrVal", "ARRAY<JSON>");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    JSONObject newValues = new JSONObject();
+    newValues.put("ArrVal", JSONObject.NULL);
+    JSONObject keyValues = new JSONObject("{\"Id\":\"1\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "T", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+
+    com.google.cloud.spanner.Value v =
+        ((SpannerMutationResponse) response).getMutation().asMap().get("ArrVal");
+    assertNotNull(v);
+    assertTrue(v.isNull());
+    assertEquals(
+        com.google.cloud.spanner.Type.array(com.google.cloud.spanner.Type.json()), v.getType());
+  }
+
+  @Test
+  public void nullArrayOfBytesIsBoundAsTypedNullArray() throws Exception {
+    Ddl ddl = buildDdlWithSingleNonPkCol("ArrVal", Type.array(Type.bytes()));
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("ArrVal", "ARRAY<BYTES>");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    JSONObject newValues = new JSONObject();
+    newValues.put("ArrVal", JSONObject.NULL);
+    JSONObject keyValues = new JSONObject("{\"Id\":\"1\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "T", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+
+    com.google.cloud.spanner.Value v =
+        ((SpannerMutationResponse) response).getMutation().asMap().get("ArrVal");
+    assertNotNull(v);
+    assertTrue(v.isNull());
+    assertEquals(
+        com.google.cloud.spanner.Type.array(com.google.cloud.spanner.Type.bytes()), v.getType());
+  }
+
+  @Test
+  public void nullArrayOfDateIsBoundAsTypedNullArray() throws Exception {
+    Ddl ddl = buildDdlWithSingleNonPkCol("ArrVal", Type.array(Type.date()));
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("ArrVal", "ARRAY<DATE>");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    JSONObject newValues = new JSONObject();
+    newValues.put("ArrVal", JSONObject.NULL);
+    JSONObject keyValues = new JSONObject("{\"Id\":\"1\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "T", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+
+    com.google.cloud.spanner.Value v =
+        ((SpannerMutationResponse) response).getMutation().asMap().get("ArrVal");
+    assertNotNull(v);
+    assertTrue(v.isNull());
+    assertEquals(
+        com.google.cloud.spanner.Type.array(com.google.cloud.spanner.Type.date()), v.getType());
+  }
+
+  @Test
+  public void nullArrayOfNumericIsBoundAsTypedNullArray() throws Exception {
+    Ddl ddl = buildDdlWithSingleNonPkCol("ArrVal", Type.array(Type.numeric()));
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("ArrVal", "ARRAY<NUMERIC>");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    JSONObject newValues = new JSONObject();
+    newValues.put("ArrVal", JSONObject.NULL);
+    JSONObject keyValues = new JSONObject("{\"Id\":\"1\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "T", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+
+    com.google.cloud.spanner.Value v =
+        ((SpannerMutationResponse) response).getMutation().asMap().get("ArrVal");
+    assertNotNull(v);
+    assertTrue(v.isNull());
+    assertEquals(
+        com.google.cloud.spanner.Type.array(com.google.cloud.spanner.Type.numeric()), v.getType());
+  }
+
+  @Test
+  public void customTransformationBytesVariants() throws Exception {
+    Ddl ddl = buildDdlWithSingleNonPkCol("BytesVal", Type.bytes());
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("BytesVal", "BYTES");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    // Test with byte[]
+    Map<String, Object> customBytes = new HashMap<>();
+    customBytes.put("BytesVal", "bytesData".getBytes());
+    DMLGeneratorResponse resp1 =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"BytesVal\":\"dummy\"}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .setCustomTransformationResponse(customBytes)
+                    .build());
+    assertEquals(
+        ByteArray.copyFrom("bytesData".getBytes()),
+        ((SpannerMutationResponse) resp1).getMutation().asMap().get("BytesVal").getBytes());
+
+    // Test with ByteArray
+    Map<String, Object> customByteArray = new HashMap<>();
+    customByteArray.put("BytesVal", ByteArray.copyFrom("byteArrayData".getBytes()));
+    DMLGeneratorResponse resp2 =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"BytesVal\":\"dummy\"}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .setCustomTransformationResponse(customByteArray)
+                    .build());
+    assertEquals(
+        ByteArray.copyFrom("byteArrayData".getBytes()),
+        ((SpannerMutationResponse) resp2).getMutation().asMap().get("BytesVal").getBytes());
+
+    // Test with Base64 String
+    Map<String, Object> customBase64 = new HashMap<>();
+    customBase64.put(
+        "BytesVal", java.util.Base64.getEncoder().encodeToString("base64Data".getBytes()));
+    DMLGeneratorResponse resp3 =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"BytesVal\":\"dummy\"}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .setCustomTransformationResponse(customBase64)
+                    .build());
+    assertEquals(
+        ByteArray.copyFrom("base64Data".getBytes()),
+        ((SpannerMutationResponse) resp3).getMutation().asMap().get("BytesVal").getBytes());
+  }
+
+  @Test
+  public void customTransformationDateVariants() throws Exception {
+    Ddl ddl = buildDdlWithSingleNonPkCol("DateVal", Type.date());
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("DateVal", "DATE");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    // Test with Date object
+    Map<String, Object> customDate = new HashMap<>();
+    customDate.put("DateVal", Date.parseDate("2024-12-25"));
+    DMLGeneratorResponse resp1 =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"DateVal\":\"dummy\"}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .setCustomTransformationResponse(customDate)
+                    .build());
+    assertEquals(
+        Date.parseDate("2024-12-25"),
+        ((SpannerMutationResponse) resp1).getMutation().asMap().get("DateVal").getDate());
+
+    // Test with Date String
+    Map<String, Object> customDateStr = new HashMap<>();
+    customDateStr.put("DateVal", "2025-01-01");
+    DMLGeneratorResponse resp2 =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"DateVal\":\"dummy\"}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .setCustomTransformationResponse(customDateStr)
+                    .build());
+    assertEquals(
+        Date.parseDate("2025-01-01"),
+        ((SpannerMutationResponse) resp2).getMutation().asMap().get("DateVal").getDate());
+  }
+
+  @Test
+  public void customTransformationTimestampObjectVariant() throws Exception {
+    Ddl ddl = buildDdlWithSingleNonPkCol("TsVal", Type.timestamp());
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("TsVal", "TIMESTAMP");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    Map<String, Object> customTs = new HashMap<>();
+    customTs.put("TsVal", Timestamp.parseTimestamp("2024-05-01T12:00:00Z"));
+    DMLGeneratorResponse resp =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"TsVal\":\"dummy\"}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .setCustomTransformationResponse(customTs)
+                    .build());
+    assertEquals(
+        Timestamp.parseTimestamp("2024-05-01T12:00:00Z"),
+        ((SpannerMutationResponse) resp).getMutation().asMap().get("TsVal").getTimestamp());
+  }
+
+  @Test
+  public void customTransformationFloat32Variants() throws Exception {
+    Ddl ddl = buildDdlWithSingleNonPkCol("F32", Type.float32());
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("F32", "FLOAT32");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    // Float object
+    Map<String, Object> customFloat = new HashMap<>();
+    customFloat.put("F32", 2.5f);
+    DMLGeneratorResponse resp1 =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"F32\":\"1.0\"}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .setCustomTransformationResponse(customFloat)
+                    .build());
+    assertEquals(
+        2.5f,
+        ((SpannerMutationResponse) resp1).getMutation().asMap().get("F32").getFloat32(),
+        0.001f);
+
+    // String representation
+    Map<String, Object> customStr = new HashMap<>();
+    customStr.put("F32", "4.75");
+    DMLGeneratorResponse resp2 =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"F32\":\"1.0\"}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .setCustomTransformationResponse(customStr)
+                    .build());
+    assertEquals(
+        4.75f,
+        ((SpannerMutationResponse) resp2).getMutation().asMap().get("F32").getFloat32(),
+        0.001f);
+  }
+
+  @Test
+  public void customTransformationJsonAndStringCoercions() throws Exception {
+    Ddl ddl = buildDdlWithSingleNonPkCol("JsonCol", Type.json());
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("JsonCol", "JSON");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    Map<String, Object> customJson = new HashMap<>();
+    customJson.put("JsonCol", "{\"status\":\"ok\"}");
+    DMLGeneratorResponse resp1 =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"JsonCol\":\"{}\"}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .setCustomTransformationResponse(customJson)
+                    .build());
+    assertEquals(
+        "{\"status\":\"ok\"}",
+        ((SpannerMutationResponse) resp1).getMutation().asMap().get("JsonCol").getJson());
+  }
+
+  @Test
+  public void customTransformationPrimitiveStringParsings() throws Exception {
+    // Bool from string
+    Ddl ddlBool = buildDdlWithSingleNonPkCol("B", Type.bool());
+    SourceSchema schemaBool = buildSchemaWithSingleNonPkCol("B", "BOOL");
+    ISchemaMapper mapperBool = buildMapperForSingleColTable(schemaBool);
+    Map<String, Object> customBool = new HashMap<>();
+    customBool.put("B", "true");
+    DMLGeneratorResponse respBool =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"B\":false}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapperBool)
+                    .setDdl(ddlBool)
+                    .setSourceSchema(schemaBool)
+                    .setCustomTransformationResponse(customBool)
+                    .build());
+    assertTrue(((SpannerMutationResponse) respBool).getMutation().asMap().get("B").getBool());
+
+    // Int64 from string
+    Ddl ddlInt = buildDdlWithSingleNonPkCol("I", Type.int64());
+    SourceSchema schemaInt = buildSchemaWithSingleNonPkCol("I", "INT64");
+    ISchemaMapper mapperInt = buildMapperForSingleColTable(schemaInt);
+    Map<String, Object> customInt = new HashMap<>();
+    customInt.put("I", "999");
+    DMLGeneratorResponse respInt =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"I\":0}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapperInt)
+                    .setDdl(ddlInt)
+                    .setSourceSchema(schemaInt)
+                    .setCustomTransformationResponse(customInt)
+                    .build());
+    assertEquals(
+        999L, ((SpannerMutationResponse) respInt).getMutation().asMap().get("I").getInt64());
+
+    // Float64 from string
+    Ddl ddlFloat = buildDdlWithSingleNonPkCol("F", Type.float64());
+    SourceSchema schemaFloat = buildSchemaWithSingleNonPkCol("F", "FLOAT64");
+    ISchemaMapper mapperFloat = buildMapperForSingleColTable(schemaFloat);
+    Map<String, Object> customFloat = new HashMap<>();
+    customFloat.put("F", "3.14159");
+    DMLGeneratorResponse respFloat =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"F\":0.0}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapperFloat)
+                    .setDdl(ddlFloat)
+                    .setSourceSchema(schemaFloat)
+                    .setCustomTransformationResponse(customFloat)
+                    .build());
+    assertEquals(
+        3.14159,
+        ((SpannerMutationResponse) respFloat).getMutation().asMap().get("F").getFloat64(),
+        0.0001);
+
+    // Numeric from string
+    Ddl ddlNum = buildDdlWithSingleNonPkCol("N", Type.numeric());
+    SourceSchema schemaNum = buildSchemaWithSingleNonPkCol("N", "NUMERIC");
+    ISchemaMapper mapperNum = buildMapperForSingleColTable(schemaNum);
+    Map<String, Object> customNum = new HashMap<>();
+    customNum.put("N", "456.78");
+    DMLGeneratorResponse respNum =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"N\":0}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapperNum)
+                    .setDdl(ddlNum)
+                    .setSourceSchema(schemaNum)
+                    .setCustomTransformationResponse(customNum)
+                    .build());
+    assertEquals(
+        new BigDecimal("456.78"),
+        ((SpannerMutationResponse) respNum).getMutation().asMap().get("N").getNumeric());
+  }
+
+  @Test
+  public void primaryKeyTypesCoverageInDeleteAndUpsert() throws Exception {
+    // 1. Bool PK
+    testPkTypeCoverage(
+        "BoolPk", Type.bool(), "BOOL", true, "true", com.google.cloud.spanner.Key.of(true));
+    // 2. Float64 PK
+    testPkTypeCoverage(
+        "Float64Pk",
+        Type.float64(),
+        "FLOAT64",
+        3.14,
+        "3.14",
+        com.google.cloud.spanner.Key.of(3.14));
+    // 3. Float32 PK
+    testPkTypeCoverage(
+        "Float32Pk", Type.float32(), "FLOAT32", 1.5f, "1.5", com.google.cloud.spanner.Key.of(1.5f));
+    // 4. Date PK
+    testPkTypeCoverage(
+        "DatePk",
+        Type.date(),
+        "DATE",
+        Date.parseDate("2024-01-01"),
+        "2024-01-01",
+        com.google.cloud.spanner.Key.of(Date.parseDate("2024-01-01")));
+    // 5. Timestamp PK
+    testPkTypeCoverage(
+        "TsPk",
+        Type.timestamp(),
+        "TIMESTAMP",
+        Timestamp.parseTimestamp("2024-01-01T00:00:00Z"),
+        "2024-01-01T00:00:00Z",
+        com.google.cloud.spanner.Key.of(Timestamp.parseTimestamp("2024-01-01T00:00:00Z")));
+    // 6. Numeric PK
+    testPkTypeCoverage(
+        "NumPk",
+        Type.numeric(),
+        "NUMERIC",
+        new BigDecimal("123.45"),
+        "123.45",
+        com.google.cloud.spanner.Key.of(new BigDecimal("123.45")));
+    // 7. Bytes PK
+    byte[] rawBytes = "key".getBytes();
+    String b64 = java.util.Base64.getEncoder().encodeToString(rawBytes);
+    testPkTypeCoverage(
+        "BytesPk",
+        Type.bytes(),
+        "BYTES",
+        rawBytes,
+        b64,
+        com.google.cloud.spanner.Key.of(ByteArray.copyFrom(rawBytes)));
+    testPkTypeCoverage(
+        "BytesPk2",
+        Type.bytes(),
+        "BYTES",
+        ByteArray.copyFrom(rawBytes),
+        b64,
+        com.google.cloud.spanner.Key.of(ByteArray.copyFrom(rawBytes)));
+    // 8. String PK
+    testPkTypeCoverage(
+        "StrPk",
+        Type.string(),
+        "STRING",
+        "my-key",
+        "my-key",
+        com.google.cloud.spanner.Key.of("my-key"));
+  }
+
+  private static void testPkTypeCoverage(
+      String colName,
+      Type type,
+      String srcType,
+      Object customVal,
+      String jsonVal,
+      com.google.cloud.spanner.Key expectedKey)
+      throws Exception {
+    Ddl.Builder ddlBuilder = Ddl.builder();
+    Table.Builder tableBuilder = ddlBuilder.createTable("PkTable");
+    tableBuilder.column(colName).type(type).notNull().endColumn();
+    tableBuilder.column("Data").string().max().endColumn();
+    tableBuilder.primaryKey().asc(colName).end();
+    tableBuilder.endTable();
+    Ddl ddl = ddlBuilder.build();
+
+    SourceColumn pkCol =
+        SourceColumn.builder(SRC_TYPE)
+            .name(colName)
+            .type(srcType)
+            .isPrimaryKey(true)
+            .isNullable(false)
+            .build();
+    SourceColumn dataCol = SourceColumn.builder(SRC_TYPE).name("Data").type("STRING").build();
+    SourceTable table =
+        SourceTable.builder(SRC_TYPE)
+            .name("PkTable")
+            .columns(ImmutableList.of(pkCol, dataCol))
+            .primaryKeyColumns(ImmutableList.of(colName))
+            .build();
+    SourceSchema schema =
+        SourceSchema.builder(SRC_TYPE)
+            .databaseName("test-db")
+            .tables(ImmutableMap.of("PkTable", table))
+            .build();
+
+    ISchemaMapper mapper = mock(ISchemaMapper.class);
+    when(mapper.getSourceTableName("", "PkTable")).thenReturn("PkTable");
+    when(mapper.getSpannerColumnName("", "PkTable", colName)).thenReturn(colName);
+    when(mapper.getSpannerColumnName("", "PkTable", "Data")).thenReturn("Data");
+    when(mapper.getSourceColumnName("", "PkTable", colName)).thenReturn(colName);
+    when(mapper.getSourceColumnName("", "PkTable", "Data")).thenReturn("Data");
+
+    // Test DELETE with customVal
+    Map<String, Object> custom = new HashMap<>();
+    custom.put(colName, customVal);
+    DMLGeneratorResponse delResp1 =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "DELETE",
+                        "PkTable",
+                        new JSONObject(),
+                        new JSONObject("{\"" + colName + "\":\"" + jsonVal + "\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .setCustomTransformationResponse(custom)
+                    .build());
+    assertEquals(
+        Mutation.Op.DELETE, ((SpannerMutationResponse) delResp1).getMutation().getOperation());
+    assertEquals(
+        expectedKey.toString(), ((SpannerMutationResponse) delResp1).getPrimaryKey().toString());
+
+    // Test DELETE without customVal (JSON parsing path)
+    DMLGeneratorResponse delResp2 =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "DELETE",
+                        "PkTable",
+                        new JSONObject(),
+                        new JSONObject("{\"" + colName + "\":\"" + jsonVal + "\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+    assertEquals(
+        expectedKey.toString(), ((SpannerMutationResponse) delResp2).getPrimaryKey().toString());
+  }
+
+  @Test
+  public void targetDdlIntegrationWithSourceProcessor() throws Exception {
+    Ddl ddl = buildDdl();
+    SourceSchema schema = buildSourceSchema();
+    ISchemaMapper mapper = buildIdentityMapper();
+
+    SpannerSpToSrcSourceConnector connector =
+        (SpannerSpToSrcSourceConnector) SourceProcessorFactory.getSource(Constants.SOURCE_SPANNER);
+    connector.setTargetDdl(ddl);
+
+    try {
+      JSONObject newValues = new JSONObject("{\"FirstName\":\"Jane\",\"LastName\":\"Doe\"}");
+      JSONObject keyValues = new JSONObject("{\"SingerId\":\"42\"}");
+
+      DMLGeneratorResponse response =
+          new SpannerDMLGenerator()
+              .getDMLStatement(
+                  new DMLGeneratorRequest.Builder(
+                          "INSERT", "Singers", newValues, keyValues, "+00:00")
+                      .setSchemaMapper(mapper)
+                      .setDdl(ddl)
+                      .setSourceSchema(schema)
+                      .build());
+
+      SpannerMutationResponse mutResp = (SpannerMutationResponse) response;
+      assertNotNull(mutResp.getMutation());
+      assertEquals(
+          com.google.cloud.spanner.Key.of(42L).toString(), mutResp.getPrimaryKey().toString());
+    } finally {
+      connector.setTargetDdl(null);
+    }
+  }
+
+  @Test
+  public void buildArrayValueNullElementsExhaustive() throws Exception {
+    // BOOL array with null
+    Ddl ddlBool = buildDdlWithSingleNonPkCol("Arr", Type.array(Type.bool()));
+    SourceSchema schemaBool = buildSchemaWithSingleNonPkCol("Arr", "ARRAY<BOOL>");
+    ISchemaMapper mapperBool = buildMapperForSingleColTable(schemaBool);
+    DMLGeneratorResponse respBool =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"Arr\":[true, null, false]}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapperBool)
+                    .setDdl(ddlBool)
+                    .setSourceSchema(schemaBool)
+                    .build());
+    assertEquals(
+        java.util.Arrays.asList(true, null, false),
+        ((SpannerMutationResponse) respBool).getMutation().asMap().get("Arr").getBoolArray());
+
+    // INT64 array with null
+    Ddl ddlInt = buildDdlWithSingleNonPkCol("Arr", Type.array(Type.int64()));
+    SourceSchema schemaInt = buildSchemaWithSingleNonPkCol("Arr", "ARRAY<INT64>");
+    ISchemaMapper mapperInt = buildMapperForSingleColTable(schemaInt);
+    DMLGeneratorResponse respInt =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"Arr\":[1, null, 2]}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapperInt)
+                    .setDdl(ddlInt)
+                    .setSourceSchema(schemaInt)
+                    .build());
+    assertEquals(
+        java.util.Arrays.asList(1L, null, 2L),
+        ((SpannerMutationResponse) respInt).getMutation().asMap().get("Arr").getInt64Array());
+
+    // FLOAT64 array with null
+    Ddl ddlFloat64 = buildDdlWithSingleNonPkCol("Arr", Type.array(Type.float64()));
+    SourceSchema schemaFloat64 = buildSchemaWithSingleNonPkCol("Arr", "ARRAY<FLOAT64>");
+    ISchemaMapper mapperFloat64 = buildMapperForSingleColTable(schemaFloat64);
+    DMLGeneratorResponse respFloat64 =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"Arr\":[1.5, null, 2.5]}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapperFloat64)
+                    .setDdl(ddlFloat64)
+                    .setSourceSchema(schemaFloat64)
+                    .build());
+    assertEquals(
+        java.util.Arrays.asList(1.5, null, 2.5),
+        ((SpannerMutationResponse) respFloat64).getMutation().asMap().get("Arr").getFloat64Array());
+
+    // FLOAT32 array with null
+    Ddl ddlFloat32 = buildDdlWithSingleNonPkCol("Arr", Type.array(Type.float32()));
+    SourceSchema schemaFloat32 = buildSchemaWithSingleNonPkCol("Arr", "ARRAY<FLOAT32>");
+    ISchemaMapper mapperFloat32 = buildMapperForSingleColTable(schemaFloat32);
+    DMLGeneratorResponse respFloat32 =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"Arr\":[1.5, null, 2.5]}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapperFloat32)
+                    .setDdl(ddlFloat32)
+                    .setSourceSchema(schemaFloat32)
+                    .build());
+    assertEquals(
+        java.util.Arrays.asList(1.5f, null, 2.5f),
+        ((SpannerMutationResponse) respFloat32).getMutation().asMap().get("Arr").getFloat32Array());
+
+    // NUMERIC array with null
+    Ddl ddlNum = buildDdlWithSingleNonPkCol("Arr", Type.array(Type.numeric()));
+    SourceSchema schemaNum = buildSchemaWithSingleNonPkCol("Arr", "ARRAY<NUMERIC>");
+    ISchemaMapper mapperNum = buildMapperForSingleColTable(schemaNum);
+    DMLGeneratorResponse respNum =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"Arr\":[\"1.1\", null, \"2.2\"]}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapperNum)
+                    .setDdl(ddlNum)
+                    .setSourceSchema(schemaNum)
+                    .build());
+    assertEquals(
+        java.util.Arrays.asList(new BigDecimal("1.1"), null, new BigDecimal("2.2")),
+        ((SpannerMutationResponse) respNum).getMutation().asMap().get("Arr").getNumericArray());
+  }
+
+  @Test
+  public void fallbackTypesInSetNullValueAndSetCustomColumnValue() throws Exception {
+    Type structType = Type.struct(Type.StructField.of("f1", Type.string()));
+    Ddl ddl = buildDdlWithSingleNonPkCol("StructVal", structType);
+    SourceSchema schema = buildSchemaWithSingleNonPkCol("StructVal", "STRUCT");
+    ISchemaMapper mapper = buildMapperForSingleColTable(schema);
+
+    // 1. setNullValue for STRUCT (hits default branch)
+    JSONObject newValuesNull = new JSONObject();
+    newValuesNull.put("StructVal", JSONObject.NULL);
+    DMLGeneratorResponse respNull =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT", "T", newValuesNull, new JSONObject("{\"Id\":\"1\"}"), "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+    assertTrue(
+        ((SpannerMutationResponse) respNull).getMutation().asMap().get("StructVal").isNull());
+
+    // 2. setNullArrayValue for ARRAY<STRUCT> (hits default branch in setNullArrayValue)
+    Type arrayStructType = Type.array(structType);
+    Ddl ddlArr = buildDdlWithSingleNonPkCol("ArrStruct", arrayStructType);
+    SourceSchema schemaArr = buildSchemaWithSingleNonPkCol("ArrStruct", "ARRAY<STRUCT>");
+    ISchemaMapper mapperArr = buildMapperForSingleColTable(schemaArr);
+    JSONObject newValuesArrNull = new JSONObject();
+    newValuesArrNull.put("ArrStruct", JSONObject.NULL);
+    DMLGeneratorResponse respArrNull =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT", "T", newValuesArrNull, new JSONObject("{\"Id\":\"1\"}"), "+00:00")
+                    .setSchemaMapper(mapperArr)
+                    .setDdl(ddlArr)
+                    .setSourceSchema(schemaArr)
+                    .build());
+    assertTrue(
+        ((SpannerMutationResponse) respArrNull).getMutation().asMap().get("ArrStruct").isNull());
+
+    // 3. setCustomColumnValue for STRUCT (hits default branch in setCustomColumnValue)
+    Map<String, Object> custom = new HashMap<>();
+    custom.put("StructVal", "{\"f1\":\"val\"}");
+    DMLGeneratorResponse respCustom =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder(
+                        "INSERT",
+                        "T",
+                        new JSONObject("{\"StructVal\":\"dummy\"}"),
+                        new JSONObject("{\"Id\":\"1\"}"),
+                        "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .setCustomTransformationResponse(custom)
+                    .build());
+    assertEquals(
+        "{\"f1\":\"val\"}",
+        ((SpannerMutationResponse) respCustom).getMutation().asMap().get("StructVal").getString());
+  }
+
+  @Test
+  public void
+      schemaMapperThrowsNoSuchElementExceptionInPrimaryKeyResolutionFallsBackToTargetColName()
+          throws Exception {
+    Ddl ddl = buildDdl();
+    SourceSchema schema = buildSourceSchema();
+    ISchemaMapper mapper = buildIdentityMapper();
+    when(mapper.getSpannerColumnName("", "Singers", "SingerId"))
+        .thenThrow(new NoSuchElementException("Column unmapped"));
+
+    JSONObject newValues = new JSONObject("{\"FirstName\":\"John\",\"LastName\":\"Doe\"}");
+    JSONObject keyValues = new JSONObject("{\"SingerId\":\"42\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "Singers", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(ddl)
+                    .setSourceSchema(schema)
+                    .build());
+
+    SpannerMutationResponse mutResp = (SpannerMutationResponse) response;
+    assertNotNull(mutResp.getMutation());
+    assertEquals(
+        com.google.cloud.spanner.Key.of(42L).toString(), mutResp.getPrimaryKey().toString());
+  }
+
+  @Test
+  public void sourceProcessorFactoryThrowsExceptionHandledGracefully() throws Exception {
+    Ddl ddl = buildDdl();
+    SourceSchema schema = buildSourceSchema();
+    ISchemaMapper mapper = buildIdentityMapper();
+
+    Map<String, com.google.cloud.teleport.v2.templates.dbutils.processor.ISpToSrcSourceConnector>
+        originalMap = SourceProcessorFactory.getSourceMap();
+    try {
+      SourceProcessorFactory.setSourceMap(
+          new HashMap<>()); // Empty map triggers UnsupportedSourceException
+
+      JSONObject newValues = new JSONObject("{\"FirstName\":\"John\",\"LastName\":\"Doe\"}");
+      JSONObject keyValues = new JSONObject("{\"SingerId\":\"42\"}");
+
+      DMLGeneratorResponse response =
+          new SpannerDMLGenerator()
+              .getDMLStatement(
+                  new DMLGeneratorRequest.Builder(
+                          "INSERT", "Singers", newValues, keyValues, "+00:00")
+                      .setSchemaMapper(mapper)
+                      .setDdl(ddl)
+                      .setSourceSchema(schema)
+                      .build());
+
+      SpannerMutationResponse mutResp = (SpannerMutationResponse) response;
+      assertNotNull(mutResp.getMutation());
+      assertEquals(
+          com.google.cloud.spanner.Key.of(42L).toString(), mutResp.getPrimaryKey().toString());
+    } finally {
+      SourceProcessorFactory.setSourceMap(originalMap);
+    }
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGeneratorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerDMLGeneratorTest.java
@@ -37,8 +37,6 @@ import com.google.cloud.teleport.v2.spanner.sourceddl.SourceDatabaseType;
 import com.google.cloud.teleport.v2.spanner.sourceddl.SourceSchema;
 import com.google.cloud.teleport.v2.spanner.sourceddl.SourceTable;
 import com.google.cloud.teleport.v2.spanner.type.Type;
-import com.google.cloud.teleport.v2.templates.constants.Constants;
-import com.google.cloud.teleport.v2.templates.dbutils.processor.SourceProcessorFactory;
 import com.google.cloud.teleport.v2.templates.exceptions.InvalidDMLGenerationException;
 import com.google.cloud.teleport.v2.templates.models.DMLGeneratorRequest;
 import com.google.cloud.teleport.v2.templates.models.DMLGeneratorResponse;
@@ -97,6 +95,7 @@ public final class SpannerDMLGeneratorTest {
     return SourceSchema.builder(SRC_TYPE)
         .databaseName("test-db")
         .tables(ImmutableMap.of("Singers", table))
+        .rawDdl(buildDdl())
         .build();
   }
 
@@ -548,6 +547,39 @@ public final class SpannerDMLGeneratorTest {
     return ddlBuilder.build();
   }
 
+  private static Type parseSpannerType(String typeStr) {
+    if (typeStr.startsWith("ARRAY<") && typeStr.endsWith(">")) {
+      String inner = typeStr.substring(6, typeStr.length() - 1);
+      return Type.array(parseSpannerType(inner));
+    }
+    switch (typeStr) {
+      case "BOOL":
+        return Type.bool();
+      case "INT64":
+        return Type.int64();
+      case "FLOAT64":
+        return Type.float64();
+      case "FLOAT32":
+        return Type.float32();
+      case "STRING":
+        return Type.string();
+      case "BYTES":
+        return Type.bytes();
+      case "TIMESTAMP":
+        return Type.timestamp();
+      case "DATE":
+        return Type.date();
+      case "NUMERIC":
+        return Type.numeric();
+      case "JSON":
+        return Type.json();
+      case "STRUCT":
+        return Type.struct(Type.StructField.of("f1", Type.string()));
+      default:
+        return Type.string();
+    }
+  }
+
   private static SourceSchema buildSchemaWithSingleNonPkCol(String colName, String colType) {
     SourceColumn idCol =
         SourceColumn.builder(SRC_TYPE)
@@ -571,6 +603,7 @@ public final class SpannerDMLGeneratorTest {
     return SourceSchema.builder(SRC_TYPE)
         .databaseName("test-db")
         .tables(ImmutableMap.of("T", table))
+        .rawDdl(buildDdlWithSingleNonPkCol(colName, parseSpannerType(colType)))
         .build();
   }
 
@@ -1102,7 +1135,11 @@ public final class SpannerDMLGeneratorTest {
   public void missingTargetTableInSourceSchemaThrows() throws Exception {
     Ddl ddl = buildDdl();
     SourceSchema emptySchema =
-        SourceSchema.builder(SRC_TYPE).databaseName("test-db").tables(ImmutableMap.of()).build();
+        SourceSchema.builder(SRC_TYPE)
+            .databaseName("test-db")
+            .tables(ImmutableMap.of())
+            .rawDdl(ddl)
+            .build();
     ISchemaMapper mapper = buildIdentityMapper();
 
     assertThrows(
@@ -1203,6 +1240,7 @@ public final class SpannerDMLGeneratorTest {
                                     .isPrimaryKey(true)
                                     .build()))
                         .build()))
+            .rawDdl(ddl)
             .build();
     ISchemaMapper mapper = buildIdentityMapper();
     when(mapper.getSourceTableName("", "Albums")).thenReturn("Albums");
@@ -1582,6 +1620,7 @@ public final class SpannerDMLGeneratorTest {
         SourceSchema.builder(SRC_TYPE)
             .databaseName("test-db")
             .tables(ImmutableMap.of("Singers", noPkTable))
+            .rawDdl(ddl)
             .build();
     ISchemaMapper mapper = buildIdentityMapper();
 
@@ -1655,6 +1694,7 @@ public final class SpannerDMLGeneratorTest {
         SourceSchema.builder(SRC_TYPE)
             .databaseName("test-db")
             .tables(ImmutableMap.of("Singers", table))
+            .rawDdl(ddl)
             .build();
 
     ISchemaMapper mapper = buildIdentityMapper();
@@ -1722,6 +1762,7 @@ public final class SpannerDMLGeneratorTest {
         SourceSchema.builder(SRC_TYPE)
             .databaseName("test-db")
             .tables(ImmutableMap.of("Singers", table))
+            .rawDdl(ddl)
             .build();
 
     ISchemaMapper mapper = buildIdentityMapper();
@@ -2536,6 +2577,7 @@ public final class SpannerDMLGeneratorTest {
         SourceSchema.builder(SRC_TYPE)
             .databaseName("test-db")
             .tables(ImmutableMap.of("PkTable", table))
+            .rawDdl(ddl)
             .build();
 
     ISchemaMapper mapper = mock(ISchemaMapper.class);
@@ -2586,36 +2628,29 @@ public final class SpannerDMLGeneratorTest {
   }
 
   @Test
-  public void targetDdlIntegrationWithSourceProcessor() throws Exception {
+  public void targetDdlNullInSourceSchemaThrows() throws Exception {
     Ddl ddl = buildDdl();
-    SourceSchema schema = buildSourceSchema();
+    SourceSchema schemaWithoutDdl =
+        SourceSchema.builder(SRC_TYPE).databaseName("test-db").tables(ImmutableMap.of()).build();
     ISchemaMapper mapper = buildIdentityMapper();
 
-    SpannerSpToSrcSourceConnector connector =
-        (SpannerSpToSrcSourceConnector) SourceProcessorFactory.getSource(Constants.SOURCE_SPANNER);
-    connector.setTargetDdl(ddl);
-
-    try {
-      JSONObject newValues = new JSONObject("{\"FirstName\":\"Jane\",\"LastName\":\"Doe\"}");
-      JSONObject keyValues = new JSONObject("{\"SingerId\":\"42\"}");
-
-      DMLGeneratorResponse response =
-          new SpannerDMLGenerator()
-              .getDMLStatement(
-                  new DMLGeneratorRequest.Builder(
-                          "INSERT", "Singers", newValues, keyValues, "+00:00")
-                      .setSchemaMapper(mapper)
-                      .setDdl(ddl)
-                      .setSourceSchema(schema)
-                      .build());
-
-      SpannerMutationResponse mutResp = (SpannerMutationResponse) response;
-      assertNotNull(mutResp.getMutation());
-      assertEquals(
-          com.google.cloud.spanner.Key.of(42L).toString(), mutResp.getPrimaryKey().toString());
-    } finally {
-      connector.setTargetDdl(null);
-    }
+    InvalidDMLGenerationException ex =
+        assertThrows(
+            InvalidDMLGenerationException.class,
+            () ->
+                new SpannerDMLGenerator()
+                    .getDMLStatement(
+                        new DMLGeneratorRequest.Builder(
+                                "INSERT",
+                                "Singers",
+                                new JSONObject("{}"),
+                                new JSONObject("{\"SingerId\":\"1\"}"),
+                                "+00:00")
+                            .setSchemaMapper(mapper)
+                            .setDdl(ddl)
+                            .setSourceSchema(schemaWithoutDdl)
+                            .build()));
+    assertEquals("target spanner ddl could not be fetched.", ex.getMessage());
   }
 
   @Test
@@ -2818,36 +2853,290 @@ public final class SpannerDMLGeneratorTest {
   }
 
   @Test
-  public void sourceProcessorFactoryThrowsExceptionHandledGracefully() throws Exception {
+  public void targetDdlInvalidTypeInSourceSchemaThrows() throws Exception {
     Ddl ddl = buildDdl();
-    SourceSchema schema = buildSourceSchema();
+    SourceSchema schemaWithInvalidDdl =
+        SourceSchema.builder(SRC_TYPE)
+            .databaseName("test-db")
+            .tables(ImmutableMap.of())
+            .rawDdl("not-a-ddl-object")
+            .build();
     ISchemaMapper mapper = buildIdentityMapper();
 
-    Map<String, com.google.cloud.teleport.v2.templates.dbutils.processor.ISpToSrcSourceConnector>
-        originalMap = SourceProcessorFactory.getSourceMap();
-    try {
-      SourceProcessorFactory.setSourceMap(
-          new HashMap<>()); // Empty map triggers UnsupportedSourceException
+    InvalidDMLGenerationException ex =
+        assertThrows(
+            InvalidDMLGenerationException.class,
+            () ->
+                new SpannerDMLGenerator()
+                    .getDMLStatement(
+                        new DMLGeneratorRequest.Builder(
+                                "INSERT",
+                                "Singers",
+                                new JSONObject("{}"),
+                                new JSONObject("{\"SingerId\":\"1\"}"),
+                                "+00:00")
+                            .setSchemaMapper(mapper)
+                            .setDdl(ddl)
+                            .setSourceSchema(schemaWithInvalidDdl)
+                            .build()));
+    assertEquals("target spanner ddl could not be fetched.", ex.getMessage());
+  }
 
-      JSONObject newValues = new JSONObject("{\"FirstName\":\"John\",\"LastName\":\"Doe\"}");
-      JSONObject keyValues = new JSONObject("{\"SingerId\":\"42\"}");
+  @Test
+  public void insertWithRenamedPrimaryKeyColumn() throws Exception {
+    Ddl origDdl = buildDdl();
 
-      DMLGeneratorResponse response =
-          new SpannerDMLGenerator()
-              .getDMLStatement(
-                  new DMLGeneratorRequest.Builder(
-                          "INSERT", "Singers", newValues, keyValues, "+00:00")
-                      .setSchemaMapper(mapper)
-                      .setDdl(ddl)
-                      .setSourceSchema(schema)
-                      .build());
+    Ddl targetDdl =
+        Ddl.builder()
+            .createTable("TargetSingers")
+            .column("TargetSingerId")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("TargetFirstName")
+            .string()
+            .max()
+            .endColumn()
+            .primaryKey()
+            .asc("TargetSingerId")
+            .end()
+            .endTable()
+            .build();
 
-      SpannerMutationResponse mutResp = (SpannerMutationResponse) response;
-      assertNotNull(mutResp.getMutation());
-      assertEquals(
-          com.google.cloud.spanner.Key.of(42L).toString(), mutResp.getPrimaryKey().toString());
-    } finally {
-      SourceProcessorFactory.setSourceMap(originalMap);
-    }
+    SourceColumn pkCol =
+        SourceColumn.builder(SRC_TYPE)
+            .name("TargetSingerId")
+            .type("INT64")
+            .isPrimaryKey(true)
+            .isNullable(false)
+            .build();
+    SourceColumn nameCol =
+        SourceColumn.builder(SRC_TYPE)
+            .name("TargetFirstName")
+            .type("STRING")
+            .isNullable(true)
+            .build();
+
+    SourceTable targetTable =
+        SourceTable.builder(SRC_TYPE)
+            .name("TargetSingers")
+            .columns(ImmutableList.of(pkCol, nameCol))
+            .primaryKeyColumns(ImmutableList.of("TargetSingerId"))
+            .foreignKeys(ImmutableList.of())
+            .indexes(ImmutableList.of())
+            .build();
+
+    SourceSchema targetSchema =
+        SourceSchema.builder(SRC_TYPE)
+            .databaseName("test-db")
+            .tables(ImmutableMap.of("TargetSingers", targetTable))
+            .rawDdl(targetDdl)
+            .build();
+
+    ISchemaMapper mapper = mock(ISchemaMapper.class);
+    when(mapper.getSourceTableName("", "Singers")).thenReturn("TargetSingers");
+    when(mapper.getSpannerColumnName("", "TargetSingers", "TargetSingerId")).thenReturn("SingerId");
+    when(mapper.getSpannerColumnName("", "TargetSingers", "TargetFirstName"))
+        .thenReturn("FirstName");
+    when(mapper.getSourceColumnName("", "Singers", "SingerId")).thenReturn("TargetSingerId");
+    when(mapper.getSourceColumnName("", "Singers", "FirstName")).thenReturn("TargetFirstName");
+
+    JSONObject newValues = new JSONObject("{\"FirstName\":\"John\"}");
+    JSONObject keyValues = new JSONObject("{\"SingerId\":\"42\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("INSERT", "Singers", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(origDdl)
+                    .setSourceSchema(targetSchema)
+                    .build());
+
+    assertNotNull(response);
+    SpannerMutationResponse mutResp = (SpannerMutationResponse) response;
+    Mutation mutation = mutResp.getMutation();
+    assertEquals(Mutation.Op.INSERT_OR_UPDATE, mutation.getOperation());
+    assertEquals("TargetSingers", mutation.getTable());
+    assertEquals(42L, mutation.asMap().get("TargetSingerId").getInt64());
+    assertEquals("John", mutation.asMap().get("TargetFirstName").getString());
+    assertEquals(
+        com.google.cloud.spanner.Key.of(42L).toString(), mutResp.getPrimaryKey().toString());
+  }
+
+  @Test
+  public void deleteWithRenamedPrimaryKeyColumn() throws Exception {
+    Ddl origDdl = buildDdl();
+
+    Ddl targetDdl =
+        Ddl.builder()
+            .createTable("TargetSingers")
+            .column("TargetSingerId")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("FirstName")
+            .string()
+            .max()
+            .endColumn()
+            .primaryKey()
+            .asc("TargetSingerId")
+            .end()
+            .endTable()
+            .build();
+
+    SourceColumn pkCol =
+        SourceColumn.builder(SRC_TYPE)
+            .name("TargetSingerId")
+            .type("INT64")
+            .isPrimaryKey(true)
+            .isNullable(false)
+            .build();
+    SourceColumn nameCol =
+        SourceColumn.builder(SRC_TYPE).name("FirstName").type("STRING").isNullable(true).build();
+
+    SourceTable targetTable =
+        SourceTable.builder(SRC_TYPE)
+            .name("TargetSingers")
+            .columns(ImmutableList.of(pkCol, nameCol))
+            .primaryKeyColumns(ImmutableList.of("TargetSingerId"))
+            .foreignKeys(ImmutableList.of())
+            .indexes(ImmutableList.of())
+            .build();
+
+    SourceSchema targetSchema =
+        SourceSchema.builder(SRC_TYPE)
+            .databaseName("test-db")
+            .tables(ImmutableMap.of("TargetSingers", targetTable))
+            .rawDdl(targetDdl)
+            .build();
+
+    ISchemaMapper mapper = mock(ISchemaMapper.class);
+    when(mapper.getSourceTableName("", "Singers")).thenReturn("TargetSingers");
+    when(mapper.getSpannerColumnName("", "TargetSingers", "TargetSingerId")).thenReturn("SingerId");
+    when(mapper.getSpannerColumnName("", "TargetSingers", "FirstName")).thenReturn("FirstName");
+    when(mapper.getSourceColumnName("", "Singers", "SingerId")).thenReturn("TargetSingerId");
+    when(mapper.getSourceColumnName("", "Singers", "FirstName")).thenReturn("FirstName");
+
+    JSONObject newValues = new JSONObject("{}");
+    JSONObject keyValues = new JSONObject("{\"SingerId\":\"42\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("DELETE", "Singers", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(origDdl)
+                    .setSourceSchema(targetSchema)
+                    .build());
+
+    assertNotNull(response);
+    SpannerMutationResponse mutResp = (SpannerMutationResponse) response;
+    Mutation mutation = mutResp.getMutation();
+    assertEquals(Mutation.Op.DELETE, mutation.getOperation());
+    assertEquals("TargetSingers", mutation.getTable());
+    assertEquals(
+        com.google.cloud.spanner.Key.of(42L).toString(), mutResp.getPrimaryKey().toString());
+    assertEquals(
+        com.google.cloud.spanner.Key.of(42L).toString(),
+        mutation.getKeySet().getKeys().iterator().next().toString());
+  }
+
+  @Test
+  public void deleteWithRenamedCompositePrimaryKey() throws Exception {
+    Ddl origDdl =
+        Ddl.builder()
+            .createTable("Albums")
+            .column("SingerId")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("AlbumId")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("Title")
+            .string()
+            .max()
+            .endColumn()
+            .primaryKey()
+            .asc("SingerId")
+            .asc("AlbumId")
+            .end()
+            .endTable()
+            .build();
+
+    Ddl targetDdl =
+        Ddl.builder()
+            .createTable("TargetAlbums")
+            .column("TargetSingerId")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("TargetAlbumId")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("Title")
+            .string()
+            .max()
+            .endColumn()
+            .primaryKey()
+            .asc("TargetSingerId")
+            .asc("TargetAlbumId")
+            .end()
+            .endTable()
+            .build();
+
+    SourceSchema targetSchema =
+        SourceSchema.builder(SRC_TYPE)
+            .databaseName("test-db")
+            .tables(
+                ImmutableMap.of(
+                    "TargetAlbums",
+                    SourceTable.builder(SRC_TYPE)
+                        .name("TargetAlbums")
+                        .primaryKeyColumns(ImmutableList.of("TargetSingerId", "TargetAlbumId"))
+                        .columns(
+                            ImmutableList.of(
+                                SourceColumn.builder(SRC_TYPE)
+                                    .name("TargetSingerId")
+                                    .type("INT64")
+                                    .isPrimaryKey(true)
+                                    .build(),
+                                SourceColumn.builder(SRC_TYPE)
+                                    .name("TargetAlbumId")
+                                    .type("INT64")
+                                    .isPrimaryKey(true)
+                                    .build()))
+                        .build()))
+            .rawDdl(targetDdl)
+            .build();
+
+    ISchemaMapper mapper = mock(ISchemaMapper.class);
+    when(mapper.getSourceTableName("", "Albums")).thenReturn("TargetAlbums");
+    when(mapper.getSpannerColumnName("", "TargetAlbums", "TargetSingerId")).thenReturn("SingerId");
+    when(mapper.getSpannerColumnName("", "TargetAlbums", "TargetAlbumId")).thenReturn("AlbumId");
+    when(mapper.getSourceColumnName("", "Albums", "SingerId")).thenReturn("TargetSingerId");
+    when(mapper.getSourceColumnName("", "Albums", "AlbumId")).thenReturn("TargetAlbumId");
+
+    JSONObject newValues = new JSONObject("{}");
+    JSONObject keyValues = new JSONObject("{\"SingerId\":\"1\", \"AlbumId\":\"2\"}");
+
+    DMLGeneratorResponse response =
+        new SpannerDMLGenerator()
+            .getDMLStatement(
+                new DMLGeneratorRequest.Builder("DELETE", "Albums", newValues, keyValues, "+00:00")
+                    .setSchemaMapper(mapper)
+                    .setDdl(origDdl)
+                    .setSourceSchema(targetSchema)
+                    .build());
+
+    SpannerMutationResponse mutResp = (SpannerMutationResponse) response;
+    Mutation mutation = mutResp.getMutation();
+    assertEquals(Mutation.Op.DELETE, mutation.getOperation());
+    assertEquals("TargetAlbums", mutation.getTable());
+    assertEquals(
+        com.google.cloud.spanner.Key.of(1L, 2L).toString(), mutResp.getPrimaryKey().toString());
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSpToSrcSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSpToSrcSourceConnectorTest.java
@@ -140,4 +140,40 @@ public class SpannerSpToSrcSourceConnectorTest {
   public void testValidate_InvalidShardType_Failure() throws Exception {
     connector.validate(List.of(mockGenericShard), null);
   }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testValidate_EmptyShards_Failure() throws Exception {
+    connector.validate(List.of(), null);
+  }
+
+  @Test
+  public void testDefaultConstructor() {
+    SpannerSpToSrcSourceConnector defaultConnector = new SpannerSpToSrcSourceConnector();
+    assertNotNull(defaultConnector.getConnectionHelper());
+    assertNotNull(defaultConnector.getDmlGenerator());
+  }
+
+  @Test
+  public void testGetConnectionUrl_Success() {
+    when(mockSpannerShard.getProjectId()).thenReturn("p");
+    when(mockSpannerShard.getInstanceId()).thenReturn("i");
+    when(mockSpannerShard.getDatabaseId()).thenReturn("d");
+
+    assertEquals("p/i/d", connector.getConnectionUrl(mockSpannerShard));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetConnectionUrl_InvalidShardTypeThrows() {
+    connector.getConnectionUrl(mockGenericShard);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetConnectionUrl_NullShardThrows() {
+    connector.getConnectionUrl(null);
+  }
+
+  @Test
+  public void testClassifyExceptionReturnsNull() {
+    org.junit.Assert.assertNull(connector.classifyException(new RuntimeException("test")));
+  }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSpToSrcSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSpToSrcSourceConnectorTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -112,45 +111,8 @@ public class SpannerSpToSrcSourceConnectorTest {
   }
 
   @Test
-  public void testValidate_Colocation_Success() throws Exception {
-    org.apache.beam.sdk.options.PipelineOptions mockPipelineOptions =
-        mock(org.apache.beam.sdk.options.PipelineOptions.class);
-    com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options mockOptions =
-        mock(com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options.class);
-    when(mockPipelineOptions.as(
-            com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options.class))
-        .thenReturn(mockOptions);
-
-    when(mockOptions.getSpannerProjectId()).thenReturn("p1");
-    when(mockOptions.getMetadataInstance()).thenReturn("i1");
-    when(mockOptions.getMetadataDatabase()).thenReturn("d1");
-
-    when(mockSpannerShard.getProjectId()).thenReturn("p1");
-    when(mockSpannerShard.getInstanceId()).thenReturn("i1");
-    when(mockSpannerShard.getDatabaseId()).thenReturn("d1");
-
-    connector.validate(List.of(mockSpannerShard), mockPipelineOptions);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testValidate_Colocation_Failure() throws Exception {
-    org.apache.beam.sdk.options.PipelineOptions mockPipelineOptions =
-        mock(org.apache.beam.sdk.options.PipelineOptions.class);
-    com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options mockOptions =
-        mock(com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options.class);
-    when(mockPipelineOptions.as(
-            com.google.cloud.teleport.v2.templates.SpannerToSourceDb.Options.class))
-        .thenReturn(mockOptions);
-
-    when(mockOptions.getSpannerProjectId()).thenReturn("p1");
-    when(mockOptions.getMetadataInstance()).thenReturn("i1");
-    when(mockOptions.getMetadataDatabase()).thenReturn("d1");
-
-    when(mockSpannerShard.getProjectId()).thenReturn("p2");
-    when(mockSpannerShard.getInstanceId()).thenReturn("i1");
-    when(mockSpannerShard.getDatabaseId()).thenReturn("d1");
-
-    connector.validate(List.of(mockSpannerShard), mockPipelineOptions);
+  public void testValidate_Success() throws Exception {
+    connector.validate(List.of(mockSpannerShard), null);
   }
 
   @Test

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSpToSrcSourceConnectorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerSpToSrcSourceConnectorTest.java
@@ -72,6 +72,12 @@ public class SpannerSpToSrcSourceConnectorTest {
     when(mockSpannerShard.getInstanceId()).thenReturn("my-instance");
     when(mockSpannerShard.getDatabaseId()).thenReturn("my-database");
 
+    com.google.cloud.teleport.v2.spanner.ddl.Ddl ddl =
+        com.google.cloud.teleport.v2.spanner.ddl.Ddl.builder().build();
+    connector.setTargetDdl(ddl);
+
+    assertEquals(ddl, connector.getTargetDdl());
+
     IDao dao = connector.getDao(mockSpannerShard);
     assertNotNull(dao);
     assertTrue(dao instanceof SpannerTargetDao);

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDaoTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDaoTest.java
@@ -70,7 +70,7 @@ public class SpannerTargetDaoTest {
             });
 
     Mutation mutation = Mutation.newInsertOrUpdateBuilder("T").set("Id").to(1L).build();
-    SpannerMutationResponse response = new SpannerMutationResponse(mutation);
+    SpannerMutationResponse response = new SpannerMutationResponse(mutation, null);
 
     SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper);
     dao.write(response, null);
@@ -129,7 +129,7 @@ public class SpannerTargetDaoTest {
             });
 
     Mutation mutation = Mutation.newInsertOrUpdateBuilder("T").set("Id").to(1L).build();
-    SpannerMutationResponse response = new SpannerMutationResponse(mutation);
+    SpannerMutationResponse response = new SpannerMutationResponse(mutation, null);
 
     com.google.cloud.teleport.v2.templates.dbutils.dao.source.TransactionalCheck mockCheck =
         mock(com.google.cloud.teleport.v2.templates.dbutils.dao.source.TransactionalCheck.class);
@@ -161,7 +161,7 @@ public class SpannerTargetDaoTest {
     when(connectionHelper.getConnection(CONNECTION_KEY)).thenReturn(null);
 
     Mutation mutation = Mutation.newInsertOrUpdateBuilder("T").set("Id").to(1L).build();
-    SpannerMutationResponse response = new SpannerMutationResponse(mutation);
+    SpannerMutationResponse response = new SpannerMutationResponse(mutation, null);
 
     SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper);
     assertThrows(

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDaoTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDaoTest.java
@@ -153,4 +153,81 @@ public class SpannerTargetDaoTest {
     SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper);
     assertThrows(IllegalArgumentException.class, () -> dao.write(wrongResponse, null));
   }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void writeThrowsWhenDatabaseClientIsNull() throws Exception {
+    IConnectionHelper<DatabaseClient> connectionHelper = mock(IConnectionHelper.class);
+    when(connectionHelper.getConnection(CONNECTION_KEY)).thenReturn(null);
+
+    Mutation mutation = Mutation.newInsertOrUpdateBuilder("T").set("Id").to(1L).build();
+    SpannerMutationResponse response = new SpannerMutationResponse(mutation);
+
+    SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper);
+    assertThrows(
+        com.google.cloud.teleport.v2.spanner.migrations.exceptions.ConnectionException.class,
+        () -> dao.write(response, null));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void writeSkipsExclusiveLockReadWhenTableNotInDdl() throws Exception {
+    IConnectionHelper<DatabaseClient> connectionHelper = mock(IConnectionHelper.class);
+    DatabaseClient mockClient = mock(DatabaseClient.class);
+    TransactionRunner mockRunner = mock(TransactionRunner.class);
+    TransactionContext mockTxnContext = mock(TransactionContext.class);
+
+    when(connectionHelper.getConnection(CONNECTION_KEY)).thenReturn(mockClient);
+    when(mockClient.readWriteTransaction(any())).thenReturn(mockRunner);
+    when(mockRunner.run(any()))
+        .thenAnswer(
+            invocation -> {
+              TransactionRunner.TransactionCallable<Void> callable = invocation.getArgument(0);
+              return callable.run(mockTxnContext);
+            });
+
+    Ddl emptyDdl = Ddl.builder().build();
+    Key key = Key.of(1L);
+    Mutation mutation = Mutation.newInsertOrUpdateBuilder("T").set("Id").to(1L).build();
+    SpannerMutationResponse response = new SpannerMutationResponse(mutation, key);
+
+    SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper, emptyDdl);
+    dao.write(response, null);
+
+    verify(mockTxnContext, org.mockito.Mockito.never()).executeQuery(any(Statement.class));
+    verify(mockTxnContext).buffer(ImmutableList.of(mutation));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void writeHandlesEmptyResultSetInExclusiveLockRead() throws Exception {
+    IConnectionHelper<DatabaseClient> connectionHelper = mock(IConnectionHelper.class);
+    DatabaseClient mockClient = mock(DatabaseClient.class);
+    TransactionRunner mockRunner = mock(TransactionRunner.class);
+    TransactionContext mockTxnContext = mock(TransactionContext.class);
+    ResultSet mockResultSet = mock(ResultSet.class);
+
+    when(connectionHelper.getConnection(CONNECTION_KEY)).thenReturn(mockClient);
+    when(mockClient.readWriteTransaction(any())).thenReturn(mockRunner);
+    when(mockRunner.run(any()))
+        .thenAnswer(
+            invocation -> {
+              TransactionRunner.TransactionCallable<Void> callable = invocation.getArgument(0);
+              return callable.run(mockTxnContext);
+            });
+    when(mockTxnContext.executeQuery(any(Statement.class))).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(false);
+
+    Ddl ddl = buildTestDdl();
+    Key key = Key.of(1L);
+    Mutation mutation = Mutation.newInsertOrUpdateBuilder("T").set("Id").to(1L).build();
+    SpannerMutationResponse response = new SpannerMutationResponse(mutation, key);
+
+    SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper, ddl);
+    dao.write(response, null);
+
+    verify(mockTxnContext).executeQuery(any(Statement.class));
+    verify(mockResultSet, org.mockito.Mockito.never()).getCurrentRowAsStruct();
+    verify(mockTxnContext).buffer(ImmutableList.of(mutation));
+  }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDaoTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDaoTest.java
@@ -16,12 +16,15 @@
 package com.google.cloud.teleport.v2.templates.source.spanner;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.Dialect;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.ResultSet;
@@ -37,6 +40,7 @@ import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
 
 @RunWith(JUnit4.class)
 public class SpannerTargetDaoTest {
@@ -62,6 +66,7 @@ public class SpannerTargetDaoTest {
 
     when(connectionHelper.getConnection(CONNECTION_KEY)).thenReturn(mockClient);
     when(mockClient.readWriteTransaction(any())).thenReturn(mockRunner);
+    when(mockRunner.allowNestedTransaction()).thenReturn(mockRunner);
     when(mockRunner.run(any()))
         .thenAnswer(
             invocation -> {
@@ -89,6 +94,7 @@ public class SpannerTargetDaoTest {
 
     when(connectionHelper.getConnection(CONNECTION_KEY)).thenReturn(mockClient);
     when(mockClient.readWriteTransaction(any())).thenReturn(mockRunner);
+    when(mockRunner.allowNestedTransaction()).thenReturn(mockRunner);
     when(mockRunner.run(any()))
         .thenAnswer(
             invocation -> {
@@ -121,6 +127,7 @@ public class SpannerTargetDaoTest {
 
     when(connectionHelper.getConnection(CONNECTION_KEY)).thenReturn(mockClient);
     when(mockClient.readWriteTransaction(any())).thenReturn(mockRunner);
+    when(mockRunner.allowNestedTransaction()).thenReturn(mockRunner);
     when(mockRunner.run(any()))
         .thenAnswer(
             invocation -> {
@@ -179,6 +186,7 @@ public class SpannerTargetDaoTest {
 
     when(connectionHelper.getConnection(CONNECTION_KEY)).thenReturn(mockClient);
     when(mockClient.readWriteTransaction(any())).thenReturn(mockRunner);
+    when(mockRunner.allowNestedTransaction()).thenReturn(mockRunner);
     when(mockRunner.run(any()))
         .thenAnswer(
             invocation -> {
@@ -194,7 +202,7 @@ public class SpannerTargetDaoTest {
     SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper, emptyDdl);
     dao.write(response, null);
 
-    verify(mockTxnContext, org.mockito.Mockito.never()).executeQuery(any(Statement.class));
+    verify(mockTxnContext, never()).executeQuery(any(Statement.class));
     verify(mockTxnContext).buffer(ImmutableList.of(mutation));
   }
 
@@ -209,6 +217,7 @@ public class SpannerTargetDaoTest {
 
     when(connectionHelper.getConnection(CONNECTION_KEY)).thenReturn(mockClient);
     when(mockClient.readWriteTransaction(any())).thenReturn(mockRunner);
+    when(mockRunner.allowNestedTransaction()).thenReturn(mockRunner);
     when(mockRunner.run(any()))
         .thenAnswer(
             invocation -> {
@@ -227,7 +236,137 @@ public class SpannerTargetDaoTest {
     dao.write(response, null);
 
     verify(mockTxnContext).executeQuery(any(Statement.class));
-    verify(mockResultSet, org.mockito.Mockito.never()).getCurrentRowAsStruct();
+    verify(mockResultSet, never()).getCurrentRowAsStruct();
     verify(mockTxnContext).buffer(ImmutableList.of(mutation));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testReadDataTableRowWithExclusiveLock_tableNotFound() {
+    IConnectionHelper<DatabaseClient> connectionHelper = mock(IConnectionHelper.class);
+    TransactionContext mockTxnContext = mock(TransactionContext.class);
+
+    Ddl ddl = buildTestDdl();
+    SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper, ddl);
+
+    dao.readDataTableRowWithExclusiveLock(mockTxnContext, "NonExistentTable", Key.of(1L), ddl);
+
+    verify(mockTxnContext, never()).executeQuery(any(Statement.class));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testReadDataTableRowWithExclusiveLock_rowFound() {
+    IConnectionHelper<DatabaseClient> connectionHelper = mock(IConnectionHelper.class);
+    TransactionContext mockTxnContext = mock(TransactionContext.class);
+    ResultSet mockResultSet = mock(ResultSet.class);
+
+    ArgumentCaptor<Statement> statementCaptor = ArgumentCaptor.forClass(Statement.class);
+    when(mockTxnContext.executeQuery(statementCaptor.capture())).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true);
+
+    Ddl ddl = buildTestDdl();
+    SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper, ddl);
+
+    dao.readDataTableRowWithExclusiveLock(mockTxnContext, "T", Key.of(1L), ddl);
+
+    Statement capturedStatement = statementCaptor.getValue();
+    assertTrue(capturedStatement.getSql().contains("LOCK_SCANNED_RANGES=exclusive"));
+    assertTrue(capturedStatement.getSql().contains("FROM T"));
+    verify(mockResultSet).getCurrentRowAsStruct();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testReadDataTableRowWithExclusiveLock_rowNotFound() {
+    IConnectionHelper<DatabaseClient> connectionHelper = mock(IConnectionHelper.class);
+    TransactionContext mockTxnContext = mock(TransactionContext.class);
+    ResultSet mockResultSet = mock(ResultSet.class);
+
+    when(mockTxnContext.executeQuery(any(Statement.class))).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(false);
+
+    Ddl ddl = buildTestDdl();
+    SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper, ddl);
+
+    dao.readDataTableRowWithExclusiveLock(mockTxnContext, "T", Key.of(1L), ddl);
+
+    verify(mockTxnContext).executeQuery(any(Statement.class));
+    verify(mockResultSet, never()).getCurrentRowAsStruct();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testReadDataTableRowWithExclusiveLock_compositePrimaryKey() {
+    IConnectionHelper<DatabaseClient> connectionHelper = mock(IConnectionHelper.class);
+    TransactionContext mockTxnContext = mock(TransactionContext.class);
+    ResultSet mockResultSet = mock(ResultSet.class);
+
+    Ddl compositeDdl =
+        Ddl.builder()
+            .createTable("Users")
+            .column("UserId")
+            .int64()
+            .notNull()
+            .endColumn()
+            .column("OrgId")
+            .string()
+            .size(50)
+            .notNull()
+            .endColumn()
+            .primaryKey()
+            .asc("UserId")
+            .asc("OrgId")
+            .end()
+            .endTable()
+            .build();
+
+    ArgumentCaptor<Statement> statementCaptor = ArgumentCaptor.forClass(Statement.class);
+    when(mockTxnContext.executeQuery(statementCaptor.capture())).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true);
+
+    SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper, compositeDdl);
+
+    dao.readDataTableRowWithExclusiveLock(
+        mockTxnContext, "Users", Key.of(100L, "org-1"), compositeDdl);
+
+    Statement capturedStatement = statementCaptor.getValue();
+    assertTrue(capturedStatement.getSql().contains("UserId=@UserId"));
+    assertTrue(capturedStatement.getSql().contains("OrgId=@OrgId"));
+    verify(mockResultSet).getCurrentRowAsStruct();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testReadDataTableRowWithExclusiveLock_postgresDialect() {
+    IConnectionHelper<DatabaseClient> connectionHelper = mock(IConnectionHelper.class);
+    TransactionContext mockTxnContext = mock(TransactionContext.class);
+    ResultSet mockResultSet = mock(ResultSet.class);
+
+    Ddl pgDdl =
+        Ddl.builder(Dialect.POSTGRESQL)
+            .createTable("Users")
+            .column("id")
+            .pgInt8()
+            .notNull()
+            .endColumn()
+            .primaryKey()
+            .asc("id")
+            .end()
+            .endTable()
+            .build();
+
+    ArgumentCaptor<Statement> statementCaptor = ArgumentCaptor.forClass(Statement.class);
+    when(mockTxnContext.executeQuery(statementCaptor.capture())).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true);
+
+    SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper, pgDdl);
+
+    dao.readDataTableRowWithExclusiveLock(mockTxnContext, "Users", Key.of(42L), pgDdl);
+
+    Statement capturedStatement = statementCaptor.getValue();
+    assertTrue(capturedStatement.getSql().contains("/*@ LOCK_SCANNED_RANGES=exclusive */"));
+    assertTrue(capturedStatement.getSql().contains("FROM \"Users\""));
+    verify(mockResultSet).getCurrentRowAsStruct();
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDaoTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDaoTest.java
@@ -53,14 +53,22 @@ public class SpannerTargetDaoTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void transactionalCheckNotSupportedThrows() {
+  public void transactionalCheckIsExecuted() throws Exception {
     IConnectionHelper<DatabaseClient> connectionHelper = mock(IConnectionHelper.class);
-    SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper);
+    DatabaseClient mockClient = mock(DatabaseClient.class);
+    when(connectionHelper.getConnection(CONNECTION_KEY)).thenReturn(mockClient);
 
     Mutation mutation = Mutation.newInsertOrUpdateBuilder("T").set("Id").to(1L).build();
     SpannerMutationResponse response = new SpannerMutationResponse(mutation);
 
-    assertThrows(UnsupportedOperationException.class, () -> dao.write(response, () -> {}));
+    com.google.cloud.teleport.v2.templates.dbutils.dao.source.TransactionalCheck mockCheck =
+        mock(com.google.cloud.teleport.v2.templates.dbutils.dao.source.TransactionalCheck.class);
+
+    SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper);
+    dao.write(response, mockCheck);
+
+    verify(mockCheck).check();
+    verify(mockClient).writeAtLeastOnce(anyIterable());
   }
 
   @Test
@@ -86,33 +94,13 @@ public class SpannerTargetDaoTest {
     Mutation mutation = Mutation.newInsertOrUpdateBuilder("T").set("Id").to(1L).build();
     SpannerMutationResponse response = new SpannerMutationResponse(mutation);
 
-    SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper);
-    dao.write(response, null, mockTxnContext);
+    com.google.cloud.teleport.v2.templates.dbutils.dao.source.TransactionalCheck mockCheck =
+        mock(com.google.cloud.teleport.v2.templates.dbutils.dao.source.TransactionalCheck.class);
 
+    SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper);
+    dao.write(response, mockCheck, mockTxnContext);
+
+    verify(mockCheck).check();
     verify(mockTxnContext).buffer(mutation);
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  public void testWriteThrowsOnTransactionalCheck() {
-    IConnectionHelper<DatabaseClient> connectionHelper = mock(IConnectionHelper.class);
-    SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper);
-    assertThrows(
-        UnsupportedOperationException.class,
-        () ->
-            dao.write(
-                new SpannerMutationResponse(null),
-                mock(
-                    com.google.cloud.teleport.v2.templates.dbutils.dao.source.TransactionalCheck
-                        .class)));
-    assertThrows(
-        UnsupportedOperationException.class,
-        () ->
-            dao.write(
-                new SpannerMutationResponse(null),
-                mock(
-                    com.google.cloud.teleport.v2.templates.dbutils.dao.source.TransactionalCheck
-                        .class),
-                new Object()));
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDaoTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/spanner/SpannerTargetDaoTest.java
@@ -16,16 +16,24 @@
 package com.google.cloud.teleport.v2.templates.source.spanner;
 
 import static org.junit.Assert.assertThrows;
-import static org.mockito.ArgumentMatchers.anyIterable;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.TransactionContext;
+import com.google.cloud.spanner.TransactionRunner;
+import com.google.cloud.teleport.v2.spanner.ddl.Ddl;
+import com.google.cloud.teleport.v2.spanner.ddl.Table;
 import com.google.cloud.teleport.v2.spanner.migrations.connection.IConnectionHelper;
 import com.google.cloud.teleport.v2.templates.models.DMLGeneratorResponse;
 import com.google.cloud.teleport.v2.templates.models.SpannerMutationResponse;
+import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -35,12 +43,31 @@ public class SpannerTargetDaoTest {
 
   private static final String CONNECTION_KEY = "my-project/my-instance/my-db";
 
+  private static Ddl buildTestDdl() {
+    Ddl.Builder builder = Ddl.builder();
+    Table.Builder tableBuilder = builder.createTable("T");
+    tableBuilder.column("Id").int64().notNull().endColumn();
+    tableBuilder.primaryKey().asc("Id").end();
+    tableBuilder.endTable();
+    return builder.build();
+  }
+
   @Test
   @SuppressWarnings("unchecked")
   public void writeDispatchesMutationToDatabaseClient() throws Exception {
     IConnectionHelper<DatabaseClient> connectionHelper = mock(IConnectionHelper.class);
     DatabaseClient mockClient = mock(DatabaseClient.class);
+    TransactionRunner mockRunner = mock(TransactionRunner.class);
+    TransactionContext mockTxnContext = mock(TransactionContext.class);
+
     when(connectionHelper.getConnection(CONNECTION_KEY)).thenReturn(mockClient);
+    when(mockClient.readWriteTransaction(any())).thenReturn(mockRunner);
+    when(mockRunner.run(any()))
+        .thenAnswer(
+            invocation -> {
+              TransactionRunner.TransactionCallable<Void> callable = invocation.getArgument(0);
+              return callable.run(mockTxnContext);
+            });
 
     Mutation mutation = Mutation.newInsertOrUpdateBuilder("T").set("Id").to(1L).build();
     SpannerMutationResponse response = new SpannerMutationResponse(mutation);
@@ -48,7 +75,40 @@ public class SpannerTargetDaoTest {
     SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper);
     dao.write(response, null);
 
-    verify(mockClient).writeAtLeastOnce(anyIterable());
+    verify(mockTxnContext).buffer(ImmutableList.of(mutation));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void writeExecutesExclusiveLockReadWhenDdlAndKeyPresent() throws Exception {
+    IConnectionHelper<DatabaseClient> connectionHelper = mock(IConnectionHelper.class);
+    DatabaseClient mockClient = mock(DatabaseClient.class);
+    TransactionRunner mockRunner = mock(TransactionRunner.class);
+    TransactionContext mockTxnContext = mock(TransactionContext.class);
+    ResultSet mockResultSet = mock(ResultSet.class);
+
+    when(connectionHelper.getConnection(CONNECTION_KEY)).thenReturn(mockClient);
+    when(mockClient.readWriteTransaction(any())).thenReturn(mockRunner);
+    when(mockRunner.run(any()))
+        .thenAnswer(
+            invocation -> {
+              TransactionRunner.TransactionCallable<Void> callable = invocation.getArgument(0);
+              return callable.run(mockTxnContext);
+            });
+    when(mockTxnContext.executeQuery(any(Statement.class))).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true);
+
+    Ddl ddl = buildTestDdl();
+    Key key = Key.of(1L);
+    Mutation mutation = Mutation.newInsertOrUpdateBuilder("T").set("Id").to(1L).build();
+    SpannerMutationResponse response = new SpannerMutationResponse(mutation, key);
+
+    SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper, ddl);
+    dao.write(response, null);
+
+    verify(mockTxnContext).executeQuery(any(Statement.class));
+    verify(mockResultSet).getCurrentRowAsStruct();
+    verify(mockTxnContext).buffer(ImmutableList.of(mutation));
   }
 
   @Test
@@ -56,7 +116,17 @@ public class SpannerTargetDaoTest {
   public void transactionalCheckIsExecuted() throws Exception {
     IConnectionHelper<DatabaseClient> connectionHelper = mock(IConnectionHelper.class);
     DatabaseClient mockClient = mock(DatabaseClient.class);
+    TransactionRunner mockRunner = mock(TransactionRunner.class);
+    TransactionContext mockTxnContext = mock(TransactionContext.class);
+
     when(connectionHelper.getConnection(CONNECTION_KEY)).thenReturn(mockClient);
+    when(mockClient.readWriteTransaction(any())).thenReturn(mockRunner);
+    when(mockRunner.run(any()))
+        .thenAnswer(
+            invocation -> {
+              TransactionRunner.TransactionCallable<Void> callable = invocation.getArgument(0);
+              return callable.run(mockTxnContext);
+            });
 
     Mutation mutation = Mutation.newInsertOrUpdateBuilder("T").set("Id").to(1L).build();
     SpannerMutationResponse response = new SpannerMutationResponse(mutation);
@@ -68,7 +138,7 @@ public class SpannerTargetDaoTest {
     dao.write(response, mockCheck);
 
     verify(mockCheck).check();
-    verify(mockClient).writeAtLeastOnce(anyIterable());
+    verify(mockTxnContext).buffer(ImmutableList.of(mutation));
   }
 
   @Test
@@ -82,25 +152,5 @@ public class SpannerTargetDaoTest {
 
     SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper);
     assertThrows(IllegalArgumentException.class, () -> dao.write(wrongResponse, null));
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  public void testWriteBuffersMutationWhenTransactionContextProvided() throws Exception {
-    IConnectionHelper<DatabaseClient> connectionHelper = mock(IConnectionHelper.class);
-    com.google.cloud.spanner.TransactionContext mockTxnContext =
-        mock(com.google.cloud.spanner.TransactionContext.class);
-
-    Mutation mutation = Mutation.newInsertOrUpdateBuilder("T").set("Id").to(1L).build();
-    SpannerMutationResponse response = new SpannerMutationResponse(mutation);
-
-    com.google.cloud.teleport.v2.templates.dbutils.dao.source.TransactionalCheck mockCheck =
-        mock(com.google.cloud.teleport.v2.templates.dbutils.dao.source.TransactionalCheck.class);
-
-    SpannerTargetDao dao = new SpannerTargetDao(CONNECTION_KEY, connectionHelper);
-    dao.write(response, mockCheck, mockTxnContext);
-
-    verify(mockCheck).check();
-    verify(mockTxnContext).buffer(mutation);
   }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFnTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFnTest.java
@@ -370,8 +370,7 @@ public class SourceWriterFnTest {
 
     sourceWriterFn.processElement(processContext);
 
-    // Verify that IDao.write was called with a TransactionContext
-    verify(mockSpannerTargetDao).write(any(), any(), any());
+    verify(mockSpannerTargetDao).write(any(), any());
   }
 
   @Test
@@ -431,7 +430,7 @@ public class SourceWriterFnTest {
 
     sourceWriterFn.processElement(processContext);
 
-    verify(mockSpannerTargetDao).write(any(), any(), any());
+    verify(mockSpannerTargetDao).write(any(), any());
   }
 
   @Test

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFnTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFnTest.java
@@ -343,7 +343,8 @@ public class SourceWriterFnTest {
     when(mockSourceProcessor.getDmlGenerator()).thenReturn(mockDMLGenerator);
     when(mockDMLGenerator.getDMLStatement(any()))
         .thenReturn(
-            new SpannerMutationResponse(Mockito.mock(com.google.cloud.spanner.Mutation.class)));
+            new SpannerMutationResponse(
+                Mockito.mock(com.google.cloud.spanner.Mutation.class), null));
 
     SourceWriterFn sourceWriterFn =
         new SourceWriterFn(
@@ -404,7 +405,8 @@ public class SourceWriterFnTest {
     when(mockSourceProcessor.getDmlGenerator()).thenReturn(mockDMLGenerator);
     when(mockDMLGenerator.getDMLStatement(any()))
         .thenReturn(
-            new SpannerMutationResponse(Mockito.mock(com.google.cloud.spanner.Mutation.class)));
+            new SpannerMutationResponse(
+                Mockito.mock(com.google.cloud.spanner.Mutation.class), null));
 
     SourceWriterFn sourceWriterFn =
         new SourceWriterFn(

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFnTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/transforms/SourceWriterFnTest.java
@@ -130,6 +130,7 @@ public class SourceWriterFnTest {
     when(mockDaoMap.get(any())).thenReturn(mockSqlDao);
     when(mockSpannerDao.getDatabaseClient()).thenReturn(mockDatabaseClient);
     when(mockDatabaseClient.readWriteTransaction(any())).thenReturn(mockTransactionRunner);
+    when(mockTransactionRunner.allowNestedTransaction()).thenReturn(mockTransactionRunner);
     when(mockTransactionRunner.run(any(TransactionRunner.TransactionCallable.class)))
         .thenAnswer(
             new Answer<Void>() {


### PR DESCRIPTION
1. Corrected 2PC transaction handling in Spanner to Spanner replication.
2. Support cross project Spanner to Spanner replication
3. The special handling for Spanner to Spanner in a single transaction has been removed from the TransactionWriter. This will need to be re-added within the TargetSpanner DAO as a follow up

