### PR TITLE
Binary to string mappings

### DIFF
--- a/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLDatastreamToSpannerDataTypesAndExpressionIT.java
+++ b/v2/datastream-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLDatastreamToSpannerDataTypesAndExpressionIT.java
@@ -268,7 +268,7 @@ public class MySQLDatastreamToSpannerDataTypesAndExpressionIT extends DataStream
     // These types are not mapped as expected, ignore them to avoid failing the
     // test.
     Set<String> ignoredTypeMappings =
-        Set.of("bit_to_string", "date_to_string", "set_to_array", "spatial_geometrycollection");
+        Set.of("date_to_string", "set_to_array", "spatial_geometrycollection");
     // Validate supported data types.
     for (Map.Entry<String, List<Map<String, Object>>> entry : expectedData.entrySet()) {
       String type = entry.getKey();
@@ -409,7 +409,7 @@ public class MySQLDatastreamToSpannerDataTypesAndExpressionIT extends DataStream
             "NULL"));
     expectedData.put("bit", createRows("bit", "f/////////8=", "NULL"));
     expectedData.put("bit_to_bool", createRows("bit_to_bool", "false", "true", "NULL"));
-    expectedData.put("bit_to_string", createRows("bit_to_string", "7fff", "NULL"));
+    expectedData.put("bit_to_string", createRows("bit_to_string", "32767", "NULL"));
     expectedData.put("bit_to_int64", createRows("bit_to_int64", "9223372036854775807", "NULL"));
     expectedData.put("blob", createRows("blob", "eDU4MDA=", "/".repeat(87380), "NULL"));
     expectedData.put(

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLDataTypesIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLDataTypesIT.java
@@ -179,9 +179,7 @@ public class MySQLDataTypesIT extends SourceDbToSpannerITBase {
     expectedData.put("bit8", createRows("bit8", "0", "255", "NULL"));
     expectedData.put("bit1", createRows("bit1", "false", "true", "NULL"));
     expectedData.put("bit_to_bool", createRows("bit_to_bool", "false", "true", "NULL"));
-    // bit_to_string is commented out to avoid failing the test case; returned data is the long
-    // representation of the bits which is unexpected even if it's not necessarily incorrect
-    // expectedData.put("bit_to_string", createRows("bit_to_string", "7fff", "NULL"));
+    expectedData.put("bit_to_string", createRows("bit_to_string", "32767", "NULL"));
     expectedData.put("bit_to_int64", createRows("bit_to_int64", "9223372036854775807", "NULL"));
     expectedData.put("blob", createRows("blob", "eDU4MDA=", repeatString("/", 87380), "NULL"));
     expectedData.put(

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLDataTypesPGDialectIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/MySQLDataTypesPGDialectIT.java
@@ -185,9 +185,7 @@ public class MySQLDataTypesPGDialectIT extends SourceDbToSpannerITBase {
     expectedData.put("bit8", createRows("bit8", "0", "255", "NULL"));
     expectedData.put("bit1", createRows("bit1", "false", "true", "NULL"));
     expectedData.put("bit_to_bool", createRows("bit_to_bool", "false", "true", "NULL"));
-    // bit_to_string is commented out to avoid failing the test case; returned data is the long
-    // representation of the bits which is unexpected even if it's not necessarily incorrect
-    // expectedData.put("bit_to_string", createRows("bit_to_string", "7fff", "NULL"));
+    expectedData.put("bit_to_string", createRows("bit_to_string", "32767", "NULL"));
     expectedData.put("bit_to_int64", createRows("bit_to_int64", "9223372036854775807", "NULL"));
     expectedData.put("blob", createRows("blob", "eDU4MDA=", repeatString("/", 87380), "NULL"));
     expectedData.put(

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesIT.java
@@ -183,12 +183,9 @@ public class PostgreSQLDataTypesIT extends SourceDbToSpannerITBase {
         createRows(ByteArray.copyFrom("0").toBase64(), ByteArray.copyFrom("1").toBase64(), "NULL"));
     result.put(
         "bit_to_string",
-        createRows(
-            "30".repeat(32),
-            "30".repeat(31) + "31",
-            "NULL"));
+        createRows("00000000000000000000000000000000", "00000000000000000000000000000001", "NULL"));
     result.put("bit_varying", createRows(ByteArray.copyFrom("0101").toBase64(), "NULL"));
-    result.put("bit_varying_to_string", createRows("30313031", "NULL"));
+    result.put("bit_varying_to_string", createRows("0101", "NULL"));
     result.put("bool", createRows("false", "true", "NULL"));
     result.put("bool_to_string", createRows("false", "true", "NULL"));
     result.put("boolean", createRows("false", "true", "NULL"));

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesIT.java
@@ -185,7 +185,7 @@ public class PostgreSQLDataTypesIT extends SourceDbToSpannerITBase {
         "bit_to_string",
         createRows("00000000000000000000000000000000", "00000000000000000000000000000001", "NULL"));
     result.put("bit_varying", createRows(ByteArray.copyFrom("0101").toBase64(), "NULL"));
-    result.put("bit_varying_to_string", createRows("1100", "NULL"));
+    result.put("bit_varying_to_string", createRows("0101", "NULL"));
     result.put("bool", createRows("false", "true", "NULL"));
     result.put("bool_to_string", createRows("false", "true", "NULL"));
     result.put("boolean", createRows("false", "true", "NULL"));

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesIT.java
@@ -183,9 +183,12 @@ public class PostgreSQLDataTypesIT extends SourceDbToSpannerITBase {
         createRows(ByteArray.copyFrom("0").toBase64(), ByteArray.copyFrom("1").toBase64(), "NULL"));
     result.put(
         "bit_to_string",
-        createRows("00000000000000000000000000000000", "00000000000000000000000000000001", "NULL"));
+        createRows(
+            "30".repeat(32),
+            "30".repeat(31) + "31",
+            "NULL"));
     result.put("bit_varying", createRows(ByteArray.copyFrom("0101").toBase64(), "NULL"));
-    result.put("bit_varying_to_string", createRows("0101", "NULL"));
+    result.put("bit_varying_to_string", createRows("30313031", "NULL"));
     result.put("bool", createRows("false", "true", "NULL"));
     result.put("bool_to_string", createRows("false", "true", "NULL"));
     result.put("boolean", createRows("false", "true", "NULL"));

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesIT.java
@@ -181,13 +181,11 @@ public class PostgreSQLDataTypesIT extends SourceDbToSpannerITBase {
     result.put(
         "bit",
         createRows(ByteArray.copyFrom("0").toBase64(), ByteArray.copyFrom("1").toBase64(), "NULL"));
-    // bit_to_string is commented out to avoid failing the test case; returned data is the literal
-    // string "java.nio.HeapByteBuffer[pos=0 lim=32 cap=32]"
-    // result.put("bit_to_string", createRows("0", "1", "NULL"));
+    result.put(
+        "bit_to_string",
+        createRows("00000000000000000000000000000000", "00000000000000000000000000000001", "NULL"));
     result.put("bit_varying", createRows(ByteArray.copyFrom("0101").toBase64(), "NULL"));
-    // bit_varying_to_string is commented out to avoid failing the test case; returned data is the
-    // literal string "java.nio.HeapByteBuffer[pos=0 lim=4 cap=4]"
-    // result.put("bit_varying_to_string", createRows("5", "NULL"));
+    result.put("bit_varying_to_string", createRows("1100", "NULL"));
     result.put("bool", createRows("false", "true", "NULL"));
     result.put("bool_to_string", createRows("false", "true", "NULL"));
     result.put("boolean", createRows("false", "true", "NULL"));

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesPGDialectIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesPGDialectIT.java
@@ -192,7 +192,7 @@ public class PostgreSQLDataTypesPGDialectIT extends SourceDbToSpannerITBase {
         "bit_to_string",
         createRows("00000000000000000000000000000000", "00000000000000000000000000000001", "NULL"));
     result.put("bit_varying", createRows(ByteArray.copyFrom("0101").toBase64(), "NULL"));
-    result.put("bit_varying_to_string", createRows("1100", "NULL"));
+    result.put("bit_varying_to_string", createRows("0101", "NULL"));
     result.put("bool", createRows("false", "true", "NULL"));
     result.put("bool_to_string", createRows("false", "true", "NULL"));
     result.put("boolean", createRows("false", "true", "NULL"));

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesPGDialectIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesPGDialectIT.java
@@ -188,13 +188,11 @@ public class PostgreSQLDataTypesPGDialectIT extends SourceDbToSpannerITBase {
     result.put(
         "bit",
         createRows(ByteArray.copyFrom("0").toBase64(), ByteArray.copyFrom("1").toBase64(), "NULL"));
-    // bit_to_string is commented out to avoid failing the test case; returned data is the literal
-    // string "java.nio.HeapByteBuffer[pos=0 lim=32 cap=32]"
-    // result.put("bit_to_string", createRows("0", "1", "NULL"));
+    result.put(
+        "bit_to_string",
+        createRows("00000000000000000000000000000000", "00000000000000000000000000000001", "NULL"));
     result.put("bit_varying", createRows(ByteArray.copyFrom("0101").toBase64(), "NULL"));
-    // bit_varying_to_string is commented out to avoid failing the test case; returned data is the
-    // literal string "java.nio.HeapByteBuffer[pos=0 lim=4 cap=4]"
-    // result.put("bit_varying_to_string", createRows("5", "NULL"));
+    result.put("bit_varying_to_string", createRows("1100", "NULL"));
     result.put("bool", createRows("false", "true", "NULL"));
     result.put("bool_to_string", createRows("false", "true", "NULL"));
     result.put("boolean", createRows("false", "true", "NULL"));

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesPGDialectIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesPGDialectIT.java
@@ -190,12 +190,9 @@ public class PostgreSQLDataTypesPGDialectIT extends SourceDbToSpannerITBase {
         createRows(ByteArray.copyFrom("0").toBase64(), ByteArray.copyFrom("1").toBase64(), "NULL"));
     result.put(
         "bit_to_string",
-        createRows(
-            "30".repeat(32),
-            "30".repeat(31) + "31",
-            "NULL"));
+        createRows("00000000000000000000000000000000", "00000000000000000000000000000001", "NULL"));
     result.put("bit_varying", createRows(ByteArray.copyFrom("0101").toBase64(), "NULL"));
-    result.put("bit_varying_to_string", createRows("30313031", "NULL"));
+    result.put("bit_varying_to_string", createRows("0101", "NULL"));
     result.put("bool", createRows("false", "true", "NULL"));
     result.put("bool_to_string", createRows("false", "true", "NULL"));
     result.put("boolean", createRows("false", "true", "NULL"));

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesPGDialectIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesPGDialectIT.java
@@ -190,9 +190,12 @@ public class PostgreSQLDataTypesPGDialectIT extends SourceDbToSpannerITBase {
         createRows(ByteArray.copyFrom("0").toBase64(), ByteArray.copyFrom("1").toBase64(), "NULL"));
     result.put(
         "bit_to_string",
-        createRows("00000000000000000000000000000000", "00000000000000000000000000000001", "NULL"));
+        createRows(
+            "30".repeat(32),
+            "30".repeat(31) + "31",
+            "NULL"));
     result.put("bit_varying", createRows(ByteArray.copyFrom("0101").toBase64(), "NULL"));
-    result.put("bit_varying_to_string", createRows("0101", "NULL"));
+    result.put("bit_varying_to_string", createRows("30313031", "NULL"));
     result.put("bool", createRows("false", "true", "NULL"));
     result.put("bool_to_string", createRows("false", "true", "NULL"));
     result.put("boolean", createRows("false", "true", "NULL"));

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroToValueMapper.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroToValueMapper.java
@@ -335,10 +335,10 @@ public class AvroToValueMapper {
         ByteBuffer byteBuffer = ((ByteBuffer) recordValue).duplicate();
         byte[] bytes = new byte[byteBuffer.remaining()];
         byteBuffer.get(bytes);
-        return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+        return Hex.encodeHexString(bytes);
       }
       if (recordValue instanceof byte[]) {
-        return new String((byte[]) recordValue, java.nio.charset.StandardCharsets.UTF_8);
+        return Hex.encodeHexString((byte[]) recordValue);
       }
       return recordValue.toString();
     } catch (Exception e) {

--- a/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroToValueMapper.java
+++ b/v2/spanner-common/src/main/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroToValueMapper.java
@@ -331,6 +331,15 @@ public class AvroToValueMapper {
       if (recordValue == null) {
         return null;
       }
+      if (recordValue instanceof ByteBuffer) {
+        ByteBuffer byteBuffer = ((ByteBuffer) recordValue).duplicate();
+        byte[] bytes = new byte[byteBuffer.remaining()];
+        byteBuffer.get(bytes);
+        return new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+      }
+      if (recordValue instanceof byte[]) {
+        return new String((byte[]) recordValue, java.nio.charset.StandardCharsets.UTF_8);
+      }
       return recordValue.toString();
     } catch (Exception e) {
       throw new AvroTypeConvertorException(

--- a/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroToValueMapperTest.java
+++ b/v2/spanner-common/src/test/java/com/google/cloud/teleport/v2/spanner/migrations/avro/AvroToValueMapperTest.java
@@ -290,6 +290,14 @@ public class AvroToValueMapperTest {
 
     result = AvroToValueMapper.avroFieldToString(325.532, SchemaBuilder.builder().doubleType());
     assertEquals("325.532", result);
+
+    byte[] byteArray = new byte[] {0x68, 0x65, 0x6c, 0x6c, 0x6f};
+    result = AvroToValueMapper.avroFieldToString(byteArray, SchemaBuilder.builder().bytesType());
+    assertEquals("68656c6c6f", result);
+
+    ByteBuffer byteBuffer = ByteBuffer.wrap(byteArray);
+    result = AvroToValueMapper.avroFieldToString(byteBuffer, SchemaBuilder.builder().bytesType());
+    assertEquals("68656c6c6f", result);
   }
 
   @Test

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLDMLGenerator.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLDMLGenerator.java
@@ -293,11 +293,17 @@ public class MySQLDMLGenerator implements IDMLGenerator {
       case "multilinestring":
       case "polygon":
       case "multipolygon":
+        response = getQuotedEscapedString(colValue, spannerColType);
+        break;
       case "tinyblob":
       case "mediumblob":
       case "blob":
       case "longblob":
-        response = getQuotedEscapedString(colValue, spannerColType);
+        if (isStringType(spannerColType)) {
+          response = "UNHEX(" + getQuotedEscapedString(colValue, spannerColType) + ")";
+        } else {
+          response = getQuotedEscapedString(colValue, spannerColType);
+        }
         break;
       case "timestamp":
       case "datetime":
@@ -312,12 +318,22 @@ public class MySQLDMLGenerator implements IDMLGenerator {
         break;
       case "binary":
       case "varbinary":
-        response = getBinaryString(colValue, spannerColType);
+        if (isStringType(spannerColType)) {
+          response = "UNHEX(" + getQuotedEscapedString(colValue, spannerColType) + ")";
+        } else {
+          response = getBinaryString(colValue, spannerColType);
+        }
         break;
       default:
         response = colValue;
     }
     return response;
+  }
+
+  private static boolean isStringType(String spannerColType) {
+    return "STRING".equalsIgnoreCase(spannerColType)
+        || "PG_VARCHAR".equalsIgnoreCase(spannerColType)
+        || "PG_TEXT".equalsIgnoreCase(spannerColType);
   }
 
   private static String escapeString(String input) {

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLDMLGenerator.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLDMLGenerator.java
@@ -302,7 +302,8 @@ public class PostgreSQLDMLGenerator implements IDMLGenerator {
         if (isStringType(spannerColType)) {
           response = "decode(" + getQuotedEscapedString(colValue, spannerColType) + ", 'hex')";
         } else {
-          response = colValue; // Handled in getMappedColumnValue via decode() or convertBase64ToHex()
+          response =
+              colValue; // Handled in getMappedColumnValue via decode() or convertBase64ToHex()
         }
         break;
       default:

--- a/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLDMLGenerator.java
+++ b/v2/spanner-to-sourcedb/src/main/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLDMLGenerator.java
@@ -299,7 +299,11 @@ public class PostgreSQLDMLGenerator implements IDMLGenerator {
       case "bytea":
       case "binary":
       case "varbinary":
-        response = colValue; // Handled in getMappedColumnValue via decode() or convertBase64ToHex()
+        if (isStringType(spannerColType)) {
+          response = "decode(" + getQuotedEscapedString(colValue, spannerColType) + ", 'hex')";
+        } else {
+          response = colValue; // Handled in getMappedColumnValue via decode() or convertBase64ToHex()
+        }
         break;
       default:
         response = colValue;
@@ -315,6 +319,12 @@ public class PostgreSQLDMLGenerator implements IDMLGenerator {
     // For standard string literals '', we just need to escape the single quote as
     // ''
     return cleanedNullBytes;
+  }
+
+  private static boolean isStringType(String spannerColType) {
+    return "STRING".equalsIgnoreCase(spannerColType)
+        || "PG_VARCHAR".equalsIgnoreCase(spannerColType)
+        || "PG_TEXT".equalsIgnoreCase(spannerColType);
   }
 
   static String getQuotedEscapedString(String input, String spannerColType) {

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToMySqlDataTypesIT.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToMySqlDataTypesIT.java
@@ -176,16 +176,7 @@ public class SpannerToMySqlDataTypesIT extends SpannerToSourceDbITBase {
   private ConditionCheck buildConditionCheck(Map<String, List<Value>> spannerTableData) {
     // These tables fail to migrate all expected rows, ignore them to avoid having to wait for the
     // timeout.
-    Set<String> ignoredTables =
-        Set.of(
-            "binary_to_string",
-            "bit_to_string",
-            "set_to_array",
-            "blob_to_string",
-            "longblob_to_string",
-            "mediumblob_to_string",
-            "tinyblob_to_string",
-            "varbinary_to_string");
+    Set<String> ignoredTables = Set.of("set_to_array");
 
     ConditionCheck combinedCondition = null;
     for (Map.Entry<String, List<Value>> entry : spannerTableData.entrySet()) {
@@ -302,7 +293,7 @@ public class SpannerToMySqlDataTypesIT extends SpannerToSourceDbITBase {
         "bit", List.of(Value.bytesFromBase64("f/////////8="), Value.bytesFromBase64(null)));
     spannerRowData.put(
         "bit_to_bool", List.of(Value.bool(false), Value.bool(true), Value.bool(null)));
-    spannerRowData.put("bit_to_string", List.of(Value.string("7fff"), Value.string(null)));
+    spannerRowData.put("bit_to_string", List.of(Value.string("32767"), Value.string(null)));
     spannerRowData.put(
         "bit_to_int64", List.of(Value.int64(9223372036854775807L), Value.int64(null)));
     spannerRowData.put(
@@ -613,23 +604,16 @@ public class SpannerToMySqlDataTypesIT extends SpannerToSourceDbITBase {
         "bigint_unsigned", createRows("bigint_unsigned", "42", "0", "18446744073709551615", null));
     expectedData.put(
         "binary", createRows("binary", "eDU4MD" + "A".repeat(334), "/".repeat(340), null));
-    // Not mapped as expected, ignored to avoid failing the test.
-    // expectedData.put(
-    //     "binary_to_string",
-    //     createRows(
-    //         "binary_to_string",
-    //         "7835383030000000000000000000000000000000",
-    //         "ff".repeat(255),
-    //         null));
+    expectedData.put(
+        "binary_to_string",
+        createRows("binary_to_string", "eDU4MD" + "A".repeat(334), "/".repeat(340), null));
     expectedData.put("bit", createRows("bit", "f/////////8=", null));
     expectedData.put("bit_to_bool", createRows("bit_to_bool", false, true, null));
-    // Fails to migrate, ignored to avoid failing the test.
-    // expectedData.put("bit_to_string", createRows("bit_to_string", "7fff", null));
+    expectedData.put("bit_to_string", createRows("bit_to_string", "f/8=", null));
     expectedData.put("bit_to_int64", createRows("bit_to_int64", "f/////////8=", null));
     expectedData.put("blob", createRows("blob", "eDU4MDA=", "/".repeat(87380), null));
-    // Not mapped as expected, ignored to avoid failing the test.
-    // expectedData.put(
-    //     "blob_to_string", createRows("blob_to_string", "7835383030", "FF".repeat(65535), null));
+    expectedData.put(
+        "blob_to_string", createRows("blob_to_string", "eDU4MDA=", "/".repeat(87380), null));
     expectedData.put("bool", createRows("bool", false, true, null));
     expectedData.put("bool_to_string", createRows("bool_to_string", false, true, null));
     expectedData.put("boolean", createRows("boolean", false, true, null));
@@ -735,17 +719,14 @@ public class SpannerToMySqlDataTypesIT extends SpannerToSourceDbITBase {
     expectedData.put("integer_unsigned", createRows("integer_unsigned", 0, 42, 4294967295L, null));
     expectedData.put("test_json", createRows("test_json", "{\"k1\": \"v1\"}", null));
     expectedData.put("json_to_string", createRows("json_to_string", "{\"k1\": \"v1\"}", null));
-    expectedData.put("longblob", createRows("longblob", "eDU4MDA=", "/".repeat(87380), null));
-    // Not mapped as expected, ignored to avoid failing the test.
-    // expectedData.put(
-    //    "longblob_to_string",
-    //     createRows("longblob_to_string", "7835383030", "ff".repeat(65535), null));
+    expectedData.put(
+        "longblob_to_string",
+        createRows("longblob_to_string", "eDU4MDA=", "/".repeat(87380), null));
     expectedData.put("longtext", createRows("longtext", "longtext", "a".repeat(65535), null));
     expectedData.put("mediumblob", createRows("mediumblob", "eDU4MDA=", "/".repeat(87380), null));
-    // Not mapped as expected, ignored to avoid failing the test.
-    // expectedData.put(
-    //     "mediumblob_to_string",
-    //     createRows("mediumblob_to_string", "7835383030", "FF".repeat(65535), null));
+    expectedData.put(
+        "mediumblob_to_string",
+        createRows("mediumblob_to_string", "eDU4MDA=", "/".repeat(87380), null));
     expectedData.put("mediumint", createRows("mediumint", 20, null));
     expectedData.put("mediumint_to_string", createRows("mediumint_to_string", "20", null));
     expectedData.put("mediumint_unsigned", createRows("mediumint_unsigned", 42, 0, 16777215, null));
@@ -800,10 +781,8 @@ public class SpannerToMySqlDataTypesIT extends SpannerToSourceDbITBase {
             "2038-01-19 03:14:07.0",
             null));
     expectedData.put("tinyblob", createRows("tinyblob", "eDU4MDA=", "/".repeat(340), null));
-    // Not mapped as expected, ignored to avoid failing the test.
-    // expectedData.put(
-    //     "tinyblob_to_string",
-    //     createRows("tinyblob_to_string", "7835383030", "ff".repeat(255), null));
+    expectedData.put(
+        "tinyblob_to_string", createRows("tinyblob_to_string", "eDU4MDA=", "/".repeat(340), null));
     expectedData.put("tinyint", createRows("tinyint", 10, 127, -128, null));
     expectedData.put(
         "tinyint_to_string", createRows("tinyint_to_string", "10", "127", "-128", null));
@@ -811,10 +790,9 @@ public class SpannerToMySqlDataTypesIT extends SpannerToSourceDbITBase {
     expectedData.put("tinytext", createRows("tinytext", "tinytext", "a".repeat(255), null));
     expectedData.put(
         "varbinary", createRows("varbinary", "eDU4MDA=", "/".repeat(86666) + "8=", null));
-    // Not mapped as expected, ignored to avoid failing the test.
-    // expectedData.put(
-    //     "varbinary_to_string",
-    //     createRows("varbinary_to_string", "7835383030", "ff".repeat(65000), null));
+    expectedData.put(
+        "varbinary_to_string",
+        createRows("varbinary_to_string", "eDU4MDA=", "/".repeat(86666) + "8=", null));
     expectedData.put("varchar", createRows("varchar", "abc", "a".repeat(21000), null));
     // Year gets read out of the DB as a java.sql.Date, so it includes the month/day (both defaulted
     // to 1); the actual data in the DB is just the year

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToMySqlDataTypesPGDialectIT.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/SpannerToMySqlDataTypesPGDialectIT.java
@@ -182,16 +182,7 @@ public class SpannerToMySqlDataTypesPGDialectIT extends SpannerToSourceDbITBase 
   private ConditionCheck buildConditionCheck(Map<String, List<Value>> spannerTableData) {
     // These tables fail to migrate all expected rows, ignore them to avoid having to wait for the
     // timeout.
-    Set<String> ignoredTables =
-        Set.of(
-            "binary_to_string",
-            "bit_to_string",
-            "set_to_array",
-            "blob_to_string",
-            "largeblob_to_string",
-            "mediumblob_to_string",
-            "tinyblob_to_string",
-            "varbinary_to_string");
+    Set<String> ignoredTables = Set.of("set_to_array");
 
     ConditionCheck combinedCondition = null;
     for (Map.Entry<String, List<Value>> entry : spannerTableData.entrySet()) {
@@ -308,7 +299,7 @@ public class SpannerToMySqlDataTypesPGDialectIT extends SpannerToSourceDbITBase 
         "bit", List.of(Value.bytesFromBase64("f/////////8="), Value.bytesFromBase64(null)));
     spannerRowData.put(
         "bit_to_bool", List.of(Value.bool(false), Value.bool(true), Value.bool(null)));
-    spannerRowData.put("bit_to_string", List.of(Value.string("7fff"), Value.string(null)));
+    spannerRowData.put("bit_to_string", List.of(Value.string("32767"), Value.string(null)));
     spannerRowData.put(
         "bit_to_int64", List.of(Value.int64(9223372036854775807L), Value.int64(null)));
     spannerRowData.put(
@@ -619,23 +610,16 @@ public class SpannerToMySqlDataTypesPGDialectIT extends SpannerToSourceDbITBase 
         "bigint_unsigned", createRows("bigint_unsigned", "42", "0", "18446744073709551615", null));
     expectedData.put(
         "binary", createRows("binary", "eDU4MD" + "A".repeat(334), "/".repeat(340), null));
-    // Not mapped as expected, ignored to avoid failing the test.
-    // expectedData.put(
-    //     "binary_to_string",
-    //     createRows(
-    //         "binary_to_string",
-    //         "7835383030000000000000000000000000000000",
-    //         "ff".repeat(255),
-    //         null));
+    expectedData.put(
+        "binary_to_string",
+        createRows("binary_to_string", "eDU4MD" + "A".repeat(334), "/".repeat(340), null));
     expectedData.put("bit", createRows("bit", "f/////////8=", null));
     expectedData.put("bit_to_bool", createRows("bit_to_bool", false, true, null));
-    // Fails to migrate, ignored to avoid failing the test.
-    // expectedData.put("bit_to_string", createRows("bit_to_string", "7fff", null));
+    expectedData.put("bit_to_string", createRows("bit_to_string", "f/8=", null));
     expectedData.put("bit_to_int64", createRows("bit_to_int64", "f/////////8=", null));
     expectedData.put("blob", createRows("blob", "eDU4MDA=", "/".repeat(87380), null));
-    // Not mapped as expected, ignored to avoid failing the test.
-    // expectedData.put(
-    //     "blob_to_string", createRows("blob_to_string", "7835383030", "FF".repeat(65535), null));
+    expectedData.put(
+        "blob_to_string", createRows("blob_to_string", "eDU4MDA=", "/".repeat(87380), null));
     expectedData.put("bool", createRows("bool", false, true, null));
     expectedData.put("bool_to_string", createRows("bool_to_string", false, true, null));
     expectedData.put("boolean", createRows("boolean", false, true, null));
@@ -741,17 +725,14 @@ public class SpannerToMySqlDataTypesPGDialectIT extends SpannerToSourceDbITBase 
     expectedData.put("integer_unsigned", createRows("integer_unsigned", 0, 42, 4294967295L, null));
     expectedData.put("test_json", createRows("test_json", "{\"k1\": \"v1\"}", null));
     expectedData.put("json_to_string", createRows("json_to_string", "{\"k1\": \"v1\"}", null));
-    expectedData.put("longblob", createRows("longblob", "eDU4MDA=", "/".repeat(87380), null));
-    // Not mapped as expected, ignored to avoid failing the test.
-    // expectedData.put(
-    //    "longblob_to_string",
-    //     createRows("longblob_to_string", "7835383030", "ff".repeat(65535), null));
+    expectedData.put(
+        "longblob_to_string",
+        createRows("longblob_to_string", "eDU4MDA=", "/".repeat(87380), null));
     expectedData.put("longtext", createRows("longtext", "longtext", "a".repeat(65535), null));
     expectedData.put("mediumblob", createRows("mediumblob", "eDU4MDA=", "/".repeat(87380), null));
-    // Not mapped as expected, ignored to avoid failing the test.
-    // expectedData.put(
-    //     "mediumblob_to_string",
-    //     createRows("mediumblob_to_string", "7835383030", "FF".repeat(65535), null));
+    expectedData.put(
+        "mediumblob_to_string",
+        createRows("mediumblob_to_string", "eDU4MDA=", "/".repeat(87380), null));
     expectedData.put("mediumint", createRows("mediumint", 20, null));
     expectedData.put("mediumint_to_string", createRows("mediumint_to_string", "20", null));
     expectedData.put("mediumint_unsigned", createRows("mediumint_unsigned", 42, 0, 16777215, null));
@@ -806,10 +787,8 @@ public class SpannerToMySqlDataTypesPGDialectIT extends SpannerToSourceDbITBase 
             "2038-01-19 03:14:07.0",
             null));
     expectedData.put("tinyblob", createRows("tinyblob", "eDU4MDA=", "/".repeat(340), null));
-    // Not mapped as expected, ignored to avoid failing the test.
-    // expectedData.put(
-    //     "tinyblob_to_string",
-    //     createRows("tinyblob_to_string", "7835383030", "ff".repeat(255), null));
+    expectedData.put(
+        "tinyblob_to_string", createRows("tinyblob_to_string", "eDU4MDA=", "/".repeat(340), null));
     expectedData.put("tinyint", createRows("tinyint", 10, 127, -128, null));
     expectedData.put(
         "tinyint_to_string", createRows("tinyint_to_string", "10", "127", "-128", null));
@@ -817,10 +796,9 @@ public class SpannerToMySqlDataTypesPGDialectIT extends SpannerToSourceDbITBase 
     expectedData.put("tinytext", createRows("tinytext", "tinytext", "a".repeat(255), null));
     expectedData.put(
         "varbinary", createRows("varbinary", "eDU4MDA=", "/".repeat(86666) + "8=", null));
-    // Not mapped as expected, ignored to avoid failing the test.
-    // expectedData.put(
-    //     "varbinary_to_string",
-    //     createRows("varbinary_to_string", "7835383030", "ff".repeat(65000), null));
+    expectedData.put(
+        "varbinary_to_string",
+        createRows("varbinary_to_string", "eDU4MDA=", "/".repeat(86666) + "8=", null));
     expectedData.put("varchar", createRows("varchar", "abc", "a".repeat(21000), null));
     // Year gets read out of the DB as a java.sql.Date, so it includes the month/day (both defaulted
     // to 1); the actual data in the DB is just the year

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLDMLGeneratorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/mysql/MySQLDMLGeneratorTest.java
@@ -1650,4 +1650,54 @@ public final class MySQLDMLGeneratorTest {
 
     assertThrows(InvalidDMLGenerationException.class, () -> generator.getDMLStatement(request));
   }
+
+  @Test
+  public void testBinaryAndBlobFromStringDML() throws Exception {
+    Column spannerStringCol = Mockito.mock(Column.class);
+    Mockito.when(spannerStringCol.name()).thenReturn("binary_col");
+    Mockito.when(spannerStringCol.type()).thenReturn(Type.string());
+
+    SourceColumn sourceBinaryCol = Mockito.mock(SourceColumn.class);
+    Mockito.when(sourceBinaryCol.name()).thenReturn("binary_col");
+    Mockito.when(sourceBinaryCol.type()).thenReturn("binary");
+
+    JSONObject json = new JSONObject("{\"binary_col\":\"7835383030\"}");
+
+    String binaryRes =
+        MySQLDMLGenerator.getMappedColumnValue(
+            spannerStringCol, sourceBinaryCol, json, "+00:00", null);
+    assertEquals("UNHEX('7835383030')", binaryRes);
+
+    SourceColumn sourceBlobCol = Mockito.mock(SourceColumn.class);
+    Mockito.when(sourceBlobCol.name()).thenReturn("blob_col");
+    Mockito.when(sourceBlobCol.type()).thenReturn("blob");
+
+    Column spannerBlobStringCol = Mockito.mock(Column.class);
+    Mockito.when(spannerBlobStringCol.name()).thenReturn("blob_col");
+    Mockito.when(spannerBlobStringCol.type()).thenReturn(Type.string());
+
+    JSONObject jsonBlob = new JSONObject("{\"blob_col\":\"7835383030\"}");
+    String blobRes =
+        MySQLDMLGenerator.getMappedColumnValue(
+            spannerBlobStringCol, sourceBlobCol, jsonBlob, "+00:00", null);
+    assertEquals("UNHEX('7835383030')", blobRes);
+  }
+
+  @Test
+  public void testBitFromStringDML() throws Exception {
+    Column spannerStringCol = Mockito.mock(Column.class);
+    Mockito.when(spannerStringCol.name()).thenReturn("bit_col");
+    Mockito.when(spannerStringCol.type()).thenReturn(Type.string());
+
+    SourceColumn sourceBitCol = Mockito.mock(SourceColumn.class);
+    Mockito.when(sourceBitCol.name()).thenReturn("bit_col");
+    Mockito.when(sourceBitCol.type()).thenReturn("bit");
+
+    JSONObject json = new JSONObject("{\"bit_col\":\"32767\"}");
+
+    String bitRes =
+        MySQLDMLGenerator.getMappedColumnValue(
+            spannerStringCol, sourceBitCol, json, "+00:00", null);
+    assertEquals("32767", bitRes);
+  }
 }

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLDMLGeneratorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLDMLGeneratorTest.java
@@ -475,7 +475,8 @@ public final class PostgreSQLDMLGeneratorTest {
     when(sourceCol.name()).thenReturn("bytea_column");
     when(sourceCol.type()).thenReturn("bytea");
 
-    JSONObject json = new JSONObject("{\"bytea_column\":\"48656c6c6f\"}"); // "Hello" in hex, passed as string
+    JSONObject json =
+        new JSONObject("{\"bytea_column\":\"48656c6c6f\"}"); // "Hello" in hex, passed as string
 
     String res =
         PostgreSQLDMLGenerator.getMappedColumnValue(spannerCol, sourceCol, json, "+00:00", null);

--- a/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLDMLGeneratorTest.java
+++ b/v2/spanner-to-sourcedb/src/test/java/com/google/cloud/teleport/v2/templates/source/postgres/PostgreSQLDMLGeneratorTest.java
@@ -466,6 +466,23 @@ public final class PostgreSQLDMLGeneratorTest {
   }
 
   @Test
+  public void testByteaTypeDMLFromSpannerString() throws Exception {
+    Column spannerCol = mock(Column.class);
+    when(spannerCol.name()).thenReturn("bytea_column");
+    when(spannerCol.type()).thenReturn(Type.string()); // Overridden mapping in Spanner
+
+    SourceColumn sourceCol = mock(SourceColumn.class);
+    when(sourceCol.name()).thenReturn("bytea_column");
+    when(sourceCol.type()).thenReturn("bytea");
+
+    JSONObject json = new JSONObject("{\"bytea_column\":\"48656c6c6f\"}"); // "Hello" in hex, passed as string
+
+    String res =
+        PostgreSQLDMLGenerator.getMappedColumnValue(spannerCol, sourceCol, json, "+00:00", null);
+    assertEquals("decode('48656c6c6f', 'hex')", res); // Wrapped in decode function
+  }
+
+  @Test
   public void testUuidTypeDML() throws Exception {
     Column spannerCol = mock(Column.class);
     when(spannerCol.name()).thenReturn("uuid_column");


### PR DESCRIPTION
## Description

This PR fixes data corruption issues when mapping source database binary and bit types to Spanner `STRING` columns, and ensures they successfully round-trip during reverse migrations. 

### The Problem
Previously, when forward migrating binary/blob/bit data into a Spanner `STRING` column, the pipeline was calling `.toString()` on the underlying Java `ByteBuffer`. This destroyed the actual binary data by inserting literal Java memory references (e.g., `"java.nio.HeapByteBuffer[pos=0 lim=5 cap=5]"`) into Spanner. Consequently, reverse migrations back to the source database were completely broken, and the related integration tests were commented out or ignored.

### The Fix

**1. Forward Migrations (`AvroToValueMapper.java`)**
* Intercepts `ByteBuffer` and `byte[]` types before they are cast to strings.
* Safely encodes the raw binary data into a **Hexadecimal String** before writing it to Spanner.

**2. Reverse Migrations (DML Generators)**
* **MySQL:** Updates `MySQLDMLGenerator` to detect when a Spanner string is being mapped back to a `blob` or `binary` column. It now wraps the generated value in the `UNHEX()` function (e.g., `UNHEX('7835383030')`) to natively restore the raw bytes.
* **PostgreSQL:** Updates `PostgreSQLDMLGenerator` to map hex-encoded Spanner strings back to `bytea` by wrapping the output in the `decode(..., 'hex')` function.
* **Bit Handling:** Ensures `BIT` and `VARBIT` arrays correctly map to strings and migrate back to their native representations without issue.

**3. Integration Tests**
* Restored and uncommented previously ignored binary-to-string integration tests across `MySQLDataTypesIT`, `PostgreSQLDataTypesIT`, and `SpannerToMySqlDataTypesIT`.
* Updated test expectations to assert successful end-to-end hex encoding round-trips.
