### PR TITLE
Exclude jline from transitive dependencies of hadoop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,17 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-yarn-client</artifactId>
+        <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jline</groupId>
+            <artifactId>jline</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
 
       <!-- If any module uses log4j 2.x, enforce patched versions -->
       <dependency>


### PR DESCRIPTION
jline was being pulled in transitively via hadoop-yarn-client, which is used by several hadoop dependencies (hadoop-common, hadoop-client, hadoop-mapreduce-client-core).
