### PR TITLE
fix(Spanner): Segregate spanner instances for templates in load test.

### DIFF
--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/spanner/SpannerResourceManager.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/spanner/SpannerResourceManager.java
@@ -63,6 +63,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Random;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -794,10 +795,11 @@ public final class SpannerResourceManager implements ResourceManager {
     /**
      * Looks at the system properties if there's an instance id, and reuses it if configured.
      *
+     * @param staticInstanceHint optional instance Id of the spanner instance.
      * @return this builder with the instance ID set.
      */
     @SuppressWarnings("nullness")
-    public Builder maybeUseStaticInstance() {
+    public Builder maybeUseStaticInstance(Optional<Integer> staticInstanceHint) {
       String spannerInstanceId = System.getProperty("spannerInstanceId");
       boolean isTestProject =
           Objects.equals(projectId, "cloud-teleport-testing")
@@ -808,12 +810,28 @@ public final class SpannerResourceManager implements ResourceManager {
       if (isTestProject && shouldPickRandomInstance) {
         this.useStaticInstance = true;
         List<String> staticInstanceList = TestConstants.SPANNER_TEST_INSTANCES;
-        this.instanceId = staticInstanceList.get(new Random().nextInt(staticInstanceList.size()));
+        if (staticInstanceHint.isPresent()) {
+          this.instanceId =
+              staticInstanceList.get(staticInstanceHint.get() % staticInstanceList.size());
+        } else {
+          this.instanceId = staticInstanceList.get(new Random().nextInt(staticInstanceList.size()));
+        }
       } else if (spannerInstanceId != null) {
         this.useStaticInstance = true;
         this.instanceId = spannerInstanceId;
       }
       // Else useStaticInstance would remain false and a new Spanner test instance would be created.
+      return this;
+    }
+
+    /**
+     * Looks at the system properties if there's an instance id, and reuses it if configured.
+     *
+     * @return this builder with the instance ID set.
+     */
+    @SuppressWarnings("nullness")
+    public Builder maybeUseStaticInstance() {
+      maybeUseStaticInstance(Optional.empty());
       return this;
     }
 

--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/DataStreamToSpannerLTBase.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/DataStreamToSpannerLTBase.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -113,7 +114,7 @@ public class DataStreamToSpannerLTBase extends TemplateLoadTestBase {
     testRootDir = getClass().getSimpleName();
     spannerResourceManager =
         SpannerResourceManager.builder(testName, project, region)
-            .maybeUseStaticInstance()
+            .maybeUseStaticInstance(Optional.of(1))
             .setNodeCount(10)
             .setMonitoringClient(monitoringClient)
             .setSuppressVerboseLogs(true)
@@ -138,7 +139,7 @@ public class DataStreamToSpannerLTBase extends TemplateLoadTestBase {
     if (separateShadowTableDb) {
       shadowTableSpannerResourceManager =
           SpannerResourceManager.builder("shadow_" + testName, project, region)
-              .maybeUseStaticInstance()
+              .maybeUseStaticInstance(Optional.of(1))
               .setNodeCount(10)
               .setMonitoringClient(monitoringClient)
               .setSuppressVerboseLogs(true)

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/MySQL5KTablesLT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/MySQL5KTablesLT.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -84,7 +85,7 @@ public class MySQL5KTablesLT extends SourceDbToSpannerLTBase {
     mySQLResourceManager = MySQLResourceManager.builder(testName).build();
     spannerResourceManager =
         SpannerResourceManager.builder(testName, project, region)
-            .maybeUseStaticInstance()
+            .maybeUseStaticInstance(Optional.of(3))
             .setMonitoringClient(monitoringClient)
             .build();
 

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/MySQLMultiSharded1024ShardsLT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/MySQLMultiSharded1024ShardsLT.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -94,7 +95,7 @@ public class MySQLMultiSharded1024ShardsLT extends SourceDbToSpannerLTBase {
 
     spannerResourceManager =
         SpannerResourceManager.builder(testName, project, region)
-            .maybeUseStaticInstance()
+            .maybeUseStaticInstance(Optional.of(3))
             .setMonitoringClient(monitoringClient)
             .build();
 

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/PostgreSQL5KTablesLT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/PostgreSQL5KTablesLT.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -79,7 +80,7 @@ public class PostgreSQL5KTablesLT extends SourceDbToSpannerLTBase {
     postgresResourceManager = PostgresResourceManager.builder(testName).build();
     spannerResourceManager =
         SpannerResourceManager.builder(testName, project, region)
-            .maybeUseStaticInstance()
+            .maybeUseStaticInstance(Optional.of(3))
             .setMonitoringClient(monitoringClient)
             .build();
 

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/PostgreSQLMultiSharded1024ShardsLT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/PostgreSQLMultiSharded1024ShardsLT.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -95,7 +96,7 @@ public class PostgreSQLMultiSharded1024ShardsLT extends SourceDbToSpannerLTBase 
 
     spannerResourceManager =
         SpannerResourceManager.builder(testName, project, region)
-            .maybeUseStaticInstance()
+            .maybeUseStaticInstance(Optional.of(3))
             .setMonitoringClient(monitoringClient)
             .build();
 

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/SourceDbToSpannerLTBase.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/loadtesting/SourceDbToSpannerLTBase.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.beam.it.common.PipelineLauncher;
 import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
@@ -111,7 +112,7 @@ public class SourceDbToSpannerLTBase extends TemplateLoadTestBase {
 
     spannerResourceManager =
         SpannerResourceManager.builder(testName, project, region)
-            .maybeUseStaticInstance()
+            .maybeUseStaticInstance(Optional.of(3))
             .setNodeCount(SPANNER_NODE_COUNT)
             .setMonitoringClient(monitoringClient)
             .build();

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb5kTablesLT.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDb5kTablesLT.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -84,21 +85,21 @@ public class SpannerToSourceDb5kTablesLT extends SpannerToSourceDbLTBase {
 
     spannerResourceManager =
         SpannerResourceManager.builder("rr-main-" + testName, project, region)
-            .maybeUseStaticInstance()
+            .maybeUseStaticInstance(Optional.of(2))
             .setMonitoringClient(monitoringClient)
             .setSuppressVerboseLogs(true)
             .build();
 
     spannerMetadataResourceManager =
         SpannerResourceManager.builder("rr-meta-" + testName, project, region)
-            .maybeUseStaticInstance()
+            .maybeUseStaticInstance(Optional.of(2))
             .setSuppressVerboseLogs(true)
             .build();
     spannerMetadataResourceManager.ensureUsableAndCreateResources();
 
     spannerChangeStreamMetadataResourceManager =
         SpannerResourceManager.builder("rr-cs-meta-" + testName, project, region)
-            .maybeUseStaticInstance()
+            .maybeUseStaticInstance(Optional.of(2))
             .setSuppressVerboseLogs(true)
             .build();
     spannerChangeStreamMetadataResourceManager.ensureUsableAndCreateResources();

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDbLTBase.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToSourceDbLTBase.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import org.apache.beam.it.common.PipelineLauncher;
 import org.apache.beam.it.common.PipelineLauncher.LaunchConfig;
@@ -136,7 +137,7 @@ public class SpannerToSourceDbLTBase extends TemplateLoadTestBase {
       throws IOException {
     SpannerResourceManager spannerResourceManager =
         SpannerResourceManager.builder("rr-loadtest-" + testName, project, region)
-            .maybeUseStaticInstance()
+            .maybeUseStaticInstance(Optional.of(2))
             .build();
     String ddl =
         String.join(
@@ -161,7 +162,7 @@ public class SpannerToSourceDbLTBase extends TemplateLoadTestBase {
     if (metadataInstanceId != null && !metadataInstanceId.isEmpty()) {
       builder.setInstanceId(metadataInstanceId).useStaticInstance();
     } else {
-      builder.maybeUseStaticInstance();
+      builder.maybeUseStaticInstance(Optional.of(2));
     }
 
     SpannerResourceManager spannerMetadataResourceManager = builder.build();


### PR DESCRIPTION
- When spanner instances are randomly selected, then 2 load tests across templates can be assigned same instances.
- This can cause the spanner instance to overload.
- Hence, every template is assigned 1 spanner instance.