### PR TITLE
fix(Iceberg): Safely close cached catalog during cleanup to prevent resource leaks

### DIFF
--- a/it/iceberg/src/main/java/com/google/cloud/teleport/it/iceberg/IcebergResourceManager.java
+++ b/it/iceberg/src/main/java/com/google/cloud/teleport/it/iceberg/IcebergResourceManager.java
@@ -300,6 +300,14 @@ public class IcebergResourceManager implements ResourceManager {
       dropNamespace(namespace, true);
     }
     createdNamespaces.clear();
+    if (cachedCatalog instanceof AutoCloseable) {
+      try {
+        ((AutoCloseable) cachedCatalog).close();
+      } catch (Exception e) {
+        LOG.warn("Error closing Iceberg catalog", e);
+      }
+    }
+    cachedCatalog = null;
     LOG.info("Cleaned up all resources for test ID: {}.", testId);
   }
 

--- a/it/iceberg/src/main/java/com/google/cloud/teleport/it/iceberg/IcebergResourceManager.java
+++ b/it/iceberg/src/main/java/com/google/cloud/teleport/it/iceberg/IcebergResourceManager.java
@@ -68,7 +68,7 @@ public class IcebergResourceManager implements ResourceManager {
   private static final String DEFAULT_CATALOG_NAME = "default";
 
   private final String testId;
-  private Catalog cachedCatalog;
+  private volatile Catalog cachedCatalog;
   private final String catalogName;
   private final Map<String, String> catalogProps;
   private final Map<String, String> configProps;
@@ -103,7 +103,7 @@ public class IcebergResourceManager implements ResourceManager {
    *
    * @return The Iceberg catalog.
    */
-  public Catalog catalog() {
+  public synchronized Catalog catalog() {
     if (cachedCatalog == null) {
       String catalogName = this.catalogName;
       Configuration config = new Configuration();
@@ -296,18 +296,21 @@ public class IcebergResourceManager implements ResourceManager {
     synchronized (createdNamespaces) {
       namespacesToClean = List.copyOf(createdNamespaces);
     }
-    for (String namespace : namespacesToClean) {
-      dropNamespace(namespace, true);
-    }
-    createdNamespaces.clear();
-    if (cachedCatalog instanceof AutoCloseable) {
-      try {
-        ((AutoCloseable) cachedCatalog).close();
-      } catch (Exception e) {
-        LOG.warn("Error closing Iceberg catalog", e);
+    try {
+      for (String namespace : namespacesToClean) {
+        dropNamespace(namespace, true);
       }
+      createdNamespaces.clear();
+    } finally {
+      if (cachedCatalog instanceof AutoCloseable) {
+        try {
+          ((AutoCloseable) cachedCatalog).close();
+        } catch (Exception e) {
+          LOG.warn("Error closing Iceberg catalog", e);
+        }
+      }
+      cachedCatalog = null;
     }
-    cachedCatalog = null;
     LOG.info("Cleaned up all resources for test ID: {}.", testId);
   }
 

--- a/it/iceberg/src/test/java/com/google/cloud/teleport/it/iceberg/IcebergResourceManagerTest.java
+++ b/it/iceberg/src/test/java/com/google/cloud/teleport/it/iceberg/IcebergResourceManagerTest.java
@@ -359,4 +359,32 @@ public class IcebergResourceManagerTest {
     testManager.catalog();
     catalogUtilMock.verify(() -> CatalogUtil.buildIcebergCatalog(any(), any(), any()), times(2));
   }
+
+  @Test
+  public void testCleanupAllClosesCatalogEvenWhenDropNamespaceFails() throws Exception {
+    Catalog closeableCatalog =
+        mock(
+            Catalog.class,
+            Mockito.withSettings().extraInterfaces(SupportsNamespaces.class, AutoCloseable.class));
+    catalogUtilMock
+        .when(() -> CatalogUtil.buildIcebergCatalog(any(), any(), any()))
+        .thenReturn(closeableCatalog);
+
+    doThrow(new RuntimeException("Drop failed"))
+        .when((SupportsNamespaces) closeableCatalog)
+        .dropNamespace(any(Namespace.class));
+    doReturn(true)
+        .when((SupportsNamespaces) closeableCatalog)
+        .namespaceExists(any(Namespace.class));
+
+    testManager.createNamespace(NAMESPACE_NAME);
+
+    assertThrows(RuntimeException.class, () -> testManager.cleanupAll());
+
+    verify((AutoCloseable) closeableCatalog).close();
+
+    // Verify cache was cleared
+    testManager.catalog();
+    catalogUtilMock.verify(() -> CatalogUtil.buildIcebergCatalog(any(), any(), any()), times(2));
+  }
 }

--- a/it/iceberg/src/test/java/com/google/cloud/teleport/it/iceberg/IcebergResourceManagerTest.java
+++ b/it/iceberg/src/test/java/com/google/cloud/teleport/it/iceberg/IcebergResourceManagerTest.java
@@ -305,4 +305,58 @@ public class IcebergResourceManagerTest {
     verify(catalog, never()).listTables(any(Namespace.class));
     verify((SupportsNamespaces) catalog, never()).dropNamespace(any(Namespace.class));
   }
+
+  @Test
+  public void testCleanupAllClosesCatalogWhenAutoCloseable() throws Exception {
+    Catalog closeableCatalog =
+        mock(
+            Catalog.class,
+            Mockito.withSettings().extraInterfaces(SupportsNamespaces.class, AutoCloseable.class));
+    catalogUtilMock
+        .when(() -> CatalogUtil.buildIcebergCatalog(any(), any(), any()))
+        .thenReturn(closeableCatalog);
+
+    testManager.catalog();
+    testManager.cleanupAll();
+
+    verify((AutoCloseable) closeableCatalog).close();
+  }
+
+  @Test
+  public void testCleanupAllClearsCachedCatalog() {
+    testManager.catalog();
+    testManager.cleanupAll();
+    testManager.catalog();
+
+    catalogUtilMock.verify(() -> CatalogUtil.buildIcebergCatalog(any(), any(), any()), times(2));
+  }
+
+  @Test
+  public void testCleanupAllHandlesCloseExceptionGracefully() throws Exception {
+    Catalog closeableCatalog =
+        mock(
+            Catalog.class,
+            Mockito.withSettings().extraInterfaces(SupportsNamespaces.class, AutoCloseable.class));
+    doThrow(new RuntimeException("Error closing catalog"))
+        .when((AutoCloseable) closeableCatalog)
+        .close();
+    catalogUtilMock
+        .when(() -> CatalogUtil.buildIcebergCatalog(any(), any(), any()))
+        .thenReturn(closeableCatalog);
+
+    testManager.catalog();
+    testManager.cleanupAll();
+
+    verify((AutoCloseable) closeableCatalog).close();
+  }
+
+  @Test
+  public void testCleanupAllWhenCatalogNotAutoCloseable() {
+    testManager.catalog();
+    testManager.cleanupAll();
+
+    // Verify cleanup completes and cache was cleared
+    testManager.catalog();
+    catalogUtilMock.verify(() -> CatalogUtil.buildIcebergCatalog(any(), any(), any()), times(2));
+  }
 }


### PR DESCRIPTION
## Description

In `IcebergResourceManager`, when resources are cleaned up, the cached catalog was not being closed. For catalogs that manage connections and file handles (such as JDBC, REST, or Hadoop catalogs), this could cause resource leaks and flaky integration tests.

This PR:
1. Safely checks if `cachedCatalog instanceof AutoCloseable` during `cleanupAll()` and invokes `close()`.
2. Sets `cachedCatalog = null` to prevent reusing a closed catalog.
3. Catches and logs any exception during `close()` so cleanup continues uninterrupted.
4. Adds unit tests to `IcebergResourceManagerTest` verifying catalog closure, cache clearing, and graceful exception handling.