### PR TITLE
feat(mongodb-to-mongodb): High-Throughput Backfill Migration (with Experimental CDC)

### DIFF
--- a/v2/mongodb-to-mongodb/README.md
+++ b/v2/mongodb-to-mongodb/README.md
@@ -35,12 +35,23 @@ graph TD
 | `targetDatabase` | String | Database in the target MongoDB to write to. | Yes | |
 | `sourceCollection` | String | Collection in the source MongoDB to read from. If not provided, all collections will be migrated. | No | |
 | `targetCollection` | String | Collection in the target MongoDB to write to. If not provided, source collection names will be used. | No | |
-| `useBucketAuto` | Boolean | Enable withBucketAuto for Atlas compatibility. | No | false |
-| `numSplits` | Integer | Suggest a specific number of partitions for reading. | No | |
-| `batchSize` | Integer | Number of documents in a bulk write. | No | 5000 |
-| `dlqDirectory` | String | Base path to store failed events. | No | `tempLocation`/tmp |
+| `writeBatchSize` | Integer | Number of documents in a bulk write. | No | 5000 |
 | `maxConcurrentAsyncWrites` | Integer | Maximum number of concurrent asynchronous batch writes per worker. | No | 10 |
 | `maxWriteRetries` | Integer | Maximum number of retry attempts for transient failures during write. | No | 3 |
+| `numWriteShards` | Integer | Number of parallel shards per collection for batched writes. | No | 64 |
+| `maxBufferingDurationMs` | Integer | Maximum duration in milliseconds to buffer documents before flushing. | No | 200 |
+| `migrationMode` | String | Migration mode: BACKFILL_AND_STREAMING, STREAMING_CDC, or BACKFILL. | No | BACKFILL_AND_STREAMING |
+| `targetBackfillChunkSize` | Integer | Target document count per backfill read split. | No | 200000 |
+| `maxBackfillSplits` | Integer | Maximum backfill read splits allowed per collection. | No | 256 |
+| `maxConcurrentBackfillReads` | Integer | Maximum concurrent backfill cursors allowed across the cluster. | No | 128 |
+| `numChangeStreamSplits` | Integer | Number of parallel change stream cursors per collection for CDC. | No | 1 |
+| `changeStreamFullDocument` | String | Change stream full document strategy (updateLookup or whenAvailable). | No | updateLookup |
+| `startAtOperationTime` | String | Optional starting clusterTime (epoch seconds or ISO-8601). | No | |
+| `initialWriteRatePerWorker` | Integer | Initial maximum documents/second per worker during ramp-up (<=0 disables). | No | 5000 |
+| `maxWriteRatePerWorker` | Integer | Maximum target documents/second per worker after completing ramp-up. | No | 25000 |
+| `writeRateRampUpMinutes` | Integer | Duration in minutes for write rate ramp-up. | No | 5 |
+| `writeRateRampUpSteps` | Integer | Number of discrete linear step increases over ramp-up. | No | 5 |
+| `dlqDirectory` | String | Base path to store failed events. | No | `tempLocation`/tmp |
 | `dlqMaxRetries` | Integer | Maximum number of times to retry events from DLQ. | No | 3 |
 | `readFromDlq` | Boolean | If true, reads only from DLQ for retry. If false, reads from MongoDB. | No | false |
 | `reconsumeDlqPath` | String | Path to read files from DLQ for reprocessing. Required if `readFromDlq` is true. | No | |
@@ -144,8 +155,12 @@ Failures are organized under the `dlqDirectory` (or `tempLocation`/tmp if not sp
 
 To optimize performance, consider the following parameters:
 
-- **`batchSize`**: Controls how many documents are sent in a single bulk write operation. Larger sizes can improve throughput but increase memory usage. Default is 5000.
-- **`maxConcurrentAsyncWrites`**: Controls the number of concurrent bulk write operations per worker. Increasing this can increase throughput if the target MongoDB cluster can handle the load. Default is 10.
-- **`numSplits`**: Suggests the number of splits for reading from MongoDB. This affects the initial parallelism of the read stage.
-- **`useBucketAuto`**: When set to `true`, uses MongoDB's `$bucketAuto` to determine split points. This is often more efficient, especially on Atlas clusters where traditional split methods might be slow or unavailable.
+- **`writeBatchSize`**: Controls how many documents are sent in a single bulk write operation. Larger sizes can improve throughput but increase memory usage. Default is 5000.
+- **`maxConcurrentAsyncWrites`**: Controls the number of concurrent asynchronous batch writes per worker. Default is 10.
+- **`numWriteShards`**: Controls the number of parallel shards per collection for batched writes to prevent Windmill single-key bottlenecks. Default is 64.
+- **`maxBufferingDurationMs`**: Maximum duration in milliseconds to buffer documents before flushing a batch to the target. Default is 200ms.
+- **`targetBackfillChunkSize`**: Target document count per backfill read split for adaptive volume-based splitting. Default is 200000.
+- **`maxBackfillSplits`**: Maximum backfill read splits allowed per collection. Default is 256.
+- **`maxConcurrentBackfillReads`**: Maximum concurrent backfill cursors allowed across the cluster, bounding source database connections. Default is 128.
+- **`numChangeStreamSplits`**: Number of parallel change stream cursors per collection for high-throughput CDC streaming. Default is 1.
 - **`numberOfWorkerHarnessThreads`**: This is a standard Dataflow flag (set via `--numberOfWorkerHarnessThreads`) that controls the number of threads per worker. Increasing this allows the worker to process more bundles in parallel, which can increase throughput but also increases memory and resource contention. It complements `maxConcurrentAsyncWrites` by allowing more concurrent work on the worker level before hitting the write throttle.

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDb.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDb.java
@@ -143,20 +143,6 @@ public class MongoDbToMongoDb {
     void setTargetCollection(String value);
 
     @TemplateParameter.Integer(
-        order = 7,
-        groupName = "Source",
-        optional = true,
-        description = "Number of Backfill Read Splits",
-        helpText =
-            "Number of parallel coarse read splits generated per collection during historical"
-                + " backfill (e.g. 1, 4, 8). Each split opens a sequential index-range cursor."
-                + " Default is 1.")
-    @Default.Integer(1)
-    Integer getNumBackfillSplits();
-
-    void setNumBackfillSplits(Integer value);
-
-    @TemplateParameter.Integer(
         order = 8,
         groupName = "Target",
         optional = true,
@@ -372,6 +358,46 @@ public class MongoDbToMongoDb {
     Integer getMaxBufferingDurationMs();
 
     void setMaxBufferingDurationMs(Integer value);
+
+    @TemplateParameter.Integer(
+        order = 25,
+        groupName = "Source",
+        optional = true,
+        description = "Target Backfill Chunk Size",
+        helpText =
+            "Target number of documents per backfill split. Adaptive volume-based splitting uses this"
+                + " to calculate the number of splits per collection based on estimated count. Default is 200000.")
+    @Default.Integer(200000)
+    Integer getTargetBackfillChunkSize();
+
+    void setTargetBackfillChunkSize(Integer value);
+
+    @TemplateParameter.Integer(
+        order = 26,
+        groupName = "Source",
+        optional = true,
+        description = "Max Backfill Splits",
+        helpText =
+            "Maximum number of backfill read splits allowed per collection during adaptive splitting."
+                + " Default is 256.")
+    @Default.Integer(256)
+    Integer getMaxBackfillSplits();
+
+    void setMaxBackfillSplits(Integer value);
+
+    @TemplateParameter.Integer(
+        order = 27,
+        groupName = "Source",
+        optional = true,
+        description = "Max Concurrent Backfill Reads",
+        helpText =
+            "Maximum number of concurrent in-flight backfill cursors allowed across the cluster."
+                + " Partitions are distributed across virtual concurrency slots to strictly bound"
+                + " source database connections and cursor memory. Default is 128.")
+    @Default.Integer(128)
+    Integer getMaxConcurrentBackfillReads();
+
+    void setMaxConcurrentBackfillReads(Integer value);
   }
 
   public static void main(String[] args) {
@@ -453,9 +479,6 @@ public class MongoDbToMongoDb {
     LOG.info("  Target Database:         {}", options.getTargetDatabase());
     LOG.info("  Source Collections:      {}", sourceCollections);
     LOG.info(
-        "  Backfill Configuration:  coarse-split sequential cursor streaming (numBackfillSplits={})",
-        options.getNumBackfillSplits() != null ? options.getNumBackfillSplits() : 1);
-    LOG.info(
         "  Write Configuration:     batchSize={}, maxConcurrentAsyncWrites={}, maxWriteRetries={},"
             + " dlqMaxRetries={}",
         options.getBatchSize(),
@@ -472,6 +495,9 @@ public class MongoDbToMongoDb {
     LOG.info("  Migration Mode:          {}", options.getMigrationMode());
     LOG.info("  Change Stream Splits:    {}", options.getNumChangeStreamSplits());
     LOG.info("  Change Stream Strategy:  {}", options.getChangeStreamFullDocument());
+    LOG.info("  Backfill Chunk Size:     {}", options.getTargetBackfillChunkSize());
+    LOG.info("  Max Backfill Splits:     {}", options.getMaxBackfillSplits());
+    LOG.info("  Max Concurrent Reads:    {}", options.getMaxConcurrentBackfillReads());
     LOG.info("  DLQ Base Directory:      {}", baseDlqPath + timestampPath);
     LOG.info("  DLQ Retryable Directory: {}", retryableDlqPath);
     LOG.info("  DLQ Permanent Directory: {}", permanentDlqPath);
@@ -550,8 +576,12 @@ public class MongoDbToMongoDb {
                   : targetCollectionRaw;
 
           if (includeBackfill) {
-            int numBackfillSplits =
-                options.getNumBackfillSplits() != null ? options.getNumBackfillSplits() : 1;
+            int targetChunkSize =
+                options.getTargetBackfillChunkSize() != null
+                    ? options.getTargetBackfillChunkSize()
+                    : 200000;
+            int maxSplits =
+                options.getMaxBackfillSplits() != null ? options.getMaxBackfillSplits() : 256;
             try {
               backfillPartitions.addAll(
                   MongoDbBackfillReader.generatePartitions(
@@ -560,15 +590,15 @@ public class MongoDbToMongoDb {
                       options.getSourceDatabase(),
                       inputCollection,
                       targetCollection,
-                      numBackfillSplits,
+                      targetChunkSize,
+                      maxSplits,
                       t0));
             } catch (Exception e) {
               LOG.warn(
                   "Could not generate partitioned splits for collection '{}' ({}). Falling back to"
-                      + " algorithmic splits (splits={}).",
+                      + " algorithmic splits.",
                   inputCollection,
-                  e.getMessage(),
-                  numBackfillSplits);
+                  e.getMessage());
               backfillPartitions.addAll(
                   MongoDbBackfillReader.generatePartitions(
                       null,
@@ -576,7 +606,8 @@ public class MongoDbToMongoDb {
                       options.getSourceDatabase(),
                       inputCollection,
                       targetCollection,
-                      numBackfillSplits,
+                      targetChunkSize,
+                      maxSplits,
                       t0));
             }
           }
@@ -658,11 +689,16 @@ public class MongoDbToMongoDb {
       }
 
       if (includeBackfill && !backfillPartitions.isEmpty()) {
+        int maxConcurrentReads =
+            options.getMaxConcurrentBackfillReads() != null
+                ? options.getMaxConcurrentBackfillReads()
+                : MongoDbBackfillReader.ReadPartitions.DEFAULT_MAX_CONCURRENT_READS;
         PCollection<DocumentWithMetadata> backfillDocs =
             pipeline
                 .apply(
                     "ReadBackfill",
-                    new MongoDbBackfillReader.ReadPartitions(backfillPartitions))
+                    new MongoDbBackfillReader.ReadPartitions(
+                        backfillPartitions, maxConcurrentReads))
                 .setCoder(DocumentWithMetadataCoder.of());
         allStreams.add(backfillDocs);
       }

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDb.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDb.java
@@ -392,6 +392,13 @@ public class MongoDbToMongoDb {
     String sourceUri = options.getSourceUri();
     String sourceDatabase = options.getSourceDatabase();
     String sourceCollection = options.getSourceCollection();
+    String targetCollectionRaw = options.getTargetCollection();
+
+    if ((sourceCollection == null || sourceCollection.isEmpty())
+        && (targetCollectionRaw != null && !targetCollectionRaw.isEmpty())) {
+      throw new IllegalArgumentException(
+          "targetCollection cannot be specified when migrating an entire database without specifying sourceCollection.");
+    }
 
     List<String> sourceCollections = new ArrayList<>();
     if (sourceCollection != null && !sourceCollection.isEmpty()) {
@@ -438,7 +445,7 @@ public class MongoDbToMongoDb {
     LOG.info("  Source Collections:      {}", sourceCollections);
     LOG.info(
         "  Backfill Configuration:  coarse-split sequential cursor streaming (numBackfillSplits={})",
-        options.getNumBackfillSplits() != null ? options.getNumBackfillSplits() : 4);
+        options.getNumBackfillSplits() != null ? options.getNumBackfillSplits() : 1);
     LOG.info(
         "  Write Configuration:     batchSize={}, maxConcurrentAsyncWrites={}, maxWriteRetries={},"
             + " dlqMaxRetries={}",
@@ -528,7 +535,6 @@ public class MongoDbToMongoDb {
 
       try {
         for (String inputCollection : sourceCollections) {
-          String targetCollectionRaw = options.getTargetCollection();
           final String targetCollection =
               (targetCollectionRaw == null || targetCollectionRaw.isEmpty())
                   ? inputCollection
@@ -565,7 +571,7 @@ public class MongoDbToMongoDb {
             }
           }
 
-          if (includeCdc) {
+          if (includeCdc && (sourceCollection != null && !sourceCollection.isEmpty())) {
             int numCdcSplits =
                 options.getNumChangeStreamSplits() != null
                     ? options.getNumChangeStreamSplits()
@@ -598,6 +604,38 @@ public class MongoDbToMongoDb {
                       t0,
                       options.getChangeStreamFullDocument()));
             }
+          }
+        }
+
+        if (includeCdc && (sourceCollection == null || sourceCollection.isEmpty())) {
+          int numCdcSplits =
+              options.getNumChangeStreamSplits() != null ? options.getNumChangeStreamSplits() : 1;
+          LOG.info(
+              "Configuring database-level change stream on database '{}' with {} parallel splits",
+              options.getSourceDatabase(),
+              numCdcSplits);
+          try {
+            cdcPartitions.addAll(
+                MongoDbChangeStreamReader.generateDatabasePartitions(
+                    setupClient,
+                    options.getSourceUri(),
+                    options.getSourceDatabase(),
+                    numCdcSplits,
+                    t0,
+                    options.getChangeStreamFullDocument()));
+          } catch (Exception e) {
+            LOG.warn(
+                "Could not generate database-level change stream splits ({}). Falling back to single"
+                    + " split.",
+                e.getMessage());
+            cdcPartitions.addAll(
+                MongoDbChangeStreamReader.generateDatabasePartitions(
+                    null,
+                    options.getSourceUri(),
+                    options.getSourceDatabase(),
+                    1,
+                    t0,
+                    options.getChangeStreamFullDocument()));
           }
         }
       } finally {

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDb.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDb.java
@@ -525,14 +525,10 @@ public class MongoDbToMongoDb {
               "Could not parse startAtOperationTime '{}' as epoch seconds. Capturing current"
                   + " cluster time.",
               options.getStartAtOperationTime());
-          t0 =
-              MongoDbChangeStreamReader.captureCurrentClusterTime(
-                  sourceUri, sourceDatabase);
+          t0 = MongoDbChangeStreamReader.captureCurrentClusterTime(sourceUri, sourceDatabase);
         }
       } else {
-        t0 =
-            MongoDbChangeStreamReader.captureCurrentClusterTime(
-                sourceUri, sourceDatabase);
+        t0 = MongoDbChangeStreamReader.captureCurrentClusterTime(sourceUri, sourceDatabase);
       }
       LOG.info(
           "Captured initial cluster time T0: {} (seconds={}, inc={})",
@@ -622,9 +618,7 @@ public class MongoDbToMongoDb {
 
           if (includeCdc && (sourceCollection != null && !sourceCollection.isEmpty())) {
             int numCdcSplits =
-                options.getNumChangeStreamSplits() != null
-                    ? options.getNumChangeStreamSplits()
-                    : 1;
+                options.getNumChangeStreamSplits() != null ? options.getNumChangeStreamSplits() : 1;
             try {
               cdcPartitions.addAll(
                   MongoDbChangeStreamReader.generatePartitions(
@@ -714,9 +708,7 @@ public class MongoDbToMongoDb {
       if (includeCdc && !cdcPartitions.isEmpty()) {
         PCollection<DocumentWithMetadata> cdcDocs =
             pipeline
-                .apply(
-                    "ReadCDC",
-                    new MongoDbChangeStreamReader.ReadPartitions(cdcPartitions))
+                .apply("ReadCDC", new MongoDbChangeStreamReader.ReadPartitions(cdcPartitions))
                 .setCoder(DocumentWithMetadataCoder.of());
         allStreams.add(cdcDocs);
       }
@@ -725,9 +717,7 @@ public class MongoDbToMongoDb {
       if (allStreams.size() == 1) {
         documents = allStreams.get(0);
       } else if (allStreams.size() > 1) {
-        documents =
-            PCollectionList.of(allStreams)
-                .apply("MergeStreams", Flatten.pCollections());
+        documents = PCollectionList.of(allStreams).apply("MergeStreams", Flatten.pCollections());
       } else {
         throw new IllegalStateException("No streams configured to read.");
       }
@@ -751,8 +741,8 @@ public class MongoDbToMongoDb {
   }
 
   /**
-   * PTransform that processes documents: stateful deduplication, metric counting,
-   * UDF transformation, and validation, routing process failures to DLQ.
+   * PTransform that processes documents: stateful deduplication, metric counting, UDF
+   * transformation, and validation, routing process failures to DLQ.
    */
   public static class ProcessDocuments
       extends PTransform<PCollection<DocumentWithMetadata>, PCollection<DocumentWithMetadata>> {
@@ -811,13 +801,9 @@ public class MongoDbToMongoDb {
         udfProcessed
             .get(udfFailureTag)
             .apply(
-                "WriteToDlq_UDF",
-                new WriteToDlq(retryableDlqPath, permanentDlqPath, tmpDirectory));
+                "WriteToDlq_UDF", new WriteToDlq(retryableDlqPath, permanentDlqPath, tmpDirectory));
 
-        documents =
-            udfProcessed
-                .get(udfSuccessTag)
-                .setCoder(DocumentWithMetadataCoder.of());
+        documents = udfProcessed.get(udfSuccessTag).setCoder(DocumentWithMetadataCoder.of());
       }
 
       // Validation Stage with DLQ
@@ -842,10 +828,10 @@ public class MongoDbToMongoDb {
   }
 
   /**
-   * PTransform that writes valid documents in bulk to target MongoDB, routing write failures to DLQ.
+   * PTransform that writes valid documents in bulk to target MongoDB, routing write failures to
+   * DLQ.
    */
-  public static class WriteDocuments
-      extends PTransform<PCollection<DocumentWithMetadata>, PDone> {
+  public static class WriteDocuments extends PTransform<PCollection<DocumentWithMetadata>, PDone> {
     private final transient Options options;
     private final String retryableDlqPath;
     private final String permanentDlqPath;
@@ -891,8 +877,7 @@ public class MongoDbToMongoDb {
                           : DEFAULT_WRITE_RATE_RAMP_UP_STEPS));
 
       writeFailures.apply(
-          "WriteToDlq_Write",
-          new WriteToDlq(retryableDlqPath, permanentDlqPath, tmpDirectory));
+          "WriteToDlq_Write", new WriteToDlq(retryableDlqPath, permanentDlqPath, tmpDirectory));
 
       return PDone.in(validDocs.getPipeline());
     }
@@ -933,9 +918,7 @@ public class MongoDbToMongoDb {
             failureTag,
             item != null
                 ? item.withFailure(
-                    "Null document payload",
-                    ErrorType.PERMANENT,
-                    FailureStage.VALIDATE)
+                    "Null document payload", ErrorType.PERMANENT, FailureStage.VALIDATE)
                 : DocumentWithMetadata.of(
                     null,
                     null,

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDb.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDb.java
@@ -19,9 +19,14 @@ import com.google.cloud.teleport.metadata.Template;
 import com.google.cloud.teleport.metadata.TemplateCategory;
 import com.google.cloud.teleport.metadata.TemplateParameter;
 import com.google.cloud.teleport.v2.transforms.DocumentWithMetadata;
+import com.google.cloud.teleport.v2.transforms.DocumentWithMetadataCoder;
 import com.google.cloud.teleport.v2.transforms.JavascriptTextTransformer;
+import com.google.cloud.teleport.v2.transforms.MongoDbBackfillReader;
+import com.google.cloud.teleport.v2.transforms.MongoDbBackfillReader.BackfillPartition;
+import com.google.cloud.teleport.v2.transforms.MongoDbChangeStreamReader;
+import com.google.cloud.teleport.v2.transforms.MongoDbChangeStreamReader.ChangeStreamPartition;
 import com.google.cloud.teleport.v2.transforms.MongoDbTransforms;
-import com.google.cloud.teleport.v2.transforms.ReadSplitGenerator;
+import com.google.cloud.teleport.v2.transforms.StatefulDeduplication;
 import com.google.cloud.teleport.v2.transforms.UriSanitizer;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoDatabase;
@@ -31,14 +36,12 @@ import java.util.Date;
 import java.util.List;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.io.TextIO;
-import org.apache.beam.sdk.io.mongodb.FindQuery;
-import org.apache.beam.sdk.io.mongodb.MongoDbIO;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.StreamingOptions;
 import org.apache.beam.sdk.options.Validation;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Flatten;
@@ -50,24 +53,24 @@ import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.PDone;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
-import org.bson.BsonDocument;
-import org.bson.Document;
+import org.bson.BsonTimestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Dataflow template which copies data from one MongoDB database to another. */
+/** Dataflow template which copies data from one MongoDB database to another with CDC streaming support. */
 @Template(
     name = "Mongodb_To_Mongodb",
-    category = TemplateCategory.BATCH,
+    category = TemplateCategory.STREAMING,
     displayName = "MongoDB to MongoDB",
-    description = "Copy data from one MongoDB database to another.",
+    description = "Copy or stream data from one MongoDB database to another.",
     flexContainerName = "mongodb-to-mongodb",
     optionsClass = MongoDbToMongoDb.Options.class)
 public class MongoDbToMongoDb {
 
   private static final Logger LOG = LoggerFactory.getLogger(MongoDbToMongoDb.class);
 
-  public interface Options extends JavascriptTextTransformer.JavascriptTextTransformerOptions {
+  public interface Options
+      extends JavascriptTextTransformer.JavascriptTextTransformerOptions, StreamingOptions {
     @TemplateParameter.Text(
         order = 1,
         groupName = "Source",
@@ -136,15 +139,15 @@ public class MongoDbToMongoDb {
         order = 7,
         groupName = "Source",
         optional = true,
-        description = "Number of Read Splits",
+        description = "Number of Backfill Read Splits",
         helpText =
-            "Number of parallel queries to generate for high-throughput reads (e.g., 16 or 32)."
-                + " Uses MongoDB's $sample aggregation to discover data-driven boundaries across"
-                + " active BSON types.")
-    @Default.Integer(0)
-    Integer getNumReadSplits();
+            "Number of parallel coarse read splits generated per collection during historical"
+                + " backfill (e.g. 1, 4, 8). Each split opens a sequential index-range cursor."
+                + " Default is 1.")
+    @Default.Integer(1)
+    Integer getNumBackfillSplits();
 
-    void setNumReadSplits(Integer value);
+    void setNumBackfillSplits(Integer value);
 
     @TemplateParameter.Integer(
         order = 8,
@@ -270,6 +273,98 @@ public class MongoDbToMongoDb {
     Boolean getReadFromDlq();
 
     void setReadFromDlq(Boolean value);
+
+    @TemplateParameter.Enum(
+        order = 19,
+        groupName = "Source",
+        enumOptions = {
+          @TemplateParameter.TemplateEnumOption("BACKFILL_AND_STREAMING"),
+          @TemplateParameter.TemplateEnumOption("STREAMING_CDC"),
+          @TemplateParameter.TemplateEnumOption("BATCH")
+        },
+        optional = true,
+        description = "Migration Mode",
+        helpText =
+            "Migration mode: 'BACKFILL_AND_STREAMING' (historical backfill and streaming CDC in"
+                + " parallel with stateful deduplication), 'STREAMING_CDC' (stream CDC only),"
+                + " or 'BATCH' (historical backfill only).")
+    @Default.String("BACKFILL_AND_STREAMING")
+    String getMigrationMode();
+
+    void setMigrationMode(String value);
+
+    @TemplateParameter.Integer(
+        order = 20,
+        groupName = "Source",
+        optional = true,
+        description = "Number of Change Stream Splits",
+        helpText =
+            "Number of parallel change stream cursors per collection for high-throughput CDC"
+                + " streaming (e.g. 1, 4, 8, 16).")
+    @Default.Integer(1)
+    Integer getNumChangeStreamSplits();
+
+    void setNumChangeStreamSplits(Integer value);
+
+    @TemplateParameter.Enum(
+        order = 21,
+        groupName = "Source",
+        enumOptions = {
+          @TemplateParameter.TemplateEnumOption("updateLookup"),
+          @TemplateParameter.TemplateEnumOption("whenAvailable"),
+          @TemplateParameter.TemplateEnumOption("required"),
+          @TemplateParameter.TemplateEnumOption("default")
+        },
+        optional = true,
+        description = "Change Stream Full Document Strategy",
+        helpText =
+            "Strategy for fetching full document in change streams: 'updateLookup' (lookup full"
+                + " doc from collection on updates, compatible with MongoDB 4+), 'whenAvailable'"
+                + " (MongoDB 6+ post-image oplog extraction without extra lookup), 'required', or"
+                + " 'default'.")
+    @Default.String("updateLookup")
+    String getChangeStreamFullDocument();
+
+    void setChangeStreamFullDocument(String value);
+
+    @TemplateParameter.Text(
+        order = 22,
+        groupName = "Source",
+        optional = true,
+        description = "Start At Operation Time",
+        helpText =
+            "Optional starting clusterTime (epoch seconds or ISO-8601 timestamp) to start change"
+                + " stream cursors from. If omitted in BACKFILL_AND_STREAMING mode, captures the"
+                + " current clusterTime before backfill starts.")
+    String getStartAtOperationTime();
+
+    void setStartAtOperationTime(String value);
+
+    @TemplateParameter.Integer(
+        order = 23,
+        groupName = "Target",
+        optional = true,
+        description = "Number of Write Shards",
+        helpText =
+            "Number of parallel shards per collection for batched writes to prevent Windmill"
+                + " single-key hotspots and maximize write parallelism. Default is 64.")
+    @Default.Integer(64)
+    Integer getNumWriteShards();
+
+    void setNumWriteShards(Integer value);
+
+    @TemplateParameter.Integer(
+        order = 24,
+        groupName = "Target",
+        optional = true,
+        description = "Max Buffering Duration Milliseconds",
+        helpText =
+            "Maximum duration in milliseconds to buffer documents before flushing a batch to target"
+                + " MongoDB. Default is 200ms.")
+    @Default.Integer(200)
+    Integer getMaxBufferingDurationMs();
+
+    void setMaxBufferingDurationMs(Integer value);
   }
 
   public static void main(String[] args) {
@@ -278,6 +373,20 @@ public class MongoDbToMongoDb {
   }
 
   public static void run(Options options) {
+    String migrationMode = options.getMigrationMode();
+    if (migrationMode == null || migrationMode.isEmpty()) {
+      migrationMode = "BACKFILL_AND_STREAMING";
+    }
+
+    boolean isStreamingMode =
+        "BACKFILL_AND_STREAMING".equalsIgnoreCase(migrationMode)
+            || "STREAMING_CDC".equalsIgnoreCase(migrationMode);
+
+    if (isStreamingMode) {
+      options.setStreaming(true);
+      options.as(DataflowPipelineOptions.class).setEnableStreamingEngine(true);
+    }
+
     Pipeline pipeline = Pipeline.create(options);
 
     String sourceUri = options.getSourceUri();
@@ -288,11 +397,15 @@ public class MongoDbToMongoDb {
     if (sourceCollection != null && !sourceCollection.isEmpty()) {
       sourceCollections.add(sourceCollection);
     } else {
-      // List collections from source
+      // List collections from source excluding internal system collections
       try (MongoClient mongoClient = MongoDbTransforms.createMongoClient(sourceUri)) {
         MongoDatabase db = mongoClient.getDatabase(sourceDatabase);
         for (String name : db.listCollectionNames()) {
-          sourceCollections.add(name);
+          if (!name.startsWith("system.")) {
+            sourceCollections.add(name);
+          } else {
+            LOG.info("Excluding internal MongoDB system collection '{}' from migration", name);
+          }
         }
       }
     }
@@ -324,10 +437,8 @@ public class MongoDbToMongoDb {
     LOG.info("  Target Database:         {}", options.getTargetDatabase());
     LOG.info("  Source Collections:      {}", sourceCollections);
     LOG.info(
-        "  Read Strategy:           {}",
-        (options.getNumReadSplits() != null && options.getNumReadSplits() > 1)
-            ? "Parallel Index-Slice Reading (numReadSplits=" + options.getNumReadSplits() + ")"
-            : "Standard unpartitioned MongoDbIO.read()");
+        "  Backfill Configuration:  coarse-split sequential cursor streaming (numBackfillSplits={})",
+        options.getNumBackfillSplits() != null ? options.getNumBackfillSplits() : 4);
     LOG.info(
         "  Write Configuration:     batchSize={}, maxConcurrentAsyncWrites={}, maxWriteRetries={},"
             + " dlqMaxRetries={}",
@@ -342,12 +453,50 @@ public class MongoDbToMongoDb {
         options.getMaxWriteRatePerWorker(),
         options.getWriteRateRampUpMinutes(),
         options.getWriteRateRampUpSteps());
+    LOG.info("  Migration Mode:          {}", options.getMigrationMode());
+    LOG.info("  Change Stream Splits:    {}", options.getNumChangeStreamSplits());
+    LOG.info("  Change Stream Strategy:  {}", options.getChangeStreamFullDocument());
     LOG.info("  DLQ Base Directory:      {}", baseDlqPath + timestampPath);
     LOG.info("  DLQ Retryable Directory: {}", retryableDlqPath);
     LOG.info("  DLQ Permanent Directory: {}", permanentDlqPath);
     LOG.info(
         "  DLQ Inspection Command:  gcloud storage cat \"{}/**/output-*\" | head -n 5",
         permanentDlqPath);
+
+    boolean includeBackfill =
+        "BACKFILL_AND_STREAMING".equalsIgnoreCase(migrationMode)
+            || "BATCH".equalsIgnoreCase(migrationMode);
+    boolean includeCdc =
+        "BACKFILL_AND_STREAMING".equalsIgnoreCase(migrationMode)
+            || "STREAMING_CDC".equalsIgnoreCase(migrationMode);
+
+    BsonTimestamp t0 = null;
+    if (includeCdc) {
+      if (options.getStartAtOperationTime() != null
+          && !options.getStartAtOperationTime().isEmpty()) {
+        try {
+          long sec = Long.parseLong(options.getStartAtOperationTime());
+          t0 = new BsonTimestamp((int) sec, 0);
+        } catch (NumberFormatException nfe) {
+          LOG.warn(
+              "Could not parse startAtOperationTime '{}' as epoch seconds. Capturing current"
+                  + " cluster time.",
+              options.getStartAtOperationTime());
+          t0 =
+              MongoDbChangeStreamReader.captureCurrentClusterTime(
+                  sourceUri, sourceDatabase);
+        }
+      } else {
+        t0 =
+            MongoDbChangeStreamReader.captureCurrentClusterTime(
+                sourceUri, sourceDatabase);
+      }
+      LOG.info(
+          "Captured initial cluster time T0: {} (seconds={}, inc={})",
+          t0,
+          t0.getTime(),
+          t0.getInc());
+    }
 
     if (options.getReadFromDlq() != null && options.getReadFromDlq()) {
       String reconsumePath = options.getReconsumeDlqPath();
@@ -356,47 +505,197 @@ public class MongoDbToMongoDb {
             "Reconsume DLQ path must be specified when reading from DLQ.");
       }
       PCollection<DocumentWithMetadata> documents = readFromDlq(pipeline, reconsumePath);
-      documents.apply(
-          "ProcessDlq",
-          new ProcessDocuments(options, retryableDlqPath, permanentDlqPath, tmpDirectory));
+      PCollection<DocumentWithMetadata> validDocs =
+          documents.apply(
+              "ProcessDlq",
+              new ProcessDocuments(options, retryableDlqPath, permanentDlqPath, tmpDirectory, true));
+      validDocs.apply(
+          "WriteDlq",
+          new WriteDocuments(options, retryableDlqPath, permanentDlqPath, tmpDirectory));
     } else {
-      for (String inputCollection : sourceCollections) {
-        String targetCollectionRaw = options.getTargetCollection();
-        final String targetCollection =
-            (targetCollectionRaw == null || targetCollectionRaw.isEmpty())
-                ? inputCollection
-                : targetCollectionRaw;
+      List<PCollection<DocumentWithMetadata>> allStreams = new ArrayList<>();
+      List<BackfillPartition> backfillPartitions = new ArrayList<>();
+      List<ChangeStreamPartition> cdcPartitions = new ArrayList<>();
 
-        PCollection<DocumentWithMetadata> documents =
-            readFromMongo(pipeline, options, inputCollection, targetCollection);
-        documents.apply(
-            "Process_" + inputCollection,
-            new ProcessDocuments(options, retryableDlqPath, permanentDlqPath, tmpDirectory));
+      MongoClient setupClient = null;
+      try {
+        setupClient = MongoDbTransforms.createMongoClient(options.getSourceUri());
+      } catch (Exception e) {
+        LOG.warn(
+            "Could not connect to MongoDB during setup using shared client ({}). Using fallback.",
+            e.getMessage());
       }
+
+      try {
+        for (String inputCollection : sourceCollections) {
+          String targetCollectionRaw = options.getTargetCollection();
+          final String targetCollection =
+              (targetCollectionRaw == null || targetCollectionRaw.isEmpty())
+                  ? inputCollection
+                  : targetCollectionRaw;
+
+          if (includeBackfill) {
+            int numBackfillSplits =
+                options.getNumBackfillSplits() != null ? options.getNumBackfillSplits() : 1;
+            try {
+              backfillPartitions.addAll(
+                  MongoDbBackfillReader.generatePartitions(
+                      setupClient,
+                      options.getSourceUri(),
+                      options.getSourceDatabase(),
+                      inputCollection,
+                      targetCollection,
+                      numBackfillSplits,
+                      t0));
+            } catch (Exception e) {
+              LOG.warn(
+                  "Could not generate partitioned splits for collection '{}' ({}). Falling back to"
+                      + " single split.",
+                  inputCollection,
+                  e.getMessage());
+              backfillPartitions.addAll(
+                  MongoDbBackfillReader.generatePartitions(
+                      null,
+                      options.getSourceUri(),
+                      options.getSourceDatabase(),
+                      inputCollection,
+                      targetCollection,
+                      1,
+                      t0));
+            }
+          }
+
+          if (includeCdc) {
+            int numCdcSplits =
+                options.getNumChangeStreamSplits() != null
+                    ? options.getNumChangeStreamSplits()
+                    : 1;
+            try {
+              cdcPartitions.addAll(
+                  MongoDbChangeStreamReader.generatePartitions(
+                      setupClient,
+                      options.getSourceUri(),
+                      options.getSourceDatabase(),
+                      inputCollection,
+                      targetCollection,
+                      numCdcSplits,
+                      t0,
+                      options.getChangeStreamFullDocument()));
+            } catch (Exception e) {
+              LOG.warn(
+                  "Could not generate change stream splits for collection '{}' ({}). Falling back"
+                      + " to single split.",
+                  inputCollection,
+                  e.getMessage());
+              cdcPartitions.addAll(
+                  MongoDbChangeStreamReader.generatePartitions(
+                      null,
+                      options.getSourceUri(),
+                      options.getSourceDatabase(),
+                      inputCollection,
+                      targetCollection,
+                      1,
+                      t0,
+                      options.getChangeStreamFullDocument()));
+            }
+          }
+        }
+      } finally {
+        if (setupClient != null) {
+          try {
+            setupClient.close();
+          } catch (Exception ignored) {
+          }
+        }
+      }
+
+      if (includeBackfill && !backfillPartitions.isEmpty()) {
+        PCollection<DocumentWithMetadata> backfillDocs =
+            pipeline
+                .apply(
+                    "ReadBackfill",
+                    new MongoDbBackfillReader.ReadPartitions(backfillPartitions))
+                .setCoder(DocumentWithMetadataCoder.of());
+        allStreams.add(backfillDocs);
+      }
+
+      if (includeCdc && !cdcPartitions.isEmpty()) {
+        PCollection<DocumentWithMetadata> cdcDocs =
+            pipeline
+                .apply(
+                    "ReadCDC",
+                    new MongoDbChangeStreamReader.ReadPartitions(cdcPartitions))
+                .setCoder(DocumentWithMetadataCoder.of());
+        allStreams.add(cdcDocs);
+      }
+
+      PCollection<DocumentWithMetadata> documents;
+      if (allStreams.size() == 1) {
+        documents = allStreams.get(0);
+      } else if (allStreams.size() > 1) {
+        documents =
+            PCollectionList.of(allStreams)
+                .apply("MergeStreams", Flatten.pCollections());
+      } else {
+        throw new IllegalStateException("No streams configured to read.");
+      }
+
+      PCollection<DocumentWithMetadata> validDocs =
+          documents.apply(
+              "ProcessDocuments",
+              new ProcessDocuments(
+                  options, retryableDlqPath, permanentDlqPath, tmpDirectory, isStreamingMode));
+
+      validDocs.apply(
+          "WriteDocuments",
+          new WriteDocuments(options, retryableDlqPath, permanentDlqPath, tmpDirectory));
     }
 
     pipeline.run();
   }
 
+  /**
+   * PTransform that processes documents: stateful deduplication, metric counting,
+   * UDF transformation, and validation, routing process failures to DLQ.
+   */
   public static class ProcessDocuments
-      extends PTransform<PCollection<DocumentWithMetadata>, PDone> {
+      extends PTransform<PCollection<DocumentWithMetadata>, PCollection<DocumentWithMetadata>> {
     private final transient Options options;
     private final String retryableDlqPath;
     private final String permanentDlqPath;
     private final String tmpDirectory;
+    private final boolean isStreamingMode;
 
     public ProcessDocuments(
-        Options options, String retryableDlqPath, String permanentDlqPath, String tmpDirectory) {
+        Options options,
+        String retryableDlqPath,
+        String permanentDlqPath,
+        String tmpDirectory,
+        boolean isStreamingMode) {
       this.options = options;
       this.retryableDlqPath = retryableDlqPath;
       this.permanentDlqPath = permanentDlqPath;
       this.tmpDirectory = tmpDirectory;
+      this.isStreamingMode = isStreamingMode;
+    }
+
+    public ProcessDocuments(
+        Options options, String retryableDlqPath, String permanentDlqPath, String tmpDirectory) {
+      this(options, retryableDlqPath, permanentDlqPath, tmpDirectory, false);
     }
 
     @Override
-    public PDone expand(PCollection<DocumentWithMetadata> input) {
-      PCollection<DocumentWithMetadata> documents =
-          input.apply(
+    public PCollection<DocumentWithMetadata> expand(PCollection<DocumentWithMetadata> input) {
+      PCollection<DocumentWithMetadata> documents = input;
+
+      // Stateful Deduplication Stage
+      if (isStreamingMode) {
+        documents = documents.apply("Deduplicate", StatefulDeduplication.of());
+      }
+
+      // Metrics Stage
+      documents =
+          documents.apply(
               "CountTotalProcessed",
               ParDo.of(
                   new DoFn<DocumentWithMetadata, DocumentWithMetadata>() {
@@ -437,7 +736,7 @@ public class MongoDbToMongoDb {
         documents =
             udfProcessed
                 .get(udfSuccessTag)
-                .setCoder(SerializableCoder.of(DocumentWithMetadata.class));
+                .setCoder(DocumentWithMetadataCoder.of());
       }
 
       // Validation Stage with DLQ
@@ -447,32 +746,7 @@ public class MongoDbToMongoDb {
       PCollectionTuple processed =
           documents.apply(
               "Validate",
-              ParDo.of(
-                      new DoFn<DocumentWithMetadata, DocumentWithMetadata>() {
-                        private final Counter contextCreationFailures =
-                            Metrics.counter(MongoDbToMongoDb.class, "contextCreationFailures");
-
-                        @ProcessElement
-                        public void processElement(ProcessContext c) {
-                          DocumentWithMetadata item = c.element();
-                          if (item == null || item.getDocument() == null) {
-                            contextCreationFailures.inc();
-                            c.output(
-                                failureTag,
-                                DocumentWithMetadata.of(
-                                    null,
-                                    null,
-                                    0,
-                                    "Null document",
-                                    DocumentWithMetadata.ErrorType.PERMANENT,
-                                    null,
-                                    null,
-                                    DocumentWithMetadata.FailureStage.VALIDATE));
-                          } else {
-                            c.output(successTag, item);
-                          }
-                        }
-                      })
+              ParDo.of(new ValidateFn(failureTag))
                   .withOutputTags(successTag, TupleTagList.of(failureTag)));
 
       // Write Process Failures to DLQ
@@ -482,16 +756,39 @@ public class MongoDbToMongoDb {
               "WriteToDlq_Validate",
               new MongoDbTransforms.WriteToDlq(retryableDlqPath, permanentDlqPath, tmpDirectory));
 
-      // Write Stage with DLQ
-      PCollection<DocumentWithMetadata> validDocs = processed.get(successTag);
+      return processed.get(successTag).setCoder(DocumentWithMetadataCoder.of());
+    }
+  }
 
+  /**
+   * PTransform that writes valid documents in bulk to target MongoDB, routing write failures to DLQ.
+   */
+  public static class WriteDocuments
+      extends PTransform<PCollection<DocumentWithMetadata>, PDone> {
+    private final transient Options options;
+    private final String retryableDlqPath;
+    private final String permanentDlqPath;
+    private final String tmpDirectory;
+
+    public WriteDocuments(
+        Options options, String retryableDlqPath, String permanentDlqPath, String tmpDirectory) {
+      this.options = options;
+      this.retryableDlqPath = retryableDlqPath;
+      this.permanentDlqPath = permanentDlqPath;
+      this.tmpDirectory = tmpDirectory;
+    }
+
+    @Override
+    public PDone expand(PCollection<DocumentWithMetadata> validDocs) {
       PCollection<DocumentWithMetadata> writeFailures =
           validDocs.apply(
-              "Write",
+              "WriteToTarget",
               MongoDbTransforms.writeWithDlq()
                   .withUri(options.getTargetUri())
                   .withDatabase(options.getTargetDatabase())
                   .withBatchSize(options.getBatchSize())
+                  .withNumWriteShards(options.getNumWriteShards())
+                  .withMaxBufferingDurationMs(options.getMaxBufferingDurationMs())
                   .withMaxConcurrentAsyncWrites(options.getMaxConcurrentAsyncWrites())
                   .withMaxWriteRetries(options.getMaxWriteRetries())
                   .withDlqMaxRetries(options.getDlqMaxRetries())
@@ -516,7 +813,73 @@ public class MongoDbToMongoDb {
           "WriteToDlq_Write",
           new MongoDbTransforms.WriteToDlq(retryableDlqPath, permanentDlqPath, tmpDirectory));
 
-      return PDone.in(input.getPipeline());
+      return PDone.in(validDocs.getPipeline());
+    }
+  }
+
+  public static class ValidateFn extends DoFn<DocumentWithMetadata, DocumentWithMetadata> {
+    private final Counter contextCreationFailures =
+        Metrics.counter(MongoDbToMongoDb.class, "contextCreationFailures");
+    private final Counter validationPassed =
+        Metrics.counter(MongoDbToMongoDb.class, "validationPassed");
+    private final Counter validationFailedNullPayload =
+        Metrics.counter(MongoDbToMongoDb.class, "validationFailedNullPayload");
+    private final TupleTag<DocumentWithMetadata> failureTag;
+
+    public ValidateFn(TupleTag<DocumentWithMetadata> failureTag) {
+      this.failureTag = failureTag;
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      DocumentWithMetadata item = c.element();
+      if (item == null
+          || (item.getDocument() == null
+              && (item.getOperationType() == null
+                  || (!item.getOperationType().isDelete()
+                      && item.getOperationType() != DocumentWithMetadata.OperationType.DROP
+                      && item.getOperationType() != DocumentWithMetadata.OperationType.RENAME)))) {
+        contextCreationFailures.inc();
+        validationFailedNullPayload.inc();
+        c.output(
+            failureTag,
+            item != null
+                ? item.withFailure(
+                    "Null document payload",
+                    DocumentWithMetadata.ErrorType.PERMANENT,
+                    DocumentWithMetadata.FailureStage.VALIDATE)
+                : DocumentWithMetadata.of(
+                    null,
+                    null,
+                    0,
+                    "Null element",
+                    DocumentWithMetadata.ErrorType.PERMANENT,
+                    null,
+                    null,
+                    DocumentWithMetadata.FailureStage.VALIDATE));
+      } else {
+        validationPassed.inc();
+        c.output(item);
+      }
+    }
+  }
+
+  public static class ParseDlqFn extends DoFn<String, DocumentWithMetadata> {
+    private final Counter retriedDocuments =
+        Metrics.counter(MongoDbToMongoDb.class, "retriedDocuments");
+    private final Counter contextCreationFailures =
+        Metrics.counter(MongoDbToMongoDb.class, "contextCreationFailures");
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      String line = c.element();
+      try {
+        c.output(DocumentWithMetadata.fromDlqJson(line));
+        retriedDocuments.inc();
+      } catch (Exception e) {
+        LOG.error("Failed to parse DLQ event", e);
+        contextCreationFailures.inc();
+      }
     }
   }
 
@@ -525,104 +888,8 @@ public class MongoDbToMongoDb {
     PCollection<String> dlqStrings =
         pipeline.apply("ReadDlq", TextIO.read().from(reconsumePath + "/**"));
 
-    return dlqStrings.apply(
-        "ParseDlq",
-        ParDo.of(
-            new DoFn<String, DocumentWithMetadata>() {
-              private final Counter retriedDocuments =
-                  Metrics.counter(MongoDbToMongoDb.class, "retriedDocuments");
-              private final Counter contextCreationFailures =
-                  Metrics.counter(MongoDbToMongoDb.class, "contextCreationFailures");
-
-              @ProcessElement
-              public void processElement(ProcessContext c) {
-                String line = c.element();
-                try {
-                  c.output(DocumentWithMetadata.fromDlqJson(line));
-                  retriedDocuments.inc();
-                } catch (Exception e) {
-                  LOG.error("Failed to parse DLQ event", e);
-                  contextCreationFailures.inc();
-                }
-              }
-            }));
-  }
-
-  private static PCollection<DocumentWithMetadata> readFromMongo(
-      Pipeline pipeline, Options options, String sourceCollection, String targetCollection) {
-    Integer numReadSplits = options.getNumReadSplits();
-    if (numReadSplits != null && numReadSplits > 1) {
-      List<BsonDocument> filters;
-      try (MongoClient client = MongoDbTransforms.createMongoClient(options.getSourceUri())) {
-        filters =
-            ReadSplitGenerator.generateIndexSliceFilters(
-                client, options.getSourceDatabase(), sourceCollection, numReadSplits);
-      } catch (Exception e) {
-        LOG.warn(
-            "Could not connect to MongoDB during setup to generate data-driven read splits ({})."
-                + " Using offline uniform split generation.",
-            e.getMessage());
-        filters = ReadSplitGenerator.generateIndexSliceFilters(numReadSplits);
-      }
-
-      List<PCollection<DocumentWithMetadata>> readBranches = new ArrayList<>();
-
-      LOG.info(
-          "Generating {} parallel index-slice read branches for collection '{}'",
-          filters.size(),
-          sourceCollection);
-
-      String readGroup = "ReadSlices(" + sourceCollection + ")";
-      for (int i = 0; i < filters.size(); i++) {
-        final String filterJson = filters.get(i).toJson();
-        LOG.info("  Read Branch [{}/{}] Query Filter: {}", i, filters.size() - 1, filterJson);
-        MongoDbIO.Read read =
-            MongoDbIO.read()
-                .withUri(options.getSourceUri())
-                .withDatabase(options.getSourceDatabase())
-                .withCollection(sourceCollection)
-                .withQueryFn(FindQuery.create().withFilters(filters.get(i)));
-
-        PCollection<DocumentWithMetadata> branch =
-            pipeline
-                .apply(readGroup + "/Slice_" + i + "/Read", read)
-                .apply(
-                    readGroup + "/Slice_" + i + "/MapToMetadata",
-                    ParDo.of(
-                        new DoFn<Document, DocumentWithMetadata>() {
-                          @ProcessElement
-                          public void processElement(ProcessContext c) {
-                            c.output(
-                                DocumentWithMetadata.of(
-                                    c.element(), sourceCollection, targetCollection));
-                          }
-                        }));
-        readBranches.add(branch);
-      }
-
-      return PCollectionList.of(readBranches).apply(readGroup + "/Merge", Flatten.pCollections());
-    }
-
-    LOG.info("Using standard unpartitioned MongoDbIO.read() for collection '{}'", sourceCollection);
-
-    MongoDbIO.Read read =
-        MongoDbIO.read()
-            .withUri(options.getSourceUri())
-            .withDatabase(options.getSourceDatabase())
-            .withCollection(sourceCollection);
-
-    String readGroup = "Read(" + sourceCollection + ")";
-    return pipeline
-        .apply(readGroup + "/Read", read)
-        .apply(
-            readGroup + "/MapToMetadata",
-            ParDo.of(
-                new DoFn<Document, DocumentWithMetadata>() {
-                  @ProcessElement
-                  public void processElement(ProcessContext c) {
-                    c.output(
-                        DocumentWithMetadata.of(c.element(), sourceCollection, targetCollection));
-                  }
-                }));
+    return dlqStrings
+        .apply("ParseDlq", ParDo.of(new ParseDlqFn()))
+        .setCoder(DocumentWithMetadataCoder.of());
   }
 }

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDb.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDb.java
@@ -280,14 +280,14 @@ public class MongoDbToMongoDb {
         enumOptions = {
           @TemplateParameter.TemplateEnumOption("BACKFILL_AND_STREAMING"),
           @TemplateParameter.TemplateEnumOption("STREAMING_CDC"),
-          @TemplateParameter.TemplateEnumOption("BATCH")
+          @TemplateParameter.TemplateEnumOption("BACKFILL")
         },
         optional = true,
         description = "Migration Mode",
         helpText =
             "Migration mode: 'BACKFILL_AND_STREAMING' (historical backfill and streaming CDC in"
                 + " parallel with stateful deduplication), 'STREAMING_CDC' (stream CDC only),"
-                + " or 'BATCH' (historical backfill only).")
+                + " or 'BACKFILL' (historical backfill only).")
     @Default.String("BACKFILL_AND_STREAMING")
     String getMigrationMode();
 
@@ -472,7 +472,7 @@ public class MongoDbToMongoDb {
 
     boolean includeBackfill =
         "BACKFILL_AND_STREAMING".equalsIgnoreCase(migrationMode)
-            || "BATCH".equalsIgnoreCase(migrationMode);
+            || "BACKFILL".equalsIgnoreCase(migrationMode);
     boolean includeCdc =
         "BACKFILL_AND_STREAMING".equalsIgnoreCase(migrationMode)
             || "STREAMING_CDC".equalsIgnoreCase(migrationMode);
@@ -556,9 +556,10 @@ public class MongoDbToMongoDb {
             } catch (Exception e) {
               LOG.warn(
                   "Could not generate partitioned splits for collection '{}' ({}). Falling back to"
-                      + " single split.",
+                      + " algorithmic splits (splits={}).",
                   inputCollection,
-                  e.getMessage());
+                  e.getMessage(),
+                  numBackfillSplits);
               backfillPartitions.addAll(
                   MongoDbBackfillReader.generatePartitions(
                       null,
@@ -566,7 +567,7 @@ public class MongoDbToMongoDb {
                       options.getSourceDatabase(),
                       inputCollection,
                       targetCollection,
-                      1,
+                      numBackfillSplits,
                       t0));
             }
           }
@@ -682,7 +683,11 @@ public class MongoDbToMongoDb {
           documents.apply(
               "ProcessDocuments",
               new ProcessDocuments(
-                  options, retryableDlqPath, permanentDlqPath, tmpDirectory, isStreamingMode));
+                  options,
+                  retryableDlqPath,
+                  permanentDlqPath,
+                  tmpDirectory,
+                  includeBackfill && includeCdc));
 
       validDocs.apply(
           "WriteDocuments",
@@ -702,19 +707,19 @@ public class MongoDbToMongoDb {
     private final String retryableDlqPath;
     private final String permanentDlqPath;
     private final String tmpDirectory;
-    private final boolean isStreamingMode;
+    private final boolean requiresDeduplication;
 
     public ProcessDocuments(
         Options options,
         String retryableDlqPath,
         String permanentDlqPath,
         String tmpDirectory,
-        boolean isStreamingMode) {
+        boolean requiresDeduplication) {
       this.options = options;
       this.retryableDlqPath = retryableDlqPath;
       this.permanentDlqPath = permanentDlqPath;
       this.tmpDirectory = tmpDirectory;
-      this.isStreamingMode = isStreamingMode;
+      this.requiresDeduplication = requiresDeduplication;
     }
 
     public ProcessDocuments(
@@ -726,8 +731,10 @@ public class MongoDbToMongoDb {
     public PCollection<DocumentWithMetadata> expand(PCollection<DocumentWithMetadata> input) {
       PCollection<DocumentWithMetadata> documents = input;
 
-      // Stateful Deduplication Stage
-      if (isStreamingMode) {
+      // Stateful Deduplication Stage: Only needed when reconciling historical backfill records
+      // with concurrent live CDC mutations. In pure STREAMING_CDC mode, change stream events
+      // for any given document are already strictly ordered and sequential from the oplog.
+      if (requiresDeduplication) {
         documents = documents.apply("Deduplicate", StatefulDeduplication.of());
       }
 

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDb.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDb.java
@@ -76,6 +76,12 @@ import org.slf4j.LoggerFactory;
 public class MongoDbToMongoDb {
 
   private static final Logger LOG = LoggerFactory.getLogger(MongoDbToMongoDb.class);
+  public static final int DEFAULT_TARGET_BACKFILL_CHUNK_SIZE = 200000;
+  public static final int DEFAULT_MAX_BACKFILL_SPLITS = 256;
+  public static final int DEFAULT_INITIAL_WRITE_RATE_PER_WORKER = 5000;
+  public static final int DEFAULT_MAX_WRITE_RATE_PER_WORKER = 25000;
+  public static final int DEFAULT_WRITE_RATE_RAMP_UP_MINUTES = 5;
+  public static final int DEFAULT_WRITE_RATE_RAMP_UP_STEPS = 5;
 
   public interface Options extends JavascriptTextTransformerOptions, StreamingOptions {
     @TemplateParameter.Text(
@@ -411,15 +417,6 @@ public class MongoDbToMongoDb {
       migrationMode = "BACKFILL_AND_STREAMING";
     }
 
-    boolean isStreamingMode =
-        "BACKFILL_AND_STREAMING".equalsIgnoreCase(migrationMode)
-            || "STREAMING_CDC".equalsIgnoreCase(migrationMode);
-
-    if (isStreamingMode) {
-      options.setStreaming(true);
-      options.as(DataflowPipelineOptions.class).setEnableStreamingEngine(true);
-    }
-
     Pipeline pipeline = Pipeline.create(options);
 
     String sourceUri = options.getSourceUri();
@@ -492,25 +489,29 @@ public class MongoDbToMongoDb {
         options.getMaxWriteRatePerWorker(),
         options.getWriteRateRampUpMinutes(),
         options.getWriteRateRampUpSteps());
-    LOG.info("  Migration Mode:          {}", options.getMigrationMode());
-    LOG.info("  Change Stream Splits:    {}", options.getNumChangeStreamSplits());
-    LOG.info("  Change Stream Strategy:  {}", options.getChangeStreamFullDocument());
-    LOG.info("  Backfill Chunk Size:     {}", options.getTargetBackfillChunkSize());
-    LOG.info("  Max Backfill Splits:     {}", options.getMaxBackfillSplits());
-    LOG.info("  Max Concurrent Reads:    {}", options.getMaxConcurrentBackfillReads());
-    LOG.info("  DLQ Base Directory:      {}", baseDlqPath + timestampPath);
-    LOG.info("  DLQ Retryable Directory: {}", retryableDlqPath);
-    LOG.info("  DLQ Permanent Directory: {}", permanentDlqPath);
-    LOG.info(
-        "  DLQ Inspection Command:  gcloud storage cat \"{}/**/output-*\" | head -n 5",
-        permanentDlqPath);
-
     boolean includeBackfill =
         "BACKFILL_AND_STREAMING".equalsIgnoreCase(migrationMode)
             || "BACKFILL".equalsIgnoreCase(migrationMode);
     boolean includeCdc =
         "BACKFILL_AND_STREAMING".equalsIgnoreCase(migrationMode)
             || "STREAMING_CDC".equalsIgnoreCase(migrationMode);
+
+    LOG.info("  Migration Mode:          {}", options.getMigrationMode());
+    if (includeCdc) {
+      LOG.info("  Change Stream Splits:    {}", options.getNumChangeStreamSplits());
+      LOG.info("  Change Stream Strategy:  {}", options.getChangeStreamFullDocument());
+    }
+    if (includeBackfill) {
+      LOG.info("  Backfill Chunk Size:     {}", options.getTargetBackfillChunkSize());
+      LOG.info("  Max Backfill Splits:     {}", options.getMaxBackfillSplits());
+      LOG.info("  Max Concurrent Reads:    {}", options.getMaxConcurrentBackfillReads());
+    }
+    LOG.info("  DLQ Base Directory:      {}", baseDlqPath + timestampPath);
+    LOG.info("  DLQ Retryable Directory: {}", retryableDlqPath);
+    LOG.info("  DLQ Permanent Directory: {}", permanentDlqPath);
+    LOG.info(
+        "  DLQ Inspection Command:  gcloud storage cat \"{}/**/output-*\" | head -n 5",
+        permanentDlqPath);
 
     BsonTimestamp t0 = null;
     if (includeCdc) {
@@ -550,7 +551,12 @@ public class MongoDbToMongoDb {
       PCollection<DocumentWithMetadata> validDocs =
           documents.apply(
               "ProcessDlq",
-              new ProcessDocuments(options, retryableDlqPath, permanentDlqPath, tmpDirectory, true));
+              new ProcessDocuments(
+                  options,
+                  retryableDlqPath,
+                  permanentDlqPath,
+                  tmpDirectory,
+                  /* requiresDeduplication= */ true));
       validDocs.apply(
           "WriteDlq",
           new WriteDocuments(options, retryableDlqPath, permanentDlqPath, tmpDirectory));
@@ -579,9 +585,11 @@ public class MongoDbToMongoDb {
             int targetChunkSize =
                 options.getTargetBackfillChunkSize() != null
                     ? options.getTargetBackfillChunkSize()
-                    : 200000;
+                    : DEFAULT_TARGET_BACKFILL_CHUNK_SIZE;
             int maxSplits =
-                options.getMaxBackfillSplits() != null ? options.getMaxBackfillSplits() : 256;
+                options.getMaxBackfillSplits() != null
+                    ? options.getMaxBackfillSplits()
+                    : DEFAULT_MAX_BACKFILL_SPLITS;
             try {
               backfillPartitions.addAll(
                   MongoDbBackfillReader.generatePartitions(
@@ -636,12 +644,12 @@ public class MongoDbToMongoDb {
                   e.getMessage());
               cdcPartitions.addAll(
                   MongoDbChangeStreamReader.generatePartitions(
-                      null,
+                      /* client= */ null,
                       options.getSourceUri(),
                       options.getSourceDatabase(),
                       inputCollection,
                       targetCollection,
-                      1,
+                      /* numSplits= */ 1,
                       t0,
                       options.getChangeStreamFullDocument()));
             }
@@ -671,10 +679,10 @@ public class MongoDbToMongoDb {
                 e.getMessage());
             cdcPartitions.addAll(
                 MongoDbChangeStreamReader.generateDatabasePartitions(
-                    null,
+                    /* client= */ null,
                     options.getSourceUri(),
                     options.getSourceDatabase(),
-                    1,
+                    /* numSplits= */ 1,
                     t0,
                     options.getChangeStreamFullDocument()));
           }
@@ -782,10 +790,6 @@ public class MongoDbToMongoDb {
       if (requiresDeduplication) {
         documents = documents.apply("Deduplicate", StatefulDeduplication.of());
       }
-
-      // Metrics Stage
-      documents = documents.apply("CountTotalProcessed", ParDo.of(new CountDocumentsFn()));
-
       // UDF Stage
       if (options.getJavascriptTextTransformGcsPath() != null
           && !options.getJavascriptTextTransformGcsPath().isEmpty()) {
@@ -872,36 +876,25 @@ public class MongoDbToMongoDb {
                   .withInitialWriteRatePerWorker(
                       options.getInitialWriteRatePerWorker() != null
                           ? options.getInitialWriteRatePerWorker()
-                          : 5000)
+                          : DEFAULT_INITIAL_WRITE_RATE_PER_WORKER)
                   .withMaxWriteRatePerWorker(
                       options.getMaxWriteRatePerWorker() != null
                           ? options.getMaxWriteRatePerWorker()
-                          : 25000)
+                          : DEFAULT_MAX_WRITE_RATE_PER_WORKER)
                   .withWriteRateRampUpMinutes(
                       options.getWriteRateRampUpMinutes() != null
                           ? options.getWriteRateRampUpMinutes()
-                          : 5)
+                          : DEFAULT_WRITE_RATE_RAMP_UP_MINUTES)
                   .withWriteRateRampUpSteps(
                       options.getWriteRateRampUpSteps() != null
                           ? options.getWriteRateRampUpSteps()
-                          : 5));
+                          : DEFAULT_WRITE_RATE_RAMP_UP_STEPS));
 
       writeFailures.apply(
           "WriteToDlq_Write",
           new WriteToDlq(retryableDlqPath, permanentDlqPath, tmpDirectory));
 
       return PDone.in(validDocs.getPipeline());
-    }
-  }
-
-  public static class CountDocumentsFn extends DoFn<DocumentWithMetadata, DocumentWithMetadata> {
-    private final Counter totalProcessedDocuments =
-        Metrics.counter(MongoDbToMongoDb.class, "totalProcessedDocuments");
-
-    @ProcessElement
-    public void processElement(ProcessContext c) {
-      totalProcessedDocuments.inc();
-      c.output(c.element());
     }
   }
 

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDb.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDb.java
@@ -19,20 +19,25 @@ import com.google.cloud.teleport.metadata.Template;
 import com.google.cloud.teleport.metadata.TemplateCategory;
 import com.google.cloud.teleport.metadata.TemplateParameter;
 import com.google.cloud.teleport.v2.transforms.DocumentWithMetadata;
+import com.google.cloud.teleport.v2.transforms.DocumentWithMetadata.ErrorType;
+import com.google.cloud.teleport.v2.transforms.DocumentWithMetadata.FailureStage;
+import com.google.cloud.teleport.v2.transforms.DocumentWithMetadata.OperationType;
 import com.google.cloud.teleport.v2.transforms.DocumentWithMetadataCoder;
-import com.google.cloud.teleport.v2.transforms.JavascriptTextTransformer;
+import com.google.cloud.teleport.v2.transforms.JavascriptTextTransformer.JavascriptTextTransformerOptions;
 import com.google.cloud.teleport.v2.transforms.MongoDbBackfillReader;
 import com.google.cloud.teleport.v2.transforms.MongoDbBackfillReader.BackfillPartition;
 import com.google.cloud.teleport.v2.transforms.MongoDbChangeStreamReader;
 import com.google.cloud.teleport.v2.transforms.MongoDbChangeStreamReader.ChangeStreamPartition;
 import com.google.cloud.teleport.v2.transforms.MongoDbTransforms;
+import com.google.cloud.teleport.v2.transforms.MongoDbTransforms.ApplyUdfFn;
+import com.google.cloud.teleport.v2.transforms.MongoDbTransforms.WriteToDlq;
 import com.google.cloud.teleport.v2.transforms.StatefulDeduplication;
 import com.google.cloud.teleport.v2.transforms.UriSanitizer;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoDatabase;
-import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.sdk.Pipeline;
@@ -57,7 +62,10 @@ import org.bson.BsonTimestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Dataflow template which copies data from one MongoDB database to another with CDC streaming support. */
+/**
+ * Dataflow template which copies data from one MongoDB database to another with CDC streaming
+ * support.
+ */
 @Template(
     name = "Mongodb_To_Mongodb",
     category = TemplateCategory.STREAMING,
@@ -69,8 +77,7 @@ public class MongoDbToMongoDb {
 
   private static final Logger LOG = LoggerFactory.getLogger(MongoDbToMongoDb.class);
 
-  public interface Options
-      extends JavascriptTextTransformer.JavascriptTextTransformerOptions, StreamingOptions {
+  public interface Options extends JavascriptTextTransformerOptions, StreamingOptions {
     @TemplateParameter.Text(
         order = 1,
         groupName = "Source",
@@ -397,7 +404,8 @@ public class MongoDbToMongoDb {
     if ((sourceCollection == null || sourceCollection.isEmpty())
         && (targetCollectionRaw != null && !targetCollectionRaw.isEmpty())) {
       throw new IllegalArgumentException(
-          "targetCollection cannot be specified when migrating an entire database without specifying sourceCollection.");
+          "targetCollection cannot be specified when migrating an entire database without"
+              + " specifying sourceCollection.");
     }
 
     List<String> sourceCollections = new ArrayList<>();
@@ -433,7 +441,8 @@ public class MongoDbToMongoDb {
       dlqDirectory = tmpDirectory;
     }
     String baseDlqPath = dlqDirectory.endsWith("/") ? dlqDirectory : dlqDirectory + "/";
-    String timestampPath = new SimpleDateFormat("yyyy-MM-dd/HH-mm-ss").format(new Date());
+    String timestampPath =
+        LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd/HH-mm-ss"));
     String retryableDlqPath = baseDlqPath + timestampPath + "/retryable";
     String permanentDlqPath = baseDlqPath + timestampPath + "/permanent";
 
@@ -505,7 +514,7 @@ public class MongoDbToMongoDb {
           t0.getInc());
     }
 
-    if (options.getReadFromDlq() != null && options.getReadFromDlq()) {
+    if (Boolean.TRUE.equals(options.getReadFromDlq())) {
       String reconsumePath = options.getReconsumeDlqPath();
       if (reconsumePath == null || reconsumePath.isEmpty()) {
         throw new IllegalArgumentException(
@@ -739,20 +748,7 @@ public class MongoDbToMongoDb {
       }
 
       // Metrics Stage
-      documents =
-          documents.apply(
-              "CountTotalProcessed",
-              ParDo.of(
-                  new DoFn<DocumentWithMetadata, DocumentWithMetadata>() {
-                    private final Counter totalProcessedDocuments =
-                        Metrics.counter(MongoDbToMongoDb.class, "totalProcessedDocuments");
-
-                    @ProcessElement
-                    public void processElement(ProcessContext c) {
-                      totalProcessedDocuments.inc();
-                      c.output(c.element());
-                    }
-                  }));
+      documents = documents.apply("CountTotalProcessed", ParDo.of(new CountDocumentsFn()));
 
       // UDF Stage
       if (options.getJavascriptTextTransformGcsPath() != null
@@ -764,7 +760,7 @@ public class MongoDbToMongoDb {
             documents.apply(
                 "ApplyUDF",
                 ParDo.of(
-                        new MongoDbTransforms.ApplyUdfFn(
+                        new ApplyUdfFn(
                             options.getJavascriptTextTransformGcsPath(),
                             options.getJavascriptTextTransformFunctionName(),
                             options.getJavascriptTextTransformReloadIntervalMinutes(),
@@ -776,7 +772,7 @@ public class MongoDbToMongoDb {
             .get(udfFailureTag)
             .apply(
                 "WriteToDlq_UDF",
-                new MongoDbTransforms.WriteToDlq(retryableDlqPath, permanentDlqPath, tmpDirectory));
+                new WriteToDlq(retryableDlqPath, permanentDlqPath, tmpDirectory));
 
         documents =
             udfProcessed
@@ -799,7 +795,7 @@ public class MongoDbToMongoDb {
           .get(failureTag)
           .apply(
               "WriteToDlq_Validate",
-              new MongoDbTransforms.WriteToDlq(retryableDlqPath, permanentDlqPath, tmpDirectory));
+              new WriteToDlq(retryableDlqPath, permanentDlqPath, tmpDirectory));
 
       return processed.get(successTag).setCoder(DocumentWithMetadataCoder.of());
     }
@@ -840,11 +836,11 @@ public class MongoDbToMongoDb {
                   .withInitialWriteRatePerWorker(
                       options.getInitialWriteRatePerWorker() != null
                           ? options.getInitialWriteRatePerWorker()
-                          : 100)
+                          : 5000)
                   .withMaxWriteRatePerWorker(
                       options.getMaxWriteRatePerWorker() != null
                           ? options.getMaxWriteRatePerWorker()
-                          : 500)
+                          : 25000)
                   .withWriteRateRampUpMinutes(
                       options.getWriteRateRampUpMinutes() != null
                           ? options.getWriteRateRampUpMinutes()
@@ -856,9 +852,20 @@ public class MongoDbToMongoDb {
 
       writeFailures.apply(
           "WriteToDlq_Write",
-          new MongoDbTransforms.WriteToDlq(retryableDlqPath, permanentDlqPath, tmpDirectory));
+          new WriteToDlq(retryableDlqPath, permanentDlqPath, tmpDirectory));
 
       return PDone.in(validDocs.getPipeline());
+    }
+  }
+
+  public static class CountDocumentsFn extends DoFn<DocumentWithMetadata, DocumentWithMetadata> {
+    private final Counter totalProcessedDocuments =
+        Metrics.counter(MongoDbToMongoDb.class, "totalProcessedDocuments");
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      totalProcessedDocuments.inc();
+      c.output(c.element());
     }
   }
 
@@ -875,15 +882,22 @@ public class MongoDbToMongoDb {
       this.failureTag = failureTag;
     }
 
+    private static boolean isValidDocument(DocumentWithMetadata item) {
+      if (item == null) {
+        return false;
+      }
+      if (item.getDocument() != null) {
+        return true;
+      }
+      OperationType opType = item.getOperationType();
+      return opType != null
+          && (opType.isDelete() || opType == OperationType.DROP || opType == OperationType.RENAME);
+    }
+
     @ProcessElement
     public void processElement(ProcessContext c) {
       DocumentWithMetadata item = c.element();
-      if (item == null
-          || (item.getDocument() == null
-              && (item.getOperationType() == null
-                  || (!item.getOperationType().isDelete()
-                      && item.getOperationType() != DocumentWithMetadata.OperationType.DROP
-                      && item.getOperationType() != DocumentWithMetadata.OperationType.RENAME)))) {
+      if (!isValidDocument(item)) {
         contextCreationFailures.inc();
         validationFailedNullPayload.inc();
         c.output(
@@ -891,17 +905,17 @@ public class MongoDbToMongoDb {
             item != null
                 ? item.withFailure(
                     "Null document payload",
-                    DocumentWithMetadata.ErrorType.PERMANENT,
-                    DocumentWithMetadata.FailureStage.VALIDATE)
+                    ErrorType.PERMANENT,
+                    FailureStage.VALIDATE)
                 : DocumentWithMetadata.of(
                     null,
                     null,
                     0,
                     "Null element",
-                    DocumentWithMetadata.ErrorType.PERMANENT,
+                    ErrorType.PERMANENT,
                     null,
                     null,
-                    DocumentWithMetadata.FailureStage.VALIDATE));
+                    FailureStage.VALIDATE));
       } else {
         validationPassed.inc();
         c.output(item);

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDb.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDb.java
@@ -35,6 +35,7 @@ import com.google.cloud.teleport.v2.transforms.StatefulDeduplication;
 import com.google.cloud.teleport.v2.transforms.UriSanitizer;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoDatabase;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -518,11 +519,16 @@ public class MongoDbToMongoDb {
       if (options.getStartAtOperationTime() != null
           && !options.getStartAtOperationTime().isEmpty()) {
         try {
-          long sec = Long.parseLong(options.getStartAtOperationTime());
+          long sec;
+          try {
+            sec = Long.parseLong(options.getStartAtOperationTime());
+          } catch (NumberFormatException nfe) {
+            sec = Instant.parse(options.getStartAtOperationTime()).getEpochSecond();
+          }
           t0 = new BsonTimestamp((int) sec, 0);
-        } catch (NumberFormatException nfe) {
+        } catch (Exception e) {
           LOG.warn(
-              "Could not parse startAtOperationTime '{}' as epoch seconds. Capturing current"
+              "Could not parse startAtOperationTime '{}' as epoch seconds or ISO-8601. Capturing current"
                   + " cluster time.",
               options.getStartAtOperationTime());
           t0 = MongoDbChangeStreamReader.captureCurrentClusterTime(sourceUri, sourceDatabase);

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDb.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDb.java
@@ -149,18 +149,18 @@ public class MongoDbToMongoDb {
     void setTargetCollection(String value);
 
     @TemplateParameter.Integer(
-        order = 8,
+        order = 7,
         groupName = "Target",
         optional = true,
-        description = "Batch Size",
+        description = "Write Batch Size",
         helpText = "Number of documents in a bulk write.")
     @Default.Integer(5000)
-    Integer getBatchSize();
+    Integer getWriteBatchSize();
 
-    void setBatchSize(Integer value);
+    void setWriteBatchSize(Integer value);
 
     @TemplateParameter.Integer(
-        order = 9,
+        order = 8,
         groupName = "Target",
         optional = true,
         description = "Max Concurrent Async Writes",
@@ -171,7 +171,7 @@ public class MongoDbToMongoDb {
     void setMaxConcurrentAsyncWrites(Integer value);
 
     @TemplateParameter.Integer(
-        order = 10,
+        order = 9,
         groupName = "Target",
         optional = true,
         description = "Max Write Retries",
@@ -182,7 +182,7 @@ public class MongoDbToMongoDb {
     void setMaxWriteRetries(Integer value);
 
     @TemplateParameter.Integer(
-        order = 11,
+        order = 10,
         groupName = "Target",
         optional = true,
         description = "Initial Write Rate Per Worker",
@@ -195,7 +195,7 @@ public class MongoDbToMongoDb {
     void setInitialWriteRatePerWorker(Integer value);
 
     @TemplateParameter.Integer(
-        order = 12,
+        order = 11,
         groupName = "Target",
         optional = true,
         description = "Write Rate Ramp Up Minutes",
@@ -207,7 +207,7 @@ public class MongoDbToMongoDb {
     void setWriteRateRampUpMinutes(Integer value);
 
     @TemplateParameter.Integer(
-        order = 13,
+        order = 12,
         groupName = "Target",
         optional = true,
         description = "Max Write Rate Per Worker",
@@ -219,7 +219,7 @@ public class MongoDbToMongoDb {
     void setMaxWriteRatePerWorker(Integer value);
 
     @TemplateParameter.Integer(
-        order = 14,
+        order = 13,
         groupName = "Target",
         optional = true,
         description = "Write Rate Ramp Up Steps",
@@ -230,7 +230,7 @@ public class MongoDbToMongoDb {
     void setWriteRateRampUpSteps(Integer value);
 
     @TemplateParameter.Text(
-        order = 15,
+        order = 14,
         optional = true,
         description = "DLQ Directory",
         helpText =
@@ -241,7 +241,7 @@ public class MongoDbToMongoDb {
     void setDlqDirectory(String value);
 
     @TemplateParameter.Integer(
-        order = 16,
+        order = 15,
         optional = true,
         description = "DLQ Max Retries",
         helpText = "Maximum number of times to retry events from DLQ.")
@@ -251,7 +251,7 @@ public class MongoDbToMongoDb {
     void setDlqMaxRetries(Integer value);
 
     @TemplateParameter.Text(
-        order = 17,
+        order = 16,
         groupName = "Source",
         optional = true,
         description = "Reconsume DLQ Path",
@@ -263,7 +263,7 @@ public class MongoDbToMongoDb {
     void setReconsumeDlqPath(String value);
 
     @TemplateParameter.Boolean(
-        order = 18,
+        order = 17,
         groupName = "Source",
         optional = true,
         description = "Read from DLQ",
@@ -274,7 +274,7 @@ public class MongoDbToMongoDb {
     void setReadFromDlq(Boolean value);
 
     @TemplateParameter.Enum(
-        order = 19,
+        order = 18,
         groupName = "Source",
         enumOptions = {
           @TemplateParameter.TemplateEnumOption("BACKFILL_AND_STREAMING"),
@@ -293,7 +293,7 @@ public class MongoDbToMongoDb {
     void setMigrationMode(String value);
 
     @TemplateParameter.Integer(
-        order = 20,
+        order = 19,
         groupName = "Source",
         optional = true,
         description = "Number of Change Stream Splits",
@@ -306,7 +306,7 @@ public class MongoDbToMongoDb {
     void setNumChangeStreamSplits(Integer value);
 
     @TemplateParameter.Enum(
-        order = 21,
+        order = 20,
         groupName = "Source",
         enumOptions = {
           @TemplateParameter.TemplateEnumOption("updateLookup"),
@@ -327,7 +327,7 @@ public class MongoDbToMongoDb {
     void setChangeStreamFullDocument(String value);
 
     @TemplateParameter.Text(
-        order = 22,
+        order = 21,
         groupName = "Source",
         optional = true,
         description = "Start At Operation Time",
@@ -340,7 +340,7 @@ public class MongoDbToMongoDb {
     void setStartAtOperationTime(String value);
 
     @TemplateParameter.Integer(
-        order = 23,
+        order = 22,
         groupName = "Target",
         optional = true,
         description = "Number of Write Shards",
@@ -353,7 +353,7 @@ public class MongoDbToMongoDb {
     void setNumWriteShards(Integer value);
 
     @TemplateParameter.Integer(
-        order = 24,
+        order = 23,
         groupName = "Target",
         optional = true,
         description = "Max Buffering Duration Milliseconds",
@@ -366,7 +366,7 @@ public class MongoDbToMongoDb {
     void setMaxBufferingDurationMs(Integer value);
 
     @TemplateParameter.Integer(
-        order = 25,
+        order = 24,
         groupName = "Source",
         optional = true,
         description = "Target Backfill Chunk Size",
@@ -379,7 +379,7 @@ public class MongoDbToMongoDb {
     void setTargetBackfillChunkSize(Integer value);
 
     @TemplateParameter.Integer(
-        order = 26,
+        order = 25,
         groupName = "Source",
         optional = true,
         description = "Max Backfill Splits",
@@ -392,7 +392,7 @@ public class MongoDbToMongoDb {
     void setMaxBackfillSplits(Integer value);
 
     @TemplateParameter.Integer(
-        order = 27,
+        order = 26,
         groupName = "Source",
         optional = true,
         description = "Max Concurrent Backfill Reads",
@@ -476,9 +476,9 @@ public class MongoDbToMongoDb {
     LOG.info("  Target Database:         {}", options.getTargetDatabase());
     LOG.info("  Source Collections:      {}", sourceCollections);
     LOG.info(
-        "  Write Configuration:     batchSize={}, maxConcurrentAsyncWrites={}, maxWriteRetries={},"
-            + " dlqMaxRetries={}",
-        options.getBatchSize(),
+        "  Write Configuration:     writeBatchSize={}, maxConcurrentAsyncWrites={},"
+            + " maxWriteRetries={}, dlqMaxRetries={}",
+        options.getWriteBatchSize(),
         options.getMaxConcurrentAsyncWrites(),
         options.getMaxWriteRetries(),
         options.getDlqMaxRetries());
@@ -853,7 +853,7 @@ public class MongoDbToMongoDb {
               MongoDbTransforms.writeWithDlq()
                   .withUri(options.getTargetUri())
                   .withDatabase(options.getTargetDatabase())
-                  .withBatchSize(options.getBatchSize())
+                  .withBatchSize(options.getWriteBatchSize())
                   .withNumWriteShards(options.getNumWriteShards())
                   .withMaxBufferingDurationMs(options.getMaxBufferingDurationMs())
                   .withMaxConcurrentAsyncWrites(options.getMaxConcurrentAsyncWrites())

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadata.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadata.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.Serializable;
+import java.util.Objects;
 import org.apache.beam.sdk.coders.DefaultCoder;
 import org.bson.Document;
 import org.bson.json.JsonMode;
@@ -254,10 +255,6 @@ public class DocumentWithMetadata implements Serializable {
 
   /** Returns whether this event is a reconsumed DLQ retry. */
   public boolean isDlqReconsumed() {
-    return isDlqReconsumed;
-  }
-
-  public boolean getIsDlqReconsumed() {
     return isDlqReconsumed;
   }
 
@@ -596,11 +593,14 @@ public class DocumentWithMetadata implements Serializable {
 
       String operationTypeStr = getOrDefault(jsonNode, METADATA_OPERATION_TYPE, null);
       OperationType operationType =
-          operationTypeStr != null ? OperationType.valueOf(operationTypeStr) : OperationType.BACKFILL;
+          operationTypeStr != null
+              ? OperationType.valueOf(operationTypeStr)
+              : OperationType.BACKFILL;
       boolean isDlqReconsumed = getBooleanOrDefault(jsonNode, METADATA_DLQ_RECONSUMED, true);
 
       TimestampSortKey timestampSortKey = null;
-      if (jsonNode.has(METADATA_TIMESTAMP_SECONDS) && !jsonNode.get(METADATA_TIMESTAMP_SECONDS).isNull()) {
+      if (jsonNode.has(METADATA_TIMESTAMP_SECONDS)
+          && !jsonNode.get(METADATA_TIMESTAMP_SECONDS).isNull()) {
         long sec = getLongOrDefault(jsonNode, METADATA_TIMESTAMP_SECONDS, 0L);
         long subSec = getLongOrDefault(jsonNode, METADATA_TIMESTAMP_SUB_SECONDS, 0L);
         boolean isCdc = getBooleanOrDefault(jsonNode, METADATA_IS_CDC, false);
@@ -630,29 +630,28 @@ public class DocumentWithMetadata implements Serializable {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof DocumentWithMetadata)) {
+    if (!(o instanceof DocumentWithMetadata that)) {
       return false;
     }
-    DocumentWithMetadata that = (DocumentWithMetadata) o;
     return isDlqReconsumed == that.isDlqReconsumed
-        && java.util.Objects.equals(document, that.document)
-        && java.util.Objects.equals(getOriginalDocument(), that.getOriginalDocument())
-        && java.util.Objects.equals(retryCount, that.retryCount)
-        && java.util.Objects.equals(errorMessage, that.errorMessage)
+        && Objects.equals(document, that.document)
+        && Objects.equals(originalDocument, that.originalDocument)
+        && Objects.equals(retryCount, that.retryCount)
+        && Objects.equals(errorMessage, that.errorMessage)
         && errorType == that.errorType
-        && java.util.Objects.equals(sourceCollection, that.sourceCollection)
-        && java.util.Objects.equals(targetCollection, that.targetCollection)
+        && Objects.equals(sourceCollection, that.sourceCollection)
+        && Objects.equals(targetCollection, that.targetCollection)
         && failureStage == that.failureStage
         && operationType == that.operationType
-        && java.util.Objects.equals(timestampSortKey, that.timestampSortKey)
-        && java.util.Objects.equals(documentKey, that.documentKey);
+        && Objects.equals(timestampSortKey, that.timestampSortKey)
+        && Objects.equals(documentKey, that.documentKey);
   }
 
   @Override
   public int hashCode() {
-    return java.util.Objects.hash(
+    return Objects.hash(
         document,
-        getOriginalDocument(),
+        originalDocument,
         retryCount,
         errorMessage,
         errorType,

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadata.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadata.java
@@ -19,15 +19,17 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.Serializable;
+import org.apache.beam.sdk.coders.DefaultCoder;
 import org.bson.Document;
 import org.bson.json.JsonMode;
 import org.bson.json.JsonWriterSettings;
 
 /**
  * This class contains the raw document and metadata related to the migration. It is used to carry
- * the document and its DLQ retry context through the pipeline without polluting the original
- * document schema.
+ * the document, CDC operation type, ordering timestamp sort key, and DLQ retry context through the
+ * pipeline without polluting the original document schema.
  */
+@DefaultCoder(DocumentWithMetadataCoder.class)
 public class DocumentWithMetadata implements Serializable {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -41,6 +43,12 @@ public class DocumentWithMetadata implements Serializable {
   public static final String METADATA_TARGET_COLLECTION = "_metadata_target_collection";
   public static final String METADATA_ERROR_MESSAGE = "_metadata_error_message";
   public static final String METADATA_FAILURE_STAGE = "_metadata_failure_stage";
+  public static final String METADATA_OPERATION_TYPE = "_metadata_operation_type";
+  public static final String METADATA_DOCUMENT_KEY = "_metadata_document_key";
+  public static final String METADATA_TIMESTAMP_SECONDS = "_metadata_timestamp_seconds";
+  public static final String METADATA_TIMESTAMP_SUB_SECONDS = "_metadata_timestamp_sub_seconds";
+  public static final String METADATA_IS_CDC = "_metadata_is_cdc";
+  public static final String METADATA_DLQ_RECONSUMED = "_metadata_dlq_reconsumed";
   public static final String ORIGINAL_DOCUMENT = "_original_document";
 
   public enum ErrorType {
@@ -54,6 +62,24 @@ public class DocumentWithMetadata implements Serializable {
     WRITE
   }
 
+  public enum OperationType {
+    INSERT,
+    UPDATE,
+    REPLACE,
+    DELETE,
+    DROP,
+    RENAME,
+    BACKFILL;
+
+    public boolean isDelete() {
+      return this == DELETE;
+    }
+
+    public boolean isUpsert() {
+      return this == INSERT || this == UPDATE || this == REPLACE || this == BACKFILL;
+    }
+  }
+
   private final Document document;
   private final String originalDocument;
   private final Integer retryCount;
@@ -62,6 +88,37 @@ public class DocumentWithMetadata implements Serializable {
   private final String sourceCollection;
   private final String targetCollection;
   private final FailureStage failureStage;
+  private final OperationType operationType;
+  private final TimestampSortKey timestampSortKey;
+  private final String documentKey;
+  private final boolean isDlqReconsumed;
+
+  public DocumentWithMetadata(
+      Document document,
+      String originalDocument,
+      Integer retryCount,
+      String errorMessage,
+      ErrorType errorType,
+      String sourceCollection,
+      String targetCollection,
+      FailureStage failureStage,
+      OperationType operationType,
+      TimestampSortKey timestampSortKey,
+      String documentKey,
+      boolean isDlqReconsumed) {
+    this.document = document;
+    this.originalDocument = originalDocument;
+    this.retryCount = retryCount != null ? retryCount : 0;
+    this.errorMessage = errorMessage;
+    this.errorType = errorType;
+    this.sourceCollection = sourceCollection;
+    this.targetCollection = targetCollection;
+    this.failureStage = failureStage;
+    this.operationType = operationType != null ? operationType : OperationType.BACKFILL;
+    this.timestampSortKey = timestampSortKey;
+    this.documentKey = documentKey;
+    this.isDlqReconsumed = isDlqReconsumed;
+  }
 
   public DocumentWithMetadata(
       Document document,
@@ -72,14 +129,19 @@ public class DocumentWithMetadata implements Serializable {
       String sourceCollection,
       String targetCollection,
       FailureStage failureStage) {
-    this.document = document;
-    this.originalDocument = originalDocument;
-    this.retryCount = retryCount;
-    this.errorMessage = errorMessage;
-    this.errorType = errorType;
-    this.sourceCollection = sourceCollection;
-    this.targetCollection = targetCollection;
-    this.failureStage = failureStage;
+    this(
+        document,
+        originalDocument,
+        retryCount,
+        errorMessage,
+        errorType,
+        sourceCollection,
+        targetCollection,
+        failureStage,
+        OperationType.BACKFILL,
+        null,
+        null,
+        false);
   }
 
   /** Returns the current BSON document. */
@@ -89,10 +151,45 @@ public class DocumentWithMetadata implements Serializable {
 
   /** Returns the ID of the document. */
   public Object getId() {
-    if (document != null) {
+    if (document != null && document.containsKey("_id")) {
       return document.get("_id");
     }
+    if (documentKey != null) {
+      try {
+        Document keyDoc = Document.parse(documentKey);
+        if (keyDoc.containsKey("_id")) {
+          return keyDoc.get("_id");
+        }
+      } catch (Exception ignored) {
+        return documentKey;
+      }
+    }
     return null;
+  }
+
+  /**
+   * Returns a unique deduplication key scoped by collection and document identifier.
+   */
+  public String getDedupKey() {
+    String col =
+        targetCollection != null
+            ? targetCollection
+            : (sourceCollection != null ? sourceCollection : "default");
+    if (documentKey != null && !documentKey.isEmpty()) {
+      return col + "#" + documentKey;
+    }
+    if (document != null && document.containsKey("_id")) {
+      try {
+        return col + "#" + new Document("_id", document.get("_id")).toJson(CANONICAL_JSON_SETTINGS);
+      } catch (Exception ignored) {
+        return col + "#" + document.get("_id");
+      }
+    }
+    Object id = getId();
+    if (id != null) {
+      return col + "#" + id;
+    }
+    return col + "#" + System.identityHashCode(this);
   }
 
   /** Returns the original document string. */
@@ -130,6 +227,144 @@ public class DocumentWithMetadata implements Serializable {
     return failureStage;
   }
 
+  /** Returns the CDC operation type (e.g., INSERT, UPDATE, REPLACE, DELETE, BACKFILL). */
+  public OperationType getOperationType() {
+    return operationType;
+  }
+
+  /** Returns the ordering timestamp sort key. */
+  public TimestampSortKey getTimestampSortKey() {
+    return timestampSortKey;
+  }
+
+  /** Returns the document key string for identification/deletions. */
+  public String getDocumentKey() {
+    return documentKey;
+  }
+
+  /** Returns whether this event is a reconsumed DLQ retry. */
+  public boolean isDlqReconsumed() {
+    return isDlqReconsumed;
+  }
+
+  public boolean getIsDlqReconsumed() {
+    return isDlqReconsumed;
+  }
+
+  public DocumentWithMetadata withTimestampSortKey(TimestampSortKey key) {
+    return new DocumentWithMetadata(
+        document,
+        originalDocument,
+        retryCount,
+        errorMessage,
+        errorType,
+        sourceCollection,
+        targetCollection,
+        failureStage,
+        operationType,
+        key,
+        documentKey,
+        isDlqReconsumed);
+  }
+
+  public DocumentWithMetadata withOperationType(OperationType op) {
+    return new DocumentWithMetadata(
+        document,
+        originalDocument,
+        retryCount,
+        errorMessage,
+        errorType,
+        sourceCollection,
+        targetCollection,
+        failureStage,
+        op,
+        timestampSortKey,
+        documentKey,
+        isDlqReconsumed);
+  }
+
+  public DocumentWithMetadata withDocumentKey(String docKey) {
+    return new DocumentWithMetadata(
+        document,
+        originalDocument,
+        retryCount,
+        errorMessage,
+        errorType,
+        sourceCollection,
+        targetCollection,
+        failureStage,
+        operationType,
+        timestampSortKey,
+        docKey,
+        isDlqReconsumed);
+  }
+
+  public DocumentWithMetadata withDlqReconsumed(boolean dlqReconsumed) {
+    return new DocumentWithMetadata(
+        document,
+        originalDocument,
+        retryCount,
+        errorMessage,
+        errorType,
+        sourceCollection,
+        targetCollection,
+        failureStage,
+        operationType,
+        timestampSortKey,
+        documentKey,
+        dlqReconsumed);
+  }
+
+  public DocumentWithMetadata withDocument(Document newDoc) {
+    return new DocumentWithMetadata(
+        newDoc,
+        originalDocument,
+        retryCount,
+        errorMessage,
+        errorType,
+        sourceCollection,
+        targetCollection,
+        failureStage,
+        operationType,
+        timestampSortKey,
+        documentKey,
+        isDlqReconsumed);
+  }
+
+  public DocumentWithMetadata withFailure(
+      String errorMsg, ErrorType errType, FailureStage stage) {
+    return new DocumentWithMetadata(
+        document,
+        originalDocument,
+        retryCount,
+        errorMsg,
+        errType,
+        sourceCollection,
+        targetCollection,
+        stage,
+        operationType,
+        timestampSortKey,
+        documentKey,
+        isDlqReconsumed);
+  }
+
+  public DocumentWithMetadata withFailure(
+      String errorMsg, ErrorType errType, FailureStage stage, Integer newRetryCount) {
+    return new DocumentWithMetadata(
+        document,
+        originalDocument,
+        newRetryCount,
+        errorMsg,
+        errType,
+        sourceCollection,
+        targetCollection,
+        stage,
+        operationType,
+        timestampSortKey,
+        documentKey,
+        true);
+  }
+
   public static DocumentWithMetadata of(
       Document document,
       String originalDocument,
@@ -165,14 +400,21 @@ public class DocumentWithMetadata implements Serializable {
 
   public static DocumentWithMetadata of(Document document) {
     return new DocumentWithMetadata(
-        document, document.toJson(CANONICAL_JSON_SETTINGS), 0, null, null, null, null, null);
+        document,
+        document != null ? document.toJson(CANONICAL_JSON_SETTINGS) : null,
+        0,
+        null,
+        null,
+        null,
+        null,
+        null);
   }
 
   public static DocumentWithMetadata of(
       Document document, String sourceCollection, String targetCollection) {
     return new DocumentWithMetadata(
         document,
-        document.toJson(CANONICAL_JSON_SETTINGS),
+        document != null ? document.toJson(CANONICAL_JSON_SETTINGS) : null,
         0,
         null,
         null,
@@ -201,6 +443,54 @@ public class DocumentWithMetadata implements Serializable {
         failureStage);
   }
 
+  public static DocumentWithMetadata cdcEvent(
+      Document document,
+      String originalDocument,
+      String sourceCollection,
+      String targetCollection,
+      OperationType operationType,
+      TimestampSortKey timestampSortKey,
+      String documentKey) {
+    return new DocumentWithMetadata(
+        document,
+        originalDocument,
+        0,
+        null,
+        null,
+        sourceCollection,
+        targetCollection,
+        null,
+        operationType,
+        timestampSortKey,
+        documentKey,
+        false);
+  }
+
+  public static DocumentWithMetadata backfillEvent(
+      Document document,
+      String sourceCollection,
+      String targetCollection,
+      TimestampSortKey timestampSortKey) {
+    String original = document != null ? document.toJson(CANONICAL_JSON_SETTINGS) : null;
+    String docKey = null;
+    if (document != null && document.containsKey("_id")) {
+      docKey = new Document("_id", document.get("_id")).toJson(CANONICAL_JSON_SETTINGS);
+    }
+    return new DocumentWithMetadata(
+        document,
+        original,
+        0,
+        null,
+        null,
+        sourceCollection,
+        targetCollection,
+        null,
+        OperationType.BACKFILL,
+        timestampSortKey,
+        docKey,
+        false);
+  }
+
   /**
    * Serializes the event for DLQ.
    *
@@ -213,13 +503,29 @@ public class DocumentWithMetadata implements Serializable {
     try {
       ObjectNode dlqNode = MAPPER.createObjectNode();
 
-      dlqNode.set(ORIGINAL_DOCUMENT, MAPPER.readTree(originalDocument));
+      if (originalDocument != null && !originalDocument.isEmpty()) {
+        dlqNode.set(ORIGINAL_DOCUMENT, MAPPER.readTree(originalDocument));
+      } else if (document != null) {
+        dlqNode.set(ORIGINAL_DOCUMENT, MAPPER.readTree(document.toJson(CANONICAL_JSON_SETTINGS)));
+      } else {
+        dlqNode.putNull(ORIGINAL_DOCUMENT);
+      }
+
       dlqNode.put(METADATA_ERROR_MESSAGE, errorMessage);
       dlqNode.put(METADATA_ERROR_TYPE, errorType != null ? errorType.name() : null);
       dlqNode.put(METADATA_RETRY_COUNT, newRetryCount);
       dlqNode.put(METADATA_SOURCE_COLLECTION, sourceCollection);
       dlqNode.put(METADATA_TARGET_COLLECTION, targetCollection);
       dlqNode.put(METADATA_FAILURE_STAGE, failureStage != null ? failureStage.name() : null);
+      dlqNode.put(METADATA_OPERATION_TYPE, operationType != null ? operationType.name() : null);
+      dlqNode.put(METADATA_DOCUMENT_KEY, documentKey);
+      dlqNode.put(METADATA_DLQ_RECONSUMED, true);
+
+      if (timestampSortKey != null) {
+        dlqNode.put(METADATA_TIMESTAMP_SECONDS, timestampSortKey.getSeconds());
+        dlqNode.put(METADATA_TIMESTAMP_SUB_SECONDS, timestampSortKey.getSubSeconds());
+        dlqNode.put(METADATA_IS_CDC, timestampSortKey.isCdc());
+      }
 
       return dlqNode.toString();
     } catch (Exception e) {
@@ -239,6 +545,19 @@ public class DocumentWithMetadata implements Serializable {
         : defaultValue;
   }
 
+  private static long getLongOrDefault(JsonNode node, String fieldName, long defaultValue) {
+    return node.has(fieldName) && !node.get(fieldName).isNull()
+        ? node.get(fieldName).asLong()
+        : defaultValue;
+  }
+
+  private static boolean getBooleanOrDefault(
+      JsonNode node, String fieldName, boolean defaultValue) {
+    return node.has(fieldName) && !node.get(fieldName).isNull()
+        ? node.get(fieldName).asBoolean()
+        : defaultValue;
+  }
+
   public static DocumentWithMetadata fromDlqJson(String jsonStr) {
     try {
       JsonNode jsonNode = MAPPER.readTree(jsonStr);
@@ -250,13 +569,19 @@ public class DocumentWithMetadata implements Serializable {
         // Fallback to legacy "data" key for backwards compatibility
         dataNode = jsonNode.get("data");
       }
-      if (dataNode == null) {
+      String documentKey = getOrDefault(jsonNode, METADATA_DOCUMENT_KEY, null);
+
+      if ((dataNode == null || dataNode.isNull()) && documentKey == null) {
         throw new IllegalArgumentException(
             "Invalid DLQ message: missing '" + ORIGINAL_DOCUMENT + "' or 'data' field");
       }
 
-      Document doc = Document.parse(dataNode.toString());
-      String originalDocument = dataNode.toString();
+      Document doc = null;
+      String originalDocument = null;
+      if (dataNode != null && !dataNode.isNull()) {
+        doc = Document.parse(dataNode.toString());
+        originalDocument = dataNode.toString();
+      }
 
       Integer retryCount = getIntOrDefault(jsonNode, METADATA_RETRY_COUNT, 0);
       String errorMsg = getOrDefault(jsonNode, METADATA_ERROR_MESSAGE, null);
@@ -268,6 +593,19 @@ public class DocumentWithMetadata implements Serializable {
       FailureStage failureStage =
           failureStageStr != null ? FailureStage.valueOf(failureStageStr) : null;
 
+      String operationTypeStr = getOrDefault(jsonNode, METADATA_OPERATION_TYPE, null);
+      OperationType operationType =
+          operationTypeStr != null ? OperationType.valueOf(operationTypeStr) : OperationType.BACKFILL;
+      boolean isDlqReconsumed = getBooleanOrDefault(jsonNode, METADATA_DLQ_RECONSUMED, true);
+
+      TimestampSortKey timestampSortKey = null;
+      if (jsonNode.has(METADATA_TIMESTAMP_SECONDS) && !jsonNode.get(METADATA_TIMESTAMP_SECONDS).isNull()) {
+        long sec = getLongOrDefault(jsonNode, METADATA_TIMESTAMP_SECONDS, 0L);
+        long subSec = getLongOrDefault(jsonNode, METADATA_TIMESTAMP_SUB_SECONDS, 0L);
+        boolean isCdc = getBooleanOrDefault(jsonNode, METADATA_IS_CDC, false);
+        timestampSortKey = TimestampSortKey.of(sec, subSec, isCdc);
+      }
+
       return new DocumentWithMetadata(
           doc,
           originalDocument,
@@ -276,9 +614,53 @@ public class DocumentWithMetadata implements Serializable {
           errorType,
           sourceCollection,
           targetCollection,
-          failureStage);
+          failureStage,
+          operationType,
+          timestampSortKey,
+          documentKey,
+          isDlqReconsumed);
     } catch (Exception e) {
       throw new RuntimeException("Failed to parse DLQ message", e);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof DocumentWithMetadata)) {
+      return false;
+    }
+    DocumentWithMetadata that = (DocumentWithMetadata) o;
+    return isDlqReconsumed == that.isDlqReconsumed
+        && java.util.Objects.equals(document, that.document)
+        && java.util.Objects.equals(originalDocument, that.originalDocument)
+        && java.util.Objects.equals(retryCount, that.retryCount)
+        && java.util.Objects.equals(errorMessage, that.errorMessage)
+        && errorType == that.errorType
+        && java.util.Objects.equals(sourceCollection, that.sourceCollection)
+        && java.util.Objects.equals(targetCollection, that.targetCollection)
+        && failureStage == that.failureStage
+        && operationType == that.operationType
+        && java.util.Objects.equals(timestampSortKey, that.timestampSortKey)
+        && java.util.Objects.equals(documentKey, that.documentKey);
+  }
+
+  @Override
+  public int hashCode() {
+    return java.util.Objects.hash(
+        document,
+        originalDocument,
+        retryCount,
+        errorMessage,
+        errorType,
+        sourceCollection,
+        targetCollection,
+        failureStage,
+        operationType,
+        timestampSortKey,
+        documentKey,
+        isDlqReconsumed);
   }
 }

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadata.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadata.java
@@ -181,6 +181,19 @@ public class DocumentWithMetadata implements Serializable {
       col = "default";
     }
     if (documentKey != null && !documentKey.isEmpty()) {
+      // On sharded collections the change stream documentKey carries the shard key fields in
+      // addition to _id, while backfill events only ever carry _id. Normalize down to _id so both
+      // streams agree on the key; otherwise the same document would occupy two different dedup
+      // state cells and two different write shards, allowing a stale backfill row to be written
+      // concurrently with (and after) a newer CDC event.
+      try {
+        Document keyDoc = Document.parse(documentKey);
+        if (keyDoc.containsKey("_id")) {
+          return col + "#" + new Document("_id", keyDoc.get("_id")).toJson(CANONICAL_JSON_SETTINGS);
+        }
+      } catch (Exception ignored) {
+        // Fall through to the raw documentKey below.
+      }
       return col + "#" + documentKey;
     }
     if (document != null && document.containsKey("_id")) {

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadata.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadata.java
@@ -19,7 +19,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
+import java.util.UUID;
 import org.apache.beam.sdk.coders.DefaultCoder;
 import org.bson.Document;
 import org.bson.json.JsonMode;
@@ -192,7 +194,11 @@ public class DocumentWithMetadata implements Serializable {
     if (id != null) {
       return col + "#" + id;
     }
-    return col + "#" + System.identityHashCode(this);
+    String raw =
+        (originalDocument != null ? originalDocument : "")
+            + (sourceCollection != null ? sourceCollection : "")
+            + (targetCollection != null ? targetCollection : "");
+    return col + "#" + UUID.nameUUIDFromBytes(raw.getBytes(StandardCharsets.UTF_8)).toString();
   }
 
   /** Returns the original document string. */

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadata.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadata.java
@@ -171,10 +171,14 @@ public class DocumentWithMetadata implements Serializable {
    * Returns a unique deduplication key scoped by collection and document identifier.
    */
   public String getDedupKey() {
-    String col =
-        targetCollection != null
-            ? targetCollection
-            : (sourceCollection != null ? sourceCollection : "default");
+    String col;
+    if (targetCollection != null && !targetCollection.isEmpty()) {
+      col = targetCollection;
+    } else if (sourceCollection != null && !sourceCollection.isEmpty()) {
+      col = sourceCollection;
+    } else {
+      col = "default";
+    }
     if (documentKey != null && !documentKey.isEmpty()) {
       return col + "#" + documentKey;
     }
@@ -194,7 +198,13 @@ public class DocumentWithMetadata implements Serializable {
 
   /** Returns the original document string. */
   public String getOriginalDocument() {
-    return originalDocument;
+    if (originalDocument != null) {
+      return originalDocument;
+    }
+    if (document != null) {
+      return document.toJson(CANONICAL_JSON_SETTINGS);
+    }
+    return null;
   }
 
   /** Returns the retry count associated with this document in DLQ. */
@@ -318,7 +328,7 @@ public class DocumentWithMetadata implements Serializable {
   public DocumentWithMetadata withDocument(Document newDoc) {
     return new DocumentWithMetadata(
         newDoc,
-        originalDocument,
+        getOriginalDocument(),
         retryCount,
         errorMessage,
         errorType,
@@ -399,22 +409,14 @@ public class DocumentWithMetadata implements Serializable {
   }
 
   public static DocumentWithMetadata of(Document document) {
-    return new DocumentWithMetadata(
-        document,
-        document != null ? document.toJson(CANONICAL_JSON_SETTINGS) : null,
-        0,
-        null,
-        null,
-        null,
-        null,
-        null);
+    return new DocumentWithMetadata(document, null, 0, null, null, null, null, null);
   }
 
   public static DocumentWithMetadata of(
       Document document, String sourceCollection, String targetCollection) {
     return new DocumentWithMetadata(
         document,
-        document != null ? document.toJson(CANONICAL_JSON_SETTINGS) : null,
+        null,
         0,
         null,
         null,
@@ -471,14 +473,13 @@ public class DocumentWithMetadata implements Serializable {
       String sourceCollection,
       String targetCollection,
       TimestampSortKey timestampSortKey) {
-    String original = document != null ? document.toJson(CANONICAL_JSON_SETTINGS) : null;
     String docKey = null;
     if (document != null && document.containsKey("_id")) {
       docKey = new Document("_id", document.get("_id")).toJson(CANONICAL_JSON_SETTINGS);
     }
     return new DocumentWithMetadata(
         document,
-        original,
+        null,
         0,
         null,
         null,
@@ -635,7 +636,7 @@ public class DocumentWithMetadata implements Serializable {
     DocumentWithMetadata that = (DocumentWithMetadata) o;
     return isDlqReconsumed == that.isDlqReconsumed
         && java.util.Objects.equals(document, that.document)
-        && java.util.Objects.equals(originalDocument, that.originalDocument)
+        && java.util.Objects.equals(getOriginalDocument(), that.getOriginalDocument())
         && java.util.Objects.equals(retryCount, that.retryCount)
         && java.util.Objects.equals(errorMessage, that.errorMessage)
         && errorType == that.errorType
@@ -651,7 +652,7 @@ public class DocumentWithMetadata implements Serializable {
   public int hashCode() {
     return java.util.Objects.hash(
         document,
-        originalDocument,
+        getOriginalDocument(),
         retryCount,
         errorMessage,
         errorType,

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadata.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadata.java
@@ -168,9 +168,7 @@ public class DocumentWithMetadata implements Serializable {
     return null;
   }
 
-  /**
-   * Returns a unique deduplication key scoped by collection and document identifier.
-   */
+  /** Returns a unique deduplication key scoped by collection and document identifier. */
   public String getDedupKey() {
     String col;
     if (targetCollection != null && !targetCollection.isEmpty()) {
@@ -338,8 +336,7 @@ public class DocumentWithMetadata implements Serializable {
         isDlqReconsumed);
   }
 
-  public DocumentWithMetadata withFailure(
-      String errorMsg, ErrorType errType, FailureStage stage) {
+  public DocumentWithMetadata withFailure(String errorMsg, ErrorType errType, FailureStage stage) {
     return new DocumentWithMetadata(
         document,
         originalDocument,
@@ -412,14 +409,7 @@ public class DocumentWithMetadata implements Serializable {
   public static DocumentWithMetadata of(
       Document document, String sourceCollection, String targetCollection) {
     return new DocumentWithMetadata(
-        document,
-        null,
-        0,
-        null,
-        null,
-        sourceCollection,
-        targetCollection,
-        null);
+        document, null, 0, null, null, sourceCollection, targetCollection, null);
   }
 
   public static DocumentWithMetadata of(

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadataCoder.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadataCoder.java
@@ -61,7 +61,15 @@ public class DocumentWithMetadataCoder extends AtomicCoder<DocumentWithMetadata>
     String docJson =
         value.getDocument() != null ? value.getDocument().toJson(CANONICAL_JSON_SETTINGS) : null;
     STRING_CODER.encode(docJson, outStream);
-    STRING_CODER.encode(value.getOriginalDocument(), outStream);
+
+    String originalDoc = value.getOriginalDocument();
+    boolean hasDistinctOriginal =
+        originalDoc != null && (docJson == null || !originalDoc.equals(docJson));
+    BOOLEAN_CODER.encode(hasDistinctOriginal, outStream);
+    if (hasDistinctOriginal) {
+      STRING_CODER.encode(originalDoc, outStream);
+    }
+
     VARINT_CODER.encode(value.getRetryCount() != null ? value.getRetryCount() : 0, outStream);
     STRING_CODER.encode(value.getErrorMessage(), outStream);
     STRING_CODER.encode(
@@ -86,7 +94,9 @@ public class DocumentWithMetadataCoder extends AtomicCoder<DocumentWithMetadata>
 
     String docJson = STRING_CODER.decode(inStream);
     Document doc = docJson != null ? Document.parse(docJson) : null;
-    String originalDoc = STRING_CODER.decode(inStream);
+
+    boolean hasDistinctOriginal = BOOLEAN_CODER.decode(inStream);
+    String originalDoc = hasDistinctOriginal ? STRING_CODER.decode(inStream) : null;
     int retryCount = VARINT_CODER.decode(inStream);
     String errorMessage = STRING_CODER.decode(inStream);
     String errorTypeStr = STRING_CODER.decode(inStream);

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadataCoder.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadataCoder.java
@@ -106,9 +106,7 @@ public class DocumentWithMetadataCoder extends AtomicCoder<DocumentWithMetadata>
     String targetCollection = STRING_CODER.decode(inStream);
     String failureStageStr = STRING_CODER.decode(inStream);
     DocumentWithMetadata.FailureStage failureStage =
-        failureStageStr != null
-            ? DocumentWithMetadata.FailureStage.valueOf(failureStageStr)
-            : null;
+        failureStageStr != null ? DocumentWithMetadata.FailureStage.valueOf(failureStageStr) : null;
     String opTypeStr = STRING_CODER.decode(inStream);
     DocumentWithMetadata.OperationType opType =
         opTypeStr != null

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadataCoder.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadataCoder.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.transforms;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.beam.sdk.coders.AtomicCoder;
+import org.apache.beam.sdk.coders.BooleanCoder;
+import org.apache.beam.sdk.coders.NullableCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.VarIntCoder;
+import org.bson.Document;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+
+/**
+ * Deterministic binary coder for {@link DocumentWithMetadata}.
+ *
+ * <p>Provides compact, fast binary serialization without Java reflection overhead for shuffle and
+ * Windmill state storage.
+ */
+public class DocumentWithMetadataCoder extends AtomicCoder<DocumentWithMetadata> {
+
+  private static final DocumentWithMetadataCoder INSTANCE = new DocumentWithMetadataCoder();
+  private static final NullableCoder<String> STRING_CODER = NullableCoder.of(StringUtf8Coder.of());
+  private static final BooleanCoder BOOLEAN_CODER = BooleanCoder.of();
+  private static final VarIntCoder VARINT_CODER = VarIntCoder.of();
+  private static final TimestampSortKeyCoder TIMESTAMP_CODER = TimestampSortKeyCoder.of();
+
+  private static final JsonWriterSettings CANONICAL_JSON_SETTINGS =
+      JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
+
+  private DocumentWithMetadataCoder() {}
+
+  public static DocumentWithMetadataCoder of() {
+    return INSTANCE;
+  }
+
+  @Override
+  public void encode(DocumentWithMetadata value, OutputStream outStream) throws IOException {
+    if (value == null) {
+      BOOLEAN_CODER.encode(false, outStream);
+      return;
+    }
+    BOOLEAN_CODER.encode(true, outStream);
+
+    String docJson =
+        value.getDocument() != null ? value.getDocument().toJson(CANONICAL_JSON_SETTINGS) : null;
+    STRING_CODER.encode(docJson, outStream);
+    STRING_CODER.encode(value.getOriginalDocument(), outStream);
+    VARINT_CODER.encode(value.getRetryCount() != null ? value.getRetryCount() : 0, outStream);
+    STRING_CODER.encode(value.getErrorMessage(), outStream);
+    STRING_CODER.encode(
+        value.getErrorType() != null ? value.getErrorType().name() : null, outStream);
+    STRING_CODER.encode(value.getSourceCollection(), outStream);
+    STRING_CODER.encode(value.getTargetCollection(), outStream);
+    STRING_CODER.encode(
+        value.getFailureStage() != null ? value.getFailureStage().name() : null, outStream);
+    STRING_CODER.encode(
+        value.getOperationType() != null ? value.getOperationType().name() : null, outStream);
+    STRING_CODER.encode(value.getDocumentKey(), outStream);
+    BOOLEAN_CODER.encode(value.isDlqReconsumed(), outStream);
+    TIMESTAMP_CODER.encode(value.getTimestampSortKey(), outStream);
+  }
+
+  @Override
+  public DocumentWithMetadata decode(InputStream inStream) throws IOException {
+    boolean isPresent = BOOLEAN_CODER.decode(inStream);
+    if (!isPresent) {
+      return null;
+    }
+
+    String docJson = STRING_CODER.decode(inStream);
+    Document doc = docJson != null ? Document.parse(docJson) : null;
+    String originalDoc = STRING_CODER.decode(inStream);
+    int retryCount = VARINT_CODER.decode(inStream);
+    String errorMessage = STRING_CODER.decode(inStream);
+    String errorTypeStr = STRING_CODER.decode(inStream);
+    DocumentWithMetadata.ErrorType errorType =
+        errorTypeStr != null ? DocumentWithMetadata.ErrorType.valueOf(errorTypeStr) : null;
+    String sourceCollection = STRING_CODER.decode(inStream);
+    String targetCollection = STRING_CODER.decode(inStream);
+    String failureStageStr = STRING_CODER.decode(inStream);
+    DocumentWithMetadata.FailureStage failureStage =
+        failureStageStr != null
+            ? DocumentWithMetadata.FailureStage.valueOf(failureStageStr)
+            : null;
+    String opTypeStr = STRING_CODER.decode(inStream);
+    DocumentWithMetadata.OperationType opType =
+        opTypeStr != null
+            ? DocumentWithMetadata.OperationType.valueOf(opTypeStr)
+            : DocumentWithMetadata.OperationType.BACKFILL;
+    String docKey = STRING_CODER.decode(inStream);
+    boolean isDlq = BOOLEAN_CODER.decode(inStream);
+    TimestampSortKey timestampKey = TIMESTAMP_CODER.decode(inStream);
+
+    return new DocumentWithMetadata(
+        doc,
+        originalDoc,
+        retryCount,
+        errorMessage,
+        errorType,
+        sourceCollection,
+        targetCollection,
+        failureStage,
+        opType,
+        timestampKey,
+        docKey,
+        isDlq);
+  }
+
+  @Override
+  public void verifyDeterministic() throws NonDeterministicException {
+    STRING_CODER.verifyDeterministic();
+    BOOLEAN_CODER.verifyDeterministic();
+    VARINT_CODER.verifyDeterministic();
+    TIMESTAMP_CODER.verifyDeterministic();
+  }
+}

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReader.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReader.java
@@ -228,8 +228,8 @@ public class MongoDbBackfillReader {
     }
 
     /**
-     * Distributes a list of backfill partitions across virtual concurrency slots using
-     * round-robin interleaving.
+     * Distributes a list of backfill partitions across virtual concurrency slots using round-robin
+     * interleaving.
      */
     public static List<BackfillSlotTask> distribute(
         List<BackfillPartition> partitions, int maxConcurrentSlots) {
@@ -419,14 +419,7 @@ public class MongoDbBackfillReader {
       int maxSplits,
       BsonTimestamp t0) {
     return generatePartitions(
-        uri,
-        database,
-        sourceCollection,
-        targetCollection,
-        1,
-        targetChunkSize,
-        maxSplits,
-        t0);
+        uri, database, sourceCollection, targetCollection, 1, targetChunkSize, maxSplits, t0);
   }
 
   /**
@@ -451,9 +444,7 @@ public class MongoDbBackfillReader {
         t0);
   }
 
-  /**
-   * Convenience overload generating a single root partition for a collection.
-   */
+  /** Convenience overload generating a single root partition for a collection. */
   public static List<BackfillPartition> generatePartitions(
       String uri,
       String database,
@@ -683,8 +674,7 @@ public class MongoDbBackfillReader {
 
     @NewTracker
     public BackfillRestrictionTracker newTracker(
-        @Element BackfillPartition partition,
-        @Restriction BackfillRestriction restriction) {
+        @Element BackfillPartition partition, @Restriction BackfillRestriction restriction) {
       return new BackfillRestrictionTracker(restriction);
     }
 
@@ -735,8 +725,7 @@ public class MongoDbBackfillReader {
           MongoClient client =
               clientCache.computeIfAbsent(partition.getUri(), clientFactory::apply);
           MongoDatabase db = client.getDatabase(partition.getDatabase());
-          MongoCollection<Document> collection =
-              db.getCollection(partition.getSourceCollection());
+          MongoCollection<Document> collection = db.getCollection(partition.getSourceCollection());
 
           Bson baseFilter =
               partition.hasFilter()
@@ -746,16 +735,13 @@ public class MongoDbBackfillReader {
           BsonValue lastSeenId = currentRestriction.getLastSeenId();
           Bson queryFilter;
           if (lastSeenId != null) {
-            BsonDocument gtFilter =
-                new BsonDocument("_id", new BsonDocument("$gt", lastSeenId));
+            BsonDocument gtFilter = new BsonDocument("_id", new BsonDocument("$gt", lastSeenId));
             if (partition.hasFilter()) {
               queryFilter =
                   new BsonDocument(
                       "$and",
                       new BsonArray(
-                          Arrays.asList(
-                              BsonDocument.parse(partition.getFilterJson()),
-                              gtFilter)));
+                          Arrays.asList(BsonDocument.parse(partition.getFilterJson()), gtFilter)));
             } else {
               queryFilter = gtFilter;
             }
@@ -814,9 +800,7 @@ public class MongoDbBackfillReader {
           Document doc = cursor.next();
           BsonValue docId = doc.toBsonDocument().get("_id");
           String nextIdJson =
-              docId != null
-                  ? new BsonDocument("_id", docId).toJson(CANONICAL_JSON_SETTINGS)
-                  : null;
+              docId != null ? new BsonDocument("_id", docId).toJson(CANONICAL_JSON_SETTINGS) : null;
 
           // Claim document position BEFORE emitting (claim-before-output)
           if (!tracker.tryClaim(
@@ -833,9 +817,7 @@ public class MongoDbBackfillReader {
                       partition.getTargetCollection(),
                       partition.getTimestampSortKey())
                   : DocumentWithMetadata.of(
-                      doc,
-                      partition.getSourceCollection(),
-                      partition.getTargetCollection());
+                      doc, partition.getSourceCollection(), partition.getTargetCollection());
 
           receiver.output(item);
           backfillDocumentsRead.inc();
@@ -876,13 +858,16 @@ public class MongoDbBackfillReader {
 
     private void evictExpiredCursors() {
       if (cursorCache != null) {
-        cursorCache.entrySet().removeIf(entry -> {
-          if (entry.getValue().isExpired(CURSOR_EXPIRATION_TIMEOUT_MS)) {
-            entry.getValue().close();
-            return true;
-          }
-          return false;
-        });
+        cursorCache
+            .entrySet()
+            .removeIf(
+                entry -> {
+                  if (entry.getValue().isExpired(CURSOR_EXPIRATION_TIMEOUT_MS)) {
+                    entry.getValue().close();
+                    return true;
+                  }
+                  return false;
+                });
       }
     }
 
@@ -911,7 +896,8 @@ public class MongoDbBackfillReader {
 
   /**
    * SDF restriction for slot-based backfill tracking current partition index within the slot,
-   * document offset within the active partition, last seen canonical BSON _id, and completion state.
+   * document offset within the active partition, last seen canonical BSON _id, and completion
+   * state.
    */
   public static class BackfillSlotRestriction implements Serializable {
     private static final long serialVersionUID = 1L;
@@ -998,9 +984,7 @@ public class MongoDbBackfillReader {
     }
   }
 
-  /**
-   * SDF restriction tracker for slot-based backfill partitions.
-   */
+  /** SDF restriction tracker for slot-based backfill partitions. */
   public static class BackfillSlotRestrictionTracker
       extends RestrictionTracker<BackfillSlotRestriction, BackfillSlotRestriction> {
 
@@ -1060,11 +1044,10 @@ public class MongoDbBackfillReader {
   }
 
   /**
-   * Splittable DoFn executing sequential backfill partitions assigned to a concurrency slot.
-   * Caps maximum active cursors against MongoDB to the total number of slots cluster-wide.
+   * Splittable DoFn executing sequential backfill partitions assigned to a concurrency slot. Caps
+   * maximum active cursors against MongoDB to the total number of slots cluster-wide.
    */
-  public static class ProcessBackfillSlotFn
-      extends DoFn<BackfillSlotTask, DocumentWithMetadata> {
+  public static class ProcessBackfillSlotFn extends DoFn<BackfillSlotTask, DocumentWithMetadata> {
 
     public static final int MAX_DOCS_PER_SLICE = 2000;
     public static final long MAX_SLICE_DURATION_MS = 10000L;
@@ -1073,7 +1056,8 @@ public class MongoDbBackfillReader {
     private final SerializableFunction<String, MongoClient> clientFactory;
 
     private transient ConcurrentHashMap<String, MongoClient> clientCache;
-    private transient ConcurrentHashMap<String, ProcessBackfillPartitionFn.PartitionCursorHolder> cursorCache;
+    private transient ConcurrentHashMap<String, ProcessBackfillPartitionFn.PartitionCursorHolder>
+        cursorCache;
 
     private final Counter backfillDocumentsRead =
         Metrics.counter(MongoDbBackfillReader.class, "backfillDocumentsRead");
@@ -1099,8 +1083,7 @@ public class MongoDbBackfillReader {
 
     @NewTracker
     public BackfillSlotRestrictionTracker newTracker(
-        @Element BackfillSlotTask slotTask,
-        @Restriction BackfillSlotRestriction restriction) {
+        @Element BackfillSlotTask slotTask, @Restriction BackfillSlotRestriction restriction) {
       return new BackfillSlotRestrictionTracker(restriction);
     }
 
@@ -1162,8 +1145,7 @@ public class MongoDbBackfillReader {
           MongoClient client =
               clientCache.computeIfAbsent(partition.getUri(), clientFactory::apply);
           MongoDatabase db = client.getDatabase(partition.getDatabase());
-          MongoCollection<Document> collection =
-              db.getCollection(partition.getSourceCollection());
+          MongoCollection<Document> collection = db.getCollection(partition.getSourceCollection());
 
           Bson baseFilter =
               partition.hasFilter()
@@ -1173,16 +1155,13 @@ public class MongoDbBackfillReader {
           BsonValue lastSeenId = currentRestriction.getLastSeenId();
           Bson queryFilter;
           if (lastSeenId != null) {
-            BsonDocument gtFilter =
-                new BsonDocument("_id", new BsonDocument("$gt", lastSeenId));
+            BsonDocument gtFilter = new BsonDocument("_id", new BsonDocument("$gt", lastSeenId));
             if (partition.hasFilter()) {
               queryFilter =
                   new BsonDocument(
                       "$and",
                       new BsonArray(
-                          Arrays.asList(
-                              BsonDocument.parse(partition.getFilterJson()),
-                              gtFilter)));
+                          Arrays.asList(BsonDocument.parse(partition.getFilterJson()), gtFilter)));
             } else {
               queryFilter = gtFilter;
             }
@@ -1251,9 +1230,7 @@ public class MongoDbBackfillReader {
           Document doc = cursor.next();
           BsonValue docId = doc.toBsonDocument().get("_id");
           String nextIdJson =
-              docId != null
-                  ? new BsonDocument("_id", docId).toJson(CANONICAL_JSON_SETTINGS)
-                  : null;
+              docId != null ? new BsonDocument("_id", docId).toJson(CANONICAL_JSON_SETTINGS) : null;
 
           if (!tracker.tryClaim(
               new BackfillSlotRestriction(
@@ -1270,9 +1247,7 @@ public class MongoDbBackfillReader {
                       partition.getTargetCollection(),
                       partition.getTimestampSortKey())
                   : DocumentWithMetadata.of(
-                      doc,
-                      partition.getSourceCollection(),
-                      partition.getTargetCollection());
+                      doc, partition.getSourceCollection(), partition.getTargetCollection());
 
           receiver.output(item);
           backfillDocumentsRead.inc();
@@ -1316,13 +1291,16 @@ public class MongoDbBackfillReader {
 
     private void evictExpiredCursors() {
       if (cursorCache != null) {
-        cursorCache.entrySet().removeIf(entry -> {
-          if (entry.getValue().isExpired(CURSOR_EXPIRATION_TIMEOUT_MS)) {
-            entry.getValue().close();
-            return true;
-          }
-          return false;
-        });
+        cursorCache
+            .entrySet()
+            .removeIf(
+                entry -> {
+                  if (entry.getValue().isExpired(CURSOR_EXPIRATION_TIMEOUT_MS)) {
+                    entry.getValue().close();
+                    return true;
+                  }
+                  return false;
+                });
       }
     }
 
@@ -1353,8 +1331,7 @@ public class MongoDbBackfillReader {
    * PTransform that reads backfill partitions using virtual concurrency slot sharding to strictly
    * bound the number of active cursors against the source database.
    */
-  public static class ReadPartitions
-      extends PTransform<PBegin, PCollection<DocumentWithMetadata>> {
+  public static class ReadPartitions extends PTransform<PBegin, PCollection<DocumentWithMetadata>> {
 
     public static final int DEFAULT_MAX_CONCURRENT_READS = 128;
 

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReader.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReader.java
@@ -74,7 +74,7 @@ import org.slf4j.LoggerFactory;
 public class MongoDbBackfillReader {
 
   private static final Logger LOG = LoggerFactory.getLogger(MongoDbBackfillReader.class);
-  public static final int DEFAULT_CURSOR_BATCH_SIZE = 5000;
+  public static final int DEFAULT_CURSOR_BATCH_SIZE = 10000;
   private static final JsonWriterSettings CANONICAL_JSON_SETTINGS =
       JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
 
@@ -213,7 +213,8 @@ public class MongoDbBackfillReader {
     List<BackfillPartition> partitions = new ArrayList<>();
     for (int i = 0; i < filters.size(); i++) {
       BsonDocument filter = filters.get(i);
-      String filterJson = (filter == null || filter.isEmpty()) ? null : filter.toJson();
+      String filterJson =
+          (filter == null || filter.isEmpty()) ? null : filter.toJson(CANONICAL_JSON_SETTINGS);
       partitions.add(
           new BackfillPartition(
               uri,
@@ -246,7 +247,8 @@ public class MongoDbBackfillReader {
     List<BackfillPartition> partitions = new ArrayList<>();
     for (int i = 0; i < filters.size(); i++) {
       BsonDocument filter = filters.get(i);
-      String filterJson = (filter == null || filter.isEmpty()) ? null : filter.toJson();
+      String filterJson =
+          (filter == null || filter.isEmpty()) ? null : filter.toJson(CANONICAL_JSON_SETTINGS);
       partitions.add(
           new BackfillPartition(
               uri,
@@ -414,8 +416,8 @@ public class MongoDbBackfillReader {
   public static class ProcessBackfillPartitionFn
       extends DoFn<BackfillPartition, DocumentWithMetadata> {
 
-    public static final int MAX_DOCS_PER_SLICE = 5000;
-    public static final long MAX_SLICE_DURATION_MS = 5000L;
+    public static final int MAX_DOCS_PER_SLICE = 10000;
+    public static final long MAX_SLICE_DURATION_MS = 10000L;
     public static final long CURSOR_EXPIRATION_TIMEOUT_MS = 300_000L; // 5 minutes idle eviction
 
     private final SerializableFunction<String, MongoClient> clientFactory;

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReader.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReader.java
@@ -79,6 +79,7 @@ public class MongoDbBackfillReader {
 
   private static final Logger LOG = LoggerFactory.getLogger(MongoDbBackfillReader.class);
   public static final int DEFAULT_CURSOR_BATCH_SIZE = 2000;
+  public static final int DEFAULT_MAX_SPLITS = 10000;
   private static final JsonWriterSettings CANONICAL_JSON_SETTINGS =
       JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
 
@@ -365,7 +366,7 @@ public class MongoDbBackfillReader {
         targetCollection,
         numSplits,
         0,
-        Math.max(numSplits, 256),
+        Math.max(numSplits, DEFAULT_MAX_SPLITS),
         t0);
   }
 
@@ -446,7 +447,7 @@ public class MongoDbBackfillReader {
         targetCollection,
         numSplits,
         0,
-        Math.max(numSplits, 256),
+        Math.max(numSplits, DEFAULT_MAX_SPLITS),
         t0);
   }
 

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReader.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReader.java
@@ -587,7 +587,12 @@ public class MongoDbBackfillReader {
 
     @Override
     public void checkDone() throws IllegalStateException {
-      // Bounded stream completion check
+      if (!shouldStop && (currentRestriction == null || !currentRestriction.isDone())) {
+        throw new IllegalStateException(
+            String.format(
+                "Last claimed restriction %s is not marked as done, but execution finished without a split.",
+                currentRestriction));
+      }
     }
 
     @Override
@@ -1039,7 +1044,12 @@ public class MongoDbBackfillReader {
 
     @Override
     public void checkDone() throws IllegalStateException {
-      // Bounded stream completion check
+      if (!shouldStop && (currentRestriction == null || !currentRestriction.isDone())) {
+        throw new IllegalStateException(
+            String.format(
+                "Last claimed slot restriction %s is not marked as done, but execution finished without a split.",
+                currentRestriction));
+      }
     }
 
     @Override

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReader.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReader.java
@@ -26,6 +26,7 @@ import com.mongodb.client.MongoDatabase;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -77,7 +78,7 @@ import org.slf4j.LoggerFactory;
 public class MongoDbBackfillReader {
 
   private static final Logger LOG = LoggerFactory.getLogger(MongoDbBackfillReader.class);
-  public static final int DEFAULT_CURSOR_BATCH_SIZE = 10000;
+  public static final int DEFAULT_CURSOR_BATCH_SIZE = 2000;
   private static final JsonWriterSettings CANONICAL_JSON_SETTINGS =
       JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
 
@@ -197,6 +198,154 @@ public class MongoDbBackfillReader {
   }
 
   /**
+   * Value object describing a sequential chain of backfill partitions executed within a single
+   * concurrency slot.
+   */
+  public static class BackfillSlotTask implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final int slotId;
+    private final int totalSlots;
+    private final List<BackfillPartition> partitions;
+
+    public BackfillSlotTask(int slotId, int totalSlots, List<BackfillPartition> partitions) {
+      this.slotId = slotId;
+      this.totalSlots = totalSlots;
+      this.partitions = partitions != null ? partitions : Collections.emptyList();
+    }
+
+    public int getSlotId() {
+      return slotId;
+    }
+
+    public int getTotalSlots() {
+      return totalSlots;
+    }
+
+    public List<BackfillPartition> getPartitions() {
+      return partitions;
+    }
+
+    /**
+     * Distributes a list of backfill partitions across virtual concurrency slots using
+     * round-robin interleaving.
+     */
+    public static List<BackfillSlotTask> distribute(
+        List<BackfillPartition> partitions, int maxConcurrentSlots) {
+      if (partitions == null || partitions.isEmpty()) {
+        return Collections.emptyList();
+      }
+      int numSlots = Math.min(Math.max(1, maxConcurrentSlots), partitions.size());
+      List<List<BackfillPartition>> slotBuckets = new ArrayList<>(numSlots);
+      for (int i = 0; i < numSlots; i++) {
+        slotBuckets.add(new ArrayList<>());
+      }
+      for (int i = 0; i < partitions.size(); i++) {
+        slotBuckets.get(i % numSlots).add(partitions.get(i));
+      }
+      List<BackfillSlotTask> tasks = new ArrayList<>(numSlots);
+      for (int i = 0; i < numSlots; i++) {
+        tasks.add(new BackfillSlotTask(i, numSlots, slotBuckets.get(i)));
+      }
+      return tasks;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      BackfillSlotTask that = (BackfillSlotTask) o;
+      return slotId == that.slotId
+          && totalSlots == that.totalSlots
+          && Objects.equals(partitions, that.partitions);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(slotId, totalSlots, partitions);
+    }
+
+    @Override
+    public String toString() {
+      return "BackfillSlotTask{slot="
+          + slotId
+          + "/"
+          + totalSlots
+          + ", partitions="
+          + partitions.size()
+          + "}";
+    }
+  }
+
+  /**
+   * Generates discrete backfill partitions for a given collection using {@link ReadSplitGenerator}
+   * and live type/quantile discovery via a shared MongoClient with adaptive volume sizing.
+   */
+  public static List<BackfillPartition> generatePartitions(
+      MongoClient client,
+      String uri,
+      String database,
+      String sourceCollection,
+      String targetCollection,
+      int numSplits,
+      int targetChunkSize,
+      int maxSplits,
+      BsonTimestamp t0) {
+    TimestampSortKey sortKey = t0 != null ? TimestampSortKey.backfill(t0.getTime()) : null;
+    int splits = Math.max(1, numSplits);
+    List<BsonDocument> filters =
+        ReadSplitGenerator.generateIndexSliceFilters(
+            client, database, sourceCollection, splits, targetChunkSize, maxSplits);
+
+    List<BackfillPartition> partitions = new ArrayList<>();
+    for (int i = 0; i < filters.size(); i++) {
+      BsonDocument filter = filters.get(i);
+      String filterJson =
+          (filter == null || filter.isEmpty()) ? null : filter.toJson(CANONICAL_JSON_SETTINGS);
+      partitions.add(
+          new BackfillPartition(
+              uri,
+              database,
+              sourceCollection,
+              targetCollection,
+              filterJson,
+              sortKey,
+              i,
+              filters.size()));
+    }
+    return partitions;
+  }
+
+  /**
+   * Generates discrete backfill partitions for a given collection using {@link ReadSplitGenerator}
+   * and live type/quantile discovery via a shared MongoClient with adaptive volume sizing.
+   */
+  public static List<BackfillPartition> generatePartitions(
+      MongoClient client,
+      String uri,
+      String database,
+      String sourceCollection,
+      String targetCollection,
+      int targetChunkSize,
+      int maxSplits,
+      BsonTimestamp t0) {
+    return generatePartitions(
+        client,
+        uri,
+        database,
+        sourceCollection,
+        targetCollection,
+        1,
+        targetChunkSize,
+        maxSplits,
+        t0);
+  }
+
+  /**
    * Generates discrete backfill partitions for a given collection using {@link ReadSplitGenerator}
    * and live type/quantile discovery via a shared MongoClient.
    */
@@ -208,10 +357,34 @@ public class MongoDbBackfillReader {
       String targetCollection,
       int numSplits,
       BsonTimestamp t0) {
+    return generatePartitions(
+        client,
+        uri,
+        database,
+        sourceCollection,
+        targetCollection,
+        numSplits,
+        0,
+        Math.max(numSplits, 256),
+        t0);
+  }
+
+  /**
+   * Generates discrete backfill partitions for a given collection using algorithmic key-space
+   * splitting without requiring a live MongoClient connection with adaptive volume sizing.
+   */
+  public static List<BackfillPartition> generatePartitions(
+      String uri,
+      String database,
+      String sourceCollection,
+      String targetCollection,
+      int numSplits,
+      int targetChunkSize,
+      int maxSplits,
+      BsonTimestamp t0) {
     TimestampSortKey sortKey = t0 != null ? TimestampSortKey.backfill(t0.getTime()) : null;
-    int splits = Math.max(1, numSplits);
-    List<BsonDocument> filters =
-        ReadSplitGenerator.generateIndexSliceFilters(client, database, sourceCollection, splits);
+    int effectiveSplits = Math.max(1, Math.min(maxSplits, numSplits));
+    List<BsonDocument> filters = ReadSplitGenerator.generateIndexSliceFilters(effectiveSplits);
 
     List<BackfillPartition> partitions = new ArrayList<>();
     for (int i = 0; i < filters.size(); i++) {
@@ -234,6 +407,29 @@ public class MongoDbBackfillReader {
 
   /**
    * Generates discrete backfill partitions for a given collection using algorithmic key-space
+   * splitting without requiring a live MongoClient connection with adaptive volume sizing.
+   */
+  public static List<BackfillPartition> generatePartitions(
+      String uri,
+      String database,
+      String sourceCollection,
+      String targetCollection,
+      int targetChunkSize,
+      int maxSplits,
+      BsonTimestamp t0) {
+    return generatePartitions(
+        uri,
+        database,
+        sourceCollection,
+        targetCollection,
+        1,
+        targetChunkSize,
+        maxSplits,
+        t0);
+  }
+
+  /**
+   * Generates discrete backfill partitions for a given collection using algorithmic key-space
    * splitting without requiring a live MongoClient connection.
    */
   public static List<BackfillPartition> generatePartitions(
@@ -243,27 +439,15 @@ public class MongoDbBackfillReader {
       String targetCollection,
       int numSplits,
       BsonTimestamp t0) {
-    TimestampSortKey sortKey = t0 != null ? TimestampSortKey.backfill(t0.getTime()) : null;
-    int splits = Math.max(1, numSplits);
-    List<BsonDocument> filters = ReadSplitGenerator.generateIndexSliceFilters(splits);
-
-    List<BackfillPartition> partitions = new ArrayList<>();
-    for (int i = 0; i < filters.size(); i++) {
-      BsonDocument filter = filters.get(i);
-      String filterJson =
-          (filter == null || filter.isEmpty()) ? null : filter.toJson(CANONICAL_JSON_SETTINGS);
-      partitions.add(
-          new BackfillPartition(
-              uri,
-              database,
-              sourceCollection,
-              targetCollection,
-              filterJson,
-              sortKey,
-              i,
-              filters.size()));
-    }
-    return partitions;
+    return generatePartitions(
+        uri,
+        database,
+        sourceCollection,
+        targetCollection,
+        numSplits,
+        0,
+        Math.max(numSplits, 256),
+        t0);
   }
 
   /**
@@ -371,7 +555,7 @@ public class MongoDbBackfillReader {
 
     @Override
     public boolean tryClaim(BackfillRestriction position) {
-      if (shouldStop) {
+      if (shouldStop || (currentRestriction != null && currentRestriction.isDone())) {
         return false;
       }
       this.currentRestriction = position;
@@ -419,7 +603,7 @@ public class MongoDbBackfillReader {
   public static class ProcessBackfillPartitionFn
       extends DoFn<BackfillPartition, DocumentWithMetadata> {
 
-    public static final int MAX_DOCS_PER_SLICE = 10000;
+    public static final int MAX_DOCS_PER_SLICE = 2000;
     public static final long MAX_SLICE_DURATION_MS = 10000L;
     public static final long CURSOR_EXPIRATION_TIMEOUT_MS = 300_000L; // 5 minutes idle eviction
 
@@ -720,23 +904,474 @@ public class MongoDbBackfillReader {
   }
 
   /**
-   * PTransform that reads all backfill partitions sequentially on worker threads using Splittable
-   * DoFn.
+   * SDF restriction for slot-based backfill tracking current partition index within the slot,
+   * document offset within the active partition, last seen canonical BSON _id, and completion state.
+   */
+  public static class BackfillSlotRestriction implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final int partitionIndexInSlot;
+    private final long offsetInCurrentPartition;
+    private final String lastSeenIdJson;
+    private final boolean done;
+
+    public BackfillSlotRestriction() {
+      this(0, 0L, null, false);
+    }
+
+    public BackfillSlotRestriction(
+        int partitionIndexInSlot,
+        long offsetInCurrentPartition,
+        String lastSeenIdJson,
+        boolean done) {
+      this.partitionIndexInSlot = partitionIndexInSlot;
+      this.offsetInCurrentPartition = offsetInCurrentPartition;
+      this.lastSeenIdJson = lastSeenIdJson;
+      this.done = done;
+    }
+
+    public int getPartitionIndexInSlot() {
+      return partitionIndexInSlot;
+    }
+
+    public long getOffsetInCurrentPartition() {
+      return offsetInCurrentPartition;
+    }
+
+    public String getLastSeenIdJson() {
+      return lastSeenIdJson;
+    }
+
+    public boolean isDone() {
+      return done;
+    }
+
+    public BsonValue getLastSeenId() {
+      if (lastSeenIdJson == null || lastSeenIdJson.isEmpty()) {
+        return null;
+      }
+      try {
+        BsonDocument doc = BsonDocument.parse(lastSeenIdJson);
+        return doc.get("_id");
+      } catch (Exception e) {
+        return null;
+      }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      BackfillSlotRestriction that = (BackfillSlotRestriction) o;
+      return partitionIndexInSlot == that.partitionIndexInSlot
+          && offsetInCurrentPartition == that.offsetInCurrentPartition
+          && done == that.done
+          && Objects.equals(lastSeenIdJson, that.lastSeenIdJson);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(partitionIndexInSlot, offsetInCurrentPartition, lastSeenIdJson, done);
+    }
+
+    @Override
+    public String toString() {
+      return "BackfillSlotRestriction{partIdx="
+          + partitionIndexInSlot
+          + ", offset="
+          + offsetInCurrentPartition
+          + ", lastId="
+          + (lastSeenIdJson != null ? lastSeenIdJson : "null")
+          + ", done="
+          + done
+          + "}";
+    }
+  }
+
+  /**
+   * SDF restriction tracker for slot-based backfill partitions.
+   */
+  public static class BackfillSlotRestrictionTracker
+      extends RestrictionTracker<BackfillSlotRestriction, BackfillSlotRestriction> {
+
+    private BackfillSlotRestriction currentRestriction;
+    private boolean shouldStop = false;
+
+    public BackfillSlotRestrictionTracker(BackfillSlotRestriction initial) {
+      this.currentRestriction = initial;
+    }
+
+    @Override
+    public boolean tryClaim(BackfillSlotRestriction position) {
+      if (shouldStop || (currentRestriction != null && currentRestriction.isDone())) {
+        return false;
+      }
+      this.currentRestriction = position;
+      return true;
+    }
+
+    @Override
+    public BackfillSlotRestriction currentRestriction() {
+      return currentRestriction;
+    }
+
+    @Override
+    public @Nullable SplitResult<BackfillSlotRestriction> trySplit(double fractionOfRemainder) {
+      if (fractionOfRemainder == 0.0) {
+        if (shouldStop || (currentRestriction != null && currentRestriction.isDone())) {
+          return null;
+        }
+        shouldStop = true;
+        return SplitResult.of(
+            currentRestriction,
+            new BackfillSlotRestriction(
+                currentRestriction.getPartitionIndexInSlot(),
+                currentRestriction.getOffsetInCurrentPartition(),
+                currentRestriction.getLastSeenIdJson(),
+                currentRestriction.isDone()));
+      }
+      return null;
+    }
+
+    @Override
+    public void checkDone() throws IllegalStateException {
+      // Bounded stream completion check
+    }
+
+    @Override
+    public IsBounded isBounded() {
+      return IsBounded.BOUNDED;
+    }
+  }
+
+  /**
+   * Splittable DoFn executing sequential backfill partitions assigned to a concurrency slot.
+   * Caps maximum active cursors against MongoDB to the total number of slots cluster-wide.
+   */
+  public static class ProcessBackfillSlotFn
+      extends DoFn<BackfillSlotTask, DocumentWithMetadata> {
+
+    public static final int MAX_DOCS_PER_SLICE = 2000;
+    public static final long MAX_SLICE_DURATION_MS = 10000L;
+    public static final long CURSOR_EXPIRATION_TIMEOUT_MS = 300_000L;
+
+    private final SerializableFunction<String, MongoClient> clientFactory;
+
+    private transient ConcurrentHashMap<String, MongoClient> clientCache;
+    private transient ConcurrentHashMap<String, ProcessBackfillPartitionFn.PartitionCursorHolder> cursorCache;
+
+    private final Counter backfillDocumentsRead =
+        Metrics.counter(MongoDbBackfillReader.class, "backfillDocumentsRead");
+    private final Counter backfillSlicesCompleted =
+        Metrics.counter(MongoDbBackfillReader.class, "backfillSlicesCompleted");
+    private final Counter backfillEmptySlices =
+        Metrics.counter(MongoDbBackfillReader.class, "backfillEmptySlices");
+    private final Counter backfillReadErrors =
+        Metrics.counter(MongoDbBackfillReader.class, "backfillReadErrors");
+
+    public ProcessBackfillSlotFn() {
+      this(MongoDbTransforms::getOrCreateMongoClient);
+    }
+
+    public ProcessBackfillSlotFn(SerializableFunction<String, MongoClient> clientFactory) {
+      this.clientFactory = clientFactory;
+    }
+
+    @GetInitialRestriction
+    public BackfillSlotRestriction getInitialRestriction(@Element BackfillSlotTask slotTask) {
+      return new BackfillSlotRestriction(0, 0L, null, false);
+    }
+
+    @NewTracker
+    public BackfillSlotRestrictionTracker newTracker(
+        @Element BackfillSlotTask slotTask,
+        @Restriction BackfillSlotRestriction restriction) {
+      return new BackfillSlotRestrictionTracker(restriction);
+    }
+
+    @GetRestrictionCoder
+    public Coder<BackfillSlotRestriction> getRestrictionCoder() {
+      return SerializableCoder.of(BackfillSlotRestriction.class);
+    }
+
+    @ProcessElement
+    public ProcessContinuation processElement(
+        @Element BackfillSlotTask slotTask,
+        RestrictionTracker<BackfillSlotRestriction, BackfillSlotRestriction> tracker,
+        OutputReceiver<DocumentWithMetadata> receiver) {
+
+      if (cursorCache == null) {
+        cursorCache = new ConcurrentHashMap<>();
+      }
+      if (clientCache == null) {
+        clientCache = new ConcurrentHashMap<>();
+      }
+      evictExpiredCursors();
+
+      BackfillSlotRestriction currentRestriction = tracker.currentRestriction();
+      if (currentRestriction.isDone() || !tracker.tryClaim(currentRestriction)) {
+        return ProcessContinuation.stop();
+      }
+
+      List<BackfillPartition> partitions = slotTask.getPartitions();
+      if (partitions.isEmpty()) {
+        return ProcessContinuation.stop();
+      }
+
+      int partitionIdx = currentRestriction.getPartitionIndexInSlot();
+      if (partitionIdx >= partitions.size()) {
+        tracker.tryClaim(new BackfillSlotRestriction(partitionIdx, 0L, null, true));
+        return ProcessContinuation.stop();
+      }
+
+      BackfillPartition partition = partitions.get(partitionIdx);
+      String partitionKey =
+          partition.getDatabase()
+              + "."
+              + partition.getSourceCollection()
+              + "#"
+              + partition.getPartitionIndex();
+
+      String currentLastSeenIdJson = currentRestriction.getLastSeenIdJson();
+      ProcessBackfillPartitionFn.PartitionCursorHolder cursorHolder = cursorCache.get(partitionKey);
+
+      if (cursorHolder != null) {
+        if (!Objects.equals(cursorHolder.getLastSeenIdJson(), currentLastSeenIdJson)) {
+          closeCursorForPartition(partitionKey);
+          cursorHolder = null;
+        }
+      }
+
+      if (cursorHolder == null) {
+        try {
+          MongoClient client =
+              clientCache.computeIfAbsent(partition.getUri(), clientFactory::apply);
+          MongoDatabase db = client.getDatabase(partition.getDatabase());
+          MongoCollection<Document> collection =
+              db.getCollection(partition.getSourceCollection());
+
+          Bson baseFilter =
+              partition.hasFilter()
+                  ? BsonDocument.parse(partition.getFilterJson())
+                  : new BsonDocument();
+
+          BsonValue lastSeenId = currentRestriction.getLastSeenId();
+          Bson queryFilter;
+          if (lastSeenId != null) {
+            BsonDocument gtFilter =
+                new BsonDocument("_id", new BsonDocument("$gt", lastSeenId));
+            if (partition.hasFilter()) {
+              queryFilter =
+                  new BsonDocument(
+                      "$and",
+                      new BsonArray(
+                          Arrays.asList(
+                              BsonDocument.parse(partition.getFilterJson()),
+                              gtFilter)));
+            } else {
+              queryFilter = gtFilter;
+            }
+          } else {
+            queryFilter = baseFilter;
+          }
+
+          FindIterable<Document> findIterable =
+              collection
+                  .find(queryFilter)
+                  .sort(new BsonDocument("_id", new BsonInt32(1)))
+                  .batchSize(DEFAULT_CURSOR_BATCH_SIZE);
+
+          MongoCursor<Document> cursor = findIterable.iterator();
+          cursorHolder =
+              new ProcessBackfillPartitionFn.PartitionCursorHolder(cursor, currentLastSeenIdJson);
+          cursorCache.put(partitionKey, cursorHolder);
+        } catch (Exception e) {
+          backfillReadErrors.inc();
+          LOG.warn(
+              "Failed opening backfill cursor for partition {} in slot {}: {}. Retrying in 1s.",
+              partition,
+              slotTask.getSlotId(),
+              e.getMessage(),
+              e);
+          closeCursorForPartition(partitionKey);
+          return ProcessContinuation.resume().withResumeDelay(Duration.millis(1000));
+        }
+      }
+
+      long sliceStartTime = System.currentTimeMillis();
+      int docsInSlice = 0;
+      long currentOffset = currentRestriction.getOffsetInCurrentPartition();
+      String lastSeenIdJson = currentLastSeenIdJson;
+
+      try {
+        MongoCursor<Document> cursor = cursorHolder.getCursor();
+        while (docsInSlice < MAX_DOCS_PER_SLICE
+            && (System.currentTimeMillis() - sliceStartTime) < MAX_SLICE_DURATION_MS) {
+          if (!cursor.hasNext()) {
+            // Reached EOF for this partition
+            closeCursorForPartition(partitionKey);
+            backfillSlicesCompleted.inc();
+            if (currentOffset + docsInSlice == 0) {
+              backfillEmptySlices.inc();
+            }
+            LOG.info(
+                "Completed backfill read for collection '{}' [Slice {}/{} in Slot {}/{}]: total {} documents",
+                partition.getSourceCollection(),
+                partition.getPartitionIndex(),
+                partition.getTotalPartitions(),
+                slotTask.getSlotId(),
+                slotTask.getTotalSlots(),
+                currentOffset + docsInSlice);
+
+            int nextPartitionIdx = partitionIdx + 1;
+            if (nextPartitionIdx < partitions.size()) {
+              tracker.tryClaim(new BackfillSlotRestriction(nextPartitionIdx, 0L, null, false));
+              return ProcessContinuation.resume();
+            } else {
+              tracker.tryClaim(new BackfillSlotRestriction(nextPartitionIdx, 0L, null, true));
+              return ProcessContinuation.stop();
+            }
+          }
+
+          Document doc = cursor.next();
+          BsonValue docId = doc.toBsonDocument().get("_id");
+          String nextIdJson =
+              docId != null
+                  ? new BsonDocument("_id", docId).toJson(CANONICAL_JSON_SETTINGS)
+                  : null;
+
+          if (!tracker.tryClaim(
+              new BackfillSlotRestriction(
+                  partitionIdx, currentOffset + docsInSlice + 1, nextIdJson, false))) {
+            closeCursorForPartition(partitionKey);
+            return ProcessContinuation.stop();
+          }
+
+          DocumentWithMetadata item =
+              partition.getTimestampSortKey() != null
+                  ? DocumentWithMetadata.backfillEvent(
+                      doc,
+                      partition.getSourceCollection(),
+                      partition.getTargetCollection(),
+                      partition.getTimestampSortKey())
+                  : DocumentWithMetadata.of(
+                      doc,
+                      partition.getSourceCollection(),
+                      partition.getTargetCollection());
+
+          receiver.output(item);
+          backfillDocumentsRead.inc();
+          docsInSlice++;
+          lastSeenIdJson = nextIdJson;
+          cursorHolder.setLastSeenIdJson(lastSeenIdJson);
+        }
+      } catch (MongoCursorNotFoundException | MongoSocketException mse) {
+        backfillReadErrors.inc();
+        LOG.warn(
+            "Cached cursor disconnected/expired for partition {} in slot {}: {}."
+                + " Resuming from lastSeenId in 500ms.",
+            partition,
+            slotTask.getSlotId(),
+            mse.getMessage());
+        closeCursorForPartition(partitionKey);
+        return ProcessContinuation.resume().withResumeDelay(Duration.millis(500));
+      } catch (MongoException me) {
+        backfillReadErrors.inc();
+        LOG.warn(
+            "Transient MongoDB exception reading partition {} in slot {}: {}. Resuming from lastSeenId in 1s.",
+            partition,
+            slotTask.getSlotId(),
+            me.getMessage());
+        closeCursorForPartition(partitionKey);
+        return ProcessContinuation.resume().withResumeDelay(Duration.millis(1000));
+      } catch (Exception e) {
+        backfillReadErrors.inc();
+        LOG.error(
+            "Unexpected error reading partition {} in slot {}: {}. Failing bundle.",
+            partition,
+            slotTask.getSlotId(),
+            e.getMessage(),
+            e);
+        closeCursorForPartition(partitionKey);
+        throw new RuntimeException("Backfill read failed for partition " + partition, e);
+      }
+
+      return ProcessContinuation.resume();
+    }
+
+    private void evictExpiredCursors() {
+      if (cursorCache != null) {
+        cursorCache.entrySet().removeIf(entry -> {
+          if (entry.getValue().isExpired(CURSOR_EXPIRATION_TIMEOUT_MS)) {
+            entry.getValue().close();
+            return true;
+          }
+          return false;
+        });
+      }
+    }
+
+    private void closeCursorForPartition(String partitionKey) {
+      if (cursorCache != null && partitionKey != null) {
+        ProcessBackfillPartitionFn.PartitionCursorHolder holder = cursorCache.remove(partitionKey);
+        if (holder != null) {
+          holder.close();
+        }
+      }
+    }
+
+    @Teardown
+    public void teardown() {
+      if (cursorCache != null) {
+        for (ProcessBackfillPartitionFn.PartitionCursorHolder holder : cursorCache.values()) {
+          holder.close();
+        }
+        cursorCache.clear();
+      }
+      if (clientCache != null) {
+        clientCache.clear();
+      }
+    }
+  }
+
+  /**
+   * PTransform that reads backfill partitions using virtual concurrency slot sharding to strictly
+   * bound the number of active cursors against the source database.
    */
   public static class ReadPartitions
       extends PTransform<PBegin, PCollection<DocumentWithMetadata>> {
 
+    public static final int DEFAULT_MAX_CONCURRENT_READS = 128;
+
     private final List<BackfillPartition> partitions;
+    private final int maxConcurrentReads;
     private final SerializableFunction<String, MongoClient> clientFactory;
 
     public ReadPartitions(List<BackfillPartition> partitions) {
-      this(partitions, MongoDbTransforms::getOrCreateMongoClient);
+      this(partitions, DEFAULT_MAX_CONCURRENT_READS, MongoDbTransforms::getOrCreateMongoClient);
+    }
+
+    public ReadPartitions(List<BackfillPartition> partitions, int maxConcurrentReads) {
+      this(partitions, maxConcurrentReads, MongoDbTransforms::getOrCreateMongoClient);
     }
 
     public ReadPartitions(
         List<BackfillPartition> partitions,
         SerializableFunction<String, MongoClient> clientFactory) {
+      this(partitions, DEFAULT_MAX_CONCURRENT_READS, clientFactory);
+    }
+
+    public ReadPartitions(
+        List<BackfillPartition> partitions,
+        int maxConcurrentReads,
+        SerializableFunction<String, MongoClient> clientFactory) {
       this.partitions = partitions;
+      this.maxConcurrentReads =
+          maxConcurrentReads > 0 ? maxConcurrentReads : DEFAULT_MAX_CONCURRENT_READS;
       this.clientFactory = clientFactory;
     }
 
@@ -745,19 +1380,22 @@ public class MongoDbBackfillReader {
       if (partitions == null || partitions.isEmpty()) {
         return input
             .apply(
-                "EmptyBackfillPartitions",
-                Create.empty(SerializableCoder.of(BackfillPartition.class)))
-            .apply("ReshuffleBackfillEmptyPartitions", Reshuffle.viaRandomKey())
-            .apply("ProcessEmptyBackfill", ParDo.of(new ProcessBackfillPartitionFn(clientFactory)))
+                "EmptyBackfillSlotTasks",
+                Create.empty(SerializableCoder.of(BackfillSlotTask.class)))
+            .apply("ReshuffleBackfillEmptySlotTasks", Reshuffle.viaRandomKey())
+            .apply("ProcessEmptyBackfillSlot", ParDo.of(new ProcessBackfillSlotFn(clientFactory)))
             .setCoder(DocumentWithMetadataCoder.of());
       }
 
+      List<BackfillSlotTask> slotTasks =
+          BackfillSlotTask.distribute(partitions, maxConcurrentReads);
+
       return input
           .apply(
-              "CreateBackfillPartitions",
-              Create.of(partitions).withCoder(SerializableCoder.of(BackfillPartition.class)))
-          .apply("ReshuffleBackfillPartitions", Reshuffle.viaRandomKey())
-          .apply("ReadBackfillPartitions", ParDo.of(new ProcessBackfillPartitionFn(clientFactory)))
+              "CreateBackfillSlotTasks",
+              Create.of(slotTasks).withCoder(SerializableCoder.of(BackfillSlotTask.class)))
+          .apply("ReshuffleBackfillSlotTasks", Reshuffle.viaRandomKey())
+          .apply("ReadBackfillSlotTasks", ParDo.of(new ProcessBackfillSlotFn(clientFactory)))
           .setCoder(DocumentWithMetadataCoder.of());
     }
   }

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReader.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReader.java
@@ -1,0 +1,757 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.transforms;
+
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.MongoDatabase;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.SerializableCoder;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.Element;
+import org.apache.beam.sdk.transforms.DoFn.GetInitialRestriction;
+import org.apache.beam.sdk.transforms.DoFn.GetRestrictionCoder;
+import org.apache.beam.sdk.transforms.DoFn.NewTracker;
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContinuation;
+import org.apache.beam.sdk.transforms.DoFn.ProcessElement;
+import org.apache.beam.sdk.transforms.DoFn.Restriction;
+import org.apache.beam.sdk.transforms.DoFn.Teardown;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Reshuffle;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.SplitResult;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonTimestamp;
+import org.bson.BsonValue;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Coarse-partitioned Splittable DoFn reader for MongoDB historical backfill.
+ *
+ * <p>Generates discrete index-slice query partitions per collection using {@link
+ * ReadSplitGenerator} and streams micro-batches of documents into Windmill using a Splittable DoFn,
+ * eliminating 2GB bundle commit limits and allowing downstream {@link
+ * org.apache.beam.sdk.transforms.GroupIntoBatches} to manage bulk writing to target databases.
+ */
+public class MongoDbBackfillReader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MongoDbBackfillReader.class);
+  public static final int DEFAULT_CURSOR_BATCH_SIZE = 1000;
+  private static final JsonWriterSettings CANONICAL_JSON_SETTINGS =
+      JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
+
+  /** Value object describing a single partitioned backfill query slice. */
+  public static class BackfillPartition implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String uri;
+    private final String database;
+    private final String sourceCollection;
+    private final String targetCollection;
+    private final String filterJson;
+    private final TimestampSortKey timestampSortKey;
+    private final int partitionIndex;
+    private final int totalPartitions;
+
+    public BackfillPartition(
+        String uri,
+        String database,
+        String sourceCollection,
+        String targetCollection,
+        String filterJson,
+        TimestampSortKey timestampSortKey,
+        int partitionIndex,
+        int totalPartitions) {
+      this.uri = uri;
+      this.database = database;
+      this.sourceCollection = sourceCollection;
+      this.targetCollection = targetCollection;
+      this.filterJson = filterJson;
+      this.timestampSortKey = timestampSortKey;
+      this.partitionIndex = partitionIndex;
+      this.totalPartitions = totalPartitions;
+    }
+
+    public String getUri() {
+      return uri;
+    }
+
+    public String getDatabase() {
+      return database;
+    }
+
+    public String getSourceCollection() {
+      return sourceCollection;
+    }
+
+    public String getTargetCollection() {
+      return targetCollection;
+    }
+
+    public String getFilterJson() {
+      return filterJson;
+    }
+
+    public TimestampSortKey getTimestampSortKey() {
+      return timestampSortKey;
+    }
+
+    public int getPartitionIndex() {
+      return partitionIndex;
+    }
+
+    public int getTotalPartitions() {
+      return totalPartitions;
+    }
+
+    public boolean hasFilter() {
+      return filterJson != null && !filterJson.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      BackfillPartition that = (BackfillPartition) o;
+      return partitionIndex == that.partitionIndex
+          && totalPartitions == that.totalPartitions
+          && Objects.equals(uri, that.uri)
+          && Objects.equals(database, that.database)
+          && Objects.equals(sourceCollection, that.sourceCollection)
+          && Objects.equals(targetCollection, that.targetCollection)
+          && Objects.equals(filterJson, that.filterJson)
+          && Objects.equals(timestampSortKey, that.timestampSortKey);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          uri,
+          database,
+          sourceCollection,
+          targetCollection,
+          filterJson,
+          timestampSortKey,
+          partitionIndex,
+          totalPartitions);
+    }
+
+    @Override
+    public String toString() {
+      return "BackfillPartition{"
+          + "col='"
+          + sourceCollection
+          + "', slice="
+          + partitionIndex
+          + "/"
+          + totalPartitions
+          + ", filter="
+          + (filterJson != null ? filterJson : "[FullScan]")
+          + '}';
+    }
+  }
+
+  /**
+   * Generates discrete backfill partitions for a given collection using {@link ReadSplitGenerator}
+   * and live type/quantile discovery via a shared MongoClient.
+   */
+  public static List<BackfillPartition> generatePartitions(
+      MongoClient client,
+      String uri,
+      String database,
+      String sourceCollection,
+      String targetCollection,
+      int numSplits,
+      BsonTimestamp t0) {
+    TimestampSortKey sortKey = t0 != null ? TimestampSortKey.backfill(t0.getTime()) : null;
+    int splits = Math.max(1, numSplits);
+    List<BsonDocument> filters =
+        ReadSplitGenerator.generateIndexSliceFilters(client, database, sourceCollection, splits);
+
+    List<BackfillPartition> partitions = new ArrayList<>();
+    for (int i = 0; i < filters.size(); i++) {
+      BsonDocument filter = filters.get(i);
+      String filterJson = (filter == null || filter.isEmpty()) ? null : filter.toJson();
+      partitions.add(
+          new BackfillPartition(
+              uri,
+              database,
+              sourceCollection,
+              targetCollection,
+              filterJson,
+              sortKey,
+              i,
+              filters.size()));
+    }
+    return partitions;
+  }
+
+  /**
+   * Generates discrete backfill partitions for a given collection using algorithmic key-space
+   * splitting without requiring a live MongoClient connection.
+   */
+  public static List<BackfillPartition> generatePartitions(
+      String uri,
+      String database,
+      String sourceCollection,
+      String targetCollection,
+      int numSplits,
+      BsonTimestamp t0) {
+    TimestampSortKey sortKey = t0 != null ? TimestampSortKey.backfill(t0.getTime()) : null;
+    int splits = Math.max(1, numSplits);
+    List<BsonDocument> filters = ReadSplitGenerator.generateIndexSliceFilters(splits);
+
+    List<BackfillPartition> partitions = new ArrayList<>();
+    for (int i = 0; i < filters.size(); i++) {
+      BsonDocument filter = filters.get(i);
+      String filterJson = (filter == null || filter.isEmpty()) ? null : filter.toJson();
+      partitions.add(
+          new BackfillPartition(
+              uri,
+              database,
+              sourceCollection,
+              targetCollection,
+              filterJson,
+              sortKey,
+              i,
+              filters.size()));
+    }
+    return partitions;
+  }
+
+  /**
+   * Convenience overload generating a single root partition for a collection.
+   */
+  public static List<BackfillPartition> generatePartitions(
+      String uri,
+      String database,
+      String sourceCollection,
+      String targetCollection,
+      BsonTimestamp t0) {
+    return generatePartitions(uri, database, sourceCollection, targetCollection, 1, t0);
+  }
+
+  /**
+   * SDF restriction for MongoDB backfill tracking sequential offset, serialized canonical BSON _id,
+   * and completion state.
+   */
+  public static class BackfillRestriction implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final long offset;
+    private final String lastSeenIdJson;
+    private final boolean done;
+
+    public BackfillRestriction() {
+      this(0L, null, false);
+    }
+
+    public BackfillRestriction(long offset, String lastSeenIdJson, boolean done) {
+      this.offset = offset;
+      this.lastSeenIdJson = lastSeenIdJson;
+      this.done = done;
+    }
+
+    public long getOffset() {
+      return offset;
+    }
+
+    public String getLastSeenIdJson() {
+      return lastSeenIdJson;
+    }
+
+    public boolean isDone() {
+      return done;
+    }
+
+    public BsonValue getLastSeenId() {
+      if (lastSeenIdJson == null || lastSeenIdJson.isEmpty()) {
+        return null;
+      }
+      try {
+        return BsonDocument.parse(lastSeenIdJson).get("_id");
+      } catch (Exception e) {
+        LOG.warn("Failed parsing lastSeenIdJson: {}", lastSeenIdJson, e);
+        return null;
+      }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof BackfillRestriction)) {
+        return false;
+      }
+      BackfillRestriction that = (BackfillRestriction) o;
+      return offset == that.offset
+          && done == that.done
+          && Objects.equals(lastSeenIdJson, that.lastSeenIdJson);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(offset, lastSeenIdJson, done);
+    }
+
+    @Override
+    public String toString() {
+      return "BackfillRestriction{offset="
+          + offset
+          + ", hasLastSeenId="
+          + (lastSeenIdJson != null)
+          + ", done="
+          + done
+          + "}";
+    }
+  }
+
+  /**
+   * RestrictionTracker for BackfillRestriction ensuring slice-per-offset claiming, claim-before-output,
+   * and checkpoint splitting.
+   */
+  public static class BackfillRestrictionTracker
+      extends RestrictionTracker<BackfillRestriction, BackfillRestriction> {
+
+    private BackfillRestriction currentRestriction;
+    private boolean shouldStop = false;
+
+    public BackfillRestrictionTracker(BackfillRestriction restriction) {
+      this.currentRestriction =
+          restriction != null ? restriction : new BackfillRestriction(0L, null, false);
+    }
+
+    @Override
+    public boolean tryClaim(BackfillRestriction position) {
+      if (shouldStop) {
+        return false;
+      }
+      this.currentRestriction = position;
+      return true;
+    }
+
+    @Override
+    public BackfillRestriction currentRestriction() {
+      return currentRestriction;
+    }
+
+    @Override
+    public @Nullable SplitResult<BackfillRestriction> trySplit(double fractionOfRemainder) {
+      if (fractionOfRemainder == 0) {
+        if (shouldStop || currentRestriction.isDone()) {
+          return null;
+        }
+        shouldStop = true;
+        BackfillRestriction primary = currentRestriction;
+        BackfillRestriction residual =
+            new BackfillRestriction(
+                currentRestriction.getOffset(),
+                currentRestriction.getLastSeenIdJson(),
+                currentRestriction.isDone());
+        return SplitResult.of(primary, residual);
+      }
+      return null;
+    }
+
+    @Override
+    public void checkDone() throws IllegalStateException {
+      // Bounded stream completion check
+    }
+
+    @Override
+    public IsBounded isBounded() {
+      return IsBounded.BOUNDED;
+    }
+  }
+
+  /**
+   * Splittable DoFn that executes partitioned MongoDB backfill reads on worker threads, streaming
+   * micro-batches of documents into Windmill without exceeding bundle commit limits.
+   */
+  public static class ProcessBackfillPartitionFn
+      extends DoFn<BackfillPartition, DocumentWithMetadata> {
+
+    public static final int MAX_DOCS_PER_SLICE = 2000;
+    public static final long MAX_SLICE_DURATION_MS = 3000L;
+    public static final long CURSOR_EXPIRATION_TIMEOUT_MS = 300_000L; // 5 minutes idle eviction
+
+    private final SerializableFunction<String, MongoClient> clientFactory;
+
+    private transient ConcurrentHashMap<String, MongoClient> clientCache;
+    private transient ConcurrentHashMap<String, PartitionCursorHolder> cursorCache;
+
+    private final Counter backfillDocumentsRead =
+        Metrics.counter(MongoDbBackfillReader.class, "backfillDocumentsRead");
+    private final Counter backfillSlicesCompleted =
+        Metrics.counter(MongoDbBackfillReader.class, "backfillSlicesCompleted");
+    private final Counter backfillEmptySlices =
+        Metrics.counter(MongoDbBackfillReader.class, "backfillEmptySlices");
+    private final Counter backfillReadErrors =
+        Metrics.counter(MongoDbBackfillReader.class, "backfillReadErrors");
+
+    /** Holds a cached cursor and tracks its last access timestamp and last seen document ID. */
+    public static class PartitionCursorHolder implements AutoCloseable {
+      private final MongoCursor<Document> cursor;
+      private volatile long lastAccessedMs;
+      private volatile String lastSeenIdJson;
+
+      public PartitionCursorHolder(MongoCursor<Document> cursor, String initialLastSeenIdJson) {
+        this.cursor = cursor;
+        this.lastAccessedMs = System.currentTimeMillis();
+        this.lastSeenIdJson = initialLastSeenIdJson;
+      }
+
+      public MongoCursor<Document> getCursor() {
+        this.lastAccessedMs = System.currentTimeMillis();
+        return cursor;
+      }
+
+      public String getLastSeenIdJson() {
+        return lastSeenIdJson;
+      }
+
+      public void setLastSeenIdJson(String lastSeenIdJson) {
+        this.lastSeenIdJson = lastSeenIdJson;
+        this.lastAccessedMs = System.currentTimeMillis();
+      }
+
+      public boolean isExpired(long timeoutMs) {
+        return (System.currentTimeMillis() - lastAccessedMs) > timeoutMs;
+      }
+
+      @Override
+      public void close() {
+        if (cursor != null) {
+          try {
+            cursor.close();
+          } catch (Exception ignored) {
+          }
+        }
+      }
+    }
+
+    public ProcessBackfillPartitionFn() {
+      this(MongoDbTransforms::getOrCreateMongoClient);
+    }
+
+    public ProcessBackfillPartitionFn(SerializableFunction<String, MongoClient> clientFactory) {
+      this.clientFactory = clientFactory;
+    }
+
+    @GetInitialRestriction
+    public BackfillRestriction getInitialRestriction(@Element BackfillPartition partition) {
+      return new BackfillRestriction(0L, null, false);
+    }
+
+    @NewTracker
+    public BackfillRestrictionTracker newTracker(
+        @Element BackfillPartition partition,
+        @Restriction BackfillRestriction restriction) {
+      return new BackfillRestrictionTracker(restriction);
+    }
+
+    @GetRestrictionCoder
+    public Coder<BackfillRestriction> getRestrictionCoder() {
+      return SerializableCoder.of(BackfillRestriction.class);
+    }
+
+    @ProcessElement
+    public ProcessContinuation processElement(
+        @Element BackfillPartition partition,
+        RestrictionTracker<BackfillRestriction, BackfillRestriction> tracker,
+        OutputReceiver<DocumentWithMetadata> receiver) {
+
+      if (cursorCache == null) {
+        cursorCache = new ConcurrentHashMap<>();
+      }
+      if (clientCache == null) {
+        clientCache = new ConcurrentHashMap<>();
+      }
+      evictExpiredCursors();
+
+      BackfillRestriction currentRestriction = tracker.currentRestriction();
+      if (currentRestriction.isDone() || !tracker.tryClaim(currentRestriction)) {
+        return ProcessContinuation.stop();
+      }
+
+      String partitionKey =
+          partition.getDatabase()
+              + "."
+              + partition.getSourceCollection()
+              + "#"
+              + partition.getPartitionIndex();
+
+      String currentLastSeenIdJson = currentRestriction.getLastSeenIdJson();
+      PartitionCursorHolder cursorHolder = cursorCache.get(partitionKey);
+
+      // Validate that cached cursor position matches the incoming restriction
+      if (cursorHolder != null) {
+        if (!Objects.equals(cursorHolder.getLastSeenIdJson(), currentLastSeenIdJson)) {
+          closeCursorForPartition(partitionKey);
+          cursorHolder = null;
+        }
+      }
+
+      if (cursorHolder == null) {
+        try {
+          MongoClient client =
+              clientCache.computeIfAbsent(partition.getUri(), clientFactory::apply);
+          MongoDatabase db = client.getDatabase(partition.getDatabase());
+          MongoCollection<Document> collection =
+              db.getCollection(partition.getSourceCollection());
+
+          Bson baseFilter =
+              partition.hasFilter()
+                  ? BsonDocument.parse(partition.getFilterJson())
+                  : new BsonDocument();
+
+          BsonValue lastSeenId = currentRestriction.getLastSeenId();
+          Bson queryFilter;
+          if (lastSeenId != null) {
+            BsonDocument gtFilter =
+                new BsonDocument("_id", new BsonDocument("$gt", lastSeenId));
+            if (partition.hasFilter()) {
+              queryFilter =
+                  new BsonDocument(
+                      "$and",
+                      new BsonArray(
+                          Arrays.asList(
+                              BsonDocument.parse(partition.getFilterJson()),
+                              gtFilter)));
+            } else {
+              queryFilter = gtFilter;
+            }
+          } else {
+            queryFilter = baseFilter;
+          }
+
+          FindIterable<Document> findIterable =
+              collection
+                  .find(queryFilter)
+                  .sort(new BsonDocument("_id", new BsonInt32(1)))
+                  .batchSize(DEFAULT_CURSOR_BATCH_SIZE);
+
+          MongoCursor<Document> cursor = findIterable.iterator();
+          cursorHolder = new PartitionCursorHolder(cursor, currentLastSeenIdJson);
+          cursorCache.put(partitionKey, cursorHolder);
+        } catch (Exception e) {
+          backfillReadErrors.inc();
+          LOG.warn(
+              "Failed opening backfill cursor for partition {}: {}. Retrying in 1s.",
+              partition,
+              e.getMessage(),
+              e);
+          closeCursorForPartition(partitionKey);
+          return ProcessContinuation.resume().withResumeDelay(Duration.millis(1000));
+        }
+      }
+
+      long sliceStartTime = System.currentTimeMillis();
+      int docsInSlice = 0;
+      long currentOffset = currentRestriction.getOffset();
+      String lastSeenIdJson = currentLastSeenIdJson;
+
+      try {
+        MongoCursor<Document> cursor = cursorHolder.getCursor();
+        while (docsInSlice < MAX_DOCS_PER_SLICE
+            && (System.currentTimeMillis() - sliceStartTime) < MAX_SLICE_DURATION_MS) {
+          if (!cursor.hasNext()) {
+            // Reached EOF for this partition
+            tracker.tryClaim(
+                new BackfillRestriction(currentOffset + docsInSlice, lastSeenIdJson, true));
+            closeCursorForPartition(partitionKey);
+            backfillSlicesCompleted.inc();
+            if (currentOffset + docsInSlice == 0) {
+              backfillEmptySlices.inc();
+            }
+            LOG.info(
+                "Completed backfill read for collection '{}' [Slice {}/{}]: total {} documents",
+                partition.getSourceCollection(),
+                partition.getPartitionIndex(),
+                partition.getTotalPartitions(),
+                currentOffset + docsInSlice);
+            return ProcessContinuation.stop();
+          }
+
+          Document doc = cursor.next();
+          BsonValue docId = doc.toBsonDocument().get("_id");
+          String nextIdJson =
+              docId != null
+                  ? new BsonDocument("_id", docId).toJson(CANONICAL_JSON_SETTINGS)
+                  : null;
+
+          // Claim document position BEFORE emitting (claim-before-output)
+          if (!tracker.tryClaim(
+              new BackfillRestriction(currentOffset + docsInSlice + 1, nextIdJson, false))) {
+            closeCursorForPartition(partitionKey);
+            return ProcessContinuation.stop();
+          }
+
+          DocumentWithMetadata item =
+              partition.getTimestampSortKey() != null
+                  ? DocumentWithMetadata.backfillEvent(
+                      doc,
+                      partition.getSourceCollection(),
+                      partition.getTargetCollection(),
+                      partition.getTimestampSortKey())
+                  : DocumentWithMetadata.of(
+                      doc,
+                      partition.getSourceCollection(),
+                      partition.getTargetCollection());
+
+          receiver.output(item);
+          backfillDocumentsRead.inc();
+          docsInSlice++;
+          lastSeenIdJson = nextIdJson;
+          cursorHolder.setLastSeenIdJson(lastSeenIdJson);
+        }
+      } catch (com.mongodb.MongoCursorNotFoundException | com.mongodb.MongoSocketException mse) {
+        backfillReadErrors.inc();
+        LOG.warn(
+            "Cached cursor disconnected/expired for partition {}: {}. Resuming from lastSeenId in 500ms.",
+            partition,
+            mse.getMessage());
+        closeCursorForPartition(partitionKey);
+        return ProcessContinuation.resume().withResumeDelay(Duration.millis(500));
+      } catch (com.mongodb.MongoException me) {
+        backfillReadErrors.inc();
+        LOG.warn(
+            "Transient MongoDB exception reading partition {}: {}. Resuming from lastSeenId in 1s.",
+            partition,
+            me.getMessage());
+        closeCursorForPartition(partitionKey);
+        return ProcessContinuation.resume().withResumeDelay(Duration.millis(1000));
+      } catch (Exception e) {
+        backfillReadErrors.inc();
+        LOG.error(
+            "Unexpected error reading partition {}: {}. Failing bundle.",
+            partition,
+            e.getMessage(),
+            e);
+        closeCursorForPartition(partitionKey);
+        throw new RuntimeException("Backfill read failed for partition " + partition, e);
+      }
+
+      return ProcessContinuation.resume();
+    }
+
+    private void evictExpiredCursors() {
+      if (cursorCache != null) {
+        cursorCache.entrySet().removeIf(entry -> {
+          if (entry.getValue().isExpired(CURSOR_EXPIRATION_TIMEOUT_MS)) {
+            entry.getValue().close();
+            return true;
+          }
+          return false;
+        });
+      }
+    }
+
+    private void closeCursorForPartition(String partitionKey) {
+      if (cursorCache != null && partitionKey != null) {
+        PartitionCursorHolder holder = cursorCache.remove(partitionKey);
+        if (holder != null) {
+          holder.close();
+        }
+      }
+    }
+
+    @Teardown
+    public void teardown() {
+      if (cursorCache != null) {
+        for (PartitionCursorHolder holder : cursorCache.values()) {
+          holder.close();
+        }
+        cursorCache.clear();
+      }
+      if (clientCache != null) {
+        clientCache.clear();
+      }
+    }
+  }
+
+  /**
+   * PTransform that reads all backfill partitions sequentially on worker threads using Splittable DoFn.
+   */
+  public static class ReadPartitions
+      extends PTransform<PBegin, PCollection<DocumentWithMetadata>> {
+
+    private final List<BackfillPartition> partitions;
+    private final SerializableFunction<String, MongoClient> clientFactory;
+
+    public ReadPartitions(List<BackfillPartition> partitions) {
+      this(partitions, MongoDbTransforms::getOrCreateMongoClient);
+    }
+
+    public ReadPartitions(
+        List<BackfillPartition> partitions,
+        SerializableFunction<String, MongoClient> clientFactory) {
+      this.partitions = partitions;
+      this.clientFactory = clientFactory;
+    }
+
+    @Override
+    public PCollection<DocumentWithMetadata> expand(PBegin input) {
+      if (partitions == null || partitions.isEmpty()) {
+        return input
+            .apply(
+                "EmptyBackfillPartitions",
+                Create.empty(SerializableCoder.of(BackfillPartition.class)))
+            .apply("ReshuffleBackfillEmptyPartitions", Reshuffle.viaRandomKey())
+            .apply("ProcessEmptyBackfill", ParDo.of(new ProcessBackfillPartitionFn(clientFactory)))
+            .setCoder(DocumentWithMetadataCoder.of());
+      }
+
+      return input
+          .apply(
+              "CreateBackfillPartitions",
+              Create.of(partitions).withCoder(SerializableCoder.of(BackfillPartition.class)))
+          .apply("ReshuffleBackfillPartitions", Reshuffle.viaRandomKey())
+          .apply("ReadBackfillPartitions", ParDo.of(new ProcessBackfillPartitionFn(clientFactory)))
+          .setCoder(DocumentWithMetadataCoder.of());
+    }
+  }
+}

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReader.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReader.java
@@ -74,7 +74,7 @@ import org.slf4j.LoggerFactory;
 public class MongoDbBackfillReader {
 
   private static final Logger LOG = LoggerFactory.getLogger(MongoDbBackfillReader.class);
-  public static final int DEFAULT_CURSOR_BATCH_SIZE = 1000;
+  public static final int DEFAULT_CURSOR_BATCH_SIZE = 5000;
   private static final JsonWriterSettings CANONICAL_JSON_SETTINGS =
       JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
 
@@ -414,8 +414,8 @@ public class MongoDbBackfillReader {
   public static class ProcessBackfillPartitionFn
       extends DoFn<BackfillPartition, DocumentWithMetadata> {
 
-    public static final int MAX_DOCS_PER_SLICE = 2000;
-    public static final long MAX_SLICE_DURATION_MS = 3000L;
+    public static final int MAX_DOCS_PER_SLICE = 5000;
+    public static final long MAX_SLICE_DURATION_MS = 5000L;
     public static final long CURSOR_EXPIRATION_TIMEOUT_MS = 300_000L; // 5 minutes idle eviction
 
     private final SerializableFunction<String, MongoClient> clientFactory;

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReader.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReader.java
@@ -889,6 +889,12 @@ public class MongoDbBackfillReader {
         cursorCache.clear();
       }
       if (clientCache != null) {
+        for (MongoClient client : clientCache.values()) {
+          try {
+            client.close();
+          } catch (Exception ignored) {
+          }
+        }
         clientCache.clear();
       }
     }
@@ -1322,6 +1328,12 @@ public class MongoDbBackfillReader {
         cursorCache.clear();
       }
       if (clientCache != null) {
+        for (MongoClient client : clientCache.values()) {
+          try {
+            client.close();
+          } catch (Exception ignored) {
+          }
+        }
         clientCache.clear();
       }
     }

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReader.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReader.java
@@ -15,6 +15,9 @@
  */
 package com.google.cloud.teleport.v2.transforms;
 
+import com.mongodb.MongoCursorNotFoundException;
+import com.mongodb.MongoException;
+import com.mongodb.MongoSocketException;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
@@ -352,8 +355,8 @@ public class MongoDbBackfillReader {
   }
 
   /**
-   * RestrictionTracker for BackfillRestriction ensuring slice-per-offset claiming, claim-before-output,
-   * and checkpoint splitting.
+   * RestrictionTracker for BackfillRestriction ensuring slice-per-offset claiming,
+   * claim-before-output, and checkpoint splitting.
    */
   public static class BackfillRestrictionTracker
       extends RestrictionTracker<BackfillRestriction, BackfillRestriction> {
@@ -650,15 +653,16 @@ public class MongoDbBackfillReader {
           lastSeenIdJson = nextIdJson;
           cursorHolder.setLastSeenIdJson(lastSeenIdJson);
         }
-      } catch (com.mongodb.MongoCursorNotFoundException | com.mongodb.MongoSocketException mse) {
+      } catch (MongoCursorNotFoundException | MongoSocketException mse) {
         backfillReadErrors.inc();
         LOG.warn(
-            "Cached cursor disconnected/expired for partition {}: {}. Resuming from lastSeenId in 500ms.",
+            "Cached cursor disconnected/expired for partition {}: {}."
+                + " Resuming from lastSeenId in 500ms.",
             partition,
             mse.getMessage());
         closeCursorForPartition(partitionKey);
         return ProcessContinuation.resume().withResumeDelay(Duration.millis(500));
-      } catch (com.mongodb.MongoException me) {
+      } catch (MongoException me) {
         backfillReadErrors.inc();
         LOG.warn(
             "Transient MongoDB exception reading partition {}: {}. Resuming from lastSeenId in 1s.",
@@ -716,7 +720,8 @@ public class MongoDbBackfillReader {
   }
 
   /**
-   * PTransform that reads all backfill partitions sequentially on worker threads using Splittable DoFn.
+   * PTransform that reads all backfill partitions sequentially on worker threads using Splittable
+   * DoFn.
    */
   public static class ReadPartitions
       extends PTransform<PBegin, PCollection<DocumentWithMetadata>> {

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReader.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReader.java
@@ -650,12 +650,23 @@ public class MongoDbChangeStreamReader {
   public static class ProcessChangeStreamPartitionFn
       extends DoFn<ChangeStreamPartition, DocumentWithMetadata> {
 
-    public static final int MAX_EVENTS_PER_SLICE = 5000;
-    public static final long MAX_SLICE_DURATION_MS = 5000L;
-    public static final long IDLE_RESUME_DELAY_MS = 100L;
+    public static final int MAX_EVENTS_PER_SLICE = 10000;
+    public static final long MAX_SLICE_DURATION_MS = 10000L;
+    public static final long IDLE_RESUME_DELAY_MS = 20L;
+    public static final long GRACE_POLL_TIMEOUT_MS = 300L;
     public static final long CURSOR_EXPIRATION_TIMEOUT_MS = 300_000L; // 5 minutes idle timeout
     public static final int MONGO_ERROR_CHANGE_STREAM_HISTORY_LOST_280 = 280;
     public static final int MONGO_ERROR_CHANGE_STREAM_HISTORY_LOST_286 = 286;
+
+    /**
+     * Stride (in events) at which the BSON resume token is serialized to an Extended JSON string
+     * during the inner polling loop. Serializing toJson() on all 10,000 events per slice causes
+     * heavy CPU and heap contention on reader threads. Reusing the serialized token string across
+     * this stride eliminates 99.5% of serialization overhead while still satisfying Beam's
+     * claim-before-output requirement on every single element. The exact final resume token is always
+     * serialized and committed at slice completion.
+     */
+    public static final int RESUME_TOKEN_SERIALIZATION_STRIDE = 200;
 
     private final Counter changeEventsRead =
         Metrics.counter(MongoDbChangeStreamReader.class, "changeEventsRead");
@@ -823,7 +834,7 @@ public class MongoDbChangeStreamReader {
 
           stream
               .batchSize(MAX_EVENTS_PER_SLICE)
-              .maxAwaitTime(500L, java.util.concurrent.TimeUnit.MILLISECONDS);
+              .maxAwaitTime(250L, java.util.concurrent.TimeUnit.MILLISECONDS);
 
           String fullDocStrategy = partition.getFullDocumentStrategy();
           if ("whenAvailable".equalsIgnoreCase(fullDocStrategy)) {
@@ -896,22 +907,36 @@ public class MongoDbChangeStreamReader {
       int eventsInSlice = 0;
       long currentOffset = currentRestriction.getOffset();
       BsonDocument postBatchToken = null;
+      BsonDocument lastSeenResumeToken = null;
+      String currentResumeTokenJson = currentRestriction.getResumeTokenJson();
 
       try {
         MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor = cursorHolder.getCursor();
+        long lastEventTimeMs = sliceStartTime;
         while (eventsInSlice < MAX_EVENTS_PER_SLICE
             && (System.currentTimeMillis() - sliceStartTime) < MAX_SLICE_DURATION_MS) {
           ChangeStreamDocument<Document> event = cursor.tryNext();
           if (event == null) {
+            long timeSinceLastEvent = System.currentTimeMillis() - lastEventTimeMs;
+            if (timeSinceLastEvent < GRACE_POLL_TIMEOUT_MS
+                && (System.currentTimeMillis() - sliceStartTime) < MAX_SLICE_DURATION_MS) {
+              try {
+                Thread.sleep(5);
+              } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+                break;
+              }
+              continue;
+            }
             // Post-batch resume token capture on idle
             try {
               postBatchToken = cursor.getResumeToken();
               if (postBatchToken != null) {
                 cursorHolder.setLastResumeToken(postBatchToken);
+                currentResumeTokenJson = postBatchToken.toJson(CANONICAL_JSON_SETTINGS);
                 if (!tracker.tryClaim(
                     new ChangeStreamRestriction(
-                        currentOffset + eventsInSlice,
-                        postBatchToken.toJson(CANONICAL_JSON_SETTINGS)))) {
+                        currentOffset + eventsInSlice, currentResumeTokenJson))) {
                   closeCursorForPartition(partitionKey);
                   return ProcessContinuation.stop();
                 }
@@ -922,6 +947,7 @@ public class MongoDbChangeStreamReader {
             break;
           }
 
+          lastEventTimeMs = System.currentTimeMillis();
           eventsInSlice++;
           changeEventsRead.inc();
 
@@ -953,11 +979,14 @@ public class MongoDbChangeStreamReader {
           }
 
           if (event.getResumeToken() != null) {
-            cursorHolder.setLastResumeToken(event.getResumeToken());
+            lastSeenResumeToken = event.getResumeToken();
+            cursorHolder.setLastResumeToken(lastSeenResumeToken);
+            if (eventsInSlice % RESUME_TOKEN_SERIALIZATION_STRIDE == 0) {
+              currentResumeTokenJson = lastSeenResumeToken.toJson(CANONICAL_JSON_SETTINGS);
+            }
             if (!tracker.tryClaim(
                 new ChangeStreamRestriction(
-                    currentOffset + eventsInSlice,
-                    event.getResumeToken().toJson(CANONICAL_JSON_SETTINGS)))) {
+                    currentOffset + eventsInSlice, currentResumeTokenJson))) {
               closeCursorForPartition(partitionKey);
               return ProcessContinuation.stop();
             }
@@ -972,6 +1001,12 @@ public class MongoDbChangeStreamReader {
           } else {
             changeEventsDroppedNullPayload.inc();
           }
+        }
+
+        if (lastSeenResumeToken != null && eventsInSlice % RESUME_TOKEN_SERIALIZATION_STRIDE != 0) {
+          currentResumeTokenJson = lastSeenResumeToken.toJson(CANONICAL_JSON_SETTINGS);
+          tracker.tryClaim(
+              new ChangeStreamRestriction(currentOffset + eventsInSlice, currentResumeTokenJson));
         }
       } catch (com.mongodb.MongoCommandException mce) {
         int errCode = mce.getErrorCode();

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReader.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReader.java
@@ -650,8 +650,9 @@ public class MongoDbChangeStreamReader {
   public static class ProcessChangeStreamPartitionFn
       extends DoFn<ChangeStreamPartition, DocumentWithMetadata> {
 
-    public static final int MAX_EVENTS_PER_SLICE = 1000;
-    public static final long MAX_SLICE_DURATION_MS = 3000L;
+    public static final int MAX_EVENTS_PER_SLICE = 5000;
+    public static final long MAX_SLICE_DURATION_MS = 5000L;
+    public static final long IDLE_RESUME_DELAY_MS = 100L;
     public static final long CURSOR_EXPIRATION_TIMEOUT_MS = 300_000L; // 5 minutes idle timeout
     public static final int MONGO_ERROR_CHANGE_STREAM_HISTORY_LOST_280 = 280;
     public static final int MONGO_ERROR_CHANGE_STREAM_HISTORY_LOST_286 = 286;
@@ -1014,7 +1015,7 @@ public class MongoDbChangeStreamReader {
       } else {
         changeStreamEmptyPolls.inc();
         return ProcessContinuation.resume()
-            .withResumeDelay(Duration.millis(200)); // 200ms idle backoff
+            .withResumeDelay(Duration.millis(IDLE_RESUME_DELAY_MS));
       }
     }
 

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReader.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReader.java
@@ -74,11 +74,15 @@ import org.slf4j.LoggerFactory;
  * Streaming reader that consumes MongoDB Change Streams across partitioned cursors.
  *
  * <p>Features:
+ *
  * <ul>
- *   <li>Multi-cursor partitioning per collection using orthogonal match filters on {@code documentKey._id}.
+ *   <li>Multi-cursor partitioning per collection using orthogonal match filters on {@code
+ *       documentKey._id}.
  *   <li>Capture-before-read starting timestamp support ({@code startAtOperationTime}).
- *   <li>Configurable {@link FullDocument} strategy (e.g. {@code updateLookup} or {@code whenAvailable}).
- *   <li>Automatic resume-token tracking (including post-batch tokens) and retry with exponential backoff on transient disconnects.
+ *   <li>Configurable {@link FullDocument} strategy (e.g. {@code updateLookup} or {@code
+ *       whenAvailable}).
+ *   <li>Automatic resume-token tracking (including post-batch tokens) and retry with exponential
+ *       backoff on transient disconnects.
  *   <li>Multi-cursor caching per partition with idle cursor auto-eviction.
  *   <li>Continuous watermark progression on idle polls via resume tokens and bounded wall clock.
  * </ul>
@@ -273,8 +277,8 @@ public class MongoDbChangeStreamReader {
   }
 
   /**
-   * Generates a MongoDB Change Stream $match filter that uniformly partitions events across
-   * {@code numSplits} parallel cursors using server-side keyset hashing ($toHashedIndexKey).
+   * Generates a MongoDB Change Stream $match filter that uniformly partitions events across {@code
+   * numSplits} parallel cursors using server-side keyset hashing ($toHashedIndexKey).
    *
    * @param numSplits Total number of parallel change stream partitions.
    * @param splitIndex 0-based partition index.
@@ -303,15 +307,12 @@ public class MongoDbChangeStreamReader {
 
     BsonDocument exprDoc =
         new BsonDocument(
-            "$expr",
-            new BsonDocument("$in", new BsonArray(Arrays.asList(modDoc, matchingValues))));
+            "$expr", new BsonDocument("$in", new BsonArray(Arrays.asList(modDoc, matchingValues))));
 
     return new BsonDocument("$match", exprDoc);
   }
 
-  /**
-   * Generates partition descriptors for a collection using server-side keyset hashing.
-   */
+  /** Generates partition descriptors for a collection using server-side keyset hashing. */
   public static List<ChangeStreamPartition> generatePartitions(
       MongoClient client,
       String sourceUri,
@@ -362,9 +363,7 @@ public class MongoDbChangeStreamReader {
     return partitions;
   }
 
-  /**
-   * Generates partition descriptors for a collection based on the requested split count.
-   */
+  /** Generates partition descriptors for a collection based on the requested split count. */
   public static List<ChangeStreamPartition> generatePartitions(
       String sourceUri,
       String sourceDatabase,
@@ -384,9 +383,7 @@ public class MongoDbChangeStreamReader {
         fullDocumentStrategy);
   }
 
-  /**
-   * Generates database-level change stream partition descriptors for an entire database.
-   */
+  /** Generates database-level change stream partition descriptors for an entire database. */
   public static List<ChangeStreamPartition> generateDatabasePartitions(
       MongoClient client,
       String sourceUri,
@@ -435,9 +432,7 @@ public class MongoDbChangeStreamReader {
     return partitions;
   }
 
-  /**
-   * Generates database-level change stream partition descriptors for an entire database.
-   */
+  /** Generates database-level change stream partition descriptors for an entire database. */
   public static List<ChangeStreamPartition> generateDatabasePartitions(
       String sourceUri,
       String sourceDatabase,
@@ -445,17 +440,12 @@ public class MongoDbChangeStreamReader {
       BsonTimestamp startAtOperationTime,
       String fullDocumentStrategy) {
     return generateDatabasePartitions(
-        null,
-        sourceUri,
-        sourceDatabase,
-        numSplits,
-        startAtOperationTime,
-        fullDocumentStrategy);
+        null, sourceUri, sourceDatabase, numSplits, startAtOperationTime, fullDocumentStrategy);
   }
 
   /**
-   * Recursively rewrites {@code "_id"} field references in query filters to {@code "documentKey._id"}
-   * for Change Stream {@code $match} pipeline stages.
+   * Recursively rewrites {@code "_id"} field references in query filters to {@code
+   * "documentKey._id"} for Change Stream {@code $match} pipeline stages.
    */
   public static BsonValue rewriteIdToDocumentKey(BsonValue value) {
     if (value == null) {
@@ -610,11 +600,8 @@ public class MongoDbChangeStreamReader {
     }
   }
 
-  /**
-   * PTransform that reads unbounded MongoDB Change Streams for a list of partition descriptors.
-   */
-  public static class ReadPartitions
-      extends PTransform<PBegin, PCollection<DocumentWithMetadata>> {
+  /** PTransform that reads unbounded MongoDB Change Streams for a list of partition descriptors. */
+  public static class ReadPartitions extends PTransform<PBegin, PCollection<DocumentWithMetadata>> {
 
     private final List<ChangeStreamPartition> partitions;
     private final SerializableFunction<String, MongoClient> clientFactory;
@@ -649,15 +636,14 @@ public class MongoDbChangeStreamReader {
               "CreateCDCPartitions",
               Create.of(partitions).withCoder(SerializableCoder.of(ChangeStreamPartition.class)))
           .apply("ReshuffleCDCPartitions", Reshuffle.viaRandomKey())
-          .apply(
-              "StreamChangeEvents",
-              ParDo.of(new ProcessChangeStreamPartitionFn(clientFactory)))
+          .apply("StreamChangeEvents", ParDo.of(new ProcessChangeStreamPartitionFn(clientFactory)))
           .setCoder(DocumentWithMetadataCoder.of());
     }
   }
 
   /**
-   * Splittable DoFn that maintains high-throughput streaming Change Stream cursors cached per partition.
+   * Splittable DoFn that maintains high-throughput streaming Change Stream cursors cached per
+   * partition.
    */
   public static class ProcessChangeStreamPartitionFn
       extends DoFn<ChangeStreamPartition, DocumentWithMetadata> {
@@ -675,8 +661,8 @@ public class MongoDbChangeStreamReader {
      * during the inner polling loop. Serializing toJson() on all 10,000 events per slice causes
      * heavy CPU and heap contention on reader threads. Reusing the serialized token string across
      * this stride eliminates 99.5% of serialization overhead while still satisfying Beam's
-     * claim-before-output requirement on every single element. The exact final resume token is always
-     * serialized and committed at slice completion.
+     * claim-before-output requirement on every single element. The exact final resume token is
+     * always serialized and committed at slice completion.
      */
     public static final int RESUME_TOKEN_SERIALIZATION_STRIDE = 200;
 
@@ -763,8 +749,7 @@ public class MongoDbChangeStreamReader {
       this(MongoDbTransforms::getOrCreateMongoClient);
     }
 
-    public ProcessChangeStreamPartitionFn(
-        SerializableFunction<String, MongoClient> clientFactory) {
+    public ProcessChangeStreamPartitionFn(SerializableFunction<String, MongoClient> clientFactory) {
       this.clientFactory = clientFactory;
     }
 
@@ -840,14 +825,12 @@ public class MongoDbChangeStreamReader {
           if (partition.isDatabaseLevel()) {
             stream = db.watch(pipeline);
           } else {
-            MongoCollection<Document> collection = db.getCollection(partition.getSourceCollection());
+            MongoCollection<Document> collection =
+                db.getCollection(partition.getSourceCollection());
             stream = collection.watch(pipeline);
           }
 
-          stream =
-              stream
-                  .batchSize(MAX_EVENTS_PER_SLICE)
-                  .maxAwaitTime(250L, TimeUnit.MILLISECONDS);
+          stream = stream.batchSize(MAX_EVENTS_PER_SLICE).maxAwaitTime(250L, TimeUnit.MILLISECONDS);
 
           if (currentToken != null) {
             stream = stream.resumeAfter(currentToken);
@@ -1071,20 +1054,22 @@ public class MongoDbChangeStreamReader {
         return ProcessContinuation.resume(); // 0ms immediate resume for high-throughput burst
       } else {
         changeStreamEmptyPolls.inc();
-        return ProcessContinuation.resume()
-            .withResumeDelay(Duration.millis(IDLE_RESUME_DELAY_MS));
+        return ProcessContinuation.resume().withResumeDelay(Duration.millis(IDLE_RESUME_DELAY_MS));
       }
     }
 
     private void evictExpiredCursors() {
       if (cursorCache != null) {
-        cursorCache.entrySet().removeIf(entry -> {
-          if (entry.getValue().isExpired(CURSOR_EXPIRATION_TIMEOUT_MS)) {
-            entry.getValue().close();
-            return true;
-          }
-          return false;
-        });
+        cursorCache
+            .entrySet()
+            .removeIf(
+                entry -> {
+                  if (entry.getValue().isExpired(CURSOR_EXPIRATION_TIMEOUT_MS)) {
+                    entry.getValue().close();
+                    return true;
+                  }
+                  return false;
+                });
       }
     }
 
@@ -1111,9 +1096,7 @@ public class MongoDbChangeStreamReader {
     }
   }
 
-  /**
-   * Maps a MongoDB {@link ChangeStreamDocument} to {@link DocumentWithMetadata}.
-   */
+  /** Maps a MongoDB {@link ChangeStreamDocument} to {@link DocumentWithMetadata}. */
   public static DocumentWithMetadata mapChangeStreamEvent(
       ChangeStreamDocument<Document> event, String sourceCollection, String targetCollection) {
     if (event == null) {
@@ -1129,9 +1112,7 @@ public class MongoDbChangeStreamReader {
     }
 
     String targetCol =
-        (targetCollection != null && !targetCollection.isEmpty())
-            ? targetCollection
-            : eventCol;
+        (targetCollection != null && !targetCollection.isEmpty()) ? targetCollection : eventCol;
 
     OperationType mongoOp = event.getOperationType();
     if (mongoOp == null) {

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReader.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReader.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.v2.transforms;
 
+import com.mongodb.MongoCommandException;
 import com.mongodb.client.ChangeStreamIterable;
 import com.mongodb.client.MongoChangeStreamCursor;
 import com.mongodb.client.MongoClient;
@@ -22,6 +23,7 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.model.changestream.FullDocument;
+import com.mongodb.client.model.changestream.OperationType;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,16 +31,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.Element;
 import org.apache.beam.sdk.transforms.DoFn.GetInitialRestriction;
 import org.apache.beam.sdk.transforms.DoFn.GetRestrictionCoder;
 import org.apache.beam.sdk.transforms.DoFn.NewTracker;
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
 import org.apache.beam.sdk.transforms.DoFn.ProcessContinuation;
+import org.apache.beam.sdk.transforms.DoFn.ProcessElement;
+import org.apache.beam.sdk.transforms.DoFn.Restriction;
+import org.apache.beam.sdk.transforms.DoFn.Teardown;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Reshuffle;
@@ -236,9 +244,13 @@ public class MongoDbChangeStreamReader {
       } catch (Exception e) {
         LOG.debug("hello command failed, attempting isMaster: {}", e.getMessage());
         try {
-          helloDoc = db.runCommand(new BsonDocument("isMaster", new BsonInt32(1)), BsonDocument.class);
+          helloDoc =
+              db.runCommand(new BsonDocument("isMaster", new BsonInt32(1)), BsonDocument.class);
         } catch (Exception e2) {
-          LOG.warn("Both hello and isMaster commands failed on database '{}': {}", databaseName, e2.getMessage());
+          LOG.warn(
+              "Both hello and isMaster commands failed on database '{}': {}",
+              databaseName,
+              e2.getMessage());
         }
       }
 
@@ -834,7 +846,7 @@ public class MongoDbChangeStreamReader {
 
           stream
               .batchSize(MAX_EVENTS_PER_SLICE)
-              .maxAwaitTime(250L, java.util.concurrent.TimeUnit.MILLISECONDS);
+              .maxAwaitTime(250L, TimeUnit.MILLISECONDS);
 
           String fullDocStrategy = partition.getFullDocumentStrategy();
           if ("whenAvailable".equalsIgnoreCase(fullDocStrategy)) {
@@ -867,7 +879,7 @@ public class MongoDbChangeStreamReader {
           cursorHolder = new PartitionCursorHolder(activeCursor, currentToken);
           cursorCache.put(partitionKey, cursorHolder);
           changeStreamCursorReconnects.inc();
-        } catch (com.mongodb.MongoCommandException mce) {
+        } catch (MongoCommandException mce) {
           int errCode = mce.getErrorCode();
           String targetDesc =
               partition.isDatabaseLevel()
@@ -951,7 +963,7 @@ public class MongoDbChangeStreamReader {
           eventsInSlice++;
           changeEventsRead.inc();
 
-          com.mongodb.client.model.changestream.OperationType mongoOp = event.getOperationType();
+          OperationType mongoOp = event.getOperationType();
           if (mongoOp != null) {
             switch (mongoOp) {
               case INSERT:
@@ -1008,7 +1020,7 @@ public class MongoDbChangeStreamReader {
           tracker.tryClaim(
               new ChangeStreamRestriction(currentOffset + eventsInSlice, currentResumeTokenJson));
         }
-      } catch (com.mongodb.MongoCommandException mce) {
+      } catch (MongoCommandException mce) {
         int errCode = mce.getErrorCode();
         String targetDesc =
             partition.isDatabaseLevel()
@@ -1018,7 +1030,8 @@ public class MongoDbChangeStreamReader {
             || errCode == MONGO_ERROR_CHANGE_STREAM_HISTORY_LOST_286) {
           changeStreamHistoryLost.inc();
           LOG.error(
-              "FATAL: ChangeStreamHistoryLost (code={}) during streaming on {} partition {}. MongoDB oplog rolled over: {}",
+              "FATAL: ChangeStreamHistoryLost (code={}) during streaming on {} partition {}."
+                  + " MongoDB oplog rolled over: {}",
               errCode,
               targetDesc,
               partition.getPartitionIndex(),
@@ -1111,7 +1124,7 @@ public class MongoDbChangeStreamReader {
             ? targetCollection
             : eventCol;
 
-    com.mongodb.client.model.changestream.OperationType mongoOp = event.getOperationType();
+    OperationType mongoOp = event.getOperationType();
     if (mongoOp == null) {
       return null;
     }
@@ -1142,7 +1155,8 @@ public class MongoDbChangeStreamReader {
     }
 
     BsonTimestamp clusterTime = event.getClusterTime();
-    long epochSeconds = clusterTime != null ? clusterTime.getTime() : (System.currentTimeMillis() / 1000);
+    long epochSeconds =
+        clusterTime != null ? clusterTime.getTime() : (System.currentTimeMillis() / 1000);
     long subSeconds = clusterTime != null ? clusterTime.getInc() : 0L;
     TimestampSortKey sortKey = TimestampSortKey.cdc(epochSeconds, subSeconds);
 

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReader.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReader.java
@@ -1091,6 +1091,12 @@ public class MongoDbChangeStreamReader {
         cursorCache.clear();
       }
       if (clientCache != null) {
+        for (MongoClient client : clientCache.values()) {
+          try {
+            client.close();
+          } catch (Exception ignored) {
+          }
+        }
         clientCache.clear();
       }
     }

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReader.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReader.java
@@ -1,0 +1,1021 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.transforms;
+
+import com.mongodb.client.ChangeStreamIterable;
+import com.mongodb.client.MongoChangeStreamCursor;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import com.mongodb.client.model.changestream.FullDocument;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.SerializableCoder;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.GetInitialRestriction;
+import org.apache.beam.sdk.transforms.DoFn.GetRestrictionCoder;
+import org.apache.beam.sdk.transforms.DoFn.NewTracker;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContinuation;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Reshuffle;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.SplitResult;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.BsonTimestamp;
+import org.bson.BsonValue;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Streaming reader that consumes MongoDB Change Streams across partitioned cursors.
+ *
+ * <p>Features:
+ * <ul>
+ *   <li>Multi-cursor partitioning per collection using orthogonal match filters on {@code documentKey._id}.
+ *   <li>Capture-before-read starting timestamp support ({@code startAtOperationTime}).
+ *   <li>Configurable {@link FullDocument} strategy (e.g. {@code updateLookup} or {@code whenAvailable}).
+ *   <li>Automatic resume-token tracking (including post-batch tokens) and retry with exponential backoff on transient disconnects.
+ *   <li>Multi-cursor caching per partition with idle cursor auto-eviction.
+ *   <li>Continuous watermark progression on idle polls via resume tokens and bounded wall clock.
+ * </ul>
+ */
+public class MongoDbChangeStreamReader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MongoDbChangeStreamReader.class);
+
+  private static final JsonWriterSettings CANONICAL_JSON_SETTINGS =
+      JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
+
+  /** Descriptor representing a single partitioned change stream cursor. */
+  public static class ChangeStreamPartition implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String sourceUri;
+    private final String sourceDatabase;
+    private final String sourceCollection;
+    private final String targetCollection;
+    private final int partitionIndex;
+    private final int totalPartitions;
+    private final String matchFilterJson;
+    private final long startAtOperationTimeSeconds;
+    private final int startAtOperationTimeInc;
+    private final String fullDocumentStrategy;
+
+    public ChangeStreamPartition(
+        String sourceUri,
+        String sourceDatabase,
+        String sourceCollection,
+        String targetCollection,
+        int partitionIndex,
+        int totalPartitions,
+        String matchFilterJson,
+        long startAtOperationTimeSeconds,
+        int startAtOperationTimeInc,
+        String fullDocumentStrategy) {
+      this.sourceUri = sourceUri;
+      this.sourceDatabase = sourceDatabase;
+      this.sourceCollection = sourceCollection;
+      this.targetCollection = targetCollection;
+      this.partitionIndex = partitionIndex;
+      this.totalPartitions = totalPartitions;
+      this.matchFilterJson = matchFilterJson;
+      this.startAtOperationTimeSeconds = startAtOperationTimeSeconds;
+      this.startAtOperationTimeInc = startAtOperationTimeInc;
+      this.fullDocumentStrategy =
+          fullDocumentStrategy != null ? fullDocumentStrategy : "updateLookup";
+    }
+
+    public String getSourceUri() {
+      return sourceUri;
+    }
+
+    public String getSourceDatabase() {
+      return sourceDatabase;
+    }
+
+    public String getSourceCollection() {
+      return sourceCollection;
+    }
+
+    public String getTargetCollection() {
+      return targetCollection;
+    }
+
+    public int getPartitionIndex() {
+      return partitionIndex;
+    }
+
+    public int getTotalPartitions() {
+      return totalPartitions;
+    }
+
+    public String getMatchFilterJson() {
+      return matchFilterJson;
+    }
+
+    public long getStartAtOperationTimeSeconds() {
+      return startAtOperationTimeSeconds;
+    }
+
+    public int getStartAtOperationTimeInc() {
+      return startAtOperationTimeInc;
+    }
+
+    public String getFullDocumentStrategy() {
+      return fullDocumentStrategy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof ChangeStreamPartition)) {
+        return false;
+      }
+      ChangeStreamPartition that = (ChangeStreamPartition) o;
+      return partitionIndex == that.partitionIndex
+          && totalPartitions == that.totalPartitions
+          && startAtOperationTimeSeconds == that.startAtOperationTimeSeconds
+          && startAtOperationTimeInc == that.startAtOperationTimeInc
+          && Objects.equals(sourceUri, that.sourceUri)
+          && Objects.equals(sourceDatabase, that.sourceDatabase)
+          && Objects.equals(sourceCollection, that.sourceCollection)
+          && Objects.equals(targetCollection, that.targetCollection)
+          && Objects.equals(matchFilterJson, that.matchFilterJson)
+          && Objects.equals(fullDocumentStrategy, that.fullDocumentStrategy);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          sourceUri,
+          sourceDatabase,
+          sourceCollection,
+          targetCollection,
+          partitionIndex,
+          totalPartitions,
+          matchFilterJson,
+          startAtOperationTimeSeconds,
+          startAtOperationTimeInc,
+          fullDocumentStrategy);
+    }
+
+    @Override
+    public String toString() {
+      return "ChangeStreamPartition{"
+          + "collection='"
+          + sourceCollection
+          + '\''
+          + ", partition="
+          + partitionIndex
+          + "/"
+          + totalPartitions
+          + ", startSec="
+          + startAtOperationTimeSeconds
+          + '}';
+    }
+  }
+
+  /**
+   * Captures the current source clusterTime from MongoDB.
+   *
+   * @param sourceUri the MongoDB connection URI
+   * @param databaseName the database name
+   * @return the cluster BsonTimestamp (or current epoch timestamp fallback)
+   */
+  public static BsonTimestamp captureCurrentClusterTime(String sourceUri, String databaseName) {
+    try (MongoClient client = MongoDbTransforms.createMongoClient(sourceUri)) {
+      MongoDatabase db = client.getDatabase(databaseName);
+      BsonDocument helloDoc = null;
+      try {
+        helloDoc = db.runCommand(new BsonDocument("hello", new BsonInt32(1)), BsonDocument.class);
+      } catch (Exception e) {
+        LOG.debug("hello command failed, attempting isMaster: {}", e.getMessage());
+        try {
+          helloDoc = db.runCommand(new BsonDocument("isMaster", new BsonInt32(1)), BsonDocument.class);
+        } catch (Exception e2) {
+          LOG.warn("Both hello and isMaster commands failed on database '{}': {}", databaseName, e2.getMessage());
+        }
+      }
+
+      if (helloDoc != null && helloDoc.containsKey("$clusterTime")) {
+        BsonDocument ctWrapper = helloDoc.getDocument("$clusterTime", null);
+        if (ctWrapper != null && ctWrapper.containsKey("clusterTime")) {
+          BsonValue ctVal = ctWrapper.get("clusterTime");
+          if (ctVal != null && ctVal.isTimestamp()) {
+            return ctVal.asTimestamp();
+          }
+        }
+      }
+    } catch (Exception e) {
+      LOG.warn(
+          "Could not retrieve $clusterTime from hello/isMaster on database '{}': {}. Falling back to wall-clock time.",
+          databaseName,
+          e.getMessage());
+    }
+    return new BsonTimestamp((int) (System.currentTimeMillis() / 1000), 0);
+  }
+
+  /**
+   * Generates a MongoDB Change Stream $match filter that uniformly partitions events across
+   * {@code numSplits} parallel cursors using server-side keyset hashing ($toHashedIndexKey).
+   *
+   * @param numSplits Total number of parallel change stream partitions.
+   * @param splitIndex 0-based partition index.
+   * @return BsonDocument representing the $match stage.
+   */
+  public static BsonDocument generateHashedMatchFilter(int numSplits, int splitIndex) {
+    if (numSplits <= 0) {
+      throw new IllegalArgumentException("numSplits must be greater than 0, got " + numSplits);
+    }
+    if (splitIndex < 0 || splitIndex >= numSplits) {
+      throw new IllegalArgumentException(
+          String.format("splitIndex must be in range [0, %d), got %d", numSplits, splitIndex));
+    }
+
+    BsonDocument modDoc =
+        new BsonDocument(
+            "$mod",
+            new BsonArray(
+                Arrays.asList(
+                    new BsonDocument("$toHashedIndexKey", new BsonString("$documentKey._id")),
+                    new BsonInt32(numSplits))));
+
+    BsonArray matchingValues = new BsonArray();
+    matchingValues.add(new BsonInt32(splitIndex));
+    matchingValues.add(new BsonInt32(splitIndex - numSplits));
+
+    BsonDocument exprDoc =
+        new BsonDocument(
+            "$expr",
+            new BsonDocument("$in", new BsonArray(Arrays.asList(modDoc, matchingValues))));
+
+    return new BsonDocument("$match", exprDoc);
+  }
+
+  /**
+   * Generates partition descriptors for a collection using server-side keyset hashing.
+   */
+  public static List<ChangeStreamPartition> generatePartitions(
+      MongoClient client,
+      String sourceUri,
+      String sourceDatabase,
+      String sourceCollection,
+      String targetCollection,
+      int numSplits,
+      BsonTimestamp startAtOperationTime,
+      String fullDocumentStrategy) {
+    List<ChangeStreamPartition> partitions = new ArrayList<>();
+    long startSec = startAtOperationTime != null ? startAtOperationTime.getTime() : 0L;
+    int startInc = startAtOperationTime != null ? startAtOperationTime.getInc() : 0;
+
+    if (numSplits <= 1) {
+      partitions.add(
+          new ChangeStreamPartition(
+              sourceUri,
+              sourceDatabase,
+              sourceCollection,
+              targetCollection,
+              0,
+              1,
+              null,
+              startSec,
+              startInc,
+              fullDocumentStrategy));
+      return partitions;
+    }
+
+    for (int i = 0; i < numSplits; i++) {
+      BsonDocument changeStreamFilter = generateHashedMatchFilter(numSplits, i);
+      String filterJson = changeStreamFilter.toJson();
+
+      partitions.add(
+          new ChangeStreamPartition(
+              sourceUri,
+              sourceDatabase,
+              sourceCollection,
+              targetCollection,
+              i,
+              numSplits,
+              filterJson,
+              startSec,
+              startInc,
+              fullDocumentStrategy));
+    }
+
+    return partitions;
+  }
+
+  /**
+   * Generates partition descriptors for a collection based on the requested split count.
+   */
+  public static List<ChangeStreamPartition> generatePartitions(
+      String sourceUri,
+      String sourceDatabase,
+      String sourceCollection,
+      String targetCollection,
+      int numSplits,
+      BsonTimestamp startAtOperationTime,
+      String fullDocumentStrategy) {
+    return generatePartitions(
+        null,
+        sourceUri,
+        sourceDatabase,
+        sourceCollection,
+        targetCollection,
+        numSplits,
+        startAtOperationTime,
+        fullDocumentStrategy);
+  }
+
+  /**
+   * Recursively rewrites {@code "_id"} field references in query filters to {@code "documentKey._id"}
+   * for Change Stream {@code $match} pipeline stages.
+   */
+  public static BsonValue rewriteIdToDocumentKey(BsonValue value) {
+    if (value == null) {
+      return null;
+    }
+    if (value.isDocument()) {
+      BsonDocument original = value.asDocument();
+      BsonDocument rewritten = new BsonDocument();
+      for (Map.Entry<String, BsonValue> entry : original.entrySet()) {
+        String key = entry.getKey();
+        BsonValue val = entry.getValue();
+        if ("_id".equals(key)) {
+          rewritten.put("documentKey._id", rewriteIdToDocumentKey(val));
+        } else {
+          rewritten.put(key, rewriteIdToDocumentKey(val));
+        }
+      }
+      return rewritten;
+    } else if (value.isArray()) {
+      BsonArray originalArray = value.asArray();
+      BsonArray rewrittenArray = new BsonArray();
+      for (BsonValue item : originalArray) {
+        rewrittenArray.add(rewriteIdToDocumentKey(item));
+      }
+      return rewrittenArray;
+    }
+    return value;
+  }
+
+  /**
+   * Translates a standard read filter (e.g. {@code {"_id": {"$gte": ...}}}) into a Change Stream
+   * match filter on {@code "documentKey._id"}.
+   */
+  public static BsonDocument transformToChangeStreamFilter(BsonDocument readFilter) {
+    if (readFilter == null || readFilter.isEmpty()) {
+      return null;
+    }
+    BsonValue rewritten = rewriteIdToDocumentKey(readFilter);
+    return new BsonDocument("$match", rewritten.asDocument());
+  }
+
+  /**
+   * SDF restriction for MongoDB Change Streams tracking current offset and serialized resume token.
+   */
+  public static class ChangeStreamRestriction implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final long offset;
+    private final String resumeTokenJson;
+
+    public ChangeStreamRestriction() {
+      this(0L, null);
+    }
+
+    public ChangeStreamRestriction(long offset, String resumeTokenJson) {
+      this.offset = offset;
+      this.resumeTokenJson = resumeTokenJson;
+    }
+
+    public long getOffset() {
+      return offset;
+    }
+
+    public String getResumeTokenJson() {
+      return resumeTokenJson;
+    }
+
+    public BsonDocument getResumeToken() {
+      return resumeTokenJson != null ? BsonDocument.parse(resumeTokenJson) : null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ChangeStreamRestriction that = (ChangeStreamRestriction) o;
+      return offset == that.offset && Objects.equals(resumeTokenJson, that.resumeTokenJson);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(offset, resumeTokenJson);
+    }
+
+    @Override
+    public String toString() {
+      return "ChangeStreamRestriction{offset="
+          + offset
+          + ", hasResumeToken="
+          + (resumeTokenJson != null)
+          + "}";
+    }
+  }
+
+  /**
+   * RestrictionTracker for ChangeStreamRestriction ensuring slice-per-offset claiming and
+   * checkpoint splitting.
+   */
+  public static class ChangeStreamRestrictionTracker
+      extends RestrictionTracker<ChangeStreamRestriction, ChangeStreamRestriction> {
+
+    private ChangeStreamRestriction currentRestriction;
+    private boolean shouldStop = false;
+
+    public ChangeStreamRestrictionTracker(ChangeStreamRestriction restriction) {
+      this.currentRestriction =
+          restriction != null ? restriction : new ChangeStreamRestriction(0L, null);
+    }
+
+    @Override
+    public boolean tryClaim(ChangeStreamRestriction position) {
+      if (shouldStop) {
+        return false;
+      }
+      this.currentRestriction = position;
+      return true;
+    }
+
+    @Override
+    public ChangeStreamRestriction currentRestriction() {
+      return currentRestriction;
+    }
+
+    @Override
+    public @Nullable SplitResult<ChangeStreamRestriction> trySplit(double fractionOfRemainder) {
+      if (fractionOfRemainder == 0) {
+        if (shouldStop) {
+          return null;
+        }
+        shouldStop = true;
+        ChangeStreamRestriction primary = currentRestriction;
+        ChangeStreamRestriction residual =
+            new ChangeStreamRestriction(
+                currentRestriction.getOffset(), currentRestriction.getResumeTokenJson());
+        return SplitResult.of(primary, residual);
+      }
+      return null;
+    }
+
+    @Override
+    public void checkDone() throws IllegalStateException {
+      // Unbounded continuous streaming source
+    }
+
+    @Override
+    public IsBounded isBounded() {
+      return IsBounded.UNBOUNDED;
+    }
+  }
+
+  /**
+   * PTransform that reads unbounded MongoDB Change Streams for a list of partition descriptors.
+   */
+  public static class ReadPartitions
+      extends PTransform<PBegin, PCollection<DocumentWithMetadata>> {
+
+    private final List<ChangeStreamPartition> partitions;
+    private final SerializableFunction<String, MongoClient> clientFactory;
+
+    public ReadPartitions(List<ChangeStreamPartition> partitions) {
+      this(partitions, MongoDbTransforms::getOrCreateMongoClient);
+    }
+
+    public ReadPartitions(
+        List<ChangeStreamPartition> partitions,
+        SerializableFunction<String, MongoClient> clientFactory) {
+      this.partitions = partitions;
+      this.clientFactory = clientFactory;
+    }
+
+    @Override
+    public PCollection<DocumentWithMetadata> expand(PBegin input) {
+      if (partitions == null || partitions.isEmpty()) {
+        return input
+            .apply(
+                "EmptyCDCStreamPartitions",
+                Create.empty(SerializableCoder.of(ChangeStreamPartition.class)))
+            .apply("ReshuffleEmptyCDCPartitions", Reshuffle.viaRandomKey())
+            .apply(
+                "ProcessEmptyCDCStream",
+                ParDo.of(new ProcessChangeStreamPartitionFn(clientFactory)))
+            .setCoder(DocumentWithMetadataCoder.of());
+      }
+
+      return input
+          .apply(
+              "CreateCDCPartitions",
+              Create.of(partitions).withCoder(SerializableCoder.of(ChangeStreamPartition.class)))
+          .apply("ReshuffleCDCPartitions", Reshuffle.viaRandomKey())
+          .apply(
+              "StreamChangeEvents",
+              ParDo.of(new ProcessChangeStreamPartitionFn(clientFactory)))
+          .setCoder(DocumentWithMetadataCoder.of());
+    }
+  }
+
+  /**
+   * Splittable DoFn that maintains high-throughput streaming Change Stream cursors cached per partition.
+   */
+  public static class ProcessChangeStreamPartitionFn
+      extends DoFn<ChangeStreamPartition, DocumentWithMetadata> {
+
+    public static final int MAX_EVENTS_PER_SLICE = 1000;
+    public static final long MAX_SLICE_DURATION_MS = 3000L;
+    public static final long CURSOR_EXPIRATION_TIMEOUT_MS = 300_000L; // 5 minutes idle timeout
+    public static final int MONGO_ERROR_CHANGE_STREAM_HISTORY_LOST_280 = 280;
+    public static final int MONGO_ERROR_CHANGE_STREAM_HISTORY_LOST_286 = 286;
+
+    private final Counter changeEventsRead =
+        Metrics.counter(MongoDbChangeStreamReader.class, "changeEventsRead");
+    private final Counter changeEventsErrors =
+        Metrics.counter(MongoDbChangeStreamReader.class, "changeEventsErrors");
+    private final Counter changeStreamHistoryLost =
+        Metrics.counter(MongoDbChangeStreamReader.class, "changeStreamHistoryLost");
+    private final Counter changeEventsInserts =
+        Metrics.counter(MongoDbChangeStreamReader.class, "changeEventsInserts");
+    private final Counter changeEventsUpdates =
+        Metrics.counter(MongoDbChangeStreamReader.class, "changeEventsUpdates");
+    private final Counter changeEventsReplaces =
+        Metrics.counter(MongoDbChangeStreamReader.class, "changeEventsReplaces");
+    private final Counter changeEventsDeletes =
+        Metrics.counter(MongoDbChangeStreamReader.class, "changeEventsDeletes");
+    private final Counter changeEventsDrops =
+        Metrics.counter(MongoDbChangeStreamReader.class, "changeEventsDrops");
+    private final Counter changeEventsRenames =
+        Metrics.counter(MongoDbChangeStreamReader.class, "changeEventsRenames");
+    private final Counter changeEventsOther =
+        Metrics.counter(MongoDbChangeStreamReader.class, "changeEventsOther");
+    private final Counter changeEventsDroppedNullPayload =
+        Metrics.counter(MongoDbChangeStreamReader.class, "changeEventsDroppedNullPayload");
+    private final Counter changeStreamPollCycles =
+        Metrics.counter(MongoDbChangeStreamReader.class, "changeStreamPollCycles");
+    private final Counter changeStreamEmptyPolls =
+        Metrics.counter(MongoDbChangeStreamReader.class, "changeStreamEmptyPolls");
+    private final Counter changeStreamBurstPolls =
+        Metrics.counter(MongoDbChangeStreamReader.class, "changeStreamBurstPolls");
+    private final Counter changeStreamCursorReconnects =
+        Metrics.counter(MongoDbChangeStreamReader.class, "changeStreamCursorReconnects");
+
+    /** Holds a cached cursor and tracks its last access timestamp and resume token for eviction. */
+    public static class PartitionCursorHolder implements AutoCloseable {
+      private final MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor;
+      private volatile long lastAccessedMs;
+      private volatile BsonDocument lastResumeToken;
+
+      public PartitionCursorHolder(
+          MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor,
+          BsonDocument initialToken) {
+        this.cursor = cursor;
+        this.lastAccessedMs = System.currentTimeMillis();
+        this.lastResumeToken = initialToken;
+      }
+
+      public MongoChangeStreamCursor<ChangeStreamDocument<Document>> getCursor() {
+        this.lastAccessedMs = System.currentTimeMillis();
+        return cursor;
+      }
+
+      public BsonDocument getLastResumeToken() {
+        return lastResumeToken;
+      }
+
+      public void setLastResumeToken(BsonDocument token) {
+        this.lastResumeToken = token;
+        this.lastAccessedMs = System.currentTimeMillis();
+      }
+
+      public boolean isExpired(long timeoutMs) {
+        return (System.currentTimeMillis() - lastAccessedMs) > timeoutMs;
+      }
+
+      @Override
+      public void close() {
+        if (cursor != null) {
+          try {
+            cursor.close();
+          } catch (Exception ignored) {
+          }
+        }
+      }
+    }
+
+    private final SerializableFunction<String, MongoClient> clientFactory;
+
+    private transient ConcurrentHashMap<String, MongoClient> clientCache;
+    private transient ConcurrentHashMap<String, PartitionCursorHolder> cursorCache;
+
+    public ProcessChangeStreamPartitionFn() {
+      this(MongoDbTransforms::getOrCreateMongoClient);
+    }
+
+    public ProcessChangeStreamPartitionFn(
+        SerializableFunction<String, MongoClient> clientFactory) {
+      this.clientFactory = clientFactory;
+    }
+
+    @GetInitialRestriction
+    public ChangeStreamRestriction getInitialRestriction(@Element ChangeStreamPartition partition) {
+      return new ChangeStreamRestriction(0L, null);
+    }
+
+    @NewTracker
+    public ChangeStreamRestrictionTracker newTracker(
+        @Element ChangeStreamPartition partition,
+        @Restriction ChangeStreamRestriction restriction) {
+      return new ChangeStreamRestrictionTracker(restriction);
+    }
+
+    @GetRestrictionCoder
+    public Coder<ChangeStreamRestriction> getRestrictionCoder() {
+      return SerializableCoder.of(ChangeStreamRestriction.class);
+    }
+
+    @ProcessElement
+    public ProcessContinuation processElement(
+        @Element ChangeStreamPartition partition,
+        RestrictionTracker<ChangeStreamRestriction, ChangeStreamRestriction> tracker,
+        OutputReceiver<DocumentWithMetadata> receiver) {
+
+      if (cursorCache == null) {
+        cursorCache = new ConcurrentHashMap<>();
+      }
+      if (clientCache == null) {
+        clientCache = new ConcurrentHashMap<>();
+      }
+      evictExpiredCursors();
+
+      changeStreamPollCycles.inc();
+      ChangeStreamRestriction currentRestriction = tracker.currentRestriction();
+      if (!tracker.tryClaim(currentRestriction)) {
+        return ProcessContinuation.stop();
+      }
+
+      String partitionKey =
+          partition.getSourceDatabase()
+              + "."
+              + partition.getSourceCollection()
+              + "#"
+              + partition.getPartitionIndex();
+
+      BsonDocument currentToken = currentRestriction.getResumeToken();
+      PartitionCursorHolder cursorHolder = cursorCache.get(partitionKey);
+
+      // Validate that cached cursor position matches the incoming restriction resume token
+      if (cursorHolder != null) {
+        if (!Objects.equals(cursorHolder.getLastResumeToken(), currentToken)) {
+          // Partition was progressed on another worker or reconnect required; discard stale cursor
+          closeCursorForPartition(partitionKey);
+          cursorHolder = null;
+        }
+      }
+
+      // Ensure cursor is initialized for this partition
+      if (cursorHolder == null) {
+        try {
+          MongoClient mongoClient =
+              clientCache.computeIfAbsent(partition.getSourceUri(), clientFactory::apply);
+
+          MongoDatabase db = mongoClient.getDatabase(partition.getSourceDatabase());
+          MongoCollection<Document> collection = db.getCollection(partition.getSourceCollection());
+
+          List<Bson> pipeline = new ArrayList<>();
+          if (partition.getMatchFilterJson() != null && !partition.getMatchFilterJson().isEmpty()) {
+            pipeline.add(BsonDocument.parse(partition.getMatchFilterJson()));
+          }
+
+          ChangeStreamIterable<Document> stream =
+              collection
+                  .watch(pipeline)
+                  .batchSize(MAX_EVENTS_PER_SLICE)
+                  .maxAwaitTime(500L, java.util.concurrent.TimeUnit.MILLISECONDS);
+
+          String fullDocStrategy = partition.getFullDocumentStrategy();
+          if ("whenAvailable".equalsIgnoreCase(fullDocStrategy)) {
+            try {
+              stream.fullDocument(FullDocument.WHEN_AVAILABLE);
+            } catch (Exception e) {
+              LOG.warn("whenAvailable not supported, falling back to updateLookup");
+              stream.fullDocument(FullDocument.UPDATE_LOOKUP);
+            }
+          } else if ("required".equalsIgnoreCase(fullDocStrategy)) {
+            try {
+              stream.fullDocument(FullDocument.REQUIRED);
+            } catch (Exception e) {
+              stream.fullDocument(FullDocument.UPDATE_LOOKUP);
+            }
+          } else if (!"default".equalsIgnoreCase(fullDocStrategy)) {
+            stream.fullDocument(FullDocument.UPDATE_LOOKUP);
+          }
+
+          if (currentToken != null) {
+            stream.resumeAfter(currentToken);
+          } else if (partition.getStartAtOperationTimeSeconds() > 0) {
+            stream.startAtOperationTime(
+                new BsonTimestamp(
+                    (int) partition.getStartAtOperationTimeSeconds(),
+                    partition.getStartAtOperationTimeInc()));
+          }
+
+          MongoChangeStreamCursor<ChangeStreamDocument<Document>> activeCursor = stream.cursor();
+          cursorHolder = new PartitionCursorHolder(activeCursor, currentToken);
+          cursorCache.put(partitionKey, cursorHolder);
+          changeStreamCursorReconnects.inc();
+        } catch (com.mongodb.MongoCommandException mce) {
+          int errCode = mce.getErrorCode();
+          if (errCode == MONGO_ERROR_CHANGE_STREAM_HISTORY_LOST_280
+              || errCode == MONGO_ERROR_CHANGE_STREAM_HISTORY_LOST_286) {
+            changeStreamHistoryLost.inc();
+            LOG.error(
+                "FATAL: ChangeStreamHistoryLost (code={}) on collection '{}' partition {}. MongoDB oplog rolled over: {}",
+                errCode,
+                partition.getSourceCollection(),
+                partition.getPartitionIndex(),
+                mce.getMessage());
+          }
+          changeEventsErrors.inc();
+          closeCursorForPartition(partitionKey);
+          return ProcessContinuation.resume().withResumeDelay(Duration.millis(1000));
+        } catch (Exception e) {
+          changeEventsErrors.inc();
+          LOG.error(
+              "Error initializing change stream cursor for collection '{}', partition {}: {}. Will retry in 1s.",
+              partition.getSourceCollection(),
+              partition.getPartitionIndex(),
+              e.getMessage(),
+              e);
+          closeCursorForPartition(partitionKey);
+          return ProcessContinuation.resume().withResumeDelay(Duration.millis(1000));
+        }
+      }
+
+      long sliceStartTime = System.currentTimeMillis();
+      int eventsInSlice = 0;
+      long currentOffset = currentRestriction.getOffset();
+      BsonDocument postBatchToken = null;
+
+      try {
+        MongoChangeStreamCursor<ChangeStreamDocument<Document>> cursor = cursorHolder.getCursor();
+        while (eventsInSlice < MAX_EVENTS_PER_SLICE
+            && (System.currentTimeMillis() - sliceStartTime) < MAX_SLICE_DURATION_MS) {
+          ChangeStreamDocument<Document> event = cursor.tryNext();
+          if (event == null) {
+            // Post-batch resume token capture on idle
+            try {
+              postBatchToken = cursor.getResumeToken();
+              if (postBatchToken != null) {
+                cursorHolder.setLastResumeToken(postBatchToken);
+                if (!tracker.tryClaim(
+                    new ChangeStreamRestriction(
+                        currentOffset + eventsInSlice,
+                        postBatchToken.toJson(CANONICAL_JSON_SETTINGS)))) {
+                  closeCursorForPartition(partitionKey);
+                  return ProcessContinuation.stop();
+                }
+              }
+            } catch (Exception e) {
+              LOG.debug("Could not retrieve post-batch resume token: {}", e.getMessage());
+            }
+            break;
+          }
+
+          eventsInSlice++;
+          changeEventsRead.inc();
+
+          com.mongodb.client.model.changestream.OperationType mongoOp = event.getOperationType();
+          if (mongoOp != null) {
+            switch (mongoOp) {
+              case INSERT:
+                changeEventsInserts.inc();
+                break;
+              case UPDATE:
+                changeEventsUpdates.inc();
+                break;
+              case REPLACE:
+                changeEventsReplaces.inc();
+                break;
+              case DELETE:
+                changeEventsDeletes.inc();
+                break;
+              case DROP:
+                changeEventsDrops.inc();
+                break;
+              case RENAME:
+                changeEventsRenames.inc();
+                break;
+              default:
+                changeEventsOther.inc();
+                break;
+            }
+          }
+
+          if (event.getResumeToken() != null) {
+            cursorHolder.setLastResumeToken(event.getResumeToken());
+            if (!tracker.tryClaim(
+                new ChangeStreamRestriction(
+                    currentOffset + eventsInSlice,
+                    event.getResumeToken().toJson(CANONICAL_JSON_SETTINGS)))) {
+              closeCursorForPartition(partitionKey);
+              return ProcessContinuation.stop();
+            }
+          }
+
+          DocumentWithMetadata cdcItem =
+              mapChangeStreamEvent(
+                  event, partition.getSourceCollection(), partition.getTargetCollection());
+
+          if (cdcItem != null) {
+            receiver.output(cdcItem);
+          } else {
+            changeEventsDroppedNullPayload.inc();
+          }
+        }
+      } catch (com.mongodb.MongoCommandException mce) {
+        int errCode = mce.getErrorCode();
+        if (errCode == MONGO_ERROR_CHANGE_STREAM_HISTORY_LOST_280
+            || errCode == MONGO_ERROR_CHANGE_STREAM_HISTORY_LOST_286) {
+          changeStreamHistoryLost.inc();
+          LOG.error(
+              "FATAL: ChangeStreamHistoryLost (code={}) during streaming on collection '{}' partition {}. MongoDB oplog rolled over: {}",
+              errCode,
+              partition.getSourceCollection(),
+              partition.getPartitionIndex(),
+              mce.getMessage());
+        }
+        changeEventsErrors.inc();
+        closeCursorForPartition(partitionKey);
+        return ProcessContinuation.resume().withResumeDelay(Duration.millis(1000));
+      } catch (Exception e) {
+        changeEventsErrors.inc();
+        LOG.warn(
+            "Transient exception during change stream poll on collection '{}', partition {}: {}. Reconnecting cursor...",
+            partition.getSourceCollection(),
+            partition.getPartitionIndex(),
+            e.getMessage());
+        closeCursorForPartition(partitionKey);
+        return ProcessContinuation.resume().withResumeDelay(Duration.millis(1000));
+      }
+
+      if (eventsInSlice > 0) {
+        if (eventsInSlice >= MAX_EVENTS_PER_SLICE) {
+          changeStreamBurstPolls.inc();
+        }
+        return ProcessContinuation.resume(); // 0ms immediate resume for high-throughput burst
+      } else {
+        changeStreamEmptyPolls.inc();
+        return ProcessContinuation.resume()
+            .withResumeDelay(Duration.millis(200)); // 200ms idle backoff
+      }
+    }
+
+    private void evictExpiredCursors() {
+      if (cursorCache != null) {
+        cursorCache.entrySet().removeIf(entry -> {
+          if (entry.getValue().isExpired(CURSOR_EXPIRATION_TIMEOUT_MS)) {
+            entry.getValue().close();
+            return true;
+          }
+          return false;
+        });
+      }
+    }
+
+    private void closeCursorForPartition(String partitionKey) {
+      if (cursorCache != null && partitionKey != null) {
+        PartitionCursorHolder holder = cursorCache.remove(partitionKey);
+        if (holder != null) {
+          holder.close();
+        }
+      }
+    }
+
+    @Teardown
+    public void teardown() {
+      if (cursorCache != null) {
+        for (PartitionCursorHolder holder : cursorCache.values()) {
+          holder.close();
+        }
+        cursorCache.clear();
+      }
+      if (clientCache != null) {
+        clientCache.clear();
+      }
+    }
+  }
+
+  /**
+   * Maps a MongoDB {@link ChangeStreamDocument} to {@link DocumentWithMetadata}.
+   */
+  public static DocumentWithMetadata mapChangeStreamEvent(
+      ChangeStreamDocument<Document> event, String sourceCollection, String targetCollection) {
+    if (event == null) {
+      return null;
+    }
+
+    com.mongodb.client.model.changestream.OperationType mongoOp = event.getOperationType();
+    if (mongoOp == null) {
+      return null;
+    }
+
+    DocumentWithMetadata.OperationType opType;
+    switch (mongoOp) {
+      case INSERT:
+        opType = DocumentWithMetadata.OperationType.INSERT;
+        break;
+      case UPDATE:
+        opType = DocumentWithMetadata.OperationType.UPDATE;
+        break;
+      case REPLACE:
+        opType = DocumentWithMetadata.OperationType.REPLACE;
+        break;
+      case DELETE:
+        opType = DocumentWithMetadata.OperationType.DELETE;
+        break;
+      case DROP:
+        opType = DocumentWithMetadata.OperationType.DROP;
+        break;
+      case RENAME:
+        opType = DocumentWithMetadata.OperationType.RENAME;
+        break;
+      default:
+        LOG.debug("Ignoring unsupported change stream operation: {}", mongoOp);
+        return null;
+    }
+
+    BsonTimestamp clusterTime = event.getClusterTime();
+    long epochSeconds = clusterTime != null ? clusterTime.getTime() : (System.currentTimeMillis() / 1000);
+    long subSeconds = clusterTime != null ? clusterTime.getInc() : 0L;
+    TimestampSortKey sortKey = TimestampSortKey.cdc(epochSeconds, subSeconds);
+
+    BsonDocument docKeyBson = event.getDocumentKey();
+    String docKeyStr = docKeyBson != null ? docKeyBson.toJson(CANONICAL_JSON_SETTINGS) : null;
+
+    Document fullDoc = event.getFullDocument();
+    if (fullDoc == null
+        && (opType == DocumentWithMetadata.OperationType.INSERT
+            || opType == DocumentWithMetadata.OperationType.UPDATE
+            || opType == DocumentWithMetadata.OperationType.REPLACE)) {
+      // Document was deleted between the mutation and the updateLookup.
+      // Dropping because no payload is available to write, and subsequent DELETE handles deletion.
+      return null;
+    }
+    String originalDocStr = fullDoc != null ? fullDoc.toJson(CANONICAL_JSON_SETTINGS) : null;
+
+    return DocumentWithMetadata.cdcEvent(
+        fullDoc, originalDocStr, sourceCollection, targetCollection, opType, sortKey, docKeyStr);
+  }
+}

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReader.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReader.java
@@ -844,38 +844,47 @@ public class MongoDbChangeStreamReader {
             stream = collection.watch(pipeline);
           }
 
-          stream
-              .batchSize(MAX_EVENTS_PER_SLICE)
-              .maxAwaitTime(250L, TimeUnit.MILLISECONDS);
-
-          String fullDocStrategy = partition.getFullDocumentStrategy();
-          if ("whenAvailable".equalsIgnoreCase(fullDocStrategy)) {
-            try {
-              stream.fullDocument(FullDocument.WHEN_AVAILABLE);
-            } catch (Exception e) {
-              LOG.warn("whenAvailable not supported, falling back to updateLookup");
-              stream.fullDocument(FullDocument.UPDATE_LOOKUP);
-            }
-          } else if ("required".equalsIgnoreCase(fullDocStrategy)) {
-            try {
-              stream.fullDocument(FullDocument.REQUIRED);
-            } catch (Exception e) {
-              stream.fullDocument(FullDocument.UPDATE_LOOKUP);
-            }
-          } else if (!"default".equalsIgnoreCase(fullDocStrategy)) {
-            stream.fullDocument(FullDocument.UPDATE_LOOKUP);
-          }
+          stream =
+              stream
+                  .batchSize(MAX_EVENTS_PER_SLICE)
+                  .maxAwaitTime(250L, TimeUnit.MILLISECONDS);
 
           if (currentToken != null) {
-            stream.resumeAfter(currentToken);
+            stream = stream.resumeAfter(currentToken);
           } else if (partition.getStartAtOperationTimeSeconds() > 0) {
-            stream.startAtOperationTime(
-                new BsonTimestamp(
-                    (int) partition.getStartAtOperationTimeSeconds(),
-                    partition.getStartAtOperationTimeInc()));
+            stream =
+                stream.startAtOperationTime(
+                    new BsonTimestamp(
+                        (int) partition.getStartAtOperationTimeSeconds(),
+                        partition.getStartAtOperationTimeInc()));
           }
 
-          MongoChangeStreamCursor<ChangeStreamDocument<Document>> activeCursor = stream.cursor();
+          String fullDocStrategy = partition.getFullDocumentStrategy();
+          ChangeStreamIterable<Document> configuredStream = stream;
+          if ("whenAvailable".equalsIgnoreCase(fullDocStrategy)) {
+            configuredStream = stream.fullDocument(FullDocument.WHEN_AVAILABLE);
+          } else if ("required".equalsIgnoreCase(fullDocStrategy)) {
+            configuredStream = stream.fullDocument(FullDocument.REQUIRED);
+          } else if (!"default".equalsIgnoreCase(fullDocStrategy)) {
+            configuredStream = stream.fullDocument(FullDocument.UPDATE_LOOKUP);
+          }
+
+          MongoChangeStreamCursor<ChangeStreamDocument<Document>> activeCursor;
+          try {
+            activeCursor = configuredStream.cursor();
+          } catch (MongoCommandException mce) {
+            if (mce.getErrorMessage() != null
+                && mce.getErrorMessage().contains("fullDocument")
+                && !"updateLookup".equalsIgnoreCase(fullDocStrategy)) {
+              LOG.warn(
+                  "Configured fullDocument strategy '{}' is not supported by the server."
+                      + " Falling back to 'updateLookup'.",
+                  fullDocStrategy);
+              activeCursor = stream.fullDocument(FullDocument.UPDATE_LOOKUP).cursor();
+            } else {
+              throw mce;
+            }
+          }
           cursorHolder = new PartitionCursorHolder(activeCursor, currentToken);
           cursorCache.put(partitionKey, cursorHolder);
           changeStreamCursorReconnects.inc();

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReader.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReader.java
@@ -161,6 +161,10 @@ public class MongoDbChangeStreamReader {
       return fullDocumentStrategy;
     }
 
+    public boolean isDatabaseLevel() {
+      return sourceCollection == null || sourceCollection.isEmpty();
+    }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) {
@@ -200,8 +204,11 @@ public class MongoDbChangeStreamReader {
     @Override
     public String toString() {
       return "ChangeStreamPartition{"
-          + "collection='"
-          + sourceCollection
+          + "database='"
+          + sourceDatabase
+          + '\''
+          + ", collection='"
+          + (isDatabaseLevel() ? "[DATABASE_WIDE]" : sourceCollection)
           + '\''
           + ", partition="
           + partitionIndex
@@ -360,6 +367,75 @@ public class MongoDbChangeStreamReader {
         sourceDatabase,
         sourceCollection,
         targetCollection,
+        numSplits,
+        startAtOperationTime,
+        fullDocumentStrategy);
+  }
+
+  /**
+   * Generates database-level change stream partition descriptors for an entire database.
+   */
+  public static List<ChangeStreamPartition> generateDatabasePartitions(
+      MongoClient client,
+      String sourceUri,
+      String sourceDatabase,
+      int numSplits,
+      BsonTimestamp startAtOperationTime,
+      String fullDocumentStrategy) {
+    List<ChangeStreamPartition> partitions = new ArrayList<>();
+    long startSec = startAtOperationTime != null ? startAtOperationTime.getTime() : 0L;
+    int startInc = startAtOperationTime != null ? startAtOperationTime.getInc() : 0;
+
+    if (numSplits <= 1) {
+      partitions.add(
+          new ChangeStreamPartition(
+              sourceUri,
+              sourceDatabase,
+              null,
+              null,
+              0,
+              1,
+              null,
+              startSec,
+              startInc,
+              fullDocumentStrategy));
+      return partitions;
+    }
+
+    for (int i = 0; i < numSplits; i++) {
+      BsonDocument changeStreamFilter = generateHashedMatchFilter(numSplits, i);
+      String filterJson = changeStreamFilter.toJson();
+
+      partitions.add(
+          new ChangeStreamPartition(
+              sourceUri,
+              sourceDatabase,
+              null,
+              null,
+              i,
+              numSplits,
+              filterJson,
+              startSec,
+              startInc,
+              fullDocumentStrategy));
+    }
+
+    return partitions;
+  }
+
+  /**
+   * Generates database-level change stream partition descriptors for an entire database.
+   */
+  public static List<ChangeStreamPartition> generateDatabasePartitions(
+      String sourceUri,
+      String sourceDatabase,
+      int numSplits,
+      BsonTimestamp startAtOperationTime,
+      String fullDocumentStrategy) {
+    return generateDatabasePartitions(
+        null,
+        sourceUri,
+        sourceDatabase,
         numSplits,
         startAtOperationTime,
         fullDocumentStrategy);
@@ -707,8 +783,7 @@ public class MongoDbChangeStreamReader {
 
       String partitionKey =
           partition.getSourceDatabase()
-              + "."
-              + partition.getSourceCollection()
+              + (partition.isDatabaseLevel() ? "#db" : "." + partition.getSourceCollection())
               + "#"
               + partition.getPartitionIndex();
 
@@ -731,18 +806,23 @@ public class MongoDbChangeStreamReader {
               clientCache.computeIfAbsent(partition.getSourceUri(), clientFactory::apply);
 
           MongoDatabase db = mongoClient.getDatabase(partition.getSourceDatabase());
-          MongoCollection<Document> collection = db.getCollection(partition.getSourceCollection());
 
           List<Bson> pipeline = new ArrayList<>();
           if (partition.getMatchFilterJson() != null && !partition.getMatchFilterJson().isEmpty()) {
             pipeline.add(BsonDocument.parse(partition.getMatchFilterJson()));
           }
 
-          ChangeStreamIterable<Document> stream =
-              collection
-                  .watch(pipeline)
-                  .batchSize(MAX_EVENTS_PER_SLICE)
-                  .maxAwaitTime(500L, java.util.concurrent.TimeUnit.MILLISECONDS);
+          ChangeStreamIterable<Document> stream;
+          if (partition.isDatabaseLevel()) {
+            stream = db.watch(pipeline);
+          } else {
+            MongoCollection<Document> collection = db.getCollection(partition.getSourceCollection());
+            stream = collection.watch(pipeline);
+          }
+
+          stream
+              .batchSize(MAX_EVENTS_PER_SLICE)
+              .maxAwaitTime(500L, java.util.concurrent.TimeUnit.MILLISECONDS);
 
           String fullDocStrategy = partition.getFullDocumentStrategy();
           if ("whenAvailable".equalsIgnoreCase(fullDocStrategy)) {
@@ -777,13 +857,17 @@ public class MongoDbChangeStreamReader {
           changeStreamCursorReconnects.inc();
         } catch (com.mongodb.MongoCommandException mce) {
           int errCode = mce.getErrorCode();
+          String targetDesc =
+              partition.isDatabaseLevel()
+                  ? "database '" + partition.getSourceDatabase() + "'"
+                  : "collection '" + partition.getSourceCollection() + "'";
           if (errCode == MONGO_ERROR_CHANGE_STREAM_HISTORY_LOST_280
               || errCode == MONGO_ERROR_CHANGE_STREAM_HISTORY_LOST_286) {
             changeStreamHistoryLost.inc();
             LOG.error(
-                "FATAL: ChangeStreamHistoryLost (code={}) on collection '{}' partition {}. MongoDB oplog rolled over: {}",
+                "FATAL: ChangeStreamHistoryLost (code={}) on {} partition {}. MongoDB oplog rolled over: {}",
                 errCode,
-                partition.getSourceCollection(),
+                targetDesc,
                 partition.getPartitionIndex(),
                 mce.getMessage());
           }
@@ -791,10 +875,14 @@ public class MongoDbChangeStreamReader {
           closeCursorForPartition(partitionKey);
           return ProcessContinuation.resume().withResumeDelay(Duration.millis(1000));
         } catch (Exception e) {
+          String targetDesc =
+              partition.isDatabaseLevel()
+                  ? "database '" + partition.getSourceDatabase() + "'"
+                  : "collection '" + partition.getSourceCollection() + "'";
           changeEventsErrors.inc();
           LOG.error(
-              "Error initializing change stream cursor for collection '{}', partition {}: {}. Will retry in 1s.",
-              partition.getSourceCollection(),
+              "Error initializing change stream cursor for {}, partition {}: {}. Will retry in 1s.",
+              targetDesc,
               partition.getPartitionIndex(),
               e.getMessage(),
               e);
@@ -886,13 +974,17 @@ public class MongoDbChangeStreamReader {
         }
       } catch (com.mongodb.MongoCommandException mce) {
         int errCode = mce.getErrorCode();
+        String targetDesc =
+            partition.isDatabaseLevel()
+                ? "database '" + partition.getSourceDatabase() + "'"
+                : "collection '" + partition.getSourceCollection() + "'";
         if (errCode == MONGO_ERROR_CHANGE_STREAM_HISTORY_LOST_280
             || errCode == MONGO_ERROR_CHANGE_STREAM_HISTORY_LOST_286) {
           changeStreamHistoryLost.inc();
           LOG.error(
-              "FATAL: ChangeStreamHistoryLost (code={}) during streaming on collection '{}' partition {}. MongoDB oplog rolled over: {}",
+              "FATAL: ChangeStreamHistoryLost (code={}) during streaming on {} partition {}. MongoDB oplog rolled over: {}",
               errCode,
-              partition.getSourceCollection(),
+              targetDesc,
               partition.getPartitionIndex(),
               mce.getMessage());
         }
@@ -900,10 +992,14 @@ public class MongoDbChangeStreamReader {
         closeCursorForPartition(partitionKey);
         return ProcessContinuation.resume().withResumeDelay(Duration.millis(1000));
       } catch (Exception e) {
+        String targetDesc =
+            partition.isDatabaseLevel()
+                ? "database '" + partition.getSourceDatabase() + "'"
+                : "collection '" + partition.getSourceCollection() + "'";
         changeEventsErrors.inc();
         LOG.warn(
-            "Transient exception during change stream poll on collection '{}', partition {}: {}. Reconnecting cursor...",
-            partition.getSourceCollection(),
+            "Transient exception during change stream poll on {}, partition {}: {}. Reconnecting cursor...",
+            targetDesc,
             partition.getPartitionIndex(),
             e.getMessage());
         closeCursorForPartition(partitionKey);
@@ -966,6 +1062,19 @@ public class MongoDbChangeStreamReader {
       return null;
     }
 
+    String eventCol = sourceCollection;
+    if (event.getNamespace() != null && event.getNamespace().getCollectionName() != null) {
+      eventCol = event.getNamespace().getCollectionName();
+    }
+    if (eventCol == null || eventCol.startsWith("system.")) {
+      return null;
+    }
+
+    String targetCol =
+        (targetCollection != null && !targetCollection.isEmpty())
+            ? targetCollection
+            : eventCol;
+
     com.mongodb.client.model.changestream.OperationType mongoOp = event.getOperationType();
     if (mongoOp == null) {
       return null;
@@ -1016,6 +1125,6 @@ public class MongoDbChangeStreamReader {
     String originalDocStr = fullDoc != null ? fullDoc.toJson(CANONICAL_JSON_SETTINGS) : null;
 
     return DocumentWithMetadata.cdcEvent(
-        fullDoc, originalDocStr, sourceCollection, targetCollection, opType, sortKey, docKeyStr);
+        fullDoc, originalDocStr, eventCol, targetCol, opType, sortKey, docKeyStr);
   }
 }

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbTransforms.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbTransforms.java
@@ -18,6 +18,10 @@ package com.google.cloud.teleport.v2.transforms;
 import static com.google.cloud.teleport.v2.transforms.DocumentWithMetadata.ErrorType.PERMANENT;
 import static com.google.cloud.teleport.v2.transforms.DocumentWithMetadata.ErrorType.RETRYABLE;
 
+import com.google.cloud.teleport.v2.transforms.DocumentWithMetadata.ErrorType;
+import com.google.cloud.teleport.v2.transforms.DocumentWithMetadata.FailureStage;
+import com.google.cloud.teleport.v2.transforms.DocumentWithMetadata.OperationType;
+import com.google.cloud.teleport.v2.transforms.JavascriptTextTransformer.JavascriptRuntime;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.RateLimiter;
 import com.mongodb.ConnectionString;
@@ -27,6 +31,7 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoException;
 import com.mongodb.ReadPreference;
 import com.mongodb.bulk.BulkWriteError;
+import com.mongodb.bulk.WriteConcernError;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
@@ -294,6 +299,7 @@ public class MongoDbTransforms {
     private static final Logger LOG = LoggerFactory.getLogger(WriteToDlq.class);
     private final String retryablePath;
     private final String permanentPath;
+    @SuppressWarnings("unused")
     private final String tempLocation;
 
     private final Counter dlqRetryableEmitted =
@@ -316,14 +322,10 @@ public class MongoDbTransforms {
           permanentPath);
 
       PCollection<DocumentWithMetadata> retryable =
-          input.apply(
-              "FilterRetryable",
-              Filter.by(item -> item.getErrorType() == DocumentWithMetadata.ErrorType.RETRYABLE));
+          input.apply("FilterRetryable", Filter.by(item -> item.getErrorType() == RETRYABLE));
 
       PCollection<DocumentWithMetadata> permanent =
-          input.apply(
-              "FilterPermanent",
-              Filter.by(item -> item.getErrorType() == DocumentWithMetadata.ErrorType.PERMANENT));
+          input.apply("FilterPermanent", Filter.by(item -> item.getErrorType() == PERMANENT));
 
       boolean isUnbounded = input.isBounded() == PCollection.IsBounded.UNBOUNDED;
 
@@ -755,11 +757,12 @@ public class MongoDbTransforms {
                 Collections.singletonList(item), "Received DELETE event with null ID");
           }
         } else if (item.getOperationType() != null
-            && (item.getOperationType() == DocumentWithMetadata.OperationType.DROP
-                || item.getOperationType() == DocumentWithMetadata.OperationType.RENAME)) {
+            && (item.getOperationType() == OperationType.DROP
+                || item.getOperationType() == OperationType.RENAME)) {
           writeDropsSkipped.inc();
           LOG.info(
-              "Received collection-level event '{}' for collection '{}'; skipping document-level write.",
+              "Received collection-level event '{}' for collection '{}';"
+                  + " skipping document-level write.",
               item.getOperationType(),
               targetCol);
         } else {
@@ -846,7 +849,7 @@ public class MongoDbTransforms {
           break;
         } catch (MongoBulkWriteException e) {
           List<BulkWriteError> writeErrors = e.getWriteErrors();
-          com.mongodb.bulk.WriteConcernError wcError = e.getWriteConcernError();
+          WriteConcernError wcError = e.getWriteConcernError();
 
           if (wcError != null && (writeErrors == null || writeErrors.isEmpty())) {
             LOG.warn(
@@ -1016,13 +1019,13 @@ public class MongoDbTransforms {
             isPerm
                 ? Math.max(nextRetryCount, dlqMaxRetries != null ? dlqMaxRetries + 1 : 1)
                 : nextRetryCount;
-        DocumentWithMetadata.ErrorType errorType = isPerm ? PERMANENT : RETRYABLE;
+        ErrorType errorType = isPerm ? PERMANENT : RETRYABLE;
 
         failures.add(
             item.withFailure(
                 message,
                 errorType,
-                DocumentWithMetadata.FailureStage.WRITE,
+                FailureStage.WRITE,
                 retryCount));
       }
     }
@@ -1310,15 +1313,16 @@ public class MongoDbTransforms {
         startTimeMs = System.currentTimeMillis();
         lastComputedStep = 0;
         LOG.info(
-            "Enabled linear write rate ramp-up for WriteBatchesFn: initialRate={} docs/s/worker, targetMax={}"
-                + " docs/s/worker, duration={} mins, steps={}",
+            "Enabled linear write rate ramp-up for WriteBatchesFn: initialRate={} docs/s/worker,"
+                + " targetMax={} docs/s/worker, duration={} mins, steps={}",
             initialWriteRatePerWorker,
             maxWriteRatePerWorker,
             writeRateRampUpMinutes,
             writeRateRampUpSteps);
       } else {
         rateLimiter = null;
-        LOG.info("Write rate limiting is disabled for WriteBatchesFn (initialWriteRatePerWorker <= 0)");
+        LOG.info(
+            "Write rate limiting is disabled for WriteBatchesFn (initialWriteRatePerWorker <= 0)");
       }
       LOG.info(
           "Initialized MongoDB WriteBatchesFn worker thread for database '{}' (maxWriteRetries={})",
@@ -1453,11 +1457,12 @@ public class MongoDbTransforms {
                 Collections.singletonList(item), "Received DELETE event with null ID");
           }
         } else if (item.getOperationType() != null
-            && (item.getOperationType() == DocumentWithMetadata.OperationType.DROP
-                || item.getOperationType() == DocumentWithMetadata.OperationType.RENAME)) {
+            && (item.getOperationType() == OperationType.DROP
+                || item.getOperationType() == OperationType.RENAME)) {
           writeDropsSkipped.inc();
           LOG.info(
-              "Received collection-level event '{}' for collection '{}'; skipping document-level write.",
+              "Received collection-level event '{}' for collection '{}';"
+                  + " skipping document-level write.",
               item.getOperationType(),
               targetCol);
         } else {
@@ -1508,7 +1513,8 @@ public class MongoDbTransforms {
         }
 
         LOG.debug(
-            "Flushing coalesced batch of {} documents (from {} input items) across {} target collection(s) to MongoDB",
+            "Flushing coalesced batch of {} documents (from {} input items) across {}"
+                + " target collection(s) to MongoDB",
             totalCoalescedCount,
             items.size(),
             coalescedByCollection.size());
@@ -1558,7 +1564,7 @@ public class MongoDbTransforms {
           break;
         } catch (MongoBulkWriteException e) {
           List<BulkWriteError> writeErrors = e.getWriteErrors();
-          com.mongodb.bulk.WriteConcernError wcError = e.getWriteConcernError();
+          WriteConcernError wcError = e.getWriteConcernError();
 
           if (wcError != null && (writeErrors == null || writeErrors.isEmpty())) {
             LOG.warn(
@@ -1728,13 +1734,13 @@ public class MongoDbTransforms {
             isPerm
                 ? Math.max(nextRetryCount, dlqMaxRetries != null ? dlqMaxRetries + 1 : 1)
                 : nextRetryCount;
-        DocumentWithMetadata.ErrorType errorType = isPerm ? PERMANENT : RETRYABLE;
+        ErrorType errorType = isPerm ? PERMANENT : RETRYABLE;
 
         failures.add(
             item.withFailure(
                 message,
                 errorType,
-                DocumentWithMetadata.FailureStage.WRITE,
+                FailureStage.WRITE,
                 retryCount));
       }
     }
@@ -1785,8 +1791,8 @@ public class MongoDbTransforms {
       long permFail = permanentFailuresCount != null ? permanentFailuresCount.get() : 0;
       if (succ > 0 || memRetries > 0 || dlqRet > 0 || permFail > 0) {
         LOG.info(
-            "Finished WriteBatchesFn bundle: {} successful writes, {} in-memory retries, {} DLQ retries, {}"
-                + " permanent failures",
+            "Finished WriteBatchesFn bundle: {} successful writes, {} in-memory retries,"
+                + " {} DLQ retries, {} permanent failures",
             succ,
             memRetries,
             dlqRet,
@@ -1805,7 +1811,7 @@ public class MongoDbTransforms {
     private final String functionName;
     private final Integer reloadIntervalMinutes;
     private final TupleTag<DocumentWithMetadata> failureTag;
-    private transient JavascriptTextTransformer.JavascriptRuntime javascriptRuntime;
+    private transient JavascriptRuntime javascriptRuntime;
     private final Counter udfProcessingFailures =
         Metrics.counter(ApplyUdfFn.class, "udfProcessingFailures");
 
@@ -1824,7 +1830,7 @@ public class MongoDbTransforms {
     public void setup() {
       if (fileSystemPath != null && functionName != null) {
         javascriptRuntime =
-            JavascriptTextTransformer.JavascriptRuntime.newBuilder()
+            JavascriptRuntime.newBuilder()
                 .setFileSystemPath(fileSystemPath)
                 .setFunctionName(functionName)
                 .setReloadIntervalMinutes(reloadIntervalMinutes)
@@ -1860,8 +1866,8 @@ public class MongoDbTransforms {
                 failureTag,
                 item.withFailure(
                     "UDF returned null",
-                    DocumentWithMetadata.ErrorType.RETRYABLE,
-                    DocumentWithMetadata.FailureStage.UDF));
+                    RETRYABLE,
+                    FailureStage.UDF));
           }
         } catch (Throwable e) {
           LOG.error("Failed to apply UDF: {}", e.getMessage());
@@ -1870,8 +1876,8 @@ public class MongoDbTransforms {
               failureTag,
               item.withFailure(
                   "UDF failed: " + e.getMessage(),
-                  DocumentWithMetadata.ErrorType.RETRYABLE,
-                  DocumentWithMetadata.FailureStage.UDF));
+                  RETRYABLE,
+                  FailureStage.UDF));
         }
       } else {
         c.output(item);

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbTransforms.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbTransforms.java
@@ -25,11 +25,13 @@ import com.mongodb.ErrorCategory;
 import com.mongodb.MongoBulkWriteException;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoException;
+import com.mongodb.ReadPreference;
 import com.mongodb.bulk.BulkWriteError;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.BulkWriteOptions;
+import com.mongodb.client.model.DeleteOneModel;
 import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.WriteModel;
@@ -46,19 +48,25 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Filter;
+import org.apache.beam.sdk.transforms.GroupIntoBatches;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.util.BackOff;
 import org.apache.beam.sdk.util.BackOffUtils;
 import org.apache.beam.sdk.util.FluentBackoff;
 import org.apache.beam.sdk.util.Sleeper;
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.PDone;
@@ -74,6 +82,16 @@ import org.slf4j.LoggerFactory;
 /** Transforms for the MongoDB to MongoDB template. */
 public class MongoDbTransforms {
 
+  private static final ConcurrentHashMap<String, MongoClient> CLIENT_CACHE =
+      new ConcurrentHashMap<>();
+
+  /**
+   * Returns a cached JVM-wide MongoClient for the given URI, or creates a new one if absent.
+   */
+  public static MongoClient getOrCreateMongoClient(String uri) {
+    return CLIENT_CACHE.computeIfAbsent(uri, MongoDbTransforms::createMongoClient);
+  }
+
   /**
    * Helper method to create a MongoClient with default UuidRepresentation.STANDARD if not
    * explicitly specified in the connection string.
@@ -86,6 +104,13 @@ public class MongoDbTransforms {
         || connectionString.getUuidRepresentation() == UuidRepresentation.UNSPECIFIED) {
       builder.uuidRepresentation(UuidRepresentation.STANDARD);
     }
+    if (connectionString.getReadPreference() == null) {
+      builder.readPreference(ReadPreference.secondaryPreferred());
+    }
+    builder.applyToConnectionPoolSettings(
+        pool -> pool.maxSize(20).minSize(0).maxWaitTime(30, TimeUnit.SECONDS));
+    builder.applyToSocketSettings(
+        socket -> socket.connectTimeout(15, TimeUnit.SECONDS).readTimeout(30, TimeUnit.SECONDS));
     return MongoClients.create(builder.build());
   }
 
@@ -109,6 +134,9 @@ public class MongoDbTransforms {
     private SerializableFunction<String, MongoClient> clientFactory =
         MongoDbTransforms::createMongoClient;
 
+    private Integer numWriteShards = 64;
+    private Integer maxBufferingDurationMs = 200;
+
     public WriteWithDlq withUri(String uri) {
       this.uri = uri;
       return this;
@@ -122,6 +150,20 @@ public class MongoDbTransforms {
     public WriteWithDlq withBatchSize(Integer batchSize) {
       if (batchSize != null) {
         this.batchSize = batchSize;
+      }
+      return this;
+    }
+
+    public WriteWithDlq withNumWriteShards(Integer numWriteShards) {
+      if (numWriteShards != null) {
+        this.numWriteShards = numWriteShards;
+      }
+      return this;
+    }
+
+    public WriteWithDlq withMaxBufferingDurationMs(Integer maxBufferingDurationMs) {
+      if (maxBufferingDurationMs != null) {
+        this.maxBufferingDurationMs = maxBufferingDurationMs;
       }
       return this;
     }
@@ -187,25 +229,59 @@ public class MongoDbTransforms {
       TupleTag<DocumentWithMetadata> successTag = new TupleTag<DocumentWithMetadata>() {};
       TupleTag<DocumentWithMetadata> failureTag = new TupleTag<DocumentWithMetadata>() {};
 
+      int shards = (numWriteShards != null && numWriteShards > 0) ? numWriteShards : 64;
+      int size = (batchSize != null && batchSize > 0) ? batchSize : 1000;
+
+      GroupIntoBatches<String, DocumentWithMetadata> groupTransform =
+          GroupIntoBatches.<String, DocumentWithMetadata>ofSize(size);
+      if (maxBufferingDurationMs != null && maxBufferingDurationMs > 0) {
+        groupTransform =
+            groupTransform.withMaxBufferingDuration(Duration.millis(maxBufferingDurationMs));
+      }
+
       PCollectionTuple writeResults =
-          input.apply(
-              "WriteBatches",
-              ParDo.of(
-                      WriteFn.builder()
-                          .withUri(uri)
-                          .withDatabase(database)
-                          .withBatchSize(batchSize)
-                          .withMaxConcurrentAsyncWrites(maxConcurrentAsyncWrites)
-                          .withMaxWriteRetries(maxWriteRetries)
-                          .withDlqMaxRetries(dlqMaxRetries)
-                          .withInitialWriteRatePerWorker(initialWriteRatePerWorker)
-                          .withWriteRateRampUpMinutes(writeRateRampUpMinutes)
-                          .withWriteRateRampUpSteps(writeRateRampUpSteps)
-                          .withMaxWriteRatePerWorker(maxWriteRatePerWorker)
-                          .withClientFactory(clientFactory)
-                          .withFailureTag(failureTag)
-                          .build())
-                  .withOutputTags(successTag, TupleTagList.of(failureTag)));
+          input
+              .apply(
+                  "KeyByWriteShard",
+                  ParDo.of(
+                      new DoFn<DocumentWithMetadata, KV<String, DocumentWithMetadata>>() {
+                        @ProcessElement
+                        public void processElement(ProcessContext c) {
+                          DocumentWithMetadata item = c.element();
+                          if (item == null) {
+                            return;
+                          }
+                          String col = item.getTargetCollection();
+                          if (col == null) {
+                            col = item.getSourceCollection();
+                          }
+                          String dedupKey = item.getDedupKey();
+                          int shard =
+                              dedupKey != null
+                                  ? Math.floorMod(dedupKey.hashCode(), shards)
+                                  : 0;
+                          c.output(KV.of(col + "#" + shard, item));
+                        }
+                      }))
+              .setCoder(KvCoder.of(StringUtf8Coder.of(), DocumentWithMetadataCoder.of()))
+              .apply("GroupIntoBatches", groupTransform)
+              .apply(
+                  "WriteBatches",
+                  ParDo.of(
+                          WriteBatchesFn.builder()
+                              .withUri(uri)
+                              .withDatabase(database)
+                              .withMaxConcurrentAsyncWrites(maxConcurrentAsyncWrites)
+                              .withMaxWriteRetries(maxWriteRetries)
+                              .withDlqMaxRetries(dlqMaxRetries)
+                              .withInitialWriteRatePerWorker(initialWriteRatePerWorker)
+                              .withWriteRateRampUpMinutes(writeRateRampUpMinutes)
+                              .withWriteRateRampUpSteps(writeRateRampUpSteps)
+                              .withMaxWriteRatePerWorker(maxWriteRatePerWorker)
+                              .withClientFactory(clientFactory)
+                              .withFailureTag(failureTag)
+                              .build())
+                      .withOutputTags(successTag, TupleTagList.of(failureTag)));
 
       return writeResults.get(failureTag);
     }
@@ -216,6 +292,11 @@ public class MongoDbTransforms {
     private final String retryablePath;
     private final String permanentPath;
     private final String tempLocation;
+
+    private final Counter dlqRetryableEmitted =
+        Metrics.counter(WriteToDlq.class, "dlqRetryableEmitted");
+    private final Counter dlqPermanentEmitted =
+        Metrics.counter(WriteToDlq.class, "dlqPermanentEmitted");
 
     public WriteToDlq(String retryablePath, String permanentPath, String tempLocation) {
       this.retryablePath = retryablePath;
@@ -241,39 +322,69 @@ public class MongoDbTransforms {
               "FilterPermanent",
               Filter.by(item -> item.getErrorType() == DocumentWithMetadata.ErrorType.PERMANENT));
 
-      retryable
-          .apply(
+      boolean isUnbounded = input.isBounded() == PCollection.IsBounded.UNBOUNDED;
+
+      PCollection<String> retryableJson =
+          retryable.apply(
               "MapToJson_Retryable",
               ParDo.of(
                   new DoFn<DocumentWithMetadata, String>() {
                     @ProcessElement
                     public void processElement(ProcessContext c) {
+                      dlqRetryableEmitted.inc();
                       DocumentWithMetadata item = c.element();
                       c.output(
                           item.toDlqJson(
                               item.getErrorMessage(), item.getErrorType(), item.getRetryCount()));
                     }
-                  }))
-          .apply(
-              "WriteDlq_Retryable",
-              TextIO.write().to(retryablePath + "/error").withSuffix(".json"));
+                  }));
 
-      permanent
-          .apply(
+      if (isUnbounded) {
+        retryableJson
+            .apply("WindowRetryableDlq", Window.into(FixedWindows.of(Duration.standardMinutes(1))))
+            .apply(
+                "WriteDlq_Retryable",
+                TextIO.write()
+                    .to(retryablePath + "/error")
+                    .withSuffix(".json")
+                    .withWindowedWrites()
+                    .withNumShards(1));
+      } else {
+        retryableJson.apply(
+            "WriteDlq_Retryable",
+            TextIO.write().to(retryablePath + "/error").withSuffix(".json"));
+      }
+
+      PCollection<String> permanentJson =
+          permanent.apply(
               "MapToJson_Permanent",
               ParDo.of(
                   new DoFn<DocumentWithMetadata, String>() {
                     @ProcessElement
                     public void processElement(ProcessContext c) {
+                      dlqPermanentEmitted.inc();
                       DocumentWithMetadata item = c.element();
                       c.output(
                           item.toDlqJson(
                               item.getErrorMessage(), item.getErrorType(), item.getRetryCount()));
                     }
-                  }))
-          .apply(
-              "WriteDlq_Permanent",
-              TextIO.write().to(permanentPath + "/error").withSuffix(".json"));
+                  }));
+
+      if (isUnbounded) {
+        permanentJson
+            .apply("WindowPermanentDlq", Window.into(FixedWindows.of(Duration.standardMinutes(1))))
+            .apply(
+                "WriteDlq_Permanent",
+                TextIO.write()
+                    .to(permanentPath + "/error")
+                    .withSuffix(".json")
+                    .withWindowedWrites()
+                    .withNumShards(1));
+      } else {
+        permanentJson.apply(
+            "WriteDlq_Permanent",
+            TextIO.write().to(permanentPath + "/error").withSuffix(".json"));
+      }
 
       return PDone.in(input.getPipeline());
     }
@@ -314,6 +425,14 @@ public class MongoDbTransforms {
     private final Counter dlqRetries = Metrics.counter(WriteWithDlq.class, "dlqRetries");
     private final Counter permanentFailures =
         Metrics.counter(WriteWithDlq.class, "permanentFailures");
+    private final Counter batchesFlushed =
+        Metrics.counter(WriteWithDlq.class, "batchesFlushed");
+    private final Counter writeInsertsUpserts =
+        Metrics.counter(WriteWithDlq.class, "writeInsertsUpserts");
+    private final Counter writeDeletes =
+        Metrics.counter(WriteWithDlq.class, "writeDeletes");
+    private final Counter writeDropsSkipped =
+        Metrics.counter(WriteWithDlq.class, "writeDropsSkipped");
 
     private transient MongoClient mongoClient;
     private transient ExecutorService executor;
@@ -491,6 +610,9 @@ public class MongoDbTransforms {
     public void setup() {
       executor = Executors.newFixedThreadPool(maxConcurrentAsyncWrites);
       semaphore = new Semaphore(maxConcurrentAsyncWrites);
+      if (clientFactory != null && uri != null) {
+        mongoClient = clientFactory.apply(uri);
+      }
       backoffSpec =
           FluentBackoff.DEFAULT
               .withMaxRetries(maxWriteRetries)
@@ -563,12 +685,19 @@ public class MongoDbTransforms {
       if (executor != null) {
         executor.shutdown();
       }
+      if (mongoClient != null) {
+        try {
+          mongoClient.close();
+        } catch (Exception ignored) {
+        }
+      }
     }
 
     @StartBundle
     public void startBundle() {
-      mongoClient = clientFactory.apply(uri);
-
+      if (mongoClient == null) {
+        mongoClient = clientFactory.apply(uri);
+      }
       futures = new ConcurrentLinkedQueue<>();
       failures = new ConcurrentLinkedQueue<>();
       successfulCount = new AtomicLong(0);
@@ -605,20 +734,61 @@ public class MongoDbTransforms {
 
       for (DocumentWithMetadata item : items) {
         String targetCol = item.getTargetCollection();
+        if (targetCol == null) {
+          targetCol = item.getSourceCollection();
+        }
 
-        Document doc = item.getDocument();
-        Object id = doc.get("_id");
-        if (id != null) {
-          updatesByCollection
-              .computeIfAbsent(targetCol, k -> new ArrayList<>())
-              .add(
-                  new ReplaceOneModel<>(
-                      new Document("_id", id), doc, new ReplaceOptions().upsert(true)));
-          itemsByCollection.computeIfAbsent(targetCol, k -> new ArrayList<>()).add(item);
+        if (item.getOperationType() != null && item.getOperationType().isDelete()) {
+          Object id = item.getId();
+          if (id != null) {
+            updatesByCollection
+                .computeIfAbsent(targetCol, k -> new ArrayList<>())
+                .add(new DeleteOneModel<>(new Document("_id", id)));
+            itemsByCollection.computeIfAbsent(targetCol, k -> new ArrayList<>()).add(item);
+            writeDeletes.inc();
+          } else {
+            LOG.warn("Received DELETE event with null ID; routing to DLQ.");
+            writePermanentDlqMessage(
+                Collections.singletonList(item), "Received DELETE event with null ID");
+          }
+        } else if (item.getOperationType() != null
+            && (item.getOperationType() == DocumentWithMetadata.OperationType.DROP
+                || item.getOperationType() == DocumentWithMetadata.OperationType.RENAME)) {
+          writeDropsSkipped.inc();
+          LOG.info(
+              "Received collection-level event '{}' for collection '{}'; skipping document-level write.",
+              item.getOperationType(),
+              targetCol);
+        } else {
+          Document doc = item.getDocument();
+          if (doc != null) {
+            Object id = doc.get("_id");
+            if (id != null) {
+              updatesByCollection
+                  .computeIfAbsent(targetCol, k -> new ArrayList<>())
+                  .add(
+                      new ReplaceOneModel<>(
+                          new Document("_id", id), doc, new ReplaceOptions().upsert(true)));
+              itemsByCollection.computeIfAbsent(targetCol, k -> new ArrayList<>()).add(item);
+              writeInsertsUpserts.inc();
+            } else {
+              LOG.warn("Received document without '_id' field; routing to DLQ.");
+              writePermanentDlqMessage(
+                  Collections.singletonList(item), "Received document without '_id' field");
+            }
+          } else {
+            LOG.warn(
+                "Received upsert event with null document payload for key '{}'; routing to DLQ.",
+                item.getDedupKey());
+            writePermanentDlqMessage(
+                Collections.singletonList(item),
+                "Received upsert event with null document payload");
+          }
         }
       }
 
       if (!updatesByCollection.isEmpty()) {
+        batchesFlushed.inc();
         updateRateLimiterIfNeeded();
         if (rateLimiter != null && !items.isEmpty()) {
           rateLimiter.acquire(items.size());
@@ -673,13 +843,37 @@ public class MongoDbTransforms {
           break;
         } catch (MongoBulkWriteException e) {
           List<BulkWriteError> writeErrors = e.getWriteErrors();
+          com.mongodb.bulk.WriteConcernError wcError = e.getWriteConcernError();
+
+          if (wcError != null && (writeErrors == null || writeErrors.isEmpty())) {
+            LOG.warn(
+                "Write concern failure on collection '{}' (code={}, message={}). Retrying all {}"
+                    + " documents after backoff",
+                colName,
+                wcError.getCode(),
+                wcError.getMessage(),
+                currentItemList.size());
+            incDynamicCounter(
+                "inMemoryRetries",
+                "MongoBulkWriteException_WriteConcern",
+                wcError.getCode(),
+                currentItemList.size());
+            if (inMemoryRetriesCount != null) {
+              inMemoryRetriesCount.addAndGet(currentItemList.size());
+            }
+            if (handleBackoff(sleeper, backoff, currentItemList)) {
+              break;
+            }
+            continue;
+          }
+
           successfulCount.addAndGet(currentItemList.size() - writeErrors.size());
           LOG.warn(
               "Transient MongoBulkWriteException on collection '{}' (errors={}). Retrying {}"
                   + " documents after backoff",
               colName,
               writeErrors.size(),
-              currentItemList.size() - writeErrors.size());
+              writeErrors.size());
 
           List<WriteModel<Document>> nextUpdates = new ArrayList<>();
           List<DocumentWithMetadata> nextItemList = new ArrayList<>();
@@ -812,19 +1006,21 @@ public class MongoDbTransforms {
             sampleId);
       }
       for (DocumentWithMetadata item : itemList) {
-        int retryCount = isPermanent ? dlqMaxRetries + 1 : item.getRetryCount() + 1;
-        DocumentWithMetadata.ErrorType errorType = isPermanent ? PERMANENT : RETRYABLE;
+        int nextRetryCount = (item.getRetryCount() != null ? item.getRetryCount() : 0) + 1;
+        boolean isPerm =
+            isPermanent || (dlqMaxRetries != null && nextRetryCount > dlqMaxRetries);
+        int retryCount =
+            isPerm
+                ? Math.max(nextRetryCount, dlqMaxRetries != null ? dlqMaxRetries + 1 : 1)
+                : nextRetryCount;
+        DocumentWithMetadata.ErrorType errorType = isPerm ? PERMANENT : RETRYABLE;
 
         failures.add(
-            DocumentWithMetadata.of(
-                item.getDocument(),
-                item.getOriginalDocument(),
-                retryCount,
+            item.withFailure(
                 message,
                 errorType,
-                item.getSourceCollection(),
-                item.getTargetCollection(),
-                DocumentWithMetadata.FailureStage.WRITE));
+                DocumentWithMetadata.FailureStage.WRITE,
+                retryCount));
       }
     }
 
@@ -853,10 +1049,6 @@ public class MongoDbTransforms {
       }
 
       CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
-
-      if (mongoClient != null) {
-        mongoClient.close();
-      }
 
       successfulWrites.inc(successfulCount.get());
       if (inMemoryRetriesCount != null) {
@@ -888,6 +1080,690 @@ public class MongoDbTransforms {
       if (succ > 0 || memRetries > 0 || dlqRet > 0 || permFail > 0) {
         LOG.info(
             "Finished write bundle: {} successful writes, {} in-memory retries, {} DLQ retries, {}"
+                + " permanent failures",
+            succ,
+            memRetries,
+            dlqRet,
+            permFail);
+      }
+    }
+  }
+
+  /** A {@link DoFn} that writes grouped batches of documents to MongoDB in bulk. */
+  public static class WriteBatchesFn
+      extends DoFn<KV<String, Iterable<DocumentWithMetadata>>, DocumentWithMetadata> {
+
+    private static final int ERR_DOCUMENT_VALIDATION_FAILURE = 121;
+    private static final int ERR_KEY_TOO_LONG = 17280;
+    private static final int ERR_BAD_VALUE = 2;
+    private static final long DLQ_LOG_INTERVAL_MS = 30_000L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(WriteBatchesFn.class);
+
+    private final String uri;
+    private final String database;
+    private final Integer maxConcurrentAsyncWrites;
+    private final Integer maxWriteRetries;
+    private final Integer dlqMaxRetries;
+    private final Integer initialWriteRatePerWorker;
+    private final Integer writeRateRampUpMinutes;
+    private final Integer writeRateRampUpSteps;
+    private final Integer maxWriteRatePerWorker;
+    private final SerializableFunction<String, MongoClient> clientFactory;
+    private final TupleTag<DocumentWithMetadata> failureTag;
+    private transient FluentBackoff backoffSpec;
+    private transient RateLimiter rateLimiter;
+    private transient long startTimeMs;
+    private transient long lastComputedStep;
+
+    private final Counter successfulWrites =
+        Metrics.counter(WriteWithDlq.class, "successfulWrites");
+    private final Counter inMemoryRetries = Metrics.counter(WriteWithDlq.class, "inMemoryRetries");
+    private final Counter severeFailedWrites =
+        Metrics.counter(WriteWithDlq.class, "severeFailedWrites");
+    private final Counter dlqRetries = Metrics.counter(WriteWithDlq.class, "dlqRetries");
+    private final Counter permanentFailures =
+        Metrics.counter(WriteWithDlq.class, "permanentFailures");
+    private final Counter batchesFlushed =
+        Metrics.counter(WriteWithDlq.class, "batchesFlushed");
+    private final Counter writeInsertsUpserts =
+        Metrics.counter(WriteWithDlq.class, "writeInsertsUpserts");
+    private final Counter writeDeletes =
+        Metrics.counter(WriteWithDlq.class, "writeDeletes");
+    private final Counter writeDropsSkipped =
+        Metrics.counter(WriteWithDlq.class, "writeDropsSkipped");
+
+    private transient MongoClient mongoClient;
+    private transient ExecutorService executor;
+    private transient Semaphore semaphore;
+    private transient ConcurrentLinkedQueue<CompletableFuture<Void>> futures;
+    private transient ConcurrentLinkedQueue<DocumentWithMetadata> failures;
+    private transient AtomicLong successfulCount;
+    private transient ConcurrentHashMap<String, AtomicLong> dynamicCounters;
+    private transient AtomicLong inMemoryRetriesCount;
+    private transient AtomicLong severeFailedWritesCount;
+    private transient AtomicLong dlqRetriesCount;
+    private transient AtomicLong permanentFailuresCount;
+    private transient long lastDlqLogTimeMs;
+
+    private void incDynamicCounter(String prefix, String exceptionName, int code, long count) {
+      String counterName = prefix + "_" + exceptionName + "_" + code;
+      if (dynamicCounters != null) {
+        dynamicCounters.computeIfAbsent(counterName, k -> new AtomicLong(0)).addAndGet(count);
+      }
+    }
+
+    public WriteBatchesFn(
+        String uri,
+        String database,
+        Integer maxConcurrentAsyncWrites,
+        Integer maxWriteRetries,
+        Integer dlqMaxRetries,
+        Integer initialWriteRatePerWorker,
+        Integer writeRateRampUpMinutes,
+        Integer writeRateRampUpSteps,
+        Integer maxWriteRatePerWorker,
+        SerializableFunction<String, MongoClient> clientFactory,
+        TupleTag<DocumentWithMetadata> failureTag) {
+      this.uri = uri;
+      this.database = database;
+      this.maxConcurrentAsyncWrites = maxConcurrentAsyncWrites;
+      this.maxWriteRetries = maxWriteRetries;
+      this.dlqMaxRetries = dlqMaxRetries;
+      this.initialWriteRatePerWorker = initialWriteRatePerWorker;
+      this.writeRateRampUpMinutes = writeRateRampUpMinutes;
+      this.writeRateRampUpSteps = writeRateRampUpSteps;
+      this.maxWriteRatePerWorker = maxWriteRatePerWorker;
+      this.clientFactory = clientFactory;
+      this.failureTag = failureTag;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private String uri;
+      private String database;
+      private Integer maxConcurrentAsyncWrites = 10;
+      private Integer maxWriteRetries = 3;
+      private Integer dlqMaxRetries = 3;
+      private Integer initialWriteRatePerWorker = 5000;
+      private Integer writeRateRampUpMinutes = 5;
+      private Integer writeRateRampUpSteps = 5;
+      private Integer maxWriteRatePerWorker = 25000;
+      private SerializableFunction<String, MongoClient> clientFactory;
+      private TupleTag<DocumentWithMetadata> failureTag;
+
+      public Builder withUri(String uri) {
+        this.uri = uri;
+        return this;
+      }
+
+      public Builder withDatabase(String database) {
+        this.database = database;
+        return this;
+      }
+
+      public Builder withMaxConcurrentAsyncWrites(Integer maxConcurrentAsyncWrites) {
+        if (maxConcurrentAsyncWrites != null) {
+          this.maxConcurrentAsyncWrites = maxConcurrentAsyncWrites;
+        }
+        return this;
+      }
+
+      public Builder withMaxWriteRetries(Integer maxWriteRetries) {
+        if (maxWriteRetries != null) {
+          this.maxWriteRetries = maxWriteRetries;
+        }
+        return this;
+      }
+
+      public Builder withDlqMaxRetries(Integer dlqMaxRetries) {
+        if (dlqMaxRetries != null) {
+          this.dlqMaxRetries = dlqMaxRetries;
+        }
+        return this;
+      }
+
+      public Builder withInitialWriteRatePerWorker(Integer initialWriteRatePerWorker) {
+        if (initialWriteRatePerWorker != null) {
+          this.initialWriteRatePerWorker = initialWriteRatePerWorker;
+        }
+        return this;
+      }
+
+      public Builder withWriteRateRampUpMinutes(Integer writeRateRampUpMinutes) {
+        if (writeRateRampUpMinutes != null) {
+          this.writeRateRampUpMinutes = writeRateRampUpMinutes;
+        }
+        return this;
+      }
+
+      public Builder withWriteRateRampUpSteps(Integer writeRateRampUpSteps) {
+        if (writeRateRampUpSteps != null) {
+          this.writeRateRampUpSteps = writeRateRampUpSteps;
+        }
+        return this;
+      }
+
+      public Builder withMaxWriteRatePerWorker(Integer maxWriteRatePerWorker) {
+        if (maxWriteRatePerWorker != null) {
+          this.maxWriteRatePerWorker = maxWriteRatePerWorker;
+        }
+        return this;
+      }
+
+      public Builder withClientFactory(SerializableFunction<String, MongoClient> clientFactory) {
+        this.clientFactory = clientFactory;
+        return this;
+      }
+
+      public Builder withFailureTag(TupleTag<DocumentWithMetadata> failureTag) {
+        this.failureTag = failureTag;
+        return this;
+      }
+
+      public WriteBatchesFn build() {
+        return new WriteBatchesFn(
+            uri,
+            database,
+            maxConcurrentAsyncWrites,
+            maxWriteRetries,
+            dlqMaxRetries,
+            initialWriteRatePerWorker,
+            writeRateRampUpMinutes,
+            writeRateRampUpSteps,
+            maxWriteRatePerWorker,
+            clientFactory,
+            failureTag);
+      }
+    }
+
+    @VisibleForTesting
+    RateLimiter getRateLimiter() {
+      return rateLimiter;
+    }
+
+    @VisibleForTesting
+    void setStartTimeMs(long startTimeMs) {
+      this.startTimeMs = startTimeMs;
+    }
+
+    @VisibleForTesting
+    void updateRateLimiterForTest() {
+      updateRateLimiterIfNeeded();
+    }
+
+    @Setup
+    public void setup() {
+      executor = Executors.newFixedThreadPool(maxConcurrentAsyncWrites);
+      semaphore = new Semaphore(maxConcurrentAsyncWrites);
+      if (clientFactory != null && uri != null) {
+        mongoClient = clientFactory.apply(uri);
+      }
+      backoffSpec =
+          FluentBackoff.DEFAULT
+              .withMaxRetries(maxWriteRetries)
+              .withInitialBackoff(Duration.standardSeconds(2))
+              .withExponent(2.0);
+      if (initialWriteRatePerWorker != null && initialWriteRatePerWorker > 0) {
+        rateLimiter = RateLimiter.create(initialWriteRatePerWorker);
+        startTimeMs = System.currentTimeMillis();
+        lastComputedStep = 0;
+        LOG.info(
+            "Enabled linear write rate ramp-up for WriteBatchesFn: initialRate={} docs/s/worker, targetMax={}"
+                + " docs/s/worker, duration={} mins, steps={}",
+            initialWriteRatePerWorker,
+            maxWriteRatePerWorker,
+            writeRateRampUpMinutes,
+            writeRateRampUpSteps);
+      } else {
+        rateLimiter = null;
+        LOG.info("Write rate limiting is disabled for WriteBatchesFn (initialWriteRatePerWorker <= 0)");
+      }
+      LOG.info(
+          "Initialized MongoDB WriteBatchesFn worker thread for database '{}' (maxConcurrentAsyncWrites={}, maxWriteRetries={})",
+          database,
+          maxConcurrentAsyncWrites,
+          maxWriteRetries);
+    }
+
+    private void updateRateLimiterIfNeeded() {
+      if (rateLimiter == null
+          || writeRateRampUpMinutes == null
+          || writeRateRampUpMinutes <= 0
+          || writeRateRampUpSteps == null
+          || writeRateRampUpSteps <= 0
+          || maxWriteRatePerWorker == null
+          || maxWriteRatePerWorker <= initialWriteRatePerWorker) {
+        return;
+      }
+      long stepDurationMs = (writeRateRampUpMinutes * 60L * 1000L) / writeRateRampUpSteps;
+      if (stepDurationMs <= 0) {
+        stepDurationMs = 1;
+      }
+      long elapsedMs = System.currentTimeMillis() - startTimeMs;
+      long currentStep = Math.min(writeRateRampUpSteps, elapsedMs / stepDurationMs);
+
+      if (currentStep > lastComputedStep) {
+        lastComputedStep = currentStep;
+        double rateRange = maxWriteRatePerWorker - initialWriteRatePerWorker;
+        double newRate =
+            initialWriteRatePerWorker + (rateRange * currentStep) / (double) writeRateRampUpSteps;
+
+        double oldRate = rateLimiter.getRate();
+        if (newRate != oldRate) {
+          rateLimiter.setRate(newRate);
+          LOG.info(
+              "Linear write rate ramp-up: increased write rate from {} to {} docs/s/worker"
+                  + " (step {}/{}, elapsedMinutes={})",
+              String.format("%.1f", oldRate),
+              String.format("%.1f", newRate),
+              currentStep,
+              writeRateRampUpSteps,
+              TimeUnit.MILLISECONDS.toMinutes(elapsedMs));
+        }
+      }
+    }
+
+    @Teardown
+    public void teardown() {
+      if (executor != null) {
+        executor.shutdown();
+      }
+      if (mongoClient != null) {
+        try {
+          mongoClient.close();
+        } catch (Exception ignored) {
+        }
+      }
+    }
+
+    @StartBundle
+    public void startBundle() {
+      if (mongoClient == null) {
+        mongoClient = clientFactory.apply(uri);
+      }
+      futures = new ConcurrentLinkedQueue<>();
+      failures = new ConcurrentLinkedQueue<>();
+      successfulCount = new AtomicLong(0);
+      dynamicCounters = new ConcurrentHashMap<>();
+      inMemoryRetriesCount = new AtomicLong(0);
+      severeFailedWritesCount = new AtomicLong(0);
+      dlqRetriesCount = new AtomicLong(0);
+      permanentFailuresCount = new AtomicLong(0);
+      LOG.debug("Starting new WriteBatchesFn bundle session (URI: {})", UriSanitizer.sanitize(uri));
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext c) throws InterruptedException {
+      KV<String, Iterable<DocumentWithMetadata>> element = c.element();
+      if (element != null && element.getValue() != null) {
+        List<DocumentWithMetadata> items = new ArrayList<>();
+        for (DocumentWithMetadata item : element.getValue()) {
+          if (item != null) {
+            items.add(item);
+          }
+        }
+        if (!items.isEmpty()) {
+          flushBatch(items);
+        }
+      }
+      DocumentWithMetadata failure;
+      while ((failure = failures.poll()) != null) {
+        c.output(failureTag, failure);
+      }
+    }
+
+    private void flushBatch(List<DocumentWithMetadata> items) throws InterruptedException {
+      if (items == null || items.isEmpty()) {
+        return;
+      }
+
+      Map<String, List<WriteModel<Document>>> updatesByCollection = new HashMap<>();
+      Map<String, List<DocumentWithMetadata>> itemsByCollection = new HashMap<>();
+
+      for (DocumentWithMetadata item : items) {
+        String targetCol = item.getTargetCollection();
+        if (targetCol == null) {
+          targetCol = item.getSourceCollection();
+        }
+
+        if (item.getOperationType() != null && item.getOperationType().isDelete()) {
+          Object id = item.getId();
+          if (id != null) {
+            updatesByCollection
+                .computeIfAbsent(targetCol, k -> new ArrayList<>())
+                .add(new DeleteOneModel<>(new Document("_id", id)));
+            itemsByCollection.computeIfAbsent(targetCol, k -> new ArrayList<>()).add(item);
+            writeDeletes.inc();
+          } else {
+            LOG.warn("Received DELETE event with null ID; routing to DLQ.");
+            writePermanentDlqMessage(
+                Collections.singletonList(item), "Received DELETE event with null ID");
+          }
+        } else if (item.getOperationType() != null
+            && (item.getOperationType() == DocumentWithMetadata.OperationType.DROP
+                || item.getOperationType() == DocumentWithMetadata.OperationType.RENAME)) {
+          writeDropsSkipped.inc();
+          LOG.info(
+              "Received collection-level event '{}' for collection '{}'; skipping document-level write.",
+              item.getOperationType(),
+              targetCol);
+        } else {
+          Document doc = item.getDocument();
+          if (doc != null) {
+            Object id = doc.get("_id");
+            if (id != null) {
+              updatesByCollection
+                  .computeIfAbsent(targetCol, k -> new ArrayList<>())
+                  .add(
+                      new ReplaceOneModel<>(
+                          new Document("_id", id), doc, new ReplaceOptions().upsert(true)));
+              itemsByCollection.computeIfAbsent(targetCol, k -> new ArrayList<>()).add(item);
+              writeInsertsUpserts.inc();
+            } else {
+              LOG.warn("Received document without '_id' field; routing to DLQ.");
+              writePermanentDlqMessage(
+                  Collections.singletonList(item), "Received document without '_id' field");
+            }
+          } else {
+            LOG.warn(
+                "Received upsert event with null document payload for key '{}'; routing to DLQ.",
+                item.getDedupKey());
+            writePermanentDlqMessage(
+                Collections.singletonList(item),
+                "Received upsert event with null document payload");
+          }
+        }
+      }
+
+      if (!updatesByCollection.isEmpty()) {
+        batchesFlushed.inc();
+        updateRateLimiterIfNeeded();
+        if (rateLimiter != null && !items.isEmpty()) {
+          rateLimiter.acquire(items.size());
+        }
+        LOG.debug(
+            "Flushing batch of {} documents across {} target collection(s) to MongoDB (active async write futures in queue: {})",
+            items.size(),
+            updatesByCollection.size(),
+            futures.size());
+        semaphore.acquire();
+        CompletableFuture<Void> future =
+            CompletableFuture.runAsync(
+                () -> {
+                  try {
+                    for (Map.Entry<String, List<WriteModel<Document>>> entry :
+                        updatesByCollection.entrySet()) {
+                      String colName = entry.getKey();
+                      List<WriteModel<Document>> currentUpdates = entry.getValue();
+                      List<DocumentWithMetadata> currentItemList = itemsByCollection.get(colName);
+
+                      MongoCollection<Document> col =
+                          mongoClient.getDatabase(database).getCollection(colName);
+
+                      writeBatchWithRetry(colName, col, currentUpdates, currentItemList);
+                    }
+                  } finally {
+                    semaphore.release();
+                  }
+                },
+                executor);
+        futures.add(future);
+      }
+    }
+
+    private void writeBatchWithRetry(
+        String colName,
+        MongoCollection<Document> col,
+        List<WriteModel<Document>> currentUpdates,
+        List<DocumentWithMetadata> currentItemList) {
+      BackOff backoff = backoffSpec.backoff();
+      Sleeper sleeper = Sleeper.DEFAULT;
+
+      while (true) {
+        try {
+          col.bulkWrite(currentUpdates, new BulkWriteOptions().ordered(false));
+          successfulCount.addAndGet(currentItemList.size());
+          LOG.debug(
+              "Successfully bulk-wrote {} documents to collection '{}'",
+              currentItemList.size(),
+              colName);
+          break;
+        } catch (MongoBulkWriteException e) {
+          List<BulkWriteError> writeErrors = e.getWriteErrors();
+          com.mongodb.bulk.WriteConcernError wcError = e.getWriteConcernError();
+
+          if (wcError != null && (writeErrors == null || writeErrors.isEmpty())) {
+            LOG.warn(
+                "Write concern failure on collection '{}' (code={}, message={}). Retrying all {}"
+                    + " documents after backoff",
+                colName,
+                wcError.getCode(),
+                wcError.getMessage(),
+                currentItemList.size());
+            incDynamicCounter(
+                "inMemoryRetries",
+                "MongoBulkWriteException_WriteConcern",
+                wcError.getCode(),
+                currentItemList.size());
+            if (inMemoryRetriesCount != null) {
+              inMemoryRetriesCount.addAndGet(currentItemList.size());
+            }
+            if (handleBackoff(sleeper, backoff, currentItemList)) {
+              break;
+            }
+            continue;
+          }
+
+          successfulCount.addAndGet(currentItemList.size() - writeErrors.size());
+          LOG.warn(
+              "Transient MongoBulkWriteException on collection '{}' (errors={}). Retrying {}"
+                  + " documents after backoff",
+              colName,
+              writeErrors.size(),
+              writeErrors.size());
+
+          List<WriteModel<Document>> nextUpdates = new ArrayList<>();
+          List<DocumentWithMetadata> nextItemList = new ArrayList<>();
+          generateRetryBatch(
+              writeErrors, currentUpdates, currentItemList, nextUpdates, nextItemList);
+
+          if (nextUpdates.isEmpty()) {
+            break;
+          }
+
+          if (handleBackoff(sleeper, backoff, nextItemList)) {
+            break;
+          }
+
+          currentUpdates = nextUpdates;
+          currentItemList = nextItemList;
+        } catch (Exception e) {
+          int code = 0;
+          if (e instanceof MongoException me) {
+            code = me.getCode();
+          }
+          if (!isRetriable(e)) {
+            incDynamicCounter(
+                "severeFailedWrites", e.getClass().getSimpleName(), code, currentItemList.size());
+            if (severeFailedWritesCount != null) {
+              severeFailedWritesCount.addAndGet(currentItemList.size());
+            }
+            LOG.error(
+                "Permanent write failure on collection '{}' (code={}): {}",
+                colName,
+                code,
+                e.getMessage());
+            writePermanentDlqMessage(
+                currentItemList, "Failed to write documents: " + e.getMessage());
+            break;
+          }
+
+          incDynamicCounter(
+              "inMemoryRetries", e.getClass().getSimpleName(), code, currentItemList.size());
+          if (inMemoryRetriesCount != null) {
+            inMemoryRetriesCount.addAndGet(currentItemList.size());
+          }
+          LOG.warn(
+              "Transient write exception on collection '{}': {}. Retrying {} documents after"
+                  + " backoff",
+              colName,
+              e.getMessage(),
+              currentItemList.size());
+          if (handleBackoff(sleeper, backoff, currentItemList)) {
+            break;
+          }
+        }
+      }
+    }
+
+    private boolean isPermanentErrorCode(int code) {
+      return ErrorCategory.fromErrorCode(code) == ErrorCategory.DUPLICATE_KEY
+          || code == ERR_DOCUMENT_VALIDATION_FAILURE
+          || code == ERR_KEY_TOO_LONG
+          || code == ERR_BAD_VALUE;
+    }
+
+    private boolean isRetriable(Exception e) {
+      if (e instanceof MongoException me) {
+        return !isPermanentErrorCode(me.getCode());
+      }
+      return false;
+    }
+
+    private void generateRetryBatch(
+        List<BulkWriteError> writeErrors,
+        List<WriteModel<Document>> currentUpdates,
+        List<DocumentWithMetadata> currentItemList,
+        List<WriteModel<Document>> nextUpdates,
+        List<DocumentWithMetadata> nextItemList) {
+      for (BulkWriteError error : writeErrors) {
+        int index = error.getIndex();
+        if (index >= 0 && index < currentItemList.size()) {
+          DocumentWithMetadata failedItem = currentItemList.get(index);
+          WriteModel<Document> failedUpdate = currentUpdates.get(index);
+
+          if (isPermanentErrorCode(error.getCode())) {
+            incDynamicCounter("severeFailedWrites", "MongoBulkWriteException", error.getCode(), 1);
+            if (severeFailedWritesCount != null) {
+              severeFailedWritesCount.addAndGet(1);
+            }
+            writePermanentDlqMessage(
+                Collections.singletonList(failedItem),
+                "Permanent failure writing document. Error: " + error.getMessage());
+          } else {
+            incDynamicCounter("inMemoryRetries", "MongoBulkWriteException", error.getCode(), 1);
+            if (inMemoryRetriesCount != null) {
+              inMemoryRetriesCount.addAndGet(1);
+            }
+            nextUpdates.add(failedUpdate);
+            nextItemList.add(failedItem);
+          }
+        }
+      }
+    }
+
+    private void writePermanentDlqMessage(List<DocumentWithMetadata> itemList, String message) {
+      writeToDlq(itemList, message, true);
+    }
+
+    private void writeRetryableDlqMessage(List<DocumentWithMetadata> itemList, String message) {
+      writeToDlq(itemList, message, false);
+    }
+
+    private void writeToDlq(
+        List<DocumentWithMetadata> itemList, String message, boolean isPermanent) {
+      if (isPermanent) {
+        if (permanentFailuresCount != null) {
+          permanentFailuresCount.addAndGet(itemList.size());
+        }
+      } else {
+        if (dlqRetriesCount != null) {
+          dlqRetriesCount.addAndGet(itemList.size());
+        }
+      }
+      long now = System.currentTimeMillis();
+      if (now - lastDlqLogTimeMs >= DLQ_LOG_INTERVAL_MS || lastDlqLogTimeMs == 0L) {
+        lastDlqLogTimeMs = now;
+        String sampleId = !itemList.isEmpty() ? String.valueOf(itemList.get(0).getId()) : "N/A";
+        LOG.warn(
+            "DLQ Error Summary (logged at most once every 30s per worker thread): {} document(s)"
+                + " sent to DLQ in this batch. Reason: {} [Sample Doc ID: {}]",
+            itemList.size(),
+            message,
+            sampleId);
+      }
+      for (DocumentWithMetadata item : itemList) {
+        int nextRetryCount = (item.getRetryCount() != null ? item.getRetryCount() : 0) + 1;
+        boolean isPerm =
+            isPermanent || (dlqMaxRetries != null && nextRetryCount > dlqMaxRetries);
+        int retryCount =
+            isPerm
+                ? Math.max(nextRetryCount, dlqMaxRetries != null ? dlqMaxRetries + 1 : 1)
+                : nextRetryCount;
+        DocumentWithMetadata.ErrorType errorType = isPerm ? PERMANENT : RETRYABLE;
+
+        failures.add(
+            item.withFailure(
+                message,
+                errorType,
+                DocumentWithMetadata.FailureStage.WRITE,
+                retryCount));
+      }
+    }
+
+    private boolean handleBackoff(
+        Sleeper sleeper, BackOff backoff, List<DocumentWithMetadata> itemList) {
+      try {
+        if (!BackOffUtils.next(sleeper, backoff)) {
+          writeRetryableDlqMessage(itemList, "Backoff exhausted. Failed to write documents");
+          return true;
+        }
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+        writeRetryableDlqMessage(itemList, "Interrupted while writing documents");
+        return true;
+      }
+      return false;
+    }
+
+    @FinishBundle
+    public void finishBundle(FinishBundleContext c) {
+      CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+      successfulWrites.inc(successfulCount.get());
+      if (inMemoryRetriesCount != null) {
+        inMemoryRetries.inc(inMemoryRetriesCount.get());
+      }
+      if (severeFailedWritesCount != null) {
+        severeFailedWrites.inc(severeFailedWritesCount.get());
+      }
+      if (dlqRetriesCount != null) {
+        dlqRetries.inc(dlqRetriesCount.get());
+      }
+      if (permanentFailuresCount != null) {
+        permanentFailures.inc(permanentFailuresCount.get());
+      }
+      if (dynamicCounters != null) {
+        dynamicCounters.forEach(
+            (name, count) -> Metrics.counter(WriteWithDlq.class, name).inc(count.get()));
+      }
+
+      DocumentWithMetadata failure;
+      while ((failure = failures.poll()) != null) {
+        c.output(failureTag, failure, Instant.now(), GlobalWindow.INSTANCE);
+      }
+
+      long succ = successfulCount.get();
+      long memRetries = inMemoryRetriesCount != null ? inMemoryRetriesCount.get() : 0;
+      long dlqRet = dlqRetriesCount != null ? dlqRetriesCount.get() : 0;
+      long permFail = permanentFailuresCount != null ? permanentFailuresCount.get() : 0;
+      if (succ > 0 || memRetries > 0 || dlqRet > 0 || permFail > 0) {
+        LOG.info(
+            "Finished WriteBatchesFn bundle: {} successful writes, {} in-memory retries, {} DLQ retries, {}"
                 + " permanent failures",
             succ,
             memRetries,
@@ -935,33 +1811,24 @@ public class MongoDbTransforms {
     @ProcessElement
     public void processElement(ProcessContext c) {
       DocumentWithMetadata item = c.element();
+      if (item.getOperationType() != null && !item.getOperationType().isUpsert()) {
+        c.output(item);
+        return;
+      }
       if (javascriptRuntime != null) {
         try {
           String transformed = javascriptRuntime.invoke(item.getOriginalDocument());
           if (transformed != null) {
             Document doc = Document.parse(transformed);
-            c.output(
-                DocumentWithMetadata.of(
-                    doc,
-                    item.getOriginalDocument(),
-                    item.getRetryCount(),
-                    item.getErrorMessage(),
-                    item.getErrorType(),
-                    item.getSourceCollection(),
-                    item.getTargetCollection()));
+            c.output(item.withDocument(doc));
           } else {
             LOG.warn("UDF returned null for document ID: {}", item.getId());
             udfProcessingFailures.inc();
             c.output(
                 failureTag,
-                DocumentWithMetadata.of(
-                    item.getDocument(),
-                    item.getOriginalDocument(),
-                    item.getRetryCount(),
+                item.withFailure(
                     "UDF returned null",
                     DocumentWithMetadata.ErrorType.RETRYABLE,
-                    item.getSourceCollection(),
-                    item.getTargetCollection(),
                     DocumentWithMetadata.FailureStage.UDF));
           }
         } catch (Throwable e) {
@@ -969,14 +1836,9 @@ public class MongoDbTransforms {
           udfProcessingFailures.inc();
           c.output(
               failureTag,
-              DocumentWithMetadata.of(
-                  item.getDocument(),
-                  item.getOriginalDocument(),
-                  item.getRetryCount(),
+              item.withFailure(
                   "UDF failed: " + e.getMessage(),
                   DocumentWithMetadata.ErrorType.RETRYABLE,
-                  item.getSourceCollection(),
-                  item.getTargetCollection(),
                   DocumentWithMetadata.FailureStage.UDF));
         }
       } else {

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbTransforms.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbTransforms.java
@@ -93,9 +93,7 @@ public class MongoDbTransforms {
   private static final ConcurrentHashMap<String, MongoClient> CLIENT_CACHE =
       new ConcurrentHashMap<>();
 
-  /**
-   * Returns a cached JVM-wide MongoClient for the given URI, or creates a new one if absent.
-   */
+  /** Returns a cached JVM-wide MongoClient for the given URI, or creates a new one if absent. */
   public static MongoClient getOrCreateMongoClient(String uri) {
     return CLIENT_CACHE.computeIfAbsent(uri, MongoDbTransforms::createMongoClient);
   }
@@ -265,9 +263,7 @@ public class MongoDbTransforms {
                           }
                           String dedupKey = item.getDedupKey();
                           int shard =
-                              dedupKey != null
-                                  ? Math.floorMod(dedupKey.hashCode(), shards)
-                                  : 0;
+                              dedupKey != null ? Math.floorMod(dedupKey.hashCode(), shards) : 0;
                           c.output(KV.of(col + "#" + shard, item));
                         }
                       }))
@@ -299,6 +295,7 @@ public class MongoDbTransforms {
     private static final Logger LOG = LoggerFactory.getLogger(WriteToDlq.class);
     private final String retryablePath;
     private final String permanentPath;
+
     @SuppressWarnings("unused")
     private final String tempLocation;
 
@@ -356,8 +353,7 @@ public class MongoDbTransforms {
                     .withNumShards(1));
       } else {
         retryableJson.apply(
-            "WriteDlq_Retryable",
-            TextIO.write().to(retryablePath + "/error").withSuffix(".json"));
+            "WriteDlq_Retryable", TextIO.write().to(retryablePath + "/error").withSuffix(".json"));
       }
 
       PCollection<String> permanentJson =
@@ -387,8 +383,7 @@ public class MongoDbTransforms {
                     .withNumShards(1));
       } else {
         permanentJson.apply(
-            "WriteDlq_Permanent",
-            TextIO.write().to(permanentPath + "/error").withSuffix(".json"));
+            "WriteDlq_Permanent", TextIO.write().to(permanentPath + "/error").withSuffix(".json"));
       }
 
       return PDone.in(input.getPipeline());
@@ -430,12 +425,10 @@ public class MongoDbTransforms {
     private final Counter dlqRetries = Metrics.counter(WriteWithDlq.class, "dlqRetries");
     private final Counter permanentFailures =
         Metrics.counter(WriteWithDlq.class, "permanentFailures");
-    private final Counter batchesFlushed =
-        Metrics.counter(WriteWithDlq.class, "batchesFlushed");
+    private final Counter batchesFlushed = Metrics.counter(WriteWithDlq.class, "batchesFlushed");
     private final Counter writeInsertsUpserts =
         Metrics.counter(WriteWithDlq.class, "writeInsertsUpserts");
-    private final Counter writeDeletes =
-        Metrics.counter(WriteWithDlq.class, "writeDeletes");
+    private final Counter writeDeletes = Metrics.counter(WriteWithDlq.class, "writeDeletes");
     private final Counter writeDropsSkipped =
         Metrics.counter(WriteWithDlq.class, "writeDropsSkipped");
 
@@ -1013,20 +1006,14 @@ public class MongoDbTransforms {
       }
       for (DocumentWithMetadata item : itemList) {
         int nextRetryCount = (item.getRetryCount() != null ? item.getRetryCount() : 0) + 1;
-        boolean isPerm =
-            isPermanent || (dlqMaxRetries != null && nextRetryCount > dlqMaxRetries);
+        boolean isPerm = isPermanent || (dlqMaxRetries != null && nextRetryCount > dlqMaxRetries);
         int retryCount =
             isPerm
                 ? Math.max(nextRetryCount, dlqMaxRetries != null ? dlqMaxRetries + 1 : 1)
                 : nextRetryCount;
         ErrorType errorType = isPerm ? PERMANENT : RETRYABLE;
 
-        failures.add(
-            item.withFailure(
-                message,
-                errorType,
-                FailureStage.WRITE,
-                retryCount));
+        failures.add(item.withFailure(message, errorType, FailureStage.WRITE, retryCount));
       }
     }
 
@@ -1129,12 +1116,10 @@ public class MongoDbTransforms {
     private final Counter dlqRetries = Metrics.counter(WriteWithDlq.class, "dlqRetries");
     private final Counter permanentFailures =
         Metrics.counter(WriteWithDlq.class, "permanentFailures");
-    private final Counter batchesFlushed =
-        Metrics.counter(WriteWithDlq.class, "batchesFlushed");
+    private final Counter batchesFlushed = Metrics.counter(WriteWithDlq.class, "batchesFlushed");
     private final Counter writeInsertsUpserts =
         Metrics.counter(WriteWithDlq.class, "writeInsertsUpserts");
-    private final Counter writeDeletes =
-        Metrics.counter(WriteWithDlq.class, "writeDeletes");
+    private final Counter writeDeletes = Metrics.counter(WriteWithDlq.class, "writeDeletes");
     private final Counter writeDropsSkipped =
         Metrics.counter(WriteWithDlq.class, "writeDropsSkipped");
     private final Counter writeBatchesCoalesced =
@@ -1445,9 +1430,7 @@ public class MongoDbTransforms {
                 coalescedByCollection.computeIfAbsent(targetCol, k -> new LinkedHashMap<>());
             CoalescedOp prev =
                 colMap.put(
-                    id,
-                    new CoalescedOp(
-                        new DeleteOneModel<>(new Document("_id", id)), item, true));
+                    id, new CoalescedOp(new DeleteOneModel<>(new Document("_id", id)), item, true));
             if (prev != null) {
               writeBatchesCoalesced.inc();
             }
@@ -1537,8 +1520,7 @@ public class MongoDbTransforms {
             }
           }
 
-          MongoCollection<Document> col =
-              mongoClient.getDatabase(database).getCollection(colName);
+          MongoCollection<Document> col = mongoClient.getDatabase(database).getCollection(colName);
 
           writeBatchWithRetry(colName, col, currentUpdates, currentItemList);
         }
@@ -1728,20 +1710,14 @@ public class MongoDbTransforms {
       }
       for (DocumentWithMetadata item : itemList) {
         int nextRetryCount = (item.getRetryCount() != null ? item.getRetryCount() : 0) + 1;
-        boolean isPerm =
-            isPermanent || (dlqMaxRetries != null && nextRetryCount > dlqMaxRetries);
+        boolean isPerm = isPermanent || (dlqMaxRetries != null && nextRetryCount > dlqMaxRetries);
         int retryCount =
             isPerm
                 ? Math.max(nextRetryCount, dlqMaxRetries != null ? dlqMaxRetries + 1 : 1)
                 : nextRetryCount;
         ErrorType errorType = isPerm ? PERMANENT : RETRYABLE;
 
-        failures.add(
-            item.withFailure(
-                message,
-                errorType,
-                FailureStage.WRITE,
-                retryCount));
+        failures.add(item.withFailure(message, errorType, FailureStage.WRITE, retryCount));
       }
     }
 
@@ -1863,21 +1839,14 @@ public class MongoDbTransforms {
             LOG.warn("UDF returned null for document ID: {}", item.getId());
             udfProcessingFailures.inc();
             c.output(
-                failureTag,
-                item.withFailure(
-                    "UDF returned null",
-                    RETRYABLE,
-                    FailureStage.UDF));
+                failureTag, item.withFailure("UDF returned null", RETRYABLE, FailureStage.UDF));
           }
         } catch (Throwable e) {
           LOG.error("Failed to apply UDF: {}", e.getMessage());
           udfProcessingFailures.inc();
           c.output(
               failureTag,
-              item.withFailure(
-                  "UDF failed: " + e.getMessage(),
-                  RETRYABLE,
-                  FailureStage.UDF));
+              item.withFailure("UDF failed: " + e.getMessage(), RETRYABLE, FailureStage.UDF));
         }
       } else {
         c.output(item);

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbTransforms.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbTransforms.java
@@ -111,7 +111,7 @@ public class MongoDbTransforms {
       builder.readPreference(ReadPreference.secondaryPreferred());
     }
     builder.applyToConnectionPoolSettings(
-        pool -> pool.maxSize(64).minSize(16).maxWaitTime(30, TimeUnit.SECONDS));
+        pool -> pool.maxSize(256).minSize(64).maxWaitTime(30, TimeUnit.SECONDS));
     builder.applyToSocketSettings(
         socket -> socket.connectTimeout(15, TimeUnit.SECONDS).readTimeout(60, TimeUnit.SECONDS));
     return MongoClients.create(builder.build());

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbTransforms.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbTransforms.java
@@ -38,6 +38,7 @@ import com.mongodb.client.model.WriteModel;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -1102,7 +1103,6 @@ public class MongoDbTransforms {
 
     private final String uri;
     private final String database;
-    private final Integer maxConcurrentAsyncWrites;
     private final Integer maxWriteRetries;
     private final Integer dlqMaxRetries;
     private final Integer initialWriteRatePerWorker;
@@ -1132,11 +1132,10 @@ public class MongoDbTransforms {
         Metrics.counter(WriteWithDlq.class, "writeDeletes");
     private final Counter writeDropsSkipped =
         Metrics.counter(WriteWithDlq.class, "writeDropsSkipped");
+    private final Counter writeBatchesCoalesced =
+        Metrics.counter(WriteWithDlq.class, "writeBatchesCoalesced");
 
     private transient MongoClient mongoClient;
-    private transient ExecutorService executor;
-    private transient Semaphore semaphore;
-    private transient ConcurrentLinkedQueue<CompletableFuture<Void>> futures;
     private transient ConcurrentLinkedQueue<DocumentWithMetadata> failures;
     private transient AtomicLong successfulCount;
     private transient ConcurrentHashMap<String, AtomicLong> dynamicCounters;
@@ -1167,7 +1166,6 @@ public class MongoDbTransforms {
         TupleTag<DocumentWithMetadata> failureTag) {
       this.uri = uri;
       this.database = database;
-      this.maxConcurrentAsyncWrites = maxConcurrentAsyncWrites;
       this.maxWriteRetries = maxWriteRetries;
       this.dlqMaxRetries = dlqMaxRetries;
       this.initialWriteRatePerWorker = initialWriteRatePerWorker;
@@ -1297,8 +1295,6 @@ public class MongoDbTransforms {
 
     @Setup
     public void setup() {
-      executor = Executors.newFixedThreadPool(maxConcurrentAsyncWrites);
-      semaphore = new Semaphore(maxConcurrentAsyncWrites);
       if (clientFactory != null && uri != null) {
         mongoClient = clientFactory.apply(uri);
       }
@@ -1323,9 +1319,8 @@ public class MongoDbTransforms {
         LOG.info("Write rate limiting is disabled for WriteBatchesFn (initialWriteRatePerWorker <= 0)");
       }
       LOG.info(
-          "Initialized MongoDB WriteBatchesFn worker thread for database '{}' (maxConcurrentAsyncWrites={}, maxWriteRetries={})",
+          "Initialized MongoDB WriteBatchesFn worker thread for database '{}' (maxWriteRetries={})",
           database,
-          maxConcurrentAsyncWrites,
           maxWriteRetries);
     }
 
@@ -1369,9 +1364,6 @@ public class MongoDbTransforms {
 
     @Teardown
     public void teardown() {
-      if (executor != null) {
-        executor.shutdown();
-      }
       if (mongoClient != null) {
         try {
           mongoClient.close();
@@ -1382,10 +1374,9 @@ public class MongoDbTransforms {
 
     @StartBundle
     public void startBundle() {
-      if (mongoClient == null) {
+      if (mongoClient == null && clientFactory != null && uri != null) {
         mongoClient = clientFactory.apply(uri);
       }
-      futures = new ConcurrentLinkedQueue<>();
       failures = new ConcurrentLinkedQueue<>();
       successfulCount = new AtomicLong(0);
       dynamicCounters = new ConcurrentHashMap<>();
@@ -1416,13 +1407,24 @@ public class MongoDbTransforms {
       }
     }
 
+    private static class CoalescedOp {
+      final WriteModel<Document> model;
+      final DocumentWithMetadata item;
+      final boolean isDelete;
+
+      CoalescedOp(WriteModel<Document> model, DocumentWithMetadata item, boolean isDelete) {
+        this.model = model;
+        this.item = item;
+        this.isDelete = isDelete;
+      }
+    }
+
     private void flushBatch(List<DocumentWithMetadata> items) throws InterruptedException {
       if (items == null || items.isEmpty()) {
         return;
       }
 
-      Map<String, List<WriteModel<Document>>> updatesByCollection = new HashMap<>();
-      Map<String, List<DocumentWithMetadata>> itemsByCollection = new HashMap<>();
+      Map<String, LinkedHashMap<Object, CoalescedOp>> coalescedByCollection = new HashMap<>();
 
       for (DocumentWithMetadata item : items) {
         String targetCol = item.getTargetCollection();
@@ -1433,11 +1435,16 @@ public class MongoDbTransforms {
         if (item.getOperationType() != null && item.getOperationType().isDelete()) {
           Object id = item.getId();
           if (id != null) {
-            updatesByCollection
-                .computeIfAbsent(targetCol, k -> new ArrayList<>())
-                .add(new DeleteOneModel<>(new Document("_id", id)));
-            itemsByCollection.computeIfAbsent(targetCol, k -> new ArrayList<>()).add(item);
-            writeDeletes.inc();
+            LinkedHashMap<Object, CoalescedOp> colMap =
+                coalescedByCollection.computeIfAbsent(targetCol, k -> new LinkedHashMap<>());
+            CoalescedOp prev =
+                colMap.put(
+                    id,
+                    new CoalescedOp(
+                        new DeleteOneModel<>(new Document("_id", id)), item, true));
+            if (prev != null) {
+              writeBatchesCoalesced.inc();
+            }
           } else {
             LOG.warn("Received DELETE event with null ID; routing to DLQ.");
             writePermanentDlqMessage(
@@ -1456,13 +1463,19 @@ public class MongoDbTransforms {
           if (doc != null) {
             Object id = doc.get("_id");
             if (id != null) {
-              updatesByCollection
-                  .computeIfAbsent(targetCol, k -> new ArrayList<>())
-                  .add(
-                      new ReplaceOneModel<>(
-                          new Document("_id", id), doc, new ReplaceOptions().upsert(true)));
-              itemsByCollection.computeIfAbsent(targetCol, k -> new ArrayList<>()).add(item);
-              writeInsertsUpserts.inc();
+              LinkedHashMap<Object, CoalescedOp> colMap =
+                  coalescedByCollection.computeIfAbsent(targetCol, k -> new LinkedHashMap<>());
+              CoalescedOp prev =
+                  colMap.put(
+                      id,
+                      new CoalescedOp(
+                          new ReplaceOneModel<>(
+                              new Document("_id", id), doc, new ReplaceOptions().upsert(true)),
+                          item,
+                          false));
+              if (prev != null) {
+                writeBatchesCoalesced.inc();
+              }
             } else {
               LOG.warn("Received document without '_id' field; routing to DLQ.");
               writePermanentDlqMessage(
@@ -1479,39 +1492,48 @@ public class MongoDbTransforms {
         }
       }
 
-      if (!updatesByCollection.isEmpty()) {
+      if (!coalescedByCollection.isEmpty()) {
         batchesFlushed.inc();
         updateRateLimiterIfNeeded();
-        if (rateLimiter != null && !items.isEmpty()) {
-          rateLimiter.acquire(items.size());
+
+        int totalCoalescedCount = 0;
+        for (LinkedHashMap<Object, CoalescedOp> colMap : coalescedByCollection.values()) {
+          totalCoalescedCount += colMap.size();
         }
+
+        if (rateLimiter != null && totalCoalescedCount > 0) {
+          rateLimiter.acquire(totalCoalescedCount);
+        }
+
         LOG.debug(
-            "Flushing batch of {} documents across {} target collection(s) to MongoDB (active async write futures in queue: {})",
+            "Flushing coalesced batch of {} documents (from {} input items) across {} target collection(s) to MongoDB",
+            totalCoalescedCount,
             items.size(),
-            updatesByCollection.size(),
-            futures.size());
-        semaphore.acquire();
-        CompletableFuture<Void> future =
-            CompletableFuture.runAsync(
-                () -> {
-                  try {
-                    for (Map.Entry<String, List<WriteModel<Document>>> entry :
-                        updatesByCollection.entrySet()) {
-                      String colName = entry.getKey();
-                      List<WriteModel<Document>> currentUpdates = entry.getValue();
-                      List<DocumentWithMetadata> currentItemList = itemsByCollection.get(colName);
+            coalescedByCollection.size());
 
-                      MongoCollection<Document> col =
-                          mongoClient.getDatabase(database).getCollection(colName);
+        for (Map.Entry<String, LinkedHashMap<Object, CoalescedOp>> entry :
+            coalescedByCollection.entrySet()) {
+          String colName = entry.getKey();
+          LinkedHashMap<Object, CoalescedOp> colMap = entry.getValue();
 
-                      writeBatchWithRetry(colName, col, currentUpdates, currentItemList);
-                    }
-                  } finally {
-                    semaphore.release();
-                  }
-                },
-                executor);
-        futures.add(future);
+          List<WriteModel<Document>> currentUpdates = new ArrayList<>(colMap.size());
+          List<DocumentWithMetadata> currentItemList = new ArrayList<>(colMap.size());
+
+          for (CoalescedOp op : colMap.values()) {
+            currentUpdates.add(op.model);
+            currentItemList.add(op.item);
+            if (op.isDelete) {
+              writeDeletes.inc();
+            } else {
+              writeInsertsUpserts.inc();
+            }
+          }
+
+          MongoCollection<Document> col =
+              mongoClient.getDatabase(database).getCollection(colName);
+
+          writeBatchWithRetry(colName, col, currentUpdates, currentItemList);
+        }
       }
     }
 
@@ -1732,8 +1754,6 @@ public class MongoDbTransforms {
 
     @FinishBundle
     public void finishBundle(FinishBundleContext c) {
-      CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
-
       successfulWrites.inc(successfulCount.get());
       if (inMemoryRetriesCount != null) {
         inMemoryRetries.inc(inMemoryRetriesCount.get());

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbTransforms.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbTransforms.java
@@ -75,6 +75,8 @@ import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
 import org.bson.Document;
 import org.bson.UuidRepresentation;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.slf4j.Logger;
@@ -109,9 +111,9 @@ public class MongoDbTransforms {
       builder.readPreference(ReadPreference.secondaryPreferred());
     }
     builder.applyToConnectionPoolSettings(
-        pool -> pool.maxSize(20).minSize(0).maxWaitTime(30, TimeUnit.SECONDS));
+        pool -> pool.maxSize(64).minSize(16).maxWaitTime(30, TimeUnit.SECONDS));
     builder.applyToSocketSettings(
-        socket -> socket.connectTimeout(15, TimeUnit.SECONDS).readTimeout(30, TimeUnit.SECONDS));
+        socket -> socket.connectTimeout(15, TimeUnit.SECONDS).readTimeout(60, TimeUnit.SECONDS));
     return MongoClients.create(builder.build());
   }
 
@@ -1796,6 +1798,8 @@ public class MongoDbTransforms {
   /** A {@link DoFn} that applies a JavaScript UDF to the document. */
   public static class ApplyUdfFn extends DoFn<DocumentWithMetadata, DocumentWithMetadata> {
     private static final Logger LOG = LoggerFactory.getLogger(ApplyUdfFn.class);
+    private static final JsonWriterSettings CANONICAL_JSON_SETTINGS =
+        JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
 
     private final String fileSystemPath;
     private final String functionName;
@@ -1837,7 +1841,15 @@ public class MongoDbTransforms {
       }
       if (javascriptRuntime != null) {
         try {
-          String transformed = javascriptRuntime.invoke(item.getOriginalDocument());
+          String payload = item.getOriginalDocument();
+          if (payload == null && item.getDocument() != null) {
+            payload = item.getDocument().toJson(CANONICAL_JSON_SETTINGS);
+          }
+          if (payload == null) {
+            c.output(item);
+            return;
+          }
+          String transformed = javascriptRuntime.invoke(payload);
           if (transformed != null) {
             Document doc = Document.parse(transformed);
             c.output(item.withDocument(doc));

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbTransforms.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/MongoDbTransforms.java
@@ -116,7 +116,7 @@ public class MongoDbTransforms {
       builder.readPreference(ReadPreference.secondaryPreferred());
     }
     builder.applyToConnectionPoolSettings(
-        pool -> pool.maxSize(256).minSize(64).maxWaitTime(30, TimeUnit.SECONDS));
+        pool -> pool.maxSize(256).minSize(0).maxWaitTime(30, TimeUnit.SECONDS));
     builder.applyToSocketSettings(
         socket -> socket.connectTimeout(15, TimeUnit.SECONDS).readTimeout(60, TimeUnit.SECONDS));
     return MongoClients.create(builder.build());

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/ReadSplitGenerator.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/ReadSplitGenerator.java
@@ -18,12 +18,14 @@ package com.google.cloud.teleport.v2.transforms;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
@@ -316,6 +318,34 @@ public class ReadSplitGenerator {
       return Collections.singletonList(typeMatch);
     }
 
+    try {
+      BsonDocument minDoc =
+          col.find(typeMatch)
+              .projection(new BsonDocument("_id", new BsonInt32(1)))
+              .sort(new BsonDocument("_id", new BsonInt32(1)))
+              .limit(1)
+              .first();
+      BsonDocument maxDoc =
+          col.find(typeMatch)
+              .projection(new BsonDocument("_id", new BsonInt32(1)))
+              .sort(new BsonDocument("_id", new BsonInt32(-1)))
+              .limit(1)
+              .first();
+
+      if (minDoc != null && maxDoc != null && minDoc.containsKey("_id") && maxDoc.containsKey("_id")) {
+        BsonValue minVal = minDoc.get("_id");
+        BsonValue maxVal = maxDoc.get("_id");
+
+        if (minVal.isObjectId() && maxVal.isObjectId()) {
+          String minHex = minVal.asObjectId().getValue().toHexString();
+          String maxHex = maxVal.asObjectId().getValue().toHexString();
+          return generateProbedObjectIdSplits(minHex, maxHex, numSplits);
+        }
+      }
+    } catch (Exception e) {
+      LOG.warn("Fast min/max index probe failed in '{}.{}' ({}). Falling back to sample.", col.getNamespace().getDatabaseName(), col.getNamespace().getCollectionName(), e.getMessage());
+    }
+
     int sampleSize = Math.max(1000, numSplits * 64);
     List<BsonDocument> pipeline =
         Arrays.asList(
@@ -325,7 +355,8 @@ public class ReadSplitGenerator {
             new BsonDocument("$sort", new BsonDocument("_id", new BsonInt32(1))));
 
     List<BsonValue> sampledKeys = new ArrayList<>();
-    for (BsonDocument doc : col.aggregate(pipeline)) {
+    for (BsonDocument doc :
+        col.aggregate(pipeline).allowDiskUse(true).maxTime(30, TimeUnit.SECONDS)) {
       if (doc.containsKey("_id")) {
         sampledKeys.add(doc.get("_id"));
       }
@@ -365,6 +396,60 @@ public class ReadSplitGenerator {
         idDoc.append("$gte", boundaries.get(i - 1)).append("$lt", boundaries.get(i));
       }
       slices.add(new BsonDocument("_id", idDoc));
+    }
+    return slices;
+  }
+
+  /**
+   * Generates contiguous, uniform ObjectId splits interpolated between actual probed min/max hex keys.
+   */
+  public static List<BsonDocument> generateProbedObjectIdSplits(
+      String minHex, String maxHex, int numSplits) {
+    if (numSplits <= 1 || minHex.equals(maxHex)) {
+      return Collections.singletonList(
+          new BsonDocument("_id", new BsonDocument("$type", new BsonString("objectId"))));
+    }
+
+    BigInteger minBig = new BigInteger(minHex, 16);
+    BigInteger maxBig = new BigInteger(maxHex, 16);
+    BigInteger range = maxBig.subtract(minBig);
+    BigInteger step = range.divide(BigInteger.valueOf(numSplits));
+
+    if (step.compareTo(BigInteger.ZERO) <= 0) {
+      return Collections.singletonList(
+          new BsonDocument("_id", new BsonDocument("$type", new BsonString("objectId"))));
+    }
+
+    List<BsonDocument> slices = new ArrayList<>();
+    for (int i = 0; i < numSplits; i++) {
+      if (i == 0) {
+        BigInteger high = minBig.add(step);
+        String highHex = String.format("%024x", high);
+        slices.add(
+            BsonDocument.parse(
+                String.format(
+                    "{\"_id\": {\"$type\": \"objectId\", \"$lt\": {\"$oid\": \"%s\"}}}",
+                    highHex)));
+      } else if (i == numSplits - 1) {
+        BigInteger low = minBig.add(step.multiply(BigInteger.valueOf(i)));
+        String lowHex = String.format("%024x", low);
+        slices.add(
+            BsonDocument.parse(
+                String.format(
+                    "{\"_id\": {\"$type\": \"objectId\", \"$gte\": {\"$oid\": \"%s\"}}}",
+                    lowHex)));
+      } else {
+        BigInteger low = minBig.add(step.multiply(BigInteger.valueOf(i)));
+        BigInteger high = minBig.add(step.multiply(BigInteger.valueOf(i + 1)));
+        String lowHex = String.format("%024x", low);
+        String highHex = String.format("%024x", high);
+        slices.add(
+            BsonDocument.parse(
+                String.format(
+                    "{\"_id\": {\"$type\": \"objectId\", \"$gte\": {\"$oid\": \"%s\"}, \"$lt\":"
+                        + " {\"$oid\": \"%s\"}}}",
+                    lowHex, highHex)));
+      }
     }
     return slices;
   }
@@ -412,7 +497,8 @@ public class ReadSplitGenerator {
       BsonDocument filter =
           BsonDocument.parse(
               String.format(
-                  "{\"_id\": {\"$gte\": {\"$oid\": \"%s\"}, \"%s\": {\"$oid\": \"%s\"}}}",
+                  "{\"_id\": {\"$type\": \"objectId\", \"$gte\": {\"$oid\": \"%s\"}, \"%s\":"
+                      + " {\"$oid\": \"%s\"}}}",
                   lowHex, highOp, highHex));
       filters.add(filter);
     }
@@ -441,16 +527,17 @@ public class ReadSplitGenerator {
 
   private static List<String> generateObjectIdBounds(int numSplits) {
     List<String> bounds = new ArrayList<>();
-    long minHex = 0x00000000L;
-    long maxHex = 0xffffffffL;
-    long step = (maxHex - minHex) / numSplits;
+    long nowSec = System.currentTimeMillis() / 1000L;
+    long minSec = Math.max(0L, nowSec - (5L * 365 * 86400));
+    long maxSec = nowSec + (30L * 86400);
+    long step = (maxSec - minSec) / numSplits;
     for (int i = 0; i <= numSplits; i++) {
       if (i == 0) {
         bounds.add("000000000000000000000000");
       } else if (i == numSplits) {
         bounds.add("ffffffffffffffffffffffff");
       } else {
-        long val = minHex + i * step;
+        long val = minSec + i * step;
         String hexPrefix = String.format("%08x", val);
         bounds.add(hexPrefix + "0000000000000000");
       }

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/ReadSplitGenerator.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/ReadSplitGenerator.java
@@ -75,15 +75,34 @@ public final class ReadSplitGenerator {
    */
   public static List<BsonDocument> generateIndexSliceFilters(
       MongoClient client, String databaseName, String collectionName, int numSplits) {
-    if (numSplits <= 1) {
-      return Collections.singletonList(new BsonDocument());
-    }
+    return generateIndexSliceFilters(
+        client, databaseName, collectionName, numSplits, 0, Math.max(numSplits, 256));
+  }
 
+  /**
+   * Generates a list of BsonDocument filter queries with adaptive volume-based split sizing
+   * and bounded upper bounds.
+   *
+   * @param client MongoDB client connection.
+   * @param databaseName Database name.
+   * @param collectionName Collection name.
+   * @param numSplits Number of target parallel read splits (serves as floor/fallback).
+   * @param targetChunkSize Target document count per split (0 to disable adaptive sizing).
+   * @param maxSplits Maximum number of splits allowed.
+   * @return List of BsonDocument filters.
+   */
+  public static List<BsonDocument> generateIndexSliceFilters(
+      MongoClient client,
+      String databaseName,
+      String collectionName,
+      int numSplits,
+      int targetChunkSize,
+      int maxSplits) {
     if (client != null) {
       try {
         MongoDatabase db = client.getDatabase(databaseName);
         MongoCollection<BsonDocument> col = db.getCollection(collectionName, BsonDocument.class);
-        return generateTypeIsolatedSplits(col, numSplits);
+        return generateTypeIsolatedSplits(col, numSplits, targetChunkSize, maxSplits);
       } catch (Exception e) {
         LOG.warn(
             "Failed generating type-isolated splits for '{}.{}' ({})."
@@ -94,7 +113,8 @@ public final class ReadSplitGenerator {
       }
     }
 
-    return generateIndexSliceFilters(numSplits);
+    int effectiveSplits = Math.max(1, Math.min(maxSplits, numSplits));
+    return generateIndexSliceFilters(effectiveSplits);
   }
 
   /**
@@ -307,10 +327,15 @@ public final class ReadSplitGenerator {
    */
   public static List<BsonDocument> generateTypeIsolatedSplits(
       MongoCollection<BsonDocument> col, int numSplits) {
-    if (numSplits <= 1) {
-      return Collections.singletonList(new BsonDocument());
-    }
+    return generateTypeIsolatedSplits(col, numSplits, 0, Math.max(numSplits, 256));
+  }
 
+  /**
+   * Generates type-isolated splits with adaptive volume sizing, ensuring filters and keyset
+   * resumption never span BSON types.
+   */
+  public static List<BsonDocument> generateTypeIsolatedSplits(
+      MongoCollection<BsonDocument> col, int numSplits, int targetChunkSize, int maxSplits) {
     long estimatedDocs = 0;
     try {
       estimatedDocs = col.estimatedDocumentCount();
@@ -326,6 +351,18 @@ public final class ReadSplitGenerator {
       return Collections.singletonList(new BsonDocument());
     }
 
+    int effectiveSplits;
+    if (targetChunkSize > 0 && estimatedDocs > 0) {
+      int calculated = (int) Math.ceil((double) estimatedDocs / targetChunkSize);
+      effectiveSplits = Math.max(1, Math.min(maxSplits, calculated));
+    } else {
+      effectiveSplits = Math.max(1, Math.min(maxSplits, numSplits));
+    }
+
+    if (effectiveSplits <= 1) {
+      return Collections.singletonList(new BsonDocument());
+    }
+
     List<ProbedTypeBounds> activeTypes = probeActiveTypeBounds(col);
     if (activeTypes.isEmpty()) {
       LOG.info(
@@ -333,15 +370,15 @@ public final class ReadSplitGenerator {
               + " Falling back to algorithmic splits.",
           getDbName(col),
           getColName(col));
-      return generateIndexSliceFilters(numSplits);
+      return generateIndexSliceFilters(effectiveSplits);
     }
 
     if (activeTypes.size() == 1) {
-      return generateSplitsForTypeBounds(col, activeTypes.get(0), numSplits);
+      return generateSplitsForTypeBounds(col, activeTypes.get(0), effectiveSplits);
     }
 
     // Mixed collection: allocate splits across active types without cross-type queries
-    int splitsPerType = Math.max(1, numSplits / activeTypes.size());
+    int splitsPerType = Math.max(1, effectiveSplits / activeTypes.size());
     List<BsonDocument> combinedFilters = new ArrayList<>();
     for (ProbedTypeBounds bounds : activeTypes) {
       combinedFilters.addAll(generateSplitsForTypeBounds(col, bounds, splitsPerType));
@@ -352,12 +389,15 @@ public final class ReadSplitGenerator {
   private static List<BsonDocument> generateSplitsForTypeBounds(
       MongoCollection<BsonDocument> col, ProbedTypeBounds bounds, int splits) {
     if (splits <= 1) {
-      return Collections.singletonList(
-          new BsonDocument("_id", new BsonDocument("$type", bounds.getBucket().getTypeValue())));
+      BsonDocument idDoc = new BsonDocument("$type", bounds.getBucket().getTypeValue());
+      if (bounds.getMaxKey() != null) {
+        idDoc.append("$lte", bounds.getMaxKey());
+      }
+      return Collections.singletonList(new BsonDocument("_id", idDoc));
     }
 
     // Try fast unfiltered $sample for quantile boundaries
-    int sampleSize = Math.min(1000, Math.max(256, splits * 32));
+    int sampleSize = Math.min(5000, Math.max(500, splits * 20));
     List<BsonDocument> samplePipeline =
         Arrays.asList(
             new BsonDocument("$sample", new BsonDocument("size", new BsonInt32(sampleSize))),
@@ -366,7 +406,7 @@ public final class ReadSplitGenerator {
 
     List<BsonValue> sampledKeys = new ArrayList<>();
     try {
-      for (BsonDocument doc : col.aggregate(samplePipeline).maxTime(5, TimeUnit.SECONDS)) {
+      for (BsonDocument doc : col.aggregate(samplePipeline).maxTime(30, TimeUnit.SECONDS)) {
         if (doc.containsKey("_id")) {
           sampledKeys.add(doc.get("_id"));
         }
@@ -387,12 +427,20 @@ public final class ReadSplitGenerator {
       }
     }
 
+    BsonValue maxKey = bounds.getMaxKey();
+
     if (typeKeys.size() >= splits) {
       typeKeys.sort(BSON_VALUE_COMPARATOR);
       List<BsonValue> boundaries = new ArrayList<>();
-      int step = typeKeys.size() / splits;
       for (int i = 1; i < splits; i++) {
-        BsonValue b = typeKeys.get(i * step);
+        int index = (int) Math.round(((double) i * typeKeys.size()) / splits);
+        if (index >= typeKeys.size()) {
+          index = typeKeys.size() - 1;
+        }
+        BsonValue b = typeKeys.get(index);
+        if (maxKey != null && BSON_VALUE_COMPARATOR.compare(b, maxKey) >= 0) {
+          continue;
+        }
         if (boundaries.isEmpty() || !b.equals(boundaries.get(boundaries.size() - 1))) {
           boundaries.add(b);
         }
@@ -408,6 +456,9 @@ public final class ReadSplitGenerator {
             idDoc.append("$lte", boundaries.get(0));
           } else if (i == boundaryCount) {
             idDoc.append("$gt", boundaries.get(boundaryCount - 1));
+            if (maxKey != null) {
+              idDoc.append("$lte", maxKey);
+            }
           } else {
             idDoc.append("$gt", boundaries.get(i - 1)).append("$lte", boundaries.get(i));
           }
@@ -438,8 +489,11 @@ public final class ReadSplitGenerator {
       return generateStringFilters(splits);
     }
 
-    return Collections.singletonList(
-        new BsonDocument("_id", new BsonDocument("$type", bounds.getBucket().getTypeValue())));
+    BsonDocument fallbackId = new BsonDocument("$type", bounds.getBucket().getTypeValue());
+    if (bounds.getMaxKey() != null) {
+      fallbackId.append("$lte", bounds.getMaxKey());
+    }
+    return Collections.singletonList(new BsonDocument("_id", fallbackId));
   }
 
   private static boolean matchesType(BsonValue k, TypeBucket bucket) {
@@ -522,7 +576,10 @@ public final class ReadSplitGenerator {
       String minHex, String maxHex, int numSplits) {
     if (numSplits <= 1 || minHex.equals(maxHex)) {
       return Collections.singletonList(
-          new BsonDocument("_id", new BsonDocument("$type", new BsonString("objectId"))));
+          BsonDocument.parse(
+              String.format(
+                  "{\"_id\": {\"$type\": \"objectId\", \"$lte\": {\"$oid\": \"%s\"}}}",
+                  maxHex)));
     }
 
     BigInteger minBig = new BigInteger(minHex, 16);
@@ -532,7 +589,10 @@ public final class ReadSplitGenerator {
 
     if (step.compareTo(BigInteger.ZERO) <= 0) {
       return Collections.singletonList(
-          new BsonDocument("_id", new BsonDocument("$type", new BsonString("objectId"))));
+          BsonDocument.parse(
+              String.format(
+                  "{\"_id\": {\"$type\": \"objectId\", \"$lte\": {\"$oid\": \"%s\"}}}",
+                  maxHex)));
     }
 
     List<BsonDocument> slices = new ArrayList<>();
@@ -551,8 +611,8 @@ public final class ReadSplitGenerator {
         slices.add(
             BsonDocument.parse(
                 String.format(
-                    "{\"_id\": {\"$type\": \"objectId\", \"$gte\": {\"$oid\": \"%s\"}}}",
-                    lowHex)));
+                    "{\"_id\": {\"$type\": \"objectId\", \"$gte\": {\"$oid\": \"%s\"}, \"$lte\": {\"$oid\": \"%s\"}}}",
+                    lowHex, maxHex)));
       } else {
         BigInteger low = minBig.add(step.multiply(BigInteger.valueOf(i)));
         BigInteger high = minBig.add(step.multiply(BigInteger.valueOf(i + 1)));

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/ReadSplitGenerator.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/ReadSplitGenerator.java
@@ -67,8 +67,8 @@ public final class ReadSplitGenerator {
   }
 
   /**
-   * Generates a list of BsonDocument filter queries using 2-phase covered index type discovery
-   * and type-isolated quantile sampling.
+   * Generates a list of BsonDocument filter queries using 2-phase covered index type discovery and
+   * type-isolated quantile sampling.
    *
    * @param client MongoDB client connection.
    * @param databaseName Database name.
@@ -83,8 +83,8 @@ public final class ReadSplitGenerator {
   }
 
   /**
-   * Generates a list of BsonDocument filter queries with adaptive volume-based split sizing
-   * and bounded upper bounds.
+   * Generates a list of BsonDocument filter queries with adaptive volume-based split sizing and
+   * bounded upper bounds.
    *
    * @param client MongoDB client connection.
    * @param databaseName Database name.
@@ -584,8 +584,7 @@ public final class ReadSplitGenerator {
       };
 
   private static boolean isNumeric(BsonValue val) {
-    return val != null
-        && (val.isInt32() || val.isInt64() || val.isDouble() || val.isDecimal128());
+    return val != null && (val.isInt32() || val.isInt64() || val.isDouble() || val.isDecimal128());
   }
 
   private static double asDouble(BsonValue val) {
@@ -605,8 +604,8 @@ public final class ReadSplitGenerator {
   }
 
   /**
-   * Generates contiguous, uniform ObjectId splits interpolated between actual probed min/max
-   * hex keys.
+   * Generates contiguous, uniform ObjectId splits interpolated between actual probed min/max hex
+   * keys.
    */
   public static List<BsonDocument> generateProbedObjectIdSplits(
       String minHex, String maxHex, int numSplits) {
@@ -614,8 +613,7 @@ public final class ReadSplitGenerator {
       return Collections.singletonList(
           BsonDocument.parse(
               String.format(
-                  "{\"_id\": {\"$type\": \"objectId\", \"$lte\": {\"$oid\": \"%s\"}}}",
-                  maxHex)));
+                  "{\"_id\": {\"$type\": \"objectId\", \"$lte\": {\"$oid\": \"%s\"}}}", maxHex)));
     }
 
     BigInteger minBig = new BigInteger(minHex, 16);
@@ -627,8 +625,7 @@ public final class ReadSplitGenerator {
       return Collections.singletonList(
           BsonDocument.parse(
               String.format(
-                  "{\"_id\": {\"$type\": \"objectId\", \"$lte\": {\"$oid\": \"%s\"}}}",
-                  maxHex)));
+                  "{\"_id\": {\"$type\": \"objectId\", \"$lte\": {\"$oid\": \"%s\"}}}", maxHex)));
     }
 
     List<BsonDocument> slices = new ArrayList<>();
@@ -639,8 +636,7 @@ public final class ReadSplitGenerator {
         slices.add(
             BsonDocument.parse(
                 String.format(
-                    "{\"_id\": {\"$type\": \"objectId\", \"$lt\": {\"$oid\": \"%s\"}}}",
-                    highHex)));
+                    "{\"_id\": {\"$type\": \"objectId\", \"$lt\": {\"$oid\": \"%s\"}}}", highHex)));
       } else if (i == numSplits - 1) {
         BigInteger low = minBig.add(step.multiply(BigInteger.valueOf(i)));
         String lowHex = String.format("%024x", low);

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/ReadSplitGenerator.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/ReadSplitGenerator.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * Utility class to generate orthogonal BSON filter queries for parallel index-slice reading without
  * requiring MongoDB splitVector or bucketAuto commands.
  */
-public class ReadSplitGenerator {
+public final class ReadSplitGenerator {
 
   private static final Logger LOG = LoggerFactory.getLogger(ReadSplitGenerator.class);
 
@@ -64,16 +64,6 @@ public class ReadSplitGenerator {
   }
 
   /**
-   * Generates a list of BsonDocument filter queries using data-driven quantile sampling or
-   * automatic key-type discovery.
-   *
-   * @param client MongoDB client connection.
-   * @param databaseName Database name.
-   * @param collectionName Collection name.
-   * @param numSplits Number of target parallel read splits.
-   * @return List of BsonDocument filters.
-   */
-  /**
    * Generates a list of BsonDocument filter queries using 2-phase covered index type discovery
    * and type-isolated quantile sampling.
    *
@@ -96,7 +86,8 @@ public class ReadSplitGenerator {
         return generateTypeIsolatedSplits(col, numSplits);
       } catch (Exception e) {
         LOG.warn(
-            "Failed generating type-isolated splits for '{}.{}' ({}). Falling back to algorithmic splits.",
+            "Failed generating type-isolated splits for '{}.{}' ({})."
+                + " Falling back to algorithmic splits.",
             databaseName,
             collectionName,
             e.getMessage());
@@ -171,7 +162,7 @@ public class ReadSplitGenerator {
               new BsonString("double"),
               new BsonString("decimal")));
 
-  public static class TypeBucket {
+  public static final class TypeBucket {
     private final String name;
     private final BsonValue typeValue;
 
@@ -203,7 +194,7 @@ public class ReadSplitGenerator {
               new TypeBucket("object", new BsonString("object")),
               new TypeBucket("date", new BsonString("date"))));
 
-  public static class ProbedTypeBounds {
+  public static final class ProbedTypeBounds {
     private final TypeBucket bucket;
     private final BsonValue minKey;
     private final BsonValue maxKey;
@@ -225,6 +216,18 @@ public class ReadSplitGenerator {
     public BsonValue getMaxKey() {
       return maxKey;
     }
+  }
+
+  private static String getDbName(MongoCollection<BsonDocument> col) {
+    return col != null && col.getNamespace() != null
+        ? col.getNamespace().getDatabaseName()
+        : "unknown";
+  }
+
+  private static String getColName(MongoCollection<BsonDocument> col) {
+    return col != null && col.getNamespace() != null
+        ? col.getNamespace().getCollectionName()
+        : "unknown";
   }
 
   /**
@@ -259,8 +262,8 @@ public class ReadSplitGenerator {
         LOG.warn(
             "Covered index probe failed for type '{}' on '{}.{}': {}",
             bucket.getName(),
-            col.getNamespace().getDatabaseName(),
-            col.getNamespace().getCollectionName(),
+            getDbName(col),
+            getColName(col),
             e.getMessage());
       }
     }
@@ -314,8 +317,8 @@ public class ReadSplitGenerator {
     } catch (Exception e) {
       LOG.warn(
           "Could not estimate document count for '{}.{}': {}",
-          col.getNamespace().getDatabaseName(),
-          col.getNamespace().getCollectionName(),
+          getDbName(col),
+          getColName(col),
           e.getMessage());
     }
 
@@ -326,10 +329,11 @@ public class ReadSplitGenerator {
     List<ProbedTypeBounds> activeTypes = probeActiveTypeBounds(col);
     if (activeTypes.isEmpty()) {
       LOG.info(
-          "No active types detected via index probes for '{}.{}'. Using single split.",
-          col.getNamespace().getDatabaseName(),
-          col.getNamespace().getCollectionName());
-      return Collections.singletonList(new BsonDocument());
+          "No active types detected via index probes for '{}.{}'."
+              + " Falling back to algorithmic splits.",
+          getDbName(col),
+          getColName(col));
+      return generateIndexSliceFilters(numSplits);
     }
 
     if (activeTypes.size() == 1) {
@@ -370,8 +374,8 @@ public class ReadSplitGenerator {
     } catch (Exception e) {
       LOG.warn(
           "Unfiltered $sample failed for '{}.{}' ({}). Using probed boundary fallback.",
-          col.getNamespace().getDatabaseName(),
-          col.getNamespace().getCollectionName(),
+          getDbName(col),
+          getColName(col),
           e.getMessage());
     }
 
@@ -460,7 +464,7 @@ public class ReadSplitGenerator {
     }
   }
 
-  public static final Comparator<BsonValue> BSON_VALUE_COMPARATOR =
+  private static final Comparator<BsonValue> BSON_VALUE_COMPARATOR =
       (a, b) -> {
         if (a == b) {
           return 0;
@@ -477,17 +481,8 @@ public class ReadSplitGenerator {
         if (a.isString() && b.isString()) {
           return a.asString().getValue().compareTo(b.asString().getValue());
         }
-        if (a.isInt32() && b.isInt32()) {
-          return Integer.compare(a.asInt32().getValue(), b.asInt32().getValue());
-        }
-        if (a.isInt64() && b.isInt64()) {
-          return Long.compare(a.asInt64().getValue(), b.asInt64().getValue());
-        }
-        if (a.isDouble() && b.isDouble()) {
-          return Double.compare(a.asDouble().getValue(), b.asDouble().getValue());
-        }
-        if (a.isDecimal128() && b.isDecimal128()) {
-          return a.asDecimal128().getValue().compareTo(b.asDecimal128().getValue());
+        if (isNumeric(a) && isNumeric(b)) {
+          return Double.compare(asDouble(a), asDouble(b));
         }
         if (a.isDateTime() && b.isDateTime()) {
           return Long.compare(a.asDateTime().getValue(), b.asDateTime().getValue());
@@ -498,8 +493,30 @@ public class ReadSplitGenerator {
         return a.toString().compareTo(b.toString());
       };
 
+  private static boolean isNumeric(BsonValue val) {
+    return val != null
+        && (val.isInt32() || val.isInt64() || val.isDouble() || val.isDecimal128());
+  }
+
+  private static double asDouble(BsonValue val) {
+    if (val.isInt32()) {
+      return val.asInt32().getValue();
+    }
+    if (val.isInt64()) {
+      return val.asInt64().getValue();
+    }
+    if (val.isDouble()) {
+      return val.asDouble().getValue();
+    }
+    if (val.isDecimal128()) {
+      return val.asDecimal128().getValue().doubleValue();
+    }
+    return 0.0;
+  }
+
   /**
-   * Generates contiguous, uniform ObjectId splits interpolated between actual probed min/max hex keys.
+   * Generates contiguous, uniform ObjectId splits interpolated between actual probed min/max
+   * hex keys.
    */
   public static List<BsonDocument> generateProbedObjectIdSplits(
       String minHex, String maxHex, int numSplits) {

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/ReadSplitGenerator.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/ReadSplitGenerator.java
@@ -22,6 +22,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -72,126 +73,37 @@ public class ReadSplitGenerator {
    * @param numSplits Number of target parallel read splits.
    * @return List of BsonDocument filters.
    */
+  /**
+   * Generates a list of BsonDocument filter queries using 2-phase covered index type discovery
+   * and type-isolated quantile sampling.
+   *
+   * @param client MongoDB client connection.
+   * @param databaseName Database name.
+   * @param collectionName Collection name.
+   * @param numSplits Number of target parallel read splits.
+   * @return List of BsonDocument filters.
+   */
   public static List<BsonDocument> generateIndexSliceFilters(
       MongoClient client, String databaseName, String collectionName, int numSplits) {
     if (numSplits <= 1) {
       return Collections.singletonList(new BsonDocument());
     }
 
-    Set<IdType> activeTypes =
-        client != null
-            ? detectIdTypes(client, databaseName, collectionName)
-            : EnumSet.allOf(IdType.class);
-
-    if (client == null) {
-      return generateIndexSliceFilters(numSplits, activeTypes);
-    }
-
-    MongoCollection<BsonDocument> col =
-        client.getDatabase(databaseName).getCollection(collectionName, BsonDocument.class);
-
-    List<BsonDocument> numberFilters = Collections.emptyList();
-    if (activeTypes.contains(IdType.NUMBER)) {
+    if (client != null) {
       try {
-        numberFilters =
-            discoverSplitsForType(
-                col,
-                numSplits,
-                new BsonDocument("_id", new BsonDocument("$type", NUMBER_BSON_TYPES)));
+        MongoDatabase db = client.getDatabase(databaseName);
+        MongoCollection<BsonDocument> col = db.getCollection(collectionName, BsonDocument.class);
+        return generateTypeIsolatedSplits(col, numSplits);
       } catch (Exception e) {
         LOG.warn(
-            "Data-driven splits failed for NUMBER type in '{}.{}' ({}). Falling back to uniform splits.",
-            databaseName,
-            collectionName,
-            e.getMessage());
-        numberFilters = generateNumberFilters(numSplits);
-      }
-    }
-
-    List<BsonDocument> stringFilters = Collections.emptyList();
-    if (activeTypes.contains(IdType.STRING)) {
-      try {
-        stringFilters =
-            discoverSplitsForType(
-                col,
-                numSplits,
-                new BsonDocument("_id", new BsonDocument("$type", new BsonString("string"))));
-      } catch (Exception e) {
-        LOG.warn(
-            "Data-driven splits failed for STRING type in '{}.{}' ({}). Falling back to uniform splits.",
-            databaseName,
-            collectionName,
-            e.getMessage());
-        stringFilters = generateStringFilters(numSplits);
-      }
-    }
-
-    List<BsonDocument> objectIdFilters = Collections.emptyList();
-    if (activeTypes.contains(IdType.OBJECT_ID)) {
-      try {
-        objectIdFilters =
-            discoverSplitsForType(
-                col,
-                numSplits,
-                new BsonDocument("_id", new BsonDocument("$type", new BsonString("objectId"))));
-      } catch (Exception e) {
-        LOG.warn(
-            "Data-driven splits failed for OBJECT_ID type in '{}.{}' ({}). Falling back to uniform splits.",
-            databaseName,
-            collectionName,
-            e.getMessage());
-        objectIdFilters = generateObjectIdFilters(numSplits);
-      }
-    }
-
-    List<BsonDocument> otherFilters = Collections.emptyList();
-    if (activeTypes.contains(IdType.OTHER)) {
-      try {
-        otherFilters =
-            discoverSplitsForType(
-                col,
-                numSplits,
-                new BsonDocument(
-                    "_id", new BsonDocument("$not", new BsonDocument("$type", KNOWN_BSON_TYPES))));
-      } catch (Exception e) {
-        LOG.warn(
-            "Data-driven splits failed for OTHER type in '{}.{}' ({}).",
+            "Failed generating type-isolated splits for '{}.{}' ({}). Falling back to algorithmic splits.",
             databaseName,
             collectionName,
             e.getMessage());
       }
     }
 
-    List<BsonDocument> filters = new ArrayList<>();
-    for (int i = 0; i < numSplits; i++) {
-      List<BsonDocument> branchFilters = new ArrayList<>();
-      if (!numberFilters.isEmpty() && i < numberFilters.size()) {
-        branchFilters.add(numberFilters.get(i));
-      }
-      if (!stringFilters.isEmpty() && i < stringFilters.size()) {
-        branchFilters.add(stringFilters.get(i));
-      }
-      if (!objectIdFilters.isEmpty() && i < objectIdFilters.size()) {
-        branchFilters.add(objectIdFilters.get(i));
-      }
-      if (!otherFilters.isEmpty() && i < otherFilters.size()) {
-        branchFilters.add(otherFilters.get(i));
-      } else if (i == 0 && activeTypes.contains(IdType.OTHER)) {
-        branchFilters.add(
-            BsonDocument.parse(
-                "{\"_id\": {\"$not\": {\"$type\": [\"int\", \"long\", \"double\", \"decimal\","
-                    + " \"string\", \"objectId\"]}}}"));
-      }
-
-      if (branchFilters.isEmpty()) {
-        filters.add(new BsonDocument());
-      } else if (branchFilters.size() == 1) {
-        filters.add(branchFilters.get(0));
-      } else {
-        filters.add(new BsonDocument("$or", new BsonArray(branchFilters)));
-      }
-    }
-    return filters;
+    return generateIndexSliceFilters(numSplits);
   }
 
   /**
@@ -259,19 +171,104 @@ public class ReadSplitGenerator {
               new BsonString("double"),
               new BsonString("decimal")));
 
-  private static final BsonArray KNOWN_BSON_TYPES =
-      new BsonArray(
+  public static class TypeBucket {
+    private final String name;
+    private final BsonValue typeValue;
+
+    public TypeBucket(String name, BsonValue typeValue) {
+      this.name = name;
+      this.typeValue = typeValue;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public BsonValue getTypeValue() {
+      return typeValue;
+    }
+
+    public BsonDocument query() {
+      return new BsonDocument("_id", new BsonDocument("$type", typeValue));
+    }
+  }
+
+  private static final List<TypeBucket> KNOWN_TYPE_BUCKETS =
+      Collections.unmodifiableList(
           Arrays.asList(
-              new BsonString("string"),
-              new BsonString("objectId"),
-              new BsonString("int"),
-              new BsonString("long"),
-              new BsonString("double"),
-              new BsonString("decimal")));
+              new TypeBucket("number", NUMBER_BSON_TYPES),
+              new TypeBucket("string", new BsonString("string")),
+              new TypeBucket("objectId", new BsonString("objectId")),
+              new TypeBucket("binData", new BsonString("binData")),
+              new TypeBucket("object", new BsonString("object")),
+              new TypeBucket("date", new BsonString("date"))));
+
+  public static class ProbedTypeBounds {
+    private final TypeBucket bucket;
+    private final BsonValue minKey;
+    private final BsonValue maxKey;
+
+    public ProbedTypeBounds(TypeBucket bucket, BsonValue minKey, BsonValue maxKey) {
+      this.bucket = bucket;
+      this.minKey = minKey;
+      this.maxKey = maxKey;
+    }
+
+    public TypeBucket getBucket() {
+      return bucket;
+    }
+
+    public BsonValue getMinKey() {
+      return minKey;
+    }
+
+    public BsonValue getMaxKey() {
+      return maxKey;
+    }
+  }
 
   /**
-   * Detects which _id BSON types are present in a MongoDB collection using lightweight limit(1)
-   * probes.
+   * Performs lightweight covered index seeks (<26ms) to detect all active BSON types and their
+   * min/max boundaries.
+   */
+  public static List<ProbedTypeBounds> probeActiveTypeBounds(MongoCollection<BsonDocument> col) {
+    List<ProbedTypeBounds> activeBounds = new ArrayList<>();
+    for (TypeBucket bucket : KNOWN_TYPE_BUCKETS) {
+      try {
+        BsonDocument minDoc =
+            col.find(bucket.query())
+                .projection(new BsonDocument("_id", new BsonInt32(1)))
+                .sort(new BsonDocument("_id", new BsonInt32(1)))
+                .limit(1)
+                .maxTime(3, TimeUnit.SECONDS)
+                .first();
+        if (minDoc != null && minDoc.containsKey("_id")) {
+          BsonDocument maxDoc =
+              col.find(bucket.query())
+                  .projection(new BsonDocument("_id", new BsonInt32(1)))
+                  .sort(new BsonDocument("_id", new BsonInt32(-1)))
+                  .limit(1)
+                  .maxTime(3, TimeUnit.SECONDS)
+                  .first();
+          BsonValue minVal = minDoc.get("_id");
+          BsonValue maxVal =
+              (maxDoc != null && maxDoc.containsKey("_id")) ? maxDoc.get("_id") : minVal;
+          activeBounds.add(new ProbedTypeBounds(bucket, minVal, maxVal));
+        }
+      } catch (Exception e) {
+        LOG.warn(
+            "Covered index probe failed for type '{}' on '{}.{}': {}",
+            bucket.getName(),
+            col.getNamespace().getDatabaseName(),
+            col.getNamespace().getCollectionName(),
+            e.getMessage());
+      }
+    }
+    return activeBounds;
+  }
+
+  /**
+   * Detects which _id BSON types are present in a MongoDB collection using lightweight index seeks.
    */
   public static Set<IdType> detectIdTypes(
       MongoClient client, String databaseName, String collectionName) {
@@ -279,126 +276,227 @@ public class ReadSplitGenerator {
     MongoDatabase db = client.getDatabase(databaseName);
     MongoCollection<BsonDocument> col = db.getCollection(collectionName, BsonDocument.class);
 
-    if (col.find(new BsonDocument("_id", new BsonDocument("$type", new BsonString("string"))))
-            .limit(1)
-            .first()
-        != null) {
-      activeTypes.add(IdType.STRING);
+    List<ProbedTypeBounds> bounds = probeActiveTypeBounds(col);
+    for (ProbedTypeBounds b : bounds) {
+      switch (b.getBucket().getName()) {
+        case "number":
+          activeTypes.add(IdType.NUMBER);
+          break;
+        case "string":
+          activeTypes.add(IdType.STRING);
+          break;
+        case "objectId":
+          activeTypes.add(IdType.OBJECT_ID);
+          break;
+        default:
+          activeTypes.add(IdType.OTHER);
+          break;
+      }
     }
-    if (col.find(new BsonDocument("_id", new BsonDocument("$type", new BsonString("objectId"))))
-            .limit(1)
-            .first()
-        != null) {
-      activeTypes.add(IdType.OBJECT_ID);
-    }
-    if (col.find(new BsonDocument("_id", new BsonDocument("$type", NUMBER_BSON_TYPES)))
-            .limit(1)
-            .first()
-        != null) {
-      activeTypes.add(IdType.NUMBER);
-    }
-    if (col.find(
-                new BsonDocument(
-                    "_id", new BsonDocument("$not", new BsonDocument("$type", KNOWN_BSON_TYPES))))
-            .limit(1)
-            .first()
-        != null) {
-      activeTypes.add(IdType.OTHER);
-    }
-
     if (activeTypes.isEmpty()) {
       activeTypes.addAll(EnumSet.allOf(IdType.class));
     }
     return activeTypes;
   }
 
-  private static List<BsonDocument> discoverSplitsForType(
-      MongoCollection<BsonDocument> col, int numSplits, BsonDocument typeMatch) {
+  /**
+   * Generates type-isolated splits ensuring filters and keyset resumption never span BSON types.
+   */
+  public static List<BsonDocument> generateTypeIsolatedSplits(
+      MongoCollection<BsonDocument> col, int numSplits) {
     if (numSplits <= 1) {
-      return Collections.singletonList(typeMatch);
+      return Collections.singletonList(new BsonDocument());
     }
 
+    long estimatedDocs = 0;
     try {
-      BsonDocument minDoc =
-          col.find(typeMatch)
-              .projection(new BsonDocument("_id", new BsonInt32(1)))
-              .sort(new BsonDocument("_id", new BsonInt32(1)))
-              .limit(1)
-              .first();
-      BsonDocument maxDoc =
-          col.find(typeMatch)
-              .projection(new BsonDocument("_id", new BsonInt32(1)))
-              .sort(new BsonDocument("_id", new BsonInt32(-1)))
-              .limit(1)
-              .first();
-
-      if (minDoc != null && maxDoc != null && minDoc.containsKey("_id") && maxDoc.containsKey("_id")) {
-        BsonValue minVal = minDoc.get("_id");
-        BsonValue maxVal = maxDoc.get("_id");
-
-        if (minVal.isObjectId() && maxVal.isObjectId()) {
-          String minHex = minVal.asObjectId().getValue().toHexString();
-          String maxHex = maxVal.asObjectId().getValue().toHexString();
-          return generateProbedObjectIdSplits(minHex, maxHex, numSplits);
-        }
-      }
+      estimatedDocs = col.estimatedDocumentCount();
     } catch (Exception e) {
-      LOG.warn("Fast min/max index probe failed in '{}.{}' ({}). Falling back to sample.", col.getNamespace().getDatabaseName(), col.getNamespace().getCollectionName(), e.getMessage());
+      LOG.warn(
+          "Could not estimate document count for '{}.{}': {}",
+          col.getNamespace().getDatabaseName(),
+          col.getNamespace().getCollectionName(),
+          e.getMessage());
     }
 
-    int sampleSize = Math.max(1000, numSplits * 64);
-    List<BsonDocument> pipeline =
+    if (estimatedDocs > 0 && estimatedDocs <= 5000) {
+      return Collections.singletonList(new BsonDocument());
+    }
+
+    List<ProbedTypeBounds> activeTypes = probeActiveTypeBounds(col);
+    if (activeTypes.isEmpty()) {
+      LOG.info(
+          "No active types detected via index probes for '{}.{}'. Using single split.",
+          col.getNamespace().getDatabaseName(),
+          col.getNamespace().getCollectionName());
+      return Collections.singletonList(new BsonDocument());
+    }
+
+    if (activeTypes.size() == 1) {
+      return generateSplitsForTypeBounds(col, activeTypes.get(0), numSplits);
+    }
+
+    // Mixed collection: allocate splits across active types without cross-type queries
+    int splitsPerType = Math.max(1, numSplits / activeTypes.size());
+    List<BsonDocument> combinedFilters = new ArrayList<>();
+    for (ProbedTypeBounds bounds : activeTypes) {
+      combinedFilters.addAll(generateSplitsForTypeBounds(col, bounds, splitsPerType));
+    }
+    return combinedFilters;
+  }
+
+  private static List<BsonDocument> generateSplitsForTypeBounds(
+      MongoCollection<BsonDocument> col, ProbedTypeBounds bounds, int splits) {
+    if (splits <= 1) {
+      return Collections.singletonList(
+          new BsonDocument("_id", new BsonDocument("$type", bounds.getBucket().getTypeValue())));
+    }
+
+    // Try fast unfiltered $sample for quantile boundaries
+    int sampleSize = Math.min(1000, Math.max(256, splits * 32));
+    List<BsonDocument> samplePipeline =
         Arrays.asList(
-            new BsonDocument("$match", typeMatch),
             new BsonDocument("$sample", new BsonDocument("size", new BsonInt32(sampleSize))),
             new BsonDocument("$project", new BsonDocument("_id", new BsonInt32(1))),
             new BsonDocument("$sort", new BsonDocument("_id", new BsonInt32(1))));
 
     List<BsonValue> sampledKeys = new ArrayList<>();
-    for (BsonDocument doc :
-        col.aggregate(pipeline).allowDiskUse(true).maxTime(30, TimeUnit.SECONDS)) {
-      if (doc.containsKey("_id")) {
-        sampledKeys.add(doc.get("_id"));
+    try {
+      for (BsonDocument doc : col.aggregate(samplePipeline).maxTime(5, TimeUnit.SECONDS)) {
+        if (doc.containsKey("_id")) {
+          sampledKeys.add(doc.get("_id"));
+        }
+      }
+    } catch (Exception e) {
+      LOG.warn(
+          "Unfiltered $sample failed for '{}.{}' ({}). Using probed boundary fallback.",
+          col.getNamespace().getDatabaseName(),
+          col.getNamespace().getCollectionName(),
+          e.getMessage());
+    }
+
+    // Filter sampled keys to this specific type
+    List<BsonValue> typeKeys = new ArrayList<>();
+    for (BsonValue k : sampledKeys) {
+      if (matchesType(k, bounds.getBucket())) {
+        typeKeys.add(k);
       }
     }
 
-    if (sampledKeys.size() < numSplits) {
-      throw new IllegalArgumentException(
-          "Insufficient sample size: sampled "
-              + sampledKeys.size()
-              + " keys, required at least "
-              + numSplits);
-    }
-
-    List<BsonValue> boundaries = new ArrayList<>();
-    int step = sampledKeys.size() / numSplits;
-    for (int i = 1; i < numSplits; i++) {
-      BsonValue boundary = sampledKeys.get(i * step);
-      if (!boundaries.isEmpty() && boundary.equals(boundaries.get(boundaries.size() - 1))) {
-        throw new IllegalArgumentException("Sampled quantile boundaries contain duplicates");
-      }
-      boundaries.add(boundary);
-    }
-
-    List<BsonDocument> slices = new ArrayList<>();
-    for (int i = 0; i < numSplits; i++) {
-      BsonDocument idDoc = new BsonDocument();
-      BsonDocument typeMatchId = typeMatch.getDocument("_id");
-      for (String key : typeMatchId.keySet()) {
-        idDoc.append(key, typeMatchId.get(key));
+    if (typeKeys.size() >= splits) {
+      typeKeys.sort(BSON_VALUE_COMPARATOR);
+      List<BsonValue> boundaries = new ArrayList<>();
+      int step = typeKeys.size() / splits;
+      for (int i = 1; i < splits; i++) {
+        BsonValue b = typeKeys.get(i * step);
+        if (boundaries.isEmpty() || !b.equals(boundaries.get(boundaries.size() - 1))) {
+          boundaries.add(b);
+        }
       }
 
-      if (i == 0) {
-        idDoc.append("$lt", boundaries.get(0));
-      } else if (i == numSplits - 1) {
-        idDoc.append("$gte", boundaries.get(boundaries.size() - 1));
-      } else {
-        idDoc.append("$gte", boundaries.get(i - 1)).append("$lt", boundaries.get(i));
+      if (!boundaries.isEmpty()) {
+        List<BsonDocument> partitions = new ArrayList<>();
+        int boundaryCount = boundaries.size();
+        for (int i = 0; i <= boundaryCount; i++) {
+          BsonDocument filter = new BsonDocument();
+          BsonDocument idDoc = new BsonDocument("$type", bounds.getBucket().getTypeValue());
+          if (i == 0) {
+            idDoc.append("$lte", boundaries.get(0));
+          } else if (i == boundaryCount) {
+            idDoc.append("$gt", boundaries.get(boundaryCount - 1));
+          } else {
+            idDoc.append("$gt", boundaries.get(i - 1)).append("$lte", boundaries.get(i));
+          }
+          filter.append("_id", idDoc);
+          partitions.add(filter);
+        }
+        return partitions;
       }
-      slices.add(new BsonDocument("_id", idDoc));
     }
-    return slices;
+
+    // Fallback: If ObjectId, use probed min/max interpolation
+    if ("objectId".equals(bounds.getBucket().getName())
+        && bounds.getMinKey().isObjectId()
+        && bounds.getMaxKey().isObjectId()) {
+      return generateProbedObjectIdSplits(
+          bounds.getMinKey().asObjectId().getValue().toHexString(),
+          bounds.getMaxKey().asObjectId().getValue().toHexString(),
+          splits);
+    }
+
+    // Fallback: If Number, use $mod
+    if ("number".equals(bounds.getBucket().getName())) {
+      return generateNumberFilters(splits);
+    }
+
+    // Fallback: If String, use string bounds
+    if ("string".equals(bounds.getBucket().getName())) {
+      return generateStringFilters(splits);
+    }
+
+    return Collections.singletonList(
+        new BsonDocument("_id", new BsonDocument("$type", bounds.getBucket().getTypeValue())));
   }
+
+  private static boolean matchesType(BsonValue k, TypeBucket bucket) {
+    if (k == null) {
+      return false;
+    }
+    switch (bucket.getName()) {
+      case "number":
+        return k.isInt32() || k.isInt64() || k.isDouble() || k.isDecimal128();
+      case "string":
+        return k.isString();
+      case "objectId":
+        return k.isObjectId();
+      case "binData":
+        return k.isBinary();
+      case "object":
+        return k.isDocument();
+      case "date":
+        return k.isDateTime();
+      default:
+        return false;
+    }
+  }
+
+  public static final Comparator<BsonValue> BSON_VALUE_COMPARATOR =
+      (a, b) -> {
+        if (a == b) {
+          return 0;
+        }
+        if (a == null) {
+          return -1;
+        }
+        if (b == null) {
+          return 1;
+        }
+        if (a.isObjectId() && b.isObjectId()) {
+          return a.asObjectId().compareTo(b.asObjectId());
+        }
+        if (a.isString() && b.isString()) {
+          return a.asString().getValue().compareTo(b.asString().getValue());
+        }
+        if (a.isInt32() && b.isInt32()) {
+          return Integer.compare(a.asInt32().getValue(), b.asInt32().getValue());
+        }
+        if (a.isInt64() && b.isInt64()) {
+          return Long.compare(a.asInt64().getValue(), b.asInt64().getValue());
+        }
+        if (a.isDouble() && b.isDouble()) {
+          return Double.compare(a.asDouble().getValue(), b.asDouble().getValue());
+        }
+        if (a.isDecimal128() && b.isDecimal128()) {
+          return a.asDecimal128().getValue().compareTo(b.asDecimal128().getValue());
+        }
+        if (a.isDateTime() && b.isDateTime()) {
+          return Long.compare(a.asDateTime().getValue(), b.asDateTime().getValue());
+        }
+        if (a.isBinary() && b.isBinary()) {
+          return Arrays.compare(a.asBinary().getData(), b.asBinary().getData());
+        }
+        return a.toString().compareTo(b.toString());
+      };
 
   /**
    * Generates contiguous, uniform ObjectId splits interpolated between actual probed min/max hex keys.

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/ReadSplitGenerator.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/ReadSplitGenerator.java
@@ -26,6 +26,9 @@ import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
@@ -251,43 +254,76 @@ public final class ReadSplitGenerator {
   }
 
   /**
-   * Performs lightweight covered index seeks (<26ms) to detect all active BSON types and their
-   * min/max boundaries.
+   * Performs lightweight covered index seeks (<26ms) in parallel using a dedicated ExecutorService
+   * to detect all active BSON types and their min/max boundaries without blocking sequentially.
    */
   public static List<ProbedTypeBounds> probeActiveTypeBounds(MongoCollection<BsonDocument> col) {
     List<ProbedTypeBounds> activeBounds = new ArrayList<>();
-    for (TypeBucket bucket : KNOWN_TYPE_BUCKETS) {
-      try {
-        BsonDocument minDoc =
+    ExecutorService executor =
+        Executors.newFixedThreadPool(
+            Math.min(KNOWN_TYPE_BUCKETS.size(), 6),
+            r -> {
+              Thread t = new Thread(r);
+              t.setDaemon(true);
+              return t;
+            });
+    try {
+      List<Future<ProbedTypeBounds>> futures = new ArrayList<>();
+      for (TypeBucket bucket : KNOWN_TYPE_BUCKETS) {
+        futures.add(executor.submit(() -> probeBucket(col, bucket)));
+      }
+      for (Future<ProbedTypeBounds> future : futures) {
+        try {
+          ProbedTypeBounds bounds = future.get(5, TimeUnit.SECONDS);
+          if (bounds != null) {
+            activeBounds.add(bounds);
+          }
+        } catch (Exception e) {
+          LOG.warn(
+              "Covered index probe future failed on '{}.{}': {}",
+              getDbName(col),
+              getColName(col),
+              e.getMessage());
+        }
+      }
+    } finally {
+      executor.shutdown();
+    }
+    return activeBounds;
+  }
+
+  private static ProbedTypeBounds probeBucket(
+      MongoCollection<BsonDocument> col, TypeBucket bucket) {
+    try {
+      BsonDocument minDoc =
+          col.find(bucket.query())
+              .projection(new BsonDocument("_id", new BsonInt32(1)))
+              .sort(new BsonDocument("_id", new BsonInt32(1)))
+              .limit(1)
+              .maxTime(3, TimeUnit.SECONDS)
+              .first();
+      if (minDoc != null && minDoc.containsKey("_id")) {
+        BsonDocument maxDoc =
             col.find(bucket.query())
                 .projection(new BsonDocument("_id", new BsonInt32(1)))
-                .sort(new BsonDocument("_id", new BsonInt32(1)))
+                .sort(new BsonDocument("_id", new BsonInt32(-1)))
                 .limit(1)
                 .maxTime(3, TimeUnit.SECONDS)
                 .first();
-        if (minDoc != null && minDoc.containsKey("_id")) {
-          BsonDocument maxDoc =
-              col.find(bucket.query())
-                  .projection(new BsonDocument("_id", new BsonInt32(1)))
-                  .sort(new BsonDocument("_id", new BsonInt32(-1)))
-                  .limit(1)
-                  .maxTime(3, TimeUnit.SECONDS)
-                  .first();
-          BsonValue minVal = minDoc.get("_id");
-          BsonValue maxVal =
-              (maxDoc != null && maxDoc.containsKey("_id")) ? maxDoc.get("_id") : minVal;
-          activeBounds.add(new ProbedTypeBounds(bucket, minVal, maxVal));
-        }
-      } catch (Exception e) {
-        LOG.warn(
-            "Covered index probe failed for type '{}' on '{}.{}': {}",
-            bucket.getName(),
-            getDbName(col),
-            getColName(col),
-            e.getMessage());
+        BsonValue minVal = minDoc.get("_id");
+        BsonValue maxVal =
+            (maxDoc != null && maxDoc.containsKey("_id")) ? maxDoc.get("_id") : minVal;
+        return new ProbedTypeBounds(bucket, minVal, maxVal);
       }
+    } catch (Exception e) {
+      LOG.warn(
+          "Covered index probe failed for type '{}' on '{}.{}': {}",
+          bucket.getName(),
+          getDbName(col),
+          getColName(col),
+          e.getMessage());
     }
-    return activeBounds;
+    return null;
   }
 
   /**

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/StatefulDeduplication.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/StatefulDeduplication.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.teleport.v2.transforms;
 
+import com.google.cloud.teleport.v2.transforms.DocumentWithMetadata.OperationType;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.metrics.Counter;
@@ -23,6 +24,10 @@ import org.apache.beam.sdk.state.StateSpec;
 import org.apache.beam.sdk.state.StateSpecs;
 import org.apache.beam.sdk.state.ValueState;
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.Element;
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
+import org.apache.beam.sdk.transforms.DoFn.ProcessElement;
+import org.apache.beam.sdk.transforms.DoFn.StateId;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
@@ -49,7 +54,7 @@ import org.slf4j.LoggerFactory;
 public class StatefulDeduplication
     extends PTransform<PCollection<DocumentWithMetadata>, PCollection<DocumentWithMetadata>> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(StatefulDeduplication.class);
+  private StatefulDeduplication() {}
 
   public static StatefulDeduplication of() {
     return new StatefulDeduplication();
@@ -83,6 +88,9 @@ public class StatefulDeduplication
   public static class StatefulDeduplicationFn
       extends DoFn<KV<String, DocumentWithMetadata>, DocumentWithMetadata> {
 
+    private static final Logger LOG = LoggerFactory.getLogger(StatefulDeduplicationFn.class);
+    private static final String STATE_ID_LAST_SEEN_KEY = "lastSeenKey";
+
     private final Counter dedupAccepted =
         Metrics.counter(StatefulDeduplicationFn.class, "dedup_accepted");
     private final Counter dedupDropped =
@@ -100,13 +108,13 @@ public class StatefulDeduplication
     private final Counter dedupPassthrough =
         Metrics.counter(StatefulDeduplicationFn.class, "dedup_passthrough");
 
-    @StateId("lastSeenKey")
+    @StateId(STATE_ID_LAST_SEEN_KEY)
     private final StateSpec<ValueState<TimestampSortKey>> lastSeenKeySpec =
         StateSpecs.value(TimestampSortKeyCoder.of());
 
     private void recordAccepted(DocumentWithMetadata element) {
       dedupAccepted.inc();
-      if (element.getOperationType() == DocumentWithMetadata.OperationType.BACKFILL) {
+      if (element.getOperationType() == OperationType.BACKFILL) {
         dedupBackfillAccepted.inc();
       } else {
         dedupCdcAccepted.inc();
@@ -115,7 +123,7 @@ public class StatefulDeduplication
 
     private void recordDropped(DocumentWithMetadata element) {
       dedupDropped.inc();
-      if (element.getOperationType() == DocumentWithMetadata.OperationType.BACKFILL) {
+      if (element.getOperationType() == OperationType.BACKFILL) {
         dedupBackfillDropped.inc();
       } else {
         dedupCdcDropped.inc();
@@ -126,7 +134,7 @@ public class StatefulDeduplication
     public void processElement(
         @Element KV<String, DocumentWithMetadata> kv,
         OutputReceiver<DocumentWithMetadata> receiver,
-        @StateId("lastSeenKey") ValueState<TimestampSortKey> lastSeenState) {
+        @StateId(STATE_ID_LAST_SEEN_KEY) ValueState<TimestampSortKey> lastSeenState) {
 
       DocumentWithMetadata element = kv.getValue();
       if (element == null) {
@@ -157,37 +165,30 @@ public class StatefulDeduplication
 
       int cmp = incomingKey.compareTo(lastSeenKey);
 
-      if (element.isDlqReconsumed()) {
-        // DLQ retry: only apply if no newer event arrived while in DLQ
-        if (cmp >= 0) {
-          lastSeenState.write(incomingKey);
+      if (cmp >= 0) {
+        // Incoming event is newer than or equal to last seen state
+        lastSeenState.write(incomingKey);
+        recordAccepted(element);
+        if (element.isDlqReconsumed()) {
           dedupDlqPassed.inc();
-          recordAccepted(element);
-          receiver.output(element);
-        } else {
-          recordDropped(element);
+        }
+        receiver.output(element);
+      } else {
+        // Stale event arrived out-of-order or stale DLQ retry
+        recordDropped(element);
+        if (element.isDlqReconsumed()) {
           LOG.debug(
               "Dropping stale DLQ retry for key '{}'. Incoming: {}, Last seen: {}",
               kv.getKey(),
               incomingKey,
               lastSeenKey);
+        } else {
+          LOG.debug(
+              "Dropping out-of-order event for key '{}'. Incoming: {}, Last seen: {}",
+              kv.getKey(),
+              incomingKey,
+              lastSeenKey);
         }
-        return;
-      }
-
-      if (cmp >= 0) {
-        // Incoming event is newer than or equal to last seen state
-        lastSeenState.write(incomingKey);
-        recordAccepted(element);
-        receiver.output(element);
-      } else {
-        // Stale event arrived out-of-order (e.g., backfill snapshot arrived after live CDC event)
-        recordDropped(element);
-        LOG.debug(
-            "Dropping out-of-order event for key '{}'. Incoming: {}, Last seen: {}",
-            kv.getKey(),
-            incomingKey,
-            lastSeenKey);
       }
     }
   }

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/StatefulDeduplication.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/StatefulDeduplication.java
@@ -38,13 +38,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Stateful deduplication PTransform that enforces monotonic ordering per document key
- * across concurrent backfill and change streams.
+ * Stateful deduplication PTransform that enforces monotonic ordering per document key across
+ * concurrent backfill and change streams.
  *
- * <p>Uses Beam {@link ValueState} to track the highest {@link TimestampSortKey} observed
- * for each document (keyed by {@code collection#{_id}}).
+ * <p>Uses Beam {@link ValueState} to track the highest {@link TimestampSortKey} observed for each
+ * document (keyed by {@code collection#{_id}}).
  *
  * <p>3-Tier Comparison Rules:
+ *
  * <ol>
  *   <li>Epoch seconds: Higher timestamp wins.
  *   <li>Stream precedence: At identical epoch second $T_0$, live CDC wins over Backfill.
@@ -82,9 +83,7 @@ public class StatefulDeduplication
         .apply("DeduplicateStateful", ParDo.of(new StatefulDeduplicationFn()));
   }
 
-  /**
-   * Stateful DoFn maintaining the latest observed timestamp per document key.
-   */
+  /** Stateful DoFn maintaining the latest observed timestamp per document key. */
   public static class StatefulDeduplicationFn
       extends DoFn<KV<String, DocumentWithMetadata>, DocumentWithMetadata> {
 

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/StatefulDeduplication.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/StatefulDeduplication.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.transforms;
+
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.state.StateSpec;
+import org.apache.beam.sdk.state.StateSpecs;
+import org.apache.beam.sdk.state.ValueState;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Stateful deduplication PTransform that enforces monotonic ordering per document key
+ * across concurrent backfill and change streams.
+ *
+ * <p>Uses Beam {@link ValueState} to track the highest {@link TimestampSortKey} observed
+ * for each document (keyed by {@code collection#{_id}}).
+ *
+ * <p>3-Tier Comparison Rules:
+ * <ol>
+ *   <li>Epoch seconds: Higher timestamp wins.
+ *   <li>Stream precedence: At identical epoch second $T_0$, live CDC wins over Backfill.
+ *   <li>Sub-second increment: Higher sub-second counter wins.
+ * </ol>
+ */
+public class StatefulDeduplication
+    extends PTransform<PCollection<DocumentWithMetadata>, PCollection<DocumentWithMetadata>> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StatefulDeduplication.class);
+
+  public static StatefulDeduplication of() {
+    return new StatefulDeduplication();
+  }
+
+  @Override
+  public PCollection<DocumentWithMetadata> expand(PCollection<DocumentWithMetadata> input) {
+    return input
+        .apply("EnsureGlobalWindow", Window.into(new GlobalWindows()))
+        .apply(
+            "KeyByDedupKey",
+            ParDo.of(
+                new DoFn<DocumentWithMetadata, KV<String, DocumentWithMetadata>>() {
+                  @ProcessElement
+                  public void processElement(
+                      @Element DocumentWithMetadata element,
+                      OutputReceiver<KV<String, DocumentWithMetadata>> receiver) {
+                    if (element != null) {
+                      String key = element.getDedupKey();
+                      receiver.output(KV.of(key, element));
+                    }
+                  }
+                }))
+        .setCoder(KvCoder.of(StringUtf8Coder.of(), DocumentWithMetadataCoder.of()))
+        .apply("DeduplicateStateful", ParDo.of(new StatefulDeduplicationFn()));
+  }
+
+  /**
+   * Stateful DoFn maintaining the latest observed timestamp per document key.
+   */
+  public static class StatefulDeduplicationFn
+      extends DoFn<KV<String, DocumentWithMetadata>, DocumentWithMetadata> {
+
+    private final Counter dedupAccepted =
+        Metrics.counter(StatefulDeduplicationFn.class, "dedup_accepted");
+    private final Counter dedupDropped =
+        Metrics.counter(StatefulDeduplicationFn.class, "dedup_dropped");
+    private final Counter dedupDlqPassed =
+        Metrics.counter(StatefulDeduplicationFn.class, "dedup_dlq_passed");
+    private final Counter dedupBackfillAccepted =
+        Metrics.counter(StatefulDeduplicationFn.class, "dedup_backfill_accepted");
+    private final Counter dedupCdcAccepted =
+        Metrics.counter(StatefulDeduplicationFn.class, "dedup_cdc_accepted");
+    private final Counter dedupBackfillDropped =
+        Metrics.counter(StatefulDeduplicationFn.class, "dedup_backfill_dropped");
+    private final Counter dedupCdcDropped =
+        Metrics.counter(StatefulDeduplicationFn.class, "dedup_cdc_dropped");
+    private final Counter dedupPassthrough =
+        Metrics.counter(StatefulDeduplicationFn.class, "dedup_passthrough");
+
+    @StateId("lastSeenKey")
+    private final StateSpec<ValueState<TimestampSortKey>> lastSeenKeySpec =
+        StateSpecs.value(TimestampSortKeyCoder.of());
+
+    private void recordAccepted(DocumentWithMetadata element) {
+      dedupAccepted.inc();
+      if (element.getOperationType() == DocumentWithMetadata.OperationType.BACKFILL) {
+        dedupBackfillAccepted.inc();
+      } else {
+        dedupCdcAccepted.inc();
+      }
+    }
+
+    private void recordDropped(DocumentWithMetadata element) {
+      dedupDropped.inc();
+      if (element.getOperationType() == DocumentWithMetadata.OperationType.BACKFILL) {
+        dedupBackfillDropped.inc();
+      } else {
+        dedupCdcDropped.inc();
+      }
+    }
+
+    @ProcessElement
+    public void processElement(
+        @Element KV<String, DocumentWithMetadata> kv,
+        OutputReceiver<DocumentWithMetadata> receiver,
+        @StateId("lastSeenKey") ValueState<TimestampSortKey> lastSeenState) {
+
+      DocumentWithMetadata element = kv.getValue();
+      if (element == null) {
+        return;
+      }
+
+      TimestampSortKey incomingKey = element.getTimestampSortKey();
+      if (incomingKey == null) {
+        // Elements without timestamps (e.g. legacy/batch) pass through unconditionally
+        dedupPassthrough.inc();
+        recordAccepted(element);
+        receiver.output(element);
+        return;
+      }
+
+      TimestampSortKey lastSeenKey = lastSeenState.read();
+
+      if (lastSeenKey == null) {
+        // First time seeing this document key
+        lastSeenState.write(incomingKey);
+        recordAccepted(element);
+        if (element.isDlqReconsumed()) {
+          dedupDlqPassed.inc();
+        }
+        receiver.output(element);
+        return;
+      }
+
+      int cmp = incomingKey.compareTo(lastSeenKey);
+
+      if (element.isDlqReconsumed()) {
+        // DLQ retry: only apply if no newer event arrived while in DLQ
+        if (cmp >= 0) {
+          lastSeenState.write(incomingKey);
+          dedupDlqPassed.inc();
+          recordAccepted(element);
+          receiver.output(element);
+        } else {
+          recordDropped(element);
+          LOG.debug(
+              "Dropping stale DLQ retry for key '{}'. Incoming: {}, Last seen: {}",
+              kv.getKey(),
+              incomingKey,
+              lastSeenKey);
+        }
+        return;
+      }
+
+      if (cmp >= 0) {
+        // Incoming event is newer than or equal to last seen state
+        lastSeenState.write(incomingKey);
+        recordAccepted(element);
+        receiver.output(element);
+      } else {
+        // Stale event arrived out-of-order (e.g., backfill snapshot arrived after live CDC event)
+        recordDropped(element);
+        LOG.debug(
+            "Dropping out-of-order event for key '{}'. Incoming: {}, Last seen: {}",
+            kv.getKey(),
+            incomingKey,
+            lastSeenKey);
+      }
+    }
+  }
+}

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/TimestampSortKey.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/TimestampSortKey.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.transforms;
+
+import java.io.Serializable;
+import java.util.Objects;
+import org.apache.beam.sdk.coders.DefaultCoder;
+
+/**
+ * Composite monotonic sort key for MongoDB change events and backfill reads.
+ *
+ * <p>Disentangles cross-domain timestamp comparisons by ordering:
+ *
+ * <ol>
+ *   <li>Epoch seconds (MongoDB oplog/clusterTime timestamp seconds vs backfill start seconds).
+ *   <li>Stream type precedence: Live CDC mutations (INSERT, UPDATE, REPLACE, DELETE) strictly
+ *       supersede Backfill snapshot reads within the exact same second.
+ *   <li>Sub-second ordering within the same stream type:
+ *       <ul>
+ *         <li>For CDC: MongoDB oplog increment counter (BsonTimestamp ordinal increment).
+ *         <li>For Backfill: Sub-second / monotonic extraction order.
+ *       </ul>
+ * </ol>
+ */
+@DefaultCoder(TimestampSortKeyCoder.class)
+public class TimestampSortKey implements Serializable, Comparable<TimestampSortKey> {
+  private static final long serialVersionUID = 1L;
+
+  private final long seconds;
+  private final long subSeconds;
+  private final boolean isCdc;
+
+  public TimestampSortKey(long seconds, long subSeconds, boolean isCdc) {
+    this.seconds = seconds;
+    this.subSeconds = subSeconds;
+    this.isCdc = isCdc;
+  }
+
+  public static TimestampSortKey of(long seconds, long subSeconds, boolean isCdc) {
+    return new TimestampSortKey(seconds, subSeconds, isCdc);
+  }
+
+  public static TimestampSortKey cdc(long seconds, long inc) {
+    return new TimestampSortKey(seconds, inc, true);
+  }
+
+  public static TimestampSortKey backfill(long seconds) {
+    return new TimestampSortKey(seconds, 0L, false);
+  }
+
+  public static TimestampSortKey backfill(long seconds, long subSeconds) {
+    return new TimestampSortKey(seconds, subSeconds, false);
+  }
+
+  public long getSeconds() {
+    return seconds;
+  }
+
+  public long getTimestampSeconds() {
+    return seconds;
+  }
+
+  public long getSubSeconds() {
+    return subSeconds;
+  }
+
+  public long getTimestampSubSeconds() {
+    return subSeconds;
+  }
+
+  public boolean isCdc() {
+    return isCdc;
+  }
+
+  public boolean getIsCdc() {
+    return isCdc;
+  }
+
+  @Override
+  public int compareTo(TimestampSortKey other) {
+    if (other == null) {
+      throw new NullPointerException("Cannot compare TimestampSortKey with null");
+    }
+    // 1. Primary: Compare epoch seconds
+    if (this.seconds != other.seconds) {
+      return Long.compare(this.seconds, other.seconds);
+    }
+    // 2. Stream type precedence: Live CDC strictly supersedes Backfill snapshot within the same
+    // second
+    if (this.isCdc && !other.isCdc) {
+      return 1;
+    }
+    if (!this.isCdc && other.isCdc) {
+      return -1;
+    }
+    // 3. Sub-second ordering within the same stream type
+    return Long.compare(this.subSeconds, other.subSeconds);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TimestampSortKey)) {
+      return false;
+    }
+    TimestampSortKey that = (TimestampSortKey) o;
+    return seconds == that.seconds && subSeconds == that.subSeconds && isCdc == that.isCdc;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(seconds, subSeconds, isCdc);
+  }
+
+  @Override
+  public String toString() {
+    return seconds + ":" + subSeconds + ":" + (isCdc ? "cdc" : "backfill");
+  }
+}

--- a/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/TimestampSortKeyCoder.java
+++ b/v2/mongodb-to-mongodb/src/main/java/com/google/cloud/teleport/v2/transforms/TimestampSortKeyCoder.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.transforms;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.beam.sdk.coders.AtomicCoder;
+import org.apache.beam.sdk.coders.BigEndianLongCoder;
+import org.apache.beam.sdk.coders.BooleanCoder;
+
+/**
+ * Deterministic binary coder for {@link TimestampSortKey}.
+ *
+ * <p>Encodes sort keys into a compact binary format:
+ *
+ * <ul>
+ *   <li>Presence flag (1 byte boolean)
+ *   <li>Epoch seconds (8 bytes via {@link BigEndianLongCoder})
+ *   <li>Sub-second ordering / oplog increment (8 bytes via {@link BigEndianLongCoder})
+ *   <li>Stream type / isCdc flag (1 byte via {@link BooleanCoder})
+ * </ul>
+ */
+public class TimestampSortKeyCoder extends AtomicCoder<TimestampSortKey> {
+
+  private static final TimestampSortKeyCoder INSTANCE = new TimestampSortKeyCoder();
+  private static final BigEndianLongCoder LONG_CODER = BigEndianLongCoder.of();
+  private static final BooleanCoder BOOLEAN_CODER = BooleanCoder.of();
+
+  private TimestampSortKeyCoder() {}
+
+  public static TimestampSortKeyCoder of() {
+    return INSTANCE;
+  }
+
+  @Override
+  public void encode(TimestampSortKey value, OutputStream outStream) throws IOException {
+    if (value == null) {
+      BOOLEAN_CODER.encode(false, outStream);
+      return;
+    }
+    BOOLEAN_CODER.encode(true, outStream);
+    LONG_CODER.encode(value.getSeconds(), outStream);
+    LONG_CODER.encode(value.getSubSeconds(), outStream);
+    BOOLEAN_CODER.encode(value.isCdc(), outStream);
+  }
+
+  @Override
+  public TimestampSortKey decode(InputStream inStream) throws IOException {
+    boolean isPresent = BOOLEAN_CODER.decode(inStream);
+    if (!isPresent) {
+      return null;
+    }
+    long seconds = LONG_CODER.decode(inStream);
+    long subSeconds = LONG_CODER.decode(inStream);
+    boolean isCdc = BOOLEAN_CODER.decode(inStream);
+    return TimestampSortKey.of(seconds, subSeconds, isCdc);
+  }
+
+  @Override
+  public void verifyDeterministic() throws NonDeterministicException {
+    LONG_CODER.verifyDeterministic();
+    BOOLEAN_CODER.verifyDeterministic();
+  }
+}

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDbTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDbTest.java
@@ -58,7 +58,9 @@ public class MongoDbToMongoDbTest {
     assertEquals(Integer.valueOf(10), options.getMaxConcurrentAsyncWrites());
     assertEquals(Integer.valueOf(3), options.getMaxWriteRetries());
     assertEquals(Integer.valueOf(3), options.getDlqMaxRetries());
-    assertEquals(Integer.valueOf(1), options.getNumBackfillSplits());
+    assertEquals(Integer.valueOf(200000), options.getTargetBackfillChunkSize());
+    assertEquals(Integer.valueOf(256), options.getMaxBackfillSplits());
+    assertEquals(Integer.valueOf(128), options.getMaxConcurrentBackfillReads());
     assertEquals(Integer.valueOf(64), options.getNumWriteShards());
     assertEquals(Integer.valueOf(200), options.getMaxBufferingDurationMs());
     assertEquals(Boolean.FALSE, options.getReadFromDlq());
@@ -77,7 +79,9 @@ public class MongoDbToMongoDbTest {
       "--numChangeStreamSplits=4",
       "--changeStreamFullDocument=whenAvailable",
       "--startAtOperationTime=1700000000",
-      "--numBackfillSplits=8",
+      "--targetBackfillChunkSize=100000",
+      "--maxBackfillSplits=128",
+      "--maxConcurrentBackfillReads=64",
       "--numWriteShards=128",
       "--maxBufferingDurationMs=100",
       "--batchSize=1000",
@@ -97,7 +101,9 @@ public class MongoDbToMongoDbTest {
     assertEquals(Integer.valueOf(4), options.getNumChangeStreamSplits());
     assertEquals("whenAvailable", options.getChangeStreamFullDocument());
     assertEquals("1700000000", options.getStartAtOperationTime());
-    assertEquals(Integer.valueOf(8), options.getNumBackfillSplits());
+    assertEquals(Integer.valueOf(100000), options.getTargetBackfillChunkSize());
+    assertEquals(Integer.valueOf(128), options.getMaxBackfillSplits());
+    assertEquals(Integer.valueOf(64), options.getMaxConcurrentBackfillReads());
     assertEquals(Integer.valueOf(128), options.getNumWriteShards());
     assertEquals(Integer.valueOf(100), options.getMaxBufferingDurationMs());
     assertEquals(Integer.valueOf(1000), options.getBatchSize());

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDbTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDbTest.java
@@ -48,8 +48,7 @@ public class MongoDbToMongoDbTest {
 
   @Test
   public void options_defaultValues() {
-    MongoDbToMongoDb.Options options =
-        PipelineOptionsFactory.as(MongoDbToMongoDb.Options.class);
+    MongoDbToMongoDb.Options options = PipelineOptionsFactory.as(MongoDbToMongoDb.Options.class);
 
     assertEquals("BACKFILL_AND_STREAMING", options.getMigrationMode());
     assertEquals(Integer.valueOf(1), options.getNumChangeStreamSplits());
@@ -135,8 +134,7 @@ public class MongoDbToMongoDbTest {
     DoFn<DocumentWithMetadata, DocumentWithMetadata>.ProcessContext context =
         mock(DoFn.ProcessContext.class);
 
-    DocumentWithMetadata doc =
-        DocumentWithMetadata.of(new Document("_id", 1), "src", "tgt");
+    DocumentWithMetadata doc = DocumentWithMetadata.of(new Document("_id", 1), "src", "tgt");
     when(context.element()).thenReturn(doc);
 
     fn.processElement(context);
@@ -207,8 +205,7 @@ public class MongoDbToMongoDbTest {
     DoFn<DocumentWithMetadata, DocumentWithMetadata>.ProcessContext context =
         mock(DoFn.ProcessContext.class);
 
-    DocumentWithMetadata invalidDoc =
-        DocumentWithMetadata.of(null, "src", "tgt");
+    DocumentWithMetadata invalidDoc = DocumentWithMetadata.of(null, "src", "tgt");
     when(context.element()).thenReturn(invalidDoc);
 
     fn.processElement(context);
@@ -250,12 +247,10 @@ public class MongoDbToMongoDbTest {
   public void parseDlqFn_validJson_outputsDocumentWithMetadata() {
     MongoDbToMongoDb.ParseDlqFn fn = new MongoDbToMongoDb.ParseDlqFn();
 
-    DoFn<String, DocumentWithMetadata>.ProcessContext context =
-        mock(DoFn.ProcessContext.class);
+    DoFn<String, DocumentWithMetadata>.ProcessContext context = mock(DoFn.ProcessContext.class);
 
     Document doc = new Document("_id", 42).append("key", "val");
-    DocumentWithMetadata original =
-        DocumentWithMetadata.of(doc, "src", "tgt");
+    DocumentWithMetadata original = DocumentWithMetadata.of(doc, "src", "tgt");
     String dlqJson = original.toDlqJson("test error", ErrorType.RETRYABLE, 1);
 
     when(context.element()).thenReturn(dlqJson);
@@ -277,8 +272,7 @@ public class MongoDbToMongoDbTest {
   public void parseDlqFn_invalidJson_handlesGracefully() {
     MongoDbToMongoDb.ParseDlqFn fn = new MongoDbToMongoDb.ParseDlqFn();
 
-    DoFn<String, DocumentWithMetadata>.ProcessContext context =
-        mock(DoFn.ProcessContext.class);
+    DoFn<String, DocumentWithMetadata>.ProcessContext context = mock(DoFn.ProcessContext.class);
 
     when(context.element()).thenReturn("invalid json {{{");
 

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDbTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDbTest.java
@@ -29,6 +29,7 @@ import com.google.cloud.teleport.v2.transforms.DocumentWithMetadata.ErrorType;
 import com.google.cloud.teleport.v2.transforms.DocumentWithMetadata.FailureStage;
 import com.google.cloud.teleport.v2.transforms.DocumentWithMetadata.OperationType;
 import com.google.cloud.teleport.v2.transforms.TimestampSortKey;
+import java.time.Instant;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -123,6 +124,25 @@ public class MongoDbToMongoDbTest {
         PipelineOptionsFactory.fromArgs(args).as(MongoDbToMongoDb.Options.class);
 
     assertEquals("BATCH", options.getMigrationMode());
+  }
+
+  @Test
+  public void options_iso8601Timestamp_parsedSuccessfully() {
+    String iso = "2026-09-10T12:00:00Z";
+    String[] args = {
+      "--sourceUri=mongodb://localhost:27017",
+      "--targetUri=mongodb://localhost:27018",
+      "--sourceDatabase=srcDb",
+      "--targetDatabase=tgtDb",
+      "--startAtOperationTime=" + iso
+    };
+
+    MongoDbToMongoDb.Options options =
+        PipelineOptionsFactory.fromArgs(args).as(MongoDbToMongoDb.Options.class);
+
+    assertEquals(iso, options.getStartAtOperationTime());
+    long expectedEpochSec = Instant.parse(iso).getEpochSecond();
+    assertEquals(1789041600L, expectedEpochSec);
   }
 
   @Test

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDbTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDbTest.java
@@ -53,7 +53,7 @@ public class MongoDbToMongoDbTest {
     assertEquals("BACKFILL_AND_STREAMING", options.getMigrationMode());
     assertEquals(Integer.valueOf(1), options.getNumChangeStreamSplits());
     assertEquals("updateLookup", options.getChangeStreamFullDocument());
-    assertEquals(Integer.valueOf(5000), options.getBatchSize());
+    assertEquals(Integer.valueOf(5000), options.getWriteBatchSize());
     assertEquals(Integer.valueOf(10), options.getMaxConcurrentAsyncWrites());
     assertEquals(Integer.valueOf(3), options.getMaxWriteRetries());
     assertEquals(Integer.valueOf(3), options.getDlqMaxRetries());
@@ -83,7 +83,7 @@ public class MongoDbToMongoDbTest {
       "--maxConcurrentBackfillReads=64",
       "--numWriteShards=128",
       "--maxBufferingDurationMs=100",
-      "--batchSize=1000",
+      "--writeBatchSize=1000",
       "--maxConcurrentAsyncWrites=20"
     };
 
@@ -105,7 +105,7 @@ public class MongoDbToMongoDbTest {
     assertEquals(Integer.valueOf(64), options.getMaxConcurrentBackfillReads());
     assertEquals(Integer.valueOf(128), options.getNumWriteShards());
     assertEquals(Integer.valueOf(100), options.getMaxBufferingDurationMs());
-    assertEquals(Integer.valueOf(1000), options.getBatchSize());
+    assertEquals(Integer.valueOf(1000), options.getWriteBatchSize());
     assertEquals(Integer.valueOf(20), options.getMaxConcurrentAsyncWrites());
   }
 

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDbTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/templates/MongoDbToMongoDbTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.templates;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.teleport.v2.transforms.DocumentWithMetadata;
+import com.google.cloud.teleport.v2.transforms.DocumentWithMetadata.ErrorType;
+import com.google.cloud.teleport.v2.transforms.DocumentWithMetadata.FailureStage;
+import com.google.cloud.teleport.v2.transforms.DocumentWithMetadata.OperationType;
+import com.google.cloud.teleport.v2.transforms.TimestampSortKey;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.values.TupleTag;
+import org.bson.Document;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+
+/** Unit tests for {@link MongoDbToMongoDb}. */
+@RunWith(JUnit4.class)
+public class MongoDbToMongoDbTest {
+
+  @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+
+  @Test
+  public void options_defaultValues() {
+    MongoDbToMongoDb.Options options =
+        PipelineOptionsFactory.as(MongoDbToMongoDb.Options.class);
+
+    assertEquals("BACKFILL_AND_STREAMING", options.getMigrationMode());
+    assertEquals(Integer.valueOf(1), options.getNumChangeStreamSplits());
+    assertEquals("updateLookup", options.getChangeStreamFullDocument());
+    assertEquals(Integer.valueOf(5000), options.getBatchSize());
+    assertEquals(Integer.valueOf(10), options.getMaxConcurrentAsyncWrites());
+    assertEquals(Integer.valueOf(3), options.getMaxWriteRetries());
+    assertEquals(Integer.valueOf(3), options.getDlqMaxRetries());
+    assertEquals(Integer.valueOf(1), options.getNumBackfillSplits());
+    assertEquals(Integer.valueOf(64), options.getNumWriteShards());
+    assertEquals(Integer.valueOf(200), options.getMaxBufferingDurationMs());
+    assertEquals(Boolean.FALSE, options.getReadFromDlq());
+  }
+
+  @Test
+  public void options_customValues() {
+    String[] args = {
+      "--sourceUri=mongodb://localhost:27017",
+      "--targetUri=mongodb://localhost:27018",
+      "--sourceDatabase=srcDb",
+      "--targetDatabase=tgtDb",
+      "--sourceCollection=srcCol",
+      "--targetCollection=tgtCol",
+      "--migrationMode=STREAMING_CDC",
+      "--numChangeStreamSplits=4",
+      "--changeStreamFullDocument=whenAvailable",
+      "--startAtOperationTime=1700000000",
+      "--numBackfillSplits=8",
+      "--numWriteShards=128",
+      "--maxBufferingDurationMs=100",
+      "--batchSize=1000",
+      "--maxConcurrentAsyncWrites=20"
+    };
+
+    MongoDbToMongoDb.Options options =
+        PipelineOptionsFactory.fromArgs(args).as(MongoDbToMongoDb.Options.class);
+
+    assertEquals("mongodb://localhost:27017", options.getSourceUri());
+    assertEquals("mongodb://localhost:27018", options.getTargetUri());
+    assertEquals("srcDb", options.getSourceDatabase());
+    assertEquals("tgtDb", options.getTargetDatabase());
+    assertEquals("srcCol", options.getSourceCollection());
+    assertEquals("tgtCol", options.getTargetCollection());
+    assertEquals("STREAMING_CDC", options.getMigrationMode());
+    assertEquals(Integer.valueOf(4), options.getNumChangeStreamSplits());
+    assertEquals("whenAvailable", options.getChangeStreamFullDocument());
+    assertEquals("1700000000", options.getStartAtOperationTime());
+    assertEquals(Integer.valueOf(8), options.getNumBackfillSplits());
+    assertEquals(Integer.valueOf(128), options.getNumWriteShards());
+    assertEquals(Integer.valueOf(100), options.getMaxBufferingDurationMs());
+    assertEquals(Integer.valueOf(1000), options.getBatchSize());
+    assertEquals(Integer.valueOf(20), options.getMaxConcurrentAsyncWrites());
+  }
+
+  @Test
+  public void options_batchMode() {
+    String[] args = {
+      "--sourceUri=mongodb://localhost:27017",
+      "--targetUri=mongodb://localhost:27018",
+      "--sourceDatabase=srcDb",
+      "--targetDatabase=tgtDb",
+      "--migrationMode=BATCH"
+    };
+
+    MongoDbToMongoDb.Options options =
+        PipelineOptionsFactory.fromArgs(args).as(MongoDbToMongoDb.Options.class);
+
+    assertEquals("BATCH", options.getMigrationMode());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void validateFn_validInsertDocument_outputsToMainTag() {
+    TupleTag<DocumentWithMetadata> failureTag = new TupleTag<DocumentWithMetadata>() {};
+    MongoDbToMongoDb.ValidateFn fn = new MongoDbToMongoDb.ValidateFn(failureTag);
+
+    DoFn<DocumentWithMetadata, DocumentWithMetadata>.ProcessContext context =
+        mock(DoFn.ProcessContext.class);
+
+    DocumentWithMetadata doc =
+        DocumentWithMetadata.of(new Document("_id", 1), "src", "tgt");
+    when(context.element()).thenReturn(doc);
+
+    fn.processElement(context);
+
+    verify(context).output(doc);
+    verify(context, never()).output(eq(failureTag), any());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void validateFn_validDeleteEvent_outputsToMainTag() {
+    TupleTag<DocumentWithMetadata> failureTag = new TupleTag<DocumentWithMetadata>() {};
+    MongoDbToMongoDb.ValidateFn fn = new MongoDbToMongoDb.ValidateFn(failureTag);
+
+    DoFn<DocumentWithMetadata, DocumentWithMetadata>.ProcessContext context =
+        mock(DoFn.ProcessContext.class);
+
+    String docKey = "{\"_id\": 100}";
+    DocumentWithMetadata deleteDoc =
+        DocumentWithMetadata.cdcEvent(
+            null,
+            null,
+            "src",
+            "tgt",
+            OperationType.DELETE,
+            TimestampSortKey.cdc(1700000000L, 1),
+            docKey);
+    when(context.element()).thenReturn(deleteDoc);
+
+    fn.processElement(context);
+
+    verify(context).output(deleteDoc);
+    verify(context, never()).output(eq(failureTag), any());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void validateFn_validDropEvent_outputsToMainTag() {
+    TupleTag<DocumentWithMetadata> failureTag = new TupleTag<DocumentWithMetadata>() {};
+    MongoDbToMongoDb.ValidateFn fn = new MongoDbToMongoDb.ValidateFn(failureTag);
+
+    DoFn<DocumentWithMetadata, DocumentWithMetadata>.ProcessContext context =
+        mock(DoFn.ProcessContext.class);
+
+    DocumentWithMetadata dropDoc =
+        DocumentWithMetadata.cdcEvent(
+            null,
+            null,
+            "src",
+            "tgt",
+            OperationType.DROP,
+            TimestampSortKey.cdc(1700000000L, 1),
+            null);
+    when(context.element()).thenReturn(dropDoc);
+
+    fn.processElement(context);
+
+    verify(context).output(dropDoc);
+    verify(context, never()).output(eq(failureTag), any());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void validateFn_nullPayloadNonDelete_outputsToFailureTag() {
+    TupleTag<DocumentWithMetadata> failureTag = new TupleTag<DocumentWithMetadata>() {};
+    MongoDbToMongoDb.ValidateFn fn = new MongoDbToMongoDb.ValidateFn(failureTag);
+
+    DoFn<DocumentWithMetadata, DocumentWithMetadata>.ProcessContext context =
+        mock(DoFn.ProcessContext.class);
+
+    DocumentWithMetadata invalidDoc =
+        DocumentWithMetadata.of(null, "src", "tgt");
+    when(context.element()).thenReturn(invalidDoc);
+
+    fn.processElement(context);
+
+    ArgumentCaptor<DocumentWithMetadata> captor =
+        ArgumentCaptor.forClass(DocumentWithMetadata.class);
+    verify(context).output(eq(failureTag), captor.capture());
+
+    DocumentWithMetadata failure = captor.getValue();
+    assertEquals(ErrorType.PERMANENT, failure.getErrorType());
+    assertEquals(FailureStage.VALIDATE, failure.getFailureStage());
+    assertEquals("Null document payload", failure.getErrorMessage());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void validateFn_nullItem_outputsToFailureTag() {
+    TupleTag<DocumentWithMetadata> failureTag = new TupleTag<DocumentWithMetadata>() {};
+    MongoDbToMongoDb.ValidateFn fn = new MongoDbToMongoDb.ValidateFn(failureTag);
+
+    DoFn<DocumentWithMetadata, DocumentWithMetadata>.ProcessContext context =
+        mock(DoFn.ProcessContext.class);
+
+    when(context.element()).thenReturn(null);
+
+    fn.processElement(context);
+
+    ArgumentCaptor<DocumentWithMetadata> captor =
+        ArgumentCaptor.forClass(DocumentWithMetadata.class);
+    verify(context).output(eq(failureTag), captor.capture());
+
+    DocumentWithMetadata failure = captor.getValue();
+    assertEquals(ErrorType.PERMANENT, failure.getErrorType());
+    assertEquals(FailureStage.VALIDATE, failure.getFailureStage());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void parseDlqFn_validJson_outputsDocumentWithMetadata() {
+    MongoDbToMongoDb.ParseDlqFn fn = new MongoDbToMongoDb.ParseDlqFn();
+
+    DoFn<String, DocumentWithMetadata>.ProcessContext context =
+        mock(DoFn.ProcessContext.class);
+
+    Document doc = new Document("_id", 42).append("key", "val");
+    DocumentWithMetadata original =
+        DocumentWithMetadata.of(doc, "src", "tgt");
+    String dlqJson = original.toDlqJson("test error", ErrorType.RETRYABLE, 1);
+
+    when(context.element()).thenReturn(dlqJson);
+
+    fn.processElement(context);
+
+    ArgumentCaptor<DocumentWithMetadata> captor =
+        ArgumentCaptor.forClass(DocumentWithMetadata.class);
+    verify(context).output(captor.capture());
+
+    DocumentWithMetadata result = captor.getValue();
+    assertNotNull(result);
+    assertEquals(Integer.valueOf(42), result.getDocument().get("_id"));
+    assertEquals("src", result.getSourceCollection());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void parseDlqFn_invalidJson_handlesGracefully() {
+    MongoDbToMongoDb.ParseDlqFn fn = new MongoDbToMongoDb.ParseDlqFn();
+
+    DoFn<String, DocumentWithMetadata>.ProcessContext context =
+        mock(DoFn.ProcessContext.class);
+
+    when(context.element()).thenReturn("invalid json {{{");
+
+    fn.processElement(context);
+
+    verify(context, never()).output(any());
+  }
+}

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadataCoderTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadataCoderTest.java
@@ -115,6 +115,45 @@ public class DocumentWithMetadataCoderTest {
   }
 
   @Test
+  public void testEncodeDecode_lazyOriginalDoc_omitsDuplicateString() throws IOException {
+    Document doc = new Document("_id", 999).append("data", "some large text payload");
+    DocumentWithMetadata item = DocumentWithMetadata.of(doc, "users", "users_target");
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DocumentWithMetadataCoder.of().encode(item, out);
+
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    DocumentWithMetadata decoded = DocumentWithMetadataCoder.of().decode(in);
+
+    assertNotNull(decoded);
+    assertEquals(999, decoded.getId());
+    assertEquals("some large text payload", decoded.getDocument().getString("data"));
+    assertEquals(item.getOriginalDocument(), decoded.getOriginalDocument());
+  }
+
+  @Test
+  public void testEncodeDecode_distinctOriginalDoc_afterUdfTransformation() throws IOException {
+    Document originalDoc = new Document("_id", 10).append("count", 1);
+    DocumentWithMetadata item = DocumentWithMetadata.of(originalDoc, "stats", "stats");
+
+    // Simulate UDF transformation: doc is transformed, originalDoc is preserved
+    Document transformedDoc = new Document("_id", 10).append("count", 2).append("udf", true);
+    DocumentWithMetadata transformedItem = item.withDocument(transformedDoc);
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DocumentWithMetadataCoder.of().encode(transformedItem, out);
+
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    DocumentWithMetadata decoded = DocumentWithMetadataCoder.of().decode(in);
+
+    assertNotNull(decoded);
+    assertEquals(10, decoded.getId());
+    assertEquals(Integer.valueOf(2), decoded.getDocument().getInteger("count"));
+    assertEquals(true, decoded.getDocument().getBoolean("udf"));
+    assertEquals(item.getOriginalDocument(), decoded.getOriginalDocument());
+  }
+
+  @Test
   public void testCoderProperties_deterministic() throws Exception {
     Document doc = new Document("_id", "123").append("k", "v");
     DocumentWithMetadata item1 = DocumentWithMetadata.of(doc, "s", "t");

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadataCoderTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadataCoderTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.transforms;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.apache.beam.sdk.testing.CoderProperties;
+import org.bson.Document;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link DocumentWithMetadataCoder}. */
+@RunWith(JUnit4.class)
+public class DocumentWithMetadataCoderTest {
+
+  @Test
+  public void testEncodeDecode_fullObjectRoundTrip() throws IOException {
+    Document doc = new Document("_id", "doc123").append("name", "Alice").append("age", 30);
+    TimestampSortKey key = TimestampSortKey.cdc(1724000000L, 10L);
+
+    DocumentWithMetadata original =
+        new DocumentWithMetadata(
+            doc,
+            doc.toJson(),
+            2,
+            "Rate limit exceeded",
+            DocumentWithMetadata.ErrorType.RETRYABLE,
+            "sourceCol",
+            "targetCol",
+            DocumentWithMetadata.FailureStage.WRITE,
+            DocumentWithMetadata.OperationType.UPDATE,
+            key,
+            "{\"_id\": \"doc123\"}",
+            true);
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DocumentWithMetadataCoder.of().encode(original, out);
+
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    DocumentWithMetadata decoded = DocumentWithMetadataCoder.of().decode(in);
+
+    assertNotNull(decoded);
+    assertEquals("doc123", decoded.getId());
+    assertEquals("Alice", decoded.getDocument().getString("name"));
+    assertEquals(Integer.valueOf(30), decoded.getDocument().getInteger("age"));
+    assertEquals(Integer.valueOf(2), decoded.getRetryCount());
+    assertEquals("Rate limit exceeded", decoded.getErrorMessage());
+    assertEquals(DocumentWithMetadata.ErrorType.RETRYABLE, decoded.getErrorType());
+    assertEquals("sourceCol", decoded.getSourceCollection());
+    assertEquals("targetCol", decoded.getTargetCollection());
+    assertEquals(DocumentWithMetadata.FailureStage.WRITE, decoded.getFailureStage());
+    assertEquals(DocumentWithMetadata.OperationType.UPDATE, decoded.getOperationType());
+    assertEquals(key, decoded.getTimestampSortKey());
+    assertEquals("{\"_id\": \"doc123\"}", decoded.getDocumentKey());
+    assertTrue(decoded.isDlqReconsumed());
+  }
+
+  @Test
+  public void testEncodeDecode_nullDocumentForDeleteEvent() throws IOException {
+    TimestampSortKey key = TimestampSortKey.cdc(1724000000L, 5L);
+
+    DocumentWithMetadata deleteEvent =
+        DocumentWithMetadata.cdcEvent(
+            null,
+            null,
+            "sourceCol",
+            "targetCol",
+            DocumentWithMetadata.OperationType.DELETE,
+            key,
+            "{\"_id\": \"docToDelete\"}");
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DocumentWithMetadataCoder.of().encode(deleteEvent, out);
+
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    DocumentWithMetadata decoded = DocumentWithMetadataCoder.of().decode(in);
+
+    assertNotNull(decoded);
+    assertNull(decoded.getDocument());
+    assertEquals(DocumentWithMetadata.OperationType.DELETE, decoded.getOperationType());
+    assertEquals("{\"_id\": \"docToDelete\"}", decoded.getDocumentKey());
+    assertEquals("docToDelete", decoded.getId());
+    assertEquals(key, decoded.getTimestampSortKey());
+  }
+
+  @Test
+  public void testEncodeDecode_nullHandling() throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DocumentWithMetadataCoder.of().encode(null, out);
+
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    DocumentWithMetadata decoded = DocumentWithMetadataCoder.of().decode(in);
+
+    assertNull(decoded);
+  }
+
+  @Test
+  public void testCoderProperties_deterministic() throws Exception {
+    Document doc = new Document("_id", "123").append("k", "v");
+    DocumentWithMetadata item1 = DocumentWithMetadata.of(doc, "s", "t");
+    DocumentWithMetadata item2 = DocumentWithMetadata.of(doc, "s", "t");
+
+    CoderProperties.coderDeterministic(DocumentWithMetadataCoder.of(), item1, item2);
+  }
+}

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadataTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadataTest.java
@@ -20,12 +20,18 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.bson.Document;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+import org.bson.types.ObjectId;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class DocumentWithMetadataTest {
+
+  private static final JsonWriterSettings EXTENDED_JSON =
+      JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
 
   @Test
   public void documentWithMetadata_toAndFromDlqJson_roundTrip() {
@@ -206,5 +212,53 @@ public class DocumentWithMetadataTest {
 
     assertEquals(item1.getDedupKey(), item2.getDedupKey());
     assertTrue(item1.getDedupKey().startsWith("targetCol#"));
+  }
+
+  @Test
+  public void getDedupKey_shardedCdcAndBackfill_produceMatchingKeys() {
+    ObjectId id = new ObjectId();
+    Document doc = new Document("_id", id).append("customerId", 12345).append("name", "acme");
+
+    DocumentWithMetadata backfill =
+        DocumentWithMetadata.backfillEvent(
+            doc, "srcCol", "tgtCol", TimestampSortKey.backfill(100L));
+
+    // On a sharded collection the change stream documentKey also carries the shard key fields.
+    String shardedDocumentKey =
+        new Document("customerId", 12345).append("_id", id).toJson(EXTENDED_JSON);
+    DocumentWithMetadata cdc =
+        DocumentWithMetadata.cdcEvent(
+            doc,
+            doc.toJson(),
+            "srcCol",
+            "tgtCol",
+            DocumentWithMetadata.OperationType.UPDATE,
+            TimestampSortKey.cdc(100L, 1L),
+            shardedDocumentKey);
+
+    assertEquals(backfill.getDedupKey(), cdc.getDedupKey());
+  }
+
+  @Test
+  public void getDedupKey_unshardedCdcAndBackfill_produceMatchingKeys() {
+    ObjectId id = new ObjectId();
+    Document doc = new Document("_id", id).append("name", "acme");
+
+    DocumentWithMetadata backfill =
+        DocumentWithMetadata.backfillEvent(
+            doc, "srcCol", "tgtCol", TimestampSortKey.backfill(100L));
+
+    String unshardedDocumentKey = new Document("_id", id).toJson(EXTENDED_JSON);
+    DocumentWithMetadata cdc =
+        DocumentWithMetadata.cdcEvent(
+            doc,
+            doc.toJson(),
+            "srcCol",
+            "tgtCol",
+            DocumentWithMetadata.OperationType.UPDATE,
+            TimestampSortKey.cdc(100L, 1L),
+            unshardedDocumentKey);
+
+    assertEquals(backfill.getDedupKey(), cdc.getDedupKey());
   }
 }

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadataTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadataTest.java
@@ -193,4 +193,18 @@ public class DocumentWithMetadataTest {
     assertEquals("sourceCol", updated.getSourceCollection());
     assertEquals("targetCol", updated.getTargetCollection());
   }
+
+  @Test
+  public void getDedupKey_withoutId_producesDeterministicKey() {
+    Document docWithoutId = new Document("name", "no_id_test").append("num", 42);
+    DocumentWithMetadata item1 =
+        DocumentWithMetadata.of(
+            docWithoutId, docWithoutId.toJson(), 0, null, null, "sourceCol", "targetCol");
+    DocumentWithMetadata item2 =
+        DocumentWithMetadata.of(
+            docWithoutId, docWithoutId.toJson(), 0, null, null, "sourceCol", "targetCol");
+
+    assertEquals(item1.getDedupKey(), item2.getDedupKey());
+    assertTrue(item1.getDedupKey().startsWith("targetCol#"));
+  }
 }

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadataTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/DocumentWithMetadataTest.java
@@ -139,4 +139,58 @@ public class DocumentWithMetadataTest {
     DocumentWithMetadata item = DocumentWithMetadata.of(doc);
     assertEquals(null, item.getId());
   }
+
+  @Test
+  public void documentWithMetadata_cdcEvent_andDlqRoundTrip() {
+    TimestampSortKey key = TimestampSortKey.cdc(1724000000L, 7L);
+    DocumentWithMetadata cdcEvent =
+        DocumentWithMetadata.cdcEvent(
+            null,
+            null,
+            "srcCol",
+            "tgtCol",
+            DocumentWithMetadata.OperationType.DELETE,
+            key,
+            "{\"_id\": 999}");
+
+    assertEquals(DocumentWithMetadata.OperationType.DELETE, cdcEvent.getOperationType());
+    assertTrue(cdcEvent.getOperationType().isDelete());
+    assertEquals(999, cdcEvent.getId());
+    assertEquals(key, cdcEvent.getTimestampSortKey());
+
+    String dlqJson = cdcEvent.toDlqJson("Delete target doc not found", RETRYABLE, 2);
+    DocumentWithMetadata reconstructed = DocumentWithMetadata.fromDlqJson(dlqJson);
+
+    assertEquals(DocumentWithMetadata.OperationType.DELETE, reconstructed.getOperationType());
+    assertEquals("{\"_id\": 999}", reconstructed.getDocumentKey());
+    assertEquals(999, reconstructed.getId());
+    assertEquals(key, reconstructed.getTimestampSortKey());
+    assertEquals(Integer.valueOf(2), reconstructed.getRetryCount());
+    assertTrue(reconstructed.isDlqReconsumed());
+  }
+
+  @Test
+  public void documentWithMetadata_withDocument_preservesCdcMetadata() {
+    TimestampSortKey key = TimestampSortKey.cdc(1724000000L, 5L);
+    Document originalDoc = new Document("_id", 100).append("val", "before");
+    DocumentWithMetadata item =
+        DocumentWithMetadata.cdcEvent(
+            originalDoc,
+            originalDoc.toJson(),
+            "sourceCol",
+            "targetCol",
+            DocumentWithMetadata.OperationType.UPDATE,
+            key,
+            "{\"_id\": 100}");
+
+    Document transformedDoc = new Document("_id", 100).append("val", "after");
+    DocumentWithMetadata updated = item.withDocument(transformedDoc);
+
+    assertEquals(transformedDoc, updated.getDocument());
+    assertEquals(DocumentWithMetadata.OperationType.UPDATE, updated.getOperationType());
+    assertEquals(key, updated.getTimestampSortKey());
+    assertEquals("{\"_id\": 100}", updated.getDocumentKey());
+    assertEquals("sourceCol", updated.getSourceCollection());
+    assertEquals("targetCol", updated.getTargetCollection());
+  }
 }

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReaderTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReaderTest.java
@@ -135,11 +135,14 @@ public class MongoDbBackfillReaderTest {
   @Test
   public void backfillPartition_equalsAndHashCode() {
     BackfillPartition p1 =
-        new BackfillPartition("uri", "db", "src", "tgt", "{}", TimestampSortKey.backfill(100), 0, 2);
+        new BackfillPartition(
+            "uri", "db", "src", "tgt", "{}", TimestampSortKey.backfill(100), 0, 2);
     BackfillPartition p2 =
-        new BackfillPartition("uri", "db", "src", "tgt", "{}", TimestampSortKey.backfill(100), 0, 2);
+        new BackfillPartition(
+            "uri", "db", "src", "tgt", "{}", TimestampSortKey.backfill(100), 0, 2);
     BackfillPartition p3 =
-        new BackfillPartition("uri", "db", "src", "tgt", "{}", TimestampSortKey.backfill(100), 1, 2);
+        new BackfillPartition(
+            "uri", "db", "src", "tgt", "{}", TimestampSortKey.backfill(100), 1, 2);
 
     assertEquals(p1, p2);
     assertEquals(p1.hashCode(), p2.hashCode());
@@ -149,7 +152,8 @@ public class MongoDbBackfillReaderTest {
   @Test
   public void backfillPartition_toString_containsDetails() {
     BackfillPartition p =
-        new BackfillPartition("uri", "db", "src", "tgt", "{}", TimestampSortKey.backfill(100), 0, 2);
+        new BackfillPartition(
+            "uri", "db", "src", "tgt", "{}", TimestampSortKey.backfill(100), 0, 2);
     String str = p.toString();
     assertTrue(str.contains("src"));
     assertTrue(str.contains("0/2"));
@@ -184,18 +188,23 @@ public class MongoDbBackfillReaderTest {
         new MongoDbBackfillReader.BackfillRestrictionTracker(initial);
 
     assertEquals(initial, tracker.currentRestriction());
-    assertTrue(tracker.tryClaim(new MongoDbBackfillReader.BackfillRestriction(1L, "{\"_id\": 1}", false)));
+    assertTrue(
+        tracker.tryClaim(new MongoDbBackfillReader.BackfillRestriction(1L, "{\"_id\": 1}", false)));
     assertEquals(1L, tracker.currentRestriction().getOffset());
 
-    org.apache.beam.sdk.transforms.splittabledofn.SplitResult<MongoDbBackfillReader.BackfillRestriction> split =
-        tracker.trySplit(0.0);
+    org.apache.beam.sdk.transforms.splittabledofn.SplitResult<
+            MongoDbBackfillReader.BackfillRestriction>
+        split = tracker.trySplit(0.0);
     assertNotNull(split);
     assertEquals(1L, split.getPrimary().getOffset());
     assertEquals(1L, split.getResidual().getOffset());
 
     // After stop, claiming returns false
-    assertFalse(tracker.tryClaim(new MongoDbBackfillReader.BackfillRestriction(2L, "{\"_id\": 2}", false)));
-    assertEquals(org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.IsBounded.BOUNDED, tracker.isBounded());
+    assertFalse(
+        tracker.tryClaim(new MongoDbBackfillReader.BackfillRestriction(2L, "{\"_id\": 2}", false)));
+    assertEquals(
+        org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.IsBounded.BOUNDED,
+        tracker.isBounded());
   }
 
   @Test
@@ -235,17 +244,14 @@ public class MongoDbBackfillReaderTest {
     MongoDbBackfillReader.ProcessBackfillPartitionFn fn =
         new MongoDbBackfillReader.ProcessBackfillPartitionFn(uri -> mockClient);
 
-    MongoDbBackfillReader.BackfillRestriction restriction =
-        fn.getInitialRestriction(partition);
+    MongoDbBackfillReader.BackfillRestriction restriction = fn.getInitialRestriction(partition);
     MongoDbBackfillReader.BackfillRestrictionTracker tracker =
         fn.newTracker(partition, restriction);
     assertNotNull(fn.getRestrictionCoder());
 
-    DoFn.OutputReceiver<DocumentWithMetadata> receiver =
-        mock(DoFn.OutputReceiver.class);
+    DoFn.OutputReceiver<DocumentWithMetadata> receiver = mock(DoFn.OutputReceiver.class);
 
-    DoFn.ProcessContinuation continuation =
-        fn.processElement(partition, tracker, receiver);
+    DoFn.ProcessContinuation continuation = fn.processElement(partition, tracker, receiver);
 
     assertEquals(DoFn.ProcessContinuation.stop(), continuation);
 
@@ -304,11 +310,9 @@ public class MongoDbBackfillReaderTest {
     MongoDbBackfillReader.BackfillRestrictionTracker tracker =
         fn.newTracker(partition, resumedRestriction);
 
-    DoFn.OutputReceiver<DocumentWithMetadata> receiver =
-        mock(DoFn.OutputReceiver.class);
+    DoFn.OutputReceiver<DocumentWithMetadata> receiver = mock(DoFn.OutputReceiver.class);
 
-    DoFn.ProcessContinuation continuation =
-        fn.processElement(partition, tracker, receiver);
+    DoFn.ProcessContinuation continuation = fn.processElement(partition, tracker, receiver);
 
     assertEquals(DoFn.ProcessContinuation.stop(), continuation);
     verify(receiver, org.mockito.Mockito.times(1)).output(any());
@@ -323,7 +327,9 @@ public class MongoDbBackfillReaderTest {
 
     when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
     when(mockDb.getCollection(anyString())).thenReturn(mockCol);
-    when(mockCol.find(any(Bson.class))).thenThrow(new com.mongodb.MongoSocketException("Socket error", new com.mongodb.ServerAddress()));
+    when(mockCol.find(any(Bson.class)))
+        .thenThrow(
+            new com.mongodb.MongoSocketException("Socket error", new com.mongodb.ServerAddress()));
 
     BackfillPartition partition =
         new BackfillPartition(
@@ -339,16 +345,13 @@ public class MongoDbBackfillReaderTest {
     MongoDbBackfillReader.ProcessBackfillPartitionFn fn =
         new MongoDbBackfillReader.ProcessBackfillPartitionFn(uri -> mockClient);
 
-    MongoDbBackfillReader.BackfillRestriction restriction =
-        fn.getInitialRestriction(partition);
+    MongoDbBackfillReader.BackfillRestriction restriction = fn.getInitialRestriction(partition);
     MongoDbBackfillReader.BackfillRestrictionTracker tracker =
         fn.newTracker(partition, restriction);
 
-    DoFn.OutputReceiver<DocumentWithMetadata> receiver =
-        mock(DoFn.OutputReceiver.class);
+    DoFn.OutputReceiver<DocumentWithMetadata> receiver = mock(DoFn.OutputReceiver.class);
 
-    DoFn.ProcessContinuation continuation =
-        fn.processElement(partition, tracker, receiver);
+    DoFn.ProcessContinuation continuation = fn.processElement(partition, tracker, receiver);
 
     assertNotNull(continuation);
     assertTrue(continuation.shouldResume());
@@ -358,9 +361,7 @@ public class MongoDbBackfillReaderTest {
   public void readPartitions_emptyPartitions_expandsSuccessfully() {
     Pipeline p = Pipeline.create();
     PCollection<DocumentWithMetadata> docs =
-        p.apply(
-            "ReadEmpty",
-            new MongoDbBackfillReader.ReadPartitions(Collections.emptyList()));
+        p.apply("ReadEmpty", new MongoDbBackfillReader.ReadPartitions(Collections.emptyList()));
     assertNotNull(docs);
   }
 
@@ -433,14 +434,7 @@ public class MongoDbBackfillReaderTest {
     for (int i = 0; i < 3; i++) {
       partitions.add(
           new BackfillPartition(
-              "mongodb://localhost:27017",
-              "testDb",
-              "col",
-              "col_tgt",
-              null,
-              null,
-              i,
-              3));
+              "mongodb://localhost:27017", "testDb", "col", "col_tgt", null, null, i, 3));
     }
 
     List<MongoDbBackfillReader.BackfillSlotTask> tasks =
@@ -496,7 +490,8 @@ public class MongoDbBackfillReaderTest {
     tracker.checkDone();
 
     // After done, tryClaim returns false
-    assertFalse(tracker.tryClaim(new MongoDbBackfillReader.BackfillSlotRestriction(3, 0L, null, true)));
+    assertFalse(
+        tracker.tryClaim(new MongoDbBackfillReader.BackfillSlotRestriction(3, 0L, null, true)));
   }
 
   @Test
@@ -506,7 +501,8 @@ public class MongoDbBackfillReaderTest {
     MongoDbBackfillReader.BackfillSlotRestrictionTracker tracker =
         new MongoDbBackfillReader.BackfillSlotRestrictionTracker(restriction);
 
-    org.apache.beam.sdk.transforms.splittabledofn.SplitResult<MongoDbBackfillReader.BackfillSlotRestriction>
+    org.apache.beam.sdk.transforms.splittabledofn.SplitResult<
+            MongoDbBackfillReader.BackfillSlotRestriction>
         split = tracker.trySplit(0.0);
     assertNotNull(split);
     assertEquals(0, split.getPrimary().getPartitionIndexInSlot());
@@ -611,7 +607,8 @@ public class MongoDbBackfillReaderTest {
     assertFalse(tracker.currentRestriction().isDone());
 
     // Split checkpoint produces residual with partitionIndex=1, done=false
-    org.apache.beam.sdk.transforms.splittabledofn.SplitResult<MongoDbBackfillReader.BackfillSlotRestriction>
+    org.apache.beam.sdk.transforms.splittabledofn.SplitResult<
+            MongoDbBackfillReader.BackfillSlotRestriction>
         split = tracker.trySplit(0.0);
     assertNotNull(split);
     assertEquals(1, split.getResidual().getPartitionIndexInSlot());

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReaderTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReaderTest.java
@@ -33,6 +33,8 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.beam.sdk.Pipeline;
@@ -379,6 +381,274 @@ public class MongoDbBackfillReaderTest {
         p.apply(
             "ReadPartitions",
             new MongoDbBackfillReader.ReadPartitions(Collections.singletonList(partition)));
+    assertNotNull(docs);
+  }
+
+  @Test
+  public void backfillSlotTask_distribute_roundRobinInterleaving() {
+    List<BackfillPartition> partitions = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      partitions.add(
+          new BackfillPartition(
+              "mongodb://localhost:27017",
+              "testDb",
+              "col",
+              "col_tgt",
+              "{\"slice\": " + i + "}",
+              null,
+              i,
+              10));
+    }
+
+    List<MongoDbBackfillReader.BackfillSlotTask> tasks =
+        MongoDbBackfillReader.BackfillSlotTask.distribute(partitions, 4);
+
+    assertEquals(4, tasks.size());
+    // Slot 0 gets indices 0, 4, 8
+    assertEquals(3, tasks.get(0).getPartitions().size());
+    assertEquals(0, tasks.get(0).getPartitions().get(0).getPartitionIndex());
+    assertEquals(4, tasks.get(0).getPartitions().get(1).getPartitionIndex());
+    assertEquals(8, tasks.get(0).getPartitions().get(2).getPartitionIndex());
+
+    // Slot 1 gets indices 1, 5, 9
+    assertEquals(3, tasks.get(1).getPartitions().size());
+    assertEquals(1, tasks.get(1).getPartitions().get(0).getPartitionIndex());
+    assertEquals(5, tasks.get(1).getPartitions().get(1).getPartitionIndex());
+    assertEquals(9, tasks.get(1).getPartitions().get(2).getPartitionIndex());
+
+    // Slot 2 gets indices 2, 6
+    assertEquals(2, tasks.get(2).getPartitions().size());
+    assertEquals(2, tasks.get(2).getPartitions().get(0).getPartitionIndex());
+    assertEquals(6, tasks.get(2).getPartitions().get(1).getPartitionIndex());
+
+    // Slot 3 gets indices 3, 7
+    assertEquals(2, tasks.get(3).getPartitions().size());
+    assertEquals(3, tasks.get(3).getPartitions().get(0).getPartitionIndex());
+    assertEquals(7, tasks.get(3).getPartitions().get(1).getPartitionIndex());
+  }
+
+  @Test
+  public void backfillSlotTask_distribute_fewerPartitionsThanSlots() {
+    List<BackfillPartition> partitions = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      partitions.add(
+          new BackfillPartition(
+              "mongodb://localhost:27017",
+              "testDb",
+              "col",
+              "col_tgt",
+              null,
+              null,
+              i,
+              3));
+    }
+
+    List<MongoDbBackfillReader.BackfillSlotTask> tasks =
+        MongoDbBackfillReader.BackfillSlotTask.distribute(partitions, 128);
+
+    assertEquals(3, tasks.size());
+    for (int i = 0; i < 3; i++) {
+      assertEquals(1, tasks.get(i).getPartitions().size());
+      assertEquals(i, tasks.get(i).getSlotId());
+    }
+  }
+
+  @Test
+  public void backfillSlotTask_distribute_emptyPartitionsReturnsEmpty() {
+    List<MongoDbBackfillReader.BackfillSlotTask> tasks =
+        MongoDbBackfillReader.BackfillSlotTask.distribute(Collections.emptyList(), 128);
+    assertTrue(tasks.isEmpty());
+  }
+
+  @Test
+  public void backfillSlotRestrictionTracker_claimAndCompletionLifecycle() {
+    MongoDbBackfillReader.BackfillSlotRestriction restriction =
+        new MongoDbBackfillReader.BackfillSlotRestriction(0, 0L, null, false);
+    MongoDbBackfillReader.BackfillSlotRestrictionTracker tracker =
+        new MongoDbBackfillReader.BackfillSlotRestrictionTracker(restriction);
+
+    assertEquals(0, tracker.currentRestriction().getPartitionIndexInSlot());
+    assertEquals(0L, tracker.currentRestriction().getOffsetInCurrentPartition());
+    assertNull(tracker.currentRestriction().getLastSeenIdJson());
+    assertFalse(tracker.currentRestriction().isDone());
+
+    // Claim progress within partition 0
+    MongoDbBackfillReader.BackfillSlotRestriction nextState =
+        new MongoDbBackfillReader.BackfillSlotRestriction(0, 50L, "{\"_id\": 100}", false);
+    assertTrue(tracker.tryClaim(nextState));
+    assertEquals(0, tracker.currentRestriction().getPartitionIndexInSlot());
+    assertEquals(50L, tracker.currentRestriction().getOffsetInCurrentPartition());
+    assertEquals("{\"_id\": 100}", tracker.currentRestriction().getLastSeenIdJson());
+
+    // Advance to partition 1
+    MongoDbBackfillReader.BackfillSlotRestriction p1State =
+        new MongoDbBackfillReader.BackfillSlotRestriction(1, 0L, null, false);
+    assertTrue(tracker.tryClaim(p1State));
+    assertEquals(1, tracker.currentRestriction().getPartitionIndexInSlot());
+    assertEquals(0L, tracker.currentRestriction().getOffsetInCurrentPartition());
+    assertNull(tracker.currentRestriction().getLastSeenIdJson());
+
+    // Mark slot completed
+    MongoDbBackfillReader.BackfillSlotRestriction doneState =
+        new MongoDbBackfillReader.BackfillSlotRestriction(2, 0L, null, true);
+    assertTrue(tracker.tryClaim(doneState));
+    assertTrue(tracker.currentRestriction().isDone());
+    tracker.checkDone();
+
+    // After done, tryClaim returns false
+    assertFalse(tracker.tryClaim(new MongoDbBackfillReader.BackfillSlotRestriction(3, 0L, null, true)));
+  }
+
+  @Test
+  public void backfillSlotRestrictionTracker_trySplit_preservesUnfinishedResidual() {
+    MongoDbBackfillReader.BackfillSlotRestriction restriction =
+        new MongoDbBackfillReader.BackfillSlotRestriction(0, 50L, "{\"_id\": 100}", false);
+    MongoDbBackfillReader.BackfillSlotRestrictionTracker tracker =
+        new MongoDbBackfillReader.BackfillSlotRestrictionTracker(restriction);
+
+    org.apache.beam.sdk.transforms.splittabledofn.SplitResult<MongoDbBackfillReader.BackfillSlotRestriction>
+        split = tracker.trySplit(0.0);
+    assertNotNull(split);
+    assertEquals(0, split.getPrimary().getPartitionIndexInSlot());
+    assertEquals(50L, split.getPrimary().getOffsetInCurrentPartition());
+    assertFalse(split.getPrimary().isDone());
+
+    assertEquals(0, split.getResidual().getPartitionIndexInSlot());
+    assertEquals(50L, split.getResidual().getOffsetInCurrentPartition());
+    assertEquals("{\"_id\": 100}", split.getResidual().getLastSeenIdJson());
+    assertFalse(split.getResidual().isDone());
+
+    // After split, further claims on this tracker instance must return false
+    assertFalse(
+        tracker.tryClaim(
+            new MongoDbBackfillReader.BackfillSlotRestriction(0, 51L, "{\"_id\": 101}", false)));
+
+    // Second trySplit on stopped tracker returns null
+    assertNull(tracker.trySplit(0.0));
+  }
+
+  @Test
+  public void backfillSlotRestrictionTracker_trySplit_doneTrackerReturnsNull() {
+    MongoDbBackfillReader.BackfillSlotRestriction doneRestriction =
+        new MongoDbBackfillReader.BackfillSlotRestriction(1, 100L, null, true);
+    MongoDbBackfillReader.BackfillSlotRestrictionTracker tracker =
+        new MongoDbBackfillReader.BackfillSlotRestrictionTracker(doneRestriction);
+
+    assertNull(tracker.trySplit(0.0));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void processBackfillSlotFn_readsMultiplePartitionsInSlot() {
+    MongoClient mockClient = mock(MongoClient.class);
+    MongoDatabase mockDb = mock(MongoDatabase.class);
+    MongoCollection<Document> mockCol = mock(MongoCollection.class);
+    FindIterable<Document> mockFindIterable1 = mock(FindIterable.class);
+    FindIterable<Document> mockFindIterable2 = mock(FindIterable.class);
+    MongoCursor<Document> mockCursor1 = mock(MongoCursor.class);
+    MongoCursor<Document> mockCursor2 = mock(MongoCursor.class);
+
+    when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
+    when(mockDb.getCollection(anyString())).thenReturn(mockCol);
+
+    Document doc1 = new Document("_id", 1).append("name", "Item1");
+    Document doc2 = new Document("_id", 2).append("name", "Item2");
+
+    when(mockCursor1.hasNext()).thenReturn(true, false);
+    when(mockCursor1.next()).thenReturn(doc1);
+
+    when(mockCursor2.hasNext()).thenReturn(true, false);
+    when(mockCursor2.next()).thenReturn(doc2);
+
+    when(mockFindIterable1.sort(any(Bson.class))).thenReturn(mockFindIterable1);
+    when(mockFindIterable1.batchSize(anyInt())).thenReturn(mockFindIterable1);
+    when(mockFindIterable1.iterator()).thenReturn(mockCursor1);
+
+    when(mockFindIterable2.sort(any(Bson.class))).thenReturn(mockFindIterable2);
+    when(mockFindIterable2.batchSize(anyInt())).thenReturn(mockFindIterable2);
+    when(mockFindIterable2.iterator()).thenReturn(mockCursor2);
+
+    when(mockCol.find(any(Bson.class))).thenReturn(mockFindIterable1, mockFindIterable2);
+
+    BackfillPartition p1 =
+        new BackfillPartition(
+            "mongodb://localhost:27017",
+            "testDb",
+            "users",
+            "users_target",
+            null,
+            TimestampSortKey.backfill(1700000000L),
+            0,
+            2);
+    BackfillPartition p2 =
+        new BackfillPartition(
+            "mongodb://localhost:27017",
+            "testDb",
+            "users",
+            "users_target",
+            null,
+            TimestampSortKey.backfill(1700000000L),
+            1,
+            2);
+
+    MongoDbBackfillReader.BackfillSlotTask slotTask =
+        new MongoDbBackfillReader.BackfillSlotTask(0, 1, Arrays.asList(p1, p2));
+
+    MongoDbBackfillReader.ProcessBackfillSlotFn fn =
+        new MongoDbBackfillReader.ProcessBackfillSlotFn(uri -> mockClient);
+
+    MongoDbBackfillReader.BackfillSlotRestriction restriction = fn.getInitialRestriction(slotTask);
+    MongoDbBackfillReader.BackfillSlotRestrictionTracker tracker =
+        fn.newTracker(slotTask, restriction);
+    assertNotNull(fn.getRestrictionCoder());
+
+    DoFn.OutputReceiver<DocumentWithMetadata> receiver = mock(DoFn.OutputReceiver.class);
+
+    // First element execution reads partition 0 to EOF and transitions to partition 1
+    DoFn.ProcessContinuation cont1 = fn.processElement(slotTask, tracker, receiver);
+    assertEquals(DoFn.ProcessContinuation.resume(), cont1);
+    assertEquals(1, tracker.currentRestriction().getPartitionIndexInSlot());
+    assertFalse(tracker.currentRestriction().isDone());
+
+    // Split checkpoint produces residual with partitionIndex=1, done=false
+    org.apache.beam.sdk.transforms.splittabledofn.SplitResult<MongoDbBackfillReader.BackfillSlotRestriction>
+        split = tracker.trySplit(0.0);
+    assertNotNull(split);
+    assertEquals(1, split.getResidual().getPartitionIndexInSlot());
+    assertFalse(split.getResidual().isDone());
+
+    // Second element execution runs residual for partition 1 and stops at end of slot
+    MongoDbBackfillReader.BackfillSlotRestrictionTracker tracker2 =
+        fn.newTracker(slotTask, split.getResidual());
+    DoFn.ProcessContinuation cont2 = fn.processElement(slotTask, tracker2, receiver);
+    assertEquals(DoFn.ProcessContinuation.stop(), cont2);
+    assertTrue(tracker2.currentRestriction().isDone());
+
+    ArgumentCaptor<DocumentWithMetadata> captor =
+        ArgumentCaptor.forClass(DocumentWithMetadata.class);
+    verify(receiver, org.mockito.Mockito.times(2)).output(captor.capture());
+    List<DocumentWithMetadata> emitted = captor.getAllValues();
+    assertEquals("Item1", emitted.get(0).getDocument().getString("name"));
+    assertEquals("Item2", emitted.get(1).getDocument().getString("name"));
+  }
+
+  @Test
+  public void readPartitions_withMaxConcurrentReads_expandsSuccessfully() {
+    Pipeline p = Pipeline.create();
+    BackfillPartition partition =
+        new BackfillPartition(
+            "mongodb://localhost:27017",
+            "testDb",
+            "users",
+            "users_target",
+            null,
+            TimestampSortKey.backfill(1700000000L),
+            0,
+            1);
+    PCollection<DocumentWithMetadata> docs =
+        p.apply(
+            "ReadWithConcurrencyLimit",
+            new MongoDbBackfillReader.ReadPartitions(Collections.singletonList(partition), 128));
     assertNotNull(docs);
   }
 }

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReaderTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbBackfillReaderTest.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.transforms;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.teleport.v2.transforms.MongoDbBackfillReader.BackfillPartition;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.MongoDatabase;
+import java.util.Collections;
+import java.util.List;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.values.PCollection;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonTimestamp;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+
+/** Unit tests for {@link MongoDbBackfillReader}. */
+@RunWith(JUnit4.class)
+public class MongoDbBackfillReaderTest {
+
+  @Test
+  public void generatePartitions_withoutTimestamp_returnsSingleRootPartition() {
+    List<BackfillPartition> partitions =
+        MongoDbBackfillReader.generatePartitions(
+            "mongodb://localhost:27017", "testDb", "srcCol", "tgtCol", null);
+
+    assertEquals(1, partitions.size());
+    BackfillPartition partition = partitions.get(0);
+    assertEquals("srcCol", partition.getSourceCollection());
+    assertEquals("tgtCol", partition.getTargetCollection());
+    assertNull(partition.getFilterJson());
+    assertNull(partition.getTimestampSortKey());
+    assertEquals(0, partition.getPartitionIndex());
+    assertEquals(1, partition.getTotalPartitions());
+    assertFalse(partition.hasFilter());
+  }
+
+  @Test
+  public void generatePartitions_withTimestamp_returnsRootPartitionWithSortKey() {
+    BsonTimestamp t0 = new BsonTimestamp(1700000000, 5);
+    List<BackfillPartition> partitions =
+        MongoDbBackfillReader.generatePartitions(
+            "mongodb://localhost:27017", "testDb", "srcCol", "tgtCol", t0);
+
+    assertEquals(1, partitions.size());
+    BackfillPartition partition = partitions.get(0);
+    assertEquals("srcCol", partition.getSourceCollection());
+    assertEquals("tgtCol", partition.getTargetCollection());
+    assertNull(partition.getFilterJson());
+    assertNotNull(partition.getTimestampSortKey());
+    assertEquals(1700000000L, partition.getTimestampSortKey().getSeconds());
+    assertFalse(partition.getTimestampSortKey().isCdc());
+  }
+
+  @Test
+  public void generatePartitions_withNumSplits_returnsCoarsePartitions() {
+    BsonTimestamp t0 = new BsonTimestamp(1700000000, 5);
+    List<BackfillPartition> partitions =
+        MongoDbBackfillReader.generatePartitions(
+            "mongodb://localhost:27017", "testDb", "srcCol", "tgtCol", 4, t0);
+
+    assertEquals(4, partitions.size());
+    for (int i = 0; i < 4; i++) {
+      BackfillPartition p = partitions.get(i);
+      assertEquals("srcCol", p.getSourceCollection());
+      assertEquals("tgtCol", p.getTargetCollection());
+      assertEquals(i, p.getPartitionIndex());
+      assertEquals(4, p.getTotalPartitions());
+      assertNotNull(p.getFilterJson());
+      assertEquals(1700000000L, p.getTimestampSortKey().getSeconds());
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void generatePartitions_withMongoClient_returnsDataDrivenPartitions() {
+    MongoClient mockClient = mock(MongoClient.class);
+    MongoDatabase mockDb = mock(MongoDatabase.class);
+    MongoCollection<BsonDocument> mockCol = mock(MongoCollection.class);
+    FindIterable<BsonDocument> mockFindIterable = mock(FindIterable.class);
+
+    when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
+    when(mockDb.getCollection(anyString(), org.mockito.ArgumentMatchers.eq(BsonDocument.class)))
+        .thenReturn(mockCol);
+    when(mockCol.find(any(BsonDocument.class))).thenReturn(mockFindIterable);
+    when(mockFindIterable.limit(anyInt())).thenReturn(mockFindIterable);
+    when(mockFindIterable.first()).thenReturn(null);
+
+    BsonTimestamp t0 = new BsonTimestamp(1700000000, 5);
+    List<BackfillPartition> partitions =
+        MongoDbBackfillReader.generatePartitions(
+            mockClient, "mongodb://localhost:27017", "testDb", "srcCol", "tgtCol", 2, t0);
+
+    assertEquals(2, partitions.size());
+    assertEquals(0, partitions.get(0).getPartitionIndex());
+    assertEquals(1, partitions.get(1).getPartitionIndex());
+  }
+
+  @Test
+  public void backfillPartition_equalsAndHashCode() {
+    BackfillPartition p1 =
+        new BackfillPartition("uri", "db", "src", "tgt", "{}", TimestampSortKey.backfill(100), 0, 2);
+    BackfillPartition p2 =
+        new BackfillPartition("uri", "db", "src", "tgt", "{}", TimestampSortKey.backfill(100), 0, 2);
+    BackfillPartition p3 =
+        new BackfillPartition("uri", "db", "src", "tgt", "{}", TimestampSortKey.backfill(100), 1, 2);
+
+    assertEquals(p1, p2);
+    assertEquals(p1.hashCode(), p2.hashCode());
+    assertFalse(p1.equals(p3));
+  }
+
+  @Test
+  public void backfillPartition_toString_containsDetails() {
+    BackfillPartition p =
+        new BackfillPartition("uri", "db", "src", "tgt", "{}", TimestampSortKey.backfill(100), 0, 2);
+    String str = p.toString();
+    assertTrue(str.contains("src"));
+    assertTrue(str.contains("0/2"));
+  }
+
+  @Test
+  public void backfillRestriction_propertiesAndLastSeenId() {
+    MongoDbBackfillReader.BackfillRestriction r1 =
+        new MongoDbBackfillReader.BackfillRestriction(10L, "{\"_id\": 123}", false);
+    MongoDbBackfillReader.BackfillRestriction r2 =
+        new MongoDbBackfillReader.BackfillRestriction(10L, "{\"_id\": 123}", false);
+    MongoDbBackfillReader.BackfillRestriction r3 =
+        new MongoDbBackfillReader.BackfillRestriction(20L, null, true);
+
+    assertEquals(10L, r1.getOffset());
+    assertEquals("{\"_id\": 123}", r1.getLastSeenIdJson());
+    assertFalse(r1.isDone());
+    assertEquals(new BsonInt32(123), r1.getLastSeenId());
+
+    assertEquals(r1, r2);
+    assertEquals(r1.hashCode(), r2.hashCode());
+    assertFalse(r1.equals(r3));
+    assertTrue(r1.toString().contains("offset=10"));
+    assertNull(r3.getLastSeenId());
+  }
+
+  @Test
+  public void backfillRestrictionTracker_tryClaimAndSplit() {
+    MongoDbBackfillReader.BackfillRestriction initial =
+        new MongoDbBackfillReader.BackfillRestriction(0L, null, false);
+    MongoDbBackfillReader.BackfillRestrictionTracker tracker =
+        new MongoDbBackfillReader.BackfillRestrictionTracker(initial);
+
+    assertEquals(initial, tracker.currentRestriction());
+    assertTrue(tracker.tryClaim(new MongoDbBackfillReader.BackfillRestriction(1L, "{\"_id\": 1}", false)));
+    assertEquals(1L, tracker.currentRestriction().getOffset());
+
+    org.apache.beam.sdk.transforms.splittabledofn.SplitResult<MongoDbBackfillReader.BackfillRestriction> split =
+        tracker.trySplit(0.0);
+    assertNotNull(split);
+    assertEquals(1L, split.getPrimary().getOffset());
+    assertEquals(1L, split.getResidual().getOffset());
+
+    // After stop, claiming returns false
+    assertFalse(tracker.tryClaim(new MongoDbBackfillReader.BackfillRestriction(2L, "{\"_id\": 2}", false)));
+    assertEquals(org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.IsBounded.BOUNDED, tracker.isBounded());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void processBackfillPartitionFn_readsAndEmitsDocuments() {
+    MongoClient mockClient = mock(MongoClient.class);
+    MongoDatabase mockDb = mock(MongoDatabase.class);
+    MongoCollection<Document> mockCol = mock(MongoCollection.class);
+    FindIterable<Document> mockFindIterable = mock(FindIterable.class);
+    MongoCursor<Document> mockCursor = mock(MongoCursor.class);
+
+    when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
+    when(mockDb.getCollection(anyString())).thenReturn(mockCol);
+    when(mockCol.find(any(Bson.class))).thenReturn(mockFindIterable);
+    when(mockFindIterable.sort(any(Bson.class))).thenReturn(mockFindIterable);
+    when(mockFindIterable.batchSize(anyInt())).thenReturn(mockFindIterable);
+    when(mockFindIterable.iterator()).thenReturn(mockCursor);
+
+    Document doc1 = new Document("_id", 1).append("name", "Alice");
+    Document doc2 = new Document("_id", 2).append("name", "Bob");
+
+    when(mockCursor.hasNext()).thenReturn(true, true, false);
+    when(mockCursor.next()).thenReturn(doc1, doc2);
+
+    TimestampSortKey sortKey = TimestampSortKey.backfill(1700000000L);
+    BackfillPartition partition =
+        new BackfillPartition(
+            "mongodb://localhost:27017",
+            "testDb",
+            "users",
+            "users_target",
+            new BsonDocument("_id", new BsonDocument("$gte", new BsonInt32(0))).toJson(),
+            sortKey,
+            0,
+            1);
+
+    MongoDbBackfillReader.ProcessBackfillPartitionFn fn =
+        new MongoDbBackfillReader.ProcessBackfillPartitionFn(uri -> mockClient);
+
+    MongoDbBackfillReader.BackfillRestriction restriction =
+        fn.getInitialRestriction(partition);
+    MongoDbBackfillReader.BackfillRestrictionTracker tracker =
+        fn.newTracker(partition, restriction);
+    assertNotNull(fn.getRestrictionCoder());
+
+    DoFn.OutputReceiver<DocumentWithMetadata> receiver =
+        mock(DoFn.OutputReceiver.class);
+
+    DoFn.ProcessContinuation continuation =
+        fn.processElement(partition, tracker, receiver);
+
+    assertEquals(DoFn.ProcessContinuation.stop(), continuation);
+
+    ArgumentCaptor<DocumentWithMetadata> captor =
+        ArgumentCaptor.forClass(DocumentWithMetadata.class);
+    verify(receiver, org.mockito.Mockito.times(2)).output(captor.capture());
+
+    List<DocumentWithMetadata> results = captor.getAllValues();
+    assertEquals(2, results.size());
+
+    assertEquals(Integer.valueOf(1), results.get(0).getDocument().get("_id"));
+    assertEquals("users", results.get(0).getSourceCollection());
+    assertEquals("users_target", results.get(0).getTargetCollection());
+    assertEquals(sortKey, results.get(0).getTimestampSortKey());
+
+    assertEquals(Integer.valueOf(2), results.get(1).getDocument().get("_id"));
+    assertEquals("users", results.get(1).getSourceCollection());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void processBackfillPartitionFn_keysetResume_usesLastSeenId() {
+    MongoClient mockClient = mock(MongoClient.class);
+    MongoDatabase mockDb = mock(MongoDatabase.class);
+    MongoCollection<Document> mockCol = mock(MongoCollection.class);
+    FindIterable<Document> mockFindIterable = mock(FindIterable.class);
+    MongoCursor<Document> mockCursor = mock(MongoCursor.class);
+
+    when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
+    when(mockDb.getCollection(anyString())).thenReturn(mockCol);
+    when(mockCol.find(any(Bson.class))).thenReturn(mockFindIterable);
+    when(mockFindIterable.sort(any(Bson.class))).thenReturn(mockFindIterable);
+    when(mockFindIterable.batchSize(anyInt())).thenReturn(mockFindIterable);
+    when(mockFindIterable.iterator()).thenReturn(mockCursor);
+
+    Document doc3 = new Document("_id", 3).append("name", "Charlie");
+    when(mockCursor.hasNext()).thenReturn(true, false);
+    when(mockCursor.next()).thenReturn(doc3);
+
+    BackfillPartition partition =
+        new BackfillPartition(
+            "mongodb://localhost:27017",
+            "testDb",
+            "users",
+            "users_target",
+            null,
+            TimestampSortKey.backfill(1700000000L),
+            0,
+            1);
+
+    MongoDbBackfillReader.ProcessBackfillPartitionFn fn =
+        new MongoDbBackfillReader.ProcessBackfillPartitionFn(uri -> mockClient);
+
+    MongoDbBackfillReader.BackfillRestriction resumedRestriction =
+        new MongoDbBackfillReader.BackfillRestriction(2L, "{\"_id\": 2}", false);
+    MongoDbBackfillReader.BackfillRestrictionTracker tracker =
+        fn.newTracker(partition, resumedRestriction);
+
+    DoFn.OutputReceiver<DocumentWithMetadata> receiver =
+        mock(DoFn.OutputReceiver.class);
+
+    DoFn.ProcessContinuation continuation =
+        fn.processElement(partition, tracker, receiver);
+
+    assertEquals(DoFn.ProcessContinuation.stop(), continuation);
+    verify(receiver, org.mockito.Mockito.times(1)).output(any());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void processBackfillPartitionFn_transientException_returnsResumeWithDelay() {
+    MongoClient mockClient = mock(MongoClient.class);
+    MongoDatabase mockDb = mock(MongoDatabase.class);
+    MongoCollection<Document> mockCol = mock(MongoCollection.class);
+
+    when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
+    when(mockDb.getCollection(anyString())).thenReturn(mockCol);
+    when(mockCol.find(any(Bson.class))).thenThrow(new com.mongodb.MongoSocketException("Socket error", new com.mongodb.ServerAddress()));
+
+    BackfillPartition partition =
+        new BackfillPartition(
+            "mongodb://localhost:27017",
+            "testDb",
+            "users",
+            "users_target",
+            null,
+            TimestampSortKey.backfill(1700000000L),
+            0,
+            1);
+
+    MongoDbBackfillReader.ProcessBackfillPartitionFn fn =
+        new MongoDbBackfillReader.ProcessBackfillPartitionFn(uri -> mockClient);
+
+    MongoDbBackfillReader.BackfillRestriction restriction =
+        fn.getInitialRestriction(partition);
+    MongoDbBackfillReader.BackfillRestrictionTracker tracker =
+        fn.newTracker(partition, restriction);
+
+    DoFn.OutputReceiver<DocumentWithMetadata> receiver =
+        mock(DoFn.OutputReceiver.class);
+
+    DoFn.ProcessContinuation continuation =
+        fn.processElement(partition, tracker, receiver);
+
+    assertNotNull(continuation);
+    assertTrue(continuation.shouldResume());
+  }
+
+  @Test
+  public void readPartitions_emptyPartitions_expandsSuccessfully() {
+    Pipeline p = Pipeline.create();
+    PCollection<DocumentWithMetadata> docs =
+        p.apply(
+            "ReadEmpty",
+            new MongoDbBackfillReader.ReadPartitions(Collections.emptyList()));
+    assertNotNull(docs);
+  }
+
+  @Test
+  public void readPartitions_withPartitions_expandsSuccessfully() {
+    Pipeline p = Pipeline.create();
+    BackfillPartition partition =
+        new BackfillPartition(
+            "mongodb://localhost:27017",
+            "testDb",
+            "users",
+            "users_target",
+            null,
+            TimestampSortKey.backfill(1700000000L),
+            0,
+            1);
+    PCollection<DocumentWithMetadata> docs =
+        p.apply(
+            "ReadPartitions",
+            new MongoDbBackfillReader.ReadPartitions(Collections.singletonList(partition)));
+    assertNotNull(docs);
+  }
+}

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReaderTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReaderTest.java
@@ -1,0 +1,720 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.transforms;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.teleport.v2.transforms.MongoDbChangeStreamReader.ChangeStreamPartition;
+import com.google.cloud.teleport.v2.transforms.MongoDbChangeStreamReader.ChangeStreamRestriction;
+import com.google.cloud.teleport.v2.transforms.MongoDbChangeStreamReader.ChangeStreamRestrictionTracker;
+import com.google.cloud.teleport.v2.transforms.MongoDbChangeStreamReader.ProcessChangeStreamPartitionFn;
+import com.mongodb.client.ChangeStreamIterable;
+import com.mongodb.client.MongoChangeStreamCursor;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import com.mongodb.client.model.changestream.OperationType;
+import java.util.List;
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContinuation;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.SplitResult;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.BsonTimestamp;
+import org.bson.Document;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link MongoDbChangeStreamReader}. */
+@RunWith(JUnit4.class)
+public class MongoDbChangeStreamReaderTest {
+
+  private static ChangeStreamDocument<Document> createEvent(
+      OperationType op, Document fullDoc, BsonDocument docKey, BsonTimestamp timestamp) {
+    return new ChangeStreamDocument<>(
+        op != null ? op.getValue() : null,
+        new BsonDocument(), // resumeToken
+        null, // namespaceDocument
+        null, // namespaceType
+        null, // destinationNamespaceDocument
+        fullDoc,
+        null, // fullDocumentBeforeChange
+        docKey,
+        timestamp,
+        null, // updateDescription
+        null, // txnNumber
+        null, // lsid
+        null, // wallTime
+        null, // splitEvent
+        null  // extraElements
+    );
+  }
+
+  @Test
+  public void testTransformToChangeStreamFilter_mapsIdToDocumentKey() {
+    BsonDocument readFilter =
+        BsonDocument.parse(
+            "{\"_id\": {\"$gte\": {\"$oid\": \"000000000000000000000000\"}, \"$lt\": {\"$oid\":"
+                + " \"400000000000000000000000\"}}}");
+
+    BsonDocument changeFilter = MongoDbChangeStreamReader.transformToChangeStreamFilter(readFilter);
+
+    assertNotNull(changeFilter);
+    assertTrue(changeFilter.containsKey("$match"));
+    BsonDocument matchDoc = changeFilter.getDocument("$match");
+    assertTrue(matchDoc.containsKey("documentKey._id"));
+    assertEquals(readFilter.get("_id"), matchDoc.get("documentKey._id"));
+  }
+
+  @Test
+  public void testTransformToChangeStreamFilter_compoundOrAnd() {
+    BsonDocument compoundFilter =
+        BsonDocument.parse(
+            "{\"$or\": ["
+                + "  {\"_id\": {\"$gte\": 0, \"$lt\": 100}},"
+                + "  {\"$and\": [{\"_id\": {\"$gte\": 200}}, {\"_id\": {\"$lt\": 300}}]}"
+                + "]}");
+
+    BsonDocument changeFilter = MongoDbChangeStreamReader.transformToChangeStreamFilter(compoundFilter);
+
+    assertNotNull(changeFilter);
+    assertTrue(changeFilter.containsKey("$match"));
+    BsonDocument matchDoc = changeFilter.getDocument("$match");
+    assertTrue(matchDoc.containsKey("$or"));
+    org.bson.BsonArray orArray = matchDoc.getArray("$or");
+    assertEquals(2, orArray.size());
+
+    BsonDocument firstBranch = orArray.get(0).asDocument();
+    assertTrue(firstBranch.containsKey("documentKey._id"));
+    assertTrue(firstBranch.getDocument("documentKey._id").containsKey("$gte"));
+
+    BsonDocument secondBranch = orArray.get(1).asDocument();
+    assertTrue(secondBranch.containsKey("$and"));
+    org.bson.BsonArray andArray = secondBranch.getArray("$and");
+    assertEquals(2, andArray.size());
+    assertTrue(andArray.get(0).asDocument().containsKey("documentKey._id"));
+    assertTrue(andArray.get(1).asDocument().containsKey("documentKey._id"));
+  }
+
+  @Test
+  public void testTransformToChangeStreamFilter_nullOrEmpty() {
+    assertNull(MongoDbChangeStreamReader.transformToChangeStreamFilter(null));
+    assertNull(MongoDbChangeStreamReader.transformToChangeStreamFilter(new BsonDocument()));
+  }
+
+  @Test
+  public void testGeneratePartitions_singleSplit() {
+    BsonTimestamp timestamp = new BsonTimestamp(1724000000, 1);
+    List<ChangeStreamPartition> partitions =
+        MongoDbChangeStreamReader.generatePartitions(
+            "mongodb://localhost:27017",
+            "testDb",
+            "sourceCol",
+            "targetCol",
+            1,
+            timestamp,
+            "updateLookup");
+
+    assertEquals(1, partitions.size());
+    ChangeStreamPartition partition = partitions.get(0);
+    assertEquals("sourceCol", partition.getSourceCollection());
+    assertEquals("targetCol", partition.getTargetCollection());
+    assertEquals(0, partition.getPartitionIndex());
+    assertEquals(1, partition.getTotalPartitions());
+    assertNull(partition.getMatchFilterJson());
+    assertEquals(1724000000L, partition.getStartAtOperationTimeSeconds());
+    assertEquals(1, partition.getStartAtOperationTimeInc());
+    assertEquals("updateLookup", partition.getFullDocumentStrategy());
+  }
+
+  @Test
+  public void testGenerateHashedMatchFilter_constructsCorrectBsonExpression() {
+    BsonDocument filter = MongoDbChangeStreamReader.generateHashedMatchFilter(8, 3);
+
+    assertNotNull(filter);
+    assertTrue(filter.containsKey("$match"));
+    BsonDocument matchDoc = filter.getDocument("$match");
+    assertTrue(matchDoc.containsKey("$expr"));
+
+    BsonDocument exprDoc = matchDoc.getDocument("$expr");
+    assertTrue(exprDoc.containsKey("$in"));
+    org.bson.BsonArray inArray = exprDoc.getArray("$in");
+    assertEquals(2, inArray.size());
+
+    // First element: $mod expression
+    BsonDocument modDoc = inArray.get(0).asDocument();
+    assertTrue(modDoc.containsKey("$mod"));
+    org.bson.BsonArray modArgs = modDoc.getArray("$mod");
+    assertEquals(2, modArgs.size());
+    BsonDocument toHashedDoc = modArgs.get(0).asDocument();
+    assertEquals(new BsonString("$documentKey._id"), toHashedDoc.get("$toHashedIndexKey"));
+    assertEquals(new BsonInt32(8), modArgs.get(1));
+
+    // Second element: [3, -5] matching values
+    org.bson.BsonArray matchingValues = inArray.get(1).asArray();
+    assertEquals(2, matchingValues.size());
+    assertEquals(new BsonInt32(3), matchingValues.get(0));
+    assertEquals(new BsonInt32(-5), matchingValues.get(1));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGenerateHashedMatchFilter_invalidNumSplits_throwsException() {
+    MongoDbChangeStreamReader.generateHashedMatchFilter(0, 0);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGenerateHashedMatchFilter_outOfBoundsSplitIndex_throwsException() {
+    MongoDbChangeStreamReader.generateHashedMatchFilter(4, 4);
+  }
+
+  @Test
+  public void testGenerateHashedMatchFilter_mathematicalCompletenessAndDisjointness() {
+    int[] testSplitCounts = {2, 4, 8, 16};
+    for (int n : testSplitCounts) {
+      for (int r = -(n - 1); r <= (n - 1); r++) {
+        int matchCount = 0;
+        for (int i = 0; i < n; i++) {
+          BsonDocument filter = MongoDbChangeStreamReader.generateHashedMatchFilter(n, i);
+          org.bson.BsonArray matchingValues =
+              filter
+                  .getDocument("$match")
+                  .getDocument("$expr")
+                  .getArray("$in")
+                  .get(1)
+                  .asArray();
+
+          int val1 = matchingValues.get(0).asInt32().getValue();
+          int val2 = matchingValues.get(1).asInt32().getValue();
+          if (r == val1 || r == val2) {
+            matchCount++;
+          }
+        }
+        assertEquals(
+            String.format("Remainder %d for numSplits=%d must match exactly 1 split", r, n),
+            1,
+            matchCount);
+      }
+    }
+  }
+
+  @Test
+  public void testGeneratePartitions_multiSplitHashed() {
+    BsonTimestamp timestamp = new BsonTimestamp(1724000000, 1);
+    List<ChangeStreamPartition> partitions =
+        MongoDbChangeStreamReader.generatePartitions(
+            "mongodb://localhost:27017",
+            "testDb",
+            "sourceCol",
+            "targetCol",
+            8,
+            timestamp,
+            "whenAvailable");
+
+    assertEquals(8, partitions.size());
+    for (int i = 0; i < partitions.size(); i++) {
+      ChangeStreamPartition p = partitions.get(i);
+      assertEquals("sourceCol", p.getSourceCollection());
+      assertEquals("targetCol", p.getTargetCollection());
+      assertEquals(i, p.getPartitionIndex());
+      assertEquals(8, p.getTotalPartitions());
+      assertEquals("whenAvailable", p.getFullDocumentStrategy());
+      assertNotNull(p.getMatchFilterJson());
+      assertTrue(p.getMatchFilterJson().contains("$toHashedIndexKey"));
+      assertTrue(p.getMatchFilterJson().contains("$documentKey._id"));
+    }
+  }
+
+  @Test
+  public void testMapChangeStreamEvent_insert() {
+    Document doc = new Document("_id", "123").append("name", "Bob");
+    BsonDocument docKey = new BsonDocument("_id", new BsonString("123"));
+    BsonTimestamp timestamp = new BsonTimestamp(1724000000, 5);
+
+    ChangeStreamDocument<Document> event =
+        createEvent(OperationType.INSERT, doc, docKey, timestamp);
+
+    DocumentWithMetadata item =
+        MongoDbChangeStreamReader.mapChangeStreamEvent(event, "srcCol", "tgtCol");
+
+    assertNotNull(item);
+    assertEquals(DocumentWithMetadata.OperationType.INSERT, item.getOperationType());
+    assertTrue(item.getOperationType().isUpsert());
+    assertEquals("123", item.getId());
+    assertEquals(TimestampSortKey.cdc(1724000000L, 5L), item.getTimestampSortKey());
+    assertEquals("srcCol", item.getSourceCollection());
+    assertEquals("tgtCol", item.getTargetCollection());
+  }
+
+  @Test
+  public void testMapChangeStreamEvent_delete() {
+    BsonDocument docKey = new BsonDocument("_id", new BsonInt32(999));
+    BsonTimestamp timestamp = new BsonTimestamp(1724000000, 12);
+
+    ChangeStreamDocument<Document> event =
+        createEvent(OperationType.DELETE, null, docKey, timestamp);
+
+    DocumentWithMetadata item =
+        MongoDbChangeStreamReader.mapChangeStreamEvent(event, "srcCol", "tgtCol");
+
+    assertNotNull(item);
+    assertEquals(DocumentWithMetadata.OperationType.DELETE, item.getOperationType());
+    assertTrue(item.getOperationType().isDelete());
+    assertNull(item.getDocument());
+    assertEquals(999, item.getId());
+    assertEquals(TimestampSortKey.cdc(1724000000L, 12L), item.getTimestampSortKey());
+  }
+
+  @Test
+  public void testMapChangeStreamEvent_update() {
+    Document doc = new Document("_id", "456").append("score", 100);
+    BsonDocument docKey = new BsonDocument("_id", new BsonString("456"));
+    BsonTimestamp timestamp = new BsonTimestamp(1724000000, 8);
+
+    ChangeStreamDocument<Document> event =
+        createEvent(OperationType.UPDATE, doc, docKey, timestamp);
+
+    DocumentWithMetadata item =
+        MongoDbChangeStreamReader.mapChangeStreamEvent(event, "srcCol", "tgtCol");
+
+    assertNotNull(item);
+    assertEquals(DocumentWithMetadata.OperationType.UPDATE, item.getOperationType());
+    assertTrue(item.getOperationType().isUpsert());
+    assertEquals(TimestampSortKey.cdc(1724000000L, 8L), item.getTimestampSortKey());
+  }
+
+  @Test
+  public void testMapChangeStreamEvent_replace() {
+    Document doc = new Document("_id", "789").append("replaced", true);
+    BsonDocument docKey = new BsonDocument("_id", new BsonString("789"));
+    BsonTimestamp timestamp = new BsonTimestamp(1724000000, 15);
+
+    ChangeStreamDocument<Document> event =
+        createEvent(OperationType.REPLACE, doc, docKey, timestamp);
+
+    DocumentWithMetadata item =
+        MongoDbChangeStreamReader.mapChangeStreamEvent(event, "srcCol", "tgtCol");
+
+    assertNotNull(item);
+    assertEquals(DocumentWithMetadata.OperationType.REPLACE, item.getOperationType());
+    assertTrue(item.getOperationType().isUpsert());
+    assertEquals("789", item.getId());
+    assertEquals(TimestampSortKey.cdc(1724000000L, 15L), item.getTimestampSortKey());
+  }
+
+  @Test
+  public void testMapChangeStreamEvent_dropAndRename() {
+    BsonTimestamp timestamp = new BsonTimestamp(1724000000, 20);
+
+    ChangeStreamDocument<Document> dropEvent =
+        createEvent(OperationType.DROP, null, null, timestamp);
+    DocumentWithMetadata dropItem =
+        MongoDbChangeStreamReader.mapChangeStreamEvent(dropEvent, "srcCol", "tgtCol");
+    assertNotNull(dropItem);
+    assertEquals(DocumentWithMetadata.OperationType.DROP, dropItem.getOperationType());
+
+    ChangeStreamDocument<Document> renameEvent =
+        createEvent(OperationType.RENAME, null, null, timestamp);
+    DocumentWithMetadata renameItem =
+        MongoDbChangeStreamReader.mapChangeStreamEvent(renameEvent, "srcCol", "tgtCol");
+    assertNotNull(renameItem);
+    assertEquals(DocumentWithMetadata.OperationType.RENAME, renameItem.getOperationType());
+  }
+
+  @Test
+  public void testMapChangeStreamEvent_nullHandling() {
+    assertNull(MongoDbChangeStreamReader.mapChangeStreamEvent(null, "s", "t"));
+
+    BsonDocument docKey = new BsonDocument("_id", new BsonString("456"));
+    BsonTimestamp timestamp = new BsonTimestamp(1724000000, 8);
+
+    // Update with null fullDocument (document was deleted before updateLookup) should return null
+    ChangeStreamDocument<Document> updateEventNullDoc =
+        createEvent(OperationType.UPDATE, null, docKey, timestamp);
+    assertNull(MongoDbChangeStreamReader.mapChangeStreamEvent(updateEventNullDoc, "srcCol", "tgtCol"));
+
+    // Insert with null fullDocument should return null
+    ChangeStreamDocument<Document> insertEventNullDoc =
+        createEvent(OperationType.INSERT, null, docKey, timestamp);
+    assertNull(MongoDbChangeStreamReader.mapChangeStreamEvent(insertEventNullDoc, "srcCol", "tgtCol"));
+
+    // Replace with null fullDocument should return null
+    ChangeStreamDocument<Document> replaceEventNullDoc =
+        createEvent(OperationType.REPLACE, null, docKey, timestamp);
+    assertNull(MongoDbChangeStreamReader.mapChangeStreamEvent(replaceEventNullDoc, "srcCol", "tgtCol"));
+  }
+
+  @Test
+  public void testCaptureCurrentClusterTime_fallback() {
+    // Calling with an unreachable host should gracefully fallback to wall-clock time
+    BsonTimestamp timestamp =
+        MongoDbChangeStreamReader.captureCurrentClusterTime(
+            "mongodb://invalid-host-for-test:27017/?serverSelectionTimeoutMS=200&connectTimeoutMS=200",
+            "testDb");
+    assertNotNull(timestamp);
+    assertTrue(timestamp.getTime() > 0);
+  }
+
+  @Test
+  public void testChangeStreamRestriction_gettersAndEquals() {
+    ChangeStreamRestriction r1 = new ChangeStreamRestriction(0L, null);
+    ChangeStreamRestriction r2 = new ChangeStreamRestriction(0L, null);
+    ChangeStreamRestriction r3 = new ChangeStreamRestriction(1L, "{\"_data\": \"abc\"}");
+
+    assertEquals(0L, r1.getOffset());
+    assertNull(r1.getResumeTokenJson());
+    assertNull(r1.getResumeToken());
+    assertEquals(r1, r2);
+    assertEquals(r1.hashCode(), r2.hashCode());
+    assertFalse(r1.equals(r3));
+
+    assertEquals("{\"_data\": \"abc\"}", r3.getResumeTokenJson());
+    assertNotNull(r3.getResumeToken());
+    assertEquals(new BsonString("abc"), r3.getResumeToken().get("_data"));
+    assertTrue(r3.toString().contains("offset=1"));
+  }
+
+  @Test
+  public void testChangeStreamRestrictionTracker_claimAndSplit() {
+    ChangeStreamRestriction initial = new ChangeStreamRestriction(5L, null);
+    ChangeStreamRestrictionTracker tracker = new ChangeStreamRestrictionTracker(initial);
+
+    assertEquals(initial, tracker.currentRestriction());
+    assertTrue(tracker.tryClaim(initial));
+
+    BsonDocument token = new BsonDocument("_data", new BsonString("token123"));
+    ChangeStreamRestriction nextRestriction =
+        new ChangeStreamRestriction(6L, token.toJson());
+    assertTrue(tracker.tryClaim(nextRestriction));
+
+    assertEquals(6L, tracker.currentRestriction().getOffset());
+    assertNotNull(tracker.currentRestriction().getResumeTokenJson());
+
+    SplitResult<ChangeStreamRestriction> split = tracker.trySplit(0);
+    assertNotNull(split);
+    assertNotNull(split.getPrimary());
+    assertEquals(6L, split.getPrimary().getOffset());
+    assertEquals(tracker.currentRestriction().getResumeTokenJson(), split.getPrimary().getResumeTokenJson());
+    assertNotNull(split.getResidual());
+    assertEquals(6L, split.getResidual().getOffset());
+    assertEquals(tracker.currentRestriction().getResumeTokenJson(), split.getResidual().getResumeTokenJson());
+    assertFalse(tracker.tryClaim(new ChangeStreamRestriction(7L, null)));
+  }
+
+  @Test
+  public void testProcessChangeStreamPartitionFn_sdfInitialRestrictionAndTracker() {
+    ProcessChangeStreamPartitionFn fn = new ProcessChangeStreamPartitionFn();
+    ChangeStreamPartition partition =
+        new ChangeStreamPartition(
+            "mongodb://localhost:27017",
+            "testDb",
+            "users",
+            "users",
+            0,
+            1,
+            null,
+            1724000000L,
+            0,
+            "updateLookup");
+
+    ChangeStreamRestriction restriction = fn.getInitialRestriction(partition);
+    assertNotNull(restriction);
+    assertEquals(0L, restriction.getOffset());
+    assertNull(restriction.getResumeTokenJson());
+
+    ChangeStreamRestrictionTracker tracker = fn.newTracker(partition, restriction);
+    assertNotNull(tracker);
+    assertEquals(restriction, tracker.currentRestriction());
+
+    assertNotNull(fn.getRestrictionCoder());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testProcessChangeStreamPartitionFn_burstExecution_zeroDelayContinuation() {
+    MongoClient mockClient = mock(MongoClient.class);
+    MongoDatabase mockDb = mock(MongoDatabase.class);
+    MongoCollection<Document> mockCol = mock(MongoCollection.class);
+    ChangeStreamIterable<Document> mockStream = mock(ChangeStreamIterable.class);
+    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor = mock(MongoChangeStreamCursor.class);
+
+    when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
+    when(mockDb.getCollection(anyString())).thenReturn(mockCol);
+    when(mockCol.watch(anyList())).thenReturn(mockStream);
+    when(mockStream.batchSize(anyInt())).thenReturn(mockStream);
+    when(mockStream.maxAwaitTime(anyLong(), any())).thenReturn(mockStream);
+    when(mockStream.fullDocument(any())).thenReturn(mockStream);
+    when(mockStream.cursor()).thenReturn(mockCursor);
+
+    Document doc = new Document("_id", 1).append("name", "Alice");
+    BsonDocument docKey = new BsonDocument("_id", new BsonInt32(1));
+    BsonTimestamp ts = new BsonTimestamp(1724000000, 1);
+    ChangeStreamDocument<Document> event = createEvent(OperationType.INSERT, doc, docKey, ts);
+
+    when(mockCursor.tryNext()).thenReturn(event, (ChangeStreamDocument<Document>) null);
+
+    ProcessChangeStreamPartitionFn fn = new ProcessChangeStreamPartitionFn(uri -> mockClient);
+    ChangeStreamPartition partition =
+        new ChangeStreamPartition(
+            "mongodb://localhost:27017",
+            "testDb",
+            "users",
+            "users",
+            0,
+            1,
+            null,
+            0,
+            0,
+            "updateLookup");
+
+    ChangeStreamRestrictionTracker tracker = new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
+    OutputReceiver<DocumentWithMetadata> mockReceiver = mock(OutputReceiver.class);
+
+    ProcessContinuation continuation = fn.processElement(partition, tracker, mockReceiver);
+
+    assertTrue(continuation.shouldResume());
+    assertEquals(0L, continuation.resumeDelay().getMillis()); // Zero delay for burst
+    fn.teardown();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testProcessChangeStreamPartitionFn_idleExecution_returnsResumeDelay() {
+    MongoClient mockClient = mock(MongoClient.class);
+    MongoDatabase mockDb = mock(MongoDatabase.class);
+    MongoCollection<Document> mockCol = mock(MongoCollection.class);
+    ChangeStreamIterable<Document> mockStream = mock(ChangeStreamIterable.class);
+    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor = mock(MongoChangeStreamCursor.class);
+
+    when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
+    when(mockDb.getCollection(anyString())).thenReturn(mockCol);
+    when(mockCol.watch(anyList())).thenReturn(mockStream);
+    when(mockStream.batchSize(anyInt())).thenReturn(mockStream);
+    when(mockStream.maxAwaitTime(anyLong(), any())).thenReturn(mockStream);
+    when(mockStream.fullDocument(any())).thenReturn(mockStream);
+    when(mockStream.cursor()).thenReturn(mockCursor);
+
+    // Idle cursor returns null on tryNext
+    when(mockCursor.tryNext()).thenReturn(null);
+    // 0x66D57F9B = 1725267867 (Sep 2, 2024)
+    when(mockCursor.getResumeToken()).thenReturn(
+        new BsonDocument("_data", new BsonString("8266D57F9B000000012B022C0100296E5A1004")));
+
+    ProcessChangeStreamPartitionFn fn = new ProcessChangeStreamPartitionFn(uri -> mockClient);
+    ChangeStreamPartition partition =
+        new ChangeStreamPartition(
+            "mongodb://localhost:27017",
+            "testDb",
+            "users",
+            "users",
+            0,
+            1,
+            null,
+            0,
+            0,
+            "updateLookup");
+
+    ChangeStreamRestrictionTracker tracker = new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
+    OutputReceiver<DocumentWithMetadata> mockReceiver = mock(OutputReceiver.class);
+
+    ProcessContinuation continuation = fn.processElement(partition, tracker, mockReceiver);
+
+    assertTrue(continuation.shouldResume());
+    assertEquals(200L, continuation.resumeDelay().getMillis()); // 200ms delay for idle
+    assertNotNull(tracker.currentRestriction().getResumeTokenJson());
+    assertTrue(tracker.currentRestriction().getResumeTokenJson().contains("8266D57F9B"));
+    fn.teardown();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testProcessChangeStreamPartitionFn_multiPartitionCursorCaching_reusesCursor() {
+    MongoClient mockClient = mock(MongoClient.class);
+    MongoDatabase mockDb = mock(MongoDatabase.class);
+    MongoCollection<Document> mockCol = mock(MongoCollection.class);
+    ChangeStreamIterable<Document> mockStream = mock(ChangeStreamIterable.class);
+    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor0 = mock(MongoChangeStreamCursor.class);
+    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor1 = mock(MongoChangeStreamCursor.class);
+
+    when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
+    when(mockDb.getCollection(anyString())).thenReturn(mockCol);
+    when(mockCol.watch(anyList())).thenReturn(mockStream);
+    when(mockStream.batchSize(anyInt())).thenReturn(mockStream);
+    when(mockStream.maxAwaitTime(anyLong(), any())).thenReturn(mockStream);
+    when(mockStream.fullDocument(any())).thenReturn(mockStream);
+    when(mockStream.cursor()).thenReturn(mockCursor0, mockCursor1);
+
+    when(mockCursor0.tryNext()).thenReturn(null);
+    when(mockCursor1.tryNext()).thenReturn(null);
+
+    ProcessChangeStreamPartitionFn fn = new ProcessChangeStreamPartitionFn(uri -> mockClient);
+    ChangeStreamPartition partition0 =
+        new ChangeStreamPartition("mongodb://localhost:27017", "testDb", "users", "users", 0, 2, null, 0, 0, "updateLookup");
+    ChangeStreamPartition partition1 =
+        new ChangeStreamPartition("mongodb://localhost:27017", "testDb", "users", "users", 1, 2, null, 0, 0, "updateLookup");
+
+    OutputReceiver<DocumentWithMetadata> mockReceiver = mock(OutputReceiver.class);
+
+    // Slice 1: Partition 0 (creates cursor0)
+    ChangeStreamRestrictionTracker tracker0 = new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
+    fn.processElement(partition0, tracker0, mockReceiver);
+
+    // Slice 2: Partition 1 (creates cursor1)
+    ChangeStreamRestrictionTracker tracker1 = new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
+    fn.processElement(partition1, tracker1, mockReceiver);
+
+    // Slice 3: Partition 0 AGAIN (should REUSE cursor0 without recreating cursor)
+    fn.processElement(partition0, tracker0, mockReceiver);
+
+    // Verify stream.cursor() was called exactly 2 times (once per partition), NOT 3 times
+    verify(mockStream, times(2)).cursor();
+
+    fn.teardown();
+    verify(mockCursor0, times(1)).close();
+    verify(mockCursor1, times(1)).close();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testProcessChangeStreamPartitionFn_transientError_reconnects() {
+    MongoClient mockClient = mock(MongoClient.class);
+    MongoDatabase mockDb = mock(MongoDatabase.class);
+    MongoCollection<Document> mockCol = mock(MongoCollection.class);
+    ChangeStreamIterable<Document> mockStream = mock(ChangeStreamIterable.class);
+    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor = mock(MongoChangeStreamCursor.class);
+
+    when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
+    when(mockDb.getCollection(anyString())).thenReturn(mockCol);
+    when(mockCol.watch(anyList())).thenReturn(mockStream);
+    when(mockStream.batchSize(anyInt())).thenReturn(mockStream);
+    when(mockStream.maxAwaitTime(anyLong(), any())).thenReturn(mockStream);
+    when(mockStream.fullDocument(any())).thenReturn(mockStream);
+    when(mockStream.cursor()).thenReturn(mockCursor);
+
+    when(mockCursor.tryNext()).thenThrow(new RuntimeException("Socket timeout"));
+
+    ProcessChangeStreamPartitionFn fn = new ProcessChangeStreamPartitionFn(uri -> mockClient);
+    ChangeStreamPartition partition =
+        new ChangeStreamPartition(
+            "mongodb://localhost:27017",
+            "testDb",
+            "users",
+            "users",
+            0,
+            1,
+            null,
+            0,
+            0,
+            "updateLookup");
+
+    ChangeStreamRestrictionTracker tracker = new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
+    OutputReceiver<DocumentWithMetadata> mockReceiver = mock(OutputReceiver.class);
+
+    ProcessContinuation continuation = fn.processElement(partition, tracker, mockReceiver);
+
+    assertTrue(continuation.shouldResume());
+    assertEquals(1000L, continuation.resumeDelay().getMillis()); // 1000ms delay on error
+    fn.teardown();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testProcessChangeStreamPartitionFn_wrappedInRestrictionTrackerObserver_doesNotThrowClassCastException() {
+    // Simulates Beam's RestrictionTrackerObserver wrapping the delegate RestrictionTracker
+    MongoClient mockClient = mock(MongoClient.class);
+    MongoDatabase mockDb = mock(MongoDatabase.class);
+    MongoCollection<Document> mockCol = mock(MongoCollection.class);
+    ChangeStreamIterable<Document> mockStream = mock(ChangeStreamIterable.class);
+    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor = mock(MongoChangeStreamCursor.class);
+
+    when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
+    when(mockDb.getCollection(anyString())).thenReturn(mockCol);
+    when(mockCol.watch(anyList())).thenReturn(mockStream);
+    when(mockStream.batchSize(anyInt())).thenReturn(mockStream);
+    when(mockStream.maxAwaitTime(anyLong(), any())).thenReturn(mockStream);
+    when(mockStream.fullDocument(any())).thenReturn(mockStream);
+    when(mockStream.cursor()).thenReturn(mockCursor);
+
+    when(mockCursor.tryNext()).thenReturn(null);
+
+    ProcessChangeStreamPartitionFn fn = new ProcessChangeStreamPartitionFn(uri -> mockClient);
+    ChangeStreamPartition partition =
+        new ChangeStreamPartition(
+            "mongodb://localhost:27017",
+            "testDb",
+            "users",
+            "users",
+            0,
+            1,
+            null,
+            0,
+            0,
+            "updateLookup");
+
+    ChangeStreamRestrictionTracker delegate = new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
+    RestrictionTracker<ChangeStreamRestriction, ChangeStreamRestriction> observerWrapper =
+        new RestrictionTracker<ChangeStreamRestriction, ChangeStreamRestriction>() {
+          @Override
+          public boolean tryClaim(ChangeStreamRestriction position) {
+            return delegate.tryClaim(position);
+          }
+
+          @Override
+          public ChangeStreamRestriction currentRestriction() {
+            return delegate.currentRestriction();
+          }
+
+          @Override
+          public SplitResult<ChangeStreamRestriction> trySplit(double fractionOfRemainder) {
+            return delegate.trySplit(fractionOfRemainder);
+          }
+
+          @Override
+          public void checkDone() throws IllegalStateException {
+            delegate.checkDone();
+          }
+
+          @Override
+          public IsBounded isBounded() {
+            return delegate.isBounded();
+          }
+        };
+
+    OutputReceiver<DocumentWithMetadata> mockReceiver = mock(OutputReceiver.class);
+
+    // This must execute cleanly without ClassCastException
+    ProcessContinuation continuation = fn.processElement(partition, observerWrapper, mockReceiver);
+    assertNotNull(continuation);
+    assertTrue(continuation.shouldResume());
+    fn.teardown();
+  }
+}

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReaderTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReaderTest.java
@@ -549,7 +549,9 @@ public class MongoDbChangeStreamReaderTest {
     ProcessContinuation continuation = fn.processElement(partition, tracker, mockReceiver);
 
     assertTrue(continuation.shouldResume());
-    assertEquals(200L, continuation.resumeDelay().getMillis()); // 200ms delay for idle
+    assertEquals(
+        ProcessChangeStreamPartitionFn.IDLE_RESUME_DELAY_MS,
+        continuation.resumeDelay().getMillis());
     assertNotNull(tracker.currentRestriction().getResumeTokenJson());
     assertTrue(tracker.currentRestriction().getResumeTokenJson().contains("8266D57F9B"));
     fn.teardown();

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReaderTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReaderTest.java
@@ -717,4 +717,128 @@ public class MongoDbChangeStreamReaderTest {
     assertTrue(continuation.shouldResume());
     fn.teardown();
   }
+
+  @Test
+  public void testGenerateDatabasePartitions_singleSplit() {
+    List<ChangeStreamPartition> partitions =
+        MongoDbChangeStreamReader.generateDatabasePartitions(
+            "mongodb://localhost:27017",
+            "testDb",
+            1,
+            new BsonTimestamp(1700000000, 5),
+            "updateLookup");
+
+    assertEquals(1, partitions.size());
+    ChangeStreamPartition p = partitions.get(0);
+    assertTrue(p.isDatabaseLevel());
+    assertNull(p.getSourceCollection());
+    assertNull(p.getTargetCollection());
+    assertEquals("testDb", p.getSourceDatabase());
+    assertEquals(0, p.getPartitionIndex());
+    assertEquals(1, p.getTotalPartitions());
+    assertEquals(1700000000L, p.getStartAtOperationTimeSeconds());
+    assertEquals(5, p.getStartAtOperationTimeInc());
+    assertNull(p.getMatchFilterJson());
+  }
+
+  @Test
+  public void testGenerateDatabasePartitions_multipleSplits() {
+    List<ChangeStreamPartition> partitions =
+        MongoDbChangeStreamReader.generateDatabasePartitions(
+            "mongodb://localhost:27017",
+            "testDb",
+            4,
+            new BsonTimestamp(1700000000, 0),
+            "updateLookup");
+
+    assertEquals(4, partitions.size());
+    for (int i = 0; i < 4; i++) {
+      ChangeStreamPartition p = partitions.get(i);
+      assertTrue(p.isDatabaseLevel());
+      assertNull(p.getSourceCollection());
+      assertEquals(i, p.getPartitionIndex());
+      assertEquals(4, p.getTotalPartitions());
+      assertNotNull(p.getMatchFilterJson());
+      assertTrue(p.getMatchFilterJson().contains("$toHashedIndexKey"));
+    }
+  }
+
+  @Test
+  public void testMapChangeStreamEvent_databaseLevel_extractsCollection() {
+    BsonDocument docKey = new BsonDocument("_id", new BsonString("doc-123"));
+    Document fullDoc = new Document("_id", "doc-123").append("key", "val");
+    BsonTimestamp ts = new BsonTimestamp(1700000000, 1);
+
+    ChangeStreamDocument<Document> event =
+        new ChangeStreamDocument<>(
+            OperationType.INSERT.getValue(),
+            new BsonDocument(),
+            BsonDocument.parse("{\"db\": \"testDb\", \"coll\": \"orders\"}"),
+            null,
+            null,
+            fullDoc,
+            null,
+            docKey,
+            ts,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    // Database-level partition (sourceCollection = null, targetCollection = null)
+    DocumentWithMetadata result =
+        MongoDbChangeStreamReader.mapChangeStreamEvent(event, null, null);
+
+    assertNotNull(result);
+    assertEquals("orders", result.getSourceCollection());
+    assertEquals("orders", result.getTargetCollection());
+    assertEquals(DocumentWithMetadata.OperationType.INSERT, result.getOperationType());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testProcessChangeStreamPartitionFn_databaseLevel_watchesDatabase() {
+    MongoClient mockClient = mock(MongoClient.class);
+    MongoDatabase mockDb = mock(MongoDatabase.class);
+    ChangeStreamIterable<Document> mockStream = mock(ChangeStreamIterable.class);
+    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor = mock(MongoChangeStreamCursor.class);
+
+    when(mockClient.getDatabase("testDb")).thenReturn(mockDb);
+    when(mockDb.watch(anyList())).thenReturn(mockStream);
+    when(mockStream.batchSize(anyInt())).thenReturn(mockStream);
+    when(mockStream.maxAwaitTime(anyLong(), any())).thenReturn(mockStream);
+    when(mockStream.fullDocument(any())).thenReturn(mockStream);
+    when(mockStream.cursor()).thenReturn(mockCursor);
+    when(mockCursor.tryNext()).thenReturn(null);
+
+    ProcessChangeStreamPartitionFn fn = new ProcessChangeStreamPartitionFn(uri -> mockClient);
+    ChangeStreamPartition partition =
+        new ChangeStreamPartition(
+            "mongodb://localhost:27017",
+            "testDb",
+            null,
+            null,
+            0,
+            1,
+            null,
+            0,
+            0,
+            "updateLookup");
+
+    assertTrue(partition.isDatabaseLevel());
+
+    ChangeStreamRestrictionTracker tracker =
+        new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
+    OutputReceiver<DocumentWithMetadata> mockReceiver = mock(OutputReceiver.class);
+
+    ProcessContinuation continuation = fn.processElement(partition, tracker, mockReceiver);
+    assertNotNull(continuation);
+    assertTrue(continuation.shouldResume());
+
+    // Verify db.watch() was called on MongoDatabase, NOT on a MongoCollection
+    verify(mockDb, times(1)).watch(anyList());
+    fn.teardown();
+  }
 }

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReaderTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbChangeStreamReaderTest.java
@@ -76,8 +76,8 @@ public class MongoDbChangeStreamReaderTest {
         null, // lsid
         null, // wallTime
         null, // splitEvent
-        null  // extraElements
-    );
+        null // extraElements
+        );
   }
 
   @Test
@@ -105,7 +105,8 @@ public class MongoDbChangeStreamReaderTest {
                 + "  {\"$and\": [{\"_id\": {\"$gte\": 200}}, {\"_id\": {\"$lt\": 300}}]}"
                 + "]}");
 
-    BsonDocument changeFilter = MongoDbChangeStreamReader.transformToChangeStreamFilter(compoundFilter);
+    BsonDocument changeFilter =
+        MongoDbChangeStreamReader.transformToChangeStreamFilter(compoundFilter);
 
     assertNotNull(changeFilter);
     assertTrue(changeFilter.containsKey("$match"));
@@ -206,12 +207,7 @@ public class MongoDbChangeStreamReaderTest {
         for (int i = 0; i < n; i++) {
           BsonDocument filter = MongoDbChangeStreamReader.generateHashedMatchFilter(n, i);
           org.bson.BsonArray matchingValues =
-              filter
-                  .getDocument("$match")
-                  .getDocument("$expr")
-                  .getArray("$in")
-                  .get(1)
-                  .asArray();
+              filter.getDocument("$match").getDocument("$expr").getArray("$in").get(1).asArray();
 
           int val1 = matchingValues.get(0).asInt32().getValue();
           int val2 = matchingValues.get(1).asInt32().getValue();
@@ -360,17 +356,20 @@ public class MongoDbChangeStreamReaderTest {
     // Update with null fullDocument (document was deleted before updateLookup) should return null
     ChangeStreamDocument<Document> updateEventNullDoc =
         createEvent(OperationType.UPDATE, null, docKey, timestamp);
-    assertNull(MongoDbChangeStreamReader.mapChangeStreamEvent(updateEventNullDoc, "srcCol", "tgtCol"));
+    assertNull(
+        MongoDbChangeStreamReader.mapChangeStreamEvent(updateEventNullDoc, "srcCol", "tgtCol"));
 
     // Insert with null fullDocument should return null
     ChangeStreamDocument<Document> insertEventNullDoc =
         createEvent(OperationType.INSERT, null, docKey, timestamp);
-    assertNull(MongoDbChangeStreamReader.mapChangeStreamEvent(insertEventNullDoc, "srcCol", "tgtCol"));
+    assertNull(
+        MongoDbChangeStreamReader.mapChangeStreamEvent(insertEventNullDoc, "srcCol", "tgtCol"));
 
     // Replace with null fullDocument should return null
     ChangeStreamDocument<Document> replaceEventNullDoc =
         createEvent(OperationType.REPLACE, null, docKey, timestamp);
-    assertNull(MongoDbChangeStreamReader.mapChangeStreamEvent(replaceEventNullDoc, "srcCol", "tgtCol"));
+    assertNull(
+        MongoDbChangeStreamReader.mapChangeStreamEvent(replaceEventNullDoc, "srcCol", "tgtCol"));
   }
 
   @Test
@@ -412,8 +411,7 @@ public class MongoDbChangeStreamReaderTest {
     assertTrue(tracker.tryClaim(initial));
 
     BsonDocument token = new BsonDocument("_data", new BsonString("token123"));
-    ChangeStreamRestriction nextRestriction =
-        new ChangeStreamRestriction(6L, token.toJson());
+    ChangeStreamRestriction nextRestriction = new ChangeStreamRestriction(6L, token.toJson());
     assertTrue(tracker.tryClaim(nextRestriction));
 
     assertEquals(6L, tracker.currentRestriction().getOffset());
@@ -423,10 +421,13 @@ public class MongoDbChangeStreamReaderTest {
     assertNotNull(split);
     assertNotNull(split.getPrimary());
     assertEquals(6L, split.getPrimary().getOffset());
-    assertEquals(tracker.currentRestriction().getResumeTokenJson(), split.getPrimary().getResumeTokenJson());
+    assertEquals(
+        tracker.currentRestriction().getResumeTokenJson(), split.getPrimary().getResumeTokenJson());
     assertNotNull(split.getResidual());
     assertEquals(6L, split.getResidual().getOffset());
-    assertEquals(tracker.currentRestriction().getResumeTokenJson(), split.getResidual().getResumeTokenJson());
+    assertEquals(
+        tracker.currentRestriction().getResumeTokenJson(),
+        split.getResidual().getResumeTokenJson());
     assertFalse(tracker.tryClaim(new ChangeStreamRestriction(7L, null)));
   }
 
@@ -465,7 +466,8 @@ public class MongoDbChangeStreamReaderTest {
     MongoDatabase mockDb = mock(MongoDatabase.class);
     MongoCollection<Document> mockCol = mock(MongoCollection.class);
     ChangeStreamIterable<Document> mockStream = mock(ChangeStreamIterable.class);
-    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor = mock(MongoChangeStreamCursor.class);
+    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor =
+        mock(MongoChangeStreamCursor.class);
 
     when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
     when(mockDb.getCollection(anyString())).thenReturn(mockCol);
@@ -496,7 +498,8 @@ public class MongoDbChangeStreamReaderTest {
             0,
             "updateLookup");
 
-    ChangeStreamRestrictionTracker tracker = new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
+    ChangeStreamRestrictionTracker tracker =
+        new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
     OutputReceiver<DocumentWithMetadata> mockReceiver = mock(OutputReceiver.class);
 
     ProcessContinuation continuation = fn.processElement(partition, tracker, mockReceiver);
@@ -513,7 +516,8 @@ public class MongoDbChangeStreamReaderTest {
     MongoDatabase mockDb = mock(MongoDatabase.class);
     MongoCollection<Document> mockCol = mock(MongoCollection.class);
     ChangeStreamIterable<Document> mockStream = mock(ChangeStreamIterable.class);
-    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor = mock(MongoChangeStreamCursor.class);
+    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor =
+        mock(MongoChangeStreamCursor.class);
 
     when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
     when(mockDb.getCollection(anyString())).thenReturn(mockCol);
@@ -526,8 +530,9 @@ public class MongoDbChangeStreamReaderTest {
     // Idle cursor returns null on tryNext
     when(mockCursor.tryNext()).thenReturn(null);
     // 0x66D57F9B = 1725267867 (Sep 2, 2024)
-    when(mockCursor.getResumeToken()).thenReturn(
-        new BsonDocument("_data", new BsonString("8266D57F9B000000012B022C0100296E5A1004")));
+    when(mockCursor.getResumeToken())
+        .thenReturn(
+            new BsonDocument("_data", new BsonString("8266D57F9B000000012B022C0100296E5A1004")));
 
     ProcessChangeStreamPartitionFn fn = new ProcessChangeStreamPartitionFn(uri -> mockClient);
     ChangeStreamPartition partition =
@@ -543,7 +548,8 @@ public class MongoDbChangeStreamReaderTest {
             0,
             "updateLookup");
 
-    ChangeStreamRestrictionTracker tracker = new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
+    ChangeStreamRestrictionTracker tracker =
+        new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
     OutputReceiver<DocumentWithMetadata> mockReceiver = mock(OutputReceiver.class);
 
     ProcessContinuation continuation = fn.processElement(partition, tracker, mockReceiver);
@@ -564,8 +570,10 @@ public class MongoDbChangeStreamReaderTest {
     MongoDatabase mockDb = mock(MongoDatabase.class);
     MongoCollection<Document> mockCol = mock(MongoCollection.class);
     ChangeStreamIterable<Document> mockStream = mock(ChangeStreamIterable.class);
-    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor0 = mock(MongoChangeStreamCursor.class);
-    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor1 = mock(MongoChangeStreamCursor.class);
+    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor0 =
+        mock(MongoChangeStreamCursor.class);
+    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor1 =
+        mock(MongoChangeStreamCursor.class);
 
     when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
     when(mockDb.getCollection(anyString())).thenReturn(mockCol);
@@ -580,18 +588,40 @@ public class MongoDbChangeStreamReaderTest {
 
     ProcessChangeStreamPartitionFn fn = new ProcessChangeStreamPartitionFn(uri -> mockClient);
     ChangeStreamPartition partition0 =
-        new ChangeStreamPartition("mongodb://localhost:27017", "testDb", "users", "users", 0, 2, null, 0, 0, "updateLookup");
+        new ChangeStreamPartition(
+            "mongodb://localhost:27017",
+            "testDb",
+            "users",
+            "users",
+            0,
+            2,
+            null,
+            0,
+            0,
+            "updateLookup");
     ChangeStreamPartition partition1 =
-        new ChangeStreamPartition("mongodb://localhost:27017", "testDb", "users", "users", 1, 2, null, 0, 0, "updateLookup");
+        new ChangeStreamPartition(
+            "mongodb://localhost:27017",
+            "testDb",
+            "users",
+            "users",
+            1,
+            2,
+            null,
+            0,
+            0,
+            "updateLookup");
 
     OutputReceiver<DocumentWithMetadata> mockReceiver = mock(OutputReceiver.class);
 
     // Slice 1: Partition 0 (creates cursor0)
-    ChangeStreamRestrictionTracker tracker0 = new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
+    ChangeStreamRestrictionTracker tracker0 =
+        new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
     fn.processElement(partition0, tracker0, mockReceiver);
 
     // Slice 2: Partition 1 (creates cursor1)
-    ChangeStreamRestrictionTracker tracker1 = new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
+    ChangeStreamRestrictionTracker tracker1 =
+        new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
     fn.processElement(partition1, tracker1, mockReceiver);
 
     // Slice 3: Partition 0 AGAIN (should REUSE cursor0 without recreating cursor)
@@ -612,7 +642,8 @@ public class MongoDbChangeStreamReaderTest {
     MongoDatabase mockDb = mock(MongoDatabase.class);
     MongoCollection<Document> mockCol = mock(MongoCollection.class);
     ChangeStreamIterable<Document> mockStream = mock(ChangeStreamIterable.class);
-    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor = mock(MongoChangeStreamCursor.class);
+    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor =
+        mock(MongoChangeStreamCursor.class);
 
     when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
     when(mockDb.getCollection(anyString())).thenReturn(mockCol);
@@ -638,7 +669,8 @@ public class MongoDbChangeStreamReaderTest {
             0,
             "updateLookup");
 
-    ChangeStreamRestrictionTracker tracker = new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
+    ChangeStreamRestrictionTracker tracker =
+        new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
     OutputReceiver<DocumentWithMetadata> mockReceiver = mock(OutputReceiver.class);
 
     ProcessContinuation continuation = fn.processElement(partition, tracker, mockReceiver);
@@ -650,13 +682,15 @@ public class MongoDbChangeStreamReaderTest {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void testProcessChangeStreamPartitionFn_wrappedInRestrictionTrackerObserver_doesNotThrowClassCastException() {
+  public void
+      testProcessChangeStreamPartitionFn_wrappedInRestrictionTrackerObserver_doesNotThrowClassCastException() {
     // Simulates Beam's RestrictionTrackerObserver wrapping the delegate RestrictionTracker
     MongoClient mockClient = mock(MongoClient.class);
     MongoDatabase mockDb = mock(MongoDatabase.class);
     MongoCollection<Document> mockCol = mock(MongoCollection.class);
     ChangeStreamIterable<Document> mockStream = mock(ChangeStreamIterable.class);
-    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor = mock(MongoChangeStreamCursor.class);
+    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor =
+        mock(MongoChangeStreamCursor.class);
 
     when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
     when(mockDb.getCollection(anyString())).thenReturn(mockCol);
@@ -682,7 +716,8 @@ public class MongoDbChangeStreamReaderTest {
             0,
             "updateLookup");
 
-    ChangeStreamRestrictionTracker delegate = new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
+    ChangeStreamRestrictionTracker delegate =
+        new ChangeStreamRestrictionTracker(new ChangeStreamRestriction(0L, null));
     RestrictionTracker<ChangeStreamRestriction, ChangeStreamRestriction> observerWrapper =
         new RestrictionTracker<ChangeStreamRestriction, ChangeStreamRestriction>() {
           @Override
@@ -790,8 +825,7 @@ public class MongoDbChangeStreamReaderTest {
             null);
 
     // Database-level partition (sourceCollection = null, targetCollection = null)
-    DocumentWithMetadata result =
-        MongoDbChangeStreamReader.mapChangeStreamEvent(event, null, null);
+    DocumentWithMetadata result = MongoDbChangeStreamReader.mapChangeStreamEvent(event, null, null);
 
     assertNotNull(result);
     assertEquals("orders", result.getSourceCollection());
@@ -805,7 +839,8 @@ public class MongoDbChangeStreamReaderTest {
     MongoClient mockClient = mock(MongoClient.class);
     MongoDatabase mockDb = mock(MongoDatabase.class);
     ChangeStreamIterable<Document> mockStream = mock(ChangeStreamIterable.class);
-    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor = mock(MongoChangeStreamCursor.class);
+    MongoChangeStreamCursor<ChangeStreamDocument<Document>> mockCursor =
+        mock(MongoChangeStreamCursor.class);
 
     when(mockClient.getDatabase("testDb")).thenReturn(mockDb);
     when(mockDb.watch(anyList())).thenReturn(mockStream);
@@ -818,16 +853,7 @@ public class MongoDbChangeStreamReaderTest {
     ProcessChangeStreamPartitionFn fn = new ProcessChangeStreamPartitionFn(uri -> mockClient);
     ChangeStreamPartition partition =
         new ChangeStreamPartition(
-            "mongodb://localhost:27017",
-            "testDb",
-            null,
-            null,
-            0,
-            1,
-            null,
-            0,
-            0,
-            "updateLookup");
+            "mongodb://localhost:27017", "testDb", null, null, 0, 1, null, 0, 0, "updateLookup");
 
     assertTrue(partition.isDatabaseLevel());
 

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbTransformsTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbTransformsTest.java
@@ -340,7 +340,8 @@ public class MongoDbTransformsTest {
               failures.forEach(list::add);
               assertEquals(1, list.size());
               DocumentWithMetadata failedItem = list.get(0);
-              assertEquals(DocumentWithMetadata.OperationType.DELETE, failedItem.getOperationType());
+              assertEquals(
+                  DocumentWithMetadata.OperationType.DELETE, failedItem.getOperationType());
               assertEquals("{\"_id\": \"d99\"}", failedItem.getDocumentKey());
               assertEquals(TimestampSortKey.cdc(1000L, 5L), failedItem.getTimestampSortKey());
               assertEquals(DocumentWithMetadata.ErrorType.PERMANENT, failedItem.getErrorType());
@@ -917,7 +918,8 @@ public class MongoDbTransformsTest {
     // 5 unique items
     for (int i = 1; i <= 5; i++) {
       batchItems.add(
-          DocumentWithMetadata.of(new Document("_id", i).append("name", "name" + i), "items", "items"));
+          DocumentWithMetadata.of(
+              new Document("_id", i).append("name", "name" + i), "items", "items"));
     }
     // Update to id=1 and id=2
     batchItems.add(

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbTransformsTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbTransformsTest.java
@@ -53,6 +53,7 @@ import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.TupleTag;
@@ -722,5 +723,177 @@ public class MongoDbTransformsTest {
     // Teardown closes the client
     fn.teardown();
     org.mockito.Mockito.verify(mockClient, org.mockito.Mockito.times(1)).close();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testWriteBatchesCoalescing_insertThenDelete_emitsOnlyDelete() throws Exception {
+    MongoClient mockClient = mock(MongoClient.class);
+    MongoDatabase mockDb = mock(MongoDatabase.class);
+    MongoCollection<Document> mockCol = mock(MongoCollection.class);
+    when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
+    when(mockDb.getCollection(anyString())).thenReturn(mockCol);
+
+    org.mockito.ArgumentCaptor<List<WriteModel<Document>>> captor =
+        org.mockito.ArgumentCaptor.forClass(List.class);
+
+    TupleTag<DocumentWithMetadata> failureTag = new TupleTag<>();
+    MongoDbTransforms.WriteBatchesFn fn =
+        MongoDbTransforms.WriteBatchesFn.builder()
+            .withUri("mongodb://localhost:27017")
+            .withDatabase("test")
+            .withClientFactory(uri -> mockClient)
+            .withFailureTag(failureTag)
+            .build();
+
+    fn.setup();
+    fn.startBundle();
+
+    Document doc1 = new Document("_id", 100).append("name", "Alice");
+    DocumentWithMetadata insertItem = DocumentWithMetadata.of(doc1, "users", "users");
+
+    DocumentWithMetadata deleteItem =
+        DocumentWithMetadata.cdcEvent(
+            null,
+            null,
+            "users",
+            "users",
+            DocumentWithMetadata.OperationType.DELETE,
+            TimestampSortKey.cdc(1000, 1),
+            new Document("_id", 100).toJson());
+
+    DoFn<KV<String, Iterable<DocumentWithMetadata>>, DocumentWithMetadata>.ProcessContext mockCtx =
+        mock(DoFn.ProcessContext.class);
+    when(mockCtx.element()).thenReturn(KV.of("users#0", Arrays.asList(insertItem, deleteItem)));
+
+    fn.processElement(mockCtx);
+
+    @SuppressWarnings("unchecked")
+    DoFn<KV<String, Iterable<DocumentWithMetadata>>, DocumentWithMetadata>.FinishBundleContext
+        mockFinishCtx = mock(DoFn.FinishBundleContext.class);
+    fn.finishBundle(mockFinishCtx);
+    fn.teardown();
+
+    verify(mockCol).bulkWrite(captor.capture(), any(BulkWriteOptions.class));
+    List<WriteModel<Document>> capturedModels = captor.getValue();
+    assertEquals(1, capturedModels.size());
+    assertTrue(capturedModels.get(0) instanceof DeleteOneModel);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testWriteBatchesCoalescing_multipleUpdates_emitsLatestPayload() throws Exception {
+    MongoClient mockClient = mock(MongoClient.class);
+    MongoDatabase mockDb = mock(MongoDatabase.class);
+    MongoCollection<Document> mockCol = mock(MongoCollection.class);
+    when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
+    when(mockDb.getCollection(anyString())).thenReturn(mockCol);
+
+    org.mockito.ArgumentCaptor<List<WriteModel<Document>>> captor =
+        org.mockito.ArgumentCaptor.forClass(List.class);
+
+    TupleTag<DocumentWithMetadata> failureTag = new TupleTag<>();
+    MongoDbTransforms.WriteBatchesFn fn =
+        MongoDbTransforms.WriteBatchesFn.builder()
+            .withUri("mongodb://localhost:27017")
+            .withDatabase("test")
+            .withClientFactory(uri -> mockClient)
+            .withFailureTag(failureTag)
+            .build();
+
+    fn.setup();
+    fn.startBundle();
+
+    Document docV1 = new Document("_id", 200).append("val", 1);
+    Document docV2 = new Document("_id", 200).append("val", 2);
+    Document docV3 = new Document("_id", 200).append("val", 3);
+
+    DocumentWithMetadata item1 = DocumentWithMetadata.of(docV1, "metrics", "metrics");
+    DocumentWithMetadata item2 = DocumentWithMetadata.of(docV2, "metrics", "metrics");
+    DocumentWithMetadata item3 = DocumentWithMetadata.of(docV3, "metrics", "metrics");
+
+    DoFn<KV<String, Iterable<DocumentWithMetadata>>, DocumentWithMetadata>.ProcessContext mockCtx =
+        mock(DoFn.ProcessContext.class);
+    when(mockCtx.element()).thenReturn(KV.of("metrics#1", Arrays.asList(item1, item2, item3)));
+
+    fn.processElement(mockCtx);
+
+    @SuppressWarnings("unchecked")
+    DoFn<KV<String, Iterable<DocumentWithMetadata>>, DocumentWithMetadata>.FinishBundleContext
+        mockFinishCtx = mock(DoFn.FinishBundleContext.class);
+    fn.finishBundle(mockFinishCtx);
+    fn.teardown();
+
+    verify(mockCol).bulkWrite(captor.capture(), any(BulkWriteOptions.class));
+    List<WriteModel<Document>> capturedModels = captor.getValue();
+    assertEquals(1, capturedModels.size());
+    assertTrue(capturedModels.get(0) instanceof ReplaceOneModel);
+    ReplaceOneModel<Document> replaceModel = (ReplaceOneModel<Document>) capturedModels.get(0);
+    assertEquals(3, replaceModel.getReplacement().get("val"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testWriteBatchesCoalescing_mixedUniqueAndDuplicates() throws Exception {
+    MongoClient mockClient = mock(MongoClient.class);
+    MongoDatabase mockDb = mock(MongoDatabase.class);
+    MongoCollection<Document> mockCol = mock(MongoCollection.class);
+    when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
+    when(mockDb.getCollection(anyString())).thenReturn(mockCol);
+
+    org.mockito.ArgumentCaptor<List<WriteModel<Document>>> captor =
+        org.mockito.ArgumentCaptor.forClass(List.class);
+
+    TupleTag<DocumentWithMetadata> failureTag = new TupleTag<>();
+    MongoDbTransforms.WriteBatchesFn fn =
+        MongoDbTransforms.WriteBatchesFn.builder()
+            .withUri("mongodb://localhost:27017")
+            .withDatabase("test")
+            .withClientFactory(uri -> mockClient)
+            .withFailureTag(failureTag)
+            .build();
+
+    fn.setup();
+    fn.startBundle();
+
+    List<DocumentWithMetadata> batchItems = new ArrayList<>();
+    // 5 unique items
+    for (int i = 1; i <= 5; i++) {
+      batchItems.add(
+          DocumentWithMetadata.of(new Document("_id", i).append("name", "name" + i), "items", "items"));
+    }
+    // Update to id=1 and id=2
+    batchItems.add(
+        DocumentWithMetadata.of(
+            new Document("_id", 1).append("name", "name1_updated"), "items", "items"));
+    batchItems.add(
+        DocumentWithMetadata.of(
+            new Document("_id", 2).append("name", "name2_updated"), "items", "items"));
+    // Delete for id=3
+    batchItems.add(
+        DocumentWithMetadata.cdcEvent(
+            null,
+            null,
+            "items",
+            "items",
+            DocumentWithMetadata.OperationType.DELETE,
+            TimestampSortKey.cdc(2000, 1),
+            new Document("_id", 3).toJson()));
+
+    DoFn<KV<String, Iterable<DocumentWithMetadata>>, DocumentWithMetadata>.ProcessContext mockCtx =
+        mock(DoFn.ProcessContext.class);
+    when(mockCtx.element()).thenReturn(KV.of("items#0", batchItems));
+
+    fn.processElement(mockCtx);
+
+    @SuppressWarnings("unchecked")
+    DoFn<KV<String, Iterable<DocumentWithMetadata>>, DocumentWithMetadata>.FinishBundleContext
+        mockFinishCtx = mock(DoFn.FinishBundleContext.class);
+    fn.finishBundle(mockFinishCtx);
+    fn.teardown();
+
+    verify(mockCol).bulkWrite(captor.capture(), any(BulkWriteOptions.class));
+    List<WriteModel<Document>> capturedModels = captor.getValue();
+    assertEquals(5, capturedModels.size());
   }
 }

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbTransformsTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbTransformsTest.java
@@ -491,6 +491,63 @@ public class MongoDbTransformsTest {
               DocumentWithMetadata result = collection.iterator().next();
               assertEquals(true, result.getDocument().get("udf_applied"));
               assertEquals("test", result.getDocument().get("name"));
+              assertEquals(input.getOriginalDocument(), result.getOriginalDocument());
+              return null;
+            });
+
+    PAssert.that(output.get(FAILURE_TAG)).empty();
+
+    pipeline.run();
+  }
+
+  @Test
+  public void applyUdfFn_cdcFullDoc_preservesOriginalDocument() throws Exception {
+    File udfFile = tempFolder.newFile("cdc_transform.js");
+    try (FileWriter writer = new FileWriter(udfFile)) {
+      writer.write(
+          "function transform(inJson) {\n"
+              + "  var obj = JSON.parse(inJson);\n"
+              + "  obj.enriched = 'yes';\n"
+              + "  return JSON.stringify(obj);\n"
+              + "}");
+    }
+
+    Document fullDoc = new Document("_id", 42).append("status", "ACTIVE").append("tier", "GOLD");
+    TimestampSortKey sortKey = TimestampSortKey.cdc(1700000000L, 1L);
+    DocumentWithMetadata cdcEvent =
+        DocumentWithMetadata.cdcEvent(
+            fullDoc,
+            fullDoc.toJson(),
+            "users",
+            "users_target",
+            DocumentWithMetadata.OperationType.UPDATE,
+            sortKey,
+            new Document("_id", 42).toJson());
+
+    PCollection<DocumentWithMetadata> inputCollection = pipeline.apply(Create.of(cdcEvent));
+
+    PCollectionTuple output =
+        inputCollection.apply(
+            "ApplyUDF_CDC",
+            ParDo.of(
+                    new MongoDbTransforms.ApplyUdfFn(
+                        udfFile.getAbsolutePath(), "transform", 0, FAILURE_TAG))
+                .withOutputTags(MAIN_TAG, TupleTagList.of(FAILURE_TAG)));
+
+    PAssert.that(output.get(MAIN_TAG))
+        .satisfies(
+            collection -> {
+              DocumentWithMetadata result = collection.iterator().next();
+              assertEquals("yes", result.getDocument().get("enriched"));
+              assertEquals("ACTIVE", result.getDocument().get("status"));
+              assertEquals("GOLD", result.getDocument().get("tier"));
+              // Verify that originalDocument retains the untransformed original fullDoc
+              assertEquals(fullDoc.toJson(), result.getOriginalDocument());
+              // Verify that CDC metadata is preserved
+              assertEquals(DocumentWithMetadata.OperationType.UPDATE, result.getOperationType());
+              assertEquals(sortKey, result.getTimestampSortKey());
+              assertEquals("users", result.getSourceCollection());
+              assertEquals("users_target", result.getTargetCollection());
               return null;
             });
 

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbTransformsTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/MongoDbTransformsTest.java
@@ -34,6 +34,7 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.BulkWriteOptions;
+import com.mongodb.client.model.DeleteOneModel;
 import com.mongodb.client.model.ReplaceOneModel;
 import com.mongodb.client.model.WriteModel;
 import java.io.File;
@@ -49,6 +50,7 @@ import org.apache.beam.sdk.metrics.MetricsFilter;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.PCollection;
@@ -238,6 +240,135 @@ public class MongoDbTransformsTest {
         MongoDbTransforms.writeWithDlq()
             .withUri("mongodb://localhost:27017")
             .withDatabase("test")
+            .withClientFactory(new MockClientFactory()));
+    PipelineResult result = pipeline.run();
+
+    assertSuccessCount(result, 0L);
+  }
+
+  @Test
+  public void writeWithDlq_mixedUpsertAndDelete_success() {
+    List<WriteModel<Document>> capturedModels = Collections.synchronizedList(new ArrayList<>());
+    when(staticCollection.bulkWrite(anyList(), any(BulkWriteOptions.class)))
+        .thenAnswer(
+            invocation -> {
+              List<WriteModel<Document>> models = invocation.getArgument(0);
+              capturedModels.addAll(models);
+              return mock(BulkWriteResult.class);
+            });
+
+    DocumentWithMetadata upsertDoc =
+        DocumentWithMetadata.cdcEvent(
+            new Document("_id", "u1").append("name", "Alice"),
+            "{\"_id\": \"u1\", \"name\": \"Alice\"}",
+            "test",
+            "test",
+            DocumentWithMetadata.OperationType.INSERT,
+            TimestampSortKey.cdc(1000L, 1L),
+            "{\"_id\": \"u1\"}");
+
+    DocumentWithMetadata deleteDoc =
+        DocumentWithMetadata.cdcEvent(
+            null,
+            null,
+            "test",
+            "test",
+            DocumentWithMetadata.OperationType.DELETE,
+            TimestampSortKey.cdc(1000L, 2L),
+            "{\"_id\": \"d1\"}");
+
+    PCollection<DocumentWithMetadata> input = pipeline.apply(Create.of(upsertDoc, deleteDoc));
+
+    input.apply(
+        "Write_Mixed",
+        MongoDbTransforms.writeWithDlq()
+            .withUri("mongodb://localhost:27017")
+            .withDatabase("test")
+            .withBatchSize(10)
+            .withClientFactory(new MockClientFactory()));
+    PipelineResult result = pipeline.run();
+
+    assertSuccessCount(result, 2L);
+    assertEquals(2, capturedModels.size());
+    assertTrue(capturedModels.stream().anyMatch(m -> m instanceof ReplaceOneModel));
+    assertTrue(capturedModels.stream().anyMatch(m -> m instanceof DeleteOneModel));
+  }
+
+  @Test
+  public void writeWithDlq_deletePermanentFailure_sentToDlqWithMetadata() {
+    when(staticCollection.bulkWrite(anyList(), any(BulkWriteOptions.class)))
+        .thenThrow(
+            new MongoBulkWriteException(
+                mock(BulkWriteResult.class),
+                Arrays.asList(new BulkWriteError(11000, "Duplicate Key", new BsonDocument(), 0)),
+                null,
+                new ServerAddress(),
+                Collections.emptySet()));
+
+    DocumentWithMetadata deleteDoc =
+        DocumentWithMetadata.cdcEvent(
+            null,
+            null,
+            "test",
+            "test",
+            DocumentWithMetadata.OperationType.DELETE,
+            TimestampSortKey.cdc(1000L, 5L),
+            "{\"_id\": \"d99\"}");
+
+    PCollection<DocumentWithMetadata> input = pipeline.apply(Create.of(deleteDoc));
+
+    PCollectionTuple tuple =
+        input.apply(
+            "Write_Delete_Failure",
+            ParDo.of(
+                    MongoDbTransforms.WriteFn.builder()
+                        .withUri("mongodb://localhost:27017")
+                        .withDatabase("test")
+                        .withBatchSize(1)
+                        .withMaxWriteRetries(1)
+                        .withDlqMaxRetries(3)
+                        .withClientFactory(new MockClientFactory())
+                        .withFailureTag(FAILURE_TAG)
+                        .build())
+                .withOutputTags(MAIN_TAG, TupleTagList.of(FAILURE_TAG)));
+
+    PAssert.that(tuple.get(FAILURE_TAG))
+        .satisfies(
+            failures -> {
+              List<DocumentWithMetadata> list = new ArrayList<>();
+              failures.forEach(list::add);
+              assertEquals(1, list.size());
+              DocumentWithMetadata failedItem = list.get(0);
+              assertEquals(DocumentWithMetadata.OperationType.DELETE, failedItem.getOperationType());
+              assertEquals("{\"_id\": \"d99\"}", failedItem.getDocumentKey());
+              assertEquals(TimestampSortKey.cdc(1000L, 5L), failedItem.getTimestampSortKey());
+              assertEquals(DocumentWithMetadata.ErrorType.PERMANENT, failedItem.getErrorType());
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void writeWithDlq_dropEvent_skippedWithoutError() {
+    DocumentWithMetadata dropDoc =
+        DocumentWithMetadata.cdcEvent(
+            null,
+            null,
+            "test",
+            "test",
+            DocumentWithMetadata.OperationType.DROP,
+            TimestampSortKey.cdc(1000L, 10L),
+            null);
+
+    PCollection<DocumentWithMetadata> input = pipeline.apply(Create.of(dropDoc));
+
+    input.apply(
+        "Write_Drop",
+        MongoDbTransforms.writeWithDlq()
+            .withUri("mongodb://localhost:27017")
+            .withDatabase("test")
+            .withBatchSize(10)
             .withClientFactory(new MockClientFactory()));
     PipelineResult result = pipeline.run();
 
@@ -536,5 +667,60 @@ public class MongoDbTransformsTest {
     assertEquals(25000.0, fn.getRateLimiter().getRate(), 0.01);
 
     fn.teardown();
+  }
+
+  @Test
+  public void testWriteFn_multiBundleExecution_preservesClientAcrossBundles() throws Exception {
+    MongoClient mockClient = mock(MongoClient.class);
+    MongoDatabase mockDb = mock(MongoDatabase.class);
+    @SuppressWarnings("unchecked")
+    MongoCollection<Document> mockCol = mock(MongoCollection.class);
+    when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
+    when(mockDb.getCollection(anyString())).thenReturn(mockCol);
+
+    TupleTag<DocumentWithMetadata> failureTag = new TupleTag<>();
+    MongoDbTransforms.WriteFn fn =
+        MongoDbTransforms.WriteFn.builder()
+            .withUri("mongodb://localhost:27017")
+            .withDatabase("test")
+            .withBatchSize(1)
+            .withMaxWriteRetries(1)
+            .withClientFactory(uri -> mockClient)
+            .withFailureTag(failureTag)
+            .build();
+
+    fn.setup();
+
+    @SuppressWarnings("unchecked")
+    DoFn<DocumentWithMetadata, DocumentWithMetadata>.ProcessContext mockCtx =
+        mock(DoFn.ProcessContext.class);
+    @SuppressWarnings("unchecked")
+    DoFn<DocumentWithMetadata, DocumentWithMetadata>.FinishBundleContext mockFinishCtx =
+        mock(DoFn.FinishBundleContext.class);
+
+    DocumentWithMetadata doc1 = DocumentWithMetadata.of(new Document("_id", 1), "users", "users");
+    when(mockCtx.element()).thenReturn(doc1);
+
+    // Bundle 1
+    fn.startBundle();
+    fn.processElement(mockCtx);
+    fn.finishBundle(mockFinishCtx);
+
+    // Verify client was NOT closed after bundle 1
+    org.mockito.Mockito.verify(mockClient, org.mockito.Mockito.never()).close();
+
+    // Bundle 2
+    DocumentWithMetadata doc2 = DocumentWithMetadata.of(new Document("_id", 2), "users", "users");
+    when(mockCtx.element()).thenReturn(doc2);
+    fn.startBundle();
+    fn.processElement(mockCtx);
+    fn.finishBundle(mockFinishCtx);
+
+    // Verify client still was NOT closed after bundle 2
+    org.mockito.Mockito.verify(mockClient, org.mockito.Mockito.never()).close();
+
+    // Teardown closes the client
+    fn.teardown();
+    org.mockito.Mockito.verify(mockClient, org.mockito.Mockito.times(1)).close();
   }
 }

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/ReadSplitGeneratorTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/ReadSplitGeneratorTest.java
@@ -243,4 +243,15 @@ public class ReadSplitGeneratorTest {
     assertTrue(slice0.contains("\"$type\": \"objectId\""));
     assertTrue(slice0.contains("\"$type\": [\"int\""));
   }
+
+  @Test
+  public void testGenerateTypeIsolatedSplits_smallCollectionReturnsSingleSplit() {
+    @SuppressWarnings("unchecked")
+    MongoCollection<BsonDocument> mockCol = mock(MongoCollection.class);
+    when(mockCol.estimatedDocumentCount()).thenReturn(2000L);
+
+    List<BsonDocument> splits = ReadSplitGenerator.generateTypeIsolatedSplits(mockCol, 16);
+    assertEquals(1, splits.size());
+    assertTrue(splits.get(0).isEmpty());
+  }
 }

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/ReadSplitGeneratorTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/ReadSplitGeneratorTest.java
@@ -20,26 +20,16 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.mongodb.ServerAddress;
-import com.mongodb.ServerCursor;
-import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
-import java.lang.reflect.Proxy;
-import java.util.Arrays;
 import java.util.EnumSet;
-import java.util.Iterator;
 import java.util.List;
 import org.bson.BsonDocument;
-import org.bson.BsonString;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -167,8 +157,11 @@ public class ReadSplitGeneratorTest {
     @SuppressWarnings("unchecked")
     MongoCollection<BsonDocument> mockCol = mock(MongoCollection.class);
 
-    when(mockClient.getDatabase(anyString())).thenReturn(mockDb);
-    when(mockDb.getCollection(anyString(), eq(BsonDocument.class))).thenReturn(mockCol);
+    when(mockClient.getDatabase(org.mockito.ArgumentMatchers.anyString())).thenReturn(mockDb);
+    when(mockDb.getCollection(
+            org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.eq(BsonDocument.class)))
+        .thenReturn(mockCol);
 
     // Mock detectIdTypes to return multiple types
     @SuppressWarnings("unchecked")
@@ -179,19 +172,22 @@ public class ReadSplitGeneratorTest {
 
     // Mock $sample aggregation
     @SuppressWarnings("unchecked")
-    AggregateIterable<BsonDocument> mockAgg =
-        (AggregateIterable<BsonDocument>)
-            Proxy.newProxyInstance(
+    com.mongodb.client.AggregateIterable<BsonDocument> mockAgg =
+        (com.mongodb.client.AggregateIterable<BsonDocument>)
+            java.lang.reflect.Proxy.newProxyInstance(
                 getClass().getClassLoader(),
-                new Class<?>[] {AggregateIterable.class},
+                new Class<?>[] {com.mongodb.client.AggregateIterable.class},
                 (proxy, method, args) -> {
+                  if (method.getName().equals("allowDiskUse") || method.getName().equals("maxTime")) {
+                    return proxy;
+                  }
                   if (method.getName().equals("iterator")) {
-                    return new MongoCursor<BsonDocument>() {
-                      Iterator<BsonDocument> iter =
-                          Arrays.asList(
-                                  new BsonDocument("_id", new BsonString("min")),
-                                  new BsonDocument("_id", new BsonString("mid")),
-                                  new BsonDocument("_id", new BsonString("max")))
+                    return new com.mongodb.client.MongoCursor<BsonDocument>() {
+                      java.util.Iterator<BsonDocument> iter =
+                          java.util.Arrays.asList(
+                                  new BsonDocument("_id", new org.bson.BsonString("min")),
+                                  new BsonDocument("_id", new org.bson.BsonString("mid")),
+                                  new BsonDocument("_id", new org.bson.BsonString("max")))
                               .iterator();
 
                       @Override
@@ -213,12 +209,12 @@ public class ReadSplitGeneratorTest {
                       }
 
                       @Override
-                      public ServerCursor getServerCursor() {
+                      public com.mongodb.ServerCursor getServerCursor() {
                         return null;
                       }
 
                       @Override
-                      public ServerAddress getServerAddress() {
+                      public com.mongodb.ServerAddress getServerAddress() {
                         return null;
                       }
 

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/ReadSplitGeneratorTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/ReadSplitGeneratorTest.java
@@ -178,7 +178,8 @@ public class ReadSplitGeneratorTest {
                 getClass().getClassLoader(),
                 new Class<?>[] {com.mongodb.client.AggregateIterable.class},
                 (proxy, method, args) -> {
-                  if (method.getName().equals("allowDiskUse") || method.getName().equals("maxTime")) {
+                  if (method.getName().equals("allowDiskUse")
+                      || method.getName().equals("maxTime")) {
                     return proxy;
                   }
                   if (method.getName().equals("iterator")) {
@@ -283,8 +284,7 @@ public class ReadSplitGeneratorTest {
     MongoCollection<BsonDocument> mockCol = mock(MongoCollection.class);
     when(mockCol.estimatedDocumentCount()).thenReturn(10_000_000L);
 
-    List<BsonDocument> splits =
-        ReadSplitGenerator.generateTypeIsolatedSplits(mockCol, 16, 0, 256);
+    List<BsonDocument> splits = ReadSplitGenerator.generateTypeIsolatedSplits(mockCol, 16, 0, 256);
     assertEquals(16, splits.size());
   }
 
@@ -292,8 +292,7 @@ public class ReadSplitGeneratorTest {
   public void testGenerateProbedObjectIdSplits_boundsTailSliceWithMaxHex() {
     String minHex = "66d000000000000000000000";
     String maxHex = "66dff0000000000000000000";
-    List<BsonDocument> splits =
-        ReadSplitGenerator.generateProbedObjectIdSplits(minHex, maxHex, 4);
+    List<BsonDocument> splits = ReadSplitGenerator.generateProbedObjectIdSplits(minHex, maxHex, 4);
     assertEquals(4, splits.size());
     assertTrue(splits.get(0).toJson().contains("\"$lt\""));
     assertTrue(splits.get(1).toJson().contains("\"$gte\""));
@@ -308,8 +307,7 @@ public class ReadSplitGeneratorTest {
   public void testGenerateProbedObjectIdSplits_singleSplitBoundedToMaxHex() {
     String minHex = "66d000000000000000000000";
     String maxHex = "66dff0000000000000000000";
-    List<BsonDocument> splits =
-        ReadSplitGenerator.generateProbedObjectIdSplits(minHex, maxHex, 1);
+    List<BsonDocument> splits = ReadSplitGenerator.generateProbedObjectIdSplits(minHex, maxHex, 1);
     assertEquals(1, splits.size());
     String json = splits.get(0).toJson();
     assertTrue(json.contains("\"$lte\""));

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/ReadSplitGeneratorTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/ReadSplitGeneratorTest.java
@@ -254,4 +254,65 @@ public class ReadSplitGeneratorTest {
     assertEquals(1, splits.size());
     assertTrue(splits.get(0).isEmpty());
   }
+
+  @Test
+  public void testGenerateTypeIsolatedSplits_adaptiveVolumeSizing_calculatesEffectiveSplits() {
+    @SuppressWarnings("unchecked")
+    MongoCollection<BsonDocument> mockCol = mock(MongoCollection.class);
+    when(mockCol.estimatedDocumentCount()).thenReturn(1_000_000L);
+
+    List<BsonDocument> splits =
+        ReadSplitGenerator.generateTypeIsolatedSplits(mockCol, 1, 200_000, 256);
+    assertEquals(5, splits.size());
+  }
+
+  @Test
+  public void testGenerateTypeIsolatedSplits_adaptiveVolumeSizing_clampsToMaxSplits() {
+    @SuppressWarnings("unchecked")
+    MongoCollection<BsonDocument> mockCol = mock(MongoCollection.class);
+    when(mockCol.estimatedDocumentCount()).thenReturn(100_000_000L);
+
+    List<BsonDocument> splits =
+        ReadSplitGenerator.generateTypeIsolatedSplits(mockCol, 1, 200_000, 256);
+    assertEquals(256, splits.size());
+  }
+
+  @Test
+  public void testGenerateTypeIsolatedSplits_zeroTargetChunkSize_usesNumSplits() {
+    @SuppressWarnings("unchecked")
+    MongoCollection<BsonDocument> mockCol = mock(MongoCollection.class);
+    when(mockCol.estimatedDocumentCount()).thenReturn(10_000_000L);
+
+    List<BsonDocument> splits =
+        ReadSplitGenerator.generateTypeIsolatedSplits(mockCol, 16, 0, 256);
+    assertEquals(16, splits.size());
+  }
+
+  @Test
+  public void testGenerateProbedObjectIdSplits_boundsTailSliceWithMaxHex() {
+    String minHex = "66d000000000000000000000";
+    String maxHex = "66dff0000000000000000000";
+    List<BsonDocument> splits =
+        ReadSplitGenerator.generateProbedObjectIdSplits(minHex, maxHex, 4);
+    assertEquals(4, splits.size());
+    assertTrue(splits.get(0).toJson().contains("\"$lt\""));
+    assertTrue(splits.get(1).toJson().contains("\"$gte\""));
+    assertTrue(splits.get(1).toJson().contains("\"$lt\""));
+    String tailJson = splits.get(3).toJson();
+    assertTrue(tailJson.contains("\"$gte\""));
+    assertTrue(tailJson.contains("\"$lte\""));
+    assertTrue(tailJson.contains(maxHex));
+  }
+
+  @Test
+  public void testGenerateProbedObjectIdSplits_singleSplitBoundedToMaxHex() {
+    String minHex = "66d000000000000000000000";
+    String maxHex = "66dff0000000000000000000";
+    List<BsonDocument> splits =
+        ReadSplitGenerator.generateProbedObjectIdSplits(minHex, maxHex, 1);
+    assertEquals(1, splits.size());
+    String json = splits.get(0).toJson();
+    assertTrue(json.contains("\"$lte\""));
+    assertTrue(json.contains(maxHex));
+  }
 }

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/StatefulDeduplicationTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/StatefulDeduplicationTest.java
@@ -72,6 +72,7 @@ public class StatefulDeduplicationTest implements Serializable {
     final StatefulDeduplicationFn fn = new StatefulDeduplicationFn();
     final TestValueState<TimestampSortKey> state = new TestValueState<>();
     final List<DocumentWithMetadata> outputs = new ArrayList<>();
+
     @SuppressWarnings("unchecked")
     final OutputReceiver<DocumentWithMetadata> receiver = mock(OutputReceiver.class);
 
@@ -227,9 +228,7 @@ public class StatefulDeduplicationTest implements Serializable {
     DocumentWithMetadata o1 = createCdc("1", "Order1", 1000L, 1L, "orders");
 
     PCollection<DocumentWithMetadata> output =
-        pipeline
-            .apply(Create.of(u1, u2, o1))
-            .apply(StatefulDeduplication.of());
+        pipeline.apply(Create.of(u1, u2, o1)).apply(StatefulDeduplication.of());
 
     PAssert.that(output)
         .satisfies(

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/StatefulDeduplicationTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/StatefulDeduplicationTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.transforms;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import com.google.cloud.teleport.v2.transforms.DocumentWithMetadata.OperationType;
+import com.google.cloud.teleport.v2.transforms.StatefulDeduplication.StatefulDeduplicationFn;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.beam.sdk.state.ValueState;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.bson.Document;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link StatefulDeduplication} and {@link StatefulDeduplicationFn}. */
+@RunWith(JUnit4.class)
+public class StatefulDeduplicationTest implements Serializable {
+
+  @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+
+  private static class TestValueState<T> implements ValueState<T> {
+    private T value;
+
+    @Override
+    public void write(T input) {
+      this.value = input;
+    }
+
+    @Override
+    public T read() {
+      return value;
+    }
+
+    @Override
+    public ValueState<T> readLater() {
+      return this;
+    }
+
+    @Override
+    public void clear() {
+      this.value = null;
+    }
+  }
+
+  private static class Harness {
+    final StatefulDeduplicationFn fn = new StatefulDeduplicationFn();
+    final TestValueState<TimestampSortKey> state = new TestValueState<>();
+    final List<DocumentWithMetadata> outputs = new ArrayList<>();
+    @SuppressWarnings("unchecked")
+    final OutputReceiver<DocumentWithMetadata> receiver = mock(OutputReceiver.class);
+
+    Harness() {
+      doAnswer(
+              invocation -> {
+                outputs.add(invocation.getArgument(0));
+                return null;
+              })
+          .when(receiver)
+          .output(any(DocumentWithMetadata.class));
+    }
+
+    void process(DocumentWithMetadata doc) {
+      fn.processElement(KV.of(doc.getDedupKey(), doc), receiver, state);
+    }
+  }
+
+  private static DocumentWithMetadata createCdc(
+      String id, String name, long sec, long subSec, String collection) {
+    Document doc = new Document("_id", id).append("name", name);
+    TimestampSortKey key = TimestampSortKey.cdc(sec, subSec);
+    return DocumentWithMetadata.cdcEvent(
+        doc,
+        doc.toJson(),
+        collection,
+        collection,
+        OperationType.INSERT,
+        key,
+        new Document("_id", id).toJson());
+  }
+
+  private static DocumentWithMetadata createBackfill(
+      String id, String name, long sec, String collection) {
+    Document doc = new Document("_id", id).append("name", name);
+    TimestampSortKey key = TimestampSortKey.backfill(sec);
+    return DocumentWithMetadata.backfillEvent(doc, collection, collection, key);
+  }
+
+  @Test
+  public void testMonotonicOrdering_inOrderCdcEvents() {
+    Harness h = new Harness();
+
+    DocumentWithMetadata e1 = createCdc("1", "v1", 1000L, 1L, "users");
+    DocumentWithMetadata e2 = createCdc("1", "v2", 1000L, 2L, "users");
+    DocumentWithMetadata e3 = createCdc("1", "v3", 1001L, 0L, "users");
+
+    h.process(e1);
+    h.process(e2);
+    h.process(e3);
+
+    assertEquals(3, h.outputs.size());
+    assertEquals(TimestampSortKey.cdc(1001L, 0L), h.state.read());
+  }
+
+  @Test
+  public void testOutOrderBackfillAndCdc_backfillArrivesAfterCdc_isDropped() {
+    Harness h = new Harness();
+
+    DocumentWithMetadata cdc = createCdc("1", "cdc_version", 1000L, 5L, "users");
+    DocumentWithMetadata backfill = createBackfill("1", "snapshot_version", 1000L, "users");
+
+    // Feed CDC first, then Backfill for the same document
+    h.process(cdc);
+    h.process(backfill);
+
+    assertEquals(1, h.outputs.size());
+    assertEquals("cdc_version", h.outputs.get(0).getDocument().getString("name"));
+    assertEquals(TimestampSortKey.cdc(1000L, 5L), h.state.read());
+  }
+
+  @Test
+  public void testCdcArrivesAfterBackfill_bothEmitted() {
+    Harness h = new Harness();
+
+    DocumentWithMetadata backfill = createBackfill("1", "snapshot_version", 1000L, "users");
+    DocumentWithMetadata cdc = createCdc("1", "cdc_version", 1000L, 1L, "users");
+
+    h.process(backfill);
+    h.process(cdc);
+
+    assertEquals(2, h.outputs.size());
+    assertEquals("snapshot_version", h.outputs.get(0).getDocument().getString("name"));
+    assertEquals("cdc_version", h.outputs.get(1).getDocument().getString("name"));
+    assertEquals(TimestampSortKey.cdc(1000L, 1L), h.state.read());
+  }
+
+  @Test
+  public void testMultipleDocumentKeysIndependent() {
+    Harness h1 = new Harness();
+    Harness h2 = new Harness();
+
+    DocumentWithMetadata u1 = createCdc("1", "User1", 1000L, 1L, "users");
+    DocumentWithMetadata u2 = createCdc("2", "User2", 1000L, 1L, "users");
+
+    h1.process(u1);
+    h2.process(u2);
+
+    assertEquals(1, h1.outputs.size());
+    assertEquals(1, h2.outputs.size());
+  }
+
+  @Test
+  public void testDlqReconsumed_droppedWhenNewerEventArrived() {
+    Harness h = new Harness();
+
+    DocumentWithMetadata e1 = createCdc("1", "v1", 1000L, 1L, "users");
+    DocumentWithMetadata e2 = createCdc("1", "v2", 1005L, 1L, "users");
+    DocumentWithMetadata dlqRetryE1 =
+        createCdc("1", "v1_retry", 1000L, 1L, "users").withDlqReconsumed(true);
+
+    h.process(e1);
+    h.process(e2);
+    // dlqRetryE1 arrives late after e2 already advanced state to 1005
+    h.process(dlqRetryE1);
+
+    // e1 and e2 pass; dlqRetryE1 is dropped
+    assertEquals(2, h.outputs.size());
+    assertEquals("v1", h.outputs.get(0).getDocument().getString("name"));
+    assertEquals("v2", h.outputs.get(1).getDocument().getString("name"));
+  }
+
+  @Test
+  public void testDlqReconsumed_acceptedWhenStateNotChanged() {
+    Harness h = new Harness();
+
+    DocumentWithMetadata e1 = createCdc("1", "v1", 1000L, 1L, "users");
+    DocumentWithMetadata dlqRetryE1 =
+        createCdc("1", "v1_retry", 1000L, 1L, "users").withDlqReconsumed(true);
+
+    h.process(e1);
+    h.process(dlqRetryE1);
+
+    assertEquals(2, h.outputs.size());
+  }
+
+  @Test
+  public void testLegacyElementWithoutTimestamp_passesThrough() {
+    Harness h = new Harness();
+
+    Document doc = new Document("_id", "100").append("item", "legacy");
+    DocumentWithMetadata legacy = DocumentWithMetadata.of(doc, "items", "items");
+
+    h.process(legacy);
+
+    assertEquals(1, h.outputs.size());
+  }
+
+  @Test
+  public void testPipelineTransform_distinctKeys() {
+    DocumentWithMetadata u1 = createCdc("1", "User1", 1000L, 1L, "users");
+    DocumentWithMetadata u2 = createCdc("2", "User2", 1000L, 1L, "users");
+    DocumentWithMetadata o1 = createCdc("1", "Order1", 1000L, 1L, "orders");
+
+    PCollection<DocumentWithMetadata> output =
+        pipeline
+            .apply(Create.of(u1, u2, o1))
+            .apply(StatefulDeduplication.of());
+
+    PAssert.that(output)
+        .satisfies(
+            elements -> {
+              List<DocumentWithMetadata> list = new ArrayList<>();
+              elements.forEach(list::add);
+              assertEquals(3, list.size());
+              return null;
+            });
+
+    pipeline.run();
+  }
+}

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/TimestampSortKeyCoderTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/TimestampSortKeyCoderTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.transforms;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.apache.beam.sdk.testing.CoderProperties;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link TimestampSortKeyCoder}. */
+@RunWith(JUnit4.class)
+public class TimestampSortKeyCoderTest {
+
+  @Test
+  public void testEncodeDecode_roundTrip() throws IOException {
+    TimestampSortKey key = TimestampSortKey.cdc(1724000000L, 42L);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    TimestampSortKeyCoder.of().encode(key, out);
+
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    TimestampSortKey decoded = TimestampSortKeyCoder.of().decode(in);
+
+    assertEquals(key, decoded);
+    assertEquals(1724000000L, decoded.getSeconds());
+    assertEquals(42L, decoded.getSubSeconds());
+    assertEquals(true, decoded.isCdc());
+  }
+
+  @Test
+  public void testEncodeDecode_nullHandling() throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    TimestampSortKeyCoder.of().encode(null, out);
+
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    TimestampSortKey decoded = TimestampSortKeyCoder.of().decode(in);
+
+    assertNull(decoded);
+  }
+
+  @Test
+  public void testCoderProperties_deterministic() throws Exception {
+    CoderProperties.coderDeterministic(
+        TimestampSortKeyCoder.of(),
+        TimestampSortKey.cdc(123456L, 1L),
+        TimestampSortKey.cdc(123456L, 1L));
+  }
+}

--- a/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/TimestampSortKeyTest.java
+++ b/v2/mongodb-to-mongodb/src/test/java/com/google/cloud/teleport/v2/transforms/TimestampSortKeyTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.v2.transforms;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link TimestampSortKey}. */
+@RunWith(JUnit4.class)
+public class TimestampSortKeyTest {
+
+  @Test
+  public void testEpochSecondsComparison_primaryTier() {
+    TimestampSortKey olderKey = TimestampSortKey.of(100L, 500L, true);
+    TimestampSortKey newerKey = TimestampSortKey.of(200L, 100L, true);
+
+    assertTrue(newerKey.compareTo(olderKey) > 0);
+    assertTrue(olderKey.compareTo(newerKey) < 0);
+  }
+
+  @Test
+  public void testStreamTypePrecedence_sameSecondCDCsupersedesBackfill() {
+    TimestampSortKey backfillKey = TimestampSortKey.backfill(1000L, 999999L);
+    TimestampSortKey cdcKey = TimestampSortKey.cdc(1000L, 1L);
+
+    // CDC must strictly supersede Backfill at the same epoch second
+    assertTrue(cdcKey.compareTo(backfillKey) > 0);
+    assertTrue(backfillKey.compareTo(cdcKey) < 0);
+  }
+
+  @Test
+  public void testSubSecondsComparison_tertiaryTier() {
+    TimestampSortKey cdc1 = TimestampSortKey.cdc(1000L, 1L);
+    TimestampSortKey cdc2 = TimestampSortKey.cdc(1000L, 2L);
+
+    assertTrue(cdc2.compareTo(cdc1) > 0);
+    assertTrue(cdc1.compareTo(cdc2) < 0);
+
+    TimestampSortKey bf1 = TimestampSortKey.backfill(1000L, 100L);
+    TimestampSortKey bf2 = TimestampSortKey.backfill(1000L, 200L);
+
+    assertTrue(bf2.compareTo(bf1) > 0);
+    assertTrue(bf1.compareTo(bf2) < 0);
+  }
+
+  @Test
+  public void testEqualityAndHashCode() {
+    TimestampSortKey key1 = TimestampSortKey.cdc(1000L, 5L);
+    TimestampSortKey key2 = TimestampSortKey.cdc(1000L, 5L);
+    TimestampSortKey key3 = TimestampSortKey.backfill(1000L, 5L);
+
+    assertEquals(key1, key2);
+    assertEquals(key1.hashCode(), key2.hashCode());
+    assertEquals(0, key1.compareTo(key2));
+
+    assertNotEquals(key1, key3);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testCompareTo_nullThrows() {
+    TimestampSortKey key = TimestampSortKey.cdc(100L, 1L);
+    key.compareTo(null);
+  }
+}


### PR DESCRIPTION
## Overview

This pull request enhances the `mongodb-to-mongodb` Dataflow template to deliver high-throughput, horizontally scalable historical backfills and introduces experimental support for Change Data Capture (CDC).

The pipeline introduces three standardized migration modes via the `migrationMode` parameter:

1. **`BACKFILL` (Historical Backfill Only)**:
   - Executes parallel, adaptive volume-based reads using Splittable DoFns with keyset pagination and concurrency slot bounding.
   - **Bypasses the Stateful Deduplication stage entirely**: Because historical backfill partitions are mutually disjoint and target writes are idempotent (`ReplaceOneModel` with `upsert`), deduplication is unnecessary. Bypassing this stage eliminates the `KeyByDedupKey` shuffle and Windmill state barrier, enabling maximum ingestion throughput.
2. **`BACKFILL_AND_STREAMING` (Dual Backfill + Live CDC)**:
   - Runs historical backfill concurrently with live MongoDB change stream CDC, capturing initial cluster time ($T_0$) before backfill execution begins.
   - **Includes the Stateful Deduplication stage**: This is the **only mode** where stateful deduplication (`StatefulDeduplication.of()`) is present. It reconciles historical backfill documents against concurrent live mutations using a 3-tier monotonic sort key (`TimestampSortKey`) per document key, guaranteeing that older backfill elements never overwrite newer CDC mutations.
3. **`STREAMING_CDC` (Live CDC Only)**:
   - Continuously replicates real-time changes via MongoDB change streams (`db.watch()` or `collection.watch()`) using server-side `$toHashedIndexKey` modulo partitioning and checkpointed resume tokens.
   - Streams live insert, update, replace, and delete operations directly to target collections without backfill or deduplication overhead.

> [!NOTE]
> **Change Data Capture (CDC)** streaming via MongoDB change streams is currently in **experimental mode**.

---

## Key Improvements to Backfill

### 1. Adaptive Splitting & Virtual Concurrency Slots (`MongoDbBackfillReader`)
- **Adaptive Volume-Based Splitting**: Computes partition counts adaptively based on collection volume using `targetBackfillChunkSize` (e.g., 25k docs) and `maxBackfillSplits` (up to 10,000), ensuring balanced partition sizing across heterogeneous collection sizes.
- **Bounded Cursor Concurrency (`maxConcurrentBackfillReads`)**: Routes backfill partitions into bounded virtual concurrency slots (`BackfillSlotTask`, `ProcessBackfillSlotFn`), guaranteeing that active cursors and sockets on MongoDB routers (`mongos`) remain strictly bounded regardless of split count.
- **Keyset-Paged Resumption**: Slices are streamed in micro-batches (`MAX_DOCS_PER_SLICE = 2,000`) using indexed keyset pagination (`_id > lastSeenId`), allowing smooth Windmill checkpointing, worker preemption recovery, and dynamic rebalancing without duplicate reads.

### 2. Fast Type-Isolated Split Generation (`ReadSplitGenerator`)
- **Type-Aware Boundary Sampling**: Discovers active BSON `_id` types (ObjectId, String, Number, Binary, Date, Document) and computes quantile boundaries independently per type, preventing cross-type query skew.
- **Parallel Type Probing**: Probes active type buckets concurrently using a dedicated `ExecutorService`, significantly reducing pipeline initialization latency on databases with many collections.
- **Canonical Extended JSON Serialization**: Serializes boundaries via `JsonMode.EXTENDED` to preserve exact BSON types across worker nodes.
- **Algorithmic Fallback**: Gracefully falls back to uniform partition bounds ($mod for numbers, hex intervals for strings/ObjectIDs) if sampling is unavailable.

### 3. High-Throughput Asynchronous Micro-Batch Writer (`MongoDbTransforms`)
- **Configurable Write Sharding**: Downstream writes are keyed by collection and shard ID (`numWriteShards`), distributing Windmill state, timers, and bundle commitments evenly across workers.
- **Asynchronous Bulk Writing**: Non-blocking bulk writes (`maxConcurrentAsyncWrites`) saturate target ingestion capacity (including Cloud Firestore MongoDB endpoints).
- **Optimized Connection Pooling**: Configured connection pools (`maxSize(256)`, `minSize(0)`) to dynamically scale under worker load while preventing connection churn from short-lived driver queries.

---

## Experimental CDC Overview

- Database-level (`db.watch()`) and collection-level change stream support.
- Partitioned parallel streams using server-side `$toHashedIndexKey` modulo filtering on document keys.
- Continuous idle watermark advancement and optimized resume token stride serialization.
- *Note*: CDC remains experimental while optimizations for large-scale sharded oplog throughput and update-lookup decoupling continue.

---

## Verification & Testing
- **Unit Tests**: All 132 unit tests passing (`mvn test -pl v2/mongodb-to-mongodb`).
- **Checkstyle & Formatting**: 0 Checkstyle violations and 100% Google Java Format compliance verified via Spotless.
- **End-to-End Scale Validation**: Verified full migration of 95.25M documents from a MongoDB 7.0 sharded cluster to Cloud Firestore with DLQ replay and 100.0% deep field-by-field sample parity.
