### PR TITLE
fix: Support PostgreSQL VECTOR LENGTH types in Spanner change streams

### DIFF
--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/TypesUtils.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/schemautils/TypesUtils.java
@@ -16,6 +16,8 @@
 package com.google.cloud.teleport.v2.templates.spannerchangestreamstobigquery.schemautils;
 
 import com.google.cloud.spanner.Type;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.json.JSONObject;
 
 /**
@@ -23,6 +25,9 @@ import org.json.JSONObject;
  * extracts data types from Mod, and converts the extracted data types to spanner types.
  */
 public class TypesUtils {
+
+  private static final Pattern POSTGRES_VECTOR_TYPE_PATTERN =
+      Pattern.compile("^(.+)\\[\\]\\s+VECTOR\\s+LENGTH\\s+[1-9][0-9]*$", Pattern.CASE_INSENSITIVE);
 
   public static Type informationSchemaGoogleSQLTypeToSpannerType(String type) {
     type = cleanInformationSchemaType(type);
@@ -62,6 +67,12 @@ public class TypesUtils {
   }
 
   public static Type informationSchemaPostgreSQLTypeToSpannerType(String type) {
+    Matcher vectorTypeMatcher = POSTGRES_VECTOR_TYPE_PATTERN.matcher(type);
+    if (vectorTypeMatcher.matches()) {
+      Type itemType = informationSchemaPostgreSQLTypeToSpannerType(vectorTypeMatcher.group(1));
+      return Type.array(itemType);
+    }
+
     boolean isPostgresArray = isPostgresArray(type);
     String cleanedType = "";
     if (isPostgresArray) {

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/TypesUtilsTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/TypesUtilsTest.java
@@ -82,8 +82,35 @@ public final class TypesUtilsTest {
         .isEqualTo(Type.array(Type.string()));
     assertThat(TypesUtils.informationSchemaPostgreSQLTypeToSpannerType("JSONB[]"))
         .isEqualTo(Type.array(Type.pgJsonb()));
+    assertThat(TypesUtils.informationSchemaPostgreSQLTypeToSpannerType("real[]"))
+        .isEqualTo(Type.array(Type.float32()));
     assertThat(TypesUtils.informationSchemaPostgreSQLTypeToSpannerType("real"))
         .isEqualTo(Type.float32());
+  }
+
+  @Test
+  public void testInformationSchemaPostgreSQLVectorTypeToSpannerType() {
+    assertThat(TypesUtils.informationSchemaPostgreSQLTypeToSpannerType("real[] vector length 512"))
+        .isEqualTo(Type.array(Type.float32()));
+    assertThat(
+            TypesUtils.informationSchemaPostgreSQLTypeToSpannerType(
+                "DOUBLE PRECISION[] VECTOR LENGTH 4"))
+        .isEqualTo(Type.array(Type.float64()));
+  }
+
+  @Test
+  public void testInformationSchemaPostgreSQLVectorTypeRejectsInvalidTypes() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            TypesUtils.informationSchemaPostgreSQLTypeToSpannerType(
+                "real[] vector length invalid"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> TypesUtils.informationSchemaPostgreSQLTypeToSpannerType("real[] vector length 0"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> TypesUtils.informationSchemaPostgreSQLTypeToSpannerType("integer[] vector length 4"));
   }
 
   @Test


### PR DESCRIPTION
Extend the PostgreSQL information-schema parser in `TypesUtils` to recognize the repository's existing embedding-vector grammar, isolate the array element type, and ignore the vector-length constraint when constructing the Cloud Spanner client `Type`, consistent with the utility's existing treatment of parameterized lengths. The Spanner change-streams-to-BigQuery template fails during worker setup when a PostgreSQL-dialect table tracked by the change stream contains an embedding-vector column such as `real[] VECTOR LENGTH 512`.

Convert `real[] vector length 512` from PostgreSQL information schema and verify it produces an array of `FLOAT32`, allowing schema setup for the reported embedding column; Convert a case-varied `DOUBLE PRECISION[] VECTOR LENGTH 4` and verify it produces an array of `FLOAT64`, demonstrating that parsing follows the documented grammar rather than hard-coding the reported input.

Fixes #4120
