### PR TITLE
[SpannerToSourceDb] Add support for PostgreSQL native enums

### DIFF
--- a/v2/sourcedb-to-spanner/README.md
+++ b/v2/sourcedb-to-spanner/README.md
@@ -208,3 +208,6 @@ However, because the continuous reader watches the `retry/` directory indefinite
   * **`JSON` / `JSONB`:**
     * *Spanner GoogleSQL:* `JSON`, `STRING`
     * *Spanner PostgreSQL:* `JSONB`, `VARCHAR` / `TEXT`
+  * **`ENUM`:**
+    * *Spanner GoogleSQL:* `STRING`
+    * *Spanner PostgreSQL:* `VARCHAR` / `TEXT`

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/postgres/PostgresSrcToSpSourceConnector.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/postgres/PostgresSrcToSpSourceConnector.java
@@ -64,6 +64,7 @@ public class PostgresSrcToSpSourceConnector extends AbstractJdbcSrcToSpSourceCon
           // precision and scale are >= 0, map to DECIMAL)
           .put("DECIMAL", UnifiedMappingProvider.Type.NUMBER)
           .put("DOUBLE PRECISION", UnifiedMappingProvider.Type.DOUBLE)
+          .put("ENUM", UnifiedMappingProvider.Type.STRING)
           .put("FLOAT4", UnifiedMappingProvider.Type.FLOAT)
           .put("FLOAT8", UnifiedMappingProvider.Type.DOUBLE)
           .put("INET", UnifiedMappingProvider.Type.STRING)

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/dialectadapter/postgresql/PostgreSQLDialectAdapter.java
@@ -256,18 +256,23 @@ public class PostgreSQLDialectAdapter implements DialectAdapter {
         tables);
 
     final String query =
-        "SELECT table_name,"
-            + "  column_name,"
-            + "  data_type,"
-            + "  character_maximum_length,"
-            + "  numeric_precision,"
-            + "  numeric_scale"
-            + " FROM information_schema.columns"
-            + " WHERE table_catalog = ?"
-            + "  AND table_schema = ?"
-            + "  AND table_name IN "
+        "SELECT c.table_name,"
+            + "  c.column_name,"
+            // Enum columns are reported as the placeholder `USER-DEFINED` by
+            // information_schema; follow udt_name into pg_type to report them as `ENUM`.
+            + "  CASE WHEN t.typtype = 'e' THEN 'ENUM' ELSE c.data_type END AS data_type,"
+            + "  c.character_maximum_length,"
+            + "  c.numeric_precision,"
+            + "  c.numeric_scale"
+            + " FROM information_schema.columns c"
+            + "  LEFT OUTER JOIN pg_catalog.pg_namespace n ON n.nspname = c.udt_schema"
+            + "  LEFT OUTER JOIN pg_catalog.pg_type t ON t.typname = c.udt_name"
+            + "   AND t.typnamespace = n.oid"
+            + " WHERE c.table_catalog = ?"
+            + "  AND c.table_schema = ?"
+            + "  AND c.table_name IN "
             + DialectAdapter.generateInClause(tables.size())
-            + " ORDER BY table_name, ordinal_position";
+            + " ORDER BY c.table_name, c.ordinal_position";
 
     Map<String, ImmutableMap.Builder<String, SourceColumnType>> builders = new HashMap<>();
     tables.forEach(

--- a/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/rowmapper/provider/PostgreSQLJdbcValueMappings.java
+++ b/v2/sourcedb-to-spanner/src/main/java/com/google/cloud/teleport/v2/source/postgres/reader/io/jdbc/rowmapper/provider/PostgreSQLJdbcValueMappings.java
@@ -276,6 +276,12 @@ public class PostgreSQLJdbcValueMappings implements JdbcValueMappingsProvider {
                 return (int) (n / 2 + 8);
               })
           .put("DOUBLE PRECISION", ResultSet::getDouble, valuePassThrough, 8)
