### PR TITLE
Remove jline static Log; use SLF4J Logger

### DIFF
--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/reader/io/jdbc/iowrapper/JdbcDataSource.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/reader/io/jdbc/iowrapper/JdbcDataSource.java
@@ -26,7 +26,6 @@ import java.net.URLClassLoader;
 import javax.sql.DataSource;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.commons.lang3.StringUtils;
-import org.jline.utils.Log;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -139,7 +138,7 @@ public final class JdbcDataSource extends BasicDataSource implements Serializabl
 
   private void initializeSuper() {
 
-    Log.info("Initializing {}", this);
+    LOG.info("Initializing {}", this);
 
     super.setDriverClassName(jdbcDriverClassName);
 

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/cassandra/reader/io/cassandra/iowrapper/CassandraConnector.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/cassandra/reader/io/cassandra/iowrapper/CassandraConnector.java
@@ -22,7 +22,6 @@ import com.google.cloud.teleport.v2.source.cassandra.reader.io.cassandra.schema.
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.sdk.io.astra.db.CqlSessionHolder;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
-import org.jline.utils.Log;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +42,7 @@ public final class CassandraConnector implements AutoCloseable {
           case ASTRA -> getSessionAstra(cassandraDataSource.astra(), schemaReference);
           default -> getSessionOss(cassandraDataSource.oss(), schemaReference);
         };
-    Log.info(
+    LOG.info(
         "Connected to Cassandra Source dataSource = {}, schemaReference = {}",
         cassandraDataSource,
         schemaReference);
@@ -51,7 +50,7 @@ public final class CassandraConnector implements AutoCloseable {
 
   private CqlSession getSessionOss(
       CassandraDataSourceOss dataSourceOss, CassandraSchemaReference schemaReference) {
-    Log.info(
+    LOG.info(
         "Connecting to Cassandra OSS Source dataSource = {}, schemaReference = {}",
         dataSourceOss,
         schemaReference);
@@ -66,7 +65,7 @@ public final class CassandraConnector implements AutoCloseable {
 
   private CqlSession getSessionAstra(
       AstraDbDataSource astraDbDataSource, CassandraSchemaReference schemaReference) {
-    Log.info(
+    LOG.info(
         "Connecting to Cassandra Astra Source dataSource = {}, schemaReference = {}",
         astraDbDataSource,
         schemaReference);

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/cassandra/reader/io/cassandra/schema/CassandraSchemaDiscovery.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/cassandra/reader/io/cassandra/schema/CassandraSchemaDiscovery.java
@@ -31,7 +31,6 @@ import com.google.cloud.teleport.v2.spanner.migrations.schema.SourceColumnType;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.jline.utils.Log;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +53,7 @@ public final class CassandraSchemaDiscovery implements RetriableSchemaDiscovery 
   public ImmutableList<String> discoverTables(
       DataSource dataSource, SourceSchemaReference sourceSchemaReference)
       throws SchemaDiscoveryException, RetriableSchemaDiscoveryException {
-    Log.info(
+    LOG.info(
         "CassandraSchemaDiscovery discoverTables started dataSource = {}, sourceSchemaReference = {}",
         dataSource,
         sourceSchemaReference);
@@ -63,7 +62,7 @@ public final class CassandraSchemaDiscovery implements RetriableSchemaDiscovery 
         sourceSchemaReference.getKind().equals(SourceSchemaReference.Kind.CASSANDRA));
     ImmutableList<String> tables =
         discoverTables(dataSource.cassandra(), sourceSchemaReference.cassandra());
-    Log.info(
+    LOG.info(
         "CassandraSchemaDiscovery discoverTables completed dataSource = {}, sourceSchemaReference = {}, tables = {}",
         dataSource,
         sourceSchemaReference,
@@ -87,7 +86,7 @@ public final class CassandraSchemaDiscovery implements RetriableSchemaDiscovery 
           .map(n -> n.asCql(true))
           .collect(ImmutableList.toImmutableList());
     } catch (DriverException e) {
-      Log.error(
+      LOG.error(
           "CassandraSchemaDiscovery discoverTables dataSource = {}, sourceSchemaReference = {}",
           dataSource,
           sourceSchemaReference,
@@ -112,7 +111,7 @@ public final class CassandraSchemaDiscovery implements RetriableSchemaDiscovery 
   public ImmutableMap<String, ImmutableMap<String, SourceColumnType>> discoverTableSchema(
       DataSource dataSource, SourceSchemaReference schemaReference, ImmutableList<String> tables)
       throws SchemaDiscoveryException, RetriableSchemaDiscoveryException {
-    Log.info(
+    LOG.info(
         "CassandraSchemaDiscovery discoverTableSchema started dataSource = {}, sourceSchemaReference = {}, tables = {}",
         dataSource,
         schemaReference,
@@ -122,7 +121,7 @@ public final class CassandraSchemaDiscovery implements RetriableSchemaDiscovery 
         schemaReference.getKind().equals(SourceSchemaReference.Kind.CASSANDRA));
     ImmutableMap<String, ImmutableMap<String, SourceColumnType>> schema =
         this.discoverTableSchema(dataSource.cassandra(), schemaReference.cassandra(), tables);
-    Log.info(
+    LOG.info(
         "CassandraSchemaDiscovery discoverTableSchema completed dataSource = {}, sourceSchemaReference = {}, tables = {}, schema = {}",
         dataSource,
         schemaReference,
@@ -146,7 +145,7 @@ public final class CassandraSchemaDiscovery implements RetriableSchemaDiscovery 
       }
       return builder.build();
     } catch (DriverException e) {
-      Log.error(
+      LOG.error(
           "CassandraSchemaDiscovery discoverTableSchema dataSource = {}, sourceSchemaReference = {}, tables = {}",
           dataSource,
           schemaReference,

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/CassandraAllDataTypesIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/CassandraAllDataTypesIT.java
@@ -51,7 +51,6 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
 import org.jetbrains.annotations.NotNull;
-import org.jline.utils.Log;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -252,7 +251,7 @@ public class CassandraAllDataTypesIT extends SourceDbToSpannerITBase {
                             : row.getValue(colName).toString()));
         readValues.add(rowMapBuilder.build());
       }
-      Log.info("Spanner Cassandra Values are: {}", readValues);
+      LOG.info("Spanner Cassandra Values are: {}", readValues);
       assertThat(readValues).isEqualTo(entry.getValue());
     }
   }

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/convertors/ChangeEventToMapConvertor.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/convertors/ChangeEventToMapConvertor.java
@@ -24,10 +24,13 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import org.jline.utils.Log;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ChangeEventToMapConvertor {
+  private static final Logger LOG = LoggerFactory.getLogger(ChangeEventToMapConvertor.class);
+
   public static Map<String, Object> convertChangeEventToMap(JsonNode changeEvent)
       throws InvalidChangeEventException {
     Map<String, Object> sourceRecord = new HashMap<>();
@@ -83,7 +86,7 @@ public class ChangeEventToMapConvertor {
       } else if (columnValue instanceof String) {
         ((ObjectNode) changeEvent).put(columnName, (String) columnValue);
       } else {
-        Log.error(
+        LOG.error(
             "Column name(" + columnName + ") has unsupported column value(" + columnValue + ")");
         throw new InvalidTransformationException(
             "Column name(" + columnName + ") has unsupported column value(" + columnValue + ")");


### PR DESCRIPTION
It seems this was added but it was never needed - we use slf4j everywhere. It is present in the transitive dependencies but not even in direct dependencies, I think. A dependency analysis plugin will prevent this in the future; I will add that as a follow-up, as it usually causes a large diff when first applied.