### PR TITLE
Fix(datastream-to-bigquery): enable schema update options for Storage Write API (requires drain & relaunch)

### DIFF
--- a/v2/datastream-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToBigQuery.java
+++ b/v2/datastream-to-bigquery/src/main/java/com/google/cloud/teleport/v2/templates/DataStreamToBigQuery.java
@@ -42,7 +42,9 @@ import com.google.cloud.teleport.v2.transforms.UDFTextTransformer.InputUDFOption
 import com.google.cloud.teleport.v2.transforms.UDFTextTransformer.InputUDFToTableRow;
 import com.google.cloud.teleport.v2.utils.BigQueryIOUtils;
 import com.google.cloud.teleport.v2.values.FailsafeElement;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -53,6 +55,7 @@ import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.SchemaUpdateOption;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
 import org.apache.beam.sdk.io.gcp.bigquery.InsertRetryPolicy;
 import org.apache.beam.sdk.io.gcp.bigquery.TableDestination;
@@ -570,24 +573,7 @@ public class DataStreamToBigQuery {
                               input.getValue());
                         }
                       }))
-              .apply(
-                  "Write Successful Records",
-                  BigQueryIO.<KV<String, TableRow>>write()
-                      .to(
-                          (SerializableFunction<
-                                  ValueInSingleWindow<KV<String, TableRow>>, TableDestination>)
-                              value -> {
-                                String tableSpec = value.getValue().getKey();
-                                return new TableDestination(tableSpec, "Table for " + tableSpec);
-                              })
-                      .withFormatFunction(
-                          element -> removeTableRowFields(element.getValue(), fieldsToIgnore))
-                      .withFormatRecordOnFailureFunction(element -> element.getValue())
-                      .withoutValidation()
-                      .ignoreInsertIds()
-                      .ignoreUnknownValues()
-                      .withCreateDisposition(CreateDisposition.CREATE_NEVER)
-                      .withWriteDisposition(WriteDisposition.WRITE_APPEND));
+              .apply("Write Successful Records", buildBigQueryStorageWrite(fieldsToIgnore));
     } else {
       writeResult =
           mappedStagingRecords.apply(
@@ -679,7 +665,29 @@ public class DataStreamToBigQuery {
     return new HashSet<>(Splitter.on(Pattern.compile("\\s*,\\s*")).splitToList(fields));
   }
 
-  private static TableRow removeTableRowFields(TableRow tableRow, Set<String> ignoreFields) {
+  @VisibleForTesting
+  static BigQueryIO.Write<KV<String, TableRow>> buildBigQueryStorageWrite(
+      Set<String> fieldsToIgnore) {
+    return BigQueryIO.<KV<String, TableRow>>write()
+        .to(
+            (SerializableFunction<ValueInSingleWindow<KV<String, TableRow>>, TableDestination>)
+                value -> {
+                  String tableSpec = value.getValue().getKey();
+                  return new TableDestination(tableSpec, "Table for " + tableSpec);
+                })
+        .withFormatFunction(element -> removeTableRowFields(element.getValue(), fieldsToIgnore))
+        .withFormatRecordOnFailureFunction(element -> element.getValue())
+        .withoutValidation()
+        .ignoreInsertIds()
+        .withSchemaUpdateOptions(
+            EnumSet.of(
+                SchemaUpdateOption.ALLOW_FIELD_ADDITION, SchemaUpdateOption.ALLOW_FIELD_RELAXATION))
+        .withCreateDisposition(CreateDisposition.CREATE_NEVER)
+        .withWriteDisposition(WriteDisposition.WRITE_APPEND);
+  }
+
+  @VisibleForTesting
+  static TableRow removeTableRowFields(TableRow tableRow, Set<String> ignoreFields) {
     LOG.debug("BigQuery Writes: {}", tableRow);
     TableRow cleanTableRow = tableRow.clone();
     Set<String> rowKeys = tableRow.keySet();

--- a/v2/datastream-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToBigQueryTest.java
+++ b/v2/datastream-to-bigquery/src/test/java/com/google/cloud/teleport/v2/templates/DataStreamToBigQueryTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.common.collect.ImmutableSet;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
+import org.apache.beam.sdk.io.gcp.bigquery.TableRowJsonCoder;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.display.DisplayData;
+import org.apache.beam.sdk.transforms.display.DisplayData.Item;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link DataStreamToBigQuery}. */
+@RunWith(JUnit4.class)
+public class DataStreamToBigQueryTest {
+
+  @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+
+  @Test
+  public void testBuildBigQueryStorageWrite_schemaUpdateOptionsConfigured() {
+    Set<String> fieldsToIgnore = Collections.emptySet();
+    BigQueryIO.Write<KV<String, TableRow>> write =
+        DataStreamToBigQuery.buildBigQueryStorageWrite(fieldsToIgnore);
+
+    DisplayData displayData = DisplayData.from(write);
+    Map<String, Item> items = new HashMap<>();
+    for (Item item : displayData.items()) {
+      items.put(item.getKey(), item);
+    }
+
+    // Storage Write API dynamically updates schema when schemaUpdateOptions is populated
+    // without requiring autoSchemaUpdate=true (which is restricted to ignoreUnknownValues=true).
+    assertTrue(items.containsKey("schemaUpdateOptions"));
+    assertEquals(
+        "[ALLOW_FIELD_ADDITION, ALLOW_FIELD_RELAXATION]",
+        String.valueOf(items.get("schemaUpdateOptions").getValue()));
+    assertTrue(items.containsKey("createDisposition"));
+    assertEquals("CREATE_NEVER", String.valueOf(items.get("createDisposition").getValue()));
+    assertTrue(items.containsKey("writeDisposition"));
+    assertEquals("WRITE_APPEND", String.valueOf(items.get("writeDisposition").getValue()));
+  }
+
+  @Test
+  public void testRemoveTableRowFields() {
+    TableRow row = new TableRow();
+    row.set("id", 123);
+    row.set("name", "foobar");
+    row.set("_metadata_deleted", true);
+
+    TableRow cleanedRow =
+        DataStreamToBigQuery.removeTableRowFields(row, ImmutableSet.of("_metadata_deleted"));
+
+    assertEquals(123, cleanedRow.get("id"));
+    assertEquals("foobar", cleanedRow.get("name"));
+    assertFalse(cleanedRow.containsKey("_metadata_deleted"));
+
+    // Ensure original row was not mutated
+    assertTrue(row.containsKey("_metadata_deleted"));
+  }
+
+  @Test
+  public void testBuildBigQueryStorageWrite_pipelineGraphConstruction() {
+    pipeline.enableAbandonedNodeEnforcement(false);
+    PCollection<KV<String, TableRow>> input =
+        pipeline.apply(Create.empty(KvCoder.of(StringUtf8Coder.of(), TableRowJsonCoder.of())));
+
+    // Applying write with Storage Write API and schemaUpdateOptions must succeed.
+    input.apply(
+        "WriteStorage",
+        DataStreamToBigQuery.buildBigQueryStorageWrite(Collections.emptySet())
+            .withMethod(BigQueryIO.Write.Method.STORAGE_WRITE_API));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testStorageWrite_incompatibleWithIgnoreUnknownValues() {
+    pipeline.enableAbandonedNodeEnforcement(false);
+    // In Beam, if ignoreUnknownValues is set alongside schemaUpdateOptions in Storage Write API,
+    // an IllegalArgumentException is thrown. This test confirms that invariant.
+    BigQueryIO.Write<KV<String, TableRow>> write =
+        DataStreamToBigQuery.buildBigQueryStorageWrite(Collections.emptySet())
+            .withMethod(BigQueryIO.Write.Method.STORAGE_WRITE_API)
+            .ignoreUnknownValues();
+
+    PCollection<KV<String, TableRow>> input =
+        pipeline.apply(Create.empty(KvCoder.of(StringUtf8Coder.of(), TableRowJsonCoder.of())));
+    input.apply("InvalidWrite", write);
+  }
+}


### PR DESCRIPTION
### Problem
When `useStorageWriteApi=true` is enabled in the Datastream to BigQuery template, `BigQueryIO.Write` was configured with `.ignoreUnknownValues()` without `.withSchemaUpdateOptions(...)`. In Apache Beam (`StorageApiDynamicDestinationsTableRow`), `SchemaUpgradingTableRowConverter` is only instantiated when `!schemaUpdateOptions.isEmpty()`. Without it, Beam uses a static `TableRowConverter` whose `Descriptor` is `final` and whose `updateSchemaFromTable()` is a no-op—causing newly added source columns (`ALTER TABLE ... ADD COLUMN`) to be silently stripped from incoming `TableRow` records even after `BigQueryMapper` updates the BigQuery staging table schema.

### Solution
Enable `ALLOW_FIELD_ADDITION` and `ALLOW_FIELD_RELAXATION` via `.withSchemaUpdateOptions(...)` when `useStorageWriteApi=true` (matching the existing `DynamicDestinations` configuration in `BigQueryDynamicDestination`), and validate the expanded `StorageApiConvertMessages` DAG behavior in unit and E2E tests.

### Release Note
* **Fixed (Datastream to BigQuery)**: Enabled automatic BigQuery schema evolution (`ALLOW_FIELD_ADDITION`, `ALLOW_FIELD_RELAXATION`) on staging tables when `useStorageWriteApi=true`, preventing newly added source columns from being silently dropped during CDC replication (b/478836130).
* **Upgrade Notice for Existing `useStorageWriteApi=true` Jobs**: Because enabling Storage Write API schema updates adds stateful schema-buffering stages (`StorageApiConvertMessages` / `SchemaUpdateHoldingFn`) to the Apache Beam pipeline graph, existing running jobs with `useStorageWriteApi=true` from prior template releases cannot be upgraded in-place via `--update`. To upgrade an existing running job to this template version without data loss, **Drain** the existing job, wait for it to reach the `Drained` state, and **Clone / Relaunch** a new job using the same Pub/Sub subscription and BigQuery datasets.