+          .put(
+              "ENUM",
+              ResultSet::getString,
+              valuePassThrough,
+              63) // Enum labels are limited to NAMEDATALEN-1 = 63 bytes.
+          // https://www.postgresql.org/docs/current/datatype-enum.html
           .put("FLOAT4", ResultSet::getFloat, valuePassThrough, 4)
           .put("FLOAT8", ResultSet::getDouble, valuePassThrough, 8)
           .put("INET", ResultSet::getString, valuePassThrough, 196)

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/reader/io/jdbc/rowmapper/JdbcSourceRowMapperTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/reader/io/jdbc/rowmapper/JdbcSourceRowMapperTest.java
@@ -630,7 +630,7 @@ public class JdbcSourceRowMapperTest {
                 .derbyColumnType("VARCHAR(100)")
                 .sourceColumnType("ENUM")
                 .inputValue("ENUM VALUE")
-                .mappedValue(null) // Unsupported
+                .mappedValue("ENUM VALUE")
                 .build())
         .add(
             Column.builder()

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/postgres/reader/io/schema/typemapping/provider/PostgreSQLMappingProviderTest.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/source/postgres/reader/io/schema/typemapping/provider/PostgreSQLMappingProviderTest.java
@@ -60,6 +60,7 @@ public class PostgreSQLMappingProviderTest {
         .put("DATE", "{\"type\":\"int\",\"logicalType\":\"date\"}")
         .put("DECIMAL", "{\"type\":\"string\",\"logicalType\":\"number\"}")
         .put("DOUBLE PRECISION", "\"double\"")
+        .put("ENUM", "\"string\"")
         .put("FLOAT4", "\"float\"")
         .put("FLOAT8", "\"double\"")
         .put("INET", "\"string\"")

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesIT.java
@@ -121,7 +121,6 @@ public class PostgreSQLDataTypesIT extends SourceDbToSpannerITBase {
             // "t_circle_to_float64_array",
             "t_datemultirange",
             "t_daterange",
-            "t_enum",
             // "t_float_array_to_float64_array",
             "t_float_array_to_string",
             // "t_int_array_to_int64_array",
@@ -206,6 +205,7 @@ public class PostgreSQLDataTypesIT extends SourceDbToSpannerITBase {
     result.put("date", createRows("0001-01-01", "9999-12-31", "NULL"));
     result.put("date_to_string", createRows("0001-01-01", "9999-12-31", "NULL"));
     result.put("decimal_to_string", createRows("0.12", "NULL"));
+    result.put("enum", createRows("enum1", "NULL"));
     result.put(
         "double_precision",
         createRows(

--- a/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesPGDialectIT.java
+++ b/v2/sourcedb-to-spanner/src/test/java/com/google/cloud/teleport/v2/templates/PostgreSQLDataTypesPGDialectIT.java
@@ -122,7 +122,6 @@ public class PostgreSQLDataTypesPGDialectIT extends SourceDbToSpannerITBase {
             // "t_circle_to_float64_array",
             "t_datemultirange",
             "t_daterange",
-            "t_enum",
             // "t_float_array_to_float64_array",
             "t_float_array_to_string",
             // "t_int_array_to_int64_array",
@@ -213,6 +212,7 @@ public class PostgreSQLDataTypesPGDialectIT extends SourceDbToSpannerITBase {
     result.put("date", createRows("0001-01-01", "9999-12-31", "NULL"));
     result.put("date_to_string", createRows("0001-01-01", "9999-12-31", "NULL"));
     result.put("decimal_to_string", createRows("0.12", "NULL"));
+    result.put("enum", createRows("enum1", "NULL"));
     result.put(
         "double_precision",
         createRows(


### PR DESCRIPTION
## Issue 

MySQL has native enum, and they are properly casted as string by the job. It's not the case for PostgreSQL, where native enums are ignored and replaced by NULL values silently, leading to data loss or failed writes.

## Contribution

Instead of emitting NULL when encountering a native enum value on PostgreSQL, we emit its string representation similarly to MySQL.

## Implementation difference with MySQL 

MySQL enum type is a native type, while in PostgreSQL, enums are hidden behind a user-defined type. So, when reading the database information schema in PostgreSQL, we have to "resolve" the user defined type and see if it maps to an enum. We had to adapt the SQL query as follow:

```sql
SELECT 
  c.table_name, 
  c.column_name,
-- Enum columns are reported as the placeholder `USER-DEFINED` by
-- information_schema; follow udt_name into pg_type to report them as `ENUM`.
  CASE WHEN t.typtype = 'e' THEN 'ENUM' ELSE c.data_type END AS data_type,
  c.character_maximum_length,
  c.numeric_precision,
  c.numeric_scale
FROM information_schema.columns c
  LEFT OUTER JOIN pg_catalog.pg_namespace n ON n.nspname = c.udt_schema
  LEFT OUTER JOIN pg_catalog.pg_type t ON t.typname = c.udt_name
   AND t.typnamespace = n.oid
WHERE c.table_catalog = ?
  AND c.table_schema = ?
  AND c.table_name IN (...)
ORDER BY c.table_name, c.ordinal_position;
```

## Test on our production schema

##### Before

Template version: `2026-08-25-00_rc00` as shipped by Google

<img width="1893" height="1000" alt="20260902_15h10m27s_grim" src="https://github.com/user-attachments/assets/929281c5-a073-46f6-9817-b6b8dd6b741a" />

Analysis: many writes are failing because we defined enum as VARCHAR(64)+CONSTRAINT+NOT NULL on Spanner, thus sending NULL fails the write


##### After

Same DDL, same data
Template version: `2026_09_02_01` (built manually by myself from this branch)

<img width="1578" height="820" alt="20260902_15h10m46s_grim" src="https://github.com/user-attachments/assets/15fee60e-d942-451c-8334-422c21bb58a7" />

Analysis: no failure at all
