### PR TITLE
fix: address CVE-2026-54399 vulnerability in httpcore5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,8 @@
     <neo4j-driver.version>5.28.12</neo4j-driver.version>
     <okio.version>3.18.1</okio.version>
     <jetty.version>12.1.11</jetty.version>
+    <httpclient5.version>5.6.4</httpclient5.version>
+    <httpcore5.version>5.4.3</httpcore5.version>
     <!-- Socket factory JARs for Cloud SQL -->
     <mysql-socket-factory.version>1.15.2</mysql-socket-factory.version>
     <postgres-socket-factory.version>1.28.1</postgres-socket-factory.version>
@@ -334,6 +336,22 @@
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
         <version>${zookeeper.version}</version>
+      </dependency>
+      <!-- Enforce non-vulnerable version of HttpComponents Core 5 and Client 5 (CVE-2026-54399) -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>${httpclient5.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
+        <version>${httpcore5.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-h2</artifactId>
+        <version>${httpcore5.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/v2/mqtt-to-pubsub/pom.xml
+++ b/v2/mqtt-to-pubsub/pom.xml
@@ -41,6 +41,7 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>hivemq</artifactId>
             <version>${testcontainers.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.hivemq</groupId>

--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -542,6 +542,12 @@
                                                 <exclude>META-INF/maven/com.squareup.okio/**</exclude>
                                             </excludes>
                                         </filter>
+                                        <filter>
+                                            <artifact>com.clickhouse:*</artifact>
+                                            <excludes>
+                                                <exclude>META-INF/maven/**</exclude>
+                                            </excludes>
+                                        </filter>
                                     </filters>
                                     <transformers>
                                         <transformer


### PR DESCRIPTION
- Enforce httpcore5 5.4.3 and httpclient5 5.6.4 in dependencyManagement
- Set testcontainers dependency in mqtt-to-pubsub to test scope to avoid bundling shaded zerodep transport into runtime container jar
- Exclude stale shaded META-INF/maven metadata from com.clickhouse artifacts in v2 shade plugin filters

Internal issue: b/546850698